### PR TITLE
darker colour for twitter badge on special reports media pages

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -85,5 +85,16 @@
             background-color: mix($news-support-6, $neutral-1, 70%);
             border-color: mix($news-support-6, $neutral-1, 70%);
         }
+
+        .button--secondary {
+            @include button-colour(
+                $neutral-2,
+                $neutral-1
+            );
+
+            @include button-hover-colour(
+                darken($neutral-2, 10%)
+            );
+        }
     }
 }

--- a/static/src/stylesheets/pasteup/buttons/_styles.scss
+++ b/static/src/stylesheets/pasteup/buttons/_styles.scss
@@ -56,6 +56,17 @@
     );
 }
 
+.content--media.tonal--tone-special-report .button--secondary {
+    @include button-colour(
+        $neutral-2,
+        $neutral-1
+    );
+
+    @include button-hover-colour(
+        darken($neutral-2, 10%)
+    );
+}
+
 .button--tertiary {
     @include button-colour(
         transparent,

--- a/static/src/stylesheets/pasteup/buttons/_styles.scss
+++ b/static/src/stylesheets/pasteup/buttons/_styles.scss
@@ -56,17 +56,6 @@
     );
 }
 
-.content--media.tonal--tone-special-report .button--secondary {
-    @include button-colour(
-        $neutral-2,
-        $neutral-1
-    );
-
-    @include button-hover-colour(
-        darken($neutral-2, 10%)
-    );
-}
-
 .button--tertiary {
     @include button-colour(
         transparent,


### PR DESCRIPTION
## What does this change?

better contrast of twitter handle button on video page of special reports
## What is the value of this and can you measure success?

less eye strain
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

before
<img width="169" alt="screen shot 2016-08-10 at 11 10 03" src="https://cloud.githubusercontent.com/assets/836140/17550064/1ae23e1a-5eeb-11e6-8d40-02af765aea8b.png">

after
<img width="168" alt="screen shot 2016-08-10 at 11 10 12" src="https://cloud.githubusercontent.com/assets/836140/17550072/203c83d4-5eeb-11e6-9576-8a72dccce9e2.png">
## Request for comment

@blongden73 @mr-mr 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
