### PR TITLE
AMP live blog byline contributor image

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -79,9 +79,6 @@
 
 .liveblog-block-byline__img {
     vertical-align: middle;
-}
-
-.liveblog-block-byline__img img {
     border-radius: 50%;
 }
 

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -78,11 +78,11 @@
 }
 
 .liveblog-block-byline__img {
-    display: inline;
-    border-radius: 50%;
-    max-width: 2.25rem;
     vertical-align: middle;
-    margin-right: 0.25rem;
+}
+
+.liveblog-block-byline__img img {
+    border-radius: 50%;
 }
 
 .liveblog-block-byline__name {

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -8,9 +8,9 @@
         <div class="byline-img">
         @if(request.isAmp) {
             @if(model.Tags(tags.tones.toList).isComment) {
-                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150" />
+                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150"></amp-img>
             } else {
-                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66" />
+                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66"></amp-img>
             }
         } else {
             <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -1,9 +1,11 @@
 @(profileTag: Tag)(implicit request: RequestHeader)
-    <div class="liveblog-block-byline">
-    @profileTag.contributorImagePath.map{ src =>
-        <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+<div class="liveblog-block-byline">
+    @profileTag.contributorImagePath.map { src =>
+        @if(request.isAmp) {
+            <amp-img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" width="36" height="36"></amp-img>
+        } else {
+            <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+        }
     }
     <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
 </div>
-
-


### PR DESCRIPTION
## What does this change?

Byline images in live blogs always use `<img>` tags, even in AMP live blogs. Vanilla `<img>` tags are not support in AMP articles, so the articles were not validating. This change introduces `<amp-img>` for byline contributor images in AMP live blogs.
## Does this affect other platforms - Amp, Apps, etc?

Nope
