### PR TITLE
Tiny PR: Message colour update

### DIFF
--- a/tools/messages.js
+++ b/tools/messages.js
@@ -1,6 +1,14 @@
 function notify(message, options, type) {
     options = options || {};
     type = type || 'log';
+
+    // Set the default text colour for info to black as white was hard to see
+    if (type === 'info') {
+       Object.assign(options, {
+            colour: 'black'
+        });
+    }
+
     try {
         require('megalog')[type](message, options);
     } catch (e) {

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -4,9 +4,9 @@ function notify(message, options, type) {
 
     // Set the default text colour for info to black as white was hard to see
     if (type === 'info') {
-       Object.assign(options, {
-            colour: 'black'
-        });
+       options = Object.assign({
+           colour: 'black'
+       }, options);
     }
 
     try {


### PR DESCRIPTION
## What does this change?

Updates the 'info' message text from white

![screen shot 2016-08-18 at 09 24 53](https://cloud.githubusercontent.com/assets/638051/17767337/7e7381e0-6527-11e6-93ca-d52cc59b91d1.jpg)

to black:

![screen shot 2016-08-18 at 09 24 47](https://cloud.githubusercontent.com/assets/638051/17767342/8186905c-6527-11e6-96f6-7745539d1dd2.jpg)
