### PR TITLE
Allow tracking display of Messages in Ophan; track engagement banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -107,6 +107,8 @@ define([
             pinOnHide: false,
             siteMessageLinkName: 'membership message',
             siteMessageCloseBtn: 'hide',
+            siteMessageComponentName: message.campaign,
+            trackDisplay: true,
             cssModifierClass: cssModifierClass
         }).show(template(messageTemplate, data));
     }

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -30,6 +30,7 @@ define([
         this.id = id;
         this.important = opts.important || false;
         this.permanent = opts.permanent || false;
+        this.trackDisplay = opts.trackDisplay || false;
         this.type = opts.type || 'banner';
         this.pinOnHide = opts.pinOnHide || false;
         this.siteMessageComponentName = opts.siteMessageComponentName || '';
@@ -72,6 +73,11 @@ define([
 
         if (this.siteMessageComponentName) {
             siteMessage.attr('data-component', this.siteMessageComponentName);
+            if (this.trackDisplay) {
+                require(['ophan/ng'], function (ophan) {
+                    ophan.trackComponentAttention(this.siteMessageComponentName, siteMessage);
+                });
+            }
         }
         if (this.siteMessageLinkName) {
             siteMessage.attr('data-link-name', this.siteMessageLinkName);


### PR DESCRIPTION
## What does this change?

This allows you to track impressions of Messages displayed on dotcom frontend.
## What is the value of this and can you measure success?

In particular, we want to track impressions of the engagement banner so we can evaluate user-conversion to membership.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

cc @markjamesbutler @AWare @philwills @joelochlann (thanks to @desbo for working out for me that ophan can't be included as a straight dependency!)

The `trackComponentAttention` method in Ophan was added quite recently, see https://github.com/guardian/ophan/pull/1522 .
