### PR TITLE
Hosted Gallery - loading optimisation

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
@@ -392,6 +392,7 @@ define([
         fastdom.write(function () {
             $header.css('width', imageWidth);
             $footer.css('margin', '0 ' + leftRight);
+            $footer.css('width', 'auto');
             $progress.css('right', leftRight);
             bonzo($ctaFloat).css('left', leftRight);
             bonzo($ojFloat).css('left', leftRight);

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -329,8 +329,13 @@
     height: calc(100% - 58px);
 }
 
+$headerHeight: 58px;
+$footerHeight: 46px;
+$approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
+
 .hosted-gallery-page {
     .hosted__headerwrap {
+        width: $approxGalleryWidth;
         max-width: 100%;
     }
     .hosted__social.host__header {
@@ -546,6 +551,8 @@ $progressColor: #ffffff;
     background: $neutral-1;
     z-index: 1;
     position: relative;
+    width: $approxGalleryWidth;
+    margin: auto;
     @include mq($until: desktop) {
         padding: 0;
     }


### PR DESCRIPTION
## What does this change?

Use some funky css to approximate the width of the gallery before the js has loaded.
## What is the value of this and can you measure success?

At the moment, while the page loads the header and footer elements sit at the far edges of the screen, then jump inwards to align to the image edges, which is a bit jarring.

Now, they should start quite close to their eventual (calculated by js) position, making it feel smoother!

NB: only works where vh & calc are supported, but is only an optimisation so not too worried
## Screenshots

Previous starting position of the header/footer:
![image](https://cloud.githubusercontent.com/assets/6290008/17740004/ed4f941c-648e-11e6-8ae0-1b48e4058142.png)

Now:
![image](https://cloud.githubusercontent.com/assets/6290008/17740032/017304b0-648f-11e6-8426-4fad686f55fa.png)
## Request for comment

@guardian/labs-beta 
