### PR TITLE
Revert "Use AdminFilters in dev-build"

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -5,7 +5,7 @@ import common.Logback.LogstashLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
 import common.DiagnosticsLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{AdminFilters, FootballLifecycle}
+import conf.FootballLifecycle
 import contentapi.SectionsLookUpLifecycle
 import controllers._
 import controllers.commercial._
@@ -87,7 +87,7 @@ trait AppComponents
     wire[ABHeadlinesLifecycle]
   )
 
-  override lazy val httpFilters = wire[DevFilters].filters ++ wire[AdminFilters].filters
+  override lazy val httpFilters = wire[DevFilters].filters
   override lazy val httpRequestHandler = wire[DevBuildParametersHttpRequestHandler]
   override lazy val httpErrorHandler = wire[CorsHttpErrorHandler]
 }


### PR DESCRIPTION
Reverts guardian/frontend#13950

Unfortunately there changes made it so you have to log in to everything.  Since there's no clear url group not going to admin, the list of urls exempt wouldn't be possible.

Reverting so we can come up with another solution - in the mean time we can run admin directly to change switches.

@desbo @TBonnin 
