### PR TITLE
Infer the status code from the server response

### DIFF
--- a/static/src/javascripts/projects/common/utils/fetch-json.js
+++ b/static/src/javascripts/projects/common/utils/fetch-json.js
@@ -17,7 +17,19 @@ define([
             if (resp.ok) {
                 return resp.json();
             } else {
-                throw new Error('Fetch error: ' + resp.statusText);
+                if (!resp.status) {
+                    // IE9 uses XDomainRequest which doesn't set the response status thus failing
+                    // even when the response was actually valid
+                    return resp.text().then(function (responseText) {
+                        try {
+                            return JSON.parse(responseText);
+                        } catch (ex) {
+                            throw new Error('Fetch error: Invalid JSON response');
+                        }
+                    });
+                } else {
+                    throw new Error('Fetch error: ' + resp.statusText);
+                }
             }
         });
     }


### PR DESCRIPTION
## What does this change?

Reqwest in Internet explorer 9 uses XDomainRequest which doesn't have a `status`

If status is missing, infer it from the `responseText`
## What is the value of this and can you measure success?

Comments, breaking news notification and all things ajaxed in work in IE9
## Does this affect other platforms - Amp, Apps, etc?

No
