### PR TITLE
Adding membership link to AU nav

### DIFF
--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -50,6 +50,7 @@ object Au extends Edition(
       NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel, skiingTravel)),
       NavItem(fashion),
       NavItem(science),
+      NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
       NavItem(video)
     )

--- a/common/test/common/NavigationTest.scala
+++ b/common/test/common/NavigationTest.scala
@@ -34,8 +34,8 @@ class NavigationTest extends FlatSpec with Matchers with OptionValues {
   "US full nav" should "not contain 'membership'" in {
     Us.navigation.filter(_.name.title == "membership").isEmpty shouldEqual true
   }
-  "AU full nav" should "not contain 'membership'" in {
-    Au.navigation.filter(_.name.title == "membership").isEmpty shouldEqual true
+  "AU full nav" should "contain 'membership'" in {
+    Au.navigation.filter(_.name.title == "membership").isEmpty shouldEqual false
   }
   "UK full nav" should "not contain 'education' or 'media'" in {
     Uk.navigation.filter(n => n.name.title == "education" || n.name.title == "media").isEmpty shouldEqual true


### PR DESCRIPTION
## What does this change?

Adds the requested membership link to the AU nav.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/8754692/17810614/1392b5a4-6616-11e6-8655-f08640fdb735.png)
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
