### PR TITLE
Expose 'Recommended For You' to 10% of audience

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -3,6 +3,7 @@ define([
     'fastdom',
     'qwery',
     'common/utils/$',
+    'common/utils/storage',
     'common/utils/config',
     'common/utils/template',
     'common/views/svg',
@@ -16,6 +17,7 @@ define([
     fastdom,
     qwery,
     $,
+    storage,
     config,
     template,
     svg,
@@ -40,11 +42,19 @@ define([
 
         var $opinionSection;
         var $recommendedForYouSection;
-
+        
         this.canRun = function () {
             $opinionSection = $('#opinion');
-            return config.page.isFront && config.page.contentType === 'Network Front' && $opinionSection.length;
+            return config.page.contentType === 'Network Front' && $opinionSection.length && !hasGivenFeedback();
         };
+
+        function hasGivenFeedback() {
+            return !!storage.local.get('gu.hasGivenRecommendedForYouFeedback');
+        }
+
+        function registerFeedback() {
+            storage.local.set('gu.hasGivenRecommendedForYouFeedback', true);
+        }
 
         function insertSection(description, variant) {
             $recommendedForYouSection = $.create(template(recommendedForYouTemplate, {
@@ -66,12 +76,14 @@ define([
                                 'If enough of you like the idea, we’ll make it happen. Fingers crossed!' +
                             '</p>'
                         );
+                        registerFeedback();
                     });
                 });
 
                 $('.js-feedback-button-no', $recommendedForYouSection[0]).each(function(el) {
                     bean.on(el, 'click', function () {
                         $recommendedForYouSection.remove();
+                        registerFeedback();
                     });
                 });
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -33,8 +33,8 @@ define([
         this.expiry = '2016-09-09';
         this.author = 'Joseph Smith';
         this.description = 'Add a personalised container to fronts';
-        this.audience = 0;
-        this.audienceOffset = 0;
+        this.audience = 0.1;
+        this.audienceOffset = 0.1;
         this.successMeasure = 'Number of clicks to turn on this section';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -43,7 +43,7 @@ define([
 
         this.canRun = function () {
             $opinionSection = $('#opinion');
-            return config.page.isFront && $opinionSection.length;
+            return config.page.isFront && config.page.contentType === 'Network Front' && $opinionSection.length;
         };
 
         function insertSection(description, variant) {

--- a/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
+++ b/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
@@ -15,7 +15,7 @@
                             <div class="fc-item__container">
                                 <div class="js-feedback fc-item__content">
                                     <p><%= description %></p>
-                                    <button class="js-feedback-button js-feedback-button-yes button button--tertiary button--large button--get-started" data-link-name="<%= variant %>-get-started">Get started <%= rightArrowIcon %></button>
+                                    <button class="js-feedback-button js-feedback-button-yes button button--tertiary button--large button--get-started" data-link-name="<%= variant %>-get-started"><%= yesCta %></button>
                                     <button class="js-feedback-button js-feedback-button-no button button--tertiary button--large button--no-thanks" data-link-name="<%= variant %>-no-thanks">No thanks</button>
                                 </div>
                             </div>
@@ -44,7 +44,7 @@
                                 <div class="js-feedback fc-item__content">
                                     <h2>recommended <span class="rfy-light-blue">for&nbsp;you</span></h2>
                                     <p><%= description %></p>
-                                    <button class="js-feedback-button js-feedback-button-yes button button--tertiary button--large button--get-started" data-link-name="<%= variant %>-get-started">Get started <%= rightArrowIcon %></button>
+                                    <button class="js-feedback-button js-feedback-button-yes button button--tertiary button--large button--get-started" data-link-name="<%= variant %>-get-started"><%= yesCta %></button>
                                     <button class="js-feedback-button js-feedback-button-no button button--tertiary button--large button--no-thanks" data-link-name="<%= variant %>-no-thanks">No thanks</button>
                                 </div>
                             </div>


### PR DESCRIPTION
Expose #13965 to 10% of our audience (5% per variant).

Also:
- Don't redisplay the section after the user has given feedback
- Track attention time of this section with Ophan
- Show just on network front
- Change the CTA for the "Yes" response to "Turn On" for the user history variant (because "Get Started" implies there's something that the user will have to give some manual input, which is not the case with the user history variant)

@katebee 
