### PR TITLE
Use 88x89 size on advertisement feature fronts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
@@ -12,6 +12,7 @@ define(function () {
 
         // guardian proprietary ad sizes
         badge:                  AdSize(140, 90),
+        merchandisingHighAdFeature: AdSize(88, 89),
         merchandisingHigh:      AdSize(88, 87),
         merchandising:          AdSize(88, 88),
         inlineMerchandising:    AdSize(88, 85),

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
@@ -61,6 +61,14 @@ define([
                 mobile: compile(adSizes.outOfPage, adSizes.merchandisingHigh, adSizes.fluid)
             }
         },
+        'merchandising-high-ad-feature': {
+            name: 'merchandising-high',
+            label: false,
+            refresh: false,
+            sizeMappings: {
+                mobile: compile(adSizes.outOfPage, adSizes.merchandisingHighAdFeature, adSizes.fluid)
+            }
+        },
         spbadge: badgeDefinition,
         adbadge: badgeDefinition,
         fobadge: badgeDefinition,

--- a/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
+++ b/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
@@ -24,7 +24,7 @@ define([
 
         var containerIndex,
             $adSlotWrapper = $.create('<div class="fc-container"></div>'),
-            $adSlot        = bonzo(createSlot('merchandising-high', 'commercial-component-high')),
+            $adSlot        = bonzo(createSlot(config.page.isAdvertisementFeature ? 'merchandising-high-ad-feature' : 'merchandising-high', 'commercial-component-high')),
             $containers    = $('.fc-container');
 
         if ($containers.length >= 2) {


### PR DESCRIPTION
Sets up everything so that ad feature fronts use 88x89 instead of 88x87 in the high-relevance merchandising slot.

cc @guardian/commercial-dev 
