### PR TITLE
Only splice dashboard data when there are more than 1000 items

### DIFF
--- a/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
@@ -81,7 +81,9 @@ define([
         // Push the new start times into the stored array to find an average.
         Array.prototype.push.apply(commercialStartTimes, startTimes);
         // Limit the size of the array to 1000.
-        commercialStartTimes.splice(1000);
+        if (commercialStartTimes.length > 1000) {
+            commercialStartTimes.splice(0, commercialStartTimes.length - 1000);
+        }
 
         if (!commercialStartTimes.length) {
             return;


### PR DESCRIPTION
Little bug here which caused the average to be miscalculated.
