### PR TITLE
Fixing new header words wrapping on safari

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -41,7 +41,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 }
 
 .new-header__nav {
-    @include fs-textSans(6);
+    @include fs-textSans(5);
     line-height: 1.6;
     display: flex;
     align-items: center;
@@ -51,7 +51,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     justify-content: space-between;
 
     @include mq($until: mobileLandscape) {
-        font-size: 5.2vw;
+        font-size: 5.1vw;
     }
 
     @include mq(mobileLandscape) {


### PR DESCRIPTION
## What does this change?

Knocks the font-size down slightly for the new header primary links.

This is to prevent them from wrapping on Safari.
## What is the value of this and can you measure success?

It looks better
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/17476314/503c98d4-5d57-11e6-87e5-bafc6389fe1c.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/17476299/400f0186-5d57-11e6-87e2-fefac0be2ce9.png)
## Request for comment

@zeftilldeath 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
