### PR TITLE
Update GA click events

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -2,7 +2,7 @@
 @import common.{Edition, StringEncodings}
 @import conf.Static
 @import play.api.libs.json.Json
-@import views.support.{CamelCase, JavaScriptPage}
+@import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount}
 
 @defining(Edition(request)) { edition =>
     {
@@ -23,6 +23,13 @@
                 "hintingAuto": {
                     "kerningOn": "@Static("stylesheets/webfonts-hinting-auto-kerning-on.css")"
                 }
+            }
+        },
+        "googleAnalytics": {
+            "trackers": {
+                "editorialTest": "@{GoogleAnalyticsAccount.editorialTest.trackerName}",
+                "editorialProd": "@{GoogleAnalyticsAccount.editorialProd.trackerName}",
+                "editorial": "@{GoogleAnalyticsAccount.editorialTracker.trackerName}"
             }
         }
     }

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -1,6 +1,5 @@
 @(page: model.Page)
 @import views.support.GoogleAnalyticsAccount
-@import conf.Configuration
 
 <script id='google_analytics'>
 
@@ -27,7 +26,9 @@
     * Code that is customised by us                                                        *
     ***************************************************************************************@
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest, GoogleAnalyticsAccount.headerBidding)) {
-        ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName');
+        ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
+            'sampleRate': @{ if (Play.isDev) 100 else tracker.samplePercentage }
+        });
     }
 
     @for(trackerName <- Seq(GoogleAnalyticsAccount.editorialProd.trackerName, GoogleAnalyticsAccount.editorialTest.trackerName)) {

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -4,15 +4,20 @@ import conf.Configuration.environment
 
 object GoogleAnalyticsAccount {
 
-  case class Tracker(trackingId: String, trackerName: String)
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")
 
-  // The "Guardian Test" property in the "Guardian Test" account.
-  // I recommend using this until you're sure your GA events are working as intended,
-  // to avoid polling the production GA property with incorrect data.
-  val editorialTest = Tracker("UA-33592456-1", "guardianTestPropertyTracker")
+  /*
+  The "Guardian Test" property in the "Guardian Test" account.
+  I recommend using this until you're sure your GA events are working as intended,
+  to avoid polling the production GA property with incorrect data.
+
+  Sample rate is set to 5% so we don't send too many events to the test tracker.
+  Sending too many events risks bumping us into a higher tier and costing us money.
+  */
+  val editorialTest = Tracker("UA-33592456-1", "guardianTestPropertyTracker", 5)
 
   // Dedicated property just for header bidding events
   val headerBidding = Tracker("UA-78705427-6", "headerBiddingPropertyTracker")

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -1,5 +1,11 @@
-define([], function () {
+define([
+    'common/utils/config'
+], function (
+    config
+) {
     var ga = window.ga;
+    var trackerName = config.googleAnalytics.trackers.editorial;
+    var send = trackerName + '.send';
 
     function extractLinkText(el) {
         var text;
@@ -10,20 +16,20 @@ define([], function () {
     }
 
     function trackNonClickInteraction(actionName) {
-        ga('guardianTestPropertyTracker.send', 'event', 'Interaction', actionName, {
+        ga(send, 'event', 'Interaction', actionName, {
             nonInteraction: true // to avoid affecting bounce rate
         });
     }
 
     function trackSamePageLinkClick(target, tag) {
-        ga('guardianTestPropertyTracker.send', 'event', 'Click', 'In Page', tag, {
+        ga(send, 'event', 'Click', 'In Page', tag, {
             nonInteraction: true, // to avoid affecting bounce rate
             dimension13: extractLinkText(target)
         });
     }
 
     function trackExternalLinkClick(target, tag) {
-        ga('guardianTestPropertyTracker.send', 'event', 'Click', 'External', tag, {
+        ga(send, 'event', 'Click', 'External', tag, {
             dimension13: extractLinkText(target)
         });
     }


### PR DESCRIPTION
## What does this change?
- Send click events (in-page/internal/external link clicks) to the correct GA property: the prod one in prod, the test one in test
- Apply sampling to the test GA tracker (except in dev mode), so people can test new types of events in prod without sending huge numbers of events to the test tracker. This means we can upgrade the test tracker to a premium property, giving better parity with the prod property, without worrying about blowing our server call quota.
## What is the value of this and can you measure success?

Send click events to the correct GA property
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@dominickendrick @ajosephides 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
