### PR TITLE
Move comment count to standalone widget

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -29,6 +29,7 @@
                 </div>
             }
 
+            @if(!requestHeader.isAmp) {
             <div class="meta__extras meta__extras--crossword">
                 <div class="meta__social" data-component="share">
                 @fragments.social(crosswordPage.content.sharelinks.pageShares, "top")
@@ -37,12 +38,17 @@
                     <div class="meta__save-for-later js-save-for-later" data-position="top"></div>
                 }
                 <div class="meta__numbers modern-visible">
-                    <div class="u-h meta__number" data-discussion-id="@crosswordPage.content.content.discussionId" data-commentcount-format="content" data-discussion-closed="@{crosswordPage.content.trail.isCommentable}">
+                    <div class="meta__number">
+                        <a href="#comments" data-link-name="Comment count" class="commentcount2 tone-colour">
+                            <h3 class="commentcount2__heading">@fragments.inlineSvg("comment-16", "icon", List("inline-tone-fill")) Comments</h3>
+                            <comment-count class="commentcount2__value tone-colour" discussion="@crosswordPage.content.content.discussionId" @{if (!crosswordPage.content.trail.isCommentable) "closed"}></comment-count>
+                        </a>
                     </div>
                     <div class="u-h meta__number js-sharecount">
                     </div>
                 </div>
             </div>
+            }
 
             @crosswordPage.crossword.instructions.map { instructions =>
                 <div class="crossword__instructions">
@@ -52,4 +58,3 @@
         </div>
     </div>
 </header>
-

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -79,7 +79,10 @@ window.curlConfig = {
 
             // plugins
             text:         'components/requirejs-text/text',
-            inlineSvg:    'projects/common/utils/inlineSvg'
+            inlineSvg:    'projects/common/utils/inlineSvg',
+
+            // external guardian libraries
+            'comment-count':               '@{Configuration.assets.path}guardian-comment-count/dist/comment-count.amd.js'
         }
     }
 };

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -39,14 +39,18 @@
                 }
             </div>
 
+            @if(!request.isAmp) {
             <div class="meta__numbers modern-visible">
                 <div class="u-h meta__number js-sharecount">
                 </div>
-                <div class="u-h meta__number" data-discussion-id="@item.content.discussionId" data-commentcount-format="content" data-discussion-closed="@{
-                    !item.trail.isCommentable
-                }">
+                <div class="meta__number js-commentcount">
+                    <a href="#comments" data-link-name="Comment count" class="commentcount2 tone-colour">
+                        <h3 class="commentcount2__heading">@fragments.inlineSvg("comment-16", "icon", List("inline-tone-fill")) Comments</h3>
+                        <comment-count class="commentcount2__value tone-colour" discussion="@item.content.discussionId" @{if (!item.trail.isCommentable) "closed"}></comment-count>
+                    </a>
                 </div>
             </div>
+            }
             @if(SaveForLaterSwitch.isSwitchedOn && !item.content.isImmersiveGallery) {
                 <div class="meta__save-for-later js-save-for-later" data-position="top"></div>
             }

--- a/common/app/views/fragments/contentMetaImmersive.scala.html
+++ b/common/app/views/fragments/contentMetaImmersive.scala.html
@@ -13,10 +13,17 @@
         @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, false, item.tags.isLiveBlog, item.fields.isLive)
     }
 
