### PR TITLE
Editionalising the new header menus with JS

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -1,85 +1,287 @@
 package common
 
-sealed class TopLevelSection(val name: String)
-
-object TopLevelSection {
-  case object News extends TopLevelSection("news")
-  case object Opinion extends TopLevelSection("opinion")
-  case object Sport extends TopLevelSection("sport")
-  case object Arts extends TopLevelSection("arts")
-  case object Life extends TopLevelSection("life")
-}
-
 case class NavLink(name: String, url: String)
 
 object NewNavigation {
-  val topLevelSections = List(TopLevelSection.News, TopLevelSection.Opinion, TopLevelSection.Sport, TopLevelSection.Arts, TopLevelSection.Life)
+  val topLevelSections = List(News, Opinion, Sport, Arts, Life)
 
-  private val newsSections = List(
-    NavLink("UK", "/uk-news"),
-    NavLink("US", "/us-news"),
-    NavLink("europe", "/world/europe-news"),
-    NavLink("world", "/world"),
-    NavLink("politics", "/politics"),
-    NavLink("business", "/business"),
-    NavLink("environment", "/environment"),
-    NavLink("science", "/science"),
-    NavLink("money", "/money"),
-    NavLink("tech", "/technology")
-  )
+  trait TopLevelSection {
+    def name: String
 
-  private val opinionSections = List(
-    NavLink("columnists", "/index/contributors"),
-    NavLink("Polly Toynbee", "/profile/pollytoynbee"),
-    NavLink("Owen Jones", "/profile/owen-jones"),
-    NavLink("Charlie Brooker", "/profile/charliebrooker"),
-    NavLink("Mark Kermode", "/profile/markkermode"),
-    NavLink("Felicity Cloake", "/profile/felicity-cloake"),
-    NavLink("Yotam Ottolenghi", "/profile/yotamottolenghi")
-  )
+    def uk: List[NavLink]
+    def us: List[NavLink]
+    def au: List[NavLink]
+    def int: List[NavLink]
 
-  private val sportSections = List(
-    NavLink("football", "/football"),
-    NavLink("cricket", "/sport/cricket"),
-    NavLink("rugby union", "/sport/rugby-union"),
-    NavLink("F1", "/sport/formulaone"),
-    NavLink("tennis", "/sport/tennis"),
-    NavLink("golf", "/sport/golf"),
-    NavLink("cycling", "/sport/cycling"),
-    NavLink("boxing", "/sport/boxing"),
-    NavLink("racing", "/sport/horse-racing"),
-    NavLink("rugby league", "/sport/rugbyleague"),
-    NavLink("US sports", "/sport/us-sport")
-  )
 
-  private val artsSections = List(
-    NavLink("film", "/film"),
-    NavLink("music", "/music"),
-    NavLink("books", "/books"),
-    NavLink("classical", "/music/classicalmusicandopera"),
-    NavLink("tv & radio", "/tv-and-radio"),
-    NavLink("games", "/technology/games"),
-    NavLink("art & design", "/artanddesign"),
-    NavLink("fashion", "/fashion"),
-    NavLink("stage", "/stage")
-  )
+    def getEditionalisedNavLinks(edition: Edition) = edition match {
+      case editions.Uk => uk
+      case editions.Au => au
+      case editions.Us => us
+      case editions.International => int
+    }
+  }
 
-  private val lifeSections = List(
-    NavLink("food", "/lifeandstyle/food-and-drink"),
-    NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing"),
-    NavLink("travel", "/travel"),
-    NavLink("love & sex", "/lifeandstyle/love-and-sex"),
-    NavLink("family", "/lifeandstyle/family"),
-    NavLink("women", "/lifeandstyle/women"),
-    NavLink("home & garden", "/lifeandstyle/home-and-garden"),
-    NavLink("tech", "/technology")
-  )
+  case object News extends TopLevelSection {
+    val name = "news"
 
-  val sectionItems: Map[TopLevelSection, List[NavLink]] = Map(
-    TopLevelSection.News -> newsSections,
-    TopLevelSection.Opinion -> opinionSections,
-    TopLevelSection.Sport -> sportSections,
-    TopLevelSection.Arts -> artsSections,
-    TopLevelSection.Life -> lifeSections
-  )
+    val uk = List(
+      NavLink("headlines", "/uk"),
+      NavLink("UK", "/uk-news"),
+      NavLink("world", "/world"),
+      NavLink("environment", "/uk/environment"),
+      NavLink("business", "/uk/business"),
+      NavLink("tech", "/uk/technology"),
+      NavLink("science", "/science"),
+      NavLink("money", "/uk/money")
+    )
+
+    val au = List(
+      NavLink("headlines", "/au"),
+      NavLink("UK", "/australia-news"),
+      NavLink("world", "/world"),
+      NavLink("australian politics", "/australia-news/australian-politics"),
+      NavLink("environment", "/au/environment"),
+      NavLink("economy", "/au/business"),
+      NavLink("immigration", "/australia-news/australian-immigration-and-asylum"),
+      NavLink("indigenous australia", "/australia-news/indigenous-australians"),
+      NavLink("media", "/au/media"),
+      NavLink("tech", "/au/technology")
+    )
+
+    val us = List(
+      NavLink("headlines", "/us"),
+      NavLink("US election", "/us-news"),
+      NavLink("US", "/us-news"),
+      NavLink("world", "/world"),
+      NavLink("environment", "/us/environment"),
+      NavLink("business", "/us/business"),
+      NavLink("US politics", "/us-news/us-politics"),
+      NavLink("tech", "/us/technology"),
+      NavLink("science", "/science"),
+      NavLink("money", "/us/money")
+    )
+
+    val int =  List(
+      NavLink("headlines", "/international"),
+      NavLink("world", "/world"),
+      NavLink("UK", "/uk-news"),
+      NavLink("environment", "/uk/environment"),
+      NavLink("business", "/uk/business"),
+      NavLink("tech", "/uk/technology"),
+      NavLink("science", "/science"),
+      NavLink("cities", "/cities"),
+      NavLink("development", "/global-development")
+    )
+  }
+
+  case object Opinion extends TopLevelSection {
+    val name = "opinion"
+
+    val uk = List(
+      NavLink("opinion home", "/uk/commentisfree"),
+      NavLink("Polly Toynbee", "/profile/pollytoynbee"),
+      NavLink("Owen Jones", "/profile/owen-jones"),
+      NavLink("Marina Hyde", "/profile/marinahyde"),
+      NavLink("George Monbiot", "/profile/georgemonbiot"),
+      NavLink("Gary Younge", "/profile/garyyounge"),
+      NavLink("Nick Cohen", "/profile/nickcohen"),
+      NavLink("more columnists", "/index/contributors"),
+      NavLink("the guardian view", "/profile/editorial"),
+      NavLink("our cartoonists", "/cartoons/archive")
+    )
+
+    val au = List(
+      NavLink("opinion home", "/au/commentisfree"),
+      NavLink("first dog on the moon", "/profile/first-dog-on-the-moon"),
+      NavLink("Katharine Murphy", "/profile/katharine-murphy"),
+      NavLink("Kristina Keneally", "/profile/kristina-keneally"),
+      NavLink("Richard Ackland", "/profile/richard-ackland"),
+      NavLink("Van Badham", "/profile/van-badham"),
+      NavLink("Lenore Taylor", "/profile/lenore-taylor"),
+      NavLink("Jason Wilson", "/profile/wilson-jason"),
+      NavLink("Brigid Delaney", "/profile/brigiddelaney"),
+      NavLink("more columnists", "/index/contributors")
+    )
+
+    val us = List(
+      NavLink("opinion home", "/us/commentisfree"),
+      NavLink("Jill Abramson", "/profile/jill-abramson"),
+      NavLink("Jessica Valenti", "/commentisfree/series/jessica-valenti-column"),
+      NavLink("Steven W Thrasher", "/profile/steven-w-thrasher"),
+      NavLink("Trevor Timm", "/profile/trevor-timm"),
+      NavLink("Rebecca Carroll", "/commentisfree/series/rebecca-carroll-column"),
+      NavLink("Chelsea E Manning", "/profile/chelsea-e-manning"),
+      NavLink("more columnists", "/index/contributors")
+    )
+
+    val int =  List(
+      NavLink("opinion home", "/uk/commentisfree"),
+      NavLink("columnists", "/index/contributors"),
+      NavLink("the guardian view", "/profile/editorial"),
+      NavLink("cartoons", "/cartoons/archive")
+    )
+  }
+
+  case object Sport extends TopLevelSection {
+    val name = "sport"
+
+    val uk = List(
+      NavLink("sport home", "/uk/sport"),
+      NavLink("football", "/football"),
+      NavLink("cricket", "/sport/cricket"),
+      NavLink("rugby union", "/sport/rugby-union"),
+      NavLink("F1", "/sport/formulaone"),
+      NavLink("tennis", "/sport/tennis"),
+      NavLink("golf", "/sport/golf"),
+      NavLink("cycling", "/sport/cycling"),
+      NavLink("boxing", "/sport/boxing"),
+      NavLink("racing", "/sport/horse-racing"),
+      NavLink("rugby league", "/sport/rugbyleague"),
+      NavLink("US sports", "/sport/us-sport")
+    )
+
+    val au = List(
+      NavLink("sport home", "/au/sport"),
+      NavLink("football", "/football"),
+      NavLink("australia sport", "/au/sport"),
+      NavLink("AFL", "/sport/afl"),
+      NavLink("NRL", "/sport/nrl"),
+      NavLink("a-league", "/football/a-league"),
+      NavLink("cricket", "/sport/cricket"),
+      NavLink("rugby union", "/sport/rugby-union"),
+      NavLink("tennis", "/sport/tennis"),
+      NavLink("cycling", "/sport/cycling")
+    )
+
+    val us = List(
+      NavLink("sport home", "/us/sport"),
+      NavLink("soccer", "/football"),
+      NavLink("NFL", "/sport/nfl"),
+      NavLink("MLS", "/sport/mls"),
+      NavLink("MLB", "/sport/mlb"),
+      NavLink("NBA", "/sport/nba"),
+      NavLink("NHL", "/sport/nhl"),
+      NavLink("tennis", "/sport/tennis")
+    )
+
+    val int =  List(
+      NavLink("sport home", "/uk/sport"),
+      NavLink("football", "/football"),
+      NavLink("cricket", "/sport/cricket"),
+      NavLink("rugby union", "/sport/rugby-union"),
+      NavLink("F1", "/sport/formulaone"),
+      NavLink("tennis", "/sport/tennis"),
+      NavLink("golf", "/sport/golf"),
+      NavLink("cycling", "/sport/cycling"),
+      NavLink("boxing", "/sport/boxing"),
+      NavLink("US sports", "/sport/us-sport")
+    )
+  }
+
+  case object Arts extends TopLevelSection {
+    val name = "arts"
+
+    val uk = List(
+      NavLink("culture home", "/uk/culture"),
+      NavLink("film", "/uk/film"),
+      NavLink("tv & radio", "/tv-and-radio"),
+      NavLink("music", "/music"),
+      NavLink("games", "/technology/games"),
+      NavLink("books", "/books"),
+      NavLink("art & design", "/artanddesign"),
+      NavLink("stage", "/stage"),
+      NavLink("classical", "/music/classicalmusicandopera")
+    )
+
+    val au = List(
+      NavLink("culture home", "/au/culture"),
+      NavLink("film", "/au/film"),
+      NavLink("music", "/music"),
+      NavLink("tv & radio", "/culture/australian-television"),
+      NavLink("books", "/books"),
+      NavLink("stage", "/stage"),
+      NavLink("art & design", "/artanddesign"),
+      NavLink("games", "/technology/games")
+    )
+
+    val us = List(
+      NavLink("culture home", "/us/culture"),
+      NavLink("film", "/us/film"),
+      NavLink("tv & radio", "/tv-and-radio"),
+      NavLink("music", "/music"),
+      NavLink("art & design", "/artanddesign"),
+      NavLink("books", "/books"),
+      NavLink("stage", "/stage"),
+      NavLink("classical", "/music/classicalmusicandopera"),
+      NavLink("games", "/technology/games")
+    )
+
+    val int =List(
+      NavLink("culture home", "/uk/culture"),
+      NavLink("film", "/uk/film"),
+      NavLink("tv & radio", "/tv-and-radio"),
+      NavLink("music", "/music"),
+      NavLink("games", "/technology/games"),
+      NavLink("books", "/books"),
+      NavLink("art & design", "/artanddesign"),
+      NavLink("stage", "/stage"),
+      NavLink("classical", "/music/classicalmusicandopera")
+    )
+  }
+
+  case object Life extends TopLevelSection {
+    val name = "life"
+
+    val uk = List(
+      NavLink("lifestyle home", "/uk/lifeandstyle"),
+      NavLink("fashion", "/fashion"),
+      NavLink("food", "/lifeandstyle/food-and-drink"),
+      NavLink("travel", "/uk/travel"),
+      NavLink("love & sex", "/lifeandstyle/love-and-sex"),
+      NavLink("family", "/lifeandstyle/family"),
+      NavLink("home & garden", "/lifeandstyle/home-and-garden"),
+      NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing"),
+      NavLink("women", "/lifeandstyle/women"),
+      NavLink("tech", "/uk/technology")
+    )
+
+    val au = List(
+      NavLink("lifestyle home", "/au/lifeandstyle"),
+      NavLink("food", "/lifeandstyle/food-and-drink"),
+      NavLink("family", "/lifeandstyle/family"),
+      NavLink("love & sex", "/lifeandstyle/love-and-sex"),
+      NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing"),
+      NavLink("home & garden", "/lifeandstyle/home-and-garden"),
+      NavLink("women", "/lifeandstyle/women"),
+      NavLink("travel", "/au/travel"),
+      NavLink("fashion", "/fashion")
+    )
+
+    val us = List(
+      NavLink("lifestyle home", "/us/lifeandstyle"),
+      NavLink("fashion", "/fashion"),
+      NavLink("food", "/lifeandstyle/food-and-drink"),
+      NavLink("travel", "/us/travel"),
+      NavLink("love & sex", "/lifeandstyle/love-and-sex"),
+      NavLink("family", "/lifeandstyle/family"),
+      NavLink("home & garden", "/lifeandstyle/home-and-garden"),
+      NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing"),
+      NavLink("women", "/lifeandstyle/women"),
+      NavLink("tech", "/us/technology")
+    )
+
+    val int = List(
+      NavLink("lifestyle home", "/uk/lifeandstyle"),
+      NavLink("fashion", "/fashion"),
+      NavLink("food", "/lifeandstyle/food-and-drink"),
+      NavLink("travel", "/uk/travel"),
+      NavLink("love & sex", "/lifeandstyle/love-and-sex"),
+      NavLink("family", "/lifeandstyle/family"),
+      NavLink("home & garden", "/lifeandstyle/home-and-garden"),
+      NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing"),
+      NavLink("women", "/lifeandstyle/women"),
+      NavLink("tech", "/uk/technology")
+    )
+  }
 }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -1,8 +1,9 @@
 @()(implicit request: RequestHeader)
 
