### PR TITLE
Commercial: add resize message

### DIFF
--- a/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
+++ b/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
@@ -1,0 +1,21 @@
+@()
+
+/* Source: https://github.com/remy/polyfills/blob/master/classList.js */
+(function (Element) {
+
+    if (!Element.prototype.matches) {
+        Element.prototype.matches =
+            Element.prototype.matchesSelector || 
+            Element.prototype.mozMatchesSelector ||
+            Element.prototype.msMatchesSelector ||
+            Element.prototype.oMatchesSelector ||
+            Element.prototype.webkitMatchesSelector ||
+            function(s) {
+                var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+                    i = matches.length;
+                while (--i >= 0 && matches.item(i) !== this) {}
+                return i > -1;
+            };
+    }
+
+})(window.Element);

--- a/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
+++ b/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
@@ -5,16 +5,19 @@
 
     if (!Element.prototype.matches) {
         Element.prototype.matches =
-            Element.prototype.matchesSelector || 
+            Element.prototype.matchesSelector ||
             Element.prototype.mozMatchesSelector ||
             Element.prototype.msMatchesSelector ||
             Element.prototype.oMatchesSelector ||
             Element.prototype.webkitMatchesSelector ||
             function(s) {
-                var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-                    i = matches.length;
-                while (--i >= 0 && matches.item(i) !== this) {}
-                return i > -1;
+                var matches = (this.document || this.ownerDocument).querySelectorAll(s);
+                var ii = matches.length;
+                var i = 0;
+                while (i < ii && matches[i] !== this) {
+                    i += 1;
+                }
+                return i < ii;
             };
     }
 

--- a/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
+++ b/common/app/templates/inlineJS/blocking/polyfills/matches.scala.js
@@ -1,15 +1,15 @@
 @()
 
 /* Source: https://github.com/remy/polyfills/blob/master/classList.js */
