### PR TITLE
add minute JS to fronts (0% A/B test)

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -19,7 +19,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = '';
         this.canRun = function() {
-            return config.page.contentType === 'Article' && qwery('[data-component="main video"]').length > 0;
+            return (config.page.contentType === 'Section' || config.page.contentType === 'Network Front') || config.page.contentType === 'Article'  && qwery('[data-component="main video"]').length > 0;
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -19,7 +19,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = '';
         this.canRun = function() {
-            return (config.page.contentType === 'Section' || config.page.contentType === 'Network Front') || config.page.contentType === 'Article'  && qwery('[data-component="main video"]').length > 0;
+            return config.page.isFront === true || config.page.contentType === 'Article'  && qwery('[data-component="main video"]').length > 0;
         };
 
         this.variants = [


### PR DESCRIPTION
## What does this change?

Extends minute JS to run on fronts
## What is the value of this and can you measure success?

Enable us to test effects on fronts with 3rd party vendor on production. (As part of opt-in 0% A/B test only)
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

CC @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
