### PR TITLE
New article images for Singapore F1 hosted campaign

### DIFF
--- a/commercial/app/views/hosted/singaporeF1Packages.scala.html
+++ b/commercial/app/views/hosted/singaporeF1Packages.scala.html
@@ -111,7 +111,7 @@
 
 <h2>
     @fragments.imageFigure(
-        ImageMedia.make(Seq(ImageAsset.make(Asset(AssetType.Image, Some("image/jpeg"), Some("https://media.guim.co.uk/21ac3894b339ac4b47dd1192c8d29a398dbff1f6/0_146_4368_2621/2000.jpg"), typeData = Some(AssetFields(width = Some(5), height = Some(3)))), 0))),
+        ImageMedia.make(Seq(ImageAsset.make(Asset(AssetType.Image, Some("image/jpeg"), Some("https://media.guim.co.uk/401252cd67a1641bf41f2609ba0a73c45a57365f/0_176_5267_3160/2000.jpg"), typeData = Some(AssetFields(width = Some(5), height = Some(3)))), 0))),
         lightboxIndex = None,
         widthsByBreakpoint = ImageContentMedia.inline
     )

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -48,7 +48,7 @@ object Formula1HostedPages {
                  "Paddock when you first walk in on Thursday afternoon \n\nand it never goes away.' Jenson Button, 2009 Formula 1 World Champion, McLaren-Honda",
     cta(packagesPageName),
     nextPageNames = List(offtrackPageName, overviewPageName),
-    mainPicture = "http://media.guim.co.uk/cabec8c6e33920a06a989d2d87d0013c9d67a32e/0_0_7273_4000/2000.jpg",
+    mainPicture = "https://media.guim.co.uk/cabec8c6e33920a06a989d2d87d0013c9d67a32e/0_0_7273_4000/2000.jpg",
     mainPictureCaption = ""
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -10,7 +10,7 @@ object Formula1HostedPages {
     id = "singapore-grand-prix",
     name = "Singapore Grand Prix",
     owner = "First Stop Singapore",
-    logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/2016_TrackLogo_RGB_FullColour.png"),
+    logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA.jpg"),
     cssClass = "f1-singapore",
     logoLink = None
   )
@@ -48,7 +48,7 @@ object Formula1HostedPages {
                  "Paddock when you first walk in on Thursday afternoon \n\nand it never goes away.' Jenson Button, 2009 Formula 1 World Champion, McLaren-Honda",
     cta(packagesPageName),
     nextPageNames = List(offtrackPageName, overviewPageName),
-    mainPicture = "https://media.guim.co.uk/b77d7b65b89fc0cc9dec0ce0ccb4250044b9367e/0_47_1504_902/1000.png",
+    mainPicture = "http://media.guim.co.uk/cabec8c6e33920a06a989d2d87d0013c9d67a32e/0_0_7273_4000/2000.jpg",
     mainPictureCaption = ""
   )
 

--- a/static/src/stylesheets/module/commercial/_hostedbadge.scss
+++ b/static/src/stylesheets/module/commercial/_hostedbadge.scss
@@ -42,8 +42,7 @@
 .hostedbadge .hostedbadge__logo {
     position: absolute;
     display: block;
-    width: calc(100% - 16px);
-    padding: 8px;
+    width: 100%;
     top: 100%;
     background-color: #ffffff;
 }


### PR DESCRIPTION
## What does this change?

New images for singapore articles as requested by client
### before

![image](https://cloud.githubusercontent.com/assets/6290008/17591144/b9a6a9e8-5fd4-11e6-830b-3a5ae2a0cc8b.png)

![image](https://cloud.githubusercontent.com/assets/6290008/17591162/ce37b97e-5fd4-11e6-848f-96f3a5377cc8.png)
### after

![image](https://cloud.githubusercontent.com/assets/6290008/17591114/8b0207d6-5fd4-11e6-8080-b55761ecdb89.png)

![image](https://cloud.githubusercontent.com/assets/6290008/17591122/9d6a49c4-5fd4-11e6-9989-0cb0e335dc50.png)
