### PR TITLE
Add link to Modern Slavery Act statement to UK footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -75,8 +75,8 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
                             dating</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo {/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
-                            masterclasses</a>
+                        <li class="colophon__item"><a data-link-name="uk : footer : modern slavery act statement" href="@LinkTo {/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT}">
+                            modern slavery act statement</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
                             Guardian labs</a>


### PR DESCRIPTION
## What does this change?

This change replaces the "masterclasses" link in the UK footer with a link to the Scott Trust's statement on the Modern Slavery Act.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![picture 71](https://cloud.githubusercontent.com/assets/5931528/17472882/58e9caea-5d45-11e6-84f1-0f5ee9339b7e.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
