### PR TITLE
Bump facia cache age

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -21,6 +21,8 @@ object CacheTime {
   object Default extends CacheTime(60)
   object LiveBlogActive extends CacheTime(5)
   object RecentlyUpdated extends CacheTime(60)
+  object Facia extends CacheTime(300)
+  object NotFound extends CacheTime(10) // This will be overwritten by fastly
 
   def LastDayUpdated = CacheTime(extended(60))
   def NotRecentlyUpdated = CacheTime(extended(300))
@@ -56,6 +58,10 @@ object Cached extends implicits.Dates {
 
   def apply(seconds: Int)(result: CacheableResult)(implicit request: RequestHeader): Result = {
     apply(seconds, result, request.headers.get("If-None-Match"))//FIXME could be comma separated
+  }
+
+  def apply(cacheTime: CacheTime)(result: CacheableResult)(implicit request: RequestHeader): Result = {
+    apply(cacheTime.cacheSeconds, result, request.headers.get("If-None-Match"))
   }
 
   def apply(duration: Duration)(result: CacheableResult)(implicit request: RequestHeader): Result = {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -20,9 +20,6 @@ import scala.concurrent.Future.successful
 
 trait FaciaController extends Controller with Logging with ExecutionContexts with implicits.Collections with implicits.Requests {
 
-  // This will be overwritten by fastly anyway for 404s
-  val notFoundCacheSeconds = 10
-
   val EditionalisedKey = """^\w\w(/.*)?$""".r
 
   val frontJsonFapi: FrontJsonFapi
@@ -59,7 +56,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     val e = if(edition.isEmpty) Edition(request) else getEditionFromString(edition)
     val collectionsPath = if(section.isEmpty) e.id.toLowerCase else Editionalise(section, e)
     getSomeCollections(collectionsPath, count, offset, "none").map { collections =>
-      Cached(60) {
+      Cached(CacheTime.Facia) {
         JsonComponent(
           "items" -> JsArray(collections.getOrElse(List()).map(getCollection))
         )
@@ -100,14 +97,13 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
   def redirectTo(path: String)(implicit request: RequestHeader): Future[Result] = successful {
     val params = request.rawQueryStringOption.map(q => s"?$q").getOrElse("")
-    Cached(60)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
+    Cached(CacheTime.Facia)(WithoutRevalidationResult(Found(LinkTo(s"/$path$params"))))
   }
 
   def renderFrontJsonLite(path: String) = Action.async { implicit request =>
-    val cacheTime = 60
     frontJsonFapi.get(path).map {
-        case Some(pressedPage) => Cached(cacheTime)(JsonComponent(FapiFrontJsonLite.get(pressedPage)))
-        case None => Cached(cacheTime)(JsonComponent(JsObject(Nil)))}
+        case Some(pressedPage) => Cached(CacheTime.Facia)(JsonComponent(FapiFrontJsonLite.get(pressedPage)))
+        case None => Cached(CacheTime.Facia)(JsonComponent(JsObject(Nil)))}
   }
 
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader) = {
@@ -116,19 +112,19 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
         successful(
           if (request.isRss) {
             val body = TrailsToRss.fromPressedPage(faciaPage)
-            Cached(faciaPage) {
+            Cached(CacheTime.Facia) {
               RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)
             }
           }
           else if (request.isJson)
-            Cached(faciaPage)(JsonFront(faciaPage))
+            Cached(CacheTime.Facia)(JsonFront(faciaPage))
           else {
-            Cached(faciaPage) {
+            Cached(CacheTime.Facia) {
               RevalidatableResult.Ok(views.html.front(faciaPage))
             }
           }
         )
-      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}
+      case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))}
 
     futureResult.onFailure { case t: Throwable => log.error(s"Failed rendering $path with $t", t)}
     futureResult
@@ -178,10 +174,10 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
           val html = container(containerDefinition, FrontProperties.empty)
           if (request.isJson)
-            Cached(60) {JsonCollection(html)}
+            Cached(CacheTime.Facia) {JsonCollection(html)}
           else
-            Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound("containers are only available as json")))
-      }.getOrElse(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound(s"collection id $collectionId does not exist"))))
+            Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound("containers are only available as json")))
+      }.getOrElse(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound(s"collection id $collectionId does not exist"))))
     }
   }
 
@@ -194,11 +190,11 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
             (container, index) <- containers.zipWithIndex.find(_._1.dataId == collectionId)
             containerLayout <- container.containerLayout}
           yield
