### PR TITLE
Fix two more addEventListener errors

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -33,29 +33,38 @@ define([
                 id: 'control',
                 test: function () {},
                 success: function (complete) {
-                    bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
-                    bean.on(qwery('.hosted__container--full')[0], 'click', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile')[0];
+                    if (nextVideo) {
+                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                        bean.on(qwery('.hosted__container--full')[0], 'click', complete);
+                    }
                 }
             },
             {
                 id: 'variant1',
                 test: function () {},
                 success: function (complete) {
-                    bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
-                    bean.on(qwery('.hosted__container--full')[0], 'click', complete);
-                    bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
-                    mediator.on('hosted video: autoredirect', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile')[0];
+                    if (nextVideo) {
+                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                        bean.on(qwery('.hosted__container--full')[0], 'click', complete);
+                        bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
+                        mediator.on('hosted video: autoredirect', complete);
+                    }
                 }
             },
             {
                 id: 'variant2',
                 test: function () {},
                 success: function (complete) {
-                    bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
-                    bean.on(qwery('.hosted__container--full')[0], 'click', complete);
-                    bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
-                    bean.on(qwery('.hosted-next-autoplay__tile')[0], 'click', complete);
-                    mediator.on('hosted video: autoredirect', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile')[0];
+                    if (nextVideo) {
+                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                        bean.on(qwery('.hosted__container--full')[0], 'click', complete);
+                        bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
+                        bean.on(qwery('.hosted-next-autoplay__tile')[0], 'click', complete);
+                        mediator.on('hosted video: autoredirect', complete);
+                    }
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -33,9 +33,9 @@ define([
                 id: 'control',
                 test: function () {},
                 success: function (complete) {
-                    var nextVideo = qwery('.hosted__next-video--tile')[0];
-                    if (nextVideo) {
-                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile');
+                    if (nextVideo.length) {
+                        bean.on(nextVideo[0], 'click', complete);
                         bean.on(qwery('.hosted__container--full')[0], 'click', complete);
                     }
                 }
@@ -44,9 +44,9 @@ define([
                 id: 'variant1',
                 test: function () {},
                 success: function (complete) {
-                    var nextVideo = qwery('.hosted__next-video--tile')[0];
-                    if (nextVideo) {
-                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile');
+                    if (nextVideo.length) {
+                        bean.on(nextVideo[0], 'click', complete);
                         bean.on(qwery('.hosted__container--full')[0], 'click', complete);
                         bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
                         mediator.on('hosted video: autoredirect', complete);
@@ -57,9 +57,9 @@ define([
                 id: 'variant2',
                 test: function () {},
                 success: function (complete) {
-                    var nextVideo = qwery('.hosted__next-video--tile')[0];
-                    if (nextVideo) {
-                        bean.on(qwery('.hosted__next-video--tile')[0], 'click', complete);
+                    var nextVideo = qwery('.hosted__next-video--tile');
+                    if (nextVideo.length) {
+                        bean.on(nextVideo[0], 'click', complete);
                         bean.on(qwery('.hosted__container--full')[0], 'click', complete);
                         bean.on(qwery('.hosted-next-autoplay__poster')[0], 'click', complete);
                         bean.on(qwery('.hosted-next-autoplay__tile')[0], 'click', complete);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-zootropolis-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-zootropolis-cta.js
@@ -37,9 +37,9 @@ define([
                 id: 'control',
                 test: function () {},
                 success: function (complete) {
-                    var hostedBanner = qwery('.hosted__cta-btn-wrapper')[0];
-                    if (hostedBanner) {
-                        bean.on(hostedBanner, 'click', complete);
+                    var hostedBanner = qwery('.hosted__cta-btn-wrapper');
+                    if (hostedBanner.length) {
+                        bean.on(hostedBanner[0], 'click', complete);
                     }
                 }
             },
@@ -54,9 +54,9 @@ define([
                     });
                 },
                 success: function (complete) {
-                    var hostedBanner = qwery('.hosted__cta-btn-wrapper')[0];
-                    if (hostedBanner) {
-                        bean.on(hostedBanner, 'click', complete);
+                    var hostedBanner = qwery('.hosted__cta-btn-wrapper');
+                    if (hostedBanner.length) {
+                        bean.on(hostedBanner[0], 'click', complete);
                     }
                 }
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-zootropolis-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-zootropolis-cta.js
@@ -37,7 +37,10 @@ define([
                 id: 'control',
                 test: function () {},
                 success: function (complete) {
-                    bean.on(qwery('.hosted__cta-btn-wrapper')[0], 'click', complete);
+                    var hostedBanner = qwery('.hosted__cta-btn-wrapper')[0];
+                    if (hostedBanner) {
+                        bean.on(hostedBanner, 'click', complete);
+                    }
                 }
             },
             {
@@ -51,7 +54,10 @@ define([
                     });
                 },
                 success: function (complete) {
-                    bean.on(qwery('.hosted__cta-btn-wrapper')[0], 'click', complete);
+                    var hostedBanner = qwery('.hosted__cta-btn-wrapper')[0];
+                    if (hostedBanner) {
+                        bean.on(hostedBanner, 'click', complete);
+                    }
                 }
             }
         ];


### PR DESCRIPTION
## What does this change?

Turns out #13899 was not the only place adding event listeners on undefined elements. This fixes other 2 occurrences
## What is the value of this and can you measure success?

Reduce sentry errors
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@regiskuckaertz @Calanthe @lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
