### PR TITLE
Media caption link tones

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -58,12 +58,26 @@
         }
     }
 
-    .caption,
     .brandbadge__header,
     .brandbadge__help,
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;
+    }
+
+    .caption {
+        color: $neutral-4;
+
+        a {
+            color: $neutral-4;
+            border-bottom: 1px solid $neutral-2;
+            transition: border-color .15s ease-out;
+
+            &:hover {
+                border-bottom: 1px solid $neutral-7;
+                text-decoration: none;
+            }
+        }
     }
 
     .byline,


### PR DESCRIPTION
Links in captions on media-tone pages like this: https://www.theguardian.com/books/picture/2016/apr/19/re-illustrating-the-jungle-book-monkey-kidnapping-by-sarah-mcintyre-and-philip-reeve fail accessibility. They now do the same as galleries.

Before:
![screen shot 2016-08-19 at 15 53 45](https://cloud.githubusercontent.com/assets/14570016/17813918/40ddee0c-6625-11e6-8ad5-adc00e63b8c8.png)

After:
![screen shot 2016-08-19 at 15 51 48](https://cloud.githubusercontent.com/assets/14570016/17813919/42495ab0-6625-11e6-9006-f6ec6c01ca8c.png)
