### PR TITLE
Ad perf dashboard visual tweaks

### DIFF
--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -16,7 +16,7 @@
                 <div class="panel-body">
                     <ul>
                         <li><a href="@controllers.admin.routes.CommercialController.renderCommercialRadiator()">Commercial Radiator</a></li>
-                        <li><a href="@controllers.admin.routes.CommercialController.renderBrowserPerformanceDashboard()">Commercial Browser Performance</a></li>
+                        <li><a href="@controllers.admin.routes.CommercialController.renderBrowserPerformanceDashboard()">Real-user advert performance</a></li>
                      </ul>
                 </div>
             </div>

--- a/admin/app/views/commercial/performance/browserDashboard.scala.html
+++ b/admin/app/views/commercial/performance/browserDashboard.scala.html
@@ -1,16 +1,17 @@
 @()(implicit request: RequestHeader)
 
-@import controllers.admin.routes.UncachedWebAssets
+@import controllers.admin.routes.{UncachedAssets, UncachedWebAssets}
 
-@admin_main("Browser Ad Performance", "Prod", isAuthed = true, loadJquery = false) {
+@admin_main("Real-user advert performance", "Prod", isAuthed = true, loadJquery = false) {
 
     <script src="@UncachedWebAssets.at("lib/jquery/jquery.min.js")"></script>
     <script src="@UncachedWebAssets.at("lib/d3/d3.min.js")"></script>
     <script src="@UncachedWebAssets.at("lib/epoch-charting/dist/js/epoch.js")"></script>
     <link rel="stylesheet" type="text/css" href="@UncachedWebAssets.at("lib/epoch-charting/dist/css/epoch.min.css")">
+    <link rel="stylesheet" type="text/css" href="@UncachedAssets.at("css/commercial-browser-performance.css")">
 
     <header>
-        <h1 class="page-header">Browser Performance Metrics</h1>
+        <h1 class="page-header">Real-user advert performance</h1>
 
         <div class="container-fluid">This data is collected from user browsers live. These performance timings measure the critical parts of our commercial system, in terms of the user-facing delay being experienced by our readers.</div>
     </header>
@@ -18,8 +19,17 @@
     <div class="container-fluid">
         <h4>Time taken to start the Commercial javascript application</h4>
 
-        <div>This is the delay between the page being executed, and the javascript commercial system starting (known as the commercial bootstrap). This delay is mostly attributed to the client-side's critical path, including the time taken to complete the inital javascript bootstrap (known as standard).</div>
+         <div class="row">
+            <div class="col-md-12">This is the delay between the page being executed, and the javascript commercial system starting (known as the commercial bootstrap). This delay is mostly attributed to the client-side's critical path, including the time taken to complete the inital javascript bootstrap (known as standard).</div>
+         </div>
 
-        <div id="browser-live-performance-data" class="epoch category10" style="height: 300px;"></div>
+        <div class="row graph graph--commercial-app-start">
+            <div class="col-md-1 graph__y-axis">
+                <div>Time (ms)</div>
+            </div>
+            <div class="col-md-11">
+                <div id="browser-live-performance-data" class="epoch category10" style="height: 300px;"></div>
+            </div>
+        </div>
     </div>
 }

--- a/admin/app/views/commercial/performance/browserDashboard.scala.html
+++ b/admin/app/views/commercial/performance/browserDashboard.scala.html
@@ -24,11 +24,16 @@
          </div>
 
         <div class="row graph graph--commercial-app-start">
-            <div class="col-md-1 graph__y-axis">
-                <div>Time (ms)</div>
+            <div class="col-md-1">
+
+                <div class="graph__y-axis">Time (ms)</div>
+                <div class="graph__average panel panel-default">
+                    <div class="graph__average-label bg-info">Average</div>
+                    <div class="graph__average-value bg-info"></div>
+                </div>
             </div>
             <div class="col-md-11">
-                <div id="browser-live-performance-data" class="epoch category10" style="height: 300px;"></div>
+                <div id="browser-live-performance-data" class="epoch category10"></div>
             </div>
         </div>
     </div>

--- a/admin/public/css/commercial-browser-performance.css
+++ b/admin/public/css/commercial-browser-performance.css
@@ -25,7 +25,7 @@ commercial/performance/browser-dashboard
 }
 
 .graph__average {
-    margin-top: 14px;
+    margin-top: 48px;
 }
 
 .graph__average-label {

--- a/admin/public/css/commercial-browser-performance.css
+++ b/admin/public/css/commercial-browser-performance.css
@@ -19,3 +19,25 @@ commercial/performance/browser-dashboard
     text-align: right;
     font-style: italic;
 }
+
+#browser-live-performance-data {
+    height: 350px;
+}
+
+.graph__average {
+    margin-top: 14px;
+}
+
+.graph__average-label {
+    font-weight: bold;
+    font-size: larger;
+    text-align: center;
+    padding: 3px 3px 0 3px;
+}
+
+.graph__average-value {
+    font-size: larger;
+    font-weight: bold;
+    text-align: center;
+    padding: 0 3px 3px 3px;
+}

--- a/admin/public/css/commercial-browser-performance.css
+++ b/admin/public/css/commercial-browser-performance.css
@@ -1,0 +1,21 @@
+/*
+Styles for the commercial dashboard: Real-user Advert Performance
+
+commercial/performance/browser-dashboard
+*/
+
+.graph {
+    margin-top: 12px;
+}
+
+/*Align contents vertically centered*/
+.graph--commercial-app-start {
+    display: flex;
+    align-items: center;
+}
+
+.graph__y-axis {
+    padding-right: 0;
+    text-align: right;
+    font-style: italic;
+}

--- a/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
@@ -1,4 +1,4 @@
-/*global $*/
+/*global $, Epoch*/
 define([
     'common/utils/config',
     'common/utils/fetch-json',
@@ -25,10 +25,13 @@ define([
 
        chart = $('#browser-live-performance-data').epoch({
             type: 'time.heatmap',
-            buckets: 10,
-            bucketRange: [0, 13000],
+            buckets: 20,
+            bucketRange: [0, 10000],
             axes: ['left', 'right', 'bottom'],
-
+            tickFormats: {
+                left: Epoch.Formats.regular,
+                right: Epoch.Formats.regular
+            },
             data: [{
                 label: 'Commercial Start Time',
                 values: commercialStartTimes


### PR DESCRIPTION
Added a label for the y-axis, and an average start time component. Also filtered erroneous datapoints coming in, I'll investigate this later. It looks like some data is using the `Date.getTime` object incorrectly.

![cursor_and_real-user_advert_performance](https://cloud.githubusercontent.com/assets/4549425/17744086/180826ec-649e-11e6-95cd-18b6d0be8349.jpg)
