### PR TITLE
Hide "More on this story" on AMP live blog

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -125,7 +125,7 @@
 
                 <div class="content__secondary-column" aria-hidden="true">
                     <div class="ad-slot-container js-ad-slot-container"></div>
-                    @if(model.related.hasStoryPackage) {
+                    @if(model.related.hasStoryPackage && !amp) {
                         <aside role="complementary" class="blog__related">
                             <h3 class="blog__related__head">More on this story</h3>
                             <ul class="u-unstyled fc-slice fc-slice--single-col">


### PR DESCRIPTION
## What does this change?

The "more on this story" section of the AMP live blog does not look too hot right now. It also prevents the AMP article from validating.

This change will prevent the section from appearing in the AMP live blog until we get it nicely styled for AMP.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![amp theguardian com-uk-news-live-2016-aug-08-southern-rail-strike-begins-live-updates iphone 5 2](https://cloud.githubusercontent.com/assets/5931528/17518506/14aea5a2-5e40-11e6-9443-98a7c3690fad.png)
