### PR TITLE
Hosted video pages - capi driven css

### DIFF
--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -1,7 +1,7 @@
 @(pageCssClass: String, brandCssClass: String, logoUrl: String, owner: String, logoLink: String)
     <div class="hosted__header @pageCssClass">
         <div class="hosted__headerwrap js-hosted-headerwrap">
-            <div class="hostedbadge hostedbadge--shouldscale hosted-tone-bg--@brandCssClass">
+            <div class="hostedbadge hostedbadge--shouldscale hosted-tone-bg--@brandCssClass hosted-tone-bg">
                 <p class="hostedbadge__info">Advertiser content</p>
                 <a href="@{logoLink}" data-link-name="hosted-logo-top-left" target="_blank">
                     <img class="hostedbadge__logo" src="@{logoUrl}" alt="logo @{owner}"/>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -44,27 +44,10 @@
     .hosted-page ~ .survey-overlay-simple .survey-text__header {
         background-color: @{page.campaign.brandColour};
     }
-
-    @if(page.campaign.brightFont) {
-        .hosted-tone-btn,
-        .hostedbadge.hosted-tone-bg .hostedbadge__info,
-        .hosted-page ~ .survey-overlay-simple .survey-text__header {
-            color: #ffffff;
-        }
-
-        .hosted-tone-btn svg,
-        .hosted-page ~ .survey-overlay-simple .survey-text__header .site-message__close-btn .inline-cross {
-            fill: #ffffff;
-        }
-
-        .hosted-page ~ .survey-overlay-simple .survey-text__header .site-message__close-btn {
-            border-color: #ffffff;
-        }
-    }
     </style>
     <!--<![endif]-->
