### PR TITLE
Change contributions coin header test so that coin icon only shows for signed in users

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-header.js
@@ -6,6 +6,7 @@ define([
     'common/views/svgs',
     'common/utils/fastdom-promise',
     'common/utils/mediator',
+    'common/utils/cookies',
     'text!common/views/contributions-header.html'
 ], function (bean,
              qwery,
@@ -14,6 +15,7 @@ define([
              svgs,
              fastdom,
              mediator,
+             cookies,
              contributionsHeader
 ) {
     return function () {
@@ -32,7 +34,8 @@ define([
         this.idealOutcome = '';
         this.canRun = function () {
             var pageObj = window.guardian.config.page;
-            return !(pageObj.isLiveBlog || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+            var userCookie = cookies.get('GU_U');
+            return !(pageObj.isLiveBlog || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK' && userCookie;
         };
 
         var writer = function (linkText, linkHref) {
@@ -43,8 +46,8 @@ define([
             }));
 
             return fastdom.write(function () {
-                var a = $('.brand-bar__item--register');
-                a.replaceWith($newThing);
+                var a = $('.brand-bar__item--subscribe');
+                $newThing.insertBefore(a);
                 mediator.emit('contributions-header:insert');
             });
         };


### PR DESCRIPTION
## What does this change?

This changes the nature of the contributions header test. Previously the contribute CTA was replacing the "become a supporter" button, so only non-signed in users would see it. Now it places itself before the subscriptions button, if and only if the user is signed in. 

It decides if a user is signed in by checking for the existence of the "GU_U" cookie. While this is a very low level way of determining if a user is logged in, it is adequate for the purpose of this small test. 
## What is the value of this and can you measure success?

We can compare the conversion rate to the previous test with non signed in users and see what the difference in behaviour is. 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screenshot at aug 10 17-26-35](https://cloud.githubusercontent.com/assets/2844554/17561925/3637006c-5f20-11e6-869c-f3b54f2a3f9a.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
