### PR TITLE
Fix: wait for ads to render before measuring their geometry

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -5,7 +5,7 @@ define([
     'common/utils/fastdom-promise',
     'common/utils/config',
     'common/utils/mediator',
-    'common/modules/commercial/dfp/track-ad-load',
+    'common/modules/commercial/dfp/track-ad-render',
     'lodash/functions/memoize'
 ], function (
     qwery,
@@ -14,7 +14,7 @@ define([
     fastdom,
     config,
     mediator,
-    trackAdLoad,
+    trackAdRender,
     memoize
 ) {
     // total_hours_spent_maintaining_this = 64
@@ -150,7 +150,7 @@ define([
     var onAdsLoaded = memoize(function (rules) {
         return Promise.all(qwery('.js-ad-slot', rules.body)
             .map(function (ad) { return ad.id; })
-            .map(trackAdLoad)
+            .map(trackAdRender)
         );
     }, getFuncId);
 


### PR DESCRIPTION
Spacefinder has an option where it can wait for ads in the root element to _load_ before performing its calculations. Thing is, an ad loaded may not have geometry yet and this is what happens:

![picture 3](https://cloud.githubusercontent.com/assets/629976/17661906/edaa3130-62d9-11e6-8ebb-8eba8f6a3175.jpg)

Here, a rich link is inserted after the inline merchandising slot has been loaded—but it shouldn't. Now, this is solved if instead we want for ads to be _rendered_:

![picture 4](https://cloud.githubusercontent.com/assets/629976/17661923/09b7ec50-62da-11e6-87a2-05ef802bcad5.jpg)

cc @guardian/commercial-dev @gtrufitt 
