### PR TITLE
Send audio/video player events to GA

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -247,9 +247,7 @@ define([
         }));
         events.addContentEvents(player, mediaId, mediaType);
         events.addPrerollEvents(player, mediaId, mediaType);
-        if (window.location.hash === '#gaMediaEvents') {
-            events.bindGoogleAnalyticsEvents(player);
-        }
+        events.bindGoogleAnalyticsEvents(player);
 
         videoInfo.then(function(videoInfo) {
             if (videoInfo.expired) {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -247,7 +247,7 @@ define([
         }));
         events.addContentEvents(player, mediaId, mediaType);
         events.addPrerollEvents(player, mediaId, mediaType);
-        events.bindGoogleAnalyticsEvents(player);
+        events.bindGoogleAnalyticsEvents(player, canonicalUrl);
 
         videoInfo.then(function(videoInfo) {
             if (videoInfo.expired) {

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -120,14 +120,14 @@ define([
         return action;
     }
 
-    function buildGoogleAnalyticsEvent(mediaEvent, metrics) {
+    function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl) {
         var category = 'Media';
         var playerName = 'guardian-videojs';
         var action = getGoogleAnalyticsEventAction(mediaEvent);
         var fieldsObject = {
             eventCategory: category,
             eventAction: action,
-            eventLabel: mediaEvent.eventType,
+            eventLabel: canonicalUrl,
             dimension19: mediaEvent.mediaId,
             dimension20: playerName
         };
@@ -139,7 +139,7 @@ define([
         return fieldsObject;
     }
 
-    function bindGoogleAnalyticsEvents(player) {
+    function bindGoogleAnalyticsEvents(player, canonicalUrl) {
         var events = {
             'play': 'metric1',
             'skip': 'metric2',
@@ -153,7 +153,7 @@ define([
             return 'media:' + eventName;
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
-                ga('guardianTestPropertyTracker.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events));
+                ga('guardianTestPropertyTracker.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
             });
         });
     }


### PR DESCRIPTION
## What does this change?

Picking up the work that James started before he left.

Fixed up the event structure and enabled the events. Sending them to the test GA tracker for now.

Events are structured as follows:
- Category = Media
- Action = { video preroll | video content | audio preroll | audio content }
- Label = { play | skip | watched25 | watched50 | watched75 | end }
- Custom dim 19 = media ID, e.g. "gu-audio-57399fd5e4b0aa79601f4818"
- Custom dim 20 = player name, hardcoded to "guardian-videojs"
- Custom metrics: increments one of 6 metrics depending on the event type

I've tested locally that it works as expected for audio and video, although I couldn't find any videos with preroll ads.
## What is the value of this and can you measure success?

Tracking of media playback events in GA
## Does this affect other platforms - Amp, Apps, etc?

No. Apps will need to do this as well at some point.
## Screenshots

n/a
## Request for comment

@akash1810 @ajosephides 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
