### PR TITLE
Better error message when fetching S3 object fails

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -52,6 +52,13 @@ trait S3 extends Logging {
         log.warn("not found at %s - %s" format(bucket, key))
         None
       }
+      case e: AmazonS3Exception => {
+        val errorMsg = s"Unable to fetch S3 object (key: $key)"
+        val hintMsg =   "Hint: your AWS credentials might be missing or expired. You can fetch new ones using Janus."
+        log.error(errorMsg, e)
+        println(errorMsg + " \n" + hintMsg)
+        None
+      }
       case e: Exception => {
         throw e
       }


### PR DESCRIPTION
## What does this change?

Add an error message when fetching S3 Object and hint about the most likely cause: expired AWS credentials.
## What is the value of this and can you measure success?

imho it is better than throwing the exception and filling the sbt console with lots of stack traces. The error message tells WHAT is happening and HOW to fix it.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@guardian/dotcom-platform @johnduffell @jfsoul @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