-            successful{Cached(pressedPage) {
+            successful{Cached(CacheTime.Facia) {
             JsonComponent(views.html.fragments.containers.facia_cards.showMore(containerLayout.remainingCards, index))}}
 
-        maybeResponse getOrElse successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))
-      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}}
+        maybeResponse getOrElse successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
+      case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))}}
 
 
   private object JsonCollection{
@@ -233,14 +229,14 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     getPressedCollection(id).flatMap {
       case Some(collection) =>
         successful{
-          Cached(60) {
+          Cached(CacheTime.Facia) {
             val config: CollectionConfig = ConfigAgent.getConfig(id).getOrElse(CollectionConfig.empty)
             val webTitle = config.displayName.getOrElse("The Guardian")
             val body = TrailsToRss.fromFaciaContent(webTitle, collection.curatedPlusBackfillDeduplicated.flatMap(_.properties.maybeContent), "", None)
             RevalidatableResult(Ok(body).as("text/xml; charset=utf8"), body)
           }
         }
-      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}
+      case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))}
   }
 
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -20,8 +20,6 @@ import scala.concurrent.Future.successful
 
 trait FaciaController extends Controller with Logging with ExecutionContexts with implicits.Collections with implicits.Requests {
 
-  val EditionalisedKey = """^\w\w(/.*)?$""".r
-
   val frontJsonFapi: FrontJsonFapi
 
   private def getEditionFromString(edition: String) = {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -20,6 +20,9 @@ import scala.concurrent.Future.successful
 
 trait FaciaController extends Controller with Logging with ExecutionContexts with implicits.Collections with implicits.Requests {
 
+  // This will be overwritten by fastly anyway for 404s
+  val notFoundCacheSeconds = 10
+
   val EditionalisedKey = """^\w\w(/.*)?$""".r
 
   val frontJsonFapi: FrontJsonFapi
@@ -125,7 +128,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
             }
           }
         )
-      case None => successful(Cached(60)(WithoutRevalidationResult(NotFound)))}
+      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}
 
     futureResult.onFailure { case t: Throwable => log.error(s"Failed rendering $path with $t", t)}
     futureResult
@@ -177,8 +180,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           if (request.isJson)
             Cached(60) {JsonCollection(html)}
           else
-            Cached(60)(WithoutRevalidationResult(NotFound("containers are only available as json")))
-      }.getOrElse(Cached(60)(WithoutRevalidationResult(NotFound(s"collection id $collectionId does not exist"))))
+            Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound("containers are only available as json")))
+      }.getOrElse(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound(s"collection id $collectionId does not exist"))))
     }
   }
 
@@ -194,8 +197,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
             successful{Cached(pressedPage) {
             JsonComponent(views.html.fragments.containers.facia_cards.showMore(containerLayout.remainingCards, index))}}
 
-        maybeResponse getOrElse successful(Cached(60)(WithoutRevalidationResult(NotFound)))
-      case None => successful(Cached(60)(WithoutRevalidationResult(NotFound)))}}
+        maybeResponse getOrElse successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))
+      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}}
 
 
   private object JsonCollection{
@@ -237,7 +240,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
             RevalidatableResult(Ok(body).as("text/xml; charset=utf8"), body)
           }
         }
-      case None => successful(Cached(60)(WithoutRevalidationResult(NotFound)))}
+      case None => successful(Cached(notFoundCacheSeconds)(WithoutRevalidationResult(NotFound)))}
   }
 
 


### PR DESCRIPTION
## What does this change?

Increases the `max-age`value in the `Cache-Control` header for all fronts (and rss/json variations).  The value has been bumped from 60 seconds to 5 minutes.

Note that the `CacheTime` objects replace calls to `Cached` with both a `Page` and an `Int`.  I believe this is safe because all the calls with `Page` would default to `CacheTime.Default` previously (see `PressedPage`).  If you have any suggestions for how we could tidy this up further I am open to suggestions.

This PR also introduces a _not found_ cache age which will be overwritten by fastly anyway (and if code comments are to be believed not passed by nginx).  Previously the value was hardcoded at 60 seconds in each call to `Cached` in the `FaciaController`.  It makes no difference other than being a bit tidier.

I also removed the redundant `EditionalisedKey`.
## What is the value of this and can you measure success?

Now that the facia purger lambda is running we can safely turn down the cache age, as fronts will be purged immediately on changes.  This will save us bandwidth especially on fronts and at times that see fewer updates (but consistent page views).
## Does this affect other platforms - Amp, Apps, etc?

Not that I am aware of.
## Request for comment

@johnduffell @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
