### PR TITLE
Prevent top banner ad overlaying header

### DIFF
--- a/static/src/stylesheets/module/_overlay.scss
+++ b/static/src/stylesheets/module/_overlay.scss
@@ -34,8 +34,7 @@
     .site-message,
     .content,
     .fc-container,
-    .l-side-margins,
-    .top-banner-ad-container {
+    .l-side-margins {
         display: none;
     }
 }


### PR DESCRIPTION
## What does this change?

This stops the ad overlay on the header when exiting from a Lightbox. 
See: https://github.com/guardian/frontend/issues/13569
## Request for comment

@regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
