### PR TITLE
Guard against undefined saved for later

### DIFF
--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -342,13 +342,15 @@ define([
 
     //--Create container link click handlers
     SaveForLater.prototype.createSaveFaciaItemHandler = function (link, id, shortUrl) {
-        bean.one(link, 'click',
-            this.save.bind(this,
-                id,
-                shortUrl,
-                this.onSaveFaciaItem.bind(this, link, id, shortUrl)
-            )
-        );
+        if (link) {
+            bean.one(link, 'click',
+                this.save.bind(this,
+                    id,
+                    shortUrl,
+                    this.onSaveFaciaItem.bind(this, link, id, shortUrl)
+                )
+            );
+        }
     };
 
     SaveForLater.prototype.signUserInToSaveArticle = function (id, shortUrl) {


### PR DESCRIPTION
## What does this change?

As of yesterday there's a spike of errors `Unable to get property 'addEventListener' of undefined or null reference`.

I noticed this while investigating an issue with the current skin, but that seems to be unrelated.

I tracked down the error to the code below, for whatever reason the link is undefined (switch turned off maybe or video container, who knows).

I don't fancy understanding why exactly we're calling the function with an undefined link, for now a simple guard seems enough.
## What is the value of this and can you measure success?

Fix a sentry error reported 1.3k times in the last 24h
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@regiskuckaertz 
