### PR TITLE
GA: send internal campaign code as custom dimension

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -14,6 +14,14 @@
         return result;
     }
 
+    function getQueryParam(key) {
+        var query = window.location.search.substring(1);
+        var vars = query.split("&");
+        var pairs = vars.map(function(x) { return x.split('=')});
+        return pairs.filter(function(xs) { return xs.length == 2 && xs[0] == key })
+            .map(function(xs) { return xs[1] })[0];
+    }
+
     @***************************************************************************************
     * Standard copy 'n paste Google Analytics code                                         *
     ***************************************************************************************@
@@ -55,6 +63,7 @@
         ga('@{trackerName}.set', 'dimension9', guardian.config.page.keywordIds);
         ga('@{trackerName}.set', 'dimension10', guardian.config.page.toneIds);
         ga('@{trackerName}.set', 'dimension11', guardian.config.page.seriesId);
+        ga('@{trackerName}.set', 'dimension21', getQueryParam('INTCMP')); @* internal campaign code *@
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?

If there is an `INTCMP` query param, send it to GA as a custom dimension
### A little background...

Historically, campaigns have been divided into "internal" and "external". e.g. a link from a Facebook page to an article on theguardian.com would be an external campaign, while a link from theguardian.com to soulmates would be an internal campaign. These are differentiated using the `INTCMP` and `CMP` URL parameters.

GA has built-in support for campaigns, using the  `utm_{source,medium,campaign,term}` URL params. With the switch to GA we have decided to get rid of `CMP` and start using these `utm` params for all external campaigns.

However, we cannot use them for internal campaigns (because they trigger an unconditional session reset in GA, which messes up session tracking), so we will continue to use `INTCMP` for those.

Hope some of that made sense.
## What is the value of this and can you measure success?

Tracking of internal campaigns.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@dominickendrick @ajosephides 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
