### PR TITLE
Add GA tracking to AMP article pages

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -11,6 +11,7 @@ import cricketPa.CricketTeams
 import model.liveblog.{Blocks, BodyBlock}
 import model.meta.{Guardian, LinkedData, PotentialAction, WebPage}
 import ophan.SurgingContentAgent
+import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
@@ -344,6 +345,13 @@ final case class MetaData (
   )).getOrElse(Nil))
 
   def iosId(referrer: String): Option[String] = iosType.map(iosType => s"$id?contenttype=$iosType&source=$referrer")
+
+  /**
+    * Content type, lowercased and with spaces removed.
+    * This is used for Google Analytics, to be consistent with what the mobile apps do.
+    */
+  def normalisedContentType: String = StringUtils.remove(contentType.toLowerCase, ' ')
+
 }
 
 object Page {

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,0 +1,36 @@
+@(content: model.Content)
+
+@import views.support.GoogleAnalyticsAccount
+
+<amp-analytics type="googleanalytics" id="google-analytics">
+    <script type="application/json">
+            {
+              "requests": {
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}"
+              },
+              "vars": {
+                "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
+              },
+              "triggers": {
+                "trackPageview": {
+                  "on": "visible",
+                  "request": "pageviewWithCustomDims",
+                  "vars": {
+                    "title": "@{content.metadata.webTitle}",
+                    "platform": "AMP",
+                    "sectionId": "@{content.metadata.sectionId}",
+                    "contentType": "@{content.metadata.normalisedContentType}",
+                    "commissioningDesks": "@{content.tags.commissioningDesks.mkString(",")}",
+                    "contentId": "@{content.metadata.id}",
+                    "contributorIds": "@{content.tags.contributors.map(_.id).mkString(",")}",
+                    "keywordIds": "@{content.tags.keywords.map(_.id).mkString(",")}",
+                    "toneIds": "@{content.tags.tones.map(_.id).mkString(",")}",
+                    "seriesId": "@{content.tags.series.map(_.id).headOption.getOrElse("")}"
+                  }
+                }
+              }
+            }
+            </script>
+</amp-analytics>
+@* GA pageview confidence pixel *@
+<amp-pixel src="//beacon.guim.co.uk/count/pvg.gif"></amp-pixel>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -3,7 +3,7 @@
 @import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
 @import conf.switches.Switches.LiveUpdateAmpSwitch
-@import views.support.OmnitureAnalyticsData
+@import views.support.{OmnitureAnalyticsData, GoogleAnalyticsAccount}
 @import views.support.FBPixel
 
 <!doctype html>
@@ -43,6 +43,38 @@
         }
         <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
         <amp-analytics config="https://ophan.theguardian.com/amp.json"></amp-analytics>
+
+        <amp-analytics type="googleanalytics" id="google-analytics">
+            <script type="application/json">
+            {
+              "requests": {
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}"
+              },
+              "vars": {
+                "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
+              },
+              "triggers": {
+                "trackPageview": {
+                  "on": "visible",
+                  "request": "pageviewWithCustomDims",
+                  "vars": {
+                    "title": "@{content.metadata.webTitle}",
+                    "platform": "AMP",
+                    "sectionId": "@{content.metadata.sectionId}",
+                    "contentType": "@{content.metadata.normalisedContentType}",
+                    "commissioningDesks": "@{content.tags.commissioningDesks.mkString(",")}",
+                    "contentId": "@{content.metadata.id}",
+                    "contributorIds": "@{content.tags.contributors.map(_.id).mkString(",")}",
+                    "keywordIds": "@{content.tags.keywords.map(_.id).mkString(",")}",
+                    "toneIds": "@{content.tags.tones.map(_.id).mkString(",")}",
+                    "seriesId": "@{content.tags.series.map(_.id).headOption.getOrElse("")}"
+                  }
+                }
+              }
+            }
+            </script>
+        </amp-analytics>
+        <amp-pixel src="//beacon.guim.co.uk/count/pvg.gif"></amp-pixel>
 
         <div class="main-body">
 

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -3,7 +3,7 @@
 @import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
 @import conf.switches.Switches.LiveUpdateAmpSwitch
-@import views.support.{OmnitureAnalyticsData, GoogleAnalyticsAccount}
+@import views.support.OmnitureAnalyticsData
 @import views.support.FBPixel
 
 <!doctype html>
@@ -31,6 +31,13 @@
         <script src="https://cdn.ampproject.org/v0.js" async></script>
     </head>
     <body class="guardian-egyptian-loading">
+        @*
+        Baseline pageview confidence pixel.
+        This, along with the corresponding pixels for GA/Omniture/Ophan,
+        are used to generate the confidence graphs on the frontend dashboard.
+        *@
+        <amp-pixel src="//beacon.guim.co.uk/count/pv.gif"></amp-pixel>
+
         @defining(s"${request.host}${request.path}") { path =>
             @defining({
                 val params = OmnitureAnalyticsData(page, "No Javascript", path, "GoogleAMP", Map(("r", "DOCUMENT_REFERRER")))
@@ -38,43 +45,14 @@
                 s"${AnalyticsHost()}/b/ss/$omnitureAccount/1/H.25.3/?$params"
             }) { omnitureCall =>
                 <amp-pixel src="@Html(omnitureCall)"></amp-pixel>
+                @* Omniture pageview confidence pixel *@
                 <amp-pixel src="//beacon.guim.co.uk/count/pva.gif"></amp-pixel>
             }
         }
         <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
         <amp-analytics config="https://ophan.theguardian.com/amp.json"></amp-analytics>
 
-        <amp-analytics type="googleanalytics" id="google-analytics">
-            <script type="application/json">
-            {
-              "requests": {
-                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}"
-              },
-              "vars": {
-                "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
-              },
-              "triggers": {
-                "trackPageview": {
-                  "on": "visible",
-                  "request": "pageviewWithCustomDims",
-                  "vars": {
-                    "title": "@{content.metadata.webTitle}",
-                    "platform": "AMP",
-                    "sectionId": "@{content.metadata.sectionId}",
-                    "contentType": "@{content.metadata.normalisedContentType}",
-                    "commissioningDesks": "@{content.tags.commissioningDesks.mkString(",")}",
-                    "contentId": "@{content.metadata.id}",
-                    "contributorIds": "@{content.tags.contributors.map(_.id).mkString(",")}",
-                    "keywordIds": "@{content.tags.keywords.map(_.id).mkString(",")}",
-                    "toneIds": "@{content.tags.tones.map(_.id).mkString(",")}",
-                    "seriesId": "@{content.tags.series.map(_.id).headOption.getOrElse("")}"
-                  }
-                }
-              }
-            }
-            </script>
-        </amp-analytics>
-        <amp-pixel src="//beacon.guim.co.uk/count/pvg.gif"></amp-pixel>
+        @fragments.amp.googleAnalytics(content)
 
         <div class="main-body">
 


### PR DESCRIPTION
## What does this change?

Adds Google Analytics to AMP article pages.

See the [AMP docs](https://developers.google.com/analytics/devguides/collection/amp-analytics/) for details.
## What is the value of this and can you measure success?

Another step towards switching off Omniture.

AMP accounts for about 2% of pageviews, so this should bump our [GA confidence](https://frontend.gutools.co.uk/analytics/confidence) by about 2%.
## Does this affect other platforms - Amp, Apps, etc?

AMP, obvs.
## Screenshots

n/a
## Request for comment

Anyone who knows about AMP. @NataliaLKB ?

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
