### PR TITLE
GA: use page path for `internalLinkSourcePage` custom dimension

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -82,7 +82,7 @@
                 var d = new Date().getTime();
                 if (d - referrerVars.value.time < 60 * 1000) { // One minute
                     ga('guardianTestPropertyTracker.send', 'event', 'Click', 'Internal', referrerVars.value.tag, {
-                        dimension12: referrerVars.value.pageName
+                        dimension12: referrerVars.value.path
                     });
                 }
             }

--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
@@ -12,6 +12,7 @@ define([
     robust
 ) {
     var NG_STORAGE_KEY = 'gu.analytics.referrerVars';
+    var loc = document.location;
 
     function addHandlers() {
         mediator.on('module:clickstream:interaction', trackNonClickInteraction);
@@ -59,6 +60,7 @@ define([
         // then Omniture will remove it from storage.
         var storeObj = {
             pageName: this.s.pageName,
+            path: loc.pathname,
             tag: spec.tag || 'untracked',
             time: new Date().getTime()
         };
@@ -73,7 +75,11 @@ define([
         omniture.trackExternalLinkClick(spec.target, spec.tag, {customEventProperties: spec.customEventProperties});
     }
 
-    function init() {
+    function init(options) {
+        options = options || {};
+        if (options.location) {
+            loc = options.location; // allow a fake location to be passed in for testing
+        }
         omniture.go();
         addHandlers();
         mediator.emit('analytics:ready');

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -57,6 +57,7 @@ define([
             // so do session storage rather than an omniture track.
             storeObj = {
                 pageName: this.s.pageName,
+                path: document.location.pathname,
                 tag: spec.tag || 'untracked',
                 time: new Date().getTime()
             };

--- a/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
+++ b/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
@@ -20,7 +20,7 @@ define([
                     trackExternalLinkClick: sinon.spy()
                 })
                 .require([
-                    'common/utils/mediator', 
+                    'common/utils/mediator',
                     'common/modules/analytics/google',
                     'common/modules/analytics/omniture',
                     'common/modules/analytics/interaction-tracking'
@@ -29,7 +29,7 @@ define([
                     google = arguments[1];
                     omniture = arguments[2];
                     interactionTracking = arguments[3];
-                    
+
                     done();
                 });
         });
@@ -42,7 +42,7 @@ define([
 
         it('should log a clickstream event for an in-page link', function () {
             interactionTracking.init();
-            
+
             var clickSpec = {
                 target: document.documentElement,
                 samePage: true,
@@ -52,14 +52,14 @@ define([
             };
 
             mediator.emit('module:clickstream:click', clickSpec);
-        
+
             expect(google.trackSamePageLinkClick).toHaveBeenCalledOnce();
             expect(omniture.trackSamePageLinkClick).toHaveBeenCalledOnce();
         });
 
         it('should not log clickstream events with an invalidTarget', function () {
             interactionTracking.init();
-            
+
             var clickSpec = {
                 target: document.documentElement,
                 samePage: true,
@@ -75,7 +75,7 @@ define([
         });
 
         it('should use local storage for same-host links', function () {
-            interactionTracking.init();
+            interactionTracking.init({ location: { pathname: '/foo/bar' }});
 
             var el        = document.createElement('a'),
                 clickSpec = {
@@ -89,6 +89,7 @@ define([
             mediator.emit('module:clickstream:click', clickSpec);
 
             expect(JSON.parse(sessionStorage.getItem('gu.analytics.referrerVars')).value.tag).toEqual('tag in localstorage');
+            expect(JSON.parse(sessionStorage.getItem('gu.analytics.referrerVars')).value.path).toEqual('/foo/bar');
         });
 
         it('should log a clickstream event for an external link', function () {


### PR DESCRIPTION
## What does this change?

For internal link clicks, we were using the deprecated `GFE:NetworkFront`-style page name to identify the page containing the clicked link. Switch to using the page path (e.g. `/uk`), which is more useful.
## What is the value of this and can you measure success?

More consistent reporting in GA
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

anyone

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
