### PR TITLE
Removing ref to global actor system Akka.system() in NewspaperBookTag

### DIFF
--- a/article/app/controllers/PublicationController.scala
+++ b/article/app/controllers/PublicationController.scala
@@ -10,8 +10,8 @@ import services._
 import scala.concurrent.Future
 
 class PublicationController(
-  bookAgent: NewspaperBookTagAgent = NewspaperBookTagAgent,
-  bookSectionAgent: NewspaperBookSectionTagAgent = NewspaperBookSectionTagAgent,
+  bookAgent: NewspaperBookTagAgent,
+  bookSectionAgent: NewspaperBookSectionTagAgent,
   articleController: ArticleController
 ) extends Controller
   with ExecutionContexts

--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -11,10 +11,12 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, blocking}
 import scala.language.postfixOps
 
-class NewspaperBooksAndSectionsAutoRefresh extends LifecycleComponent {
+class NewspaperBooksAndSectionsAutoRefresh(newspaperBookSectionTagAgent: NewspaperBookSectionTagAgent,
+                                           newspaperBookTagAgent: NewspaperBookTagAgent)
+  extends LifecycleComponent {
   override def start(): Unit = {
-    NewspaperBookTagAgent.start()
-    NewspaperBookSectionTagAgent.start()
+    newspaperBookTagAgent.start()
+    newspaperBookSectionTagAgent.start()
   }
 }
 
@@ -37,8 +39,6 @@ class NewspaperBookTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[Tag
   }
 }
 
-object NewspaperBookTagAgent extends NewspaperBookTagAgent(Akka.system())
-
 class NewspaperBookSectionTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes, actorSystem) with NewspaperTags {
   override val source = "newspaper_book_sections"
   override protected def refresh(): Future[TagIndexListings] = Future {
@@ -47,5 +47,3 @@ class NewspaperBookSectionTagAgent(actorSystem: => ActorSystem) extends AutoRefr
     }
   }
 }
-
-object NewspaperBookSectionTagAgent extends NewspaperBookSectionTagAgent(Akka.system())


### PR DESCRIPTION
## What does this change?

Removing ref to global actor system Akka.system() in NewspaperBookTagAgent
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

…Agent
