### PR TITLE
Giraffe clashing tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,10 +42,9 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        var clashingTests = [['GiraffeArticle20160802', 'everyone'], ['GiraffeArticle20160802', 'honest'], ['GiraffeArticle20160802', 'like'], ['GiraffeArticle20160802', 'complex'] ];
-
-        return some(clashingTests, function(test) {
-            return ab.isInVariant(test[0], test[1]);
+        var clashingTests = {name: "GiraffeArticle20160802", variants: ['everyone', 'honest', 'like', 'complex'] };
+        return some(clashingTests.variants, function(variant) {
+            return ab.isInVariant(clashingTests.name, variant);
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,7 +42,7 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        var clashingTests = [['Giraffe', 'everyone'], ['Giraffe', 'coffee'], ['Giraffe', 'heritage'], ['Giraffe', 'global'] ];
+        var clashingTests = [['GiraffeArticle20160802', 'everyone'], ['GiraffeArticle20160802', 'honest'], ['GiraffeArticle20160802', 'like'], ['GiraffeArticle20160802', 'complex'] ];
 
         return some(clashingTests, function(test) {
             return ab.isInVariant(test[0], test[1]);

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,7 +42,7 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        var clashingTests = {name: "GiraffeArticle20160802", variants: ['everyone', 'honest', 'like', 'complex'] };
+        var clashingTests = {name: 'GiraffeArticle20160802', variants: ['everyone', 'honest', 'like', 'complex'] };
         return some(clashingTests.variants, function(variant) {
             return ab.isInVariant(clashingTests.name, variant);
         });


### PR DESCRIPTION
## What does this change?

Prevent a test clash between the email sign-in component and Giraffe in-article. 
## What is the value of this and can you measure success?

None, this is a functional change.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

…fe test.
