### PR TITLE
Reset scroll position on re-ordering of menu (new-header)

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -33,7 +33,7 @@
         <!-- TODO: Provide tabbable alternative -->
     <a href="#" class="main-menu-container__overlay" aria-hidden="true"></a>
 
-    <div class="main-menu-container__menu">
+    <div class="main-menu-container__menu js-reset-scroll-on-menu">
         <ul class="main-navigation">
             @NewNavigation.topLevelSections.map { section =>
                 @sectionList(section)

--- a/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
+++ b/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
@@ -36,5 +36,5 @@ define([
         }
     }
 
-    return editionaliseMenu();
+    return editionaliseMenu;
 });

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -96,9 +96,13 @@ define([
                 if (itemId === targetListId) {
                     fastdomPromise.write(function () {
                         var parent = listItem.parentNode;
+                        var menuContainer = $('.js-reset-scroll-on-menu');
 
                         // Using flexbox to reorder lists based on what is clicked.
                         parent.style.order = '-' + index;
+
+                        // Make sure when the menu is open, the user is always scrolled to the top
+                        menuContainer[0].scrollTop = 0;
                     });
                 }
             });


### PR DESCRIPTION
## What does this change?

This sets the scroll position to '0' when you open the menu. 
## What is the value of this and can you measure success?

Much less annoying for users! They actually get to see what they want to see (if they click sports, they can now see the sports menu first)
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

Without the reset:
![scroll-position-bug](https://cloud.githubusercontent.com/assets/8774970/17665289/f5188260-62f1-11e6-84dc-d5aeb04697fd.gif)

Now:
![scroll-position-fix](https://cloud.githubusercontent.com/assets/8774970/17665300/0091c106-62f2-11e6-92ee-e9cfa7fda858.gif)
## Request for comment

@stephanfowler 
