### PR TITLE
Make Live Blog toast position absolute, when it is not fixed

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -617,6 +617,11 @@ $timeline-width: 15px;
     }
 }
 
+/* prevent toast from dropping behind first post when not fixed */
+.toast__container:not(.is-sticky) {
+    position: absolute;
+}
+
 .toast__container--open {
     z-index: $zindex-content;
 }


### PR DESCRIPTION
## What does this change?

There is an issue where the Live Blog toast sometimes appears behind a blog post. This happens when:
- We have navigated down to a key event using the Key Events navigation
- We are still on the first page of the Live Blog
- There is a new update on the Live Blog
- We scroll back to the top of the page

Under these circumstances:
- the new post is not automatically inserted into the Live Blog. Since we used the Key Events navigation, the URL query-string now contains a `page` parameter, [making it ineligible for autoupdates](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/ui/autoupdate.js#L136)
- the toast does not disappear when the user scrolls to the top of the page
- when the `is-sticky` class is removed by scrolling above the first post, the toast container loses its position and appears behind the first post 

This change gives the toast container a position strictly when it is not sticky. Since the `is-sticky` class is loaded before the `toast__container`, it is not possible to simply give `toast__container` a default position and have `is-sticky` override it (unless of course we give `is-sticky` a position of `fixed !important`).
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
### Before

![picture 81](https://cloud.githubusercontent.com/assets/5931528/17596158/1249531c-5fe8-11e6-9153-9011afa8986e.png)
### After

![picture 82](https://cloud.githubusercontent.com/assets/5931528/17596360/f4f71974-5fe8-11e6-8d01-46bbd12ba995.png)
