### PR TITLE
Remove Contributions from the Engagement banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -84,13 +84,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABMembershipAndContributionsEngagementBanner20160811 = Switch(
+  val ABMembershipEngagementBanner = Switch(
     SwitchGroup.ABTests,
-    "ab-membership-and-contributions-engagement-banner",
-    "Test effectiveness of header for driving contributions vs membership.",
+    "ab-membership-engagement-banner",
+    "Test effectiveness of header for driving membership.",
     owners = Seq(Owner.withGithub("rtyley")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 8, 17),
+    sellByDate = new LocalDate(2017, 9, 7),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-messages.js
@@ -29,18 +29,18 @@ define([
     return function () {
         var self = this;
 
-        this.id = 'MembershipAndContributionsEngagementBanner';
+        this.id = 'MembershipEngagementBanner';
         this.start = '2016-08-11';
-        this.expiry = '2016-08-17';
+        this.expiry = '2017-08-07';
         this.author = 'Roberto Tyley';
-        this.description = 'Show contributions as well as membership messages.';
+        this.description = 'Show membership messages. Sometimes used to show Contribution messages as well';
         this.showForSensitive = false;
         this.audience = 1.0;
         this.audienceOffset = 0;
-        this.successMeasure = 'Conversion for contributions';
+        this.successMeasure = 'Conversion';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'Conversion for contributions beats commercial component conversion by 3x.';
+        this.idealOutcome = '';
 
         var minVisited= 10;
 
@@ -159,24 +159,6 @@ define([
 
                         showMessageIfAsyncChecksPermit(message, data, cssModifierClass);
                     }
-                },
-                success: completer
-            },
-            {
-                id: 'contributions',
-                test: function () {
-                    var message ={
-                        campaign: 'CONTRIBUTIONS_ENGAGEMENT_BANNER',
-                            // increment the number at the end of the code to redisplay banners
-                            // to everyone who has previously closed them
-                            code: 'contributions-engagement-banner-2016-08-08',
-                        data: {
-                            messageText: 'If you use it, if you like it, why not pay for it? It\'s only fair. Contribute to the Guardian.'
-                        }
-                    };
-
-                    var data = defaults({linkHref: 'https://contribute.theguardian.com/uk?INTCMP='+message.campaign}, message.data, defaultData);
-                    showMessageIfAsyncChecksPermit(message, data, 'contributions-message');
                 },
                 success: completer
             }


### PR DESCRIPTION
_Do not merge until Tuesday midday, when 4 days of Contributions data has been collected_
## What does this change?

Partially undoes the work of #13957 - ie this makes Membership messages the only messages shown on the engagement-banner. We're intending to use the Engagement banner for Contributions again in the near future, so I haven't converted all the code back from being an AB test, just made Membership 100%.

@desbo 
