### PR TITLE
New header z-index fix

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -251,8 +251,7 @@ $gutter-medium: 37px;
     right: 0;
     bottom: 0;
     left: 0;
-    // TODO: Why 3?
-    z-index: 3;
+    z-index: $zindex-modal;
 
     .js-on & {
         &:not(.shown) {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -274,6 +274,8 @@ $gutter-medium: 37px;
     bottom: 0;
     left: 0;
     transition: opacity .2s;
+    // Without this, in Safari/IOS this element appears above the menu
+    z-index: -1;
 
     .main-menu-container.off-screen & {
         opacity: 0;


### PR DESCRIPTION
## What does this change?

This fixes two bugs caused by the wrong z-index.

The first is that occasionally an ad would appear over the menu.

The second is that in Safari the overlay would appear over the menu. This meant you couldn't open anything in the menu
![image](https://cloud.githubusercontent.com/assets/8774970/17329966/cf9cb3c4-58bc-11e6-91de-e6c01b2527e2.png)
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@gtrufitt @zeftilldeath 