+    @if(!request.isAmp) {
     <div class="meta__numbers">
         <div class="u-h meta__number meta__number--sharecount js-sharecount js-sharecount-immersive"></div>
-        <div class="u-h meta__number meta__number--commentcount" data-discussion-id="@item.content.discussionId" data-commentcount-format="contentImmersive" data-discussion-closed="@{!item.trail.isCommentable}"></div>
+        <div class="meta__number meta__number--commentcount">
+            <a href="#comments" data-link-name="Comment count" class="commentcount2 tone-colour">
+                @fragments.inlineSvg("comment-16", "icon", List("inline-tone-fill"))
+                <comment-count class="commentcount__value" discussion="@item.content.discussionId" @{if (!item.trail.isCommentable) "closed"}></comment-count> Comments
+            </a>
+        </div>
     </div>
+    }
 
     <div class="meta__social" data-component="share">
         @fragments.social(item.sharelinks.pageShares, "top")

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -13,16 +13,9 @@
 
 @defining(ABHeadlines.upgrade(item)) { item =>
     <div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(item.hasImage && !item.hasInlineSnapHtml) {js-snappable}"
-        @if(item.discussionSettings.isCommentable) {
-            @item.discussionSettings.discussionId.map { id =>
-            data-discussion-id="@id"
-            }
-            data-discussion-closed="@item.discussionSettings.isClosedForComments"
-            data-discussion-url="@item.header.url.get(request)#comments"
-        }
-    data-link-name="@item.analyticsPrefix | card-@{ index + 1 }"
-    data-item-visibility="@visibilityDataAttribute"
-    data-test-id="facia-card"
+        data-link-name="@item.analyticsPrefix | card-@{ index + 1 }"
+        data-item-visibility="@visibilityDataAttribute"
+        data-test-id="facia-card"
         @item.id.map { id => data-id="@id" }
         @item.snapStuff.map(_.dataAttributes)
         @item.shortUrl.map { shortUrl => data-loyalty-short-url="@shortUrl" }>
@@ -181,4 +174,3 @@
         <a @Html(item.header.url.hrefWithRel) class="u-faux-block-link__overlay js-headline-text" data-link-name="article" tabindex="-1">@RemoveOuterParaHtml(item.header.headline)</a>
     </div>
 }
-

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -30,4 +30,19 @@
             </button>
         }
     }
+
+    @if(item.discussionSettings.isCommentable) {
+        <a class="fc-trail__count fc-trail__count--commentcount"
+            href="@item.header.url.get(request)#comments"
+            data-link-name="Comment count"
+        >
+            @fragments.inlineSvg("comment-16", "icon", List("inline-tone-fill"))
+            <comment-count
+                @item.discussionSettings.discussionId.map { id =>
+                discussion="@id"
+                }
+                @{if (item.discussionSettings.isClosedForComments) "closed"}
+            ></comment-count>
+        </a>
+    }
 </aside>

--- a/common/app/views/fragments/trails/headline.scala.html
+++ b/common/app/views/fragments/trails/headline.scala.html
@@ -3,14 +3,6 @@
 @import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 
 <@element class="trail trail--headline t@rowNum"
