### PR TITLE
Less panic shedding during medium latency conditions

### DIFF
--- a/common/app/conf/PanicSheddingFilter.scala
+++ b/common/app/conf/PanicSheddingFilter.scala
@@ -72,7 +72,7 @@ class PanicSheddingFilter extends Filter with Logging {
       true
     } else if (requestsInProgress <= TRICKLE_RECOVERY_CONCURRENT_CONNECTIONS) {
       logWithStats(Some(
-        s"""Excessive latency detected, serving anyway as in progress requests ($requestsInProgress)
+        s"""Increased latency detected, serving anyway as in progress requests ($requestsInProgress)
             | is less than the minimum ($TRICKLE_RECOVERY_CONCURRENT_CONNECTIONS).
             | """.stripMargin))
       true


### PR DESCRIPTION
So due to a logic error, we weren't specifically allowing the minimum number of connections when we were only serving a percentage of responses.  Although this should still allow through enough to recover, it was not intentional, as it can happen during startup.

This fixes it so we will always allow the 4 connections.

@TBonnin have a look!
