### PR TITLE
Inject environment into Weather api (used to check the running Mode)

### DIFF
--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -5,9 +5,11 @@ import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData
 import weather.WeatherApi
 import play.api.libs.ws.WSClient
+import play.api.Environment
 
 trait OnwardServices {
   def wsClient: WSClient
+  def environment: Environment
   lazy val stocksData = wire[StocksData]
   lazy val weatherApi = wire[WeatherApi]
 }

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -1,11 +1,8 @@
 package weather
 
 import java.net.{URI, URLEncoder}
-
 import common.{ExecutionContexts, ResourcesHelper}
 import conf.Configuration
-import play.api.Play
-import play.api.Play.current
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
 import weather.geo.LatitudeLongitude
@@ -14,8 +11,10 @@ import weather.models.accuweather.{ForecastResponse, LocationResponse, WeatherRe
 import dispatch._, Defaults._
 import java.util.concurrent.{TimeoutException, TimeUnit}
 import scala.concurrent.duration.Duration
+import play.api.Environment
+import play.api.Mode
 
-class WeatherApi(wsClient: WSClient) extends ExecutionContexts with ResourcesHelper {
+class WeatherApi(wsClient: WSClient, environment: Environment) extends ExecutionContexts with ResourcesHelper {
   lazy val weatherApiKey: String = Configuration.weather.apiKey.getOrElse(
     throw new RuntimeException("Weather API Key not set")
   )
@@ -39,7 +38,7 @@ class WeatherApi(wsClient: WSClient) extends ExecutionContexts with ResourcesHel
   }
 
   private def getJson(url: String): Future[JsValue] = {
-    if (Play.isTest) {
+    if (environment.mode == Mode.Test) {
       Future(Json.parse(slurpOrDie(new URI(url).getPath.stripPrefix("/"))))
     } else {
       getJsonWithRetry(url)


### PR DESCRIPTION
## What does this change?

Inject environment into Weather api (used to check the running Mode)
This allows WeatherApi not to rely on Play.current anymore
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
