### PR TITLE
Add fluid size to merchandising slots

### DIFF
--- a/common/app/views/fragments/commercial/commercialComponent.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponent.scala.html
@@ -4,7 +4,7 @@
     @fragments.commercial.adSlot(
         "merchandising",
         Seq("commercial-component"),
-        Map("mobile" -> Seq("1,1", "88,88")),
+        Map("mobile" -> Seq("1,1", "88,88", "fluid")),
         showLabel=false,
         refresh=false
     ){ }

--- a/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
+++ b/common/app/views/fragments/commercial/commercialComponentHigh.scala.html
@@ -5,7 +5,7 @@
     @fragments.commercial.adSlot(
         "merchandising-high",
         Seq("commercial-component-high"),
-        if(isAdFeature) Map("mobile" -> Seq("1,1", "88,89")) else Map("mobile" -> Seq("1,1", "88,87")),
+        if(isAdFeature) Map("mobile" -> Seq("1,1", "88,89", "fluid")) else Map("mobile" -> Seq("1,1", "88,87", "fluid")),
         showLabel=false,
         refresh=false
     ){ }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
@@ -58,7 +58,7 @@ define([
             label: false,
             refresh: false,
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.merchandisingHigh)
+                mobile: compile(adSizes.outOfPage, adSizes.merchandisingHigh, adSizes.fluid)
             }
         },
         spbadge: badgeDefinition,

--- a/static/test/javascripts/fixtures/commercial/ad-slots/merchandising-high.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/merchandising-high.html
@@ -3,6 +3,6 @@
     data-link-name="ad slot merchandising-high"
     data-test-id="ad-slot-merchandising-high"
     data-name="merchandising-high"
-    data-mobile="1,1|88,87"
+    data-mobile="1,1|88,87|fluid"
     data-label="false"
     data-refresh="false"></div>


### PR DESCRIPTION
Since they will eventually be migrated to native ads too, but also to allow @sammorrisdesign to experiment with his hosted content component.

cc @guardian/commercial-dev 
