### PR TITLE
Fix branding of paid articles

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -2,6 +2,7 @@
 
 @import common.LinkTo
 @import layout.ContentWidths.GalleryMedia
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, GalleryCaptionCleaner}
 
@@ -43,7 +44,7 @@
     }
 </div>
 <div class="l-side-margins">
-    @fragments.contentFooter(page.item, page.related, "media")
+    @fragments.contentFooter(page.item, page.related, "media", isPaidContent(page.item, page))
 </div>
 
 @galleryItem(adSlots: Seq[String], adInterval: Int, image: model.ImageAsset, rowNum: Int, imageElement: model.ImageElement) = {

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,6 +1,7 @@
 @(page: ImageContentPage)(implicit request: RequestHeader)
 @import common.Edition
 @import layout.ContentWidths.ImageContentMedia
+@import views.support.Commercial.isPaidContent
 @import views.support.RenderClasses
 
 @defining(page.image) { image =>
@@ -44,7 +45,7 @@
     </article>
 </div>
 <div class="l-side-margins">
-    @fragments.contentFooter(image, page.related)
+    @fragments.contentFooter(image, page.related, isPaidContent = isPaidContent(image, page))
 </div>
 
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,6 +1,7 @@
 @(page: InteractivePage)(implicit request: RequestHeader)
 @import common.Edition
 @import views.support.RenderClasses
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 
 @body(page.interactive, page.item.content.isImmersive)
@@ -57,7 +58,7 @@
             </div>
         </article>
 
-        @fragments.contentFooter(interactive, page.related)
+        @fragments.contentFooter(interactive, page.related, isPaidContent = isPaidContent(interactive, page))
 
     </div>
 

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -2,6 +2,7 @@
 
 @import common.LinkTo
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640}
 
@@ -155,6 +156,6 @@
 </div>
 
 <div class="l-side-margins">
-    @fragments.contentFooter(media, page.related, "media")
+    @fragments.contentFooter(media, page.related, "media", isPaidContent(media, page))
 </div>
 }

--- a/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
+++ b/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
@@ -31,7 +31,7 @@
         </div>
     </article>
 
-    @fragments.contentFooter(page.gallery, page.related, "media")
+    @fragments.contentFooter(page.gallery, page.related, "media", isPaidContent = true)
 </div>
 
 @galleryItem(adSlots: Seq[String], adInterval: Int, image: model.ImageAsset, rowNum: Int, imageElement: model.ImageElement) = {

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,9 +1,9 @@
-
 @import model.ArticleSchemas
 @(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import views.BodyCleaner
+@import views.support.Commercial.isPaidContent
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
 
@@ -17,14 +17,15 @@
 }
 
 @defining(model.article) { article =>
+  @defining(isPaidContent(model.article, model)) { isPaidContent =>
 
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
 
         class="@RenderClasses(Map(
-            "content--advertisement-feature" -> article.commercial.isAdvertisementFeature,
+            "content--advertisement-feature" -> isPaidContent,
             "has-feature-showcase-element" -> (article.tags.isFeature && article.elements.hasShowcaseMainElement),
-            "paid-content--advertisement-feature" -> article.commercial.isAdvertisementFeature
+            "paid-content--advertisement-feature" -> isPaidContent
         ),  "content", "content--article", "tonal", s"tonal--${toneClass(article)}", s"section-${article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")}")"
 
         itemscope itemtype="@schemaType(model)" role="main">
@@ -41,11 +42,11 @@
                 }
             </div>
 
-            @if(article.commercial.isAdvertisementFeature){
+            @if(isPaidContent) {
                 @fragments.guBand()
             }
 
-            @fragments.headTonal(article, model, article.commercial.isAdvertisementFeature, amp = amp)
+            @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
                 @fragments.mainMedia(article, amp)
@@ -105,8 +106,9 @@
 
         @* Currently AMP documents don't support most of what we do in the footer *@
         @if(!amp) {
-            @fragments.contentFooter(article, model.related)
+            @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent)
         }
 
     </div>
+  }
 }

--- a/article/app/views/fragments/articleBodyHeroic.scala.html
+++ b/article/app/views/fragments/articleBodyHeroic.scala.html
@@ -2,6 +2,7 @@
 
 @import common.LinkTo
 @import views.BodyCleaner
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{ImgSrc, Item140}
 
@@ -42,7 +43,7 @@
             @fragments.labourLiverpoolContact()
         }
 
