### PR TITLE
add minute 0% a/b test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -98,7 +98,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-minute",
     "Testing if minute teasers drive video plays.",
-    owners = Seq(Owner.withGithub("guardian/multimedia")),
+    owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 9, 1),
     exposeClientSide = true

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -93,4 +93,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 9, 14),  // Wednesday
     exposeClientSide = true
   )
+
+  val ABMinute = Switch(
+    SwitchGroup.ABTests,
+    "ab-minute",
+    "Testing if minute teasers drive video plays.",
+    owners = Seq(Owner.withGithub("guardian/multimedia")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 1),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -27,7 +27,8 @@ define([
     // This must be the full path because we use curl config to change it based
     // on env
     'bootstraps/enhanced/media/video-player',
-    'text!common/views/ui/loading.html'
+    'text!common/views/ui/loading.html',
+    'common/modules/accessibility/main'
 ], function (
     bean,
     bonzo,
@@ -55,7 +56,8 @@ define([
     moreInSeriesContainer,
     videojsOptions,
     videojs,
-    loadingTmpl
+    loadingTmpl,
+    accessibility
 ) {
     function getAdUrl() {
         var queryParams = {
@@ -429,6 +431,14 @@ define([
         }
     }
 
+    function initMinute() {
+        if(ab.isInVariant('Minute','minute') && accessibility.isOn('flashing-elements')) {
+            // This is our minute account number
+            window._min = {_publisher: 'MIN-21000'};
+            require(['js!https://d2d4r7w8.map2.ssl.hwcdn.net/mi-guardian-prod.js']);
+        }
+    }
+
     function init() {
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
@@ -457,6 +467,7 @@ define([
         initFacia();
         initMoreInSection();
         initOnwardContainer();
+        initMinute();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -15,7 +15,8 @@ define([
     'common/modules/experiments/tests/remind-me-email',
     'common/modules/experiments/tests/hosted-zootropolis-cta',
     'common/modules/experiments/tests/contributions-header',
-    'common/modules/experiments/tests/ad-feedback'
+    'common/modules/experiments/tests/ad-feedback',
+    'common/modules/experiments/tests/minute'
 ], function (
     reportError,
     config,
@@ -33,7 +34,8 @@ define([
     RemindMeEmail,
     HostedZootropolisCta,
     ContributionsHeader,
-    AdFeedback
+    AdFeedback,
+    Minute
 ) {
 
     var TESTS = [
@@ -45,7 +47,8 @@ define([
         new RemindMeEmail(),
         new HostedZootropolisCta(),
         new ContributionsHeader(),
-        new AdFeedback()
+        new AdFeedback(),
+        new Minute()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -1,0 +1,38 @@
+define([
+    'common/utils/config',
+    'qwery'
+], function(
+    config,
+    qwery
+) {
+    return function() {
+        this.id = 'Minute';
+        this.start = '2016-07-26';
+        this.expiry = '2016-09-01';
+        this.author = 'Gideon Goldberg';
+        this.showForSensitive = true;
+        this.description = 'Test if minute video teaser causes more video plays.';
+        this.audience = 0;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Video starts';
+        this.audienceCriteria = '';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.canRun = function() {
+            return config.page.contentType === 'Article' && qwery('[data-component="main video"]').length > 0;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                }
+            },
+            {
+                id: 'minute',
+                test: function () {
+                }
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

Adds minute as 0% a/b test 
## What is the value of this and can you measure success?

Allows us to test this on production with 3rd party vendor before rolling out any further.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

CC @akash1810 @NataliaLKB this is a cleaned-up version of #13698

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
