### PR TITLE
Hosted By - remove old switches

### DIFF
--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -68,9 +68,9 @@ object Formula1HostedPages {
 
   def fromPageName(pageName: String): Option[HostedPage] = {
     pageName match {
-      case `overviewPageName` if Switches.hostedSingaporeF1Article.isSwitchedOn => Some(overviewArticlePage)
-      case `packagesPageName` if Switches.hostedSingaporeF1Article.isSwitchedOn => Some(packagesArticlePage)
-      case `offtrackPageName` if Switches.hostedSingaporeF1Article.isSwitchedOn => Some(offtrackArticlePage)
+      case `overviewPageName` => Some(overviewArticlePage)
+      case `packagesPageName` => Some(packagesArticlePage)
+      case `offtrackPageName` => Some(offtrackArticlePage)
       case _ => None
     }
   }

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -173,11 +173,11 @@ object LeffeHostedPages {
 
   def fromPageName(pageName: String): Option[HostedPage] = {
     pageName match {
-      case `willardWiganPageName` if Switches.hostedLeffeShowVideo1.isSwitchedOn => Some(willardWiganPage)
-      case `adrienneTreebyPageName` if Switches.hostedLeffeShowVideo1.isSwitchedOn => Some(adrienneTreebyPage)
-      case `peteLawrencePageName` if Switches.hostedLeffeShowVideo1.isSwitchedOn => Some(peteLawrencePage)
-      case `susanDergesPageName` if Switches.hostedLeffeShowVideo1.isSwitchedOn => Some(susanDergesPage)
-      case `quayBrothersPageName` if Switches.hostedLeffeShowVideo1.isSwitchedOn => Some(quayBrothersPage)
+      case `willardWiganPageName` => Some(willardWiganPage)
+      case `adrienneTreebyPageName` => Some(adrienneTreebyPage)
+      case `peteLawrencePageName` => Some(peteLawrencePage)
+      case `susanDergesPageName` => Some(susanDergesPage)
+      case `quayBrothersPageName` => Some(quayBrothersPage)
       case _ => None
     }
   }

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -247,8 +247,6 @@ object VisitBritainHostedPages {
   )
 
   def fromPageName(pageName: String): Option[HostedPage] = {
-    if (!Switches.hostedGalleryVisitBritain.isSwitchedOn) None
-    else
       pageName match {
         case `activitiesPageName` => Some(activitiesGallery)
         case `cityPageName` => Some(cityGallery)

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -88,16 +88,14 @@ object ZootropolisHostedPages {
     customData = customData
   )
 
-  private lazy val videoPage = if (Switches.hostedArticle.isSwitchedOn) videoPageWithoutNextPage
-    .copy(nextPage = Some(articlePageWithoutNextPage)) else videoPageWithoutNextPage
+  private lazy val videoPage = videoPageWithoutNextPage.copy(nextPage = Some(articlePageWithoutNextPage))
 
-  private lazy val articlePage = if (Switches.hostedVideoDisneyZootropolis.isSwitchedOn) articlePageWithoutNextPage
-    .copy(nextPage = Some(videoPageWithoutNextPage)) else articlePageWithoutNextPage
+  private lazy val articlePage = articlePageWithoutNextPage.copy(nextPage = Some(videoPageWithoutNextPage))
 
   def fromPageName(pageName: String): Option[HostedPage] = {
     pageName match {
-      case `articlePageName` if Switches.hostedArticle.isSwitchedOn => Some(articlePage)
-      case `videoPageName` if Switches.hostedVideoDisneyZootropolis.isSwitchedOn => Some(videoPage)
+      case `articlePageName` => Some(articlePage)
+      case `videoPageName` => Some(videoPage)
       case _ => None
     }
   }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -272,7 +272,7 @@ trait CommercialSwitches {
     "If on, all badges are served server side",
     owners = Owner.group(CommercialLabs),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 10),
+    sellByDate = new LocalDate(2016, 8, 26),
     exposeClientSide = true
   )
 
@@ -282,7 +282,7 @@ trait CommercialSwitches {
     "Serve container branding from capi",
     owners = Owner.group(CommercialLabs),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 10),
+    sellByDate = new LocalDate(2016, 8, 26),
     exposeClientSide = true
   )
 
@@ -292,7 +292,7 @@ trait CommercialSwitches {
     "Show series containers on paid content pages.",
     owners = Owner.group(CommercialLabs),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 10),
+    sellByDate = new LocalDate(2016, 8, 26),
     exposeClientSide = false
   )
 
@@ -302,57 +302,7 @@ trait CommercialSwitches {
     "If on, test page for gallery content is available",
     owners = Seq(Owner.withGithub("lps88")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 12),
-    exposeClientSide = false
-  )
-
-  val hostedGalleryVisitBritain = Switch(
-    group = CommercialLabs,
-    "hosted-gallery-visit-britain",
-    "If on, gallery pages for Visit Britain are available",
-    owners = Seq(Owner.withGithub("lps88")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 12),
-    exposeClientSide = false
-  )
-
-  val hostedVideoDisneyZootropolis = Switch(
-    group = CommercialLabs,
-    "hosted-video-zootropolis",
-    "If on, video page for Zootropolis is available",
-    owners = Seq(Owner.withGithub("lps88")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 12),
-    exposeClientSide = false
-  )
-
-  val hostedLeffeShowVideo1 = Switch(
-    group = CommercialLabs,
-    name = "hosted-leffe-show-video-1",
-    description = "Show video or else 404.",
-    owners = Owner.group(CommercialLabs),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 10),
-    exposeClientSide = false
-  )
-
-  val hostedArticle = Switch(
-    group = CommercialLabs,
-    name = "hosted-article",
-    description = "Show Zootropolis hosted article or 404.",
-    owners = Owner.group(CommercialLabs),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 17),
-    exposeClientSide = false
-  )
-
-  val hostedSingaporeF1Article = Switch(
-    group = CommercialLabs,
-    name = "hosted-article-singapore-grand-prix",
-    description = "Show Singapore Grand Prix hosted article or 404.",
-    owners = Owner.group(CommercialLabs),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 17),
+    sellByDate = new LocalDate(2016, 8, 24),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Delete switches for campaigns that are already live.

cc @guardian/labs-beta 
