### PR TITLE
Messenger: use the location protocol

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -3,7 +3,7 @@ define([
     'common/utils/report-error'
 ], function (Promise, reportError) {
     var allowedHosts = [
-        'http://tpc.googlesyndication.com',
+        location.protocol + '//tpc.googlesyndication.com',
         location.protocol + '//' + location.host
     ];
     var listeners = {};


### PR DESCRIPTION
Small fix: when the page is running on HTTPS, ads will be loaded from HTTPS too.

@guardian/commercial-dev 
