### PR TITLE
Refactor comment ordering test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,10 +54,20 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABParticipationDiscussionOrderingTake2 = Switch(
+  val ABParticipationDiscussionOrderingLiveBlogs = Switch(
     SwitchGroup.ABTests,
-    "ab-participation-discussion-ordering-take-2",
-    "Test to see whether ordering comments by recommends increases the number of people who read them",
+    "ab-participation-discussion-ordering-live-blog",
+    "Test to see whether ordering comments by recommends on live blogs increases the number oof people who read them",
+    owners = Seq(Owner.withGithub("NathanielBennett")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 8, 31),
+    exposeClientSide = true
+  )
+
+  val ABParticipationDiscussionOrderingNonLive = Switch(
+    SwitchGroup.ABTests,
+    "ab-participation-discussion-ordering-non-live",
+    "Test to see whether ordering comments by recommends on content o[ther than live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 31),

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,7 +11,8 @@ define([
     'common/modules/experiments/tests/hosted-autoplay',
     'common/modules/experiments/tests/giraffe',
     'common/modules/experiments/tests/video-caption',
-    'common/modules/experiments/tests/participation-discussion-ordering-take-2',
+    'common/modules/experiments/tests/participation-discussion-ordering-live-blog',
+    'common/modules/experiments/tests/participation-discussion-ordering-non-live',
     'common/modules/experiments/tests/hosted-zootropolis-cta',
     'common/modules/experiments/tests/contributions-header'
 ], function (
@@ -27,7 +28,8 @@ define([
     HostedAutoplay,
     Giraffe,
     VideoCaption,
-    ParticipationDiscussionOrderingTake2,
+    ParticipationDiscussionOrderingLiveBlog,
+    ParticipationDiscussionOrderingNonLive,
     HostedZootropolisCta,
     ContributionsHeader
 ) {
@@ -37,7 +39,8 @@ define([
         new HostedAutoplay(),
         new Giraffe(),
         new VideoCaption(),
-        new ParticipationDiscussionOrderingTake2(),
+        new ParticipationDiscussionOrderingLiveBlog(),
+        new ParticipationDiscussionOrderingNonLive(),
         new HostedZootropolisCta(),
         new ContributionsHeader()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-live-blog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-live-blog.js
@@ -1,0 +1,79 @@
+define([
+    'common/utils/config',
+    'common/utils/mediator',
+    'common/modules/user-prefs'
+], function (
+    config,
+    mediator,
+    userPrefs
+){
+
+    return function() {
+
+        var module = this;
+
+        this.id = 'ParticipationDiscussionOrderingLiveBlog';
+        this.start = '2016-08-05';
+        this.expiry = '2016-08-28';
+        this.author = 'Nathaniel Bennett';
+        this.description = 'Changes the default ordering of comments on live-blogs so we can determine whether sorting by recommended causes more users to view comments';
+        this.audience = 0.1;
+        this.audienceOffset = 0.6;
+        this.successMeasure = '';
+        this.showForSensitive = true;
+        this.audienceCriteria = 'All';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function() {
+            //If a user has already ordered comments, let's not knob them about
+            var preferredOrdering = userPrefs.get('discussion.order') || 'none';
+            return config.page.commentable && config.page.isLiveBlog && preferredOrdering === 'none';
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function(complete) {
+                    if(module.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }
+            },
+            {
+                id: 'order-by-oldest',
+                test: function() {
+                    userPrefs.set('discussion.order.test', 'oldest');
+                },
+                success: function(complete) {
+                    if(module.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }
+            },
+            {
+                id: 'order-by-newest',
+                test: function() {
+                    userPrefs.set('discussion.order.test', 'newest');
+                },
+                success: function(complete) {
+                    if(module.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }
+            },
+            {
+                id: 'order-by-recommended',
+                test: function() {
+                    userPrefs.set('discussion.order.test', 'recommendations');
+                },
+                success: function(complete) {
+                    if(module.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-non-live.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-non-live.js
@@ -12,13 +12,13 @@ define([
 
         var module = this;
 
-        this.id = 'ParticipationDiscussionOrderingTake2';
-        this.start = '2016-08-01';
+        this.id = 'ParticipationDiscussionOrderingNonLive';
+        this.start = '2016-08-05';
         this.expiry = '2016-08-28';
         this.author = 'Nathaniel Bennett';
-        this.description = 'Changes the default ordering of comments so we can determine whether sorting by recommended causes more users to view comments';
+        this.description = 'Changes the default ordering of comments on non live-blog content so we can determine whether sorting by recommended causes more users to view comments';
         this.audience = 0.1;
-        this.audienceOffset = 0.6;
+        this.audienceOffset = 0.7;
         this.successMeasure = '';
         this.showForSensitive = true;
         this.audienceCriteria = 'All';
@@ -28,7 +28,7 @@ define([
         this.canRun = function() {
             //If a user has already ordered comments, let's not knob them about
             var preferredOrdering = userPrefs.get('discussion.order') || 'none';
-            return config.page.commentable && preferredOrdering === 'none';
+            return config.page.commentable && !config.page.isLiveBlog && preferredOrdering === 'none';
         };
 
         this.variants = [


### PR DESCRIPTION
## What does this change?

This is a refactor of this: https://github.com/guardian/frontend/pull/13754/files, which tested the effect the ordering of comments had on their consumption. This time, we want to distinguish between live-blogs ( where repeat visitors may be returning to read the latest comments ) and other commentable content, by running two separate tests.
## What is the value of this and can you measure success?

As before, we want do determine how we can maximise the consumption of comments.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

@crifmulholland @piuccio @nicl 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
