### PR TITLE
Hosted video pages - HEX into RGB module

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -34,7 +34,6 @@
 
     .hosted-page .hosted__next-video--tile {
         border-top-color: @{page.campaign.brandColour};
-        background: rgba(@{page.campaign.brandColour}, 0.5); /* TODO transform hex into rgb in js */
     }
 
     .hosted-page .hosted__link {
@@ -130,7 +129,7 @@
                     <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
                     <h2 class="hosted__next-video--client-name @{page.brandColourCssClass}">@{page.campaign.owner}</h2>
                 </div>
-                <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @{nextPage.title}">
+                <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile js-next-video" data-colour="@{page.campaign.brandColour}" data-link-name="Next Hosted Video: @{nextPage.title}">
                     <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Video: @{nextPage.title}">
                     <p class="hosted__next-video-title">@{nextPage.title}</p>
                 </a>

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -16,6 +16,7 @@ define([
     'common/modules/commercial/hosted-about',
     'common/modules/commercial/hosted-video',
     'common/modules/commercial/hosted-gallery',
+    'common/modules/commercial/hosted-colours',
     'common/modules/commercial/slice-adverts',
     'common/modules/commercial/sticky-top-banner',
     'common/modules/commercial/third-party-tags',
@@ -40,6 +41,7 @@ define([
     hostedAbout,
     hostedVideo,
     hostedGallery,
+    hostedColours,
     sliceAdverts,
     stickyTopBanner,
     thirdPartyTags,
@@ -73,7 +75,8 @@ define([
         secondaryModules.unshift(
             ['cm-hostedAbout', hostedAbout.init],
             ['cm-hostedVideo', hostedVideo.init],
-            ['cm-hostedGallery', hostedGallery.init]);
+            ['cm-hostedGallery', hostedGallery.init],
+            ['cm-hostedColours', hostedColours.init]);
     }
 
     if (!(config.switches.staticBadges && config.switches.staticContainerBadges)) {

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
@@ -2,13 +2,11 @@ define([
     'Promise',
     'bean',
     'common/utils/$',
-    'common/utils/config',
     'common/modules/commercial/survey/survey-simple'
 ], function (
     Promise,
     bean,
     $,
-    config,
     SurveySimple
 ) {
     function init() {

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
@@ -6,25 +6,24 @@ define([
     $
 ) {
     function hexToRGB(hex) {
-        var hex = removeHash(hex);
         var R = parseInt(hex.substring(0,2),16);
         var G = parseInt(hex.substring(2,4),16);
         var B = parseInt(hex.substring(4,6),16);
 
-        return R + ", " + G + ", " + B;
+        return R + ', ' + G + ', ' + B;
     }
 
     function removeHash(colour) {
-        return (colour.charAt(0)=="#") ? colour.substring(1,7) : colour;
+        return (colour.charAt(0)=='#') ? colour.substring(1,7) : colour;
     }
 
     function init() {
         return new Promise(function(resolve) {
             var $nextVideo = $('.js-next-video');
-            var colour = $nextVideo.data('colour');
+            var colour = removeHash($nextVideo.data('colour'));
 
             $nextVideo.css({
-                "background": "rgba(" + hexToRGB(colour) + ", 0.1)"
+                'background': 'rgba(' + hexToRGB(colour) + ', 0.1)'
             });
 
             resolve();

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
@@ -1,0 +1,37 @@
+define([
+    'Promise',
+    'common/utils/$'
+], function (
+    Promise,
+    $
+) {
+    function hexToRGB(hex) {
+        var hex = removeHash(hex);
+        var R = parseInt(hex.substring(0,2),16);
+        var G = parseInt(hex.substring(2,4),16);
+        var B = parseInt(hex.substring(4,6),16);
+
+        return R + ", " + G + ", " + B;
+    }
+
+    function removeHash(colour) {
+        return (colour.charAt(0)=="#") ? colour.substring(1,7) : colour;
+    }
+
+    function init() {
+        return new Promise(function(resolve) {
+            var $nextVideo = $('.js-next-video');
+            var colour = $nextVideo.data('colour');
+
+            $nextVideo.css({
+                "background": "rgba(" + hexToRGB(colour) + ", 0.1)"
+            });
+
+            resolve();
+        });
+    }
+
+    return {
+        init: init
+    };
+});

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-colours.js
@@ -1,7 +1,9 @@
 define([
+    'fastdom',
     'Promise',
     'common/utils/$'
 ], function (
+    fastdom,
     Promise,
     $
 ) {
@@ -22,8 +24,10 @@ define([
             var $nextVideo = $('.js-next-video');
             var colour = removeHash($nextVideo.data('colour'));
 
-            $nextVideo.css({
-                'background': 'rgba(' + hexToRGB(colour) + ', 0.1)'
+            fastdom.write(function () {
+                $nextVideo.css({
+                    'background': 'rgba(' + hexToRGB(colour) + ', 0.1)'
+                });
             });
 
             resolve();


### PR DESCRIPTION
## What does this change?

The next video box on hosted video pages has slightly different background colour than the brand one. We don't want to use another colour variable taken from CAPI, so I created this module which translates HEX into RGB so we can change the transparency value of the background: `background: rgba(RGB, 0.1)` without introducing any new variable.
## Screenshots

Renault before:
<img width="323" alt="screen shot 2016-08-18 at 14 25 17" src="https://cloud.githubusercontent.com/assets/489567/17775319/9f6abe9a-654f-11e6-90d6-b8e4e455ee05.png">

Renault after (background colour calculated based on the brand colour):
<img width="326" alt="screen shot 2016-08-18 at 14 26 14" src="https://cloud.githubusercontent.com/assets/489567/17775349/c1fbc3aa-654f-11e6-93a3-f565f8e8c772.png">

Leffe before:
<img width="334" alt="screen shot 2016-08-18 at 14 26 49" src="https://cloud.githubusercontent.com/assets/489567/17775365/d4869a22-654f-11e6-9054-056bd9f3415b.png">

Leffe after:
<img width="327" alt="screen shot 2016-08-18 at 14 27 14" src="https://cloud.githubusercontent.com/assets/489567/17775379/e43927d2-654f-11e6-877b-c0e3e9f7f180.png">

Zootropolis before:
<img width="324" alt="screen shot 2016-08-18 at 14 28 27" src="https://cloud.githubusercontent.com/assets/489567/17775421/1245bd34-6550-11e6-83bf-65be4d58e37c.png">

Zootropolis after:
<img width="321" alt="screen shot 2016-08-18 at 14 29 20" src="https://cloud.githubusercontent.com/assets/489567/17775448/30423d80-6550-11e6-85f5-723e745ff507.png">
## Request for comment

@guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
