### PR TITLE
New AB test for hosted galleries

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -26,9 +26,7 @@
                             <div class="hosted-gallery__image--placeholder"></div>
                         }
                     </div>
-                    @if(page.ctaIndex.isDefined){
-                        @guardianHostedGalleryCta(page.cta.label, page.cta.url, page.cta.btnText, page.brandBackgroundCssClass)
-                    }
+                    @guardianHostedGalleryCta(page.cta.label, page.cta.url, page.cta.btnText, page.brandBackgroundCssClass)
                     <div class="hosted-gallery__progress js-hosted-gallery-progress">
                         @fragments.inlineSvg("arrow-right", "icon", List("inline-arrow-up"))
                         <div class="hosted-gallery__progress--wrapper">

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,6 +44,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABHostedGalleryCallToAction = Switch(
+    SwitchGroup.ABTests,
+    "ab-hosted-gallery-cta",
+    "Test which gallery image to put the call to action link on",
+    owners = Seq(Owner.withGithub("lps88")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 16),
+    exposeClientSide = true
+  )
+
   val ABContributionsArticle20160802 = Switch(
     SwitchGroup.ABTests,
     "ab-contributions-article-20160810",

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
@@ -151,6 +151,12 @@ define([
         }.bind(this));
     };
 
+    HostedGallery.prototype.ctaIndex = function () {
+        var ctaIndex = config.page.ctaIndex;
+        var images = config.page.images;
+        return (ctaIndex > 0 && ctaIndex < images.length - 1) ? ctaIndex : undefined;
+    };
+
     HostedGallery.prototype.trigger = function (event, data) {
         this.fsm.trigger(event, data);
     };
