### PR TITLE
Detect adblockers fails on IE8

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -1,5 +1,9 @@
 try {
     ((document, window) => {
+        if (typeof window.getComputedStyle !== 'function') {
+            // Old browsers not supporting getComputedStyle most likely won't have adBlockers
+            return;
+        }
         var ad = document.createElement('div');
         ad.style.position = 'absolute';
         ad.style.left = '0';


### PR DESCRIPTION
## What does this change?

Don't run detect adblock on old browsers
## What is the value of this and can you measure success?

Stop seeing [this error](https://app.getsentry.com/the-guardian/client-side-prod/issues/49237141/) on Sentry, the second most frequent error since the beginning of time.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Damn IE8
## Request for comment

@Calanthe I'm sure there's a better way to prevent adblock detect from running on IE8, let's discuss on Monday

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
