### PR TITLE
Hosted logos clickable

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -9,7 +9,7 @@
 @import views.html.hosted.guardianHostedShareButtons
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url)
+    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">
             <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -9,7 +9,7 @@
 @import views.html.hosted.guardianHostedShareButtons
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
+    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">
             <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">

--- a/commercial/app/views/hosted/guardianHostedArticle2.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle2.scala.html
@@ -5,7 +5,7 @@
 @import views.html.hosted._
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
+    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
 
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">

--- a/commercial/app/views/hosted/guardianHostedArticle2.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle2.scala.html
@@ -5,7 +5,7 @@
 @import views.html.hosted._
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url)
+    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
 
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">

--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -4,7 +4,7 @@
 
 @main(page, Some("commercial"))  { }  {
     <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @{page.campaign.cssClass}">
-        @guardianHostedHeader("hosted-gallery-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.ctaLink} else {page.campaign.logoLink})
+        @guardianHostedHeader("hosted-gallery-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.ctaLink))
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">
                 <div class="js-hosted-gallery-container hosted-gallery__gallery-container">

--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -4,7 +4,7 @@
 
 @main(page, Some("commercial"))  { }  {
     <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @{page.campaign.cssClass}">
-        @guardianHostedHeader("hosted-gallery-page", page.campaign.cssClass, page.campaign.logo.url)
+        @guardianHostedHeader("hosted-gallery-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.ctaLink} else {page.campaign.logoLink})
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">
                 <div class="js-hosted-gallery-container hosted-gallery__gallery-container">

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -1,9 +1,11 @@
-@(pageCssClass: String, brandCssClass: String, logoUrl: String)
+@(pageCssClass: String, brandCssClass: String, logoUrl: String, owner: String, logoLink: String)
     <div class="hosted__header @pageCssClass">
         <div class="hosted__headerwrap js-hosted-headerwrap">
             <div class="hostedbadge hostedbadge--shouldscale hosted-tone-bg--@brandCssClass">
                 <p class="hostedbadge__info">Advertiser content</p>
-                 <img class="hostedbadge__logo" src="@{logoUrl}"/>
+                <a href="@{logoLink}" data-link-name="hosted-logo-top-left" target="_blank">
+                    <img class="hostedbadge__logo" src="@{logoUrl}" alt="logo @{owner}"/>
+                </a>
             </div>
             <div class="paidfor-label paidfor-meta__more hosted__label has-popup">
                 <button class="u-button-reset paidfor-label__btn popup__toggle hosted__label-btn js-hosted-about" data-link-name="about-advertiser-content">About</button>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -5,7 +5,7 @@
 @import views.html.hosted.guardianHostedCta
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
+    @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
     <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass}">
         <section class="hosted-tone--dark">
             <div class="adverts hosted__container--full">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -5,7 +5,7 @@
 @import views.html.hosted.guardianHostedCta
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url)
+    @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, if(page.campaign.logoLink.length == 0) {page.cta.url} else {page.campaign.logoLink})
     <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass}">
         <section class="hosted-tone--dark">
             <div class="adverts hosted__container--full">

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -35,7 +35,7 @@ case class HostedCampaign(
   owner: String,
   logo: HostedLogo,
   cssClass: String,
-  logoLink: String
+  logoLink: Option[String] = None
 )
 
 case class HostedLogo(

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -34,7 +34,8 @@ case class HostedCampaign(
   name: String,
   owner: String,
   logo: HostedLogo,
-  cssClass: String
+  cssClass: String,
+  logoLink: String
 )
 
 case class HostedLogo(

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -13,7 +13,7 @@ object Formula1HostedPages {
     owner = "First Stop Singapore",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/2016_TrackLogo_RGB_FullColour.png"),
     cssClass = "f1-singapore",
-    logoLink = ""
+    logoLink = None
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -12,7 +12,8 @@ object Formula1HostedPages {
     name = "Singapore Grand Prix",
     owner = "First Stop Singapore",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/2016_TrackLogo_RGB_FullColour.png"),
-    cssClass = "f1-singapore"
+    cssClass = "f1-singapore",
+    logoLink = ""
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
+++ b/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
@@ -56,7 +56,8 @@ object HostedGalleryTestPage {
       name = "hosted-gallery",
       owner = "test",
       logo = HostedLogo("https://static.theguardian.com/commercial/hosted/gallery-prototype/omgb.png"),
-      cssClass = "test"
+      cssClass = "test",
+      logoLink = ""
     ),
     images = demoImages,
     pageUrl = "https://m.code.dev-theguardian.com/commercial/advertiser-content/hosted-gallery/gallery-test",

--- a/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
+++ b/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
@@ -57,7 +57,7 @@ object HostedGalleryTestPage {
       owner = "test",
       logo = HostedLogo("https://static.theguardian.com/commercial/hosted/gallery-prototype/omgb.png"),
       cssClass = "test",
-      logoLink = ""
+      logoLink = None
     ),
     images = demoImages,
     pageUrl = "https://m.code.dev-theguardian.com/commercial/advertiser-content/hosted-gallery/gallery-test",

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -19,7 +19,7 @@ object LeffeHostedPages {
     owner = "Leffe",
     logo = HostedLogo(Static("images/commercial/leffe.jpg")),
     cssClass = "leffe",
-    logoLink = ""
+    logoLink = None
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -18,7 +18,8 @@ object LeffeHostedPages {
     name = "Leffe - Rediscover Time",
     owner = "Leffe",
     logo = HostedLogo(Static("images/commercial/leffe.jpg")),
-    cssClass = "leffe"
+    cssClass = "leffe",
+    logoLink = ""
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -16,7 +16,7 @@ object RenaultHostedPages {
     owner = "Renault",
     logo = HostedLogo(Static("images/commercial/logo_renault.jpg")),
     cssClass = "renault",
-    logoLink = ""
+    logoLink = None
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -15,7 +15,8 @@ object RenaultHostedPages {
     name = "Discover your Renault Zoe",
     owner = "Renault",
     logo = HostedLogo(Static("images/commercial/logo_renault.jpg")),
-    cssClass = "renault"
+    cssClass = "renault",
+    logoLink = ""
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -15,7 +15,8 @@ object VisitBritainHostedPages {
     name = "#OMGB. Home of Amazing Moments. Great Britain & Northern Ireland",
     owner = "OMGB",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg"),
-    cssClass = "visit-britain"
+    cssClass = "visit-britain",
+    logoLink = ""
   )
 
   private val activityImages: List[HostedGalleryImage] = List(

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -16,7 +16,7 @@ object VisitBritainHostedPages {
     owner = "OMGB",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg"),
     cssClass = "visit-britain",
-    logoLink = ""
+    logoLink = None
   )
 
   private val activityImages: List[HostedGalleryImage] = List(

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -15,7 +15,7 @@ object ZootropolisHostedPages {
     owner = "Disney",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis-logo.jpg"),
     cssClass = "zootropolis",
-    logoLink = ""
+    logoLink = None
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -14,7 +14,8 @@ object ZootropolisHostedPages {
     name = "Zootropolis",
     owner = "Disney",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis-logo.jpg"),
-    cssClass = "zootropolis"
+    cssClass = "zootropolis",
+    logoLink = ""
   )
 
   private val cta = HostedCallToAction(


### PR DESCRIPTION
## What does this change?

The logos in the top left corner should be clickable. If no link is provided by the client (and currently none of them are) then the CTA link should be used. 
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
