### PR TITLE
improve Object.assign polyfill

### DIFF
--- a/static/src/javascripts/projects/common/utils/assign.js
+++ b/static/src/javascripts/projects/common/utils/assign.js
@@ -14,9 +14,11 @@ define(function () {
     function assignPolyfill(target) {
         for (var i = 1, ii = arguments.length; i < ii; i++) {
             var source = arguments[i];
-            Object.keys(source).forEach(function (key) {
-                target[key] = source[key];
-            });
+            if (source) {
+                Object.keys(source).forEach(function (key) {
+                    target[key] = source[key];
+                });
+            }
         }
         return target;
     }


### PR DESCRIPTION
It's perfectly fine to pass undefined values to `Object.assign`, but our polyfill doesn't handle that very well.

Currently it breaks on IE if you `Object.assign({}, null);`
