### PR TITLE
AMP live blog structured data

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -18,9 +18,7 @@
         id="block-@block.id"
         @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" }
         class="block block--content@block.eventClass"
-        @if(!isNewsArticle()){ itemprop="liveBlogUpdate" }
-        itemscope=""
-        @if(!isNewsArticle()){ itemtype="http://schema.org/BlogPosting" }
+        @if(!isNewsArticle()){ itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting" }
     >
         <p class="block-time published-time">
             @if(amp){

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -9,7 +9,7 @@
 @import common.LinkTo
 
 @* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isNewsArticle() = @{
+@isAmpAndStructuredAsNewsArticle() = @{
     amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
 }
 
@@ -18,7 +18,7 @@
         id="block-@block.id"
         @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" }
         class="block block--content@block.eventClass"
-        @if(!isNewsArticle()){ itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting" }
+        @if(!isAmpAndStructuredAsNewsArticle()){ itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting" }
     >
         <p class="block-time published-time">
             @if(amp){

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -2,14 +2,26 @@
 @import model.Article
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
-@import conf.switches.Switches.LiveUpdateAmpSwitch
+@import conf.switches.Switches.{LiveUpdateAmpSwitch,AmpLiveBlogNewsArticleSwitch}
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.LinkTo
 
+@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
+@isNewsArticle() = @{
+    amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
+}
+
 @blocks.map { block =>
-    <div id="block-@block.id" @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+    <div
+        id="block-@block.id"
+        @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" }
+        class="block block--content@block.eventClass"
+        @if(!isNewsArticle()){ itemprop="liveBlogUpdate" }
+        itemscope=""
+        @if(!isNewsArticle()){ itemtype="http://schema.org/BlogPosting" }
+    >
         <p class="block-time published-time">
             @if(amp){
                 <a href="@LinkTo{/@article.metadata.id?page=with:block-@block.id#block-@block.id}" itemprop="url" class="block-time__link">

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -13,11 +13,11 @@
 @import _root_.liveblog.SinceBlockId
 
 @* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isNewsArticle() = @{
+@isAmpAndStructuredAsNewsArticle() = @{
     amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
 }
 @schemaType(page: LiveBlogPage) = @{
-    if(isNewsArticle()) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
+    if(isAmpAndStructuredAsNewsArticle()) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
 }
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
@@ -29,7 +29,7 @@
         itemscope itemtype="@schemaType(model)" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
-        @if(isNewsArticle()) {
+        @if(isAmpAndStructuredAsNewsArticle()) {
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">
                 <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -12,9 +12,12 @@
 @import views.support.TrailCssClasses.toneClass
 @import _root_.liveblog.SinceBlockId
 
-@* Aug 2016: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
+@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
+@isNewsArticle() = @{
+    amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
+}
 @schemaType(page: LiveBlogPage) = @{
-    if (amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
+    if(isNewsArticle()) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
 }
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
@@ -26,6 +29,14 @@
         itemscope itemtype="@schemaType(model)" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
+        @if(isNewsArticle()) {
+            <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+                <meta itemprop="name" content="The Guardian">
+                <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+                    <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
+                </div>
+            </div>
+        }
 
         <header class="content__head tonal__head tonal__head--@toneClass(article)
                       @if(ArticleBadgesSwitch.isSwitchedOn) {

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -3,7 +3,7 @@
 @import conf.switches.Switches.AmpLiveBlogNewsArticleSwitch
 
 @* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isNewsArticle() = @{
+@isAmpAndStructuredAsNewsArticle() = @{
     request.isAmp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
 }
 
@@ -17,7 +17,7 @@
         }
     </time>
     @* Aug 2016: disable coverage start time for AMP Live Blogs, which currently have an article type of NewsArticle *@
-    @if(isLiveBlog && !isNewsArticle()) {
+    @if(isLiveBlog && !isAmpAndStructuredAsNewsArticle()) {
         <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
     @if(hasBeenModified && !isMinute) {
@@ -26,7 +26,8 @@
             Last modified on @Format(lastModified, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(lastModified)</span>
         </time>
     }
-    @if(isLiveBlog && !isLive && !isNewsArticle()) {
+    @* Aug 2016: disable coverage end time for AMP Live Blogs, which currently have an article type of NewsArticle *@
+    @if(isLiveBlog && !isLive && !isAmpAndStructuredAsNewsArticle()) {
         <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,5 +1,11 @@
 @(webPublicationDate: org.joda.time.DateTime, lastModified: org.joda.time.DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 @import views.support.AuFriendlyFormat
+@import conf.switches.Switches.AmpLiveBlogNewsArticleSwitch
+
+@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
+@isNewsArticle() = @{
+    request.isAmp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
+}
 
 <p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}" aria-hidden="true">
     <time itemprop="datePublished" datetime='@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
@@ -10,7 +16,8 @@
             @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
         }
     </time>
-    @if(isLiveBlog) {
+    @* Aug 2016: disable coverage start time for AMP Live Blogs, which currently have an article type of NewsArticle *@
+    @if(isLiveBlog && !isNewsArticle()) {
         <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
     @if(hasBeenModified && !isMinute) {
@@ -19,7 +26,7 @@
             Last modified on @Format(lastModified, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(lastModified)</span>
         </time>
     }
-    @if(isLiveBlog && !isLive) {
+    @if(isLiveBlog && !isLive && !isNewsArticle()) {
         <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>


### PR DESCRIPTION
## What does this change?

`LiveBlogPosting` articles are not currently supported in the AMP carousel or the "top stories" section of Google's search results page. 
#13916 addressed this by temporarily changing the article type of AMP live blogs to `NewsArticle`. However, this change did not apply the necessary structured data changes to make the article a valid NewsArticle, and hence AMP live blogs are failing structured data validation.

This change ensures AMP live blogs are valid NewsArticles.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @jfsoul @NataliaLKB @TBonnin @gtrufitt

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
