### PR TITLE
Fix facebook share count

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -86,12 +86,12 @@ define([
             var url = 'http://www.theguardian.com/' + config.page.pageId;
             try {
                 ajax({
-                    url: 'https://graph.facebook.com/' + url,
+                    url: 'https://graph.facebook.com/' + url, //TODO: use recent Graph API endpoint format (versioned) https://developers.facebook.com/docs/graph-api/reference/v2.7/url
                     type: 'json',
                     method: 'get',
                     crossOrigin: true
                 }).then(function (resp) {
-                    var count = resp.shares || 0;
+                    var count = resp.share && resp.share.share_count || 0;
                     counts.facebook = count;
                     addToShareCount(count);
                     updateTooltip();


### PR DESCRIPTION
## What does this change?

Fix facebook share count

To obtain an article share count we call the FB graph API using[ the v1
format](https://developers.facebook.com/docs/apps/changelog) (non versioned), probably because it doesn't require authentication.
However the response returned by this endpoint seems to have been
following the v2.0 format, which has been retired on August 7th.
I guess the non versioned url we are using is now following the v2.1
format, which seems to be different from what we used to expect.
This patch is handling this new response format as specified at
https://developers.facebook.com/docs/graph-api/reference/v2.1/url

Note: https://developers.facebook.com/docs/apps/changelog
## What is the value of this and can you measure success?

Share counts are not all displays as `0`
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@jfsoul @johnduffell @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
