### PR TITLE
Add 88x89 size for the high-merch component on ad features pages

### DIFF
--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -1,4 +1,4 @@
-@(isAdFeature: Boolean = false)
+@(isAdFeature: Boolean)
 @import conf.switches.Switches._
 
 @if(CommercialComponentsSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -1,10 +1,11 @@
+@(isAdFeature: Boolean = false)
 @import conf.switches.Switches._
 
 @if(CommercialComponentsSwitch.isSwitchedOn) {
     @fragments.commercial.adSlot(
         "merchandising-high",
         Seq("commercial-component-high"),
-        Map("mobile" -> Seq("1,1", "88,87")),
+        if(isAdFeature) Map("mobile" -> Seq("1,1", "88,89")) else Map("mobile" -> Seq("1,1", "88,87")),
         showLabel=false,
         refresh=false
     ){ }

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -15,7 +15,7 @@
         @fragments.mostPopularPlaceholder(content.metadata.sectionId)
     } {
         @if(content.commercial.needsHighMerchandisingSlot(Edition(request))) {
-            <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
+            <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh(content.commercial.isAdvertisementFeature)</div>
         }
     } {
         <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -15,7 +15,9 @@
         @fragments.mostPopularPlaceholder(content.metadata.sectionId)
     } {
         @if(content.commercial.needsHighMerchandisingSlot(Edition(request))) {
-            <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh(content.commercial.isAdvertisementFeature)</div>
+            <div class="fc-container fc-container--commercial">
+                @fragments.commercial.commercialComponentHigh(content.commercial.isAdvertisementFeature)
+            </div>
         }
     } {
         <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>

--- a/common/app/views/support/ContentFooterContainersLayout.scala
+++ b/common/app/views/support/ContentFooterContainersLayout.scala
@@ -17,15 +17,18 @@ object ContentFooterContainersLayout {
            (standardCommercialComponent: => Html)
            (externalContentPlaceholder: Html): Html = {
 
+    def optional(p: => Boolean, htmlBlock: => Html): Option[Html] = if (p) Some(htmlBlock) else None
+
     val htmlBlocks = if (isAdvertisementFeature) {
 
       // majority of footer components we don't want to appear on advertisement feature articles
-      if (showPaidSeriesContainer.isSwitchedOn) Seq(storyPackagePlaceholder, onwardPlaceholder)
-      else Seq(storyPackagePlaceholder)
+      Seq(
+          optional(!content.shouldHideAdverts, highRelevanceCommercialComponent),
+          Some(storyPackagePlaceholder),
+          optional(showPaidSeriesContainer.isSwitchedOn, onwardPlaceholder)
+      ).flatten
 
     } else {
-
-      def optional(p: => Boolean, htmlBlock: => Html): Option[Html] = if (p) Some(htmlBlock) else None
 
       def includeExternalContentPlaceholder(htmlBlocks: Seq[Html]): Seq[Html] = {
         if (content.showFooterContainers && !content.shouldHideAdverts && OutbrainSwitch.isSwitchedOn) {

--- a/common/test/views/support/ContentFooterContainersLayoutTest.scala
+++ b/common/test/views/support/ContentFooterContainersLayoutTest.scala
@@ -68,9 +68,9 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
     html.toString shouldBe "storyPackageHtml onwardHtml commentsHtml mostPopularHtml "
   }
 
-  it should "just show the story package and onward placeholder on ad features" in {
+  it should "just show the story package, commercial container and onward placeholder on ad features" in {
     val html = buildHtml(contentItem(), isAdFeature = true)
-    html.toString shouldBe "storyPackageHtml onwardHtml "
+    html.toString shouldBe "highRelevanceCommercialHtml storyPackageHtml onwardHtml "
   }
 
   it should "omit comments when article won't allow them" in {


### PR DESCRIPTION
The team needs the high-relevance commercial component on advertisement feature pages (articles, galleries, videos, etc.), but if we add it as-is it will be fed creatives that are all over the place (bookshop, masterclasses, etc.).

Now, we want some control over the creatives, and the fastest way to do that is to add a new custom size. This is what this PR does: the 88x89 size will only be used in advertisement features.

cc @guardian/commercial-dev 
