### PR TITLE
Change wording of report technical feedback page

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -28,19 +28,18 @@
                                         </ul>
                                         <p>please learn about <a href="@LinkTo{/info/2015/sep/22/making-theguardiancom-work-best-for-you}">disabling optional features on our site</a></p>
                                         <h2>Contact us</h2>
-                                        <p>Do you need a response?</p>
-                                        <p>
-                                            If not, to help our developers improve the site, send comments to
-                                            <a class="js-tech-feedback-mailto" data-link-name="tech feedback : mailto : dotcom" href="mailto:dotcom.feedback@@theguardian.com">
-                                                dotcom.feedback@@theguardian.com
-                                            </a>.<br>
-                                            <strong>We value and read all of the feedback that we receive, but we are unable to respond directly.</strong>
-                                        </p>
                                         <p>If you need help, please contact our user support desk at
                                             @* Any link with mailto userhelp will be enhanced using the Javascript *@
                                             <a data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">
                                                 userhelp@@theguardian.com
                                             </a> and someone should get back to you.
+                                        </p>
+                                        <p>
+                                            If you don't require any assistance but wish to report an issue to our developers, send comments to:
+                                            <a class="js-tech-feedback-mailto" data-link-name="tech feedback : mailto : dotcom" href="mailto:dotcom.feedback@@theguardian.com">
+                                                dotcom.feedback@@theguardian.com
+                                            </a>.<br>
+                                            <strong>We value and read all of the feedback that we receive, but we are unable to respond directly.</strong>
                                         </p>
                                         <p>Think you can fix it yourself? <a href="http://developers.theguardian.com/">Work for us</a>!</p>
                                     </div>


### PR DESCRIPTION
Changes wording of report technical feedback page to make it clearer that users should contact userhelp if they actually need a response.
## Does this affect other platforms - Amp, Apps, etc?

No.
