### PR TITLE
Standalone comments - part 1

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,5 +1,6 @@
 import http.CorsHttpErrorHandler
 import app.{FrontendApplicationLoader, FrontendComponents}
+import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
@@ -40,7 +41,8 @@ trait AppLifecycleComponents {
     wire[CloudWatchMetricsLifecycle],
     wire[SurgingContentAgentLifecycle],
     wire[SwitchboardLifecycle],
-    wire[CachedHealthCheckLifeCycle]
+    wire[CachedHealthCheckLifeCycle],
+    wire[DiscussionExternalAssetsLifecycle]
   )
 }
 

--- a/common/app/assets/DiscussionAssets.scala
+++ b/common/app/assets/DiscussionAssets.scala
@@ -85,7 +85,7 @@ class DiscussionExternalAssetsLifecycle (config: GuardianConfiguration, wsClient
       "DiscussionRefreshAssetsMap",
       config.discussion.frontendAssetsMapRefreshInterval
     ) {
-      refresh()
+      refresh().map(_ => ())
     }
   }
 

--- a/common/app/assets/DiscussionAssets.scala
+++ b/common/app/assets/DiscussionAssets.scala
@@ -1,0 +1,99 @@
+package assets
+
+import java.net.URI
+
+import app.LifecycleComponent
+import common.{AkkaAgent, ExecutionContexts, GuardianConfiguration, JobScheduler, Logging}
+import conf.switches.Switches
+import play.api.libs.ws.{WSClient, WSResponse}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * External assets are not hosted by frontend but referenced in an assets map
+  *
+  * This class pull the assets map regularly and translates a generic name into a full URL
+  *
+  * The map is a JSON object looking like
+  * {
+  *   "name": "js/name.min.hash.js"
+  * }
+  * The path in the object value is relative to the assets map
+  */
+class DiscussionExternalAssetsLifecycle (config: GuardianConfiguration, wsClient: WSClient, jobs: JobScheduler)
+  extends LifecycleComponent with ExecutionContexts with Logging {
+
+  def refresh(): Future[Unit] = {
+    config.discussion.frontendAssetsMap match {
+      case Some(url) if Switches.DiscussionFetchExternalAssets.isSwitchedOn =>
+        fetchAssetsMap(url, wsClient).map(
+          parseResponse(_, url).map(DiscussionAssetsMap.alter(_, URI.create(url)))
+        )
+      case Some(_) =>
+        log.info("Fetching discussion external assets is switched off")
+        Future.successful(None)
+      case None =>
+        log.warn("External discussion frontend endpoint is not configured, you might want to update `discussion.frontend.assetsMap`")
+        Future.successful(None)
+    }
+  }
+
+  private def fetchAssetsMap(url: String, wsClient: WSClient): Future[WSResponse] = {
+    wsClient.url(url)
+      .withHeaders("User-Agent" -> "GU-ExternalAssets")
+      .withRequestTimeout(4.seconds.toMillis)
+      .get()
+  }
+
+  private def parseResponse(response: WSResponse, url: String): Option[Map[String, String]] = {
+    response.status match {
+      case 200 => asMap(response, url)
+      case statusCode =>
+        log.error(s"Cannot download discussion assets map from $url with status code $statusCode")
+        None
+    }
+  }
+
+  private def asMap(response: WSResponse, url: String): Option[Map[String, String]] = {
+    Try(response.json.as[Map[String, String]]) match {
+      case Success(assetsMap) => Some(assetsMap)
+      case Failure(error) =>
+        log.error(s"Invalid JSON assets map from $url", error)
+        None
+    }
+  }
+
+
+  def start(): Unit = {
+    descheduleJobs()
+    scheduleJobs()
+    refresh()
+  }
+
+  private def scheduleJobs(): Unit = {
+    jobs.scheduleEvery(
+      "DiscussionRefreshAssetsMap",
+      config.discussion.frontendAssetsMapRefreshInterval
+    ) {
+      refresh()
+    }
+  }
+
+  private def descheduleJobs(): Unit = {
+    jobs.deschedule("DiscussionRefreshAssetsMap")
+  }
+}
+
+object DiscussionAssetsMap {
+  private lazy val agent = AkkaAgent[Map[String, String]](Map.empty)
+
+  def alter (map: Map[String, String], baseURI: URI): Future[Map[String, String]] = {
+    agent.alter(map.mapValues(value => baseURI.resolve(value).toString))
+  }
+
+  def getURL (assetName: String): String = {
+    agent.get().getOrElse(assetName, "")
+  }
+}

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -7,7 +7,7 @@ import java.util.{Properties => JavaProperties}
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.gu.cm.{PlayDefaultLogger, ClassPathConfigurationSource, FileConfigurationSource, Logger}
+import com.gu.cm.{ClassPathConfigurationSource, FileConfigurationSource, PlayDefaultLogger}
 import com.typesafe.config.ConfigException
 import conf.switches.Switches
 import conf.{Configuration, Static}