-@import common.{ NewNavigation, TopLevelSection, LinkTo }
+@import common.{ NewNavigation, LinkTo, Edition }
+@import views.support.RenderClasses
 
-@sectionList(topLevelSection: TopLevelSection) = {
+@sectionList(topLevelSection: NewNavigation.TopLevelSection) = {
     <li class="main-navigation__item navigation-border">
             <!-- TODO: Firefox -->
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name">
@@ -10,13 +11,23 @@
                 <i class="main-navigation__icon"></i>
                 @topLevelSection.name
             </summary>
-            <ul class="main-navigation__secondary navigation-group">
-                @NewNavigation.sectionItems(topLevelSection).map { sectionItem =>
-                    <li class = "navigation-group__item" >
-                        <a href="@LinkTo { sectionItem.url }">@sectionItem.name</a>
-                    </li>
-                }
-            </ul>
+
+            @Edition.all.map { edition =>
+                <ul class="@RenderClasses(Map(
+                    "is-hidden" -> (edition.id.toLowerCase != "uk") // Our default edition is UK
+                ), "main-navigation__secondary",
+                    s"main-navigation__secondary--${edition.id.toLowerCase}",
+                    "navigation-group",
+                    "js-editionlise-secondary-nav"
+                )">
+
+                    @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
+                        <li class = "navigation-group__item" >
+                            <a href="@LinkTo { sectionItem.url }">@sectionItem.name</a>
+                        </li>
+                    }
+                </ul>
+            }
         </details>
     </li>
 }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -1,7 +1,6 @@
 @()(implicit request: RequestHeader)
 
 @import common.{ NewNavigation, LinkTo, Edition }
