### PR TITLE
Fix font colour in immersive template

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -92,7 +92,7 @@
 }
 
 .content--immersive {
-    .paidfor-box--header {
+    .paidfor-box--header, .paidfor-box--text {
         color: $multimedia-support-4;
     }
 }

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -91,6 +91,12 @@
     padding-bottom: $gs-gutter / 4;
 }
 
+.content--immersive {
+    .paidfor-box--header {
+        color: $multimedia-support-4;
+    }
+}
+
 .paidfor-title {
     font-weight: 400;
     padding-bottom: .5em;

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -92,7 +92,7 @@
 }
 
 .content--immersive {
-    .paidfor-box--header, .paidfor-box--text {
+    .paidfor-box--header, .paidfor-box--text, .paidfor-meta {
         color: $multimedia-support-4;
     }
 }


### PR DESCRIPTION
This fixes `.paidfor-box--header` and `.paidfor-box--text` when they appear in immersive gallery pages.

This situation also occurs on campaign minute articles and "heroic" articles; I'm not sure if I need to exclude these. 
@regiskuckaertz What do you think?

![machines for living modernist american architecture in pictures art and design the guardian](https://cloud.githubusercontent.com/assets/445472/17670801/934334a8-630b-11e6-9a58-4d909e6f5223.png)
![witharticletext](https://cloud.githubusercontent.com/assets/445472/17670802/934561b0-630b-11e6-97a5-23de627b2f3f.png)
