### PR TITLE
AMP live blogs have itemtype of NewsArticle

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -23,6 +23,7 @@ trait PageWithStoryPackage extends ContentPage {
   def article: Article
   def related: RelatedContent
   override lazy val item = article
+  val articleSchemas = ArticleSchemas
 }
 
 case class ArticlePage(article: Article, related: RelatedContent) extends PageWithStoryPackage

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,4 +1,5 @@
 
+@import model.ArticleSchemas
 @(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.LinkTo
@@ -8,7 +9,7 @@
 
 @* Feb 2015: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/Review *@
 @schemaType(page: ArticlePage) = @{
-    if (amp) "http://schema.org/NewsArticle" else page.article.metadata.schemaType
+    if (amp) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
 }
 
 @bodyType(page: ArticlePage) = @{

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -1,7 +1,8 @@
 @import _root_.liveblog.KeyEventData
 @import model.Badges.badgeFor
-
+@import model.ArticleSchemas
 @import _root_.liveblog.Canonical
+
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.{Edition, LinkTo}
@@ -9,19 +10,20 @@
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
 @import views.support.TrailCssClasses.toneClass
+@import _root_.liveblog.SinceBlockId
+
+@* Aug 2016: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
+@schemaType(page: LiveBlogPage) = @{
+    if (amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
+}
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
 <div class="js-notifications-blocked"></div>
 <div class="l-side-margins">
 
-    @*
-        TODO: We override itemtype if amp as Google's AMP Carousel currently only
-            supports articles of type NewsArticle. We should remove this conditional
-            when LiveBlogPosting support is implemented
-    *@
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        itemscope itemtype="@if(amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn){@ArticleSchemas.NewsArticle} else {@article.metadata.schemaType}" role="main">
+        itemscope itemtype="@schemaType(model)" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
 

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -22,7 +22,7 @@
     *@
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        itemscope itemtype="@if(amp){http://schema.org/NewsArticle} else {@article.metadata.schemaType}" role="main">
+        itemscope itemtype="@if(amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn){http://schema.org/NewsArticle} else {@article.metadata.schemaType}" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
 

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -9,7 +9,6 @@
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
 @import views.support.TrailCssClasses.toneClass
-@import _root_.liveblog.SinceBlockId
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
 <div class="js-notifications-blocked"></div>
@@ -22,7 +21,7 @@
     *@
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        itemscope itemtype="@if(amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn){http://schema.org/NewsArticle} else {@article.metadata.schemaType}" role="main">
+        itemscope itemtype="@if(amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn){@ArticleSchemas.NewsArticle} else {@article.metadata.schemaType}" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
 

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -14,9 +14,15 @@
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
 <div class="js-notifications-blocked"></div>
 <div class="l-side-margins">
+
+    @*
+        TODO: We override itemtype if amp as Google's AMP Carousel currently only
+            supports articles of type NewsArticle. We should remove this conditional
+            when LiveBlogPosting support is implemented
+    *@
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        itemscope itemtype="@article.metadata.schemaType" role="main">
+        itemscope itemtype="@if(amp){http://schema.org/NewsArticle} else {@article.metadata.schemaType}" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -398,6 +398,17 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  // see https://github.com/guardian/frontend/pull/13916
+  val AmpLiveBlogNewsArticleSwitch = Switch(
+    SwitchGroup.Feature,
+    "live-blog-amp-news-article",
+    "If this switch is on, amp live blog articles have an itemtype of NewsArticle, and thus appear in Google's AMP carousel",
+    owners = Seq(Owner.withGithub("SiAdcock")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 9),
+    exposeClientSide = false
+  )
+
   val LiveUpdateAmpSwitch = Switch(
     SwitchGroup.Feature,
     "live-update-amp",

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -364,7 +364,9 @@ object Content {
   }
 }
 
-private object ArticleSchemas {
+object ArticleSchemas {
+  val NewsArticle = "http://schema.org/NewsArticle"
+
   def apply(articleTags: Tags): String = {
     // http://schema.org/NewsArticle
     // http://schema.org/Review
@@ -373,7 +375,7 @@ private object ArticleSchemas {
     else if (articleTags.isLiveBlog)
       "http://schema.org/LiveBlogPosting"
     else
-      "http://schema.org/NewsArticle"
+      NewsArticle
   }
 }
 


### PR DESCRIPTION
## What does this change?

This hardcodes the itemtype of AMP live blog article to be `NewsArticle`, and not `LiveBlogPosting`. The reason for this change is because Google's AMP carousel only supports articles of type `NewsArticle`.

Google's Sebastian Benz recommends:

> [...] the Top News Carousel currently supports only articles of the type NewsArticle - this is why your articles don't show up in the carousel. I'd recommend using NewsArticle markup for now and switch to LiveBlog once we've released the search integration, which will be released together with the amp-live-list component. I'll keep you updated.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @jfsoul @NataliaLKB @TBonnin @gtrufitt 
