### PR TITLE
Fix: prevent duplicate Audience Science impressions

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -73,10 +73,10 @@ define([
         window.asiDirectPrequal = function () {
             var pubads = window.googletag.pubads();
             Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
-            console.log('hey guys, I just removed all Audience Science keys. Regis, how do you do this??! I know, right?');
+
             function removeKey(key) {
                 pubads.clearTargeting(key);
             }
-        }
+        };
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -73,10 +73,9 @@ define([
         window.asiDirectPrequal = function () {
             var pubads = window.googletag.pubads();
             Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
-            console.log('hey guys, I just removed all Audience Science keys. Regis, how do you do this??! I know, right?');
             function removeKey(key) {
                 pubads.clearTargeting(key);
             }
-        }
+        };
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -10,11 +10,10 @@ define([
     'common/modules/commercial/dfp/private/on-slot-render',
     'common/modules/commercial/dfp/private/PrebidService',
     'common/modules/commercial/dfp/private/ophan-tracking',
-    'common/modules/commercial/third-party-tags/audience-science-pql',
 
     // These are cross-frame protocol messaging routines:
     'common/modules/commercial/dfp/private/get-stylesheet'
-], function (Promise, qwery, bonzo, raven, fastdom, commercialFeatures, buildPageTargeting, dfpEnv, onSlotRender, PrebidService, ophanTracking, audienceSciencePql) {
+], function (Promise, qwery, bonzo, raven, fastdom, commercialFeatures, buildPageTargeting, dfpEnv, onSlotRender, PrebidService, ophanTracking) {
 
 
     return init;
@@ -48,7 +47,6 @@ define([
             window.googletag.cmd.push(
                 setListeners,
                 setPageTargeting,
-                setAudienceScienceCallback,
                 resolve
             );
         });
@@ -65,17 +63,5 @@ define([
         Object.keys(targeting).forEach(function (key) {
             pubads.setTargeting(key, targeting[key]);
         });
-    }
-
-    // Remove all Audience Science related targeting keys as soon as we recieve
-    // an AS creative (will get called by the creative itself)
-    function setAudienceScienceCallback() {
-        window.asiDirectPrequal = function () {
-            var pubads = window.googletag.pubads();
-            Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
-            function removeKey(key) {
-                pubads.clearTargeting(key);
-            }
-        };
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -73,10 +73,10 @@ define([
         window.asiDirectPrequal = function () {
             var pubads = window.googletag.pubads();
             Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
-
+            console.log('hey guys, I just removed all Audience Science keys. Regis, how do you do this??! I know, right?');
             function removeKey(key) {
                 pubads.clearTargeting(key);
             }
-        };
+        }
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/load.js
@@ -61,7 +61,7 @@ define([
     // Remove all Audience Science related targeting keys as soon as we recieve
     // an AS creative (will get called by the creative itself)
     function setAudienceScienceCallback() {
-        window.asiDirectPrequal = function () {
+        window.onAudienceScienceCreativeLoaded = function () {
             var pubads = window.googletag.pubads();
             Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
             function removeKey(key) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/load.js
@@ -9,8 +9,9 @@ define([
     'common/modules/commercial/dfp/private/queue-advert',
     'common/modules/commercial/dfp/private/display-lazy-ads',
     'common/modules/commercial/dfp/private/display-ads',
-    'common/modules/commercial/dfp/private/refresh-on-resize'
-], function (Promise, qwery, sha1, identity, commercialFeatures, dfpEnv, Advert, queueAdvert, displayLazyAds, displayAds, refreshOnResize) {
+    'common/modules/commercial/dfp/private/refresh-on-resize',
+    'common/modules/commercial/third-party-tags/audience-science-pql'
+], function (Promise, qwery, sha1, identity, commercialFeatures, dfpEnv, Advert, queueAdvert, displayLazyAds, displayAds, refreshOnResize, audienceSciencePql) {
     return load;
 
     function load() {
@@ -27,6 +28,7 @@ define([
                 createAdverts,
                 queueAdverts,
                 setPublisherProvidedId,
+                dfpEnv.shouldLazyLoad() ? setAudienceScienceCallback : function() {},
                 dfpEnv.shouldLazyLoad() ? displayLazyAds : displayAds,
                 // anything we want to happen after displaying ads
                 refreshOnResize,
@@ -54,5 +56,17 @@ define([
             var hashedId = sha1.hash(user.id);
             window.googletag.pubads().setPublisherProvidedId(hashedId);
         }
+    }
+
+    // Remove all Audience Science related targeting keys as soon as we recieve
+    // an AS creative (will get called by the creative itself)
+    function setAudienceScienceCallback() {
+        window.asiDirectPrequal = function () {
+            var pubads = window.googletag.pubads();
+            Object.keys(audienceSciencePql.getSegments()).forEach(removeKey);
+            function removeKey(key) {
+                pubads.clearTargeting(key);
+            }
+        };
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -31,9 +31,7 @@ define([
         var asiPlacements = window.asiPlacements;
         var segments = storage.local.get(storageKey) || {};
         // override the global value with our previously stored one
-        window.asiPlacements = segments[section] || { TL3gqK: {} };
-        window.asiPlacements.TL3gqK.default = { key: 'test' };
-        window.asiPlacements.TL3gqK.blob = 'test';
+        window.asiPlacements = segments[section];
         segments[section] = asiPlacements;
         storage.local.set(storageKey, segments);
     }
@@ -56,7 +54,6 @@ define([
                     result[input[0]] = input[1];
                     return result;
                 }, {});
-            segments.pq_TL3gqK = 'T';
             // set up the global asiPlacements var in case dfp returns before asg
             window.asiPlacements = storedSegments[section];
         }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -31,7 +31,9 @@ define([
         var asiPlacements = window.asiPlacements;
         var segments = storage.local.get(storageKey) || {};
         // override the global value with our previously stored one
-        window.asiPlacements = segments[section];
+        window.asiPlacements = segments[section] || { TL3gqK: {} };
+        window.asiPlacements.TL3gqK.default = { key: 'test' };
+        window.asiPlacements.TL3gqK.blob = 'test';
         segments[section] = asiPlacements;
         storage.local.set(storageKey, segments);
     }
@@ -54,6 +56,7 @@ define([
                     result[input[0]] = input[1];
                     return result;
                 }, {});
+            segments.pq_TL3gqK = 'T';
             // set up the global asiPlacements var in case dfp returns before asg
             window.asiPlacements = storedSegments[section];
         }


### PR DESCRIPTION
## What does this change?

Prevents multiple Audience Science impressions per page. Our contract with Audience Science only allows one impression per page, and it has been estimated we are currently losing 8K£/month because of that.

The problem: Audience Science-related targeting keys are set at the page-level, because any slot can receive an AS creative. And an AS ad is _only_ delivered if some targeting keys are present. Therefore, we need to make sure that those keys are removed as soon as an AS creative is delivered.

The solution: The sooner we know an AS creative is delivered is ... in the creative itself! This creative will call a piece of code we set up in the global context, which will then remove all AS-related targeting keys.

**Small caveat**: this solution is not 100% bulletproof. Because ads are loaded asynchronously based on the user scrolling behaviour, multiple ad calls with the AS keys may still be seen before the first AS ad is rendered. Still, this solution has been accepted by the stakeholders and if it still isn't sufficient, we will make sure DFP calls are made sequentially.
## What is the value of this and can you measure success?

A drastic drop of Audience Science impressions and mo' money in the bank.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@guardian/commercial-dev 
