### PR TITLE
Schedule jobs by duration

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -13,6 +13,7 @@ import play.api.inject.ApplicationLifecycle
 import services.EmailService
 import tools.{AssetMetricsCache, CloudWatch, LoadBalancer}
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdminLifecycle(appLifecycle: ApplicationLifecycle,
@@ -53,7 +54,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
       fastlyCloudwatchLoadJob.run()
     }
 
-    jobs.scheduleEveryNSeconds("R2PagePressJob", r2PagePressRateInSeconds) {
+    jobs.scheduleEvery("R2PagePressJob", r2PagePressRateInSeconds.seconds) {
       r2PagePressJob.run()
     }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -13,6 +13,7 @@ import model.diagnostics.CloudWatch
 import play.api.inject.ApplicationLifecycle
 
 import scala.collection.JavaConversions._
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 object SystemMetrics extends implicits.Numbers {
@@ -223,7 +224,7 @@ class CloudWatchMetricsLifecycle(
 
     // Log heap usage every 5 seconds.
     if (Configuration.environment.isProd) {
-      jobs.scheduleEveryNSeconds("LogMetricsJob", 5) {
+      jobs.scheduleEvery("LogMetricsJob", 5.seconds) {
         val heapUsed = bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
         log.info(s"heap used: ${heapUsed}Mb")
         Future.successful(())

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -182,7 +182,7 @@ class CachedHealthCheckLifeCycle(
   override def start() = {
     jobs.deschedule("HealthCheckFetch")
     if (healthCheckRequestFrequencyInSec > 0) {
-      jobs.scheduleEveryNSeconds("HealthCheckFetch", healthCheckRequestFrequencyInSec) {
+      jobs.scheduleEvery("HealthCheckFetch", healthCheckRequestFrequencyInSec.seconds) {
         healthCheckController.runChecks
       }
     }


### PR DESCRIPTION
## What does this change?

Replace `scheduleEveryNSeconds`with `scheduleEvery` which takes a `Duration`. It's more versatile than having `scheduleEveryNMinutes` and `scheduleEveryNSeconds`

I don't feel like changing all `scheduleEveryNMinutes` now, maybe in a separate PR?
## What is the value of this and can you measure success?

Kinda useless 😄 
## Does this affect other platforms - Amp, Apps, etc?

R2 press and healthcheck
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
