### PR TITLE
Another attempt at link preconnect resource hint

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -227,4 +227,14 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
+
+  val UseLinkPreconnect = Switch(
+    SwitchGroup.Performance,
+    "use-link-preconnect",
+    "If this switch is on then link preconnect hints will be on the page",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 5),
+    exposeClientSide = false
+  )
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -227,14 +227,4 @@ trait PerformanceSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
-
-  val UseLinkPreconnect = Switch(
-    SwitchGroup.Performance,
-    "use-link-preconnect",
-    "If this switch is on then link preconnect hints will be on the page",
-    owners = Seq(Owner.withGithub("rich-nguyen")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 5),
-    exposeClientSide = false
-  )
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -224,7 +224,7 @@ trait PerformanceSwitches {
     "If this switch is on then content api calls will be requested in thrift format, instead of json format.",
     owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 5),
+    sellByDate = never,
     exposeClientSide = false
   )
 

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -30,23 +30,9 @@
         <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />
     }
 
-    <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
-    <link rel="preconnect" crossorigin href="@Configuration.images.path" />
-    <link rel="preconnect" crossorigin href="@Configuration.ajax.url" />
-    <link rel="preconnect" crossorigin href="@AnalyticsHost()" />
-    <link rel="preconnect" crossorigin href="//j.ophan.co.uk" />
-    <link rel="preconnect" crossorigin href="//ophan.theguardian.com" />
-    <link rel="preconnect" crossorigin href="@Configuration.debug.beaconUrl" />
-    <link rel="preconnect" crossorigin href="//www.google-analytics.com" />
-
-    @if(ComscoreSwitch.isSwitchedOn) {
-        <link rel="preconnect" href="//sb.scorecardresearch.com" />
+    @if(UseLinkPreconnect.isSwitchedOn) {
+        <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
     }
-
-    @if(CommercialSwitch.isSwitchedOn) {
-        <link rel="preconnect" crossorigin href="@Configuration.googletag.jsLocation" />
-    }
-
 
     <link rel="apple-touch-icon" sizes="152x152" href="@Static("images/favicons/152x152.png")" />
     <link rel="apple-touch-icon" sizes="144x144" href="@Static("images/favicons/144x144.png")" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -30,24 +30,23 @@
         <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />
     }
 
-    @if(UseLinkPreconnect.isSwitchedOn) {
-        <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
-        <link rel="preconnect" crossorigin href="@Configuration.images.path" />
-        <link rel="preconnect" crossorigin href="@Configuration.ajax.url" />
-        <link rel="preconnect" crossorigin href="@AnalyticsHost()" />
-        <link rel="preconnect" crossorigin href="//j.ophan.co.uk" />
-        <link rel="preconnect" crossorigin href="//ophan.theguardian.com" />
-        <link rel="preconnect" crossorigin href="@Configuration.debug.beaconUrl" />
-        <link rel="preconnect" crossorigin href="//www.google-analytics.com" />
+    <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
+    <link rel="preconnect" crossorigin href="@Configuration.images.path" />
+    <link rel="preconnect" crossorigin href="@Configuration.ajax.url" />
+    <link rel="preconnect" crossorigin href="@AnalyticsHost()" />
+    <link rel="preconnect" crossorigin href="//j.ophan.co.uk" />
+    <link rel="preconnect" crossorigin href="//ophan.theguardian.com" />
+    <link rel="preconnect" crossorigin href="@Configuration.debug.beaconUrl" />
+    <link rel="preconnect" crossorigin href="//www.google-analytics.com" />
 
-        @if(ComscoreSwitch.isSwitchedOn) {
-            <link rel="preconnect" href="//sb.scorecardresearch.com" />
-        }
-
-        @if(CommercialSwitch.isSwitchedOn) {
-            <link rel="preconnect" crossorigin href="@Configuration.googletag.jsLocation" />
-        }
+    @if(ComscoreSwitch.isSwitchedOn) {
+        <link rel="preconnect" href="//sb.scorecardresearch.com" />
     }
+
+    @if(CommercialSwitch.isSwitchedOn) {
+        <link rel="preconnect" crossorigin href="@Configuration.googletag.jsLocation" />
+    }
+
 
     <link rel="apple-touch-icon" sizes="152x152" href="@Static("images/favicons/152x152.png")" />
     <link rel="apple-touch-icon" sizes="144x144" href="@Static("images/favicons/144x144.png")" />


### PR DESCRIPTION
I don't think the [first attempt](https://github.com/guardian/frontend/pull/12935) at this potential performance optimisation worked as intended. 
### Before

Here is a waterfall without preconnect, just dns-prefetch:
![before preconnect](https://cloud.githubusercontent.com/assets/4549425/17430934/0aa56874-5aef-11e6-8560-d0e4998b651b.jpg)
### After

Here is preconnect and dns-prefetch:
![after preconnect](https://cloud.githubusercontent.com/assets/4549425/17430941/18964c1e-5aef-11e6-961b-60da145f2995.jpg)

I'm totally speculating, but maybe the browser has prioritised all the preconnect hints in front of the resource loading itself, thus extending the critical path.

I'm going to try again with a single preconnect, just to test the water.

I've extended the thrift switch too.
