### PR TITLE
Commercial: relax constraint in ad featured fronts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
+++ b/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
@@ -23,7 +23,7 @@ define([
         }
 
         var containerIndex,
-            minContainers  = config.page.isAdvertisementFeature ? 1 : 2;
+            minContainers  = config.page.isAdvertisementFeature ? 1 : 2,
             $adSlotWrapper = $.create('<div class="fc-container"></div>'),
             $adSlot        = bonzo(createSlot(config.page.isAdvertisementFeature ? 'merchandising-high-ad-feature' : 'merchandising-high', 'commercial-component-high')),
             $containers    = $('.fc-container');

--- a/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
+++ b/static/src/javascripts/projects/common/modules/commercial/front-commercial-components.js
@@ -23,11 +23,12 @@ define([
         }
 
         var containerIndex,
+            minContainers  = config.page.isAdvertisementFeature ? 1 : 2;
             $adSlotWrapper = $.create('<div class="fc-container"></div>'),
             $adSlot        = bonzo(createSlot(config.page.isAdvertisementFeature ? 'merchandising-high-ad-feature' : 'merchandising-high', 'commercial-component-high')),
             $containers    = $('.fc-container');
 
-        if ($containers.length >= 2) {
+        if ($containers.length >= minContainers) {
             containerIndex = 0;
 
             if ($containers.length >= 4) {


### PR DESCRIPTION
## What does this change?

On fronts, at least 2 containers must exist before a merchandising component is inserted. Alas, ad featured tag fronts contain only one container most of the time. In that case, we relax the constraint and insert the component if at least 1 container exists.
## What is the value of this and can you measure success?

mo' money

cc @guardian/commercial-dev 