@@ -15,6 +15,7 @@ import org.apache.commons.io.IOUtils
 import play.api.Play
 
 import scala.collection.JavaConversions._
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 class BadConfigurationException(msg: String) extends RuntimeException(msg)
@@ -307,6 +308,8 @@ class GuardianConfiguration extends Logging {
     lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
     lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
+    lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
+    lazy val frontendAssetsMapRefreshInterval = 5.seconds
   }
 
   object witness {

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -3,3 +3,8 @@ package conf
 object Configuration extends common.GuardianConfiguration
 object Static extends common.Assets.Assets(Configuration.assets.path, "assets/assets.map")
 object Atomise extends common.Assets.CssMap("assets/atomic-class-map.json")
+object DiscussionAsset {
+  def apply(assetName: String):String = {
+    assets.DiscussionAssetsMap.getURL(assetName)
+  }
+}

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -14,6 +14,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABDiscussionExternalFrontend = Switch(
+    SwitchGroup.ABTests,
+    "ab-discussion-external-frontend",
+    "Standalone frontend discussion",
+    owners = Seq(Owner.withGithub("piuccio")),
+    safeState = On,
+    sellByDate = new LocalDate(2016, 9, 30),
+    exposeClientSide = true
+  )
+
   val ABHostedAutoplay = Switch(
     SwitchGroup.ABTests,
     "ab-hosted-autoplay",

--- a/common/app/conf/switches/DiscussionSwitches.scala
+++ b/common/app/conf/switches/DiscussionSwitches.scala
@@ -1,0 +1,35 @@
+package conf.switches
+
+import conf.switches.Expiry.never
+
+trait DiscussionSwitches {
+  val DiscussionAllPageSizeSwitch = Switch(
+    SwitchGroup.Discussion,
+    "discussion-all-page-size",
+    "If this is switched on then users will have the option to load all comments",
+    owners = Seq(Owner.withGithub("johnduffell")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val DiscussionAllowAnonymousRecommendsSwitch = Switch(
+    SwitchGroup.Discussion,
+    "discussion-allow-anonymous-recommends-switch",
+    "if this is switched on, comments can be recommended by signed out users",
+    owners = Seq(Owner.withGithub("NathanielBennett")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val DiscussionFetchExternalAssets = Switch(
+    SwitchGroup.Discussion,
+    "discussion-fetch-external-assets",
+    "if this is switched on, discussion external assets map is fetched regularly",
+    owners = Seq(Owner.withGithub("piuccio")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+}

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -327,27 +327,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val DiscussionAllPageSizeSwitch = Switch(
-    SwitchGroup.Feature,
-    "discussion-all-page-size",
-    "If this is switched on then users will have the option to load all comments",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-  )
-
-  val DiscussionAllowAnonymousRecommendsSwitch = Switch(
-    SwitchGroup.Feature,
-    "discussion-allow-anonymous-recommends-switch",
-    "if this is switched on, comments can be recommended by signed out users",
-    owners = Seq(Owner.withGithub("NathanielBennett")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-
-  )
-
   val MissingVideoEndcodingsJobSwitch = Switch(
     SwitchGroup.Feature,
     "check-for-missing-video-encodings",

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -25,6 +25,7 @@ object SwitchGroup {
     name = "Commercial: Labs",
     description = Some("Features of, and experiments with, branded content.")
   )
+  var Discussion = SwitchGroup("Discussion")
   val Facia = SwitchGroup("Facia")
   val Feature = SwitchGroup("Feature")
   val Identity = SwitchGroup("Identity")
@@ -160,6 +161,7 @@ with ServerSideABTestSwitches
 with FaciaSwitches
 with ABTestSwitches
 with CommercialSwitches
+with DiscussionSwitches
 with PerformanceSwitches
 with MonitoringSwitches {
 

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -32,6 +32,8 @@ window.curlConfig = {
             react:                               '@Static("javascripts/components/react/react.js")',
             'ophan/ng':                          '@{Configuration.javascript.config("ophanJsUrl")}',
             'prebid.js':                         '@Static("javascripts/vendor/prebid/0.8.1/prebid.js")',
+            'discussion-frontend-react':         '@DiscussionAsset("discussion-frontend.react.amd")',
+            'discussion-frontend-preact':        '@DiscussionAsset("discussion-frontend.preact.amd")',
 
             // plugins
             text:                                'text', // noop
@@ -61,6 +63,8 @@ window.curlConfig = {
             'googletag.js':                 '@{Configuration.javascript.config("googletagJsUrl")}',
             'ophan/ng':                     '@{Configuration.javascript.config("ophanJsUrl")}',
             'prebid.js':                    'vendor/prebid/0.8.1/prebid.js',
+            'discussion-frontend-react':    '@DiscussionAsset("discussion-frontend.react.amd")',
+            'discussion-frontend-preact':   '@DiscussionAsset("discussion-frontend.preact.amd")',
             svgs:                           '../inline-svgs',
 
             // video

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -38,6 +38,7 @@ id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.d2Uid=zHoBy6HNKsk
+discussion.frontend.assetsMap=https://s3-eu-west-1.amazonaws.com/com-gu-discussion-frontend/CODE/static/assets-v1.0.0.json
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -35,6 +35,7 @@ id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.d2Uid=zHoBy6HNKsk
+discussion.frontend.assetsMap=https://s3-eu-west-1.amazonaws.com/com-gu-discussion-frontend/CODE/static/assets-v1.0.0.json
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -35,6 +35,7 @@ id.membership.stripePublicToken=pk_live_2O6zPMHXNs2AGea4bAmq5R7Z
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen
 discussion.d2Uid=zHoBy6HNKsk
+discussion.frontend.assetsMap=https://assets.guim.co.uk/discussion/assets-v1.0.0.json
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -1,15 +1,16 @@
-import app.{LifecycleComponent, FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
+import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
+import common.DiagnosticsLifecycle
 import common.Logback.LogstashLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
-import common.DiagnosticsLifecycle
-import conf.switches.SwitchboardLifecycle
 import conf.FootballLifecycle
+import conf.switches.SwitchboardLifecycle
 import contentapi.SectionsLookUpLifecycle
 import controllers._
 import controllers.commercial._
-import controllers.commercial.magento.{ApiSandbox, AccessTokenGenerator}
+import controllers.commercial.magento.{AccessTokenGenerator, ApiSandbox}
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import dev.DevAssetsController
@@ -82,7 +83,8 @@ trait AppComponents
     wire[SwitchboardLifecycle],
     wire[FootballLifecycle],
     wire[CricketLifecycle],
-    wire[RugbyLifecycle]
+    wire[RugbyLifecycle],
+    wire[DiscussionExternalAssetsLifecycle]
   )
 
   override lazy val httpFilters = wire[DevFilters].filters

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -1,0 +1,37 @@
+define([
+    'common/utils/report-error'
+], function(
+    reportError
+) {
+    function canRun(ab, curlConfig) {
+        return (ab.isInVariant('DiscussionExternalFrontend', 'react') && curlConfig.paths['discussion-frontend-react']) ||
+            (ab.isInVariant('DiscussionExternalFrontend', 'preact') && curlConfig.paths['discussion-frontend-preact']);
+    }
+
+    function load(ab, opts) {
+        var requireVariant = ab.isInVariant('DiscussionExternalFrontend', 'react') ? 'react' : 'preact';
+        return require('discussion-frontend-' + requireVariant, function (frontend) {
+            // Preact works in a slightly different way
+            // https://github.com/developit/preact-compat/issues/145
+            if (requireVariant === 'preact') {
+                opts.element.innerHTML = '';
+            }
+            frontend(opts)
+            .then(function (emitter) {
+                emitter.on('error', function (feature, error) {
+                    reportError(error, { feature: 'discussion-' + feature }, false);
+                });
+            })
+            .catch(function (error) {
+                reportError(error, { feature: 'discussion' });
+            });
+        }, function (error) {
+            reportError(error, { feature: 'discussion' });
+        });
+    }
+
+    return {
+        canRun: canRun,
+        load: load
+    };
+});

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -8,7 +8,7 @@ define([
             (ab.isInVariant('DiscussionExternalFrontend', 'preact') && curlConfig.paths['discussion-frontend-preact']);
     }
 
-    function load(ab, opts) {
+    function load(ab, loader, opts) {
         var requireVariant = ab.isInVariant('DiscussionExternalFrontend', 'react') ? 'react' : 'preact';
         return require('discussion-frontend-' + requireVariant, function (frontend) {
             // Preact works in a slightly different way
@@ -20,6 +20,11 @@ define([
             .then(function (emitter) {
                 emitter.on('error', function (feature, error) {
                     reportError(error, { feature: 'discussion-' + feature }, false);
+                });
+                emitter.once('comment-count', function (value) {
+                    if (value === 0) {
+                        loader.setState('empty');
+                    }
                 });
             })
             .catch(function (error) {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -380,7 +380,7 @@ Loader.prototype.renderBonzoCommentCount = function() {
 
 Loader.prototype.renderCommentCount = function () {
     if (discussionFrontend.canRun(ab, window.curlConfig)) {
-        return discussionFrontend.load(ab, {
+        return discussionFrontend.load(ab, this, {
             apiHost: config.page.discussionApiUrl,
             discussionId: this.getDiscussionId(),
             element: document.querySelector('.js-discussion-comment-count').parentNode

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -16,7 +16,9 @@ define([
     'common/modules/discussion/api',
     'common/modules/discussion/comment-box',
     'common/modules/discussion/comments',
+    'common/modules/discussion/discussion-frontend',
     'common/modules/discussion/upvote',
+    'common/modules/experiments/ab',
     'common/modules/identity/api',
     'common/modules/user-prefs',
     'lodash/objects/isNumber'
@@ -38,7 +40,9 @@ define([
     DiscussionApi,
     CommentBox,
     Comments,
+    discussionFrontend,
     upvote,
+    ab,
     Id,
     userPrefs,
     isNumber
@@ -347,7 +351,7 @@ Loader.prototype.getDiscussionClosed = function() {
     return this.elem.getAttribute('data-discussion-closed') === 'true';
 };
 
-Loader.prototype.renderCommentCount = function() {
+Loader.prototype.renderBonzoCommentCount = function() {
     fetchJson('/discussion/comment-counts.json?shortUrls=' + this.getDiscussionId(), {
         mode: 'cors'
     })
@@ -372,6 +376,18 @@ Loader.prototype.renderCommentCount = function() {
         }
     }.bind(this))
     .catch(this.logError.bind(this, 'CommentCount'));
+};
+
+Loader.prototype.renderCommentCount = function () {
+    if (discussionFrontend.canRun(ab, window.curlConfig)) {
+        return discussionFrontend.load(ab, {
+            apiHost: config.page.discussionApiUrl,
+            discussionId: this.getDiscussionId(),
+            element: document.querySelector('.js-discussion-comment-count').parentNode
+        });
+    } else {
+        return this.renderBonzoCommentCount();
+    }
 };
 
 Loader.prototype.getCommentIdFromHash = function() {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -7,6 +7,7 @@ define([
     'common/modules/analytics/mvt-cookie',
     'lodash/functions/memoize',
     'lodash/utilities/noop',
+    'common/modules/experiments/tests/discussion-external-frontend',
     'common/modules/experiments/tests/live-blog-chrome-notifications-prod',
     'common/modules/experiments/tests/hosted-autoplay',
     'common/modules/experiments/tests/giraffe',
@@ -30,6 +31,7 @@ define([
     mvtCookie,
     memoize,
     noop,
+    DiscussionExternalFrontend,
     LiveBlogChromeNotificationsProd,
     HostedAutoplay,
     Giraffe,
@@ -47,6 +49,7 @@ define([
 ) {
 
     var TESTS = [
+        new DiscussionExternalFrontend(),
         new LiveBlogChromeNotificationsProd(),
         new HostedAutoplay(),
         new Giraffe(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
@@ -1,0 +1,41 @@
+define([], function () {
+    return function () {
+
+        this.id = 'DiscussionExternalFrontend';
+        this.start = '2016-08-14';
+        this.expiry = '2016-09-30';
+        this.author = 'Fabio Crisci';
+        this.description = 'Load discussion frontend from an external location';
+        this.audience = 0;
+        this.audienceOffset = 0.0;
+        this.successMeasure = '';
+        this.showForSensitive = true;
+        this.audienceCriteria = 'Modern browsers only';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return 'fetch' in window && 'Promise' in window &&
+                window.curlConfig.paths['discussion-frontend-react'] &&
+                window.curlConfig.paths['discussion-frontend-preact'];
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function () {}
+            },
+            {
+                id: 'react',
+                test: function () {},
+                success: function () {}
+            },
+            {
+                id: 'preact',
+                test: function () {},
+                success: function () {}
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

As a first step, move the comment count of discussion module into a standalone React / preact application.

Discussion frontend is [developed here](https://github.com/guardian/discussion-frontend)

This first implementation doesn't include any CSS and is behind a 0 audience multivariant test.

The variants are:
- control: keep using the old bonzo code
- react: load react ~48kb minified gzipped
- preact: load preact + compat ~9kb minified gzipped

React / preact are loaded asynchronously by `enhanced`, so they won't impact load of other features.

`dev-build` and `article` poll the discussion frontend assets map every 5 seconds and inject that value in the curl config, all this is behind a switch in case it goes banana. The A/B test is clever enough to not run if the curl config is not populated correctly (the switch is off or something else didn't work).

For the curious minds, preact doesn't work nicely in dev mode because the `proptypes` module has a UMD definition that breaks our AMD require. Works nice once minified because proptypes are stripped off. I'm working on a fix but it's not a blocker.
## What is the value of this and can you measure success?

At this point success means all versions work just fine and it's possible to deploy comments independently of frontend.
Users won't see any difference unless they opt in in a test
## Does this affect other platforms - Amp, Apps, etc?

No, it's all loaded in JS, no html change
## Screenshots

![screen shot 2016-08-15 at 16 06 20](https://cloud.githubusercontent.com/assets/680284/17668705/7b00b374-6302-11e6-8466-2f6b16bdc4e5.png)
## Request for comment

@guardian/guardian-frontend @nicl 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
## TODO
- [x] Update platform
- [x] fastly in front of discussion frontend
- [x] readme on discussion frontend
