### PR TITLE
Refactor metadata of HostedVideoPages

### DIFF
--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -1,8 +1,6 @@
 package common.commercial.hosted
 
-import model.GuardianContentTypes._
-import model.{MetaData, SectionSummary}
-import play.api.libs.json.JsString
+import model.MetaData
 
 case class HostedVideoPage(
   campaign: HostedCampaign,
@@ -14,39 +12,13 @@ case class HostedVideoPage(
   facebookShareText: Option[String] = None,
   twitterShareText: Option[String] = None,
   emailSubjectText: Option[String] = None,
-  nextPage: Option[HostedPage] = None
+  nextPage: Option[HostedPage] = None,
+  metadata: MetaData
 ) extends HostedPage {
 
   val pageTitle: String  = s"Advertiser content hosted by the Guardian: ${video.title} - video"
   val title = video.title
   val imageUrl = video.posterUrl
-
-  override val metadata: MetaData = {
-    val keywordId = s"${campaign.id}/${campaign.id}"
-    val keywordName = campaign.id
-    MetaData.make(
-      id = s"commercial/advertiser-content/${campaign.id}/$pageName",
-      webTitle = pageTitle,
-      section = Some(SectionSummary.fromId(campaign.id)),
-      contentType = Video,
-      analyticsName = s"GFE:${campaign.id}:$Video:$pageName",
-      description = Some(standfirst),
-      javascriptConfigOverrides = Map(
-        "keywordIds" -> JsString(keywordId),
-        "keywords" -> JsString(keywordName),
-        "toneIds" -> JsString(toneId),
-        "tones" -> JsString(toneName)
-      ),
-      opengraphPropertiesOverrides = Map(
-        "og:url" -> pageUrl,
-        "og:title" -> pageTitle,
-        "og:description" ->
-        s"ADVERTISER CONTENT FROM ${campaign.owner.toUpperCase} HOSTED BY THE GUARDIAN | $standfirst",
-        "og:image" -> video.posterUrl,
-        "fb:app_id" -> "180444840287"
-      )
-    )
-  }
 }
 
 case class HostedVideo(

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -2,7 +2,6 @@ package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
 import conf.Configuration.site.host
-import conf.switches.Switches
 import conf.Static
 
 object LeffeHostedPages {
@@ -31,128 +30,153 @@ object LeffeHostedPages {
   )
 
   private val willardWiganPageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$willardWiganPageName"
+    val pageName = willardWiganPageName
+    val standfirst = "Leffe presents a film about micro-sculptor Willard Wigan, who slows down his own heartbeat to " +
+                     "create sculptures so tiny the eye can't see them."
     val videoTitle = "Slow Time: What is nothing?"
+    val video = HostedVideo(
+      mediaId = willardWiganPageName,
+      title = videoTitle,
+      duration = 127,
+      posterUrl = Static("images/commercial/willard-wigan_poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629WillardWigan_V3_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629WillardWigan_V3.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$willardWiganPageName",
-      pageName = willardWiganPageName,
-      standfirst = "Leffe presents a film about micro-sculptor Willard Wigan, who slows down his own heartbeat to " +
-                   "create sculptures so tiny the eye can't see them.",
-      video = HostedVideo(
-        mediaId = willardWiganPageName,
-        title = videoTitle,
-        duration = 127,
-        posterUrl = Static("images/commercial/willard-wigan_poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629WillardWigan_V3_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629WillardWigan_V3.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some("Leffe presents Slow Time: What Is Nothing? Features @willard_wigan. Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 
   private val adrienneTreebyPageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$adrienneTreebyPageName"
+    val pageName = adrienneTreebyPageName
+    val standfirst = "Leffe presents a film about charcuterie producer Adrienne E. Treeby, who uses centuries-old " +
+                     "recipe ideas to cure a delicious Leffe-infused salami."
     val videoTitle = "Slow Time: Tasting the past"
+    val video = HostedVideo(
+      mediaId = adrienneTreebyPageName,
+      title = videoTitle,
+      duration = 116,
+      posterUrl = Static("images/commercial/adrienne-treeby_poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian" +
+                  ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian" +
+                   ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian" +
+                  ".tv/interactive/mp4/1080/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian" +
+                ".tv/interactive/2016/06/29/HLS/160629AdrienneTreeby_KP-28311272_h264_mezzanine.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$adrienneTreebyPageName",
-      pageName = adrienneTreebyPageName,
-      standfirst = "Leffe presents a film about charcuterie producer Adrienne E. Treeby, who uses centuries-old recipe " +
-                   "ideas to cure a delicious Leffe-infused salami.",
-      video = HostedVideo(
-        mediaId = adrienneTreebyPageName,
-        title = videoTitle,
-        duration = 116,
-        posterUrl = Static("images/commercial/adrienne-treeby_poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian" +
-                    ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian" +
-                     ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian" +
-                    ".tv/interactive/mp4/1080/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian" +
-                  ".tv/interactive/2016/06/29/HLS/160629AdrienneTreeby_KP-28311272_h264_mezzanine.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some("Leffe presents Slow Time: Tasting The Past, feat @crownandqueue. Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 
   private val peteLawrencePageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$peteLawrencePageName"
+    val pageName = peteLawrencePageName
+    val standfirst = "Leffe presents a film featuring astronomical observer Pete Lawrence as he literally rediscovers" +
+                     " time, capturing distance light using long exposures."
     val videoTitle = "Slow Time: Capturing time"
+    val video = HostedVideo(
+      mediaId = peteLawrencePageName,
+      title = videoTitle,
+      duration = 138,
+      posterUrl = Static("images/commercial/pete-lawrence_poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629PeteLawrence_h264_mezzanine_mid" +
+                  ".ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629PeteLawrence_h264_mezzanine.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$peteLawrencePageName",
-      pageName = peteLawrencePageName,
-      standfirst = "Leffe presents a film featuring astronomical observer Pete Lawrence as he literally rediscovers " +
-                   "time, capturing distance light using long exposures.",
-      video = HostedVideo(
-        mediaId = peteLawrencePageName,
-        title = videoTitle,
-        duration = 138,
-        posterUrl = Static("images/commercial/pete-lawrence_poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629PeteLawrence_h264_mezzanine_mid" +
-                    ".ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629PeteLawrence_h264_mezzanine.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some("Leffe presents Slow Time: Capturing Time, featuring @Avertedvision. Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 
   private val susanDergesPageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$susanDergesPageName"
+    val pageName = susanDergesPageName
+    val standfirst = "Leffe presents a film about artist Susan Derges, who specialises in creating unique camera-less" +
+                     " photos using natural light and water."
     val videoTitle = "Slow Time: Still The river"
+    val video = HostedVideo(
+      mediaId = susanDergesPageName,
+      title = videoTitle,
+      duration = 146,
+      posterUrl = Static("images/commercial/susan-derges_poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629SusanDerges_h264_mezzanine-1_lo" +
+                  ".ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629SusanDerges_h264_mezzanine.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$susanDergesPageName",
-      pageName = susanDergesPageName,
-      standfirst = "Leffe presents a film about artist Susan Derges, who specialises in creating unique camera-less " +
-                   "photos using natural light and water.",
-      video = HostedVideo(
-        mediaId = susanDergesPageName,
-        title = videoTitle,
-        duration = 146,
-        posterUrl = Static("images/commercial/susan-derges_poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629SusanDerges_h264_mezzanine-1_lo" +
-                    ".ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629SusanDerges_h264_mezzanine.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some("Leffe presents Slow Time: Still The River. Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 
   private val quayBrothersPageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$quayBrothersPageName"
+    val pageName = quayBrothersPageName
+    val standfirst = "Leffe presents a film featuring influential stop-frame animators, Stephen and Timothy Quay, who" +
+                     " give an insight into their unique appreciation of time."
     val videoTitle = "Slow Time: Quay Brothers"
+    val video = HostedVideo(
+      mediaId = quayBrothersPageName,
+      title = videoTitle,
+      duration = 134,
+      posterUrl = Static("images/commercial/quay-brothers_poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629QuayBrothers_V3-3_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629QuayBrothers_V3.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$quayBrothersPageName",
-      pageName = quayBrothersPageName,
-      standfirst = "Leffe presents a film featuring influential stop-frame animators, Stephen and Timothy Quay, who " +
-                   "give an insight into their unique appreciation of time.",
-      video = HostedVideo(
-        mediaId = quayBrothersPageName,
-        title = videoTitle,
-        duration = 134,
-        posterUrl = Static("images/commercial/quay-brothers_poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629QuayBrothers_V3-3_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629QuayBrothers_V3.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some("Leffe presents Slow Time: Quay Brothers . Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 

--- a/common/app/common/commercial/hosted/hardcoded/Metadata.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Metadata.scala
@@ -1,0 +1,45 @@
+package common.commercial.hosted.hardcoded
+
+import common.commercial.hosted.{HostedCampaign, HostedVideo}
+import model.GuardianContentTypes.Video
+import model.{MetaData, SectionSummary}
+import play.api.libs.json.JsString
+
+object Metadata {
+
+  val toneId = "tone/hosted"
+  val toneName = "Hosted"
+
+  def forHardcodedHostedVideoPage(
+    campaign: HostedCampaign,
+    video: HostedVideo,
+    pageUrl: String,
+    pageName: String,
+    standfirst: String
+  ): MetaData = {
+    val campaignId = campaign.id
+    val pageTitle = s"Advertiser content hosted by the Guardian: ${video.title} - video"
+    MetaData.make(
+      id = s"commercial/advertiser-content/$campaignId/$pageName",
+      webTitle = pageTitle,
+      section = Some(SectionSummary.fromId(campaignId)),
+      contentType = Video,
+      analyticsName = s"GFE:$campaignId:$Video:$pageName",
+      description = Some(standfirst),
+      javascriptConfigOverrides = Map(
+        "keywordIds" -> JsString(s"$campaignId/$campaignId"),
+        "keywords" -> JsString(campaignId),
+        "toneIds" -> JsString(toneId),
+        "tones" -> JsString(toneName)
+      ),
+      opengraphPropertiesOverrides = Map(
+        "og:url" -> pageUrl,
+        "og:title" -> pageTitle,
+        "og:description" ->
+        s"ADVERTISER CONTENT FROM ${campaign.owner.toUpperCase} HOSTED BY THE GUARDIAN | $standfirst",
+        "og:image" -> video.posterUrl,
+        "fb:app_id" -> "180444840287"
+      )
+    )
+  }
+}

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -27,71 +27,93 @@ object RenaultHostedPages {
   )
 
   private val teaserWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser"
+    val pageName = teaserPageName
+    val standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at " +
+                     "Central St Martins are working with Renault to design the interior for cars that will drive " +
+                     "themselves. Watch this short video to find out more about the project, and visit this page " +
+                     "again soon to catch up on the students' progress"
     val videoTitle = "Designing the car of the future"
+    val video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = videoTitle,
+      duration = 86,
+      posterUrl = Static("images/commercial/renault-video-poster.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/17/HLS/160516GlabsTestSD.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
-      pageName = teaserPageName,
-      standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at Central St Martins are working with Renault to design the interior for cars that will drive themselves. Watch this short video to find out more about the project, and visit this page again soon to catch up on the students' progress",
-      video = HostedVideo(
-        mediaId = "renault-car-of-the-future",
-        title = videoTitle,
-        duration = 86,
-        posterUrl = Static("images/commercial/renault-video-poster.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/17/HLS/160516GlabsTestSD.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some(videoTitle + " Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName,  standfirst)
     )
   }
 
   private val episode1WithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1"
+    val pageName = episode1PageName
+    val standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning " +
+                     "design will be announced at Clerkenwell Design Week (and on this site). Watch this short video " +
+                     "to find out who made the shortlist"
     val videoTitle = "Renault shortlists 'car of the future' designs"
+    val video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = videoTitle,
+      duration = 160,
+      posterUrl = Static("images/commercial/renault-video-poster-ep1.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/23/HLS/160523GlabsRenaultTestHD.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
-      pageName = episode1PageName,
-      standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning design will be announced at Clerkenwell Design Week (and on this site). Watch this short video to find out who made the shortlist",
-      video = HostedVideo(
-        mediaId = "renault-car-of-the-future",
-        title = videoTitle,
-        duration = 160,
-        posterUrl = Static("images/commercial/renault-video-poster-ep1.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/23/HLS/160523GlabsRenaultTestHD.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some(videoTitle + " Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 
   private val episode2WithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2"
+    val pageName = episode2PageName
+    val standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the " +
+                     "future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may" +
+                     " have created a blueprint for tomorrow's autonomous cars"
     val videoTitle = "Is this the car of the future?"
+    val video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = videoTitle,
+      duration = 158,
+      posterUrl = Static("images/commercial/renault-video-poster-ep2.jpg"),
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/03/HLS/160603GlabsRenaultTest3.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2",
-      pageName = episode2PageName,
-      standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may have created a blueprint for tomorrow's autonomous cars",
-      video = HostedVideo(
-        mediaId = "renault-car-of-the-future",
-        title = videoTitle,
-        duration = 158,
-        posterUrl = Static("images/commercial/renault-video-poster-ep2.jpg"),
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/03/HLS/160603GlabsRenaultTest3.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
       twitterShareText = Some(videoTitle + " Watch full film: "),
-      nextPage = None
+      nextPage = None,
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -2,8 +2,6 @@ package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
 import conf.Configuration.site.host
-import conf.Static
-import conf.switches.Switches
 
 object ZootropolisHostedPages {
 
@@ -26,26 +24,36 @@ object ZootropolisHostedPages {
   )
 
   private lazy val videoPageWithoutNextPage: HostedVideoPage = {
+    val pageUrl = s"$host/advertiser-content/${campaign.id}/$videoPageName"
+    val pageName = videoPageName
+    val standfirst = "The residents of Zootropolis are leading the charge on Digital Download! " +
+                     "Don’t let the sloths slow you down – download instantly through Sky Store, " +
+                     "the fastest way to bring your favourite characters home!"
     val videoTitle = "Disney’s Zootropolis: Download and keep today!"
+    val video = HostedVideo(
+      mediaId = videoPageName,
+      title = videoTitle,
+      duration = 32,
+      posterUrl = "https://static.theguardian.com/commercial/hosted/disney-zootropolis/ZOO_1132_130_0_009_00_0091.jpg",
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_H264" +
+                  ".mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_vp8" +
+                   ".webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/07/18/160718GLZootropolisSpot_h264_mezzanine" +
+                  "-1_lo.ogv",
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/07/18/HLS/160718GLZootropolisSpot_h264_mezzanine.m3u8"
+    )
     HostedVideoPage(
       campaign,
-      pageUrl = s"$host/advertiser-content/${campaign.id}/$videoPageName",
-      pageName = videoPageName,
-      standfirst = "The residents of Zootropolis are leading the charge on Digital Download! " +
-        "Don’t let the sloths slow you down – download instantly through Sky Store, " +
-        "the fastest way to bring your favourite characters home!",
-      video = HostedVideo(
-        mediaId = videoPageName,
-        title = videoTitle,
-        duration = 32,
-        posterUrl = "https://static.theguardian.com/commercial/hosted/disney-zootropolis/ZOO_1132_130_0_009_00_0091.jpg",
-        srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_H264.mp4",
-        srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_vp8.webm",
-        srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/07/18/160718GLZootropolisSpot_h264_mezzanine-1_lo.ogv",
-        srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/07/18/HLS/160718GLZootropolisSpot_h264_mezzanine.m3u8"
-      ),
+      pageUrl,
+      pageName,
+      standfirst,
+      video,
       cta,
-      twitterShareText = Some("Get to know the residents of Zootropolis and find out where to download the film instantly")
+      twitterShareText = Some(
+        "Get to know the residents of Zootropolis and find out where to download the film instantly"
+      ),
+      metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
   }
 


### PR DESCRIPTION
This is enabling work to make it easier to start populating `HostedVideoPages` with data from capi.  It shouldn't have any effect on anything that's already in production.

/cc @lps88 @guardian/labs-beta 
