### PR TITLE
Hoover state on the hosted CTA banner

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -561,7 +561,13 @@ $hosted-video-height: 540px;
 }
 
 .hosted__cta-link {
-    padding-bottom: 5%;
+    display: block;
+    width: 100%;
+    height: 100%;
+
+    &:hover {
+        background-color: rgba(#333333, .2);
+    }
 }
 
 .hosted__cta-link,


### PR DESCRIPTION
## What does this change?

The CTA banner is a bit darker while hovering. 
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
