### PR TITLE
Use latest sbt-riffraff-artifact with new artifact format

### DIFF
--- a/dev/teamcity/dist-publish-assets-tc
+++ b/dev/teamcity/dist-publish-assets-tc
@@ -19,11 +19,6 @@ cp "static/deploy.json"      "$static_folder"
 cp -r static/hash/*          "$static_folder/packages/frontend-static"
 cp static/abtests.json       "$static_folder/packages/frontend-abtests"
 
-pushd $static_folder
-zip -r "../artifacts.zip" .
-mv ../artifacts.zip ./artifacts.zip
-popd
-
 echo "Uploading artifact and build manifest to S3"
 
 set +u
@@ -49,13 +44,8 @@ sed -e "s|<%build_number%>|$BUILD_NUMBER|" \
     -e "s|<%branch%>|$BUILD_VCS_BRANCH|" \
     static/build-template.json | tee $static_folder/build.json
 
+aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static_folder s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:static/$BUILD_NUMBER
 aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_BUILD_BUCKET --key dotcom:static/$BUILD_NUMBER/build.json  --body $static_folder/build.json
-aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_ARTIFACT_BUCKET --key dotcom:static/$BUILD_NUMBER/artifacts.zip --body $static_folder/artifacts.zip
-
-set +o xtrace
-echo "##teamcity[publishArtifacts '$static_folder/artifacts.zip => static']"
-echo "##teamcity[publishArtifacts '$static_folder/build.json => static']"
-set -o xtrace
 
 set +x
 echo "##teamcity[progressFinish 'asset publish']"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.1")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 


### PR DESCRIPTION
## What does this change?

This updates the frontend build to use the new riff-raff artifact format. The SBT build is now uses the latest `sbt-riffraff-artifact` plugin. I've also updated the custom `dotcom:static` build to use the new format. 

Whilst reviewing the custom build script I also switched the upload order so that `build.json` is uploaded last to eliminate a race condition.
## What is the value of this and can you measure success?

The plugin now uses the new Riff-Raff artifact format (see https://github.com/guardian/riff-raff/pull/311 and https://github.com/guardian/sbt-riffraff-artifact/pull/25). I expect the build to be a little faster as it no longer creates archives for all of the projects.

In addition I expect that these continuous delivery failures will stop: https://riffraff.gutools.co.uk/deployment/history?projectName=dotcom%3Astatic&status=Failed&pageSize=20&page=1
## Does this affect other platforms - Amp, Apps, etc?

No
