### PR TITLE
Set fixed date for `now` game date in MatchTestData

### DIFF
--- a/sport/test/football/model/MatchTestData.scala
+++ b/sport/test/football/model/MatchTestData.scala
@@ -7,8 +7,9 @@ import model.Competition
 
 
 trait MatchTestData {
-  val now = DateTime.now(DateTimeZone.forID("Europe/London"))
-  val today = LocalDate.now(DateTimeZone.forID("Europe/London"))
+  // Set a fixed date and time to ensure repeatibility of the tests
+  val now = new DateTime(2016, 8, 4, 10, 30, DateTimeZone.forID("Europe/London"))
+  val today = now.toLocalDate
 
   val spurs = MatchDayTeam("19", "Spurs", Some(4), Some(1), None, Some("Emmanuel Adebayor (19),Joe Paulo Paulinho (53),Emmanuel Adebayor (82),Nacer Chadli (88)"))
   val arsenal = MatchDayTeam("1006", "Arsenal", Some(0), Some(0), None, None)


### PR DESCRIPTION
## What does this change?

tl;dr: Don't make tests rely on current datetime. :)

One FixturesList feature consists in displaying a list of game matching
some criteria. The list is restricted to the eligible games scheduled
within 3 days of the earliest game.
In MatchTestData, mocked games are created with a relative date base on
`now`.
The earliest game date used to be now+50mins
Therefore if running the tests after 23:10, the earliest game would have
a date set to 'tomorrow'. FixturesList will list games for 3 days
starting tomorrow and not today. Tests fails then since the games in the
list are not the one expected.
Example:
It is Aug 4th at 23:30. First game is set to Aug 5th at 00:20.
FixturesList then returned all the games schedule on Aug 5th, 6th and
7th. However the test is expecting games from Aug 4th (now) to Aug 6th

The simple fix is to set a fixed date for `val now` so tests don't rely
on current datetime and are perfectly repeatable
## What is the value of this and can you measure success?

Tests don't fail if run between 23:10 and 00:00
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @jfsoul @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
