### PR TITLE
Small fixes to the email lists

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -16,29 +16,30 @@ case class EmailSubscription(
 object EmailSubscription {
   def apply(emailSubscription: EmailSubscription) = emailSubscription
 }
+
 object EmailSubscriptions {
-  val theFiver = EmailSubscription(
-    "The Fiver",
-    "sport",
-    "Football",
-    "The Fiver is theguardian.com/sport's free football email. Every weekday we round up the day's news and gossip in our own belligerent, sometimes intelligent and — very occasionally — funny way. The Fiver is delivered every Monday to Friday at around 5pm — hence the name.",
-    "Weekday afternoons",
-    "218",
-    10,
-    exampleUrl = Some("https://www.theguardian.com/football/series/thefiver/latest/email")
-  )
 
-  val guardianOpinion = EmailSubscription(
-    "The best of Guardian Opinion",
-    "news",
-    "Opinion's daily email newsletter",
-    "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
-    "Weekday afternoons",
-    "2313",
-    10
-  )
-
-  def australianEmails(subscribedListIds: Iterable[String] = None) = List(
+  def newsEmails(subscribedListIds: Iterable[String] = None) = List(
+    EmailSubscription(
+      "The Guardian today - UK",
+      "news",
+      "News",
+      "Our editors' picks for the day's top news and commentary delivered to your inbox each morning.",
+      "Every day",
+      "37",
+      12,
+      subscribedTo = subscribedListIds.exists{ x => x == "37" }
+    ),
+    EmailSubscription(
+      "The Guardian today - US",
+      "news",
+      "News",
+      "Our editors' picks for the day's top news and commentary delivered to your inbox each morning.",
+      "Every day",
+      "1493",
+      11,
+      subscribedTo = subscribedListIds.exists{ x => x == "1493" }
+    ),
     EmailSubscription(
       "The Guardian today - AUS",
       "news",
@@ -48,6 +49,56 @@ object EmailSubscriptions {
       "1506",
       11,
       subscribedTo = subscribedListIds.exists{ x => x == "1506" }
+    ),
+    EmailSubscription(
+      "Media briefing",
+      "news",
+      "Media",
+      "An indispensable summary of what the papers are saying about media on your desktop before 9am. We summarise the media headlines in every newspaper from the Wall Street Journal to the Daily Star.",
+      "Weekday mornings",
+      "217",
+      7,
+      subscribedTo = subscribedListIds.exists{ x => x == "217" }
+    ),
+    EmailSubscription(
+      "Green light",
+      "news",
+      "Environment",
+      "In each weekly edition our editors highlight the most important environment stories of the week including data, opinion pieces and background guides. We'll also flag up our best video, picture galleries, podcasts, blogs and green living guides.",
+      "Every Friday",
+      "38",
+      subscribedTo = subscribedListIds.exists{ x => x == "38" },
+      exampleUrl = Some("http://www.theguardian.com/environment/series/green-light/latest/email")
+    ),
+    EmailSubscription(
+      "Lab notes",
+      "news",
+      "Science",
+      "Get a weekly round-up of the biggest stories in science, insider knowledge from our network of bloggers, and some distractingly good fun and games.",
+      "Every Friday",
+      "3701",
+      subscribedTo = subscribedListIds.exists{ x => x == "3701" },
+      exampleUrl = Some("https://www.theguardian.com/science/series/lab-notes/latest/email")
+    ),
+    EmailSubscription(
+      "Poverty matters",
+      "news",
+      "Global development",
+      "Our editors track what's happening in development with a special focus on the millennium development goals. Sign up to get all the most important debate and discussion from around the world delivered to your inbox every fortnight.",
+      "Every other Tuesday",
+      "113",
+      subscribedTo = subscribedListIds.exists{ x => x == "113" },
+      exampleUrl = Some("http://www.theguardian.com/global-development/series/poverty-matters/latest/email")
+    ),
+    EmailSubscription(
+      "The Long Read",
+      "news",
+      "The week’s Long Reads and audio features",
+      "Bringing you the latest Long Read features and podcasts, delivered to your inbox.",
+      "Every Saturday",
+      "3322",
+      0,
+      subscribedTo = subscribedListIds.exists{ x => x == "3322" }
     ),
     EmailSubscription(
       "Morning Mail",
@@ -67,31 +118,43 @@ object EmailSubscriptions {
       "Weekdays at 10am",
       "1866",
       subscribedTo = subscribedListIds.exists{ x => x == "1866" }
+    )
+  )
+
+  def sportEmails(subscribedListIds: Iterable[String] = None) = List(
+    EmailSubscription(
+      "The Fiver",
+      "sport",
+      "Football",
+      "The Fiver is theguardian.com/sport's free football email. Every weekday we round up the day's news and gossip in our own belligerent, sometimes intelligent and — very occasionally — funny way. The Fiver is delivered every Monday to Friday at around 5pm — hence the name.",
+      "Weekday afternoons",
+      "218",
+      10,
+      exampleUrl = Some("https://www.theguardian.com/football/series/thefiver/latest/email")
     ),
     EmailSubscription(
-      "First Dog on the Moon",
-      "comment",
-      "Cartoons from Guardian Australia's resident Walkley-winning cartoonist",
-      "Subscribe to First Dog on the Moon to get his cartoons straight to your inbox every time they're published",
-      "About three times a week",
-      "2635",
-      11,
-      subscribedTo = subscribedListIds.exists{ x => x == "2635" }
+      "The Breakdown",
+      "sport",
+      "Rugby Union",
+      "Sign up for our rugby union email, written by our rugby correspondent Paul Rees. Every Thursday Paul will give his thoughts on the big stories, review the latest action and provide gossip from behind the scenes in his unique and indomitable style.",
+      "Every Thursday",
+      "219",
+      subscribedTo = subscribedListIds.exists{ x => x == "219" },
+      exampleUrl = Some("http://www.theguardian.com/sport/series/breakdown/latest/email")
     ),
     EmailSubscription(
-      "Best of Guardian Opinion - Australia",
-      "comment",
-      "An evening selection of the best reads from Guardian Opinion in Australia",
-      "An evening selection of the best reads from Guardian Opinion in Australia",
-      "Daily",
-      "2976",
-      11,
-      subscribedTo = subscribedListIds.exists{ x => x == "2976" }
+      "The Spin",
+      "sport",
+      "Cricket",
+      "The Spin brings you all the latest comment and news, rumour and humour from the world of cricket every Tuesday. It promises not to use tired old cricket cliches, but it might just bowl you over.",
+      "Every Tuesday",
+      "220",
+      subscribedTo = subscribedListIds.exists{ x => x == "220" },
+      exampleUrl = Some("http://www.theguardian.com/sport/series/thespin/latest/email")
     )
   )
 
   def cultureEmails(subscribedListIds: Iterable[String] = None) = List(
-    // Culture
     EmailSubscription(
       "Sleeve notes",
       "culture",
@@ -143,87 +206,7 @@ object EmailSubscriptions {
     )
   )
 
-  def newsEmails(subscribedListIds: Iterable[String] = None) = List(
-    EmailSubscription(
-      "The Long Read",
-      "news",
-      "The week’s Long Reads and audio features",
-      "Bringing you the latest Long Read features and podcasts, delivered to your inbox.",
-      "Every Saturday",
-      "3322",
-      0,
-      subscribedTo = subscribedListIds.exists{ x => x == "3322" }
-    )
-  )
-
-  def apply(subscribedListIds: Iterable[String] = None): EmailSubscriptions = EmailSubscriptions(List(
-    // News
-    EmailSubscription(
-      "The Guardian today - UK",
-      "news",
-      "News",
-      "Our editors' picks for the day's top news and commentary delivered to your inbox each morning.",
-      "Every day",
-      "37",
-      12,
-      subscribedTo = subscribedListIds.exists{ x => x == "37" }
-    ),
-    EmailSubscription(
-      "The Guardian today - US",
-      "news",
-      "News",
-      "Our editors' picks for the day's top news and commentary delivered to your inbox each morning.",
-      "Every day",
-      "1493",
-      11,
-      subscribedTo = subscribedListIds.exists{ x => x == "1493" }
-    ),
-    guardianOpinion.copy(subscribedTo = subscribedListIds.exists{ x => x == "2313" }, theme = "news"),
-    guardianOpinion.copy(subscribedTo = subscribedListIds.exists{ x => x == "2313" }, theme = "comment"),
-    theFiver.copy(subscribedTo = subscribedListIds.exists{ x => x == "218" }, theme = "news"),
-    theFiver.copy(subscribedTo = subscribedListIds.exists{ x => x == "218" }, theme = "sport"),
-    EmailSubscription(
-      "Media briefing",
-      "news",
-      "Media",
-      "An indispensable summary of what the papers are saying about media on your desktop before 9am. We summarise the media headlines in every newspaper from the Wall Street Journal to the Daily Star.",
-      "Weekday mornings",
-      "217",
-      7,
-      subscribedTo = subscribedListIds.exists{ x => x == "217" }
-    ),
-    EmailSubscription(
-      "Green light",
-      "news",
-      "Environment",
-      "In each weekly edition our editors highlight the most important environment stories of the week including data, opinion pieces and background guides. We'll also flag up our best video, picture galleries, podcasts, blogs and green living guides.",
-      "Every Friday",
-      "38",
-      subscribedTo = subscribedListIds.exists{ x => x == "38" },
-      exampleUrl = Some("http://www.theguardian.com/environment/series/green-light/latest/email")
-    ),
-    EmailSubscription(
-      "Lab notes",
-      "news",
-      "Science",
-      "Get a weekly round-up of the biggest stories in science, insider knowledge from our network of bloggers, and some distractingly good fun and games.",
-      "Every Friday",
-      "3701",
-      subscribedTo = subscribedListIds.exists{ x => x == "3701" },
-      exampleUrl = Some("https://www.theguardian.com/science/series/lab-notes/latest/email")
-    ),
-    EmailSubscription(
-      "Poverty matters",
-      "news",
-      "Global development",
-      "Our editors track what's happening in development with a special focus on the millennium development goals. Sign up to get all the most important debate and discussion from around the world delivered to your inbox every fortnight.",
-      "Every other Tuesday",
-      "113",
-      subscribedTo = subscribedListIds.exists{ x => x == "113" },
-      exampleUrl = Some("http://www.theguardian.com/global-development/series/poverty-matters/latest/email")
-    ),
-
-    // Lifestyle
+  def lifestyleEmails(subscribedListIds: Iterable[String] = None) = List(
     EmailSubscription(
       "Zip file",
       "lifestyle",
@@ -283,28 +266,43 @@ object EmailSubscriptions {
       "Monthly",
       "248",
       subscribedTo = subscribedListIds.exists{ x => x == "248" }
-    ),
-
-    // Sport
-    EmailSubscription(
-      "The Breakdown",
-      "sport",
-      "Rugby Union",
-      "Sign up for our rugby union email, written by our rugby correspondent Paul Rees. Every Thursday Paul will give his thoughts on the big stories, review the latest action and provide gossip from behind the scenes in his unique and indomitable style.",
-      "Every Thursday",
-      "219",
-      subscribedTo = subscribedListIds.exists{ x => x == "219" },
-      exampleUrl = Some("http://www.theguardian.com/sport/series/breakdown/latest/email")
-    ),
-    EmailSubscription(
-      "The Spin",
-      "sport",
-      "Cricket",
-      "The Spin brings you all the latest comment and news, rumour and humour from the world of cricket every Tuesday. It promises not to use tired old cricket cliches, but it might just bowl you over.",
-      "Every Tuesday",
-      "220",
-      subscribedTo = subscribedListIds.exists{ x => x == "220" },
-      exampleUrl = Some("http://www.theguardian.com/sport/series/thespin/latest/email")
     )
-  ) ++ newsEmails(subscribedListIds) ++ australianEmails(subscribedListIds) ++ cultureEmails(subscribedListIds))
+  )
+
+  def commentEmails(subscribedListIds: Iterable[String] = None) = List(
+    EmailSubscription(
+      "The best of Guardian Opinion",
+      "comment",
+      "Opinion's daily email newsletter",
+      "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
+      "Weekday afternoons",
+      "2313",
+      10,
+      subscribedTo = subscribedListIds.exists{ x => x == "2313" }
+    ),
+    EmailSubscription(
+      "Best of Guardian Opinion - Australia",
+      "comment",
+      "An evening selection of the best reads from Guardian Opinion in Australia",
+      "An evening selection of the best reads from Guardian Opinion in Australia",
+      "Daily",
+      "2976",
+      11,
+      subscribedTo = subscribedListIds.exists{ x => x == "2976" }
+    ),
+    EmailSubscription(
+      "First Dog on the Moon",
+      "comment",
+      "Cartoons from Guardian Australia's resident Walkley-winning cartoonist",
+      "Subscribe to First Dog on the Moon to get his cartoons straight to your inbox every time they're published",
+      "About three times a week",
+      "2635",
+      11,
+      subscribedTo = subscribedListIds.exists{ x => x == "2635" }
+    )
+  )
+
+  def apply(subscribedListIds: Iterable[String] = None): EmailSubscriptions = EmailSubscriptions(List(
+
+  ) ++ newsEmails(subscribedListIds) ++ sportEmails(subscribedListIds) ++ cultureEmails(subscribedListIds) ++ lifestyleEmails(subscribedListIds) ++ commentEmails(subscribedListIds))
 }


### PR DESCRIPTION
## What does this change?

Changes the email preferences page (https://profile.theguardian.com/email-prefs)
- Remove the duplicate listings for **Guardian Opinion** and **The Fiver**
- **The Fiver** now only appears in the 'Sport' section (no longer also in 'News')
- **Guardian Opinion** now only appears in the 'Comment' section (no longer also in 'News')
- Move **The Guardian Today - AUS** next to the other listings of **The Guardian Today**
- Gives some sanity to the order of emails in the big, hardcoded list, so it reflects the page
## What is the value of this and can you measure success?
- Sanity! 🌷 
- Stop treating AUS emails as a addendum, instead list them next to their UK equivalent
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

Moving **The Guardian Today - AUS** to be with the other **Guardian Today** emails:

<img width="753" alt="picture 183" src="https://cloud.githubusercontent.com/assets/8607683/17664304/003d5776-62eb-11e6-92c6-773150c9dcde.png">
## Request for comment
