### PR TITLE
Hide broken "more on this story" images

### DIFF
--- a/common/app/views/fragments/amp/storyPackageAmp.scala.html
+++ b/common/app/views/fragments/amp/storyPackageAmp.scala.html
@@ -18,12 +18,15 @@
 </div>
 
 @onward(content: CuratedContent) = {
-    <div class="fc-item @TrailCssClasses.toneClass(content)">
-        @if(content.properties.maybeContent.flatMap(_.trail.thumbnailPath)) {
-            <div class="fc-item__image-container">
-                <amp-img src="@content.properties.maybeContent.flatMap(_.trail.thumbnailPath)" layout="fixed" width=126 height=75></amp-img>
-            </div>
-        }
+    @defining({
+        content.properties.maybeContent.flatMap(_.trail.thumbnailPath)
+    }) { thumbnailPath =>
+        <div class="fc-item @TrailCssClasses.toneClass(content)">
+            @if(!thumbnailPath.isEmpty) {
+                <div class="fc-item__image-container">
+                    <amp-img src="@thumbnailPath" layout="fixed" width=126 height=75></amp-img>
+                </div>
+            }
         <div class="fc-item__content">
             <div class="fc-item__header">
                 <h2 class="fc-item__title">
@@ -54,5 +57,6 @@
             </aside>
         </div>
         <a href="@{host}@content.header.url" class="fc-item__link">@content.header.headline</a>
-    </div>
+        </div>
+    }
 }

--- a/common/app/views/fragments/amp/storyPackageAmp.scala.html
+++ b/common/app/views/fragments/amp/storyPackageAmp.scala.html
@@ -19,9 +19,11 @@
 
 @onward(content: CuratedContent) = {
     <div class="fc-item @TrailCssClasses.toneClass(content)">
-        <div class="fc-item__image-container">
-            <amp-img src="@content.properties.maybeContent.flatMap(_.trail.thumbnailPath)" layout="fixed" width=126 height=75></amp-img>
-        </div>
+        @if(content.properties.maybeContent.flatMap(_.trail.thumbnailPath)) {
+            <div class="fc-item__image-container">
+                <amp-img src="@content.properties.maybeContent.flatMap(_.trail.thumbnailPath)" layout="fixed" width=126 height=75></amp-img>
+            </div>
+        }
         <div class="fc-item__content">
             <div class="fc-item__header">
                 <h2 class="fc-item__title">


### PR DESCRIPTION
## What does this change?

For some articles, the thumbnail path for story package images is not being set. AMP articles on which this happens fail validation, causing them not to be returns in Google search results.

This initial fix will prevent an `<amp-img>` from being constructed without a `src` attribute in the story package template. I'll address the root cause in a separate PR.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

No images... but at least it validates

![picture 85](https://cloud.githubusercontent.com/assets/5931528/17662572/4c512b7c-62de-11e6-9d90-c96053af04cc.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
