### PR TITLE
AB Test name fix for Giraffe

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
 
   val ABGiraffeArticle20160802 = Switch(
     SwitchGroup.ABTests,
-    "ab-giraffe-article",
+    "ab-Giraffe-Article-20160802",
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler"), Owner.withGithub("AWare")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
 
   val ABGiraffeArticle20160802 = Switch(
     SwitchGroup.ABTests,
-    "ab-Giraffe-Article-20160802",
+    "ab-giraffe-article-20160802",
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler"), Owner.withGithub("AWare")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -83,7 +83,7 @@ define([
             {
                 id: 'like',
                 test: function () {
-                    writer('If you use it, if you like it, why not pay for it? It\'s only fair. Contribute to the Guardian ', 'https://membership.theguardian.com/contribute?INTCMP=co_uk_inarticle_like', 'Please support the Guardian and independent journalism');
+                    writer('If you use it, if you like it, why not pay for it? It\'s only fair. ', 'https://membership.theguardian.com/contribute?INTCMP=co_uk_inarticle_like', 'Contribute to the Guardian');
                 },
                 success: function (complete) {
                     completer(complete);
@@ -92,7 +92,7 @@ define([
             {
                 id: 'complex',
                 test: function () {
-                    writer('The world is complex. We\'ll give our all to help you understand it. Will you give something to help us help you? Please contribute to the Guardian ', 'https://membership.theguardian.com/contribute?INTCMP=co_uk_inarticle_complex', 'Please support the Guardian and independent journalism');
+                    writer('The world is complex. We\'ll give our all to help you understand it. Will you give something to help us help you? ', 'https://membership.theguardian.com/contribute?INTCMP=co_uk_inarticle_complex', 'Please contribute to the Guardian');
                 },
                 success: function (complete) {
                     completer(complete);


### PR DESCRIPTION
## What does this change?

Fix test name to match js test.
## What is the value of this and can you measure success?

None, except allowing the test to function.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="696" alt="screen shot 2016-08-03 at 15 56 13" src="https://cloud.githubusercontent.com/assets/406099/17370156/e852a488-5992-11e6-8f69-5dc5b2fdbaf1.png">
<img width="657" alt="screen shot 2016-08-03 at 15 55 43" src="https://cloud.githubusercontent.com/assets/406099/17370170/f5d63a66-5992-11e6-8122-2785975d8793.png">
<img width="717" alt="screen shot 2016-08-03 at 15 55 33" src="https://cloud.githubusercontent.com/assets/406099/17370174/f8745c80-5992-11e6-8cf9-7d07394b3dc3.png">

<img width="684" alt="screen shot 2016-08-03 at 15 56 00" src="https://cloud.githubusercontent.com/assets/406099/17370158/ed6ed676-5992-11e6-95f7-5a8873f16947.png">
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
