### PR TITLE
Show "More on this story" in AMP articles 

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -77,7 +77,7 @@
                 </div>
 
             @if(content.metadata.sectionId != "childrens-books-site") {
-                @if(content.hasStoryPackage) {
+                @if(related.hasStoryPackage) {
                     @fragments.amp.storyPackageAmp(related)
                 }
                 @if(content.tags.series.nonEmpty) {
@@ -86,7 +86,7 @@
                     }
                 }
                 @if(content.showInRelated
-                    && !content.hasStoryPackage
+                    && !related.hasStoryPackage
                     && content.tags.series.isEmpty) {
                     @fragments.amp.onwardTemplateAmp("related-mf2/" + page.metadata.id + ".json")
                 }


### PR DESCRIPTION
## What does this change?

The "More on this Story" section is not appearing on AMP articles. This is because the article checks whether `Content.hasStoryPackage` is flagged as true, when it should be checking whether `RelatedContent.hasStoryPackage` is flagged as true. This reflects how the "More on this Story" section is [populated in non-AMP articles](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/storyPackagePlaceholder.scala.html#L13).

We expect `Content.hasStoryPackage` to be set by CAPI, but as far as I can tell, this flag is not being passed from CAPI. This might be a bug their end, I'll chase them on it.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![localhost-3000-uk-news-live-2016-aug-08-southern-rail-strike-begins-live-updates-amp iphone 5](https://cloud.githubusercontent.com/assets/5931528/17621025/7b60c754-6088-11e6-8c2d-c80745f469d1.png)