-(function (Element) {
+(function (ElementPrototype) {
 
-    if (!Element.prototype.matches) {
-        Element.prototype.matches =
-            Element.prototype.matchesSelector ||
-            Element.prototype.mozMatchesSelector ||
-            Element.prototype.msMatchesSelector ||
-            Element.prototype.oMatchesSelector ||
-            Element.prototype.webkitMatchesSelector ||
+    if (!ElementPrototype.matches) {
+        ElementPrototype.matches =
+            ElementPrototype.matchesSelector ||
+            ElementPrototype.mozMatchesSelector ||
+            ElementPrototype.msMatchesSelector ||
+            ElementPrototype.oMatchesSelector ||
+            ElementPrototype.webkitMatchesSelector ||
             function(s) {
                 var matches = (this.document || this.ownerDocument).querySelectorAll(s);
                 var ii = matches.length;
@@ -21,4 +21,4 @@
             };
     }
 
-})(window.Element);
+})(window.Element.prototype);

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -28,6 +28,9 @@
     // Polyfill classList
     @InlineJs(classlist().body, "classlist.js")
 
+    // Polyfill Element.matches
+    @InlineJs(matches().body, "matches.js")
+
 
     // ************* CONFIG *************
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -10,7 +10,8 @@ define([
     'common/modules/commercial/dfp/private/on-slot-render',
     'common/modules/commercial/dfp/private/PrebidService',
     'common/modules/commercial/dfp/private/ophan-tracking',
-    'common/modules/commercial/dfp/private/get-stylesheet'
+    'common/modules/commercial/dfp/private/get-stylesheet',
+    'common/modules/commercial/dfp/private/resize'
 ], function (Promise, qwery, bonzo, raven, fastdom, commercialFeatures, buildPageTargeting, dfpEnv, onSlotRender, PrebidService, ophanTracking) {
 
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -80,6 +80,8 @@ define([
             return;
         }
 
+        var iframes = getMessengerIframe(event.origin);
+
         // Because any listener can have side-effects (by unregistering itself),
         // we run the promise chain on a copy of the `listeners` array.
         // Hat tip @piuccio
@@ -96,7 +98,7 @@ define([
         // occasional fastdom bomb in the middle.
         .reduce(function (promise, listener) {
             return promise.then(function promiseCallback(ret) {
-                var thisRet = listener(data.value, ret);
+                var thisRet = listener(data.value, iframes[0], ret);
                 return thisRet === undefined ? ret : thisRet;
             });
         }, Promise.resolve(true));
@@ -155,5 +157,11 @@ define([
         });
 
         return error;
+    }
+
+    function getMessengerIframe(origin) {
+        return Array.prototype.filter.call(document.getElementsByTagName('iframe'), function (iframe) {
+            return iframe.src.indexOf(origin) === 0;
+        });
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/get-stylesheet.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/get-stylesheet.js
@@ -4,7 +4,7 @@ define([
     var aProto = Array.prototype;
 
     messenger.register('get-styles', function(specs) {
-        return getStyles(specs, document.styleSheets, 'matches' in Element.prototype ? 'matches' : 'msMatchesSelector');
+        return getStyles(specs, document.styleSheets, 'matches');
     });
     return getStyles;
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/resize.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/resize.js
@@ -4,8 +4,6 @@ define([
     'common/utils/fastdom-promise',
     'common/modules/commercial/dfp/messenger'
 ], function (assign, closest, fastdom, messenger) {
-    var aProto = Array.prototype;
-
     messenger.register('resize', function(specs, iframe) {
         return resize(specs, closest(iframe, '.js-ad-slot'));
     });
@@ -33,7 +31,7 @@ define([
     }
 
     function normalise(length) {
-        var lengthRegexp = /^(\d+)(%|px|em|ex|ch|rem|vh|vw|vmin|vmax)?/
+        var lengthRegexp = /^(\d+)(%|px|em|ex|ch|rem|vh|vw|vmin|vmax)?/;
         var defaultUnit = 'px';
         var matches = String(length).match(lengthRegexp);
         if (!matches) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/resize.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/resize.js
@@ -1,0 +1,44 @@
+define([
+    'common/utils/assign',
+    'common/utils/closest',
+    'common/utils/fastdom-promise',
+    'common/modules/commercial/dfp/messenger'
+], function (assign, closest, fastdom, messenger) {
+    var aProto = Array.prototype;
+
+    messenger.register('resize', function(specs, iframe) {
+        return resize(specs, closest(iframe, '.js-ad-slot'));
+    });
+
+    return resize;
+
+    function resize(specs, adSlot) {
+        if (!specs || !('height' in specs || 'width' in specs)) {
+            return null;
+        }
+
+        var styles = {};
+
+        if ('width' in specs) {
+            styles.width = normalise(specs.width);
+        }
+
+        if ('height' in specs) {
+            styles.height = normalise(specs.height);
+        }
+
+        return fastdom.write(function () {
+            assign(adSlot.style, styles);
+        });
+    }
+
+    function normalise(length) {
+        var lengthRegexp = /^(\d+)(%|px|em|ex|ch|rem|vh|vw|vmin|vmax)?/
+        var defaultUnit = 'px';
+        var matches = String(length).match(lengthRegexp);
+        if (!matches) {
+            return null;
+        }
+        return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
+    }
+});

--- a/static/src/javascripts/projects/common/utils/closest.js
+++ b/static/src/javascripts/projects/common/utils/closest.js
@@ -2,7 +2,6 @@ define(function () {
     /**
      * Adds a wrapper around Element.closest()
      */
-    var matches = 'matches' in Element.prototype ? 'matches' : 'msMatchesSelector';
     return 'closest' in Element.prototype ? closestNative : closestPolyfill;
 
     function closestNative(element, selectors) {
@@ -10,7 +9,7 @@ define(function () {
     }
 
     function closestPolyfill(element, selectors) {
-        while (element && !element[matches](selectors)) {
+        while (element && !element.matches(selectors)) {
             element = element.parentNode;
         }
         return element;

--- a/static/src/javascripts/projects/common/utils/closest.js
+++ b/static/src/javascripts/projects/common/utils/closest.js
@@ -1,0 +1,18 @@
+define(function () {
+    /**
+     * Adds a wrapper around Element.closest()
+     */
+    var matches = 'matches' in Element.prototype ? 'matches' : 'msMatchesSelector';
+    return 'closest' in Element.prototype ? closestNative : closestPolyfill;
+
+    function closestNative(element, selectors) {
+        return element.closest(selectors);
+    }
+
+    function closestPolyfill(element, selectors) {
+        while (element && !element[matches](selectors)) {
+            element = element.parentNode;
+        }
+        return element;
+    }
+});

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -15,7 +15,7 @@ define([
                 return value + ' johnny!';
             },
             add1: function(value) { return value + 1; },
-            add2: function(_, ret) { return ret + 2; },
+            add2: function(_, _2, ret) { return ret + 2; },
             rubicon: function() { return 'rubicon'; }
         };
 


### PR DESCRIPTION
## What does this change?

Next task in the pipe for our cross-frame communication protocol, is to allow the ad to ask the page to resize the slot to a specific size. In this iteration, we will deliberately resize the ad slot as specified, but in the future we might adopt an approach ala AMP, where a user has to advertise intent (e.g. click on a button) for the ad to get expanded.
## What is the value of this and can you measure success?

For all our slots, we will try to set a fixed height according to the type of creative we expect back from DFP. But this size might not always be ideal across all breakpoints and creatives, so there is a need for dynamic resizing.
## Does this affect other platforms - Amp, Apps, etc?

Nope, not yet.

cc @guardian/commercial-dev 
