### PR TITLE
Updated clashing tests list.

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,7 +42,7 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        var clashingTests = {name: 'GiraffeArticle20160802', variants: ['everyone', 'honest', 'like', 'complex'] };
+        var clashingTests = {name: 'ContributionsArticle20160818', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
         return some(clashingTests.variants, function(variant) {
             return ab.isInVariant(clashingTests.name, variant);
         });


### PR DESCRIPTION
## What does this change?

Prevent a test clash between the email sign-in component and Giraffe in-article. 
## What is the value of this and can you measure success?

None, this is a functional change.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![image](https://cloud.githubusercontent.com/assets/406099/17814962/0cdee82c-662a-11e6-8ef0-5397a9e21430.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
