### PR TITLE
Use d3 version 3.x to support epoch-charting js library

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,5 +76,5 @@ object Dependencies {
   val lodash = "org.webjars" % "lodash" % "3.9.0"
   val react = "org.webjars" % "react" % "0.13.3"
   val epoch = "org.webjars.npm" % "epoch-charting" % "0.8.4"
-  val d3 = "org.webjars.npm" % "d3" % "4.2.0"
+  val d3 = "org.webjars.npm" % "d3" % "3.5.17"
 }


### PR DESCRIPTION
A fix for the admin dashboard which uses `epoch-charting`, which specifically needs d3 `3.x`, not `4.x`. This somehow worked locally.
