### PR TITLE
Add rounded corners and updating animation to buttons

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -72,7 +72,7 @@
                         </li>
 
                         <li>
-                            <button type="button" class="submit-input save__button" data-link-name="Save email preferences">Save</button>
+                            <button type="button" class="email-subscription__button save__button" data-link-name="Save email preferences">Save</button>
                         </li>
 
                     </ul>

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -15,8 +15,7 @@ define([
 ) {
     function reqwestEmailSubscriptionUpdate(buttonEl) {
         bean.on(buttonEl, 'click', function () {
-            buttonEl.disabled = true;
-            buttonEl.innerHTML = 'Loading...';
+            addUpdatingState(buttonEl);
             var formQueryString = generateFormQueryString(buttonEl);
             reqwest({
                 url: '/email-prefs',
@@ -30,6 +29,7 @@ define([
                     if (response && response.subscriptions && response.subscriptions.length) {
                         isSubscribed = true;
                     }
+                    $(buttonEl).removeClass('js-button-updating');
                     updateButton(buttonEl, isSubscribed);
                 }
             });
@@ -67,6 +67,14 @@ define([
         }
     }
 
+    function addUpdatingState(buttonEl) {
+        fastdom.write(function() {
+            buttonEl.disabled = true;
+            buttonEl.innerHTML = '';
+            $(buttonEl).addClass('js-button-updating');
+        });
+    }
+
     function updateSubscriptionButton(buttonEl, isSubscribed) {
         var buttonVal = buttonEl.value;
         if (isSubscribed) {
@@ -94,10 +102,10 @@ define([
     }
 
     function updateButton(buttonEl, isSubscribed) {
-        if ($(buttonEl).hasClass('email-subscription__button')) {
-            updateSubscriptionButton(buttonEl, isSubscribed);
-        } else {
+        if ($(buttonEl).hasClass('save__button')) {
             updateSaveButton(buttonEl);
+        } else {
+            updateSubscriptionButton(buttonEl, isSubscribed);
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -29,7 +29,7 @@ define([
                     if (response && response.subscriptions && response.subscriptions.length) {
                         isSubscribed = true;
                     }
-                    $(buttonEl).removeClass('js-button-updating');
+                    $(buttonEl).removeClass('is-updating-subscriptions');
                     updateButton(buttonEl, isSubscribed);
                 }
             });
@@ -71,7 +71,7 @@ define([
         fastdom.write(function() {
             buttonEl.disabled = true;
             buttonEl.innerHTML = '';
-            $(buttonEl).addClass('js-button-updating');
+            $(buttonEl).addClass('is-updating-subscriptions');
         });
     }
 

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -366,6 +366,9 @@
 .email-subscription__button {
     @include fs-textSans(2);
     background: $guardian-brand;
+    width: $gs-baseline * 9;
+    height: $gs-gutter * 2;
+    border-radius: 62.5rem;
     border: 0;
     color: #ffffff;
     cursor: pointer;
@@ -377,11 +380,21 @@
     }
 
     .email-subscription--subscribed & {
-        background: $neutral-2-contrasted;
+        background-color: $neutral-2-contrasted;
     }
 }
 
+.save__button {
+    float: none;
+}
 
+.js-button-updating {
+    background-color: $neutral-5 !important;
+    background-image: url(/assets/images/auto-update-activity.gif);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 2.5rem;
+}
 
 /* Saved-content
    ========================================================================== */

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -368,7 +368,7 @@
     background: $guardian-brand;
     width: $gs-baseline * 9;
     height: $gs-gutter * 2;
-    border-radius: 62.5rem;
+    border-radius: 100px;
     border: 0;
     color: #ffffff;
     cursor: pointer;
@@ -388,12 +388,12 @@
     float: none;
 }
 
-.js-button-updating {
+.is-updating-subscriptions {
     background-color: $neutral-5 !important;
     background-image: url(/assets/images/auto-update-activity.gif);
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 2.5rem;
+    background-size: 40px;
 }
 
 /* Saved-content


### PR DESCRIPTION
## What does this change?

Affects the email preferences page (https://profile.theguardian.com/email-prefs)
- Add rounded corners to the buttons
- Replace the 'loading...' text with the three dot animated gif (used in the profile pages when loading)
## What is the value of this and can you measure success?
- Better visual feedback to user when ajax request is waiting for response to update the button
- Improved appearance of the email prefs page
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Rounded corners:

<img width="811" alt="picture 171" src="https://cloud.githubusercontent.com/assets/8607683/17487794/3ea05afc-5d8e-11e6-9163-643ece2c7dd4.png">

Animation replaces button content:

<img width="815" alt="picture 172" src="https://cloud.githubusercontent.com/assets/8607683/17488158/f232ed0e-5d8f-11e6-9710-6c8e9c5e8a43.png">
## Request for comment

@paperboyo
@joelochlann 
