### PR TITLE
make panic shedding permanently on

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -76,36 +76,6 @@ trait PerformanceSwitches {
     exposeClientSide = true
   )
 
-  val PanicMonitoringSwitch = Switch(
-    SwitchGroup.Performance,
-    "panic-monitoring",
-    "If this switch is on, we monitor latency and requests to see if servers are overloaded",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = On,
-    sellByDate = new LocalDate(2016, 8, 24),
-    exposeClientSide = false
-  )
-
-  val PanicLoggingSwitch = Switch(
-    SwitchGroup.Performance,
-    "panic-logging",
-    "If this switch is on, we log latency when we are monitoring it with panic-monitoring",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 24),
-    exposeClientSide = false
-  )
-
-  val PanicSheddingSwitch = Switch(
-    SwitchGroup.Performance,
-    "panic-shedding",
-    "If this switch is on, we try to keep response times below 1s by returning Service Unavailable errors if we're busy",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 24),
-    exposeClientSide = false
-  )
-
   val RichLinkSwitch = Switch(
     SwitchGroup.Performance,
     "rich-links",


### PR DESCRIPTION
we tried turning this off last month for a day, and everything fell over.  We thought we'd try again, and this time it lasted a day:
Earlier applications had a wobble
![image](https://cloud.githubusercontent.com/assets/7304387/17781659/20c40510-6568-11e6-9d12-4fba658fe7e9.png)
and later discussion went completely down the pan and needed intervention
![image](https://cloud.githubusercontent.com/assets/7304387/17781697/4492451a-6568-11e6-9dd1-36b50dede400.png)

Interestingly, it turns out this pattern of failure has been around since the year dot (2013), at which point it was christened "thrashing" and the explanation degenerated into spiritual incantation in the absence of other explanation.
https://github.com/guardian/frontend/blob/2016df80df5e5cf21a165684ed65817427199648/docs/99-archives/incidents/2013-05-08.md

@guardian/dotcom-platform 