-    @if(trail.discussion.isCommentable) {
-        @trail.discussion.discussionId.map{ id =>
-            data-discussion-id="@id"
-        }
-        data-discussion-closed="@trail.discussion.isClosedForComments"
-    }
-    data-link-name="trail">
-
     @fragments.relativeDate(trail.webPublicationDate, trail.card.isLive, isFront=true)
 
     <h@headingLevel class="trail__headline">

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -35,6 +35,9 @@ module.exports = function (grunt, options) {
                 text:                 'components/requirejs-text/text',
                 inlineSvg:            'projects/common/utils/inlineSvg',
 
+                //
+                'comment-count':      '../../../node_modules/guardian-comment-count/dist/comment-count.amd',
+
                 'react':              'empty:',
                 'ophan/ng':           'empty:'
             },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,7 +7,7 @@
       "version": "1.2.13"
     },
     "acorn": {
-      "version": "3.2.0"
+      "version": "3.3.0"
     },
     "acorn-jsx": {
       "version": "3.0.1"
@@ -134,22 +134,25 @@
     "aws-sign2": {
       "version": "0.6.0"
     },
+    "aws4": {
+      "version": "1.4.1"
+    },
     "babel-code-frame": {
       "version": "6.11.0"
     },
     "babel-core": {
-      "version": "6.10.4",
+      "version": "6.11.4",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
     "babel-generator": {
-      "version": "6.11.3",
+      "version": "6.11.4",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -160,7 +163,7 @@
       "version": "6.9.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -180,7 +183,7 @@
       "version": "6.9.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -220,7 +223,7 @@
       "version": "6.10.1",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -246,13 +249,13 @@
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.10.3"
+      "version": "6.11.5"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.8.0"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.11.3"
+      "version": "6.11.4"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.8.0"
@@ -273,7 +276,7 @@
       "version": "6.11.0"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.9.0"
+      "version": "6.11.4"
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.11.3"
@@ -282,10 +285,10 @@
       "version": "6.9.0"
     },
     "babel-register": {
-      "version": "6.9.0",
+      "version": "6.11.6",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         },
         "minimist": {
           "version": "0.0.8"
@@ -296,21 +299,21 @@
       }
     },
     "babel-runtime": {
-      "version": "6.9.2"
+      "version": "6.11.6"
     },
     "babel-template": {
       "version": "6.9.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
     "babel-traverse": {
-      "version": "6.10.4",
+      "version": "6.12.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -318,7 +321,7 @@
       "version": "6.11.1",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -329,7 +332,7 @@
       "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "Base64": {
       "version": "0.2.1"
@@ -341,7 +344,7 @@
       "version": "0.0.8"
     },
     "base64-url": {
-      "version": "1.2.2"
+      "version": "1.3.2"
     },
     "base64id": {
       "version": "0.1.0"
@@ -430,7 +433,7 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.5"
+      "version": "1.1.6"
     },
     "braces": {
       "version": "1.8.5"
@@ -451,7 +454,7 @@
       "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.4"
+      "version": "1.3.5"
     },
     "bs-recipes": {
       "version": "1.2.2"
@@ -501,7 +504,7 @@
       "version": "1.0.0"
     },
     "caniuse-db": {
-      "version": "1.0.30000506"
+      "version": "1.0.30000512"
     },
     "caseless": {
       "version": "0.11.0"
@@ -572,7 +575,7 @@
       "version": "1.0.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -624,10 +627,10 @@
       "version": "1.0.2"
     },
     "convert-source-map": {
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     "core-js": {
-      "version": "2.4.0"
+      "version": "2.4.1"
     },
     "core-util-is": {
       "version": "1.0.2"
@@ -731,7 +734,7 @@
           "version": "3.0.0"
         },
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -762,7 +765,7 @@
       "version": "0.1.4"
     },
     "date-time": {
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "dateformat": {
       "version": "1.0.2-1.2.3"
@@ -799,6 +802,9 @@
     },
     "destroy": {
       "version": "1.0.4"
+    },
+    "detect-file": {
+      "version": "0.1.0"
     },
     "detect-indent": {
       "version": "3.0.1"
@@ -981,7 +987,7 @@
           "version": "6.0.4"
         },
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         },
         "user-home": {
           "version": "2.0.0"
@@ -1061,6 +1067,9 @@
     "expand-range": {
       "version": "1.8.2"
     },
+    "expand-tilde": {
+      "version": "1.2.2"
+    },
     "express": {
       "version": "2.5.11",
       "dependencies": {
@@ -1113,7 +1122,10 @@
       "version": "1.2.0"
     },
     "fast-levenshtein": {
-      "version": "1.1.3"
+      "version": "1.1.4"
+    },
+    "fastdom": {
+      "version": "0.8.6"
     },
     "fastparse": {
       "version": "1.1.1"
@@ -1172,6 +1184,14 @@
         }
       }
     },
+    "fined": {
+      "version": "1.0.1",
+      "dependencies": {
+        "lodash.isarray": {
+          "version": "4.0.0"
+        }
+      }
+    },
     "first-chunk-stream": {
       "version": "1.0.0"
     },
@@ -1201,6 +1221,9 @@
     },
     "fresh": {
       "version": "0.3.0"
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0"
     },
     "fs-extra": {
       "version": "0.26.7"
@@ -1315,6 +1338,20 @@
     "global": {
       "version": "4.3.0"
     },
+    "global-modules": {
+      "version": "0.2.3"
+    },
+    "global-prefix": {
+      "version": "0.1.4",
+      "dependencies": {
+        "osenv": {
+          "version": "0.1.3"
+        },
+        "which": {
+          "version": "1.2.10"
+        }
+      }
+    },
     "globals": {
       "version": "8.18.0"
     },
@@ -1422,7 +1459,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.4"
+      "version": "4.1.5"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -1601,10 +1638,10 @@
       "version": "18.0.0"
     },
     "grunt-frequency-graph": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "aws-sdk": {
-          "version": "2.4.6"
+          "version": "2.4.11"
         },
         "lodash": {
           "version": "3.5.0"
@@ -1760,6 +1797,9 @@
     "grunt-webfontjson": {
       "version": "0.0.4"
     },
+    "guardian-comment-count": {
+      "version": "2.1.3"
+    },
     "gulp": {
       "version": "3.9.1",
       "dependencies": {
@@ -1786,7 +1826,7 @@
       "version": "0.5.2",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -1794,7 +1834,7 @@
       "version": "1.6.0",
       "dependencies": {
         "vinyl": {
-          "version": "1.1.1"
+          "version": "1.2.0"
         }
       }
     },
@@ -1810,7 +1850,7 @@
       }
     },
     "gulp-watch": {
-      "version": "4.3.8",
+      "version": "4.3.9",
       "dependencies": {
         "chokidar": {
           "version": "1.6.0"
@@ -1973,11 +2013,14 @@
     "inherits": {
       "version": "2.0.1"
     },
+    "ini": {
+      "version": "1.3.4"
+    },
     "inquirer": {
       "version": "0.12.0",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -1989,6 +2032,14 @@
     },
     "invert-kv": {
       "version": "1.0.0"
+    },
+    "is-absolute": {
+      "version": "0.2.5",
+      "dependencies": {
+        "is-windows": {
+          "version": "0.1.1"
+        }
+      }
     },
     "is-absolute-url": {
       "version": "2.0.0"
@@ -2073,6 +2124,9 @@
     "is-property": {
       "version": "1.0.2"
     },
+    "is-relative": {
+      "version": "0.2.1"
+    },
     "is-resolvable": {
       "version": "1.0.0"
     },
@@ -2085,6 +2139,9 @@
     "is-typedarray": {
       "version": "1.0.0"
     },
+    "is-unc-path": {
+      "version": "0.1.1"
+    },
     "is-utf8": {
       "version": "0.2.1"
     },
@@ -2093,6 +2150,9 @@
     },
     "is-whitespace": {
       "version": "0.3.0"
+    },
+    "is-windows": {
+      "version": "0.2.0"
     },
     "isarray": {
       "version": "1.0.0"
@@ -2208,7 +2268,7 @@
       "version": "3.0.0"
     },
     "karma": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "accepts": {
           "version": "1.1.4"
@@ -2274,7 +2334,7 @@
       "version": "1.0.1",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -2320,7 +2380,12 @@
       "version": "0.3.0"
     },
     "liftoff": {
-      "version": "2.2.4"
+      "version": "2.3.0",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.4.2"
+        }
+      }
     },
     "limiter": {
       "version": "1.1.0"
@@ -2407,29 +2472,14 @@
     "lodash": {
       "version": "3.10.1"
     },
-    "lodash._baseclone": {
-      "version": "4.5.7"
-    },
     "lodash._basecopy": {
       "version": "3.0.1"
-    },
-    "lodash._baseiteratee": {
-      "version": "4.7.0"
-    },
-    "lodash._baseslice": {
-      "version": "4.0.0"
     },
     "lodash._basetostring": {
       "version": "3.0.1"
     },
-    "lodash._baseuniq": {
-      "version": "4.6.0"
-    },
     "lodash._basevalues": {
       "version": "3.0.0"
-    },
-    "lodash._createset": {
-      "version": "4.0.3"
     },
     "lodash._getnative": {
       "version": "3.9.1"
@@ -2449,75 +2499,65 @@
     "lodash._root": {
       "version": "3.0.1"
     },
-    "lodash._stringtopath": {
-      "version": "4.8.0",
-      "dependencies": {
-        "lodash._basetostring": {
-          "version": "4.12.0"
-        }
-      }
-    },
     "lodash.assign": {
-      "version": "4.0.9"
+      "version": "4.1.0"
+    },
+    "lodash.assignwith": {
+      "version": "4.1.0"
     },
     "lodash.capitalize": {
-      "version": "4.1.1"
+      "version": "4.2.0"
     },
     "lodash.clonedeep": {
-      "version": "4.3.2"
-    },
-    "lodash.deburr": {
-      "version": "4.0.0"
+      "version": "4.4.0"
     },
     "lodash.escape": {
       "version": "3.2.0"
     },
     "lodash.isarguments": {
-      "version": "3.0.8"
+      "version": "3.0.9"
     },
     "lodash.isarray": {
       "version": "3.0.4"
     },
-    "lodash.kebabcase": {
+    "lodash.isempty": {
+      "version": "4.3.0"
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.5"
+    },
+    "lodash.isstring": {
       "version": "4.0.1"
     },
-    "lodash.keys": {
-      "version": "4.0.7"
+    "lodash.kebabcase": {
+      "version": "4.1.0"
     },
-    "lodash.rest": {
-      "version": "4.0.3"
+    "lodash.keys": {
+      "version": "3.1.2"
+    },
+    "lodash.mapvalues": {
+      "version": "4.5.0"
+    },
+    "lodash.pick": {
+      "version": "4.3.0"
     },
     "lodash.restparam": {
       "version": "3.6.1"
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "dependencies": {
-        "lodash.keys": {
-          "version": "3.1.2"
-        }
-      }
+      "version": "3.6.2"
     },
     "lodash.templatesettings": {
       "version": "3.1.1"
     },
-    "lodash.tostring": {
-      "version": "4.1.3"
-    },
     "lodash.uniqby": {
-      "version": "4.5.0"
-    },
-    "lodash.upperfirst": {
-      "version": "4.2.0"
-    },
-    "lodash.words": {
-      "version": "4.1.1"
+      "version": "4.6.0"
     },
     "log-symbols": {
       "version": "1.0.2"
     },
     "log4js": {
-      "version": "0.6.37",
+      "version": "0.6.38",
       "dependencies": {
         "isarray": {
           "version": "0.0.1"
@@ -2707,6 +2747,9 @@
         }
       }
     },
+    "map-cache": {
+      "version": "0.2.2"
+    },
     "map-obj": {
       "version": "1.0.1"
     },
@@ -2794,7 +2837,7 @@
           "version": "0.0.1"
         },
         "process": {
-          "version": "0.11.5"
+          "version": "0.11.6"
         },
         "readable-stream": {
           "version": "1.1.14"
@@ -2918,13 +2961,16 @@
       "version": "1.0.0"
     },
     "pako": {
-      "version": "0.2.8"
+      "version": "0.2.9"
     },
     "parse-css-font": {
       "version": "2.0.2"
     },
     "parse-css-sides": {
       "version": "2.0.0"
+    },
+    "parse-filepath": {
+      "version": "1.0.1"
     },
     "parse-glob": {
       "version": "3.0.4"
@@ -2962,6 +3008,12 @@
     "path-is-inside": {
       "version": "1.0.1"
     },
+    "path-root": {
+      "version": "0.1.1"
+    },
+    "path-root-regex": {
+      "version": "0.1.2"
+    },
     "path-type": {
       "version": "1.1.0"
     },
@@ -2972,25 +3024,34 @@
       "version": "1.2.0"
     },
     "perfectionist": {
-      "version": "2.1.3"
+      "version": "2.1.4"
     },
     "phantom": {
-      "version": "2.1.11"
+      "version": "2.1.13"
     },
     "phantomjs-prebuilt": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0"
         },
+        "bl": {
+          "version": "1.1.2"
+        },
+        "fs-extra": {
+          "version": "0.30.0"
+        },
         "http-signature": {
           "version": "1.1.1"
         },
-        "qs": {
-          "version": "5.2.0"
+        "readable-stream": {
+          "version": "2.0.6"
         },
         "request": {
-          "version": "2.67.0"
+          "version": "2.74.0"
+        },
+        "tough-cookie": {
+          "version": "2.3.1"
         },
         "which": {
           "version": "1.2.10"
@@ -3027,7 +3088,7 @@
       }
     },
     "postcss": {
-      "version": "5.1.0"
+      "version": "5.1.1"
     },
     "postcss-atomised": {
       "version": "0.3.1",
@@ -3080,7 +3141,7 @@
       "version": "2.0.1"
     },
     "postcss-merge-rules": {
-      "version": "2.0.9"
+      "version": "2.0.10"
     },
     "postcss-message-helpers": {
       "version": "2.0.0"
@@ -3122,7 +3183,7 @@
       "version": "1.4.1",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -3133,7 +3194,7 @@
       "version": "1.0.7"
     },
     "postcss-scss": {
-      "version": "0.1.8"
+      "version": "0.1.9"
     },
     "postcss-selector-parser": {
       "version": "2.1.1"
@@ -3341,7 +3402,7 @@
       "version": "2.65.0",
       "dependencies": {
         "qs": {
-          "version": "5.2.0"
+          "version": "5.2.1"
         }
       }
     },
@@ -3368,6 +3429,9 @@
     },
     "resolve": {
       "version": "1.1.7"
+    },
+    "resolve-dir": {
+      "version": "0.1.0"
     },
     "resolve-from": {
       "version": "1.0.1"
@@ -3396,7 +3460,7 @@
       "version": "0.1.3"
     },
     "rimraf": {
-      "version": "2.5.3"
+      "version": "2.5.4"
     },
     "ripemd160": {
       "version": "0.2.0"
@@ -3414,7 +3478,7 @@
       "version": "2.1.2",
       "dependencies": {
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -3434,7 +3498,7 @@
           "version": "3.1.3"
         },
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         },
         "shelljs": {
           "version": "0.6.0"
@@ -3448,7 +3512,7 @@
       "version": "1.2.1"
     },
     "semver": {
-      "version": "5.2.0"
+      "version": "5.3.0"
     },
     "send": {
       "version": "0.13.2",
@@ -3492,20 +3556,7 @@
       "version": "0.5.3"
     },
     "shoe": {
-      "version": "0.0.11",
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.3.3"
-        },
-        "sockjs": {
-          "version": "0.3.1",
-          "resolved": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901"
-        },
-        "sockjs-client": {
-          "version": "0.0.0-unreleasable",
-          "resolved": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae"
-        }
-      }
+      "version": "0.0.11"
     },
     "shorthash": {
       "version": "0.0.2"
@@ -3563,6 +3614,19 @@
         }
       }
     },
