### PR TITLE
Do the nvm install step when nvm is already installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,10 +18,23 @@ installed() {
 }
 
 nvm_installed() {
-  if [ -d '/usr/local/Cellar/nvm' ] || [ -d "$HOME/.nvm" ]; then
+  if [ -d '/usr/local/opt/nvm' ] || [ -d "$HOME/.nvm" ]; then
     true
   else
     false
+  fi
+}
+
+nvm_available() {
+  type -t nvm > /dev/null
+}
+
+source_nvm() {
+  if ! nvm_available; then
+    [ -e "/usr/local/opt/nvm/nvm.sh" ] && source /usr/local/opt/nvm/nvm.sh
+  fi
+  if ! nvm_available; then
+    [ -e "$HOME/.nvm/nvm.sh" ] && source $HOME/.nvm/nvm.sh
   fi
 }
 
@@ -56,7 +69,7 @@ create_frontend_properties() {
     if [[ ! -d "$path" ]]; then
       mkdir "$path"
     fi
-    
+
     if linux; then
         EXTRA_STEPS+=("Sorry, can't check if your hard disk is encryped so won't download frontend.properties.  Please check (applies to both portable and Desktop machines) and download from s3://aws-frontend-store/template-frontend.properties")
     elif mac; then
@@ -66,7 +79,7 @@ create_frontend_properties() {
         aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
       fi
     fi
-    
+
   fi
 }
 
@@ -114,6 +127,11 @@ install_node() {
 
     nvm install
     EXTRA_STEPS+=("Add https://git.io/vKTnK to your .bash_profile")
+  else
+    if ! nvm_available; then
+      source_nvm
+    fi
+    nvm install
   fi
 }
 


### PR DESCRIPTION
## What does this change?

The command that installs the relevant version of node (`nvm install`) is only run just after `nvm` itself has just been installed. This changes it so that `install_node` will run `nvm install` when `nvm` in already installed.
## What is the value of this and can you measure success?

If a user already has `nvm` but has not worked on Frontend before (or when the version of node for Frontend is changed) then the developer is unlikely to have the specified version of node. By running `nvm install`, `setup.sh` will install node if necessary.
## Does this affect other platforms - Amp, Apps, etc?

No
