### PR TITLE
Admin: Add exemption for /deploys-notify authentication

### DIFF
--- a/admin/app/conf/AdminFilters.scala
+++ b/admin/app/conf/AdminFilters.scala
@@ -12,7 +12,8 @@ object FilterExemptions {
   lazy val exemptions: Seq[FilterExemption] = List(
     FilterExemption("/oauth2callback"),
     FilterExemption("/assets"),
-    FilterExemption("/_healthcheck")
+    FilterExemption("/_healthcheck"),
+    FilterExemption("/deploys-notify") // This endpoint is authenticated via api-key (to be accessible to riffraff hook for instance)
   )
 }
 


### PR DESCRIPTION
## What does this change?

Fix /deploy-notify endpoint (used to post deploy notifications on slack)

Yesterday I change the way the Admin app handles authentication:
Instead of having each endpoint take care of authentication themselves, it is now handle app-wide via a Play filter.
I forgot the /deploy-notify endpoint, because it is accessed by non-human, is authenticated via api-key.
This PR adds a exemption for the app-wide Google authentication for this specific endpoint
## What is the value of this and can you measure success?

Slack deploy notification works again
## Request for comment

@katebee 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
