### PR TITLE
Add static/assets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ developer.properties
 static/hash
 static/target
 static/riffraff
+static/abtests.json
 
 static/src/stylesheets/icons/*
 


### PR DESCRIPTION
Add `static/assets.json` to `.gitignore`. This is generated by some of the scripts under `dev/teamcity` - which are not usually run by devs, but none the less we should ensure it is never checked in.
