### PR TITLE
Remove API key from radiator

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -34,6 +34,7 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
     }
   }
   def renderRadiator() = Action.async { implicit request =>
+    val apiKey = Configuration.riffraff.apiKey
 
     for {
       user50x <- CloudWatch.user50x
@@ -45,7 +46,7 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
       val graphs = Seq(user50x) ++ shortLatency ++ fastlyErrors
       NoCache(Ok(views.html.radiator(
         graphs, multiLineGraphs, cost, switchesExpiringSoon,
-        Configuration.environment.stage
+        Configuration.environment.stage, apiKey
       )))
     }
   }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -3,7 +3,8 @@
     hitMissCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
     switches: Seq[conf.switches.Switch],
-    env: String)(implicit request: RequestHeader)
+    env: String,
+    apiKey: String)(implicit request: RequestHeader)
 
 @import org.joda.time.{DateTime, Days}
 
@@ -51,6 +52,9 @@
     </div>
 
     <div class="monitoring-wrapper">
+        <form hidden>
+            <input id="riffraff-api-key" type="hidden" value="@apiKey">
+        </form>
         <div class="riffraff-wrapper">
             <h2>CODE Deployments</h2>
             <ul class="riffraff" id="riffraffCODE"></ul>

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -49,8 +49,9 @@ define([
         );
 
         // riff raff - requires you to be on the guardian network
+        var apiKey = document.getElementById('riffraff-api-key').value;
         ajax({
-            url: 'https://riffraff.gutools.co.uk/api/history?projectName=dotcom%3A&key=oFsACDUt5L2HfLgfdSW2Xf1nbOKHLN5A&pageSize=200',
+            url: 'https://riffraff.gutools.co.uk/api/history?projectName=dotcom%3A&key=' + apiKey + '&pageSize=200',
             type: 'jsonp',
             crossOrigin: true
         }).then(
@@ -99,13 +100,12 @@ define([
 
                         var link = document.createElement('a');
                         link.href = 'https://riffraff.gutools.co.uk/deployment/view/' + d.uuid;
-                        target.appendChild(link);
 
                         var li = document.createElement('li');
                         li.className = d.status;
                         li.innerHTML = nameAbbreviation + ' ' + d.build;
                         li.setAttribute('title', d.projectName);
-                        link.appendChild(li);
+                        li.appendChild(link);
 
                         if (latestDeployments.CODE[deployment] && stage === 'PROD' && d.status === 'Completed') {
                             var codeBuild = (latestDeployments.CODE[deployment] || {}).build;
@@ -117,11 +117,12 @@ define([
                         if (d.status !== 'Completed') {
                             renderDeployer(stage, d.tags.vcsRevision, d.deployer);
                         }
+
+                        target.appendChild(li);
                     });
                 }
-                /*global riffraffCODE, riffraffPROD*/
-                renderDeploys('CODE', riffraffCODE);
-                renderDeploys('PROD', riffraffPROD);
+                renderDeploys('CODE', document.getElementById('riffraffCODE'));
+                renderDeploys('PROD', document.getElementById('riffraffPROD'));
             }
         );
 


### PR DESCRIPTION
## What does this change?

RiffRaff only allows access from Guardian IPs, still api keys should be kept private. I've rotated the key and instead of hard coding it, I'm passing it from the controller.
## What is the value of this and can you measure success?

Keys are private
## Does this affect other platforms - Amp, Apps, etc?

Radiator only
## Screenshots
## Request for comment

@adamnfish 
