### PR TITLE
Update comment count widget

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1798,7 +1798,7 @@
       "version": "0.0.4"
     },
     "guardian-comment-count": {
-      "version": "2.1.1"
+      "version": "2.1.3"
     },
     "gulp": {
       "version": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "fastdom": "^0.8.5",
-    "guardian-comment-count": "2.1.1",
+    "guardian-comment-count": "2.1.3",
     "hyperscript-helpers": "^3.0.0",
     "immutable": "^3.8.1",
     "monapt": "^0.5.4",


### PR DESCRIPTION
## What does this change?

Fix an issue on old Firefox. `innerText` was added in FF45. None of the older FF pass the 0.5% mark, but all together combined they're 1.4% of our readers.

The actual fix is on [this commit](https://github.com/guardian/comment-count-widget/commit/cb30bdc80750fa0cadffbfcf565f55b58c029f4d).
## What is the value of this and can you measure success?

Firefox users can see the number of comments on an article
