### PR TITLE
Stop appearance of secondary scroll bar

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -602,6 +602,7 @@
  */
 .ad-slot--page-skin {
     height: 0;
+    overflow: hidden;
 }
 @include mq(mobile, $until: wide) {
     .has-page-skin {


### PR DESCRIPTION
## What does this change?

adds an overflow: hidden attribute to the page skin in adslot.css to stop the appearance of the nasty second scroll bar
## What is the value of this and can you measure success?

Death to the second scroll
## Does this affect other platforms - Amp, Apps, etc?

Nopers
## Screenshots

![image](https://cloud.githubusercontent.com/assets/11922253/17699433/88a74dec-63b8-11e6-84da-efbac4516133.png)
## Request for comment

@regiskuckaertz @JonNorman 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