-        @fragments.contentFooter(article, model.related)
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(article, model))
 
     </div>
 }

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -2,13 +2,15 @@
 
 @import common.LinkTo
 @import views.BodyCleaner
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 
 @defining(model.article) { article =>
+  @defining(isPaidContent(model.article, model)) { isPaidContent =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
             class="content content--article content--immersive content--immersive-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
-            @if(article.commercial.isAdvertisementFeature){content--advertisement-feature}
+            @if(isPaidContent){content--advertisement-feature}
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}"
             itemscope itemtype="@article.metadata.schemaType" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
@@ -34,7 +36,7 @@
                         <div class="content__article-body from-content-api js-article__body" itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                             data-test-id="article-review-body">
 
-                            @if(article.commercial.isAdvertisementFeature || article.commercial.isSponsored(None) || article.commercial.isFoundationSupported) {
+                            @if(isPaidContent || article.commercial.isSponsored(None) || article.commercial.isFoundationSupported) {
                                 @fragments.commercial.badge(article, model)
                             }
 
@@ -55,7 +57,8 @@
             </div>
         </article>
 
-        @fragments.contentFooter(article, model.related)
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent)
 
     </div>
+  }
 }

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -1,14 +1,16 @@
 @(model: MinutePage)(implicit request: RequestHeader)
 
 @import common.LinkTo
-@import views.support.TrailCssClasses.toneClass
 @import views.BodyCleaner
+@import views.support.Commercial.isPaidContent
+@import views.support.TrailCssClasses.toneClass
 
 @defining(model.article) {  article =>
+  @defining(isPaidContent(model.article, model)) { isPaidContent =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
         class="content content--article content--minute-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
-            @if(article.commercial.isAdvertisementFeature){content--advertisement-feature}
+            @if(isPaidContent){content--advertisement-feature}
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}"
         itemscope itemtype="@article.metadata.schemaType" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
@@ -41,7 +43,8 @@
             </div>
         </article>
 
-        @fragments.contentFooter(article, model.related)
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent)
 
+    </div>
+  }
 }
-</div>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -9,6 +9,7 @@
 @import conf.switches.Switches._
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
+@import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
 @import _root_.liveblog.SinceBlockId
 
@@ -162,7 +163,7 @@
     </article>
 
     @if(!amp) {
-        @fragments.contentFooter(article, model.related)
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(article, model))
     }
 
 </div>

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,14 +1,17 @@
-@(content: model.ContentType, related: model.RelatedContent, cssClass: String = "")(implicit request: RequestHeader)
+@(content: model.ContentType,
+  related: model.RelatedContent,
+  cssClass: String = "",
+  isPaidContent: Boolean)(implicit request: RequestHeader)
 @import common.Edition
 @import views.support.ContentFooterContainersLayout
 
 <div class="content-footer @if(cssClass){content-footer--@cssClass}">
     @fragments.discussionFooter(content.content, content.trail.isCommentable, content.trail.isClosedForComments, content.content.shortUrlId)
 
