### PR TITLE
AB test for onward journey links in hosted articles

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,6 +34,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABHostedArticleOnwardJourney = Switch(
+    SwitchGroup.ABTests,
+    "ab-hosted-article-onward-journey",
+    "Vertical positioning of the onward journey links",
+    owners = Seq(Owner.withGithub("lps88")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 16),
+    exposeClientSide = true
+  )
+
   val ABContributionsArticle20160802 = Switch(
     SwitchGroup.ABTests,
     "ab-contributions-article-20160810",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,6 +14,7 @@ define([
     'common/modules/experiments/tests/participation-discussion-ordering-non-live',
     'common/modules/experiments/tests/remind-me-email',
     'common/modules/experiments/tests/hosted-zootropolis-cta',
+    'common/modules/experiments/tests/hosted-article-onward-journey',
     'common/modules/experiments/tests/contributions-header',
     'common/modules/experiments/tests/ad-feedback',
     'common/modules/experiments/tests/minute'
@@ -33,6 +34,7 @@ define([
     ParticipationDiscussionOrderingNonLive,
     RemindMeEmail,
     HostedZootropolisCta,
+    HostedArticleOnwardJourney,
     ContributionsHeader,
     AdFeedback,
     Minute
@@ -46,6 +48,7 @@ define([
         new ParticipationDiscussionOrderingNonLive(),
         new RemindMeEmail(),
         new HostedZootropolisCta(),
+        new HostedArticleOnwardJourney(),
         new ContributionsHeader(),
         new AdFeedback(),
         new Minute()

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-article-onward-journey.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-article-onward-journey.js
@@ -1,0 +1,79 @@
+define([
+    'bean',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/detect',
+    'lodash/collections/contains'
+], function (
+    bean,
+    fastdom,
+    qwery,
+    $,
+    config,
+    detect,
+    contains
+) {
+    return function () {
+        this.id = 'HostedArticleOnwardJourney';
+        this.start = '2016-08-12';
+        this.expiry = '2016-09-16';
+        this.author = 'Lydia Shepherd';
+        this.description = 'Vertical positioning of the onward journey (links to other pages in the campaign)';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'People will click on the onward journey links more often.';
+        this.audienceCriteria = 'All users on hosted article pages on desktop';
+        this.dataLinkNames = 'Next Hosted Page: Singapore Airlines Singapore Grand Prix packages, Next Hosted Page: Get the most out of the Singapore Grand Prix, Next Hosted Page: Get revved up for the Singapore Grand Prix';
+        this.idealOutcome = 'People will click on the onward journey links more often.';
+
+        this.canRun = function () {
+            return config.isHosted && config.page.section === 'singapore-grand-prix' && contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint());
+        };
+
+        this.variants = [
+            {
+                id: 'top',
+                test: function () {},
+                success: function (complete) {
+                    var hostedBanner = qwery('.hosted__next-video--tile');
+                    if (hostedBanner.length == 2) {
+                        bean.on(hostedBanner[0], 'click', complete);
+                        bean.on(hostedBanner[1], 'click', complete);
+                    }
+                }
+            },
+            {
+                id: 'middle',
+                test: function () {
+                    fastdom.write(function () {
+                        $('.hosted__next-video').css('top', '50%');
+                    });
+                },
+                success: function (complete) {
+                    var hostedBanner = qwery('.hosted__next-video--tile');
+                    if (hostedBanner.length == 2) {
+                        bean.on(hostedBanner[0], 'click', complete);
+                        bean.on(hostedBanner[1], 'click', complete);
+                    }
+                }
+            },
+            {
+                id: 'bottom',
+                test: function () {
+                    fastdom.write(function () {
+                        $('.hosted__next-video').css('top', 'auto').css('bottom', '0');
+                    });
+                },
+                success: function (complete) {
+                    var hostedBanner = qwery('.hosted__next-video--tile');
+                    if (hostedBanner.length == 2) {
+                        bean.on(hostedBanner[0], 'click', complete);
+                        bean.on(hostedBanner[1], 'click', complete);
+                    }
+                }
+            }
+        ];
+    };
+});

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -122,7 +122,8 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
         .hosted__next-video {
             width: auto;
             position: absolute;
-            top: 60%;
+            margin: 70px 0;
+            top: 0;
             .hosted__next-video--header,
             .hosted__next-video--tile {
                 margin-right: 0;


### PR DESCRIPTION
A new AB Test for where to most effectively position this:

![image](https://cloud.githubusercontent.com/assets/6290008/17586982/0a6a390c-5fbd-11e6-8995-909461dc18e3.png)

...within the Singapore f1 article pages. Three options are top, middle or bottom of the right hand column.

http://www.theguardian.com/advertiser-content/singapore-grand-prix/overview
http://www.theguardian.com/advertiser-content/singapore-grand-prix/packages
http://www.theguardian.com/advertiser-content/singapore-grand-prix/offtrack
