### PR TITLE
add minute desktop A/B test

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -429,14 +429,6 @@ define([
         }
     }
 
-    function initMinute() {
-        if(ab.isInVariant('Minute','minute')) {
-            // This is our minute account number
-            window._min = {_publisher: 'MIN-21000'};
-            require(['js!https://d2d4r7w8.map2.ssl.hwcdn.net/mi-guardian-prod.js']);
-        }
-    }
-
     function init() {
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
@@ -465,7 +457,6 @@ define([
         initFacia();
         initMoreInSection();
         initOnwardContainer();
-        initMinute();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -25,7 +25,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Increase interaction with video trails';
         this.canRun = function() {
-            return config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 && detect.getBreakpoint() == 'desktop';
+            return config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 && detect.getBreakpoint() === 'desktop';
         };
 
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -1,38 +1,64 @@
 define([
     'common/utils/config',
-    'qwery'
+    'common/utils/detect',
+    'common/utils/mediator',
+    'qwery',
+    'bean'
 ], function(
     config,
-    qwery
+    detect,
+    mediator,
+    qwery,
+    bean
 ) {
     return function() {
         this.id = 'Minute';
-        this.start = '2016-07-26';
+        this.start = '2016-08-17';
         this.expiry = '2016-09-01';
         this.author = 'Gideon Goldberg';
         this.showForSensitive = true;
-        this.description = 'Test if minute video teaser causes more video plays.';
-        this.audience = 0;
-        this.audienceOffset = 0;
+        this.description = 'Minutely desktop test';
+        this.audience = 0.1;
+        this.audienceOffset = 0.8;
         this.successMeasure = 'Video starts';
-        this.audienceCriteria = '';
+        this.audienceCriteria = 'Desktop users on fronts containing embedded video';
         this.dataLinkNames = '';
-        this.idealOutcome = '';
+        this.idealOutcome = 'Increase interaction with video trails';
         this.canRun = function() {
-            return config.page.isFront === true || config.page.contentType === 'Article'  && qwery('[data-component="main video"]').length > 0;
+            return config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 && detect.getBreakpoint() == 'desktop';
         };
+
+
+        function initMinute() {
+            // This is our minute account number
+            window._min = {_publisher: 'MIN-21000'};
+            require(['js!https://d2d4r7w8.map2.ssl.hwcdn.net/mi-guardian-prod.js']);
+        }
+
+        function success(complete) {
+            qwery('.fc-item__video').forEach(function(el) {
+                bean.on(el.parentNode, 'click', complete);
+            });
+
+        }
 
         this.variants = [
             {
-                id: 'control',
-                test: function () {
-                }
-            },
-            {
                 id: 'minute',
                 test: function () {
-                }
+                    initMinute();
+                },
+
+                success: success
+            },
+            {
+                id: 'control',
+                test: function () {
+                },
+
+                success: success
             }
         ];
     };
+
 });


### PR DESCRIPTION
## What does this change?

A/B test which adds Minute.ly JS for desktop users on fronts, which provides autoplaying video teasers for participants
## What is the value of this and can you measure success?

Measure whether the minute.ly video teasers increase interaction with video trails on fronts.
Test will count any click on the video card as a successful completion
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Best example is to see their JS running on http://abcnews.go.com/
## Request for comment

CC @akash1810 @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