-    @ContentFooterContainersLayout(content.content, related, content.commercial.isAdvertisementFeature) {
-        @fragments.storyPackagePlaceholder(content, related)
+    @ContentFooterContainersLayout(content.content, related, isPaidContent) {
+        @fragments.storyPackagePlaceholder(content, related, isPaidContent)
     } {
-        @fragments.onwardPlaceholder(content.commercial.isAdvertisementFeature)
+        @fragments.onwardPlaceholder(isPaidContent)
     } {
         <div class="js-repositioned-comments content__repositioned-comments"></div>
     } {
@@ -16,7 +19,7 @@
     } {
         @if(content.commercial.needsHighMerchandisingSlot(Edition(request))) {
             <div class="fc-container fc-container--commercial">
-                @fragments.commercial.commercialComponentHigh(content.commercial.isAdvertisementFeature)
+                @fragments.commercial.commercialComponentHigh(isPaidContent)
             </div>
         }
     } {

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -65,7 +65,7 @@
 
 
     @if(
-        (showBadge && (item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !item.commercial.isAdvertisementFeature))) ||
+        (staticBadgesSwitch.isSwitchedOff && showBadge && (item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !item.commercial.isAdvertisementFeature))) ||
             (staticBadgesSwitch.isSwitchedOn && (item.tags.isVideo || item.tags.isAudio))
     ) {
         @fragments.commercial.badge(item, page)

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -1,8 +1,10 @@
 @(item: model.ContentType, page: model.Page, showBadge: Boolean = false, showMeta: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 
+@import common.Edition
+@import model.Badges.badgeFor
+@import views.support.Commercial.isPaidContent
 @import views.support.ContributorLinks
 @import views.support.TrailCssClasses.toneClass
-@import model.Badges.badgeFor
 
 <header class="content__head tonal__head tonal__head--@toneClass(item)
     @if(item.content.hasTonalHeaderByline && item.tags.hasLargeContributorImage) { content__head--byline-pic}
@@ -88,7 +90,7 @@
                     </div>
                 }
 
-                @if(showBadge && !item.commercial.isAdvertisementFeature) {
+                @if(showBadge && !isPaidContent(item, page)) {
                     @fragments.commercial.badge(item, page)
                 }
 
@@ -100,7 +102,7 @@
         @if(item.fields.standfirst.isDefined) {
             <div class="gs-container">
                 <div class="content__main-column">
-                    @if(showBadge && item.commercial.isAdvertisementFeature) {
+                    @if(showBadge && isPaidContent(item, page)) {
                         <div class="content__meta-container js-content-meta js-football-meta u-cf">
                             @fragments.commercial.badge(item, page)
                         </div>

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -1,4 +1,6 @@
-@(content: model.ContentType, related: model.RelatedContent)(implicit request: RequestHeader)
+@(content: model.ContentType,
+  related: model.RelatedContent,
+  isPaidContent: Boolean)(implicit request: RequestHeader)
 
 @import layout.FaciaContainer
 @import views.html.fragments.containers
@@ -9,7 +11,7 @@
     )(request)
 }
 
-@defining(Seq("related") ++ (if(content.commercial.isAdvertisementFeature) Seq("paid-content--advertisement-feature") else Nil)) { classes =>
+@defining(Seq("related") ++ (if(isPaidContent) Seq("paid-content--advertisement-feature") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
         <aside class="@classes.mkString(" ") more-on-this-story" role="complementary" aria-labelledby="related-content-head">
             @container("more on this story", "more-on-this-story", href = None)

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -2,7 +2,7 @@ package views.support
 
 import common.Edition
 import common.Edition.defaultEdition
-import common.commercial._
+import common.commercial.{Sponsored, _}
 import common.dfp._
 import conf.switches.Switches.{containerBrandingFromCapi, staticBadgesSwitch}
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
@@ -34,7 +34,7 @@ object Commercial {
 
   def isSponsoredContent(item: ContentType, page: Page)(implicit request: RequestHeader): Boolean = {
     val edition = Edition(request)
-    isBrandedContent(item.commercial.isSponsored(Some(edition)), page, edition, common.commercial.Sponsored)
+    isBrandedContent(item.commercial.isSponsored(Some(edition)), page, edition, Sponsored)
   }
 
   def isFoundationFundedContent(item: ContentType, page: Page)(implicit request: RequestHeader): Boolean = {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,13 +1,14 @@
 package views.support
 
 import common.Edition
-import common.editions.Uk
-import common.commercial.{Branding, CardContent, ContainerModel, PaidContent}
+import common.Edition.defaultEdition
+import common.commercial._
 import common.dfp._
-import conf.switches.Switches.containerBrandingFromCapi
+import conf.switches.Switches.{containerBrandingFromCapi, staticBadgesSwitch}
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
 import model.pressed.{CollectionConfig, PressedContent}
 import model.{ContentType, MetaData, Page, Tag, Tags}
+import play.api.mvc.RequestHeader
 
 object Commercial {
 
@@ -16,6 +17,28 @@ object Commercial {
     case p: model.Page if p.metadata.sectionId == "identity" => false
     case p: model.CommercialExpiryPage => false
     case _ => true
+  }
+
+  private def isBrandedContent(
+    dfpDependentCondition: => Boolean,
+    page: Page,
+    edition: Edition,
+    sponsorshipType: SponsorshipType
+  ): Boolean = {
+    (staticBadgesSwitch.isSwitchedOff && dfpDependentCondition) ||
+    (staticBadgesSwitch.isSwitchedOn && page.branding(edition).exists(_.sponsorshipType == sponsorshipType))
+  }
+
+  def isPaidContent(item: ContentType, page: Page): Boolean =
+    isBrandedContent(item.commercial.isAdvertisementFeature, page, defaultEdition, PaidContent)
+
+  def isSponsoredContent(item: ContentType, page: Page)(implicit request: RequestHeader): Boolean = {
+    val edition = Edition(request)
+    isBrandedContent(item.commercial.isSponsored(Some(edition)), page, edition, common.commercial.Sponsored)
+  }
+
+  def isFoundationFundedContent(item: ContentType, page: Page)(implicit request: RequestHeader): Boolean = {
+    isBrandedContent(item.commercial.isFoundationSupported, page, defaultEdition, Foundation)
   }
 
   private def hasAdOfSize(slot: AdSlot,


### PR DESCRIPTION
When branding is driven by capi.
This is a bit cleaner and it fixes a few broken conditions.

/cc @guardian/labs-beta 
