### PR TITLE
Revert deploy radiator UI revamping

### DIFF
--- a/static/src/deploys-radiator/app/main.css
+++ b/static/src/deploys-radiator/app/main.css
@@ -26,14 +26,15 @@ body {
     margin: 0;
     padding: 0 10vw;
     font-family: 'Schoolbell';
-    background-color: #E5F9FF;
+    animation: background linear 7200s;
+    animation-iteration-count: infinite;
 }
 
 #root > h1 {
     font-size: 6vw;
-    margin-top: 0;
+    margin-top: 7vw;
     margin-bottom: 0;
-    padding-bottom: 0;
+    padding-bottom: 2vw;
     font-weight: bold;
     flex-basis: 100%
 }
@@ -113,7 +114,7 @@ h2 {
 .builds ul {
     list-style-type: none;
     text-align: center;
-    background-color: blueviolet;
+    background-color: #ff0332;
     color: white;
     padding: 1vw 0;
 }

--- a/static/src/deploys-radiator/app/main.css
+++ b/static/src/deploys-radiator/app/main.css
@@ -1,47 +1,11 @@
-@import 'https://fonts.googleapis.com/css?family=Schoolbell|Space+Mono';
-
-@keyframes background {
-    0% {
-        background-color: hsl(338, 100%, 93%);
-    }
-    33% {
-        background-color: hsl(89, 100%, 93%);
-    }
-    66% {
-        background-color: hsl(183, 100%, 93%);
-    }
-    100% {
-        background-color: hsl(338, 100%, 93%);
-    }
-}
-
-.number {
-    font-family: 'Space Mono';
-    -webkit-font-smoothing: none;
-    text-shadow: rgba(255,255,255,0.4) 1px 1px 0px, rgba(0,0,0,0.2) 2px 2px 0px;
-}
-
 body {
     /* Unset UAS body */
     margin: 0;
-    padding: 0 10vw;
-    font-family: 'Schoolbell';
-    animation: background linear 60s;
-    animation-iteration-count: infinite;
-}
-
-#root > h1 {
-    font-size: 4vw;
-    margin-top: 7vw;
-    margin-bottom: 0;
-    padding-bottom: 2vw;
-    font-weight: bold;
-    flex-basis: 100%
+    padding: 1rem;
 }
 
 h1 {
-    font-size: 3vw;
-    text-align: center;
+    font-size: 3rem;
 }
 
 h2 {
@@ -61,8 +25,9 @@ h2 {
 }
 
 .deploy {
-    width: 100%;
-    margin-bottom: 1vw;
+    width: 9em;
+    margin-right: 1em;
+    margin-bottom: 1em;
     box-sizing: border-box;
     padding: 1em;
     float: left;
@@ -72,7 +37,6 @@ h2 {
     margin-top: 0;
     margin-bottom: 0;
     text-align: center;
-    font-size: 4vw;
 }
 
 .deploy ul {
@@ -104,22 +68,6 @@ h2 {
     background-color: hsl(0, 50%, 80%);
 }
 
-.builds h2 {
-    font-size: 2.5vw;
-}
-
-.builds ul {
-    list-style-type: none;
-    text-align: center;
-    background-color: #ff0332;
-    color: white;
-    padding: 1vw 0 3vw;
-}
-
-.builds li {
-    margin-bottom: -1.6vw;
-}
-
 .hidden {
     display: none;
 }
@@ -136,12 +84,11 @@ a:hover {
 /*Clearfix*/
 .row {
     overflow: hidden;
-    display: flex;
-    flex-wrap: wrap;
 }
 
 .col {
+    float: left;
+    width: 33.333%;
     box-sizing: border-box;
-    padding: 0 1vw;
-    flex: 1
+    padding-right: 1rem;
 }

--- a/static/src/deploys-radiator/app/main.css
+++ b/static/src/deploys-radiator/app/main.css
@@ -31,7 +31,7 @@ body {
 }
 
 #root > h1 {
-    font-size: 6vw;
+    font-size: 4vw;
     margin-top: 7vw;
     margin-bottom: 0;
     padding-bottom: 2vw;
@@ -72,8 +72,7 @@ h2 {
     margin-top: 0;
     margin-bottom: 0;
     text-align: center;
-    font-size: 6vw;
-    line-height: 1;
+    font-size: 4vw;
 }
 
 .deploy ul {
@@ -87,7 +86,6 @@ h2 {
 
 .deploy li {
      display: block;
-     font-size: 3vw
 }
 
 .deploy--completed {
@@ -107,8 +105,7 @@ h2 {
 }
 
 .builds h2 {
-    font-size: 3.5vw;
-    line-height: 1;
+    font-size: 2.5vw;
 }
 
 .builds ul {
@@ -116,11 +113,11 @@ h2 {
     text-align: center;
     background-color: #ff0332;
     color: white;
-    padding: 1vw 0;
+    padding: 1vw 0 3vw;
 }
 
 .builds li {
-    margin-bottom: 0;
+    margin-bottom: -1.6vw;
 }
 
 .hidden {

--- a/static/src/deploys-radiator/app/main.css
+++ b/static/src/deploys-radiator/app/main.css
@@ -26,7 +26,7 @@ body {
     margin: 0;
     padding: 0 10vw;
     font-family: 'Schoolbell';
-    animation: background linear 7200s;
+    animation: background linear 60s;
     animation-iteration-count: infinite;
 }
 

--- a/static/src/deploys-radiator/app/render.js
+++ b/static/src/deploys-radiator/app/render.js
@@ -85,7 +85,7 @@ const renderGroupDeployListNode = (deploys) => {
     ]);
 };
 const renderPage = ([codeDeploys, prodDeploys], [latestCodeDeploy, oldestProdDeploy], commits) => {
-    const isInSync = oldestProdDeploy.build === latestCodeDeploy.build && !hasDeployStarted(oldestProdDeploy) && !hasDeployStarted(latestCodeDeploy);
+    const isInSync = oldestProdDeploy.build === latestCodeDeploy.build;
     return h(`${exp(commits.size == 0) ? '.unsynced' : ''}.row#root`, {}, [
         h('h1', [
             `${isInSync ? '🌷👌' : '🔥 ship it!'}`

--- a/static/src/deploys-radiator/app/render.js
+++ b/static/src/deploys-radiator/app/render.js
@@ -27,7 +27,7 @@ const renderGroupDeployListNode = (deploys) => {
             className: `deploy deploy--${deployGroup.status.split(' ').join('-').toLowerCase()}`
         }, [
             h('h2', [
-                h('a.number', {
+                h('a', {
                     href: createBuildLink(deployGroup.build)
                 }, `${deployGroup.build}`)
             ]),
@@ -86,17 +86,22 @@ const renderGroupDeployListNode = (deploys) => {
 };
 const renderPage = ([codeDeploys, prodDeploys], [latestCodeDeploy, oldestProdDeploy], commits) => {
     const isInSync = oldestProdDeploy.build === latestCodeDeploy.build;
-    return h(`${exp(commits.size == 0) ? '.unsynced' : ''}.row#root`, {}, [
+    return h('.row#root', {}, [
         h('h1', [
-            `${isInSync ? '🌷👌' : '🔥 ship it!'}`
+            `Status: ${isInSync ? 'in sync.' : 'out of sync – ship it!'}`
         ]),
-        h('.col', [
-            h('h1', 'code'),
-            renderGroupDeployListNode(codeDeploys)
-        ]),
-        exp(commits.size > 0) && h('.col.builds', [
+        h('hr', {}, []),
+        exp(commits.size > 0) && h('.col', [
             h('h1', [
-                'waiting…'
+                'Difference (',
+                h('span', {
+                    title: 'Oldest PROD deploy'
+                }, `${oldestProdDeploy.build}`),
+                '...',
+                h('span', {
+                    title: 'Latest CODE deploy'
+                }, `${latestCodeDeploy.build}`),
+                ')'
             ]),
             ih('ul', {}, (commits
                 .groupBy(commit => commit.authorLogin)
@@ -107,7 +112,11 @@ const renderPage = ([codeDeploys, prodDeploys], [latestCodeDeploy, oldestProdDep
                 .toList()))
         ]),
         h('.col', [
-            h('h1', 'prod'),
+            h('h1', 'CODE'),
+            renderGroupDeployListNode(codeDeploys)
+        ]),
+        h('.col', [
+            h('h1', 'PROD'),
             renderGroupDeployListNode(prodDeploys)
         ])
     ]);


### PR DESCRIPTION
## What does this change?

Last month the UI of the deploys-radiator has been updated. 
After a month of using it, it is clear it has a lot of issues:
- Long committers list doesn't fit in the screen
- List of apps doesn't fit in the screen when deploying or failed.
- Custom fonts

Previous UI was far from being pretty but it is functional and doesn't have the issue listed above.

I would like to revert until we have time to fix those UI issues and come with a better solution.
## What is the value of this and can you measure success?

You can see the whole deployment state above the fold :)
## Screenshots

![screen shot 2016-08-18 at 18 13 59](https://cloud.githubusercontent.com/assets/233326/17783353/946b3b94-656f-11e6-8af6-6f58c2dab5e5.png)
## Request for comment

@sndrs @johnduffell @jfsoul @gtrufitt @SiAdcock @NataliaLKB @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
