### PR TITLE
Add array notation to POSTed form params

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -148,9 +148,9 @@ define([
             var value = buttons[i].value;
             var unsubscribeMatches = value.match(/unsubscribe-(.*)/);
             if (unsubscribeMatches) {
-                buttonString += 'removeEmailSubscriptions=' + encodeURIComponent(unsubscribeMatches[1]) + '&';
+                buttonString += 'removeEmailSubscriptions[]=' + encodeURIComponent(unsubscribeMatches[1]) + '&';
             } else {
-                buttonString += 'addEmailSubscriptions=' + encodeURIComponent(value) + '&';
+                buttonString += 'addEmailSubscriptions[]=' + encodeURIComponent(value) + '&';
             }
         }
         return 'csrfToken=' + encodeURIComponent(csrfToken) + '&' +


### PR DESCRIPTION
This is a fix for a bug in #13948. [This last commit](https://github.com/guardian/frontend/pull/13948/commits/c6b7fd062ce66de3e583586372e0e5f21fd3e212) accidentally removed the array notation on these params which is needed for Play's form handling to correctly interpret them as lists.

@katebee 
