### PR TITLE
Fall back to trailPicture if thumbnailPath is missing

### DIFF
--- a/common/app/views/fragments/amp/storyPackageAmp.scala.html
+++ b/common/app/views/fragments/amp/storyPackageAmp.scala.html
@@ -4,6 +4,7 @@
 @import views.support.ContentOldAgeDescriber
 @import views.support.TrailCssClasses
 @import conf.Configuration.site.host
+@import views.support.{ImgSrc, Item140}
 
 <div class="fc-container__inner">
     <div class="fc-container__header__title">
@@ -18,11 +19,13 @@
 </div>
 
 @onward(content: CuratedContent) = {
-    @defining({
-        content.properties.maybeContent.flatMap(_.trail.thumbnailPath)
-    }) { thumbnailPath =>
+    @defining(
+        content.properties.maybeContent.flatMap(_.trail.thumbnailPath).getOrElse(
+            ImgSrc(content.properties.maybeContent.flatMap(_.trail.trailPicture.flatMap(_.largestImageUrl)).getOrElse(""), Item140)
+        )
+    ) { thumbnailPath =>
         <div class="fc-item @TrailCssClasses.toneClass(content)">
-            @if(!thumbnailPath.isEmpty) {
+            @if(thumbnailPath != "") {
                 <div class="fc-item__image-container">
                     <amp-img src="@thumbnailPath" layout="fixed" width=126 height=75></amp-img>
                 </div>


### PR DESCRIPTION
## What does this change?

It seems that not all articles have a thumbnail field returned by CAPI. This may happen, for instance, when the trail image does not meet the [required minimum image dimensions](https://github.com/guardian/flexible-content/blob/master/flexible-content-api/src/main/scala/com/gu/flexiblecontent/api/event/stream/model/StreamableContent.scala#L686) of 500x300.

As a fallback, this changes uses the `largestImageUrl` property on the trail picture
## Does this affect other platforms - Amp, Apps, etc?

No
