### PR TITLE
Allow ads in the top slow to overflow their container

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -67,7 +67,6 @@
 }
 
 .sticky-top-banner-ad {
-    overflow: hidden;
     z-index: $zindex-popover;
     width: 100%;
     position: relative;


### PR DESCRIPTION
Unfortunately, some ads overflow their container:

![picture 2](https://cloud.githubusercontent.com/assets/629976/17337335/12cf356e-58da-11e6-9c9d-773f5c0748bb.jpg)

So I had to remove the `overflow` rule, without which the page flickers when some creatives load and expand the top slot:

![picture 1](https://cloud.githubusercontent.com/assets/629976/17337344/1bf337c6-58da-11e6-814a-ac6793bf4b4b.jpg)

cc @guardian/commercial-dev 
