### PR TITLE
Change free become a member to become a supporter

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -243,9 +243,9 @@ class GuardianConfiguration extends Logging {
     lazy val domain = """^https?://(?:profile\.)?([^/:]+)""".r.unapplySeq(url).flatMap(_.headOption).getOrElse("theguardian.com")
     lazy val apiClientToken = configuration.getStringProperty("id.apiClientToken").getOrElse("")
     lazy val oauthUrl = configuration.getStringProperty("id.oauth.url").getOrElse("")
-    lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
+    lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com/supporter")
     lazy val digitalPackUrl = configuration.getStringProperty("id.digitalpack.url").getOrElse("https://subscribe.theguardian.com")
-    lazy val membersDataApiUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://members-data-api.theguardian.com")
+    lazy val membersDataApiUrl = configuration.getStringProperty("id.members-data-api.url").getOrElse("https://members-data-api.theguardian.com")
     lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
   }
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -24,8 +24,7 @@
                                 data-link-name="Register link"
                                 class="brand-bar__item--action">
                                     @fragments.inlineSvg("profile-add-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                                <span class="brand-bar__item__badge control__icon-wrapper control__icon-wrapper--text">free</span>
-                                <span class="control__info js-control-info control__info--supporting">become a member</span>
+                                <span class="control__info js-control-info control__info--supporting">become a supporter</span>
                             </a>
                         </div>
                     }

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -28,6 +28,7 @@ id.apiClientToken=frontend-dev-client-token
 id.webapp.url=https://id.thegulocal.com
 id.oauth.url=https://oauth.thegulocal.com
 id.membership.url=https://mem.thegulocal.com
+id.members-data-api.url=https://members-data-api.thegulocal.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion


### PR DESCRIPTION
## What does this change?
- The "free" become a supporter link now says "become a member".
- The membership url is now set to the supporter page
- The members data api url doesn't attempt to read the membership URL from config and now has its own entry.
## What is the value of this and can you measure success?

value: We get rid of the word "free" from every page on the guardian.
measure: 💰
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots

![image](https://cloud.githubusercontent.com/assets/2670496/17554434/b04f26c2-5f02-11e6-94b9-1124b2bdd02b.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
