### PR TITLE
AMP live blog key events

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -6,10 +6,12 @@
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
+@import conf.Configuration
+
 @blocks.map { block =>
     <div id="block-@block.id" @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
         <p class="block-time published-time">
-            <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
+            <a href="@if(amp){@Configuration.site.host}/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
             @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
             </a>
         </p>

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -6,14 +6,20 @@
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
-@import conf.Configuration
+@import common.LinkTo
 
 @blocks.map { block =>
     <div id="block-@block.id" @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
         <p class="block-time published-time">
-            <a href="@if(amp){@Configuration.site.host}/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-            @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
-            </a>
+            @if(amp){
+                <a href="@LinkTo{/@article.metadata.id?page=with:block-@block.id#block-@block.id}" itemprop="url" class="block-time__link">
+                    @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
+                </a>
+            } else {
+                <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
+                    @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
+                </a>
+            }
         </p>
         @block.title.map { title =>
             <h2 class="block-title" itemprop="headline">@title</h2>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -74,9 +74,12 @@
                                     <div class="modern-visible js-updates-desktop">
                                         <div data-component="timeline">
                                             @if(amp) {
-                                                <ul class="timeline js-live-blog__timeline u-unstyled">
-                                                @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
-                                                </ul>
+                                                <div class="timeline">
+                                                    <h2 class="timeline__header">Key events</h2>
+                                                    <ul class="timeline__items">
+                                                        @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
+                                                    </ul>
+                                                </div>
                                             } else {
                                                 @fragments.dropdown("Key events", Some("key-events"), true) {
                                                     <ul class="timeline js-live-blog__timeline u-unstyled">

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -70,13 +70,19 @@
                         <div class="js-top-marker"></div>
                         <div class="js-live-blog__sticky-components">
                             <div class="js-live-blog__sticky-components-container live-blog__sticky-components-container">
-                                @if(article.hasKeyEvents && !amp) {
+                                @if(article.hasKeyEvents) {
                                     <div class="modern-visible js-updates-desktop">
                                         <div data-component="timeline">
-                                            @fragments.dropdown("Key events", Some("key-events"), true) {
+                                            @if(amp) {
                                                 <ul class="timeline js-live-blog__timeline u-unstyled">
-                                                    @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
+                                                @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
                                                 </ul>
+                                            } else {
+                                                @fragments.dropdown("Key events", Some("key-events"), true) {
+                                                    <ul class="timeline js-live-blog__timeline u-unstyled">
+                                                    @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
+                                                    </ul>
+                                                }
                                             }
                                         </div>
                                     </div>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -5,6 +5,7 @@
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.{Edition, LinkTo}
+@import conf.Configuration
 @import conf.switches.Switches._
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
@@ -77,7 +78,7 @@
                                                 <div class="timeline">
                                                     <h2 class="timeline__header">Key events</h2>
                                                     <ul class="timeline__items">
-                                                        @views.html.liveblog.keyEvents("/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
+                                                        @views.html.liveblog.keyEvents(Configuration.site.host + "/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
                                                     </ul>
                                                 </div>
                                             } else {

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -5,7 +5,6 @@
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.{Edition, LinkTo}
-@import conf.Configuration
 @import conf.switches.Switches._
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
@@ -78,7 +77,7 @@
                                                 <div class="timeline">
                                                     <h2 class="timeline__header">Key events</h2>
                                                     <ul class="timeline__items">
-                                                        @views.html.liveblog.keyEvents(Configuration.site.host + "/" + article.metadata.id, KeyEventData(article.content.fields.blocks, timezone))
+                                                        @views.html.liveblog.keyEvents(LinkTo{"/" + article.metadata.id}, KeyEventData(article.content.fields.blocks, timezone))
                                                     </ul>
                                                 </div>
                                             } else {

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -74,12 +74,17 @@
                                     <div class="modern-visible js-updates-desktop">
                                         <div data-component="timeline">
                                             @if(amp) {
-                                                <div class="timeline">
-                                                    <h2 class="timeline__header">Key events</h2>
-                                                    <ul class="timeline__items">
-                                                        @views.html.liveblog.keyEvents(LinkTo{"/" + article.metadata.id}, KeyEventData(article.content.fields.blocks, timezone))
-                                                    </ul>
-                                                </div>
+                                                <amp-accordion class="timeline">
+                                                    <section>
+                                                        <h2 class="timeline__header">
+                                                            Key events
+                                                            @fragments.inlineSvg("dropdown-mask", "icon", List("control", "modern-visible"))
+                                                        </h2>
+                                                        <ul class="timeline__items">
+                                                            @views.html.liveblog.keyEvents(LinkTo{"/" + article.metadata.id}, KeyEventData(article.content.fields.blocks, timezone))
+                                                        </ul>
+                                                    </section>
+                                                </amp-accordion>
                                             } else {
                                                 @fragments.dropdown("Key events", Some("key-events"), true) {
                                                     <ul class="timeline js-live-blog__timeline u-unstyled">

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -2,6 +2,9 @@
     background: rgba(200,200,200,0.26);
 }
 
+/* Blocks
+========================================= */
+
 .blocks {
     margin: 0.75rem 0.625rem;
 }
@@ -71,6 +74,52 @@
     padding: 0;
     position: absolute;
     width: 0.0625rem;
+}
+
+/* Key Events
+========================================= */
+
+.timeline {
+    position: relative;
+    padding: 0;
+    margin: 0 20px;
+}
+
+.timeline__item {
+    display: table;
+    width: 100%;
+    overflow: hidden;
+    min-height: 2.5rem;
+    border-bottom: 0.0625rem solid #dcdcdc;
+}
+
+.timeline__link {
+    display: block;
+    padding: 0.125rem 0 0.375rem;
+    text-decoration: none;
+}
+
+.timeline__date {
+    color: #333333;
+    font-size: 0.8125rem;
+    line-height: 1.125rem;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    display: table-cell;
+    width: 3.75rem;
+    font-weight: bold;
+}
+
+.timezone {
+    display: none;
+}
+
+.timeline__title {
+    color: #333333;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    display: table-cell;
+    border-color: #f6f6f6;
 }
 
 /* Social

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -76,19 +76,22 @@
 
 .timeline {
     position: relative;
-    padding: 0;
-    margin: 0 20px;
+    margin: 0 0.625rem;
 }
 
 .timeline__header {
     font-size: 20px;
-    line-height: 24px;
+    line-height: 32px;
     font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;
     font-weight: 900;
+    background-color: #ffffff;
+    padding: 0.75rem 0.625rem 0;
+    border: 0;
 }
 
 .timeline__items {
     padding: 0;
+    margin: 0.75rem 0.625rem;
 }
 
 .timeline__item {
@@ -115,10 +118,6 @@
     font-weight: bold;
 }
 
-.timezone {
-    display: none;
-}
-
 .timeline__title {
     color: #333333;
     font-size: 0.875rem;
@@ -126,6 +125,18 @@
     font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
     display: table-cell;
     border-color: #f6f6f6;
+}
+
+.inline-dropdown-mask {
+    float: right;
+}
+
+.inline-dropdown-mask__svg {
+    background-color: #767676;
+}
+
+.timezone {
+    display: none;
 }
 
 /* Social

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -53,11 +53,6 @@
     color: #333;
 }
 
-.timestamp time, .published-time time {
-    display: inline-block;
-    margin-bottom: 0.375rem;
-}
-
 .rounded-icon {
     border-radius: 62.5rem;
     display: inline-block;

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -40,7 +40,7 @@
 .published-time {
     font-size: 0.8125rem;
     line-height: 1.125rem;
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     margin: 0;
     font-weight: bold;
 }
@@ -80,6 +80,17 @@
     margin: 0 20px;
 }
 
+.timeline__header {
+    font-size: 20px;
+    line-height: 24px;
+    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;
+    font-weight: 900;
+}
+
+.timeline__items {
+    padding: 0;
+}
+
 .timeline__item {
     display: table;
     width: 100%;
@@ -98,7 +109,7 @@
     color: #333333;
     font-size: 0.8125rem;
     line-height: 1.125rem;
-    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
     display: table-cell;
     width: 3.75rem;
     font-weight: bold;
@@ -112,7 +123,7 @@
     color: #333333;
     font-size: 0.875rem;
     line-height: 1.25rem;
-    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
     display: table-cell;
     border-color: #f6f6f6;
 }
@@ -214,7 +225,7 @@
     vertical-align: top;
     font-size: 12px;
     line-height: 16px;
-    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
     font-weight: bold;
     text-decoration: none;
     background-color: #cc2b12;
@@ -259,7 +270,7 @@
 .liveblog-navigation {
     font-size: 0.875rem;
     line-height: 1.25rem;
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     display: flex;
     padding-bottom: .75rem;
     margin: 0.75rem 0.625rem;

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -20,8 +20,11 @@
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
-        @if(content.tags.isLiveBlog && LiveUpdateAmpSwitch.isSwitchedOn) {
-            <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
+        @if(content.tags.isLiveBlog) {
+            <script custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js" async></script>
+            @if(LiveUpdateAmpSwitch.isSwitchedOn) {
+                <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
+            }
         }
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         @* Required for outbrain served in an amp-iframe *@


### PR DESCRIPTION
## What does this change?

Adds a Key Events navigation to the top of the AMP live blog.

Clicking a key event link will redirect the user to the non-AMP version of the live blog, anchored to the relevant key event blog post.

As part of this change, I have also updated the permalinks in the blog post timestamps to link to the non-AMP version of the live blog post.
## Screenshots

![picture 65](https://cloud.githubusercontent.com/assets/5931528/17402729/8beb17b0-5a4c-11e6-9777-5c18cd4bac91.png)
## Request for comment

@NataliaLKB @zeftilldeath @jfsoul @johnduffell @TBonnin 
