### PR TITLE
Extending plista-for-outbrain switch for 3 months

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -81,7 +81,7 @@ trait FeatureSwitches {
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 9),
+    sellByDate = new LocalDate(2016, 11, 10),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
This switch is used by the AU team to swap the Plista component in for Outbrain.
