### PR TITLE
Amp-validation utility for teamcity

### DIFF
--- a/article/test/ArticleAmpValidityTest.scala
+++ b/article/test/ArticleAmpValidityTest.scala
@@ -7,7 +7,8 @@ import org.scalatest.DoNotDiscover
 
   /*
       NB: these may be duplicated in tools/amp-validation - if you add or remove
-      a URL from here, think about whether it should be removed there too.
+      a URL from here, think about whether it should be changed there too. Not
+      centralising as running full suite here may be overkill as we add more tests
    */
   Seq(
     "/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics", // Comment tone

--- a/article/test/ArticleAmpValidityTest.scala
+++ b/article/test/ArticleAmpValidityTest.scala
@@ -4,6 +4,11 @@ import org.scalatest.DoNotDiscover
 
 
 @DoNotDiscover class ArticleAmpValidityTest extends AmpValidityTest {
+
+  /*
+      NB: these may be duplicated in tools/amp-validation - if you add or remove
+      a URL from here, think about whether it should be removed there too.
+   */
   Seq(
     "/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics", // Comment tone
     "/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout", // Feature tone

--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const https = require('https');
+
+const hostname = 'https://amp.theguardian.com';
+
+exports.get = function(endpoint) {
+    return makeRequest(endpoint).then(getBody);
+};
+
+function makeRequest(endpoint) {
+    return new Promise((resolve, reject) => {
+        const errorMessage = `Unable to fetch ${endpoint}`;
+
+        const req = https.get(hostname + endpoint, (res) => {
+            if (res.statusCode !== 200) {
+                res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
+                reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
+            } else {
+                resolve(res);
+            }
+        });
+        req.on('error', (error) => {
+            reject(new Error(errorMessage + ` ${error.message}`));
+        });
+        req.end();
+    });
+}
+
+function getBody(res) {
+    let body = '';
+    return new Promise((resolve, reject) => {
+        res
+            .on('data', (chunk) => { body += chunk })
+            .on('end', () => resolve(body))
+            .on('error', reject);
+    });
+}

--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -2,7 +2,7 @@
 
 const https = require('https');
 
-const hostname = 'https://amp.theguardian.com';
+const hostname = 'https://www.theguardian.com';
 
 exports.get = endpoint => makeRequest(endpoint).then(getBody);
 

--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -2,7 +2,7 @@
 
 const https = require('https');
 
-const hostname = 'https://www.theguardian.com';
+const hostname = 'https://amp.theguardian.com';
 
 exports.get = endpoint => makeRequest(endpoint).then(getBody);
 

--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -4,15 +4,13 @@ const https = require('https');
 
 const hostname = 'https://amp.theguardian.com';
 
-exports.get = function(endpoint) {
-    return makeRequest(endpoint).then(getBody);
-};
+exports.get = endpoint => makeRequest(endpoint).then(getBody);
 
 function makeRequest(endpoint) {
     return new Promise((resolve, reject) => {
         const errorMessage = `Unable to fetch ${endpoint}`;
 
-        const req = https.get(hostname + endpoint, (res) => {
+        const req = https.get(hostname + endpoint, res => {
             if (res.statusCode !== 200) {
                 res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
                 reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
@@ -20,7 +18,7 @@ function makeRequest(endpoint) {
                 resolve(res);
             }
         });
-        req.on('error', (error) => {
+        req.on('error', error => {
             reject(new Error(errorMessage + ` ${error.message}`));
         });
         req.end();
@@ -30,8 +28,7 @@ function makeRequest(endpoint) {
 function getBody(res) {
     let body = '';
     return new Promise((resolve, reject) => {
-        res
-            .on('data', (chunk) => { body += chunk })
+        res.on('data', chunk => body += chunk)
             .on('end', () => resolve(body))
             .on('error', reject);
     });

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -12,7 +12,7 @@ const fetchPage = require('./fetch-page');
  */
 const endpoints = [
     '/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics', // Comment tone
-    //'/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone
+    '/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone
     '/travel/2016/aug/09/diggerland-kent-family-day-trips-in-uk', // Review tone
     '/global/2016/aug/09/guardian-weekly-letters-media-statues-predators', // Letters tone
     '/commentisfree/2016/aug/08/the-guardian-view-on-the-southern-train-strike-keep-the-doors-open-for-talks', // Editorials tone

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -7,9 +7,9 @@ const fetchPage = require('./fetch-page');
 /*
     NB: these may be duplicated elsewhere in scala tests
     that extend AmpValidityTest - consider adding any new
-    URLs there as well.
+    URLs there as well.  Not centralising as running full
+    suite in scala tests may be overkill as we add more tests
  */
-// TODO: should we centralise these?
 const endpoints = [
     '/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics', // Comment tone
     '/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -28,11 +28,11 @@ validatorJs.fetchPreRelease().then(checkEndpoints).catch(onError);
 
 function checkEndpoints(filepath) {
     amphtmlValidator.getInstance(filepath)
-        .then((validator) => {
+        .then(validator => {
             const tests = endpoints.map(runValidator.bind(this, validator));
 
             Promise.all(tests)
-                .then((values) => {
+                .then(values => {
                     const exitValue = values.every(Boolean) ? 0 : 1; // every promise returns true <=> exit value is zero
                     validatorJs.cleanUp();
                     process.exit(exitValue);
@@ -43,13 +43,13 @@ function checkEndpoints(filepath) {
 function runValidator(validator, endpoint) {
     return fetchPage
         .get(endpoint)
-        .then((res) => {
+        .then(res => {
             console.log(`Checking the AMP validity of the page at ${endpoint}, result is:`);
             const result = validator.validateString(res);
 
             const pass = result.status === 'PASS';
             (pass ? console.log : console.error)(result.status);
-            result.errors.forEach((error) => {
+            result.errors.forEach(error => {
                 ((error.severity === 'ERROR') ? console.error : console.warn)(buildErrorMessage(error));
             });
 

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const amphtmlValidator = require('amphtml-validator');
+const validatorJs = require('./validator-js');
+const fetchPage = require('./fetch-page');
+
+/*
+    NB: these may be duplicated elsewhere in scala tests
+    that extend AmpValidityTest - consider adding any new
+    URLs there as well.
+ */
+// TODO: should we centralise these?
+const endpoints = [
+    '/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics', // Comment tone
+    '/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone
+    '/travel/2016/aug/09/diggerland-kent-family-day-trips-in-uk', // Review tone
+    '/global/2016/aug/09/guardian-weekly-letters-media-statues-predators', // Letters tone
+    '/commentisfree/2016/aug/08/the-guardian-view-on-the-southern-train-strike-keep-the-doors-open-for-talks', // Editorials tone
+    '/lifeandstyle/shortcuts/2016/aug/09/why-truck-drivers-are-sick-of-chips-with-everything', // Features tone
+    '/business/2016/aug/09/china-uk-investment-key-questions-following-hinkley-point-c-delay', // Analysis tone
+    '/books/2011/aug/24/jorge-luis-borges-google-doodle', // More on this story
+    '/uk-news/2016/aug/09/southern-rail-strike-war-of-words-heats-up-on-second-day', // Story package / tone news
+    '/football/2016/jul/10/france-portugal-euro-2016-match-report' // Match summary
+];
+
+validatorJs.fetchRelease().then(checkEndpoints).catch(onError);
+validatorJs.fetchPreRelease().then(checkEndpoints).catch(onError);
+
+function checkEndpoints(filepath) {
+    amphtmlValidator.getInstance(filepath)
+        .then((validator) => {
+            const tests = endpoints.map(runValidator.bind(this, validator));
+
+            Promise.all(tests)
+                .then((values) => {
+                    const exitValue = values.every(Boolean) ? 0 : 1; // every promise returns true <=> exit value is zero
+                    validatorJs.cleanUp();
+                    process.exit(exitValue);
+                });
+        });
+}
+
+function runValidator(validator, endpoint) {
+    return fetchPage
+        .get(endpoint)
+        .then((res) => {
+            console.log(`Checking the AMP validity of the page at ${endpoint}, result is:`);
+            const result = validator.validateString(res);
+
+            const pass = result.status === 'PASS';
+            (pass ? console.log : console.error)(result.status);
+            result.errors.forEach((error) => {
+                ((error.severity === 'ERROR') ? console.error : console.warn)(buildErrorMessage(error));
+            });
+
+            return pass;
+    }).catch(onError);
+}
+
+function onError(error) {
+    console.error(error.message);
+    validatorJs.cleanUp();
+    process.exit(1);
+}
+
+function buildErrorMessage(error) {
+    let msg = `line ${error.line}, col ${error.col}: ${error.message}`;
+    if (error.specUrl !== null) {
+        msg += ` (see ${error.specUrl})`;
+    }
+    return msg;
+}

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -12,7 +12,7 @@ const fetchPage = require('./fetch-page');
  */
 const endpoints = [
     '/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics', // Comment tone
-    '/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone
+    //'/politics/2016/aug/09/tom-watson-interview-jeremy-corbyn-labour-rifts-hug-shout', // Feature tone
     '/travel/2016/aug/09/diggerland-kent-family-day-trips-in-uk', // Review tone
     '/global/2016/aug/09/guardian-weekly-letters-media-statues-predators', // Letters tone
     '/commentisfree/2016/aug/08/the-guardian-view-on-the-southern-train-strike-keep-the-doors-open-for-talks', // Editorials tone

--- a/tools/amp-validation/index.js
+++ b/tools/amp-validation/index.js
@@ -23,13 +23,13 @@ const endpoints = [
     '/football/2016/jul/10/france-portugal-euro-2016-match-report' // Match summary
 ];
 
-validatorJs.fetchRelease().then(checkEndpoints).catch(onError);
-validatorJs.fetchPreRelease().then(checkEndpoints).catch(onError);
+validatorJs.fetchRelease().then(checkEndpoints(false)).catch(onError);
+validatorJs.fetchPreRelease().then(checkEndpoints(true)).catch(onError);
 
-function checkEndpoints(filepath) {
-    amphtmlValidator.getInstance(filepath)
+function checkEndpoints(devChannel) {
+    return validatorFilePath => amphtmlValidator.getInstance(validatorFilePath)
         .then(validator => {
-            const tests = endpoints.map(runValidator.bind(this, validator));
+            const tests = endpoints.map(runValidator(validator, devChannel));
 
             Promise.all(tests)
                 .then(values => {
@@ -40,11 +40,11 @@ function checkEndpoints(filepath) {
         });
 }
 
-function runValidator(validator, endpoint) {
-    return fetchPage
+function runValidator(validator, devChannel) {
+    return endpoint => fetchPage
         .get(endpoint)
         .then(res => {
-            console.log(`Checking the AMP validity of the page at ${endpoint}, result is:`);
+            console.log(`Checking the AMP validity (${devChannel ? 'pre-release' : 'release'}) of the page at ${endpoint}, result is:`);
             const result = validator.validateString(res);
 
             const pass = result.status === 'PASS';

--- a/tools/amp-validation/package.json
+++ b/tools/amp-validation/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "amp-validation",
+  "version": "0.0.1",
+  "description": "Utility that uses the amphtml-validator to validate AMP endpoints",
+  "license": "Apache-2.0",
+  "scripts": {
+      "start": "node index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/guardian/frontend/issues"
+  },
+  "homepage": "https://github.com/guardian/frontend#readme",
+  "dependencies": {
+    "amphtml-validator": "^1.0.10"
+  },
+  "engines": {
+    "node": ">=6"
+  }
+}

--- a/tools/amp-validation/validator-js.js
+++ b/tools/amp-validation/validator-js.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const https = require('https'); // TODO - will we ever need http?
+const os = require('os');
+const fs = require('fs');
+
+const defaultOptions = {
+    hostname: 'cdn.ampproject.org',
+    path: '/v0/validator.js'
+};
+const devOptions = {
+    headers: {
+        Cookie: 'AMP_CANARY=1;'
+    }
+};
+const tempFilenames = {
+    release: '/release.js',
+    preRelease: '/pre-release.js'
+};
+
+exports.fetchRelease = fetchValidator.bind(this, false);
+exports.fetchPreRelease = fetchValidator.bind(this, true);
+exports.cleanUp = cleanUp;
+
+function fetchValidator(devChannel) {
+
+    return new Promise(validatorRequest).then(saveToFile);
+
+    function validatorRequest(resolve, reject) {
+        const options = Object.assign({}, defaultOptions, devChannel ? devOptions : {});
+        const errorMessage = `Unable to retrieve ${options.path} with dev channel ${devChannel ? 'enabled' : 'disabled'}.`;
+
+        const req = https.get(options, (res) => {
+            if (res.statusCode !== 200) {
+                res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
+                reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
+            } else {
+                resolve(res);
+            }
+        });
+        req.on('error', (error) => {
+            reject(new Error(errorMessage + ` ${error.message}`));
+        });
+        req.end();
+    }
+
+    function saveToFile(res) {
+        const filename = os.tmpdir() + (devChannel ? tempFilenames.preRelease : tempFilenames.release);
+        const writeStream = fs.createWriteStream(filename);
+
+        return new Promise((resolve, reject) => {
+            res.pipe(writeStream)
+                .on('finish', () => { resolve(writeStream.path) })
+                .on('error', (error) => {
+                    reject(error);
+                    writeStream.close();
+                });
+        });
+    }
+}
+
+function cleanUp() {
+    // Just try and remove both files as the cost is low anyway
+    // TODO: assumption here that os.tmpdir is fixed during creation/deletion
+    [tempFilenames.preRelease, tempFilenames.release].forEach((filename) => {
+        fs.unlinkSync(os.tmpdir() + filename);
+    });
+}

--- a/tools/amp-validation/validator-js.js
+++ b/tools/amp-validation/validator-js.js
@@ -30,7 +30,7 @@ function fetchValidator(devChannel) {
         const options = Object.assign({}, defaultOptions, devChannel ? devOptions : {});
         const errorMessage = `Unable to retrieve ${options.path} with dev channel ${devChannel ? 'enabled' : 'disabled'}.`;
 
-        const req = https.get(options, (res) => {
+        const req = https.get(options, res => {
             if (res.statusCode !== 200) {
                 res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
                 reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
@@ -38,7 +38,7 @@ function fetchValidator(devChannel) {
                 resolve(res);
             }
         });
-        req.on('error', (error) => {
+        req.on('error', error => {
             reject(new Error(errorMessage + ` ${error.message}`));
         });
         req.end();
@@ -50,8 +50,8 @@ function fetchValidator(devChannel) {
 
         return new Promise((resolve, reject) => {
             res.pipe(writeStream)
-                .on('finish', () => { resolve(writeStream.path) })
-                .on('error', (error) => {
+                .on('finish', () => resolve(writeStream.path))
+                .on('error', error => {
                     reject(error);
                     writeStream.close();
                 });
@@ -62,7 +62,7 @@ function fetchValidator(devChannel) {
 function cleanUp() {
     // Just try and remove both files as the cost is low anyway
     // TODO: assumption here that os.tmpdir is fixed during creation/deletion
-    [tempFilenames.preRelease, tempFilenames.release].forEach((filename) => {
+    [tempFilenames.preRelease, tempFilenames.release].forEach(filename => {
         fs.unlinkSync(os.tmpdir() + filename);
     });
 }

--- a/tools/amp-validation/validator-js.js
+++ b/tools/amp-validation/validator-js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const https = require('https'); // TODO - will we ever need http?
+const https = require('https');
 const os = require('os');
 const fs = require('fs');
 


### PR DESCRIPTION
## What does this change?

Adds a node.js utility for running the official amphtml-validator against various AMP pages on www.theguardian.

The utility is intended to be run as a separate project on teamcity (probably on a schedule).  Right now this is ~~untested~~ tested on teamcity - at this stage it would just be good to get feedback on this ~~early (and slightly rough)~~ version.  ~~I'm guessing there might need to be tweaks to accommodate some things I haven't thought of.~~

The flow is as follows:
- Fetch 2 versions of the validator.js from cdn.ampproject.org
  - release
  - pre-release (this is fetched via addition of AMP_CANARY=1 cookie)
- For each validator.js version, run each page against the validator
- Output the results
- Exit the process with relevant exit code (i.e. 1 if any of the pages fail validation, 0 if not).

Comments on ES6-ness especially appreciated.  Dependencies are intentionally kept to a minimum at the moment, so it's quite bare-bones.
## What is the value of this and can you measure success?

Our AMP validation process should be much tighter, as this will always validate pages against the latest released validator (which is not the case for scala tests), _**and**_ the pre-release version.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/8754692/17744580/43ed11bc-64a0-11e6-9a0b-194b1cc1d1e0.png)
## Request for comment

@SiAdcock @gtrufitt @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
