### PR TITLE
Move code that fetch competitions and teams to PaFootballClient trait

### DIFF
--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -1,14 +1,14 @@
 package controllers.admin
 
-import model.Cached.{WithoutRevalidationResult, RevalidatableResult}
-import play.api.mvc.{RequestHeader, Action, Controller, Result => PlayResult}
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import play.api.mvc.{Action, Controller, RequestHeader, Result => PlayResult}
 import play.api.libs.ws.WSClient
 import play.twirl.api.Html
 import play.api.Mode
-import common.{Logging, ExecutionContexts}
-import football.services.GetPaClient
-import football.model.{SnapFields, PA}
-import model.{NoCache, Cached}
+import common.{ExecutionContexts, Logging}
+import football.services.PaFootballClient
+import football.model.PA
+import model.{Cached, NoCache}
 import conf.Configuration
 import scala.concurrent.Future
 import pa._
@@ -20,24 +20,13 @@ import pa.Fixture
 import pa.LiveMatch
 
 
-class FrontsController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with GetPaClient with Logging {
+class FrontsController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with PaFootballClient with Logging {
   val SNAP_TYPE = "json.html"
   val SNAP_CSS = "football"
 
   def index = Action.async { implicit request =>
-    for {
-      competitions <- client.competitions.map(PA.filterCompetitions)
-      competitionTeams <- Future.traverse(competitions){ comp =>
-        client.teams(comp.competitionId, comp.startDate, comp.endDate).recover {
-          case e: PaClientErrorsException =>
-            // 'No data' is returned as an error by PA API. Therefore we ignore exception and return an empty list
-            log.error(s"Admin Football Fronts - PA Client error when requesting teams for competition ${comp}: ", e)
-            List()
-        }
-      }
-      allTeams = competitionTeams.flatten.distinct
-    } yield {
-      Cached(3600)(RevalidatableResult.Ok(views.html.football.fronts.index(competitions, allTeams)))
+    fetchCompetitionsAndTeams.map {
+      case (competitions, teams) => Cached(3600)(RevalidatableResult.Ok(views.html.football.fronts.index(competitions, teams)))
     }
   }
 

--- a/admin/app/football/controllers/PaBrowserController.scala
+++ b/admin/app/football/controllers/PaBrowserController.scala
@@ -2,8 +2,8 @@ package controllers.admin
 
 import model.Cached.RevalidatableResult
 import play.api.mvc._
-import football.services.GetPaClient
-import common.ExecutionContexts
+import football.services.PaFootballClient
+import common.{ExecutionContexts, Logging}
 import java.net.URLDecoder
 import scala.language.postfixOps
 import model.{Cached, NoCache}
@@ -11,7 +11,7 @@ import play.api.libs.ws.WSClient
 import play.api.Mode
 
 
-class PaBrowserController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with GetPaClient {
+class PaBrowserController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
   def browserSubstitution() = Action { implicit request =>
     val submission = request.body.asFormUrlEncoded.getOrElse { throw new Exception("Could not read POST submission") }

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -1,8 +1,8 @@
 package controllers.admin
 
-import common.ExecutionContexts
+import common.{ExecutionContexts, Logging}
 import football.model.PA
-import football.services.GetPaClient
+import football.services.PaFootballClient
 import model.Cached.RevalidatableResult
 import model.{Cors, Cached, NoCache}
 import org.joda.time.LocalDate
@@ -12,7 +12,7 @@ import play.api.libs.ws.WSClient
 import play.api.Mode
 import scala.concurrent.Future
 
-class TablesController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with GetPaClient {
+class TablesController(val wsClient: WSClient, val mode: Mode.Mode) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
   def tablesIndex = Action.async { implicit request =>
     for {

--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -9,9 +9,7 @@ import play.api.test.Helpers._
 import football.services.PaFootballClient
 import test.{ConfiguredTestSuite, WithTestWsClient}
 
-@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with PaFootballClient with ExecutionContexts with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
-
-  override lazy val mode = app.mode
+@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with ExecutionContexts with ConfiguredTestSuite {
 
   "test redirects player card form submission to correct player page" in {
     val Some(result) = route(FakeRequest(POST, "/admin/football/player/card", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("player" -> List("123456"), "team" -> List("1"), "competition" -> List("100"), "playerCardType" -> List("attack")))))

--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -6,10 +6,10 @@ import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
-import football.services.GetPaClient
+import football.services.PaFootballClient
 import test.{ConfiguredTestSuite, WithTestWsClient}
 
-@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with GetPaClient with ExecutionContexts with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
+@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with PaFootballClient with ExecutionContexts with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   override lazy val mode = app.mode
 

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -9,14 +9,10 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
 
 @DoNotDiscover class SiteControllerTest
   extends FreeSpec
-  with PaFootballClient
   with ExecutionContexts
   with ShouldMatchers
-  with ConfiguredTestSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
+  with ConfiguredTestSuite {
 
-  override lazy val mode = app.mode
 
   "test index page loads" in {
     val Some(result) = route(FakeRequest(GET, "/admin/football"))

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -4,12 +4,12 @@ import common.ExecutionContexts
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, ShouldMatchers}
 import play.api.test._
 import play.api.test.Helpers._
-import football.services.GetPaClient
+import football.services.PaFootballClient
 import test.{ConfiguredTestSuite, WithTestWsClient}
 
 @DoNotDiscover class SiteControllerTest
   extends FreeSpec
-  with GetPaClient
+  with PaFootballClient
   with ExecutionContexts
   with ShouldMatchers
   with ConfiguredTestSuite

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -17,14 +17,11 @@ import scala.language.postfixOps
 
 @DoNotDiscover class TablesControllerTest
   extends FreeSpec
-    with PaFootballClient
     with ExecutionContexts
     with ShouldMatchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll
     with WithTestWsClient {
-
-  override lazy val mode = app.mode
 
   "test tables index page loads with leagues" in {
     val Some(result) = route(FakeRequest(GET, "/admin/football/tables"))
@@ -80,7 +77,7 @@ import scala.language.postfixOps
   }
 
   "the internal surroundingItems function should work OK" in {
-    val tablesController = new TablesController(wsClient, mode)
+    val tablesController = new TablesController(wsClient, app.mode)
     tablesController.surroundingItems[Int](1, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(3, 4, 5))
     tablesController.surroundingItems[Int](2, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(2, 3, 4, 5, 6))
     tablesController.surroundingItems[Int](3, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(1, 2, 3, 4, 5, 6))

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -11,13 +11,13 @@ import play.twirl.api.HtmlFormat
 import test.{ConfiguredTestSuite, WithTestWsClient}
 
 import scala.annotation.tailrec
-import football.services.GetPaClient
+import football.services.PaFootballClient
 
 import scala.language.postfixOps
 
 @DoNotDiscover class TablesControllerTest
   extends FreeSpec
-    with GetPaClient
+    with PaFootballClient
     with ExecutionContexts
     with ShouldMatchers
     with ConfiguredTestSuite


### PR DESCRIPTION
## What does this change?

Fix https://frontend.gutools.co.uk/admin/football/player

Follow-up of https://github.com/guardian/frontend/pull/13909
Same code used to fetch PA competitions and teams was also used in another controller `PlayerController`

This patch remove the code duplication and consolidate it in the `PaFootballClient` (which has also been renamed from `GetPaClient`)

Code duplication 🔪 
## What is the value of this and can you measure success?
- https://frontend.gutools.co.uk/admin/football/player works 
- No code duplication
## Request for comment

@johnduffell @jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
