### PR TITLE
Removing WS.url in FootballClient

### DIFF
--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -16,6 +16,8 @@ import play.api.libs.ws.ning.{NingWSClient, NingWSClientConfig}
 import play.api.test._
 import recorder.ContentApiHttpRecorder
 
+import scala.util.{Failure, Success, Try}
+
 trait TestSettings {
   val recorder = new ContentApiHttpRecorder {
     override lazy val baseDir = new File(System.getProperty("user.dir"), "data/database")
@@ -110,9 +112,13 @@ trait SingleServerSuite extends OneServerPerSuite with TestSettings with OneBrow
 
   implicit override lazy val app: Application = {
     val environment = Environment(new File("."), this.getClass.getClassLoader, Mode.Test)
+    val settings = Try(this.getClass.getClassLoader.loadClass("TestAppLoader")) match {
+      case Success(clazz) => initialSettings + ("play.application.loader" -> "TestAppLoader")
+      case Failure(_) => initialSettings
+    }
     val context = ApplicationLoader.createContext(
       environment = environment,
-      initialSettings = initialSettings
+      initialSettings = settings
     )
     ApplicationLoader.apply(context).load(context)
   }

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -4,11 +4,12 @@ import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CachedHealthCheckLifeCycle, CommonFilters, FootballLifecycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters, FootballClient, FootballLifecycle}
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import cricketPa.PaFeed
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
+import feed.{CompetitionsProvider, CompetitionsService}
 import football.controllers.{FootballControllers, HealthCheck}
 import jobs.CricketStatsJob
 import model.ApplicationIdentity
@@ -31,6 +32,9 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait SportServices {
   def wsClient: WSClient
+  lazy val footballClient = wire[FootballClient]
+  lazy val competitionDefinitions = CompetitionsProvider.allCompetitions
+  lazy val competitionsService = wire[CompetitionsService]
   lazy val cricketPaFeed = wire[PaFeed]
   lazy val cricketStatsJob = wire[CricketStatsJob]
   lazy val rugbyFeed = wire[OptaFeed]

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -2,40 +2,42 @@ package conf
 
 import app.LifecycleComponent
 import common._
-import feed.Competitions
-import model.{TeamMap, LiveBlogAgent}
-import pa.{PaClientErrorsException, Http, PaClient}
+import feed.CompetitionsService
+import model.{LiveBlogAgent, TeamMap}
+import pa.{Http, PaClient, PaClientErrorsException}
 import play.api.inject.ApplicationLifecycle
-import play.api.libs.ws.WS
+import play.api.libs.ws.WSClient
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class FootballLifecycle(
   appLifeCycle: ApplicationLifecycle,
   jobs: JobScheduler,
-  akkaAsync: AkkaAsync)(implicit ec: ExecutionContext) extends LifecycleComponent {
+  akkaAsync: AkkaAsync,
+  competitionsService: CompetitionsService)(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () => Future {
     descheduleJobs()
   }}
 
   private def scheduleJobs() {
-    Competitions.competitionIds.zipWithIndex foreach { case (id, index) =>
+    competitionsService.competitionIds.zipWithIndex foreach { case (id, index) =>
       //stagger fixtures and results refreshes to avoid timeouts
       val seconds = index * 5 % 60
       val minutes = index * 5 / 60 % 5
       val cron = s"$seconds $minutes/5 * * * ?"
 
       jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
-        Competitions.refreshCompetitionAgent(id)
+        competitionsService.refreshCompetitionAgent(id)
       }
     }
 
     jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
-      Competitions.refreshMatchDay()
+      competitionsService.refreshMatchDay()
     }
 
     jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
-      Competitions.refreshCompetitionData()
+      competitionsService.refreshCompetitionData()
     }
 
     jobs.schedule("LiveBlogRefreshJob", "0 0/2 * * * ?") {
@@ -48,7 +50,7 @@ class FootballLifecycle(
   }
 
   private def descheduleJobs() {
-    Competitions.competitionIds foreach { id =>
+    competitionsService.competitionIds foreach { id =>
       jobs.deschedule(s"CompetitionAgentRefreshJob_$id")
     }
     jobs.deschedule("MatchDayAgentRefreshJob")
@@ -62,23 +64,20 @@ class FootballLifecycle(
     scheduleJobs()
 
     akkaAsync.after1s {
-      val competitionUpdate = Competitions.refreshCompetitionData()
-      competitionUpdate.onSuccess { case _ => Competitions.competitionIds.foreach(Competitions.refreshCompetitionAgent) }
-      Competitions.refreshMatchDay()
+      val competitionUpdate = competitionsService.refreshCompetitionData()
+      competitionUpdate.onSuccess { case _ => competitionsService.competitionIds.foreach(competitionsService.refreshCompetitionAgent) }
+      competitionsService.refreshMatchDay()
       LiveBlogAgent.refresh()
       TeamMap.refresh()
     }
   }
 }
 
-object FootballClient extends PaClient with Http with Logging with ExecutionContexts {
+class FootballClient(wsClient: WSClient) extends PaClient with Http with Logging with ExecutionContexts {
 
-  import play.api.Play.current
-
-  private var _http: Http = new Http {
     override def GET(urlString: String): Future[pa.Response] = {
 
-        val promiseOfResponse = WS.url(urlString).withRequestTimeout(2000).get()
+        val promiseOfResponse = wsClient.url(urlString).withRequestTimeout(2000).get()
 
         promiseOfResponse.map{ r =>
 
@@ -87,16 +86,8 @@ object FootballClient extends PaClient with Http with Logging with ExecutionCont
           pa.Response(r.status, r.body.dropWhile(_ != '<'), r.statusText)
         }
       }
-  }
-
-  def http = _http
-  def http_=(delegateHttp: Http) = _http = delegateHttp
 
   lazy val apiKey = SportConfiguration.pa.footballKey
-
-  override def GET(urlString: String): Future[pa.Response] = {
-    _http.GET(urlString)
-  }
 
   def logErrors[T]: PartialFunction[Throwable, T] = {
     case e: PaClientErrorsException =>

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -37,11 +37,15 @@ class CompetitionAndGroupFinder(competitions: Competitions) {
 case class CompetitionAndGroup(competition: Competition, group: Group)
 
 class FixturesAndResults(competitions: Competitions) extends Football {
+
+  lazy val competitionAndGroupFinder = new CompetitionAndGroupFinder(competitions)
+  lazy val teamNameBuilder = new TeamNameBuilder(competitions)
+
   def makeContainer(tagId: String)(implicit request: RequestHeader) = {
 
     (for {
       teamId <- TeamMap.findTeamIdByUrlName(tagId)
-      teamName <- new TeamNameBuilder(competitions).withId(teamId)
+      teamName <- teamNameBuilder.withId(teamId)
     } yield {
       val relevantMatches = competitions.matches.filter({ theMatch =>
         theMatch.homeTeam.id == teamId || theMatch.awayTeam.id == teamId
@@ -55,7 +59,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
       val cssClasses = Seq("facia-snap--football", "facia-snap-embed")
       val missingComponentClasses = Seq("football-component-missing")
 
-      val maybeCompetitionAndGroup = new CompetitionAndGroupFinder(competitions).bestForTeam(teamId).filter(_ => leagueTableExists)
+      val maybeCompetitionAndGroup = competitionAndGroupFinder.bestForTeam(teamId).filter(_ => leagueTableExists)
 
       val now = LocalDate.now(Edition.defaultEdition.timezone)
       val fixturesComponent = fixtureExists option matchesComponent(

--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -2,12 +2,11 @@ package football.controllers
 
 import common._
 import conf.switches.Switches
-import model._
-import conf._
-import play.api.mvc.{ Controller, Action }
+import feed.CompetitionsService
+import play.api.mvc.{Action, Controller}
 
 
-class CompetitionListController extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
+class CompetitionListController(val competitionsService: CompetitionsService) extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
 
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions", "GFE:Football:automatic:Leagues & competitions")
 
@@ -28,4 +27,3 @@ class CompetitionListController extends Controller with CompetitionListFilters w
   }
 }
 
-object CompetitionListController extends CompetitionListController

--- a/sport/app/football/controllers/FixturesAndResultsContainerController.scala
+++ b/sport/app/football/controllers/FixturesAndResultsContainerController.scala
@@ -1,16 +1,20 @@
 package football.controllers
 
 import common.JsonComponent
+import feed.{Competitions, CompetitionsService}
 import football.containers.FixturesAndResults
 import model.Cached
 import play.api.mvc.{Action, Controller}
 import play.twirl.api.Html
 import views.html.fragments.containers.facia_cards.{container => containerHtml}
 
-class FixturesAndResultsContainerController extends Controller {
+class FixturesAndResultsContainerController(competitionsService: CompetitionsService) extends Controller {
+
+  val fixturesAndResults = new FixturesAndResults(competitionsService)
+
   def renderContainer(teamId: String) = Action { implicit request =>
     Cached(60) {
-      FixturesAndResults.makeContainer(teamId) match {
+      fixturesAndResults.makeContainer(teamId) match {
         case Some(container) =>
           JsonComponent(containerHtml(container))
 
@@ -20,5 +24,3 @@ class FixturesAndResultsContainerController extends Controller {
     }
   }
 }
-
-object FixturesAndResultsContainerController extends FixturesAndResultsContainerController

--- a/sport/app/football/controllers/FootballControllers.scala
+++ b/sport/app/football/controllers/FootballControllers.scala
@@ -1,8 +1,12 @@
 package football.controllers
 
 import com.softwaremill.macwire._
+import conf.FootballClient
+import feed.CompetitionsService
 
 trait FootballControllers {
+  def competitionsService: CompetitionsService
+  def footballClient: FootballClient
   lazy val fixturesController = wire[FixturesController]
   lazy val resultsController = wire[ResultsController]
   lazy val matchDayController = wire[MatchDayController]

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -1,10 +1,9 @@
 package football.controllers
 
 import common._
-import conf._
 import conf.switches.Switches
-import feed.Competitions
-import play.api.mvc.{ Action, Controller }
+import feed.CompetitionsService
+import play.api.mvc.{Action, Controller}
 import model._
 import model.Page
 
@@ -17,7 +16,7 @@ case class TablesPage(
   lazy val singleCompetition = tables.size == 1
 }
 
-class LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
+class LeagueTableController(val competitionsService: CompetitionsService) extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
 
     val tableOrder = Seq(
         "Premier League",
@@ -45,9 +44,7 @@ class LeagueTableController extends Controller with Logging with CompetitionTabl
         "International friendlies"
     )
 
-  private def competitions = Competitions().competitions
-
-  def sortedCompetitions:Seq[Competition] = tableOrder.map(leagueName => competitions.find(_.fullName == leagueName)).flatten
+  def sortedCompetitions:Seq[Competition] = tableOrder.map(leagueName => competitionsService.competitions.find(_.fullName == leagueName)).flatten
 
   private def loadTables: Seq[Table] = sortedCompetitions.filter(_.hasLeagueTable).map { Table(_) }
 
@@ -89,7 +86,7 @@ class LeagueTableController extends Controller with Logging with CompetitionTabl
       table.copy(groups = table.groups)
     }
 
-    val comps = competitions.filter(_.showInTeamsList).filter(_.hasTeams)
+    val comps = competitionsService.competitions.filter(_.showInTeamsList).filter(_.hasTeams)
 
     val htmlResponse = () => football.views.html.teamlist(TablesPage(page, groups, "/football", filters, None), comps)
     val jsonResponse = () => football.views.html.fragments.teamlistBody(TablesPage(page, groups, "/football", filters, None), comps)
@@ -152,5 +149,3 @@ class LeagueTableController extends Controller with Logging with CompetitionTabl
     }
   }
 }
-
-object LeagueTableController extends LeagueTableController

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -13,6 +13,7 @@ import implicits.Requests
 import pa.FootballTeam
 
 trait MatchListController extends Controller with Requests {
+  val competitionsService: Competitions
   protected val datePattern = DateTimeFormat.forPattern("yyyyMMMdd").withZone(Edition.defaultEdition.timezone)
   protected def createDate(year: String, month: String, day: String): LocalDate =
     datePattern.parseDateTime(s"$year$month$day").toLocalDate
@@ -44,12 +45,12 @@ trait MatchListController extends Controller with Requests {
   }
 
   protected def lookupCompetition(tag: String): Option[Competition] = {
-    Competitions().withTag(tag).orElse(Competitions().withId(tag))
+    competitionsService.competitionsWithTag(tag).orElse(competitionsService.competitionsWithId(tag))
   }
   protected def lookupTeam(tag: String): Option[FootballTeam] = {
     for {
       teamId <- TeamMap.findTeamIdByUrlName(tag)
-      team <- Competitions().findTeam(teamId)
+      team <- competitionsService.findTeam(teamId)
     } yield team
   }
 }

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -1,15 +1,15 @@
 package football.controllers
 
 import common.Edition
-import feed.Competitions
-import play.api.mvc.{AnyContent, Action, Result}
+import feed.CompetitionsService
+import play.api.mvc.{Action, AnyContent, Result}
 import org.joda.time.LocalDate
 import model._
 import football.model._
 import pa.FootballTeam
 import model.Competition
 
-class ResultsController extends MatchListController with CompetitionResultFilters {
+class ResultsController(val competitionsService: CompetitionsService) extends MatchListController with CompetitionResultFilters {
 
   private def competitionOrTeam(tag: String): Option[Either[Competition, FootballTeam]] = {
     lookupCompetition(tag).map(Left(_))
@@ -28,9 +28,9 @@ class ResultsController extends MatchListController with CompetitionResultFilter
   }
 
   private def results(date: LocalDate, tag: Option[String] = None): Option[Results] = {
-    def allResults = ResultsList(date, Competitions())
-    def competitionResults = (competition: Competition) => CompetitionResultsList(date, Competitions(), competition.id)
-    def teamResults = (team: FootballTeam) => TeamResultsList(date, Competitions(), team.id, TeamUrl(team))
+    def allResults = ResultsList(date, competitionsService.competitions)
+    def competitionResults = (competition: Competition) => CompetitionResultsList(date, competitionsService.competitions, competition.id)
+    def teamResults = (team: FootballTeam) => TeamResultsList(date, competitionsService.competitions, team.id, TeamUrl(team))
     byType[Results](allResults)(competitionResults)(teamResults)(tag)
   }
 
@@ -80,5 +80,3 @@ class ResultsController extends MatchListController with CompetitionResultFilter
   def moreTagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] = renderMoreForDate(createDate(year, month, day), Some(tag))
   def moreTagResultsForJson(year: String, month: String, day: String, tag: String) = moreTagResultsFor(year, month, day, tag)
 }
-
-object ResultsController extends ResultsController

--- a/sport/app/football/controllers/context.scala
+++ b/sport/app/football/controllers/context.scala
@@ -1,43 +1,48 @@
 package football.controllers
 
-import feed.Competitions
+import feed.CompetitionsService
 
 trait CompetitionFixtureFilters {
-  def filters = Competitions().withTodaysMatchesAndFutureFixtures.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
+  def competitionsService: CompetitionsService
+  def filters = competitionsService.competitionsWithTodaysMatchesAndFutureFixtures.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
     .map {
-      case (nation, competitions) =>
-        nation -> competitions.map(c => CompetitionFilter(c.fullName, s"${c.url}/fixtures"))
+      case (nation, comps) =>
+        nation -> comps.map(c => CompetitionFilter(c.fullName, s"${c.url}/fixtures"))
     }
 }
 
 trait CompetitionResultFilters {
-  def filters = Competitions().withTodaysMatchesAndPastResults.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
+  def competitionsService: CompetitionsService
+  def filters = competitionsService.competitionsWithTodaysMatchesAndPastResults.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
     .map {
-      case (nation, competitions) =>
-        nation -> competitions.map(c => CompetitionFilter(c.fullName, s"${c.url}/results"))
+      case (nation, comps) =>
+        nation -> comps.map(c => CompetitionFilter(c.fullName, s"${c.url}/results"))
     }
 }
 
 trait CompetitionLiveFilters {
-  def filters = Competitions().withTodaysMatches.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
+  def competitionsService: CompetitionsService
+  def filters = competitionsService.withTodaysMatches.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
     .map {
-      case (nation, competitions) =>
-        nation -> competitions.map(c => CompetitionFilter(c.fullName, s"${c.url}/live"))
+      case (nation, comps) =>
+        nation -> comps.map(c => CompetitionFilter(c.fullName, s"${c.url}/live"))
     }
 }
 
 trait CompetitionListFilters {
-  def filters = Competitions().competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
+  def competitionsService: CompetitionsService
+  def filters = competitionsService.competitions.filter(_.matches.nonEmpty).groupBy(_.nation)
     .map {
-      case (nation, competitions) =>
-        nation -> competitions.map(c => CompetitionFilter(c.fullName, c.url))
+      case (nation, comps) =>
+        nation -> comps.map(c => CompetitionFilter(c.fullName, c.url))
     }
 }
 
 trait CompetitionTableFilters {
-  def filters = Competitions().withTodaysMatchesAndFutureFixtures.competitions.filter(_.hasLeagueTable).groupBy(_.nation)
+  def competitionsService: CompetitionsService
+  def filters = competitionsService.competitionsWithTodaysMatchesAndFutureFixtures.competitions.filter(_.hasLeagueTable).groupBy(_.nation)
     .map {
-      case (nation, competitions) =>
-        nation -> competitions.map(c => CompetitionFilter(c.fullName, s"${c.url}/table"))
+      case (nation, comps) =>
+        nation -> comps.map(c => CompetitionFilter(c.fullName, s"${c.url}/table"))
     }
 }

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -128,12 +128,12 @@ object TeamUrl {
   def apply(team: FootballTeam): Option[String] = TeamMap(team).url
 }
 
-object TeamName {
-  def apply(team: FootballTeam) = {
+class TeamNameBuilder(competitions: Competitions) {
+  def withTeam(team: FootballTeam) = {
     TeamMap.shortNames.get(team.id).getOrElse(team.name)
   }
 
-  def fromId(id: String) = Competitions().findTeam(id).map(apply)
+  def withId(id: String) = competitions.findTeam(id).map(withTeam)
 }
 
 // if we have tags for the matches we can make a sensible url for it

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -21,7 +21,7 @@
 
                     <div class="football-leagues football-leagues--list modern-hidden">
                         <ul class="football-leagues-list u-unstyled">
-                            @matchesList.competitions.competitions.map{ comp =>
+                            @matchesList.competitions.map{ comp =>
                                 <li class="football-leagues__item"><a href="@comp.url/@matchesList.pageType" data-link-name="view @comp.fullName matches">@comp.fullName</option></a></li>
                             }
                         </ul>

--- a/sport/app/football/views/wallchart/embed.scala.html
+++ b/sport/app/football/views/wallchart/embed.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStage])(implicit request: RequestHeader)
+@(page: model.Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader)
 <!DOCTYPE html>
 <html class="js-off is-not-modern id--signed-out" lang="en-GB">
     <head>

--- a/sport/app/football/views/wallchart/page.scala.html
+++ b/sport/app/football/views/wallchart/page.scala.html
@@ -1,4 +1,4 @@
-@(page: Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStage])(implicit request: RequestHeader)
+@(page: Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader)
 
 @main(page, "football"){
 }{

--- a/sport/app/football/views/wallchart/wallchart.scala.html
+++ b/sport/app/football/views/wallchart/wallchart.scala.html
@@ -1,4 +1,4 @@
-@(competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStage])(implicit request: RequestHeader)
+@(competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader)
 
 @competitionStages.map {
     case knockoutStage: _root_.football.model.KnockoutSpider => {

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -2,7 +2,7 @@ package test
 
 import feed.CompetitionsService
 import model.Competition
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Span}
 import org.joda.time.{DateTime, DateTimeUtils, LocalDate}
@@ -13,7 +13,10 @@ import org.joda.time.{DateTime, DateTimeUtils, LocalDate}
   with Matchers
   with implicits.Football
   with Eventually
-  with FootballTestSuite {
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestFootballClient
+  with FootballTestData {
 
   override def beforeAll() = {
     // Tests in this suite are time dependent:

--- a/sport/test/FootballTestSuite.scala
+++ b/sport/test/FootballTestSuite.scala
@@ -4,9 +4,19 @@ import org.scala_tools.time.Imports._
 import org.joda.time.DateTime
 import pa._
 import model.{Competition, Tag, TagProperties, TeamMap}
-import feed.Competitions
+import feed.CompetitionsService
+import org.scalatest.{BeforeAndAfterAll, Suite}
 
-trait FootballTestData {
+trait FootballTestSuite
+  extends Suite
+  with ConfiguredTestSuite
+  with WithTestFootballClient
+  with BeforeAndAfterAll
+  with WithTestWsClient {
+
+  override def beforeAll() = loadTestData()
+
+  lazy val competitionsService = new CompetitionsService(testFootballClient, competitions)
 
   private val zone = DateTimeZone.forID("Europe/London")
 
@@ -26,7 +36,7 @@ trait FootballTestData {
     None, None, None)
 
 
-  val competitions = Seq(
+  private val competitions = Seq(
     Competition("100", "/football/premierleague", "Premier League", "Premier League", "English",
       showInTeamsList = true,
       startDate = Some((today - 2.months).toLocalDate),
@@ -70,7 +80,7 @@ trait FootballTestData {
     )
   )
 
-  val teamTags: Map[String, Tag] = Map(
+  private val teamTags: Map[String, Tag] = Map(
       "Liverpool" -> Tag(
         TagProperties("football/liverpool", "/football/liverpool", "Keyword", "football", "Football", "Liverpool",
           "https://www.theguardian.com/football/liverpool", None, None, None, None, None, None, None, Seq(), None),
@@ -106,9 +116,9 @@ trait FootballTestData {
     LeagueTeam(team, team, rank, LeagueStats(10, 5, 5, 0, 3, 2),
       LeagueStats(10, 5, 5, 0, 3, 2), LeagueStats(10, 5, 5, 0, 3, 2), 3, 30))
 
-  def loadTestData() {
-    if (Competitions().matches.isEmpty) {
-      Competitions.competitionAgents.foreach { agent =>
+  private def loadTestData() {
+    if (competitionsService.matches.isEmpty) {
+      competitionsService.competitionAgents.foreach { agent =>
         competitions.filter(_.id == agent.competition.id).map { comp =>
           agent.update(comp)
           agent.addMatches(comp.matches)

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -1,10 +1,15 @@
 package test
 
+import football.controllers.LeagueTableController
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest._
 
-@DoNotDiscover class LeagueTablesFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class LeagueTablesFeatureTest
+  extends FeatureSpec
+  with GivenWhenThen
+  with Matchers
+  with FootballTestSuite {
 
   feature("League Tables") {
 
@@ -52,7 +57,8 @@ import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
     }
 
     scenario("Should redirect when no competition table data found") {
-      val result = football.controllers.LeagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())
+      val leagueTableController = new LeagueTableController(competitionsService)
+      val result = leagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())
       status(result) should be(303)
     }
 

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -9,7 +9,8 @@ import org.scalatest._
   extends FeatureSpec
   with GivenWhenThen
   with Matchers
-  with FootballTestSuite {
+  with ConfiguredTestSuite
+  with FootballTestData {
 
   feature("League Tables") {
 
@@ -57,7 +58,7 @@ import org.scalatest._
     }
 
     scenario("Should redirect when no competition table data found") {
-      val leagueTableController = new LeagueTableController(competitionsService)
+      val leagueTableController = new LeagueTableController(testCompetitionsService)
       val result = leagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())
       status(result) should be(303)
     }

--- a/sport/test/TestAppLoader.scala
+++ b/sport/test/TestAppLoader.scala
@@ -1,0 +1,14 @@
+
+import app.FrontendComponents
+import play.api.ApplicationLoader.Context
+import play.api.BuiltInComponentsFromContext
+import test.FootballTestData
+
+trait TestComponents extends FootballTestData {
+  self: SportServices =>
+  override lazy val competitionsService = testCompetitionsService
+}
+
+class TestAppLoader extends AppLoader {
+  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents with TestComponents
+}

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -8,10 +8,10 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 @DoNotDiscover class CompetitionListControllerTest
   extends FlatSpec
   with Matchers
-  with FootballTestSuite {
+  with FootballTestData {
 
   val url = "/football/competitionsService"
-  lazy val competitionListController = new CompetitionListController(competitionsService)
+  lazy val competitionListController = new CompetitionListController(testCompetitionsService)
 
   "Competition List Controller" should "200 when content type is competition list" in {
     val result = competitionListController.renderCompetitionList()(TestRequest())

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -1,15 +1,20 @@
 package test
 
+import football.controllers.CompetitionListController
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class CompetitionListControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CompetitionListControllerTest
+  extends FlatSpec
+  with Matchers
+  with FootballTestSuite {
 
-  val url = "/football/competitions"
+  val url = "/football/competitionsService"
+  lazy val competitionListController = new CompetitionListController(competitionsService)
 
   "Competition List Controller" should "200 when content type is competition list" in {
-    val result = football.controllers.CompetitionListController.renderCompetitionList()(TestRequest())
+    val result = competitionListController.renderCompetitionList()(TestRequest())
     status(result) should be(200)
   }
 
@@ -18,7 +23,7 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = football.controllers.CompetitionListController.renderCompetitionListJson()(fakeRequest)
+    val result = competitionListController.renderCompetitionListJson()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -8,13 +8,13 @@ import org.scalatest._
 @DoNotDiscover class FixturesControllerTest
   extends FreeSpec
   with ShouldMatchers
-  with FootballTestSuite {
+  with FootballTestData {
 
   val fixturesUrl = "/football/fixtures"
   val fixtureForUrl = "/football/fixtures/2012/oct/20"
   val tag = "premierleague"
 
-  val fixturesController = new FixturesController(competitionsService)
+  val fixturesController = new FixturesController(testCompetitionsService)
 
   "can load the all fixtures page" in {
     val result = fixturesController.allFixtures()(TestRequest())

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -1,17 +1,23 @@
 package test
 
+import football.controllers.FixturesController
 import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest._
 
-@DoNotDiscover class FixturesControllerTest extends FreeSpec with ShouldMatchers with ConfiguredTestSuite {
+@DoNotDiscover class FixturesControllerTest
+  extends FreeSpec
+  with ShouldMatchers
+  with FootballTestSuite {
 
   val fixturesUrl = "/football/fixtures"
   val fixtureForUrl = "/football/fixtures/2012/oct/20"
   val tag = "premierleague"
 
+  val fixturesController = new FixturesController(competitionsService)
+
   "can load the all fixtures page" in {
-    val result = football.controllers.FixturesController.allFixtures()(TestRequest())
+    val result = fixturesController.allFixtures()(TestRequest())
     status(result) should be(200)
   }
 
@@ -19,7 +25,7 @@ import org.scalatest._
     val fakeRequest = FakeRequest(GET, s"$fixturesUrl.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-    val result = football.controllers.FixturesController.allFixtures()(fakeRequest)
+    val result = fixturesController.allFixtures()(fakeRequest)
 
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
@@ -27,7 +33,7 @@ import org.scalatest._
   }
 
   "can load fixtures for a given date" in {
-    val result = football.controllers.FixturesController.allFixturesFor("2012", "oct", "20")(TestRequest())
+    val result = fixturesController.allFixturesFor("2012", "oct", "20")(TestRequest())
     status(result) should be(200)
   }
 
@@ -35,7 +41,7 @@ import org.scalatest._
     val fakeRequest = FakeRequest(GET, s"$fixtureForUrl.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-    val result = football.controllers.FixturesController.allFixturesFor("2012", "oct", "20")(fakeRequest)
+    val result = fixturesController.allFixturesFor("2012", "oct", "20")(fakeRequest)
 
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
@@ -43,7 +49,7 @@ import org.scalatest._
   }
 
   "can load the tag fixtures page" in {
-    val result = football.controllers.FixturesController.tagFixtures(tag)(TestRequest())
+    val result = fixturesController.tagFixtures(tag)(TestRequest())
     status(result) should be(200)
   }
 
@@ -51,7 +57,7 @@ import org.scalatest._
     val fakeRequest = FakeRequest(GET, s"/football/$tag/fixtures.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-    val result = football.controllers.FixturesController.tagFixtures(tag)(fakeRequest)
+    val result = fixturesController.tagFixtures(tag)(fakeRequest)
 
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
@@ -59,7 +65,7 @@ import org.scalatest._
   }
 
   "can load tag fixtures for a given date" in {
-    val result = football.controllers.FixturesController.tagFixturesFor("2012", "oct", "20", tag)(TestRequest())
+    val result = fixturesController.tagFixturesFor("2012", "oct", "20", tag)(TestRequest())
     status(result) should be(200)
   }
 
@@ -67,7 +73,7 @@ import org.scalatest._
     val fakeRequest = FakeRequest(GET, s"$fixtureForUrl.json")
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
-    val result = football.controllers.FixturesController.tagFixturesFor("2012", "oct", "20", tag)(fakeRequest)
+    val result = fixturesController.tagFixturesFor("2012", "oct", "20", tag)(fakeRequest)
 
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -8,9 +8,9 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 @DoNotDiscover class LeagueTableControllerTest
   extends FlatSpec
   with Matchers
-  with FootballTestSuite {
+  with FootballTestData {
 
-  val leagueTableController = new LeagueTableController(competitionsService)
+  val leagueTableController = new LeagueTableController(testCompetitionsService)
 
   "League Table Controller" should "200 when content type is table" in {
     val result = leagueTableController.renderLeagueTable()(TestRequest())

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -1,13 +1,19 @@
 package test
 
+import football.controllers.LeagueTableController
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class LeagueTableControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class LeagueTableControllerTest
+  extends FlatSpec
+  with Matchers
+  with FootballTestSuite {
+
+  val leagueTableController = new LeagueTableController(competitionsService)
 
   "League Table Controller" should "200 when content type is table" in {
-    val result = football.controllers.LeagueTableController.renderLeagueTable()(TestRequest())
+    val result = leagueTableController.renderLeagueTable()(TestRequest())
     status(result) should be(200)
   }
 
@@ -16,14 +22,14 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = football.controllers.LeagueTableController.renderLeagueTableJson()(fakeRequest)
+    val result = leagueTableController.renderLeagueTableJson()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
   }
 
   it should "200 when content type is teams" in {
-    val result = football.controllers.LeagueTableController.renderTeamlist()(TestRequest().withHeaders("Accept" -> "application/javascript"))
+    val result = leagueTableController.renderTeamlist()(TestRequest().withHeaders("Accept" -> "application/javascript"))
     status(result) should be(200)
   }
 
@@ -32,7 +38,7 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = football.controllers.LeagueTableController.renderTeamlist()(fakeRequest)
+    val result = leagueTableController.renderTeamlist()(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"config\"")
@@ -41,7 +47,7 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
   val competitionId = "premierleague"
 
   it should "200 when content type is competition table" in {
-    val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(TestRequest())
+    val result = leagueTableController.renderCompetition(competitionId)(TestRequest())
     status(result) should be(200)
   }
 
@@ -50,7 +56,7 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = football.controllers.LeagueTableController.renderCompetition(competitionId)(fakeRequest)
+    val result = leagueTableController.renderCompetition(competitionId)(fakeRequest)
     status(result) should be(200)
     header("Content-Type", result).get should be("application/json; charset=utf-8")
     contentAsString(result) should startWith("{\"html\"")

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -2,14 +2,17 @@ package test
 
 import football.controllers.MatchController
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
 @DoNotDiscover class MatchControllerTest
   extends FlatSpec
   with Matchers
-  with FootballTestSuite {
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestFootballClient
+  with FootballTestData {
 
-  val matchController = new MatchController(competitionsService, testFootballClient)
+  val matchController = new MatchController(testCompetitionsService, testFootballClient)
 
   "MatchController" should "redirect to results when match is not found" in {
     val result = matchController.renderMatchId("12345")(TestRequest())

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -1,12 +1,18 @@
 package test
 
+import football.controllers.MatchController
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class MatchControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
-  
+@DoNotDiscover class MatchControllerTest
+  extends FlatSpec
+  with Matchers
+  with FootballTestSuite {
+
+  val matchController = new MatchController(competitionsService, testFootballClient)
+
   "MatchController" should "redirect to results when match is not found" in {
-    val result = football.controllers.MatchController.renderMatchId("12345")(TestRequest())
+    val result = matchController.renderMatchId("12345")(TestRequest())
     status(result) should be(302)
     header("Location", result).head should be ("/football/results")
   }

--- a/sport/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/sport/test/controllers/MoreOnMatchFeatureTest.scala
@@ -1,11 +1,17 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest._
 import football.controllers.MoreOnMatchController
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 
-@DoNotDiscover class MoreOnMatchFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MoreOnMatchFeatureTest
+  extends FeatureSpec
+  with GivenWhenThen
+  with Matchers
+  with FootballTestSuite {
+
+  val moreOnMatchController = new MoreOnMatchController(competitionsService)
 
   feature("Match Nav") {
 
@@ -16,7 +22,7 @@ import play.api.test.FakeRequest
       {
         val request = FakeRequest("GET", "/football/api/match-nav/2012/12/01/1006/65?callback=call").withHeaders("host" -> "localhost:9000")
 
-        val result = MoreOnMatchController.matchNav("2012", "12", "01", "1006", "65")(request)
+        val result = moreOnMatchController.matchNav("2012", "12", "01", "1006", "65")(request)
 
         status(result) should be(200)
 
@@ -37,7 +43,7 @@ import play.api.test.FakeRequest
       {
         val request = FakeRequest("GET", "football/api/match-nav/2010/01/01/1/2?callback=call").withHeaders("host" -> "localhost:9000")
 
-        val result = MoreOnMatchController.matchNav("2010", "01", "01", "1", "2")(request)
+        val result = moreOnMatchController.matchNav("2010", "01", "01", "1", "2")(request)
 
         status(result) should be(404)
       }
@@ -53,7 +59,7 @@ import play.api.test.FakeRequest
       {
         val request = FakeRequest("GET", "/football/api/match-nav/1010?callback=call").withHeaders("host" -> "localhost:9000")
 
-        val result = MoreOnMatchController.moreOn("1010")(request)
+        val result = moreOnMatchController.moreOn("1010")(request)
 
         status(result) should be(200)
 
@@ -74,7 +80,7 @@ import play.api.test.FakeRequest
       {
         val request = FakeRequest("GET", "/football/api/match-nav/bad-id?callback=call").withHeaders("host" -> "localhost:9000")
 
-        val result = MoreOnMatchController.moreOn("bad-id")(request)
+        val result = moreOnMatchController.moreOn("bad-id")(request)
 
         status(result) should be(404)
       }

--- a/sport/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/sport/test/controllers/MoreOnMatchFeatureTest.scala
@@ -9,9 +9,9 @@ import play.api.test.FakeRequest
   extends FeatureSpec
   with GivenWhenThen
   with Matchers
-  with FootballTestSuite {
+  with FootballTestData {
 
-  val moreOnMatchController = new MoreOnMatchController(competitionsService)
+  val moreOnMatchController = new MoreOnMatchController(testCompetitionsService)
 
   feature("Match Nav") {
 

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -6,16 +6,16 @@ import play.api.libs.json.JsValue
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.FootballTestSuite
+import test.FootballTestData
 
 import scala.concurrent.Future
 
 @DoNotDiscover class ResultsControllerTest
   extends WordSpec
   with Matchers
-  with FootballTestSuite {
+  with FootballTestData {
 
-  val resultsController = new ResultsController(competitionsService)
+  val resultsController = new ResultsController(testCompetitionsService)
 
   "GET all results" should {
     val request = FakeRequest(method = "GET", path = "/football/results.json")

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -6,14 +6,20 @@ import play.api.libs.json.JsValue
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.ConfiguredTestSuite
+import test.FootballTestSuite
+
 import scala.concurrent.Future
 
-@DoNotDiscover class ResultsControllerTest extends WordSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ResultsControllerTest
+  extends WordSpec
+  with Matchers
+  with FootballTestSuite {
+
+  val resultsController = new ResultsController(competitionsService)
 
   "GET all results" should {
     val request = FakeRequest(method = "GET", path = "/football/results.json")
-    val action = ResultsController.allResultsJson()
+    val action = resultsController.allResultsJson()
     lazy val response: Future[Result] = call(action, request)
     "200" in {
       status(response) should be(200)
@@ -22,7 +28,7 @@ import scala.concurrent.Future
   "GET all results for a specific date" when {
     "date is correct" should {
       val request = FakeRequest(method = "GET", path = "/football/results/2016/May/3.json")
-      val action = ResultsController.allResultsForJson("2016", "May", "3")
+      val action = resultsController.allResultsForJson("2016", "May", "3")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -32,7 +38,7 @@ import scala.concurrent.Future
   }
   "GET more results for a specific date" should {
     val request = FakeRequest(method = "GET", path = "/football/results/more/2016/May/3.json")
-    val action = ResultsController.moreResultsForJson("2016", "May", "3")
+    val action = resultsController.moreResultsForJson("2016", "May", "3")
     lazy val response: Future[Result] = call(action, request)
     "200" in {
       status(response) should be(200)
@@ -41,7 +47,7 @@ import scala.concurrent.Future
   "GET results for a specific tag" when {
     "tag (competition) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
-      val action = ResultsController.tagResultsJson("premierleague")
+      val action = resultsController.tagResultsJson("premierleague")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -49,7 +55,7 @@ import scala.concurrent.Future
     }
     "tag (team) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
-      val action = ResultsController.tagResultsJson("liverpool")
+      val action = resultsController.tagResultsJson("liverpool")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -57,7 +63,7 @@ import scala.concurrent.Future
     }
     "tag doesn't exist" should {
       val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
-      val action = ResultsController.tagResultsJson("DONOTEXIST")
+      val action = resultsController.tagResultsJson("DONOTEXIST")
       lazy val response: Future[Result] = call(action, request)
       "404" in {
         status(response) should be(404)
@@ -67,7 +73,7 @@ import scala.concurrent.Future
   "GET results for a specific tag and date" when {
     "tag (competition) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
-      val action = ResultsController.tagResultsForJson("2016", "May", "3", "premierleague")
+      val action = resultsController.tagResultsForJson("2016", "May", "3", "premierleague")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -75,7 +81,7 @@ import scala.concurrent.Future
     }
     "tag (team) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
-      val action = ResultsController.tagResultsForJson("2016", "May", "3", "liverpool")
+      val action = resultsController.tagResultsForJson("2016", "May", "3", "liverpool")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -83,7 +89,7 @@ import scala.concurrent.Future
     }
     "tag doesn't exist" should {
       val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
-      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
+      val action = resultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
       lazy val response: Future[Result] = call(action, request)
       "404" in {
         status(response) should be(404)
@@ -93,7 +99,7 @@ import scala.concurrent.Future
   "GET more results for a specific tag" when {
     "tag (competition) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
-      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "premierleague")
+      val action = resultsController.moreTagResultsForJson("2016", "May", "3", "premierleague")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -101,7 +107,7 @@ import scala.concurrent.Future
     }
     "tag (team) exists" should {
       val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
-      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "liverpool")
+      val action = resultsController.moreTagResultsForJson("2016", "May", "3", "liverpool")
       lazy val response: Future[Result] = call(action, request)
       "200" in {
         status(response) should be(200)
@@ -109,7 +115,7 @@ import scala.concurrent.Future
     }
     "tag doesn't exist" should {
       val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
-      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
+      val action = resultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
       lazy val response: Future[Result] = call(action, request)
       "404" in {
         status(response) should be(404)

--- a/sport/test/football/model/CompetitionStageTest.scala
+++ b/sport/test/football/model/CompetitionStageTest.scala
@@ -5,7 +5,7 @@ import pa.{Round, Stage}
 import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher}
 import org.joda.time.DateTime
 import implicits.Collections
-import test.FootballTestSuite
+import test.FootballTestData
 
 @DoNotDiscover class CompetitionStageTest
   extends FreeSpec
@@ -13,9 +13,9 @@ import test.FootballTestSuite
   with OptionValues
   with CompetitionTestData
   with Collections
-  with FootballTestSuite {
+  with FootballTestData {
 
-  val competitionStage = new CompetitionStage(competitionsService.competitions)
+  val competitionStage = new CompetitionStage(testCompetitionsService.competitions)
 
   "stagesFromCompetition" - {
     "will generate a League" in {
@@ -165,7 +165,7 @@ import test.FootballTestSuite
 
       "will work out active round as" - {
         "first round if none have started" in {
-          val ko = KnockoutList(competitionsService.competitions, futureKnockoutMatches(Stage("1")), knockoutRounds)
+          val ko = KnockoutList(testCompetitionsService.competitions, futureKnockoutMatches(Stage("1")), knockoutRounds)
           ko.activeRound.value should equal(quarterFinals)
           ko.isActiveRound(quarterFinals) should equal(true)
           ko.isActiveRound(semiFinals) should equal(false)
@@ -174,19 +174,19 @@ import test.FootballTestSuite
         }
 
         "last round if all have finished" in {
-          val ko = KnockoutList(competitionsService.competitions, pastKnockoutMatches(Stage("1")), knockoutRounds)
+          val ko = KnockoutList(testCompetitionsService.competitions, pastKnockoutMatches(Stage("1")), knockoutRounds)
           ko.activeRound.value should equal(`final`)
           ko.isActiveRound(`final`) should equal(true)
         }
 
         "current round if we're halfway through one" in {
-          val ko = KnockoutList(competitionsService.competitions, currentKnockoutMatches(Stage("1")), knockoutRounds)
+          val ko = KnockoutList(testCompetitionsService.competitions, currentKnockoutMatches(Stage("1")), knockoutRounds)
           ko.activeRound.value should equal(semiFinals)
           ko.isActiveRound(semiFinals) should equal(true)
         }
 
         "next round if we're between rounds" in {
-          val ko = KnockoutList(competitionsService.competitions, betweenRoundsKnockoutMatches(Stage("1")), knockoutRounds)
+          val ko = KnockoutList(testCompetitionsService.competitions, betweenRoundsKnockoutMatches(Stage("1")), knockoutRounds)
           ko.activeRound.value should equal(thirdPlacePlayoff)
           ko.isActiveRound(thirdPlacePlayoff) should equal(true)
         }

--- a/sport/test/football/model/FixturesListTest.scala
+++ b/sport/test/football/model/FixturesListTest.scala
@@ -10,7 +10,7 @@ import test.ConfiguredTestSuite
 
   "the all fixtures list" - {
     "for today" - {
-      val fixtures = new FixturesList(today, competitions)
+      val fixtures = new FixturesList(today, competitions.competitions)
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches.map { case (fmatch, _) =>
@@ -22,11 +22,6 @@ import test.ConfiguredTestSuite
         fixtures.matchesGroupedByDateAndCompetition.map(_._1) should equal(List(today, today.plusDays(1), today.plusDays(3)))
       }
 
-
-//      "should group matches correctly by date and league, with league ordered correctly" in {
-//        val (_, competitionMatches1) = fixtures.matchesGroupedByDateAndCompetition(0)
-//        competitionMatches1.map { case (comp, matches) => comp.id } should equal(List("100", "500"))
-//      }
 
       "should only contain matches happening on one of next 3 days that have fixtures (includes today)" in {
         val allowedDates = List(today, today.plusDays(1), today.plusDays(3))  // look at the test data to see why
@@ -55,7 +50,7 @@ import test.ConfiguredTestSuite
 
     "for a day in the future (paginated)" - {
       val targetDate = today.plusDays(3)
-      val fixtures = new FixturesList(targetDate, competitions)
+      val fixtures = new FixturesList(targetDate, competitions.competitions)
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches.map { case (fmatch, _) =>
@@ -90,7 +85,7 @@ import test.ConfiguredTestSuite
 
     "should paginate correctly" - {
       "for today" - {
-        val fixtures = new FixturesList(today, competitions)
+        val fixtures = new FixturesList(today, competitions.competitions)
 
         "should find correct value for 'nextPage'" in {
           val expectedDate = today.plusDays(4) // see test data
@@ -103,7 +98,7 @@ import test.ConfiguredTestSuite
       }
 
       "for tomorrow" - {
-        val fixtures = new FixturesList(today.plusDays(1), competitions)
+        val fixtures = new FixturesList(today.plusDays(1), competitions.competitions)
 
         "should find correct value for 'nextPage'" in {
           val expectedDate = today.plusDays(10) // see test data
@@ -117,7 +112,7 @@ import test.ConfiguredTestSuite
       }
 
       "for a date with no matches" - {
-        val fixtures = new FixturesList(today.plusDays(2), competitions)
+        val fixtures = new FixturesList(today.plusDays(2), competitions.competitions)
 
         "should find correct value for 'nextPage'" in {
           val expectedDate = today.plusDays(11) // see test data
@@ -129,7 +124,7 @@ import test.ConfiguredTestSuite
 
   "the competition fixtures list" - {
     "given competition 500" - {
-      val fixtures = new CompetitionFixturesList(today, competitions, "500")
+      val fixtures = new CompetitionFixturesList(today, competitions.competitions, "500")
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches.map { case (fmatch, _) =>
@@ -154,7 +149,7 @@ import test.ConfiguredTestSuite
     }
 
     "given competition 100" - {
-      val fixtures = new CompetitionFixturesList(today, competitions, "100")
+      val fixtures = new CompetitionFixturesList(today, competitions.competitions, "100")
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches.map { case (fmatch, _) =>
@@ -172,7 +167,7 @@ import test.ConfiguredTestSuite
 
   "the team fixtures list" - {
     "given spurs" - {
-      val fixtures = new TeamFixturesList(today, competitions, spurs.id)
+      val fixtures = new TeamFixturesList(today, competitions.competitions, spurs.id)
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches.map { case (fmatch, _) =>

--- a/sport/test/football/model/MatchDayListTest.scala
+++ b/sport/test/football/model/MatchDayListTest.scala
@@ -8,13 +8,7 @@ import test.ConfiguredTestSuite
 @DoNotDiscover class MatchDayListTest extends FreeSpec with ShouldMatchers with MatchTestData with Football with OptionValues with ConfiguredTestSuite {
   "the live matches list" - {
     "for today" - {
-      val matches = new MatchDayList(competitions, today)
-
-//      ignore "should be showing all today's matches from the test data" in {
-//        matches.relevantMatches.map { case (fmatch, _) =>
-//          fmatch.id
-//        }.sortBy(_.toInt) should equal(List("4", "5", "6", "7", "8", "31", "32", "33"))
-//      }
+      val matches = new MatchDayList(competitions.competitions, today)
 
       "matches should be ordered by datetime" in {
         val matchDates = matches.relevantMatches.map { case (fMatch, _) => fMatch.date }
@@ -52,28 +46,8 @@ import test.ConfiguredTestSuite
       }
     }
 
-//    "for a specified day in the future" - {
-//      val matches = new MatchDayList(competitions, today.plusDays(1))
-//
-//      ignore "should be showing all that day's fixtures from the test data" in {
-//        matches.relevantMatches.map { case (fmatch, _) =>
-//          fmatch.id
-//        }.sortBy(_.toInt) should equal(List("9", "34"))
-//      }
-//    }
-
-    "for a specified day in the past" - {
-      val matches = new MatchDayList(competitions, today.minusDays(1))
-
-//       ignore "should be showing all that day's results from the test data" in {
-//        matches.relevantMatches.map { case (fmatch, _) =>
-//          fmatch.id
-//        }.sortBy(_.toInt) should equal(List("3"))
-//      }
-    }
-
     "if there are no matches on the given day" - {
-      val matches = new MatchDayList(competitions, today.minusDays(20))
+      val matches = new MatchDayList(competitions.competitions, today.minusDays(20))
 
       "should be empty" in {
         matches.relevantMatches.size should equal(0)
@@ -82,7 +56,7 @@ import test.ConfiguredTestSuite
   }
 
   "the competition group matches" - {
-    val matches = new CompetitionRoundMatchesList(competitions, competition1, round2)
+    val matches = new CompetitionRoundMatchesList(competitions.competitions, competition1, round2)
 
     "should get all matches for the specified round and competition" in {
       matches.relevantMatches.map { case (fMatch, _) => fMatch.id } should equal(List("3", "8", "12"))

--- a/sport/test/football/model/MatchTestData.scala
+++ b/sport/test/football/model/MatchTestData.scala
@@ -1,8 +1,8 @@
 package football.model
 
-import org.joda.time.{DateTimeZone, LocalDate, DateTime}
+import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import pa._
-import feed.CompetitionSupport
+import feed.Competitions
 import model.Competition
 
 
@@ -51,5 +51,5 @@ trait MatchTestData {
   val competition1 = Competition("500", "/football/test", "Test competition", "Test comp", "English", Some(today.minusDays(50)), matches1, leagueTable1, showInTeamsList = true)
   val competition2 = Competition("100", "/football/test2", "Test competition 2", "Test comp 2", "Scottish", Some(today.minusDays(50)), matches2, leagueTable2, showInTeamsList = true)
 
-  val competitions = CompetitionSupport(Seq(competition1, competition2))
+  val competitions = Competitions(Seq(competition1, competition2))
 }

--- a/sport/test/football/model/ResultsListTest.scala
+++ b/sport/test/football/model/ResultsListTest.scala
@@ -9,35 +9,12 @@ import test.ConfiguredTestSuite
 @DoNotDiscover class ResultsListTest extends FreeSpec with ShouldMatchers with MatchTestData with Football with OptionValues with ConfiguredTestSuite {
   "the all results list" - {
     "for today" - {
-      val results = new ResultsList(today, competitions)
-
-//      ignore "should be showing the correct matches from the test data" in {
-//        results.relevantMatches.map { case (fmatch, _) =>
-//          fmatch.id
-//        }.sortBy(_.toInt) should equal(List("2", "3", "4", "30"))
-//      }
-
-//      ignore "should only contain matches that happened on one of previous 3 days that have fixtures (includes today)" in {
-//        val allowedDates = List(today, today.minusDays(1), today.minusDays(2))  // look at the test data to see why
-//
-//        results.relevantMatches.foreach { case (fMatch, _) =>
-//          allowedDates should contain(fMatch.date.toLocalDate)
-//        }
-//      }
+      val results = new ResultsList(today, competitions.competitions)
 
       "matches should be *reverse* ordered by datetime" in {
         val matchDates = results.relevantMatches.map { case (fMatch, _) => fMatch.date }
         matchDates should equal(matchDates.sortWith((match1Date, match2Date) => match1Date.isAfter(match2Date)))
       }
-
-//      ignore "should group matches correctly by date" in {
-//        results.matchesGroupedByDateAndCompetition.map(_._1) should equal(List(today, today.minusDays(1), today.minusDays(2)))
-//      }
-
-//      ignore "should group matches correctly by date and league, with league ordered correctly" in {
-//        val (_, competitionMatches1) = results.matchesGroupedByDateAndCompetition(2)
-//        competitionMatches1.map { case (comp, matches) => comp.id } should equal(List("500", "100"))
-//      }
 
       "should only show results" in {
         results.relevantMatches.foreach(checkIsResult)
@@ -50,37 +27,13 @@ import test.ConfiguredTestSuite
         }
       }
 
-//      ignore "should find correct value for 'nextPage'" in {
-//        val expectedDate = today.minusDays(5) // see test data
-//        results.nextPage.value should equal("/football/results/" + expectedDate.toString("yyyy/MMM/dd"))
-//      }
-
       "should find nothing for 'prevPage'" in {
         results.previousPage should be(None)
       }
     }
 
     "the day after results" - {
-      val results = new ResultsList(today.plusDays(1), competitions)
-
-//      ignore "should be showing the correct matches from the test data" in {
-//        results.relevantMatches.map { case (fmatch, _) =>
-//          fmatch.id
-//        }.sortBy(_.toInt) should equal(List("2", "3", "4", "30"))
-//      }
-
-//      ignore "should only contain matches that happened on one of previous 3 days that have results" in {
-//        val allowedDates = List(today, today.minusDays(1), today.minusDays(2))  // look at the test data to see why
-//
-//        results.relevantMatches.foreach { case (fMatch, _) =>
-//          allowedDates should contain(fMatch.date.toLocalDate)
-//        }
-//      }
-
-//      ignore "should find correct value for 'nextPage'" in {
-//        val expectedDate = today.minusDays(5) // see test data
-//        results.nextPage.value should equal("/football/results/" + expectedDate.toString("yyyy/MMM/dd"))
-//      }
+      val results = new ResultsList(today.plusDays(1), competitions.competitions)
 
       "should find nothing for 'prevPage'" in {
         results.previousPage should be(None)
@@ -90,7 +43,7 @@ import test.ConfiguredTestSuite
 
   "the competition results list" - {
     "given test competition '500'" - {
-      val results = new CompetitionResultsList(today, competitions, "500")
+      val results = new CompetitionResultsList(today, competitions.competitions, "500")
 
       "should be showing the correct matches from the test data" in {
         results.relevantMatches.map { case (fmatch, _) =>
@@ -115,7 +68,7 @@ import test.ConfiguredTestSuite
     }
 
     "given test competition '100'" - {
-      val results = new CompetitionResultsList(today, competitions, "100")
+      val results = new CompetitionResultsList(today, competitions.competitions, "100")
 
       "should be showing the correct matches from the test data" in {
         results.relevantMatches.map { case (fmatch, _) =>
@@ -132,7 +85,7 @@ import test.ConfiguredTestSuite
   }
 
   "the team results list" - {
-    val results = new TeamResultsList(today, competitions, spurs.id)
+    val results = new TeamResultsList(today, competitions.competitions, spurs.id)
 
     "should be showing the correct matches from the test data" in {
       results.relevantMatches.map { case (fmatch, _) =>

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -41,7 +41,7 @@ class SportTestSuite extends Suites (
 }
 
 trait WithTestFootballClient {
-  self: WithTestFootballClient with BeforeAndAfterAll with WithTestWsClient =>
+  self: WithTestFootballClient with WithTestWsClient =>
 
   lazy val testFootballClient = new FootballClient(wsClient) {
     override def GET(url: String): Future[PaResponse] = {

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -13,6 +13,8 @@ import play.api.libs.ws.ning.NingWSResponse
 import recorder.HttpRecorder
 import play.api.libs.ws.{WSClient, WSResponse}
 import conf.FootballClient
+import football.model._
+import football.collections.RichListTest
 import pa.{Http, Response => PaResponse}
 
 import scala.concurrent.Future
@@ -23,12 +25,12 @@ class SportTestSuite extends Suites (
   new LeagueTableControllerTest,
   new MatchControllerTest,
   new MoreOnMatchFeatureTest,
-  new football.collections.RichListTest,
-  new football.model.CompetitionStageTest,
-  new football.model.FixturesListTest,
-  new football.model.MatchDayListTest,
-  new football.model.ResultsListTest,
-  new football.model.TeamColoursTest,
+  new RichListTest,
+  new CompetitionStageTest,
+  new FixturesListTest,
+  new MatchDayListTest,
+  new ResultsListTest,
+  new TeamColoursTest,
   new CompetitionAgentTest,
   new FixturesFeatureTest,
   new LeagueTablesFeatureTest,


### PR DESCRIPTION
## What does this change?

Removing `WS.url` in `FootballClient`

Unfortunately a significant refactoring was necessary because FootballClient was an global object itself accessed in another global object (Competitions)
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
