### PR TITLE
Outbrain email checks

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -84,7 +84,7 @@ define([
             }).then(function () {
                 module.tracking(widgetCodes.code || widgetCodes.image);
                 require(['js!' + outbrainUrl]);
-            });   
+            });
         }
     }
 
@@ -118,9 +118,8 @@ define([
         if (!emailSignupPromise) {
             emailSignupPromise = new Promise(function (resolve) {
                 if (config.switches.emailInArticleOutbrain &&
-                    emailRunChecks.getEmailInserted() &&
-                    emailRunChecks.getEmailShown() === 'theGuardianToday') {
-                    // The Guardian today email is already there
+                    emailRunChecks.getEmailInserted()) {
+                    // There is an email sign-up
                     // so load the merchandising component
                     resolve('email');
                 } else if (config.switches.emailInArticleOutbrain && emailRunChecks.allEmailCanRun()) {

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -96,6 +96,11 @@ define([
         }
     }
 
+    function obWidgetIsShown() {
+        var $outbrain = $('.js-outbrain-container');
+        return $outbrain && $outbrain.length > 0;
+    }
+
     var canRunList = {
         theCampaignMinute: function () {
             return (page.keywordExists(['US elections 2016']) || config.page.isMinuteArticle)
@@ -157,6 +162,7 @@ define([
             !userIsInAClashingAbTest() &&
             storage.session.isAvailable() &&
             !userHasSeenThisSession() &&
+            !obWidgetIsShown() &&
             !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
     }
 


### PR DESCRIPTION
## What does this change?
- Show the non-compliant outbrain widget on _any_ email sign-up shown
- Don't show email sign-up if outbrain has already loaded
## What is the value of this and can you measure success?

Doesn't break Outbrain contracts

@guardian/dotcom-platform 
