### PR TITLE
add video carousel to minute test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute-load-js.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute-load-js.js
@@ -19,7 +19,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Increase interaction with video trails';
         this.canRun = function() {
-            return (config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 || config.page.contentType === 'Article' || config.page.contentType === 'Video') && detect.getBreakpoint() === 'desktop';
+            return (config.page.isFront && (document.getElementsByClassName('fc-item__video').length > 0 || document.getElementsByClassName('fc-container--video').length > 0) || config.page.contentType === 'Article' || config.page.contentType === 'Video') && detect.getBreakpoint() === 'desktop';
         };
 
 
@@ -41,7 +41,6 @@ define([
                 id: 'control',
                 test: function () {
                 }
-
             }
         ];
     };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/minute.js
@@ -25,14 +25,16 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Increase interaction with video trails';
         this.canRun = function() {
-            return config.page.isFront &&  document.getElementsByClassName('fc-item__video').length > 0 && detect.getBreakpoint() === 'desktop';
+            return config.page.isFront &&  (document.getElementsByClassName('fc-item__video').length > 0 || document.getElementsByClassName('fc-container--video').length > 0)  && detect.getBreakpoint() === 'desktop';
         };
 
         function success(complete) {
+            //video trails
             qwery('.fc-item__video').forEach(function(el) {
                 bean.on(el.parentNode, 'click', complete);
             });
-
+            //video carousel
+            bean.on(qwery('.fc-container--video')[0], 'click', complete);
         }
 
         this.variants = [


### PR DESCRIPTION
## What does this change?

Adds video carousel to be included in minute test
## What is the value of this and can you measure success?

Allow minute JS to run on pages containing video carousel and track clickthrough on those pages.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

CC @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
