### PR TITLE
break out minute loading JS into separate AB test 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -144,6 +144,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABMinuteLoadJs = Switch(
+    SwitchGroup.ABTests,
+    "ab-minute-load-js",
+    "Load JS for minute test participants on some content pages.",
+    owners = Seq(Owner.withGithub("gidsg")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 1),
+    exposeClientSide = true
+  )
+
   val ABRecommendedForYou = Switch(
     SwitchGroup.ABTests,
     "ab-recommended-for-you",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -21,7 +21,8 @@ define([
     'common/modules/experiments/tests/contributions-header',
     'common/modules/experiments/tests/ad-feedback',
     'common/modules/experiments/tests/minute',
-    'common/modules/experiments/tests/recommended-for-you'
+    'common/modules/experiments/tests/recommended-for-you',
+    'common/modules/experiments/tests/minute-load-js'
 ], function (
     reportError,
     config,
@@ -45,7 +46,8 @@ define([
     ContributionsHeader,
     AdFeedback,
     Minute,
-    RecommendedForYou
+    RecommendedForYou,
+    MinuteLoadJs
 ) {
 
     var TESTS = [
@@ -63,7 +65,8 @@ define([
         new ContributionsHeader(),
         new AdFeedback(),
         new Minute(),
-        new RecommendedForYou()
+        new RecommendedForYou(),
+        new MinuteLoadJs()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute-load-js.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute-load-js.js
@@ -1,0 +1,49 @@
+define([
+    'common/utils/config',
+    'common/utils/detect'
+], function(
+    config,
+    detect
+) {
+    return function() {
+        this.id = 'MinuteLoadJs';
+        this.start = '2016-08-17';
+        this.expiry = '2016-09-01';
+        this.author = 'Gideon Goldberg';
+        this.showForSensitive = true;
+        this.description = 'Minutely load JS';
+        this.audience = 0.1;
+        this.audienceOffset = 0.8;
+        this.successMeasure = 'Video starts';
+        this.audienceCriteria = 'Users in the minutely test require the JS in landing pages in order for their video teasers to work on fronts';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Increase interaction with video trails';
+        this.canRun = function() {
+            return (config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 || config.page.contentType === 'Article' || config.page.contentType === 'Video') && detect.getBreakpoint() === 'desktop';
+        };
+
+
+        function initMinute() {
+            // This is our minute account number
+            window._min = {_publisher: 'MIN-21000'};
+            require(['js!https://d2d4r7w8.map2.ssl.hwcdn.net/mi-guardian-prod.js']);
+        }
+
+
+        this.variants = [
+            {
+                id: 'minute',
+                test: function () {
+                    initMinute();
+                }
+            },
+            {
+                id: 'control',
+                test: function () {
+                }
+
+            }
+        ];
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -28,13 +28,6 @@ define([
             return config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 && detect.getBreakpoint() === 'desktop';
         };
 
-
-        function initMinute() {
-            // This is our minute account number
-            window._min = {_publisher: 'MIN-21000'};
-            require(['js!https://d2d4r7w8.map2.ssl.hwcdn.net/mi-guardian-prod.js']);
-        }
-
         function success(complete) {
             qwery('.fc-item__video').forEach(function(el) {
                 bean.on(el.parentNode, 'click', complete);
@@ -46,7 +39,6 @@ define([
             {
                 id: 'minute',
                 test: function () {
-                    initMinute();
                 },
 
                 success: success


### PR DESCRIPTION
## What does this change?

Breaks out the loading of the minute.ly JS into a separate AB test in order to target include it on some content pages.

In order for minute.ly to work their code is required on article and video pages in order to track clickthrough and playback. The existing minute test runs alongside to the same audience but now only tracks the clickthrough from fronts.
## What is the value of this and can you measure success?

I am aware this increases the payload for the test group but it is required to be able to test in order to assess the value of the minute.ly video teasers.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

See example video teasers on http://abcnews.go.com/
## Request for comment

CC @akash1810 @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
