### PR TITLE
Catch line id, breakpoint & UAgent values in ad feedback data.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ads/user-ad-feedback.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/user-ad-feedback.js
@@ -3,24 +3,33 @@ define([
     'qwery',
     'fastdom',
     'common/utils/fetch',
-    'common/utils/config'
+    'common/utils/config',
+    'common/utils/detect'
 ], function (
     bonzo,
     qwery,
     fastdom,
     fetch,
-    config
+    config,
+    detect
 ) {
 
-    return function recordUserAdFeedback(pagePath, adSlotId, creativeId, feedbackType) {
+    return function recordUserAdFeedback(pagePath, adSlotId, slotRenderEvent, feedbackType) {
         var feedbackUrl = 'https://j2cy9stt59.execute-api.eu-west-1.amazonaws.com/prod/adFeedback';
         var stage = config.page.isProd ? 'PROD' : 'CODE';
+        var ua = detect.getUserAgent;
+        var breakPoint = detect.getBreakpoint();
+
         var data = JSON.stringify({
             stage: stage,
             adPage: pagePath,
             adSlotId: adSlotId,
-            adCreativeId: creativeId.toString(),
-            adFeedback: feedbackType
+            adCreativeId: slotRenderEvent.creativeId.toString(),
+            adLineId: slotRenderEvent.lineItemId.toString(),
+            adFeedback: feedbackType,
+            browser: ua.browser.toString() + ua.version.toString(),
+            userAgent: window.navigator.userAgent,
+            breakPoint: breakPoint
         });
         return fetch(feedbackUrl, {
             method: 'post',

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -125,7 +125,7 @@ define([
         return applyCreativeTemplate(advert.node).then(function (isRendered) {
             return renderAdvertLabel(advert.node)
                 .then(addFeedbackDropdownToggle)
-                .then(function () { return applyFeedbackOnClickListeners(slotRenderEvent.creativeId); })
+                .then(function () { return applyFeedbackOnClickListeners(slotRenderEvent); })
                 .then(callSizeCallback)
                 .then(addRenderedClass)
                 .then(function () {
@@ -153,13 +153,13 @@ define([
                 }) : Promise.resolve();
             }
 
-            function applyFeedbackOnClickListeners(creativeId) {
+            function applyFeedbackOnClickListeners(slotRenderEvent) {
                 return isRendered ? fastdom.write(function () {
                     bonzo(qwery('[data-toggle="'+advert.node.id+'__popup--feedback"]')).each(function(el) {
                         if (!bonzo(el).hasClass('js-onclick-ready')) {
                             el.addEventListener('click', function() {
                                 if(bonzo(el).hasClass('is-active')) {
-                                    recordUserAdFeedback(window.location.pathname, advert.node.id, creativeId, 'ad-feedback-menu-opened');
+                                    recordUserAdFeedback(window.location.pathname, advert.node.id, slotRenderEvent, 'ad-feedback-menu-opened');
                                 }
                             });
                             bonzo(el).addClass('js-onclick-ready');
@@ -168,7 +168,7 @@ define([
                     bonzo(qwery('.popup__item-problem--option')).each(function(el) {
                         if (!bonzo(el).hasClass('js-onclick-ready')) {
                             el.addEventListener('click', function() {
-                                recordUserAdFeedback(window.location.pathname, el.attributes['slot'].nodeValue, creativeId, el.attributes['problem'].nodeValue);
+                                recordUserAdFeedback(window.location.pathname, el.attributes['slot'].nodeValue, slotRenderEvent, el.attributes['problem'].nodeValue);
                             });
                             bonzo(el).addClass('js-onclick-ready');
                         }


### PR DESCRIPTION
## What does this change?

Extends the data we capture with an ad feedback submission to include the line item id, user agent string (and the browser type and version we think we are serving) and the breakpoint active at the time.
## What is the value of this and can you measure success?

Enables a finer-grained focus on problematic devices / layouts / creatives.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

See https://github.com/guardian/frontend/pull/13879 (no change in appearance)
## Request for comment

@regiskuckaertz @ScottPainterGNM

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
