### PR TITLE
fixing the z-index problem for the edition picker when there is a thr…

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -204,7 +204,7 @@ $gutter-large: 55px;
     padding-top: $gs-baseline/2;
     padding-left: $gs-gutter / 2;
     width: gs-span(2);
-    z-index: 3;
+    z-index: $zindex-sticky;
 
     // Smaller size compensates for how big the word "Australia" is
     @include mq($until: $mobile-medium) {


### PR DESCRIPTION
## What does this change?

When there is a thrasher, the new header edition picker becomes hidden. This PR make the z-index higher.
## What is the value of this and can you measure success?

Makes sure people can always move onto the international edition
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/17662323/989d2c30-62dc-11e6-8964-3ed9b62e9662.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/17662314/79c55990-62dc-11e6-8732-3dcb49b309a8.png)
## Request for comment

@zeftilldeath 
