### PR TITLE
Amp five open menu

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -5,7 +5,8 @@
 @sectionList(topLevelSection: TopLevelSection) = {
     <li class="main-navigation__item navigation-border">
             <!-- TODO: Firefox -->
-        <details>
+
+        <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name">
             <summary class="main-navigation__item__button">
                 @topLevelSection.name
             </summary>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -5,7 +5,6 @@
 @sectionList(topLevelSection: TopLevelSection) = {
     <li class="main-navigation__item navigation-border">
             <!-- TODO: Firefox -->
-
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name">
             <summary class="main-navigation__item__button">
                 @topLevelSection.name

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,7 +1,18 @@
 @()(implicit request: RequestHeader)
 
 @import conf.Atomise
-@import common.LinkTo
+@import common.{LinkTo, NewNavigation}
+
+@primaryLinks(sectionName: String) = {
+    <li class="new-header__nav__primary-item">
+        <a class="new-header__nav__link js-open-section-in-menu"
+            tabindex="0"
+            aria-controls="primary-list-@sectionName"
+            href="@LinkTo{#main-menu}">
+                @sectionName
+        </a>
+    </li>
+}
 
 @fragments.nav.newHeaderMenu()
 <header class="@Atomise("New-header")" role="banner" data-link-name="global navigation: new header">
@@ -20,11 +31,9 @@
                 <span class="u-h">Menu</span>
             </a>
             <ul class="new-header__nav__list">
-                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">news</a></li>
-                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">opinion</a></li>
-                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">sport</a></li>
-                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">arts</a></li>
-                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">life</a></li>
+                @NewNavigation.topLevelSections.map { section =>
+                    @primaryLinks(section.name)
+                }
             </ul>
         </nav>
     </div>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -20,12 +20,11 @@
                 <span class="u-h">Menu</span>
             </a>
             <ul class="new-header__nav__list">
-                @* TODO: Should open a menu *@
-                <li class="new-header__nav__list-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{/}">news</a></li>
-                <li class="new-header__nav__list-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{/commentisfree}">opinion</a></li>
-                <li class="new-header__nav__list-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{/sport}">sport</a></li>
-                <li class="new-header__nav__list-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{/culture}">arts</a></li>
-                <li class="new-header__nav__list-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{/lifeandstyle}">life</a></li>
+                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">news</a></li>
+                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">opinion</a></li>
+                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">sport</a></li>
+                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">arts</a></li>
+                <li class="new-header__nav__primary-item"><a class="new-header__nav__link" tabindex="0" href="@LinkTo{#main-menu}">life</a></li>
             </ul>
         </nav>
     </div>

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -124,7 +124,7 @@ define([
         });
     }
 
-    function handlePrimaryItemClicks() {
+    function bindPrimaryItemClickEvents() {
         primaryItems.each(function (item) {
 
             item.addEventListener('click', closeAllOtherPrimaryLists.bind(null, item));
@@ -146,7 +146,7 @@ define([
         window.addEventListener('hashchange', handleHashChange);
         handleHashChange();
 
-        handlePrimaryItemClicks();
+        bindPrimaryItemClickEvents();
         openTargetListOnClick();
 
         editionPicker();

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -12,6 +12,25 @@ define([
     var mainMenuEl = $(mainMenuId);
     var burgerLink = $('.js-change-link');
     var burgerIcon = $('.js-animate-menu');
+    var primaryItems = $('.js-close-nav-list');
+
+    function closeAllOtherPrimaryLists(targetItem) {
+        primaryItems.each(function (item) {
+
+            if (item !== targetItem) {
+                item.removeAttribute("open");
+            }
+        });
+    }
+
+    function resetLists() {
+        var mainListItems = $('.main-navigation__item');
+        // Remove possible ordering for the lists
+        mainListItems.removeAttr('style');
+
+        // No targetItem to put in as the parameter. All lists should close.
+        closeAllOtherPrimaryLists();
+    }
 
     function animateMenuOpen() {
         return fastdomPromise.write(function () {
@@ -68,6 +87,20 @@ define([
         });
     }
 
+    function closeAllOtherPrimaryLists(targetItem) {
+        arrayOfPrimaryItems.forEach(function(item) {
+            if (item !== targetItem) {
+                item.removeAttribute("open");
+            }
+        });
+    }
+
+    function handlePrimaryItemClicks() {
+        arrayOfPrimaryItems.forEach(function(item) {
+            item.addEventListener('click', closeAllOtherPrimaryLists.bind(null, item));
+        });
+    }
+
     function handleHashChange () {
         var shouldShowMenu = window.location.hash === mainMenuId;
         var shouldHideMenu = window.location.hash === '';
@@ -82,7 +115,9 @@ define([
     function init() {
         window.addEventListener('hashchange', handleHashChange);
         handleHashChange();
+
         editionPicker();
+        handlePrimaryItemClicks();
     }
 
     return init;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -167,7 +167,7 @@ $gutter-large: 55px;
     white-space: nowrap;
 
     &:first-child .new-header__nav__link {
-        padding-left: 0;
+        margin-left: 0;
     }
 
     &:not(:last-child) {
@@ -182,8 +182,8 @@ $gutter-large: 55px;
     // Override a from _lists.scss
     color: #ffffff;
     // Optically aligns slashes
-    padding-left: 2px;
-    padding-right: 3px;
+    margin-left: 2px;
+    margin-right: -1px;
 }
 
 /*****************
@@ -397,12 +397,15 @@ $gutter-large: 55px;
     // Unset ul from user agent stylesheet
     margin-bottom: 0;
     text-transform: lowercase;
+    display: flex;
+    flex-wrap: wrap;
 }
 
 .main-navigation__item {
     // Override inherited ul from user agent stylesheet
     list-style: none;
     color: $news-support-1;
+    width: 100%;
 }
 
 $navigation-horizontal-padding: 38px;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -397,6 +397,8 @@ $gutter-large: 55px;
     // Unset ul from user agent stylesheet
     margin-bottom: 0;
     text-transform: lowercase;
+    // flexbox is being used for reordering the lists on click. Ordering is added by JS
+    // See PR: https://github.com/guardian/frontend/pull/13905
     display: flex;
     flex-wrap: wrap;
 }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -161,7 +161,7 @@ $gutter-large: 55px;
     }
 }
 
-.new-header__nav__list-item {
+.new-header__nav__primary-item {
     // Override inherited nav ul from _lists.scss
     list-style: none;
     white-space: nowrap;


### PR DESCRIPTION
## What does this change?

This adds the main functionality for opening the menu.

When you click any of the primary links (new, opinion, sport, arts, life), it should open the same menu the burger menu opens, but move the related link to the top of the list, and also open it.

Here is it in action:
![openingandclosingexperiments](https://cloud.githubusercontent.com/assets/8774970/17474512/2786f1b8-5d4e-11e6-9fef-68ede2a6c245.gif)
## Does this affect other platforms - Amp, Apps, etc?

Nope!
