### PR TITLE
Style AMP live blog contributor byline

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -71,6 +71,29 @@
     width: 0.0625rem;
 }
 
+.liveblog-block-byline {
+    margin-bottom: 0.375rem;
+    border-bottom: 0.0625rem dotted #dcdcdc;
+    padding-bottom: 0.375rem;
+}
+
+.liveblog-block-byline__img {
+    display: inline;
+    border-radius: 50%;
+    max-width: 2.25rem;
+    vertical-align: middle;
+    margin-right: 0.25rem;
+}
+
+.liveblog-block-byline__name {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    font-family: "Guardian Egyptian Web",Georgia,serif;
+    display: inline;
+    color: #333;
+}
+
+
 /* Key Events
 ========================================= */
 
@@ -82,7 +105,7 @@
 .timeline__header {
     font-size: 20px;
     line-height: 32px;
-    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;
+    font-family: "Guardian Egyptian Web", Georgia, serif;
     font-weight: 900;
     background-color: #ffffff;
     padding: 0.75rem 0.625rem 0;


### PR DESCRIPTION
## What does this change?

The contributor byline in the AMP version of the live blog looks pretty bad. This change will style it up a bit, in keeping with the styles of the non-AMP version of the live blog
## Screenshots
### Before

![amp theguardian com-uk-news-live-2016-aug-08-southern-rail-strike-begins-live-updates iphone 5](https://cloud.githubusercontent.com/assets/5931528/17478164/c34badd8-5d61-11e6-91ce-e4d5d4a4c1dc.png)
### After

![picture 76](https://cloud.githubusercontent.com/assets/5931528/17478158/be371f58-5d61-11e6-8cb7-81046918f867.png)
## Request for comment

@NataliaLKB @zeftilldeath 
