### PR TITLE
Inject Mode into S3BreakingNews class

### DIFF
--- a/admin-jobs/app/AppLoader.scala
+++ b/admin-jobs/app/AppLoader.scala
@@ -5,6 +5,8 @@ import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CommonFilters, CachedHealthCheckLifeCycle}
 import contentapi.SectionsLookUpLifecycle
+import controllers.BreakingNews.BreakingNewsApi
+import controllers.BreakingNews.S3BreakingNews
 import controllers.{AdminJobsControllers, HealthCheck}
 import dev.DevParametersHttpRequestHandler
 import model.ApplicationIdentity
@@ -20,6 +22,13 @@ import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
+}
+
+trait AdminJobsServices {
+  def environment: Environment
+  lazy val mode = environment.mode
+  lazy val s3BreakingNews = wire[S3BreakingNews]
+  lazy val breakingNewsApi = wire[BreakingNewsApi]
 }
 
 trait Controllers extends AdminJobsControllers {
@@ -41,7 +50,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with AdminJobsServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/admin-jobs/app/controllers/AdminJobsControllers.scala
+++ b/admin-jobs/app/controllers/AdminJobsControllers.scala
@@ -1,7 +1,9 @@
 package controllers
 
 import com.softwaremill.macwire._
+import controllers.BreakingNews.BreakingNewsApi
 
 trait AdminJobsControllers {
-  lazy val newsAlertController = wire[NewsAlertControllerImpl]
+  def breakingNewsApi: BreakingNewsApi
+  lazy val newsAlertController = wire[NewsAlertController]
 }

--- a/admin-jobs/app/controllers/BreakingNews/BreakingNewsApi.scala
+++ b/admin-jobs/app/controllers/BreakingNews/BreakingNewsApi.scala
@@ -2,22 +2,20 @@ package controllers.BreakingNews
 
 import common.{ExecutionContexts, Logging}
 import conf.Configuration
-import play.Play
 import play.api.libs.json._
 import services.S3
+import play.api.Mode
 
-trait S3BreakingNews extends S3 {
+class S3BreakingNews(mode: Mode.Mode) extends S3 {
   override lazy val bucket = Configuration.aws.bucket
-  lazy val stage = if (Play.isTest) "TEST" else Configuration.environment.stage.toUpperCase
+  lazy val stage = if(mode == Mode.Test) "TEST" else Configuration.environment.stage.toUpperCase
   val namespace = "notifications"
   lazy val location = s"$stage/$namespace"
   def getKeyForPath(path: String): String = s"$location/$path.json"
 }
-object S3BreakingNews extends S3BreakingNews
 
-trait BreakingNewsApi extends Logging with ExecutionContexts {
+class BreakingNewsApi(s3: S3BreakingNews) extends Logging with ExecutionContexts {
 
-  val s3: S3BreakingNews
   val breakingNewskey = s3.getKeyForPath("breaking-news")
 
   @throws[Exception]
@@ -50,8 +48,4 @@ trait BreakingNewsApi extends Logging with ExecutionContexts {
     }
   }
 
-}
-
-object BreakingNewsApi extends BreakingNewsApi {
-  lazy val s3 = S3BreakingNews
 }

--- a/admin-jobs/app/controllers/BreakingNews/BreakingNewsUpdater.scala
+++ b/admin-jobs/app/controllers/BreakingNews/BreakingNewsUpdater.scala
@@ -62,5 +62,5 @@ class BreakingNewsUpdater(breakingNewsApi: BreakingNewsApi) extends Actor with L
 }
 
 object BreakingNewsUpdater {
-  def props(b: BreakingNewsApi = BreakingNewsApi): Props = Props(new BreakingNewsUpdater(b))
+  def props(b: BreakingNewsApi): Props = Props(new BreakingNewsUpdater(b))
 }

--- a/admin-jobs/app/controllers/NewsAlertController.scala
+++ b/admin-jobs/app/controllers/NewsAlertController.scala
@@ -28,7 +28,7 @@ class NewsAlertController(breakingNewsApi: BreakingNewsApi) extends Controller w
   // Actor is useful here to prevent race condition
   // when accessing or updating the content of Breaking News
   // since actor's mailbox acts as a queue
-  val breakingNewsUpdater = actorSystem.actorOf(BreakingNewsUpdater.props(breakingNewsApi))
+  lazy val breakingNewsUpdater = actorSystem.actorOf(BreakingNewsUpdater.props(breakingNewsApi))
   implicit val actorTimeout = Timeout(30.seconds)
 
   case class NewsAlertError(error: String)

--- a/admin-jobs/app/controllers/NewsAlertController.scala
+++ b/admin-jobs/app/controllers/NewsAlertController.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 
 class NewsAlertController(breakingNewsApi: BreakingNewsApi) extends Controller with AuthenticationSupport with ExecutionContexts {
 
-  val apiKey: String = Configuration.NewsAlert.apiKey.getOrElse(
+  lazy val apiKey: String = Configuration.NewsAlert.apiKey.getOrElse(
     throw new RuntimeException("News Alert API Key not set")
   )
 

--- a/admin-jobs/test/controllers/NewsAlertControllerTest.scala
+++ b/admin-jobs/test/controllers/NewsAlertControllerTest.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import akka.actor.Status.{Failure => ActorFailure}
 import akka.actor.{Actor, Props}
 import common.ExecutionContexts
+import controllers.BreakingNews.{BreakingNewsApi, S3BreakingNews}
 import models.{NewsAlertNotification, NewsAlertTypes}
 import org.joda.time.DateTime
 import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
@@ -27,7 +28,8 @@ import test.ConfiguredTestSuite
 
   def controllerWithActorReponse(mockResponse: Any) = {
     val updaterActor = actorSystem.actorOf(MockUpdaterActor.props(mockResponse))
-    new NewsAlertController {
+    val fakeApi = new BreakingNewsApi(new S3BreakingNews(app.mode)) // Doesn't matter, it is not used just passed to the NewsAlertController constructor
+    new NewsAlertController(fakeApi) {
       override val breakingNewsUpdater = updaterActor
       override val apiKey = testApiKey
     }

--- a/admin-jobs/test/controllers/NewsAlertControllerTest.scala
+++ b/admin-jobs/test/controllers/NewsAlertControllerTest.scala
@@ -31,7 +31,7 @@ import test.ConfiguredTestSuite
     val fakeApi = new BreakingNewsApi(new S3BreakingNews(app.mode)) // Doesn't matter, it is not used just passed to the NewsAlertController constructor
     new NewsAlertController(fakeApi) {
       override val breakingNewsUpdater = updaterActor
-      override val apiKey = testApiKey
+      override lazy val apiKey = testApiKey
     }
   }
 

--- a/admin-jobs/test/controllers/NewsAlertControllerTest.scala
+++ b/admin-jobs/test/controllers/NewsAlertControllerTest.scala
@@ -30,7 +30,7 @@ import test.ConfiguredTestSuite
     val updaterActor = actorSystem.actorOf(MockUpdaterActor.props(mockResponse))
     val fakeApi = new BreakingNewsApi(new S3BreakingNews(app.mode)) // Doesn't matter, it is not used just passed to the NewsAlertController constructor
     new NewsAlertController(fakeApi) {
-      override val breakingNewsUpdater = updaterActor
+      override lazy val breakingNewsUpdater = updaterActor
       override lazy val apiKey = testApiKey
     }
   }

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -65,3 +65,6 @@ guardian.page.dfp.mobileAppsAdUnitRoot=beta-guardian-app
 
 # Deploys-radiator
 deploys-notify.api.key=this-is-the-dev-api-key
+
+# News Alert
+news-alert.api.key=this-is-the-dev-api-key

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -54,7 +54,15 @@ trait Controllers
   lazy val surveyPageController = wire[SurveyPageController]
 }
 
-trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices with CommercialServices with DiscussionServices with FapiServices {
+trait AppComponents
+  extends FrontendComponents
+  with Controllers
+  with AdminServices
+  with SportServices
+  with CommercialServices
+  with DiscussionServices
+  with FapiServices
+  with AdminJobsServices {
 
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -21,7 +21,12 @@ trait Controllers {
   lazy val responsiveViewerController = wire[ResponsiveViewerController]
 }
 
-trait AppComponents extends FrontendComponents with StandaloneControllerComponents with Controllers with StandaloneLifecycleComponents {
+trait AppComponents
+  extends FrontendComponents
+  with StandaloneControllerComponents
+  with Controllers
+  with StandaloneLifecycleComponents
+  with AdminJobsServices {
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/training-preview/app/AppLoader.scala
+++ b/training-preview/app/AppLoader.scala
@@ -19,7 +19,12 @@ trait Controllers {
   lazy val healthCheck = wire[HealthCheck]
 }
 
-trait AppComponents extends FrontendComponents with StandaloneControllerComponents with Controllers with StandaloneLifecycleComponents {
+trait AppComponents
+  extends FrontendComponents
+  with StandaloneControllerComponents
+  with Controllers
+  with StandaloneLifecycleComponents
+  with AdminJobsServices {
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 


### PR DESCRIPTION
## What does this change?

Inject Mode into S3BreakingNews class
## What is the value of this and can you measure success?

The goal is to remove dependency towards Play global object before to
upgrade to Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