+    "sockjs": {
+      "version": "0.3.1",
+      "resolved": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901",
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.3.3"
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "0.0.0-unreleasable",
+      "resolved": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae"
+    },
     "sort-keys": {
       "version": "1.1.2"
     },
@@ -3596,13 +3660,13 @@
       "version": "1.0.2"
     },
     "spdx-exceptions": {
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "spdx-expression-parse": {
       "version": "1.0.2"
     },
     "spdx-license-ids": {
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "specificity": {
       "version": "0.1.6"
@@ -3611,7 +3675,7 @@
       "version": "1.0.3"
     },
     "sshpk": {
-      "version": "1.8.3",
+      "version": "1.9.1",
       "dependencies": {
         "asn1": {
           "version": "0.2.3"
@@ -3719,7 +3783,7 @@
           "version": "3.4.1"
         },
         "lodash": {
-          "version": "4.13.1"
+          "version": "4.14.0"
         }
       }
     },
@@ -3764,11 +3828,14 @@
     "time-stamp": {
       "version": "1.0.1"
     },
+    "time-zone": {
+      "version": "0.1.0"
+    },
     "timers-browserify": {
       "version": "1.4.2",
       "dependencies": {
         "process": {
-          "version": "0.11.5"
+          "version": "0.11.6"
         }
       }
     },
@@ -3843,6 +3910,9 @@
     "ultron": {
       "version": "1.0.2"
     },
+    "unc-path-regex": {
+      "version": "0.1.2"
+    },
     "underscore": {
       "version": "1.7.0"
     },
@@ -3916,6 +3986,9 @@
     "vendor-prefixes": {
       "version": "0.0.1"
     },
+    "vendors": {
+      "version": "1.0.0"
+    },
     "verror": {
       "version": "1.3.6"
     },
@@ -3926,7 +3999,7 @@
       "version": "1.3.0",
       "dependencies": {
         "vinyl": {
-          "version": "1.1.1"
+          "version": "1.2.0"
         }
       }
     },
@@ -4116,10 +4189,10 @@
       }
     },
     "yargs-parser": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1"
