### PR TITLE
Hosted autoplay Ab switch extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -20,7 +20,7 @@ trait ABTestSwitches {
     "An autoplay overlay with the next video on a hosted page",
     owners = Seq(Owner.withGithub("Calanthe")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 12),
+    sellByDate = new LocalDate(2016, 8, 19),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -12,7 +12,7 @@ define([
     return function () {
         this.id = 'HostedAutoplay';
         this.start = '2016-07-15';
-        this.expiry = '2016-08-12';
+        this.expiry = '2016-08-19';
         this.author = 'Zofia Korcz';
         this.description = 'An autoplay overlay with the next video on a hosted page.';
         this.audience = 0.75;


### PR DESCRIPTION
## What does this change?

The hosted autoplay AB test is extended by one week.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