-@import views.support.RenderClasses
 
 @sectionList(topLevelSection: NewNavigation.TopLevelSection) = {
     <li class="main-navigation__item navigation-border">
@@ -13,13 +12,11 @@
             </summary>
 
             @Edition.all.map { edition =>
-                <ul class="@RenderClasses(Map(
-                    "is-hidden" -> (edition.id.toLowerCase != "uk") // Our default edition is UK
-                ), "main-navigation__secondary",
-                    s"main-navigation__secondary--${edition.id.toLowerCase}",
-                    "navigation-group",
-                    "js-editionlise-secondary-nav"
-                )">
+                <ul class="main-navigation__secondary
+                    main-navigation__secondary--@{edition.id.toLowerCase}
+                    navigation-group
+                    js-editionlise-secondary-nav"
+                    @if(edition.id.toLowerCase != "uk") { hidden }> @* Our default edition is UK *@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                         <li class = "navigation-group__item" >

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -15,6 +15,7 @@
 }
 
 @fragments.nav.newHeaderMenu()
+
 <header class="@Atomise("New-header")" role="banner" data-link-name="global navigation: new header">
     <div class="new-header__inner gs-container">
         <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0">

--- a/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
+++ b/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
@@ -26,9 +26,9 @@ define([
                    fastdomPromise.write(function () {
 
                        if (isListCurrentEdition) {
-                           navList.classList.remove('is-hidden');
+                           navList.removeAttribute('hidden');
                        } else {
-                           navList.classList.add('is-hidden');
+                           navList.setAttribute('hidden', '');
                        }
                    });
                 });