-    @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
-    <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass}">
+    @guardianHostedHeader(if(page.campaign.brightFont) "hosted-video-page hosted-page--bright" else "hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
+    <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass} @if(page.campaign.brightFont) {hosted-page--bright}">
         <section class="hosted-tone--dark">
             <div class="host hosted__container--full">
                 <div class="u-responsive-ratio u-responsive-ratio--hd">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -5,6 +5,17 @@
 @import views.html.hosted.guardianHostedCta
 
 @main(page, Some("commercial")) { } {
+    <!--[if (gt IE 9)|(IEMobile)]><!-->
+    <style>
+    .hosted-ton {
+        color: page.campaign.mainColour;
+    }
+
+    .hosted-tone-bg {
+        background-color: page.campaign.mainColour;
+    }
+    </style>
+    <!--<![endif]-->
     @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
     <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass}">
         <section class="hosted-tone--dark">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -7,12 +7,41 @@
 @main(page, Some("commercial")) { } {
     <!--[if (gt IE 9)|(IEMobile)]><!-->
     <style>
-    .hosted-ton {
-        color: page.campaign.mainColour;
+    .hosted-tone {
+        color: @{page.campaign.brandColour};
     }
 
     .hosted-tone-bg {
-        background-color: page.campaign.mainColour;
+        background-color: @{page.campaign.brandColour};
+    }
+
+    .hosted-tone-btn:focus,
+    .hosted-tone-btn:hover {
+        background-color: @{page.campaign.brandColour};
+        border-color: @{page.campaign.brandColour};
+    }
+
+    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__poster-timer,
+    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__tile {
+        background-color: @{page.campaign.brandColour};
+    }
+
+    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__video,
+    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__next-in-series {
+        border-top: 1px solid @{page.campaign.brandColour};
+    }
+
+    .hosted-page .hosted__next-video .hosted__next-video--tile {
+        border-top-color: @{page.campaign.brandColour};
+        background: @{page.campaign.brandColour};
+    }
+
+    .hosted-page .hosted__link {
+        color: @{page.campaign.brandColour};
+    }
+
+    .hosted-page.survey-overlay-simple .survey-text__header {
+        background-color: @{page.campaign.brandColour};
     }
     </style>
     <!--<![endif]-->

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -22,17 +22,17 @@
         border-color: @{page.campaign.brandColour};
     }
 
-    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__poster-timer,
-    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__tile {
+    .hosted-page .hosted-next-autoplay__poster-timer,
+    .hosted-page .hosted-next-autoplay__tile {
         background-color: @{page.campaign.brandColour};
     }
 
-    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__video,
-    .hosted-page .hosted-next-autoplay .hosted-next-autoplay__next-in-series {
+    .hosted-page .hosted-next-autoplay__video,
+    .hosted-page .hosted-next-autoplay__next-in-series {
         border-top: 1px solid @{page.campaign.brandColour};
     }
 
-    .hosted-page .hosted__next-video .hosted__next-video--tile {
+    .hosted-page .hosted__next-video--tile {
         border-top-color: @{page.campaign.brandColour};
         background: rgba(@{page.campaign.brandColour}, 0.5); /* TODO transform hex into rgb in js */
     }

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -15,6 +15,7 @@
         background-color: @{page.campaign.brandColour};
     }
 
+    .hosted-tone-btn,
     .hosted-tone-btn:focus,
     .hosted-tone-btn:hover {
         background-color: @{page.campaign.brandColour};
@@ -33,15 +34,32 @@
 
     .hosted-page .hosted__next-video .hosted__next-video--tile {
         border-top-color: @{page.campaign.brandColour};
-        background: @{page.campaign.brandColour};
+        background: rgba(@{page.campaign.brandColour}, 0.5); /* TODO transform hex into rgb in js */
     }
 
     .hosted-page .hosted__link {
         color: @{page.campaign.brandColour};
     }
 
-    .hosted-page.survey-overlay-simple .survey-text__header {
+    .hosted-page ~ .survey-overlay-simple .survey-text__header {
         background-color: @{page.campaign.brandColour};
+    }
+
+    @if(page.campaign.brightFont) {
+        .hosted-tone-btn,
+        .hostedbadge.hosted-tone-bg .hostedbadge__info,
+        .hosted-page ~ .survey-overlay-simple .survey-text__header {
+            color: #ffffff;
+        }
+
+        .hosted-tone-btn svg,
+        .hosted-page ~ .survey-overlay-simple .survey-text__header .site-message__close-btn .inline-cross {
+            fill: #ffffff;
+        }
+
+        .hosted-page ~ .survey-overlay-simple .survey-text__header .site-message__close-btn {
+            border-color: #ffffff;
+        }
     }
     </style>
     <!--<![endif]-->

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -22,8 +22,8 @@ trait HostedPage extends StandalonePage {
   final val toneId = "tone/hosted"
   final val toneName = "Hosted"
 
-  val brandColourCssClass = s"hosted-tone--${campaign.cssClass}"
-  val brandBackgroundCssClass = s"hosted-tone-bg--${campaign.cssClass}"
+  val brandColourCssClass = s"hosted-tone--${campaign.cssClass} hosted-tone"
+  val brandBackgroundCssClass = s"hosted-tone-bg--${campaign.cssClass} hosted-tone-bg"
   val brandBorderCssClass = s"hosted-tone-border--${campaign.cssClass}"
   val brandBtnCssClass = s"hosted-tone-btn--${campaign.cssClass}"
 

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -35,7 +35,7 @@ case class HostedCampaign(
   owner: String,
   logo: HostedLogo,
   cssClass: String,
-  mainColour: String,
+  brandColour: String,
   // todo: this will come through from capi once worked out how it's going to be used
   secondaryColour: Option[String] = None,
   logoLink: Option[String] = None

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -24,8 +24,8 @@ trait HostedPage extends StandalonePage {
 
   val brandColourCssClass = s"hosted-tone--${campaign.cssClass} hosted-tone"
   val brandBackgroundCssClass = s"hosted-tone-bg--${campaign.cssClass} hosted-tone-bg"
-  val brandBorderCssClass = s"hosted-tone-border--${campaign.cssClass}"
-  val brandBtnCssClass = s"hosted-tone-btn--${campaign.cssClass}"
+  val brandBorderCssClass = s"hosted-tone-border--${campaign.cssClass} hosted-tone-border"
+  val brandBtnCssClass = s"hosted-tone-btn--${campaign.cssClass} hosted-tone-btn"
 
 }
 
@@ -36,8 +36,7 @@ case class HostedCampaign(
   logo: HostedLogo,
   cssClass: String,
   brandColour: String,
-  // todo: this will come through from capi once worked out how it's going to be used
-  secondaryColour: Option[String] = None,
+  brightFont: Boolean,
   logoLink: Option[String] = None
 )
 

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -82,7 +82,7 @@ object HostedVideoPage extends Logging {
           ),
           // todo: standardise css so that only colour varies
           cssClass = "renault",
-          mainColour = hostedTag.paidContentCampaignColour getOrElse "",
+          brandColour = hostedTag.paidContentCampaignColour getOrElse "",
           logoLink = None
         ),
         pageUrl,

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -80,9 +80,9 @@ object HostedVideoPage extends Logging {
           logo = HostedLogo(
             url = sponsorship.sponsorLogo
           ),
-          // todo: standardise css so that only colour varies
           cssClass = "renault",
           brandColour = hostedTag.paidContentCampaignColour getOrElse "",
+          brightFont = false, //TODO correctly from the hostedTag?
           logoLink = None
         ),
         pageUrl,

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -13,6 +13,7 @@ object Formula1HostedPages {
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg"),
     cssClass = "f1-singapore",
     brandColour = "#063666",
+    brightFont = true,
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -12,7 +12,7 @@ object Formula1HostedPages {
     owner = "First Stop Singapore",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg"),
     cssClass = "f1-singapore",
-    mainColour = "#063666",
+    brandColour = "#063666",
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
+++ b/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
@@ -64,6 +64,7 @@ object HostedGalleryTestPage {
       logo = HostedLogo("https://static.theguardian.com/commercial/hosted/gallery-prototype/omgb.png"),
       cssClass = "test",
       brandColour = "#2ec869",
+      brightFont = true,
       logoLink = None
     ),
     images = demoImages,

--- a/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
+++ b/common/app/common/commercial/hosted/hardcoded/HostedGalleryTestPage.scala
@@ -63,7 +63,7 @@ object HostedGalleryTestPage {
       owner = "test",
       logo = HostedLogo("https://static.theguardian.com/commercial/hosted/gallery-prototype/omgb.png"),
       cssClass = "test",
-      mainColour = "#2ec869",
+      brandColour = "#2ec869",
       logoLink = None
     ),
     images = demoImages,

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -18,7 +18,7 @@ object LeffeHostedPages {
     owner = "Leffe",
     logo = HostedLogo(Static("images/commercial/leffe.jpg")),
     cssClass = "leffe",
-    mainColour = "#dec190",
+    brandColour = "#dec190",
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -19,6 +19,7 @@ object LeffeHostedPages {
     logo = HostedLogo(Static("images/commercial/leffe.jpg")),
     cssClass = "leffe",
     brandColour = "#dec190",
+    brightFont = false,
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -16,7 +16,7 @@ object RenaultHostedPages {
     owner = "Renault",
     logo = HostedLogo(Static("images/commercial/logo_renault.jpg")),
     cssClass = "renault",
-    mainColour = "#ffc421",
+    brandColour = "#ffc421",
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -17,6 +17,7 @@ object RenaultHostedPages {
     logo = HostedLogo(Static("images/commercial/logo_renault.jpg")),
     cssClass = "renault",
     brandColour = "#ffc421",
+    brightFont = false,
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -16,7 +16,7 @@ object VisitBritainHostedPages {
     owner = "OMGB",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg"),
     cssClass = "visit-britain",
-    mainColour = "#e41f13",
+    brandColour = "#e41f13",
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -17,6 +17,7 @@ object VisitBritainHostedPages {
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg"),
     cssClass = "visit-britain",
     brandColour = "#e41f13",
+    brightFont = true,
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -14,6 +14,7 @@ object ZootropolisHostedPages {
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis-logo.jpg"),
     cssClass = "zootropolis",
     brandColour = "#2ec869",
+    brightFont = true,
     logoLink = None
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -13,7 +13,7 @@ object ZootropolisHostedPages {
     owner = "Disney",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis-logo.jpg"),
     cssClass = "zootropolis",
-    mainColour = "#2ec869",
+    brandColour = "#2ec869",
     logoLink = None
   )
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-colours.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-colours.scss
@@ -203,9 +203,9 @@ $singaporef1SecondColour: #f0a93f;
     &:hover {
         background-color: $zootropolisColor;
         border-color: $zootropolisColor;
-        color: #ffffff;
+        color: #ffffff; //contrast related
         svg {
-            fill: #ffffff;
+            fill: #ffffff; //contrast related
         }
     }
 }
@@ -219,7 +219,7 @@ $singaporef1SecondColour: #f0a93f;
 
 .hostedbadge.hosted-tone-bg--zootropolis {
     .hostedbadge__info {
-        color: #ffffff;
+        color: #ffffff; //contrast related
     }
 }
 
@@ -230,13 +230,13 @@ $singaporef1SecondColour: #f0a93f;
     ~ .survey-overlay-simple {
         .survey-text__header {
             background-color: $zootropolisColor;
-            color: #ffffff;
+            color: #ffffff; //contrast related
 
             .site-message__close-btn {
-                border-color: #ffffff;
+                border-color: #ffffff; //contrast related
 
                 .inline-cross {
-                    fill: #ffffff;
+                    fill: #ffffff; //contrast related
                 }
             }
         }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -151,6 +151,39 @@ $hosted-video-height: 540px;
     display: none;
 }
 
+.hosted-page--bright {
+    .hosted-tone-btn {
+        &,
+        &:focus,
+        &:hover {
+            color: #ffffff;
+            svg {
+                fill: #ffffff;
+            }
+        }
+    }
+
+    .hostedbadge.hosted-tone-bg {
+        .hostedbadge__info {
+            color: #ffffff;
+        }
+    }
+
+    ~ .survey-overlay-simple {
+        .survey-text__header {
+            color: #ffffff;
+
+            .site-message__close-btn {
+                border-color: #ffffff;
+
+                .inline-cross {
+                    fill: #ffffff;
+                }
+            }
+        }
+    }
+}
+
 .hosted__glogo {
     display: inline-block;
     padding: 4px $gs-gutter / 2;


### PR DESCRIPTION
## What does this change?

This is the follow up to what @kelvin-chappell did in the https://github.com/guardian/frontend/pull/13988. Hosted pages (right now only video) will have brand specific styles taken from capi (brand colour and font theme - black or white). The idea is to declare those styles on top of the hosted template and in the future remove the whole `_hosted-colours.scss` file together with brand specific class names in the templates (eg `hostedbadge.hosted-tone-bg--f1-singapore`).
## What is the value of this and can you measure success?

Two values: brand colour and font theme will be specified in composer and based on the capi, proper css rules will be generated in templates.
## Does this affect other platforms - Amp, Apps, etc?

Not yet.
## Screenshots

<img width="863" alt="screen shot 2016-08-16 at 17 32 42" src="https://cloud.githubusercontent.com/assets/489567/17707260/7a0a616a-63d7-11e6-8fef-56ee51b9709a.png">
## Request for comment

@kelvin-chappell @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
