### PR TITLE
Fix another DOM access of undefined object

### DIFF
--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -163,11 +163,7 @@ define([
     };
 
     SaveForLater.prototype.getElementsIndexedById = function (context) {
-        var elements = qwery('[' + this.attributes.containerItemShortUrl + ']', context);
-
-        return forEach(elements, function (el) {
-            return bonzo(el).attr(this.attributes.containerItemShortUrl);
-        }.bind(this));
+        return qwery('[' + this.attributes.containerItemShortUrl + ']', context);
     };
 
     SaveForLater.prototype.prepareFaciaItemLinks = function (signedIn) {
@@ -206,6 +202,10 @@ define([
                 shortUrl = item.getAttribute(this.attributes.containerItemShortUrl),
                 id = item.getAttribute(this.attributes.containerItemDataId),
                 isSaved = signedIn ? this.getSavedArticle(shortUrl) : false;
+
+            if ($itemSaveLink.length === 0) {
+                return;
+            }
 
             if (signedIn) {
                 this[isSaved ? 'createDeleteFaciaItemHandler' : 'createSaveFaciaItemHandler']($itemSaveLink[0], id, shortUrl);


### PR DESCRIPTION
## What does this change?

It might happen that save for later elements on't have a link (why?), in which case all the fastdom manipulations are broken. Skip those
## What is the value of this and can you measure success?

Fix this error

![screen shot 2016-08-06 at 17 40 02](https://cloud.githubusercontent.com/assets/680284/17457937/d8b72a1e-5bfc-11e6-96a0-d0c949671903.png)

Happens on `/uk` front right now
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Above
## Request for comment

@NathanielBennett I've deleted a forEach loop that seems useless to me. However most likely it was supposed to do something, mind having a look?

It feels like there are cases where `save for later` link are not exactly what we expect, I didn't look into it too hard because it's Saturday, but we should understand the root of the problem.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
