### PR TITLE
Remove code branch that should never be needed

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -122,15 +122,6 @@ define([
                     // There is an email sign-up
                     // so load the merchandising component
                     resolve('email');
-                } else if (config.switches.emailInArticleOutbrain && emailRunChecks.allEmailCanRun()) {
-                    // We need to check the user's email subscriptions
-                    // so we don't insert the sign-up if they've already subscribed.
-                    // This is an async API request and returns a promise.
-                    emailRunChecks.getUserEmailSubscriptions().then(function () {
-                        // Check if the Guardian today list can run, if it can then load
-                        // the merchandising (non-compliant) version of Outbrain
-                        emailRunChecks.listCanRun({listName: 'theGuardianToday', listId: 37 }) ? resolve('email') : resolve();
-                    });
                 } else {
                     resolve();
                 }


### PR DESCRIPTION
## What does this change?

Removes some unneeded code - if email sign-up is in the page first, Outbrain loads the right widget, if Outbrain is in the page first, email sign-up won't load so this 'pre-check' in Outbrain is no longer required.
## What is the value of this and can you measure success?

Tidy tidy.

@guardian/commercial-dev @guardian/dotcom-platform 
