### PR TITLE
Add rich link examples link to visual guide

### DIFF
--- a/docs/01-start-here/02-guardian-visual-glossary.md
+++ b/docs/01-start-here/02-guardian-visual-glossary.md
@@ -78,6 +78,10 @@
 
 [All combinations](http://preview.gutools.co.uk/all-dynamic-fast#)
 
+## Rich Links
+
+[Lots of examples](http://preview.gutools.co.uk/info/developer-blog/2014/dec/12/rich-link-testing)
+
 ## Content Elements
 
 ### Block quote


### PR DESCRIPTION
## What does this change?

Adds link to http://preview.gutools.co.uk/info/developer-blog/2014/dec/12/rich-link-testing to the docs.