@@ -191,6 +197,7 @@ define([
             $sizer = $('.js-hosted-gallery-image-sizer', $imageDiv),
             imgRatio = this.imageRatios[imgIndex],
             ctaSize = getFrame(imgRatio < 1 ? 0 : 5 / 3),
+            ctaIndex = this.ctaIndex(),
             tabletSize = 740,
             imageSize = getFrame(imgRatio < 1 ? imgRatio : 5 / 3);
         fastdom.write(function () {
@@ -198,7 +205,7 @@ define([
             $sizer.css('height', imageSize.height);
             $sizer.css('top', imageSize.topBottom);
             $sizer.css('left', imageSize.leftRight);
-            if (imgIndex === config.page.ctaIndex) {
+            if (imgIndex === ctaIndex) {
                 bonzo($ctaFloat).css('bottom', ctaSize.topBottom);
             }
             if (imgIndex === $images.length - 1) {
@@ -252,7 +259,7 @@ define([
         var fractionProgress = progress % 1;
         var deg = Math.ceil(fractionProgress * 360);
         var newIndex = Math.round(progress + 0.75);
-        var ctaIndex = config.page.ctaIndex;
+        var ctaIndex = this.ctaIndex();
         fastdom.write(function () {
             this.$images.each(function (image, index) {
                 var opacity = (progress - index + 1) * 4 / 3;
@@ -301,7 +308,7 @@ define([
                 if (this.useSwipe) {
                     this.translateContent(this.index, 0, 100);
                     bonzo(this.$galleryEl).toggleClass('show-oj', this.index === this.$images.length);
-                    bonzo(this.$galleryEl).toggleClass('show-cta', this.index === config.page.ctaIndex + 1);
+                    bonzo(this.$galleryEl).toggleClass('show-cta', this.index === this.ctaIndex() + 1);
                 }
 
                 url.pushUrl({}, document.title, config.page.pageName + '#img-' + this.index, true);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -15,6 +15,7 @@ define([
     'common/modules/experiments/tests/remind-me-email',
     'common/modules/experiments/tests/hosted-zootropolis-cta',
     'common/modules/experiments/tests/hosted-article-onward-journey',
+    'common/modules/experiments/tests/hosted-gallery-cta',
     'common/modules/experiments/tests/membership-messages',
     'common/modules/experiments/tests/contributions-header',
     'common/modules/experiments/tests/ad-feedback',
@@ -37,6 +38,7 @@ define([
     RemindMeEmail,
     HostedZootropolisCta,
     HostedArticleOnwardJourney,
+    HostedGalleryCallToAction,
     MembershipMessages,
     ContributionsHeader,
     AdFeedback,
@@ -53,6 +55,7 @@ define([
         new RemindMeEmail(),
         new HostedZootropolisCta(),
         new HostedArticleOnwardJourney(),
+        new HostedGalleryCallToAction(),
         new MembershipMessages(),
         new ContributionsHeader(),
         new AdFeedback(),
@@ -132,7 +135,7 @@ define([
             isSensitive = config.page.shouldHideAdverts;
 
         return ((isSensitive ? test.showForSensitive : true)
-                && test.canRun() && !expired && isTestSwitchedOn(test));
+        && test.canRun() && !expired && isTestSwitchedOn(test));
     }
 
     function getId(test) {
@@ -266,7 +269,7 @@ define([
     function allocateUserToTest(test) {
         // Only allocate the user if the test is valid and they're not already participating.
         if (testCanBeRun(test) && !isParticipating(test)) {
-             addParticipation(test, variantIdFor(test));
+            addParticipation(test, variantIdFor(test));
         }
     }
 
@@ -282,7 +285,7 @@ define([
             try {
                 onTestComplete(recordTestComplete(test, variantId));
             } catch(err) {
-               reportError(err, false, false);
+                reportError(err, false, false);
             }
         }
     }
@@ -348,8 +351,8 @@ define([
         forceRegisterCompleteEvent: function(testId, variantId) {
             var test = getTest(testId);
             var variant = test && test.variants.filter(function (v) {
-                return v.id.toLowerCase() === variantId.toLowerCase();
-            })[0];
+                    return v.id.toLowerCase() === variantId.toLowerCase();
+                })[0];
             var onTestComplete = variant && variant.success || noop;
 
             onTestComplete(recordTestComplete(test, variantId));
@@ -397,8 +400,8 @@ define([
             return eventTag && getActiveTests().filter(function (test) {
                     var testEvents = test.events;
                     return testEvents && testEvents.some(function (testEvent) {
-                        return eventTag.indexOf(testEvent) === 0;
-                    });
+                            return eventTag.indexOf(testEvent) === 0;
+                        });
                 }).map(getId);
         },
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-gallery-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-gallery-cta.js
@@ -1,0 +1,84 @@
+define([
+    'bean',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/detect',
+    'lodash/collections/contains'
+], function (
+    bean,
+    fastdom,
+    qwery,
+    $,
+    config
+) {
+    return function () {
+        this.id = 'HostedGalleryCta';
+        this.start = '2016-08-12';
+        this.expiry = '2016-09-16';
+        this.author = 'Lydia Shepherd';
+        this.description = 'Tests which image in the gallery the call to action link is most effective on';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'People will click on the call to action more often.';
+        this.audienceCriteria = 'All users on hosted gallery pages';
+        this.dataLinkNames = 'Find more inspiration';
+        this.idealOutcome = 'People will click on the call to action link more often.';
+
+        this.canRun = function () {
+            return config.page.contentType === 'Gallery' && config.page.tones === 'Hosted' && config.page.images.length > 6;
+        };
+
+        this.variants = [
+            {
+                id: '3',
+                test: function () {
+                    config.page.ctaIndex = 2;
+                },
+                success: function (complete) {
+                    var ctaButton = qwery('.hosted-gallery__cta-link');
+                    if (ctaButton.length) {
+                        bean.on(ctaButton[0], 'click', complete);
+                    }
+                }
+            },
+            {
+                id: '4',
+                test: function () {
+                    config.page.ctaIndex = 3;
+                },
+                success: function (complete) {
+                    var ctaButton = qwery('.hosted-gallery__cta-link');
+                    if (ctaButton.length) {
+                        bean.on(ctaButton[0], 'click', complete);
+                    }
+                }
+            },
+            {
+                id: '5',
+                test: function () {
+                    config.page.ctaIndex = 4;
+                },
+                success: function (complete) {
+                    var ctaButton = qwery('.hosted-gallery__cta-link');
+                    if (ctaButton.length) {
+                        bean.on(ctaButton[0], 'click', complete);
+                    }
+                }
+            },
+            {
+                id: '6',
+                test: function () {
+                    config.page.ctaIndex = 5;
+                },
+                success: function (complete) {
+                    var ctaButton = qwery('.hosted-gallery__cta-link');
+                    if (ctaButton.length) {
+                        bean.on(ctaButton[0], 'click', complete);
+                    }
+                }
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What is the value of this and can you measure success?

We want to find out where is the most effective placement of the 'call to action' text and button. Success is getting then most clicks on the button.
### Testing galleries of varying length

We have 4 galleries, which (if you exclude the first and last slide) have between 3 and 7 possible placements for the CTA. Can we test the first, the middle and the last possible placements, even though those will be at different indices for each? Can we test placing it at 1st, 2nd and 3rd available positions, and ignore the rest of the images in the longer galleries? Do we need different tests for different length galleries? Answers on a postcard...
### Current test

At the moment, I've excluded the shorter galleries, so it only shows up on these two: 
https://www.theguardian.com/advertiser-content/visit-britain/activities
https://www.theguardian.com/advertiser-content/visit-britain/coast
and places them on either 3rd, 4th, 5th or 6th image.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/6290008/17623429/e0336bc8-6097-11e6-9cfa-d390fa0b6100.png)
