### PR TITLE
Change tracking of Message banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -5,6 +5,7 @@ define([
     'common/modules/user-prefs',
     'common/utils/mediator',
     'common/utils/detect',
+    'common/modules/analytics/register',
     'lodash/functions/debounce',
     'lodash/arrays/uniq'
 ], function (
@@ -14,6 +15,7 @@ define([
     userPrefs,
     mediator,
     detect,
+    register,
     debounce,
     uniq
 ) {
@@ -74,9 +76,7 @@ define([
         if (this.siteMessageComponentName) {
             siteMessage.attr('data-component', this.siteMessageComponentName);
             if (this.trackDisplay) {
-                require(['ophan/ng'], function (ophan) {
-                    ophan.trackComponentAttention(this.siteMessageComponentName, siteMessage);
-                });
+                register.begin(this.siteMessageComponentName);
             }
         }
         if (this.siteMessageLinkName) {


### PR DESCRIPTION
## What does this change?

Tracked Messages (currently, only the engagement banner) will have only the fact they were recorded displayed, rather than their attention time.
## What is the value of this and can you measure success?

We shouldn't record meaningless things!
## Does this affect other platforms - Amp, Apps, etc?

Nope, just web.

cc @joelochlann @philwills 

Prompted by feedback in https://github.com/guardian/frontend/pull/13852#issuecomment-237837097
