### PR TITLE
Links should actually work  in the new header 

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -19,8 +19,8 @@
                     @if(edition.id.toLowerCase != "uk") { hidden }> @* Our default edition is UK *@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
-                        <li class = "navigation-group__item" >
-                            <a href="@LinkTo { sectionItem.url }">@sectionItem.name</a>
+                        <li class="navigation-group__item">
+                            <a href="@LinkTo { @sectionItem.url }">@sectionItem.name</a>
                         </li>
                     }
                 </ul>


### PR DESCRIPTION
## What does this change?

Makes it so that links go to the actual link, not `/section.url` 😆 
## What is the value of this and can you measure success?

People can navigate!
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@zeftilldeath 
