### PR TITLE
Implement details element polyfill for new navigation

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -2,7 +2,8 @@ define([
     'common/utils/fastdom-promise',
     'common/utils/$',
     'common/modules/navigation/edition-picker',
-    'common/modules/navigation/editionalise-menu'
+    'common/modules/navigation/editionalise-menu',
+    'common/utils/details-polyfill'
 ], function (
     fastdomPromise,
     $,

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -8,7 +8,8 @@ define([
     fastdomPromise,
     $,
     editionPicker,
-    editionaliseMenu
+    editionaliseMenu,
+    detailsPolyfill
 ) {
     var mainMenuId = '#main-menu';
     var html = $('html');
@@ -122,7 +123,7 @@ define([
                 }).then(function (id) {
                     var menuToOpen = $('#' + id);
 
-                       fastdomPromise.write(function () {
+                    fastdomPromise.write(function () {
                         menuToOpen.attr('open', '');
                         return id;
                     }).then(moveTargetListToTop.bind(id));
@@ -133,7 +134,6 @@ define([
 
     function bindPrimaryItemClickEvents() {
         primaryItems.each(function (item) {
-
             item.addEventListener('click', closeAllOtherPrimaryLists.bind(null, item));
         });
     }
@@ -150,6 +150,8 @@ define([
     }
 
     function init() {
+        detailsPolyfill.init('.main-navigation__item__button');
+
         window.addEventListener('hashchange', handleHashChange);
         handleHashChange();
 

--- a/static/src/javascripts/projects/common/utils/details-polyfill.js
+++ b/static/src/javascripts/projects/common/utils/details-polyfill.js
@@ -1,0 +1,43 @@
+define([
+    'common/utils/fastdom-promise'
+], function (fastdomPromise) {
+    var shouldWePolyfill = !('open' in document.createElement('details'));
+
+    function onClick(event) {
+        var details = event.target.parentNode;
+
+        if (details.hasAttribute('open')) {
+            fastdomPromise.write(function () {
+                details.removeAttribute('open');
+            });
+        } else {
+            fastdomPromise.write(function () {
+                details.setAttribute('open', '');
+            });
+        }
+    }
+
+    function bindEvents() {
+        document.addEventListener('click', function(event) {
+            if (event.target.tagName.toLowerCase() === 'summary') {
+                onClick(event);
+            }
+        });
+    }
+
+    function appendCss() {
+        if(document.querySelector('#details-polyfill-css') === null) {
+            var style = document.createElement('style');
+
+            style.id = 'details-polyfill-css';
+            style.textContent = 'details:not([open]) > *:not(summary) { display: none; }';
+
+            document.head.insertBefore(style, document.head.firstChild);
+        }
+    }
+
+    if(shouldWePolyfill) {
+        bindEvents();
+        appendCss();
+    }
+});


### PR DESCRIPTION
## What does this change?

The `<details>` element is not supported in Internet Explorer and older Firefox versions. This change introduces a JavaScript-based polyfill.
## Does this affect other platforms - Amp, Apps, etc?

No
