### PR TITLE
Add heatmap param to list allowed for local dev

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -43,7 +43,8 @@ class DevParametersHttpRequestHandler(
     "stage",
     "amp", // used in dev to request the amp version of a specific url
     "__amp_source_origin", // used by amp-live-list to enforce CORS
-    "amp_latest_update_time" // used by amp-live-list to check for latest updates
+    "amp_latest_update_time", // used by amp-live-list to check for latest updates
+    "heatmap" // used by ophan javascript to enable the heatmap
   )
 
   val commercialParams = Seq(


### PR DESCRIPTION
## What does this change?

Adds 'heatmap' to the list of locally allowed params
## What is the value of this and can you measure success?

You can test the heatmap via this method locally
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![image](https://cloud.githubusercontent.com/assets/68329/17626190/1952da86-60a4-11e6-9dc1-c91452eb7f09.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
