### PR TITLE
AMP live blog pagination

### DIFF
--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -19,7 +19,7 @@
                     "arrow-left-double",
                     "icon",
                     List(
-                        "liveblog-navigation__link--secondary--newer__icon",
+                        "liveblog-navigation__link__icon--newer",
                         if(pagination.newest.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
                     )
                 )
@@ -71,7 +71,7 @@
                     "arrow-right-double",
                     "icon",
                     List(
-                        "liveblog-navigation__link--secondary--older__icon",
+                        "liveblog-navigation__link__icon--older",
                         if(pagination.oldest.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
                     )
                 )

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -15,7 +15,7 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="newest page">
-                @fragments.inlineSvg("arrow-left-double", "icon", List("liveblog-navigation__link--secondary--newer__icon"))
+                @fragments.inlineSvg("arrow-left-double", "icon", List("liveblog-navigation__link--secondary--newer__icon", if(pagination.newest.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))
                 Newest
             </a>
 
@@ -25,7 +25,7 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
             data-link-name="newer page">
-                @fragments.inlineSvg("arrow-left", "icon")<span class="u-h">Newer</span>
+                @fragments.inlineSvg("arrow-left", "icon", List(if(pagination.newer.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))<span class="u-h">Newer</span>
             </a>
         </div>
 
@@ -36,7 +36,7 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
             data-link-name="older page">
-                @fragments.inlineSvg("chevron-right", "icon")<span class="u-h">Older</span>
+                @fragments.inlineSvg("chevron-right", "icon", List(if(pagination.older.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))<span class="u-h">Older</span>
             </a>
 
             <a @pagination.oldest.map { oldest =>
@@ -46,7 +46,7 @@
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="oldest page">
                 Oldest
-                @fragments.inlineSvg("arrow-right-double", "icon", List("liveblog-navigation__link--secondary--older__icon"))
+                @fragments.inlineSvg("arrow-right-double", "icon", List("liveblog-navigation__link--secondary--older__icon", if(pagination.oldest.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))
             </a>
         </div>
     </div>

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -15,7 +15,14 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="newest page">
-                @fragments.inlineSvg("arrow-left-double", "icon", List("liveblog-navigation__link--secondary--newer__icon", if(pagination.newest.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))
+                @fragments.inlineSvg(
+                    "arrow-left-double",
+                    "icon",
+                    List(
+                        "liveblog-navigation__link--secondary--newer__icon",
+                        if(pagination.newest.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
+                    )
+                )
                 Newest
             </a>
 
@@ -25,7 +32,14 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
             data-link-name="newer page">
-                @fragments.inlineSvg("arrow-left", "icon", List(if(pagination.newer.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))<span class="u-h">Newer</span>
+                @fragments.inlineSvg(
+                    "arrow-left",
+                    "icon",
+                    List(
+                        if(pagination.newer.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
+                    )
+                )
+                <span class="u-h">Newer</span>
             </a>
         </div>
 
@@ -36,7 +50,14 @@
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
             data-link-name="older page">
-                @fragments.inlineSvg("chevron-right", "icon", List(if(pagination.older.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))<span class="u-h">Older</span>
+                @fragments.inlineSvg(
+                    "chevron-right",
+                    "icon",
+                    List(
+                        if(pagination.older.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
+                    )
+                )
+                <span class="u-h">Older</span>
             </a>
 
             <a @pagination.oldest.map { oldest =>
@@ -46,7 +67,14 @@
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="oldest page">
                 Oldest
-                @fragments.inlineSvg("arrow-right-double", "icon", List("liveblog-navigation__link--secondary--older__icon", if(pagination.oldest.isEmpty) "liveblog-navigation__link--disabled" else "liveblog-navigation__link--enabled"))
+                @fragments.inlineSvg(
+                    "arrow-right-double",
+                    "icon",
+                    List(
+                        "liveblog-navigation__link--secondary--older__icon",
+                        if(pagination.oldest.isEmpty) "liveblog-navigation__link__icon--disabled" else "liveblog-navigation__link__icon--enabled"
+                    )
+                )
             </a>
         </div>
     </div>

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -1,5 +1,7 @@
 @import _root_.liveblog.LiveBlogCurrentPage
-@(id: String, currentPage: LiveBlogCurrentPage)
+@(id: String, currentPage: LiveBlogCurrentPage, amp: Boolean = false)
+
+@import conf.Configuration
 
 @currentPage.pagination.map { pagination =>
     <div id="liveblog-navigation" class="liveblog-navigation">
@@ -10,7 +12,7 @@
 
         <div class="liveblog-navigation__newer">
             <a @pagination.newest.map { newest =>
-                href="/@id@newest.suffix"
+                href="@if(amp){@Configuration.site.host}/@id@newest.suffix"
                 title="Go to page @newest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
@@ -27,7 +29,7 @@
             </a>
 
             <a @pagination.newer.map { newer =>
-                href="/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
+                href="@if(amp){@Configuration.site.host}/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
                 title="Go to page @newer.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -45,7 +47,7 @@
 
         <div class="liveblog-navigation__older">
             <a @pagination.older.map { older =>
-                href="/@id@older.suffix#liveblog-navigation"
+                href="@if(amp){@Configuration.site.host}/@id@older.suffix#liveblog-navigation"
                 title="Go to page @older.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -61,7 +63,7 @@
             </a>
 
             <a @pagination.oldest.map { oldest =>
-                href="/@id@oldest.suffix#liveblog-navigation"
+                href="@if(amp){@Configuration.site.host}/@id@oldest.suffix#liveblog-navigation"
                 title="Go to page @oldest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -29,8 +29,12 @@
             @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
         }
         @if(LiveUpdateAmpSwitch.isSwitchedOn) {
-            <amp-live-list id="live-list" data-poll-interval="15000" data-max-items-per-page="20"
-            class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+            <amp-live-list
+                id="live-list"
+                data-poll-interval="15000"
+                data-max-items-per-page="20"
+                @if(model.currentPage.currentPage.pageNumber != 1) {disabled}
+                class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
                 _root_.liveblog.LatestBlock(article.blocks)
             }" data-test-id="live-blog-blocks"
             itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -26,7 +26,7 @@
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
     <div class="js-article__container" data-component="body">
         @if(model.currentPage.currentPage.isArchivePage) {
-            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, amp = true)
         }
         @if(LiveUpdateAmpSwitch.isSwitchedOn) {
             <amp-live-list
@@ -58,6 +58,6 @@
                 @liveBlogBlocksAMP(article, timezone)
             </div>
         }
-        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, amp = true)
     </div>
 }

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -68,7 +68,7 @@ object BodyCleaner {
     ) ++
       ListIf(!amp)(VideoEmbedCleaner(article)) ++
       ListIf(amp)(AmpEmbedCleaner(article)) ++
-      ListIf(amp && shouldShowAds)(AmpAdCleaner(edition, request.uri, article))
+      ListIf(amp && shouldShowAds && !article.isLiveBlog)(AmpAdCleaner(edition, request.uri, article))
 
     withJsoup(BulletCleaner(html))(cleaners :_*)
   }

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -1,5 +1,9 @@
+.content__main {
+    background-color: #f6f6f6;
+}
+
 .blocks {
-    margin: 0 20px;
+    margin: 0.75rem 0.625rem;
 }
 
 .block {
@@ -18,8 +22,7 @@
 }
 
 .block--content {
-    padding-top: 0.375rem;
-    padding-bottom: 0.75rem;
+    padding: 0.375rem 0.75rem 0.625rem;
     background-color: #ffffff;
     border-top: 0.0625rem solid #bdbdbd;
     border-bottom: 0.0625rem solid #eaeaea;
@@ -217,7 +220,7 @@
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     display: flex;
     padding-bottom: .75rem;
-    margin: 0 20px;
+    margin: 0.75rem 0.625rem;
 }
 
 .liveblog-navigation__detail {
@@ -244,7 +247,7 @@
     color: #333;
     border: 0.0625rem solid #dcdcdc;
     height: 2.25rem;
-    line-height: 2.375rem;
+    line-height: 2.3rem;
     font-weight: bold;
     vertical-align: middle;
 }
@@ -311,4 +314,8 @@
 
 .liveblog-navigation__link--disabled__svg {
     fill: #dfdfdf;
+}
+
+.liveblog-navigation__pages-length, .liveblog-navigation__page-number {
+    font-weight: bold;
 }

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -207,3 +207,108 @@
     left: 0;
     right: 0;
 }
+
+/* Pagination
+========================================= */
+
+.liveblog-navigation {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    display: flex;
+    padding-bottom: .75rem;
+    margin: 0 20px;
+}
+
+.liveblog-navigation__detail {
+    text-align: center;
+    order: 1;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.liveblog-navigation__newer {
+    float: left;
+}
+
+.liveblog-navigation__older {
+    float: right;
+    order: 2;
+}
+
+.liveblog-navigation__link {
+    display: inline-block;
+    position: relative;
+    color: #333;
+    border: 0.0625rem solid #dcdcdc;
+    height: 2.25rem;
+    line-height: 2.375rem;
+    font-weight: bold;
+    vertical-align: middle;
+}
+
+.liveblog-navigation__link--disabled {
+    cursor: default;
+    color: #dfdfdf;
+    border-color: #eaeaea;
+}
+
+.liveblog-navigation__link--primary {
+    width: 2.25rem;
+    -webkit-border-radius: 100%;
+    border-radius: 100%;
+}
+
+.liveblog-navigation__link--secondary {
+    border-radius: 1.3125rem;
+    padding: 0 0.625rem;
+}
+
+.liveblog-navigation__link--secondary--newer {
+    margin-right: 0.625rem;
+    padding-left: 1.875rem;
+}
+
+.liveblog-navigation__link--secondary--older {
+    margin-left: 0.3125rem;
+    padding-right: 1.875rem;
+}
+
+.inline-arrow-left-double__svg, .inline-arrow-right-double__svg, .inline-arrow-left__svg, .inline-chevron-right__svg {
+    fill: #767676;
+    position: absolute;
+}
+
+.inline-arrow-left-double__svg, .inline-arrow-right-double__svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    top: 0.6875rem;
+}
+
+.inline-arrow-left__svg, .inline-chevron-right__svg {
+    top: 0.625rem;
+    width: 1rem;
+    height: 1rem;
+}
+
+.inline-arrow-left__svg {
+    left: 0.5625rem;
+}
+
+.inline-arrow-left-double__svg {
+    left: 0.625rem;
+}
+
+.inline-chevron-right__svg {
+    right: 0.5625rem;
+}
+
+.inline-arrow-right-double__svg {
+    right: 0.625rem;
+}
+
+.liveblog-navigation__link--disabled__svg {
+    fill: #dfdfdf;
+}

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -306,7 +306,7 @@
     right: 0.625rem;
 }
 
-.liveblog-navigation__link--disabled__svg {
+.liveblog-navigation__link__icon--disabled__svg {
     fill: #dfdfdf;
 }
 

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -43,13 +43,7 @@
 }
 
 .block-time__absolute {
-    font-size: 0.75rem;
-    line-height: 1rem;
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
-    display: inline-block;
-    margin-left: 0.3125rem;
-    color: #767676;
-    font-weight: normal;
+    display: none;
 }
 
 .block-time__link {

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -319,3 +319,16 @@
 .liveblog-navigation__pages-length, .liveblog-navigation__page-number {
     font-weight: bold;
 }
+
+@@media (max-width: 29.99em) {
+    .liveblog-navigation__link--secondary {
+        width: 2.25rem;
+        padding: 0;
+    }
+}
+
+@@media (max-width: 29.99em) {
+    .liveblog-navigation__link {
+        font-size: 0;
+    }
+}

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -1,5 +1,5 @@
 .content__main {
-    background-color: #f6f6f6;
+    background: rgba(200,200,200,0.26);
 }
 
 .blocks {

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -126,6 +126,10 @@
     fill: #e15440;
 }
 
+.social-icon--facebook__svg, .social-icon--twitter__svg, .social-icon--gplus__svg {
+    fill: #ffffff;
+}
+
 /* Ads
 ========================================= */
 


### PR DESCRIPTION
## What does this change?

This change styles up the pagination controls on the AMP live blog. Clicking the "older" and "newer" buttons will display older and newer live blog content respectively, within the AMP live blog context.

The number of blog posts that will be displayed on one page follows the same logic of the non-AMP live blog.

The live updating functionality will only be enabled on the first page of the live blog (i.e. when viewing the most recently posted blog posts).
## Screenshots
### Before 😢

![picture 58](https://cloud.githubusercontent.com/assets/5931528/17361499/b70df8ac-5968-11e6-87ab-1cc9f2b6664e.png)
### After 🎉

![picture 60](https://cloud.githubusercontent.com/assets/5931528/17370977/1395af66-5996-11e6-8c2c-53c3b0bfe90c.png)
## Request for comment

@NataliaLKB @TBonnin @johnduffell @stephanfowler 
