### PR TITLE
Use existing logging bucket for commercial reports

### DIFF
--- a/diagnostics/app/model/diagnostics/commercial/RedisReport.scala
+++ b/diagnostics/app/model/diagnostics/commercial/RedisReport.scala
@@ -44,7 +44,7 @@ class ExpiredKeyEventSubscriber(client: RedisClient, system: ActorSystem) extend
         reportData <- redisClient.get(RedisReport.dataKeyFromId(id))
       } {
         log.logger.info(s"writing report to s3 bucket, view id: $id")
-        S3CommercialReports.putPublic(id, reportData, "text/plain")
+        S3CommercialReports.putPublic(s"commercial-client-logs/$id", reportData, "text/plain")
       }
     } catch {
       case e:Exception => log.logger.error(e.getMessage)
@@ -53,7 +53,7 @@ class ExpiredKeyEventSubscriber(client: RedisClient, system: ActorSystem) extend
 }
 
 object S3CommercialReports extends S3 {
-  override lazy val bucket = "commercial-client-logs"
+  override lazy val bucket = "aws-frontend-logs"
 }
 
 /*

--- a/diagnostics/app/model/diagnostics/commercial/RedisReport.scala
+++ b/diagnostics/app/model/diagnostics/commercial/RedisReport.scala
@@ -36,8 +36,6 @@ class ExpiredKeyEventSubscriber(client: RedisClient, system: ActorSystem) extend
   }
 
   private def uploadReportToS3(id: String): Unit = {
-    log.logger.info(s"attempting s3 bucket upload, view id: $id")
-
     try {
       for {
         redisClient <- RedisReport.redisClient

--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -39,7 +39,10 @@ object CSPReport {
 object CSP extends Logging {
   def report(requestBody: JsValue): Unit = {
     (requestBody \ "csp-report").validate[CSPReport] match {
-      case JsSuccess(report, _) => if (report.isHTTP) log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
+      case JsSuccess(report, _) => report match {
+        case CSPReport(None, None, None, None, None, None) => // Do not log if there is no data
+        case _ if report.isHTTP => log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
+      }
       case JsError(e) => throw new Exception(JsError.toJson(e).toString())
     }
   }


### PR DESCRIPTION
1. Uses the `aws-frontend-logs` to store log reports, which the server has write permissions for.
2. Filters out all the empty `csp report` log lines from diagnostics server log
