### PR TITLE
Extend video switch to fix build.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Testing if increasing prominence of video caption drives plays.",
     owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 3),
+    sellByDate = new LocalDate(2016, 8, 4),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extend ABVideoCaption switch in order to fix build.  I've only extended it a day to ensure video team fix the issue tomorrow.
## What is the value of this and can you measure success?

Fixes build.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
