### PR TITLE
Rename gallery ad slots for consistent mobile naming convention

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -88,17 +88,7 @@
     @if(!page.item.content.shouldHideAdverts && rowNum % adInterval == 0) {
         @adSlots.lift((rowNum / adInterval) - 1).map { adSlot =>
             <li class="gallery__item gallery__item--advert">
-                <div class="gallery__img-container">
-                    @defining(if(adSlot == "inline1") Option("300,250") else None) { mpuSlotSize =>
-                        @fragments.commercial.standardAd(
-                            adSlot,
-                            Seq("gallery-inline", "dark"),
-                            Map(
-                                "mobile" -> (Seq("1,1") ++ mpuSlotSize ++ Seq("fluid")),
-                                "tablet" -> Seq("1,1", "300,250", "fluid")
-                            )
-                        )
-                    }
+                <div class="gallery__img-container js-gallery-slot">
                 </div>
             </li>
         }

--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -1,3 +1,4 @@
+
 package test
 
 import conf.switches.Switches.FacebookShareUseTrailPicFirstSwitch
@@ -18,14 +19,6 @@ import scala.collection.JavaConversions._
   it should "render all images in the gallery" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
     import browser._
     $(".gallery__item:not(.gallery__item--advert)").length should be (22)
-  }
-
-  it should "render adverts" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
-    import browser._
-    val ads = $(".gallery__item--advert")
-    ads.length should be (2)
-    ads.get(0).find("#dfp-ad--inline1").length should be (1)
-    ads.get(1).find("#dfp-ad--inline2").length should be (1)
   }
 
   it should "show the twitter card meta-data" in goTo("/music/gallery/2012/jun/23/simon-bolivar-orchestra-dudamel-southbank-centre") { browser =>

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -13,6 +13,7 @@ define([
     'common/modules/commercial/dfp/load',
     'common/modules/commercial/dfp/sponsorships',
     'common/modules/commercial/front-commercial-components',
+    'common/modules/commercial/gallery-adverts',
     'common/modules/commercial/hosted-about',
     'common/modules/commercial/hosted-video',
     'common/modules/commercial/hosted-gallery',
@@ -37,6 +38,7 @@ define([
     dfpLoad,
     sponsorships,
     frontCommercialComponents,
+    galleryAdverts,
     hostedAbout,
     hostedVideo,
     hostedGallery,
@@ -52,6 +54,7 @@ define([
         ['cm-articleAsideAdverts', articleAsideAdverts.init],
         ['cm-articleBodyAdverts', articleBodyAdverts.init],
         ['cm-sliceAdverts', sliceAdverts.init],
+        ['cm-galleryAdverts', galleryAdverts.init],
         ['cm-frontCommercialComponents', frontCommercialComponents.init],
         ['cm-closeDisabledSlots', closeDisabledSlots.init]
     ];

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -34,6 +34,8 @@ define([
 
         var isArticle = config.page.contentType === 'Article';
 
+        var isGallery = config.page.contentType == 'Gallery';
+
         var isLiveBlog = config.page.isLiveBlog;
 
         var isHosted = config.page.tones === 'Hosted';
@@ -57,6 +59,10 @@ define([
         this.topBannerAd =
             this.dfpAdvertising &&
             !isMinuteArticle;
+
+        this.galleryAdverts =
+            this.dfpAdvertising &&
+            isGallery;
 
         this.articleBodyAdverts =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/common/modules/commercial/gallery-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gallery-adverts.js
@@ -1,0 +1,70 @@
+define([
+    'qwery',
+    'common/utils/detect',
+    'common/utils/fastdom-promise',
+    'common/modules/commercial/dfp/create-slot',
+    'common/modules/commercial/commercial-features'
+], function (
+    qwery,
+    detect,
+    fastdom,
+    createSlot,
+    commercialFeatures
+) {
+
+    return {
+        init: init
+    };
+
+    function init() {
+
+        if (!commercialFeatures.galleryAdverts) {
+            return Promise.resolve(false);
+        }
+
+        var containerSelector = '.js-gallery-slot"';
+        var adContainers;
+        var isMobile = detect.getBreakpoint() === 'mobile';
+        var classNames = ['gallery-inline', 'dark'];
+
+        if (isMobile) {
+            classNames.push('mobile');
+        }
+
+        adContainers = qwery(containerSelector)
+
+        .map(function (item, index) {
+            var adSlot;
+
+            if (isMobile && index == 0) {
+                adSlot = createSlot('top-above-nav', classNames);
+            }
+            else if (isMobile && index == 1) {
+                adSlot = createSlot('inline' + (index), classNames);
+            }
+            else if (!isMobile) {
+                adSlot = createSlot('inline' + (index+1), classNames);
+            }
+
+            return {
+                anchor: item,
+                adSlot: adSlot
+            };
+        });
+
+        if (adContainers.length < 1) {
+            return;
+        }
+
+        return fastdom.write(function () {
+
+            adContainers.forEach(insertSlot);
+
+        function insertSlot(item) {
+            item.anchor.appendChild(item.adSlot);
+        }
+
+    });
+
+    }
+});

--- a/static/src/javascripts/projects/common/modules/commercial/gallery-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gallery-adverts.js
@@ -22,7 +22,7 @@ define([
             return Promise.resolve(false);
         }
 
-        var containerSelector = '.js-gallery-slot"';
+        var containerSelector = '.js-gallery-slot';
         var adContainers;
         var isMobile = detect.getBreakpoint() === 'mobile';
         var classNames = ['gallery-inline', 'dark'];
@@ -43,7 +43,7 @@ define([
                 adSlot = createSlot('inline' + (index), classNames);
             }
             else if (!isMobile) {
-                adSlot = createSlot('inline' + (index+1), classNames);
+                adSlot = createSlot('inline' + (index + 1), classNames);
             }
 
             return {
@@ -60,9 +60,9 @@ define([
 
             adContainers.forEach(insertSlot);
 
-        function insertSlot(item) {
-            item.anchor.appendChild(item.adSlot);
-        }
+            function insertSlot(item) {
+                item.anchor.appendChild(item.adSlot);
+            }
 
     });
 


### PR DESCRIPTION
## What does this change?

The naming convention for gallery ad slots on mobile has been corrected to be consistent across site. Previously this lived server-side, and has been moved as should decide what slots are based on breakpoint.
## What is the value of this and can you measure success?

Coherent names are coherent!
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@regiskuckaertz @rich-nguyen @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

Add slot with correct mobile naming convention
