### PR TITLE
Fix regression with rubicon ads

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -115,14 +115,20 @@ define([
     // such as validating the anatomy of the payload and whitelisting
     // event type
     function isValidPayload(payload) {
-        return 'id' in payload &&
-            'type' in payload &&
+        return 'type' in payload &&
             'value' in payload &&
             payload.type in listeners &&
-            isValidId(payload.id);
+            (isStandardMessage() || isRubiconMessage());
 
-        function isValidId(id) {
-            return /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/.test(id);
+        function isStandardMessage() {
+            return 'id' in payload &&
+                /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/.test(payload.id);
+        }
+
+        function isRubiconMessage() {
+            return payload.type === 'set-ad-height' &&
+                'id' in payload.value &&
+                'height' in payload.value;
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -2,7 +2,10 @@ define([
     'Promise',
     'common/utils/report-error'
 ], function (Promise, reportError) {
-    var dfpHost = 'http://tpc.googlesyndication.com';
+    var allowedHosts = [
+        'http://tpc.googlesyndication.com',
+        location.protocol + '//' + location.host
+    ];
     var listeners = {};
     var registeredListeners = 0;
 
@@ -53,7 +56,7 @@ define([
 
     function onMessage(event) {
         // We only allow communication with ads created by DFP
-        if (event.origin !== dfpHost) {
+        if (allowedHosts.indexOf(event.origin) === -1) {
             return;
         }
 
@@ -106,7 +109,7 @@ define([
         });
 
         function respond(error, result) {
-            event.source.postMessage(JSON.stringify({ id: data.id, error: error, result: result }), dfpHost);
+            event.source.postMessage(JSON.stringify({ id: data.id, error: error, result: result }), event.origin);
         }
     }
 

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -133,7 +133,7 @@ define([
         it('should respond to Rubicon messages with no IDs', function (done) {
             var payload = { type: 'set-ad-height', value: { id: 'test', height: '20px' } };
             messenger.register('set-ad-height', routines.rubicon, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: location.protocol + '//' + location.host, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe('rubicon');

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -15,7 +15,8 @@ define([
                 return value + ' johnny!';
             },
             add1: function(value) { return value + 1; },
-            add2: function(_, ret) { return ret + 2; }
+            add2: function(_, ret) { return ret + 2; },
+            rubicon: function() { return 'rubicon'; }
         };
 
         var injector = new Injector();
@@ -114,7 +115,7 @@ define([
             .catch(done.fail);
         });
 
-        it('should resond with the listeners cumulative result', function (done) {
+        it('should respond with the listeners cumulative result', function (done) {
             var payload = { id: '01234567-89ab-cdef-fedc-ba9876543210', type: 'this', value: 1 };
             messenger.register('this', routines.add1, mockWindow);
             messenger.register('this', routines.add2, mockWindow);
@@ -124,6 +125,19 @@ define([
                 expect(response.result).toBe(4);
                 messenger.unregister('this', routines.add1, mockWindow);
                 messenger.unregister('this', routines.add2, mockWindow);
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+
+        it('should respond to Rubicon messages with no IDs', function (done) {
+            var payload = { type: 'set-ad-height', value: { id: 'test', height: '20px' } };
+            messenger.register('set-ad-height', routines.rubicon, mockWindow);
+            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            .then(function () {
+                expect(mockFrame.postMessage).toHaveBeenCalled();
+                expect(response.result).toBe('rubicon');
+                messenger.unregister('set-ad-height', routines.respond, mockWindow);
             })
             .then(done)
             .catch(done.fail);


### PR DESCRIPTION
The cross-frame protocol I created requires a simili UUID in the JSON payload, but Rubicon ads do not send that information and therefore the top banner does not get resized anymore:
![2016-08-04](https://cloud.githubusercontent.com/assets/629976/17407419/1a6206ea-5a5f-11e6-9ae0-9406569c2a92.png)

Now it does:
![picture 1](https://cloud.githubusercontent.com/assets/629976/17407392/f918b830-5a5e-11e6-8e36-00157f9d5e91.jpg)

cc @guardian/commercial-dev @piuccio 
