### PR TITLE
Change background of inline ads in advertisement features

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -83,11 +83,20 @@ define([
                 var adName = replaceTopSlot ?
                     'inline' + index :
                     'inline' + (index + 1);
-                var adSlot = replaceTopSlot && index === 0 ?
-                    createSlot('top-above-nav', 'container-inline') :
-                    createSlot(adName, 'container-inline');
+                var classNames = ['container-inline'];
+                var adSlot;
 
-                adSlot.className += ' ' + (isMobile ? 'ad-slot--mobile' : 'container-inline');
+                if (config.page.isAdvertisementFeature) {
+                    classNames.push('adfeature');
+                }
+
+                if (isMobile) {
+                    className.push('mobile');
+                }
+
+                adSlot = replaceTopSlot && index === 0 ?
+                    createSlot('top-above-nav', classNames) :
+                    createSlot(adName, classNames);
 
                 return {
                     anchor: isMobile ? item.container : item.adSlice,

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -91,7 +91,7 @@ define([
                 }
 
                 if (isMobile) {
-                    className.push('mobile');
+                    classNames.push('mobile');
                 }
 
                 adSlot = replaceTopSlot && index === 0 ?

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -177,6 +177,7 @@ $paid-article-subheader-bg: #c4c4c4;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;
+$paid-article-mpu:          #cccccc;
 $rainbow-red:               #ed1c24; // from Guss
 
 $c-top-header-background: $guardian-brand-dark; // one-off colour for header bg

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -288,6 +288,10 @@
     }
 }
 
+.ad-slot--adfeature {
+    background-color: $paid-article-mpu;
+}
+
 /**
  * Commercial Components
  */


### PR DESCRIPTION
Before:
![screen shot 2016-08-01 at 10 35 24 am](https://cloud.githubusercontent.com/assets/629976/17361068/6a406f52-5966-11e6-89f9-62fcee83c3f8.png)

After (mentally insert MPU and move the label to the left):
![picture 1](https://cloud.githubusercontent.com/assets/629976/17361053/599b856a-5966-11e6-88fd-800f3cc1ae76.jpg)

cc @guardian/commercial-dev 