+          "version": "3.0.0"
         }
       }
     },

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -67,7 +67,6 @@
                     }
                 }
             }
-            @*<div class="u-h meta__number" data-discussion-id="@content.discussionId"/>*@
         }
 
         <div class="rich-link__read-more">

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     ]
   },
   "dependencies": {
+    "fastdom": "^0.8.5",
+    "guardian-comment-count": "2.1.3",
     "hyperscript-helpers": "^3.0.0",
     "immutable": "^3.8.1",
     "monapt": "^0.5.4",

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -79,7 +79,7 @@ define([
     userAdTargeting,
     donotUseAdblock,
     userFeatures,
-    CommentCount,
+    CommentCountWidget,
     AutoSignin,
     CookieRefresh,
     navigation,
@@ -247,7 +247,7 @@ define([
 
             initDiscussion: function () {
                 if (config.switches.discussion) {
-                    CommentCount.init();
+                    CommentCountWidget.init();
                 }
             },
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -1,137 +1,71 @@
 define([
-    'bonzo',
-    'fastdom',
-    'qwery',
-    'common/utils/$',
-    'common/utils/ajax',
+    'comment-count',
+    'Promise',
+    'common/utils/assign',
+    'common/utils/config',
+    'common/utils/fastdom-promise',
+    'common/utils/fetch',
     'common/utils/formatters',
     'common/utils/mediator',
-    'common/utils/template',
-    'common/views/svgs',
-    'text!common/views/discussion/comment-count.html',
-    'text!common/views/discussion/comment-count--content.html',
-    'text!common/views/discussion/comment-count--content-immersive.html',
-    'lodash/collections/groupBy',
-    'lodash/collections/forEach',
-    'lodash/collections/sortBy',
-    'lodash/arrays/uniq',
-    'lodash/objects/keys',
-    'common/utils/chain'
+    'common/utils/report-error'
 ], function (
-    bonzo,
+    commentCountWidget,
+    Promise,
+    assign,
+    config,
     fastdom,
-    qwery,
-    $,
-    ajax,
+    fetch,
     formatters,
     mediator,
-    template,
-    svgs,
-    commentCountTemplate,
-    commentCountContentTemplate,
-    commentCountContentImmersiveTemplate,
-    groupBy,
-    forEach,
-    sortBy,
-    uniq,
-    keys,
-    chain
+    reportError
 ) {
-    var attributeName = 'data-discussion-id',
-        countUrl = '/discussion/comment-counts.json?shortUrls=',
-        templates = {
-            content: commentCountContentTemplate,
-            contentImmersive: commentCountContentImmersiveTemplate
-        },
-        defaultTemplate = commentCountTemplate;
-
-    function getElementsIndexedById(context) {
-        var elements = qwery('[' + attributeName + ']', context);
-
-        return groupBy(elements, function (el) {
-            return bonzo(el).attr(attributeName);
+    function remove (node) {
+        // Comment count widgets are inside a <a> tag
+        const container = node.parentNode;
+        return fastdom.write(function () {
+            // because Node.remove() doesn't exist on IE
+            container.parentNode.removeChild(container);
         });
     }
 
-    function getContentIds(indexedElements) {
-        return chain(indexedElements).and(keys).and(uniq).and(sortBy).join(',').value();
-    }
-
-    function getContentUrl(node) {
-        var a = node.getElementsByTagName('a')[0];
-        return (a ? a.pathname : '') + '#comments';
-    }
-
-    function renderCounts(counts, indexedElements) {
-        counts.forEach(function (c) {
-            forEach(indexedElements[c.id], function (node) {
-                var format,
-                    $node = bonzo(node),
-                    url = $node.attr('data-discussion-url') || getContentUrl(node),
-                    $container,
-                    meta,
-                    html;
-
-                if ($node.attr('data-discussion-closed') === 'true' && c.count === 0) {
-                    return; // Discussion is closed and had no comments, we don't want to show a comment count
+    function init(overrideConfig) {
+        var base = config.page.ajaxUrl || '';
+        var widgetConfig = assign({
+            apiBase: base + '/discussion/comment-counts.json',
+            apiQuery: 'shortUrls',
+            onupdate: function (node, count) {
+                if (count === 0 && node.hasAttribute('closed')) {
+                    return remove(node);
                 }
-
-                format = $node.data('commentcount-format');
-                html = template(templates[format] || defaultTemplate, {
-                    url: url,
-                    icon: svgs('commentCount16icon', ['inline-tone-fill']),
-                    count: formatters.integerCommas(c.count)
-                });
-
-                meta = qwery('.js-item__meta', node);
-                $container = meta.length ? bonzo(meta) : $node;
-
-                fastdom.write(function () {
-                    $container.append(html);
-                    $node.removeAttr(attributeName);
-                    $node.removeClass('u-h');
-                });
-            });
-        });
-
-        // This is the only way to ensure that this event is fired after all the comment counts have been rendered to
-        // the DOM.
-        fastdom.write(function () {
-            mediator.emit('modules:commentcount:loaded', counts);
-        });
-    }
-
-    function getCommentCounts(context) {
-        fastdom.read(function () {
-            var indexedElements = getElementsIndexedById(context || document.body),
-                ids = getContentIds(indexedElements);
-            ajax({
-                url: countUrl + ids,
-                type: 'json',
-                method: 'get',
-                crossOrigin: true,
-                success: function (response) {
-                    if (response && response.counts) {
-                        renderCounts(response.counts, indexedElements);
-                    }
-                }
-            });
-        });
-    }
-
-    function init() {
-        if (document.body.querySelector('[data-discussion-id]')) {
-            getCommentCounts(document.body);
-        }
+            },
+            format: formatters.integerCommas,
+            fetch: fetch,
+            Promise: Promise
+        }, overrideConfig);
 
         //Load new counts when more trails are loaded
-        mediator.on('modules:related:loaded', getCommentCounts);
+        mediator.on('modules:related:loaded', function () {
+            commentCountWidget.update(widgetConfig)
+            .then(function () {
+                mediator.emit('modules:commentcount:loaded');
+            })
+            .catch(report);
+        });
+
+        return commentCountWidget.load(widgetConfig)
+        .then(function () {
+            mediator.emit('modules:commentcount:loaded');
+        })
+        .catch(report);
+    }
+
+    function report (error) {
+        reportError(error, {
+            feature: 'comment-count'
+        }, false);
     }
 
     return {
-        init: init,
-        getCommentCounts: getCommentCounts,
-        getContentIds: getContentIds,
-        getElementsIndexedById: getElementsIndexedById
+        init: init
     };
 });

--- a/static/src/javascripts/projects/common/views/discussion/comment-count--content-immersive.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count--content-immersive.html
@@ -1,3 +1,0 @@
-<a href="<%=url%>" data-link-name="Comment count" class="commentcount2 tone-colour">
-    <%=icon%><span class="commentcount__value"><%=count%></span> Comments
-</a>

--- a/static/src/javascripts/projects/common/views/discussion/comment-count--content.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count--content.html
@@ -1,4 +1,0 @@
-<a href="<%=url%>" data-link-name="Comment count" class="commentcount2 tone-colour">
-    <h3 class="commentcount2__heading"><%=icon%> Comments</h3>
-    <span class="commentcount2__value tone-colour"><%=count%></span>
-</a>

--- a/static/src/javascripts/projects/common/views/discussion/comment-count.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count.html
@@ -1,1 +1,0 @@
-<a class="fc-trail__count fc-trail__count--commentcount" href="<%=url%>" data-link-name="Comment count"><%=icon%> <%=count%></a>

--- a/static/test/javascripts/conf/settings.js
+++ b/static/test/javascripts/conf/settings.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
         frameworks: ['jasmine', 'requirejs', 'phantomjs-shim'],
 
         files: [
+            { pattern: 'node_modules/guardian-comment-count/**/*.js', included: false, watched: false },
             { pattern: 'static/test/javascripts/components/sinonjs/sinon.js', included: true },
             { pattern: 'static/test/javascripts/components/jasmine-sinon/lib/jasmine-sinon.js', included: true },
             { pattern: 'static/test/javascripts/setup.js', included: true },

--- a/static/test/javascripts/fixtures/commentcounts.js
+++ b/static/test/javascripts/fixtures/commentcounts.js
@@ -1,9 +1,0 @@
-define(function () {
-    return JSON.stringify({
-        'counts': [
-            {'id': '/p/3ghv5', 'count': 380},
-            {'id': '/p/3ghx3', 'count': 33},
-            {'id': '/p/3gh4n', 'count': 33}
-        ]
-    });
-});

--- a/static/test/javascripts/main.js
+++ b/static/test/javascripts/main.js
@@ -28,6 +28,7 @@ requirejs.config({
         raven:        'components/raven-js/raven',
         reqwest:      'components/reqwest/reqwest',
         analytics:    'projects/common/modules/analytics/analytics',
+        'comment-count': '/base/node_modules/guardian-comment-count/dist/comment-count.amd',
         // Test specific paths
         omniture:     'vendor/omniture',
         stripe:       'vendor/stripe/stripe.min',


### PR DESCRIPTION
## What does this change?

Take two of #13712 which was reverted in #13837

Turns out that custom elements break AMP. This PR wraps `.scala.html` into `!isAMP` so that the html is not included.
## What is the value of this and can you measure success?

Same as the other PR, plus it doesn't break AMP .

The productivity benefit is controversial, I claim that
- changes are faster to implement
  - it's much quicker to work on a separate repo than inside frontend, especially if you're doing TDD
  - frontend is resistant to change, using ES6 is impossible, it's way easier to refactor from the bottom up than top down
- code is cleaner, it forces you to have a clear interface between units
- code can be reused
  - surely no one else is using `comment-count` at the moment, but it might be handy for apps in the future maybe?

Drawbacks highlighted so far
- Needs for 2 PR to make a single change
- Need to switch between 2 repos when reading code 
- Impossible to grep for something
- Hard to answer the question "what change in this feature?" since changes happened in multiple repos
## Does this affect other platforms - Amp, Apps, etc?

Amp
## Request for comment

@TBonnin @guardian/guardian-frontend 
