### PR TITLE
Remove useless background and border

### DIFF
--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -231,8 +231,6 @@ Hence why a greater depth of selector specificity is needed.
 .fc-container--dynamic-slow-mpu {
     .ad-slot--container-inline {
         width: gs-span(4);
-        background: $neutral-8;
-        border-bottom: $gs-baseline / 2 solid $neutral-8;
         @include mq(tablet) {
             width: gs-span(9);
         }

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -231,6 +231,7 @@ Hence why a greater depth of selector specificity is needed.
 .fc-container--dynamic-slow-mpu {
     .ad-slot--container-inline {
         width: gs-span(4);
+        padding-bottom: $gs-baseline / 2;
         @include mq(tablet) {
             width: gs-span(9);
         }


### PR DESCRIPTION
`.ad-slot--container-inline` already has a background color and I replaced the border with a padding... more accurate

cc @guardian/commercial-dev 
