### PR TITLE
Add (back in) the binding for user features

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -378,7 +378,7 @@ define([
                 ['c-pinterest', modules.initPinterest],
                 ['c-save-for-later', modules.saveForLater],
                 ['c-email', modules.initEmail],
-                ['c-user-features', userFeatures.refresh]
+                ['c-user-features', userFeatures.refresh.bind(userFeatures)]
 
             ]), function (fn) {
                 fn();


### PR DESCRIPTION
[This error](https://app.getsentry.com/the-guardian/client-side-prod/issues/149327536/) was fixed in [this commit](https://github.com/guardian/frontend/commit/e04f6149ed5d84d0c7d797b2791759dd013c9ea8), but the change was accidentally removed during a merge [here](https://github.com/guardian/frontend/blob/30e8c4b7c8c0d5020d9a7e9368f2bdbfb191c780/static/src/javascripts/bootstraps/enhanced/common.js).

This adds the one-line change back in!

@regiskuckaertz @guardian/commercial-dev 
