### PR TITLE
Remove the global CTA for inline membership components

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template-preprocessor.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template-preprocessor.js
@@ -162,8 +162,7 @@ define([
             manualContainerCtaMembershipTpl || (manualContainerCtaMembershipTpl = template(manualContainerCtaMembershipStr));
             tpl.params.blurb = tpl.params.title;
             tpl.params.title = tpl.params.logomembership + '<span class="u-h">The Guardian Membership</span>';
-            tpl.params.ctas = manualContainerCtaMembershipTpl(tpl.params);
-
+            tpl.params.ctas = tpl.params.type === 'inline' ? null : manualContainerCtaMembershipTpl(tpl.params);
         } else if (tpl.params.type !== 'inline'){
             manualContainerCtaTpl || (manualContainerCtaTpl = template(manualContainerCtaStr));
             tpl.params.title = tpl.params.marque54icon + tpl.params.logoguardian + '<span class="u-h">The Guardian</span>' + tpl.params.title;


### PR DESCRIPTION
Otherwise the component won't display because of a reference error. Now:

![picture 3](https://cloud.githubusercontent.com/assets/629976/17364051/d2cc309c-5975-11e6-9935-c8f116a7a88b.jpg)

cc @guardian/commercial-dev 