--- a/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
+++ b/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
@@ -1,0 +1,40 @@
+define([
+    'common/utils/fastdom-promise',
+    'common/utils/$',
+    'common/utils/config'
+], function (
+    fastdomPromise,
+    $,
+    config
+) {
+
+    function editionaliseMenu() {
+        var edition = config.page.edition.toLowerCase();
+        var editionLists = $('.js-editionlise-secondary-nav');
+
+        // UK is our default edition so we don't have to change it
+        if (edition !== 'uk') {
+
+            editionLists.each(function (navList) {
+
+                fastdomPromise.read(function() {
+
+                    return navList.classList.contains('main-navigation__secondary--' + edition);
+
+                }).then(function (isListCurrentEdition) {
+
+                   fastdomPromise.write(function () {
+
+                       if (isListCurrentEdition) {
+                           navList.classList.remove('is-hidden');
+                       } else {
+                           navList.classList.add('is-hidden');
+                       }
+                   });
+                });
+            });
+        }
+    }
+
+    return editionaliseMenu();
+});

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -1,11 +1,13 @@
 define([
     'common/utils/fastdom-promise',
     'common/utils/$',
-    'common/modules/navigation/edition-picker'
+    'common/modules/navigation/edition-picker',
+    'common/modules/navigation/editionalise-menu'
 ], function (
     fastdomPromise,
     $,
-    editionPicker
+    editionPicker,
+    editionaliseMenu
 ) {
     var mainMenuId = '#main-menu';
     var html = $('html');
@@ -150,6 +152,7 @@ define([
         openTargetListOnClick();
 
         editionPicker();
+        editionaliseMenu();
     }
 
     return init;


### PR DESCRIPTION
## What does this change?

One of the goals of the new header is to remove the need to cache four versions of every page. To do this we need to move editionalisation from happening on the server, to happening in JS.

So far the new header has been designed with that in mind. This PR adds in the correct editionalised lists.
## What is the value of this and can you measure success?

Will be tested soon!
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

UK:
![image](https://cloud.githubusercontent.com/assets/8774970/17633440/399d83ec-60c5-11e6-90d2-c02e23d3fcf3.png)

US:
![image](https://cloud.githubusercontent.com/assets/8774970/17633466/58212242-60c5-11e6-95db-c6d377cd73be.png)
