### PR TITLE
Correct ID so subscribe works

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -255,7 +255,7 @@ object EmailSubscriptions {
       "Every Thursday",
       "1902",
       10,
-      subscribedTo = subscribedListIds.exists{ x => x == "10" }
+      subscribedTo = subscribedListIds.exists{ x => x == "1902" }
     ),
     EmailSubscription(
       "The Flyer",


### PR DESCRIPTION
## What does this change?

Making change to the email preferences page (https://profile.theguardian.com/email-prefs)
the email ID of Zip file in ExactTarget is 1902 not 10, this PR corrects this.
## What is the value of this and can you measure success?

Wrong value being compared (10 relates to the _popularity_ of an email subscription) meant that the state of the Zip file button was always being set to submit a **subscribe** request.
- Users can now see if they are subscribed to Zip file
- Users now have the option to actually **unsubscribe** from Zip file! 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

Anyone 😄 
