### PR TITLE
Using aria-hidden instead of hidden

### DIFF
--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -15,7 +15,7 @@
         @Edition(request).displayName
     </label>
 
-    <ul class="edition-picker__dropdown js-edition-picker-dropdown" id="edition-picker__dropdown" hidden>
+    <ul class="edition-picker__dropdown js-edition-picker-dropdown" id="edition-picker__dropdown" aria-hidden="true">
         @Edition.others(request).map { edition =>
             <li class="edition-picker__dropdown__item">
                 <a class="edition-picker__dropdown-item-link"

--- a/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
+++ b/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
@@ -35,11 +35,11 @@ define([
                     if (button.hasClass('open')) {
                         button.removeClass('open');
                         button.attr('aria-expanded', 'false');
-                        dropdown.attr('hidden', '');
+                        dropdown.attr('aria-hidden', 'true');
                     } else {
                         button.addClass('open');
                         button.attr('aria-expanded', 'true');
-                        dropdown.removeAttr('hidden');
+                        dropdown.attr('aria-hidden', 'false');
                     }
                 });
             });

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -297,11 +297,8 @@ $gutter-medium: 37px;
         & ~ .edition-picker__dropdown {
             display: block;
             background-color: $guardian-brand-dark;
-
-            .edition-picker__dropdown__item {
-                display: block;
-            }
         }
+
         & ~ .edition-picker__current-edition {
             z-index: 3;
         }


### PR DESCRIPTION
## What does this change?

using `hidden` came with some default styling (`display:none !important;`) that I don't want. I think using aria-hidden is the best compromise. This way I can still be very explicit, while not having to override importants 😬 .
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@zeftilldeath 
