### PR TITLE
Make it so snaps don't need images

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -10,7 +10,7 @@
 
 @import Function.const
 
-<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(item.hasImage && !item.hasInlineSnapHtml) {js-snappable}"
+<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}"
     @if(item.discussionSettings.isCommentable) {
         @item.discussionSettings.discussionId.map { id =>
         data-discussion-id="@id"


### PR DESCRIPTION
## What does this change?

**STORY TIME**
So I was testing some snaps in `CODE` where the fallback was a front and not an article. In `PROD` this works because they're pressed into the page. Turns out it's because the javascript snaps require an image for some unknown reason. So snaps now don't require images.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
