### PR TITLE
ensures canonical-url data attribute is on all video elements

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -87,8 +87,9 @@
                                                         autoPlay = true,
                                                         showControlsAtStart = true,
                                                         endSlatePath = video.endSlatePath,
+                                                        path = video.metadata.id,
                                                         overrideIsRatioHd = None
-                                                    ), true
+                                                    ), enhance = true
                                                 )
                                             }
                                         </figure>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -87,7 +87,7 @@
                                                         autoPlay = true,
                                                         showControlsAtStart = true,
                                                         endSlatePath = video.endSlatePath,
-                                                        path = video.metadata.id,
+                                                        path = Some(video.metadata.id),
                                                         overrideIsRatioHd = None
                                                     ), enhance = true
                                                 )

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -49,8 +49,9 @@
                     autoPlay = true,
                     showControlsAtStart = true,
                     endSlatePath = video.endSlatePath,
-                    overrideIsRatioHd = None
-                ), true)
+                    overrideIsRatioHd = None,
+                    path = video.content.metadata.id
+                ), enhance = true)
             }
         </figure>
 

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -50,7 +50,7 @@
                     showControlsAtStart = true,
                     endSlatePath = video.endSlatePath,
                     overrideIsRatioHd = None,
-                    path = video.content.metadata.id
+                    path = Some(video.content.metadata.id)
                 ), enhance = true)
             }
         </figure>

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -26,10 +26,11 @@
                                 showControlsAtStart = true,
                                 endSlatePath = EndSlateComponents.fromContent(article.content).toUriPath,
                                 overrideIsRatioHd = None,
-                                embedPath = article.content.mainVideoCanonicalPath
+                                embedPath = Some(article.content.mainVideoCanonicalPath),
+                                path = article.content.mainVideoCanonicalPath
                             )
                         ) { player =>
-                            @fragments.media.video(player, true, amp = amp)
+                            @fragments.media.video(player, enhance = true, amp = amp)
                             <meta itemprop="name" content="@player.title">
                             <meta itemprop="image" content="@player.poster">
                             <meta itemprop="thumbnail" content="@player.poster">

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -27,7 +27,7 @@
                                 endSlatePath = EndSlateComponents.fromContent(article.content).toUriPath,
                                 overrideIsRatioHd = None,
                                 embedPath = Some(article.content.mainVideoCanonicalPath),
-                                path = article.content.mainVideoCanonicalPath
+                                path = Some(article.content.mainVideoCanonicalPath)
                             )
                         ) { player =>
                             @fragments.media.video(player, enhance = true, amp = amp)

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -26,8 +26,8 @@
                                 showControlsAtStart = true,
                                 endSlatePath = EndSlateComponents.fromContent(article.content).toUriPath,
                                 overrideIsRatioHd = None,
-                                embedPath = Some(article.content.mainVideoCanonicalPath),
-                                path = Some(article.content.mainVideoCanonicalPath)
+                                embedPath = article.content.mainVideoCanonicalPath,
+                                path = article.content.mainVideoCanonicalPath
                             )
                         ) { player =>
                             @fragments.media.video(player, enhance = true, amp = amp)

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -17,6 +17,7 @@ case class VideoPlayer(
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
   endSlatePath: String,
+  path: String,
   overrideIsRatioHd: Option[Boolean] = None,
   embedPath: Option[String] = None,
   hasFaciaHeader: Boolean = false,
@@ -41,7 +42,8 @@ object VideoPlayer {
     profile: VideoProfile,
     content: model.pressed.PressedContent,
     autoPlay: Boolean,
-    showControlsAtStart: Boolean
+    showControlsAtStart: Boolean,
+    path: String
   ) : VideoPlayer = { VideoPlayer(
     video,
     profile,
@@ -49,6 +51,7 @@ object VideoPlayer {
     autoPlay,
     showControlsAtStart,
     endSlatePath = SupportedUrl.fromFaciaContent(content),
+    path,
     hasFaciaHeader = true,
     faciaHeaderProperties = Some(VideoFaciaProperties(
       header = FaciaCardHeader.fromTrail(content, None),

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -17,7 +17,7 @@ case class VideoPlayer(
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
   endSlatePath: String,
-  path: String,
+  path: Option[String],
   overrideIsRatioHd: Option[Boolean] = None,
   embedPath: Option[String] = None,
   hasFaciaHeader: Boolean = false,
@@ -43,7 +43,7 @@ object VideoPlayer {
     content: model.pressed.PressedContent,
     autoPlay: Boolean,
     showControlsAtStart: Boolean,
-    path: String
+    path: Option[String]
   ) : VideoPlayer = { VideoPlayer(
     video,
     profile,

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -17,6 +17,7 @@ case class VideoPlayer(
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
   endSlatePath: String,
+  // TODO make `String` once `path` is available on main media on fronts
   path: Option[String],
   overrideIsRatioHd: Option[Boolean] = None,
   embedPath: Option[String] = None,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.TrailMetaData
 import common._
 import common.dfp.DfpAgent
 import conf.Configuration
-import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, FacebookShareImageLogoOverlay, TwitterShareImageLogoOverlay, HeroicTemplateSwitch}
+import conf.switches.Switches.{FacebookShareImageLogoOverlay, FacebookShareUseTrailPicFirstSwitch, HeroicTemplateSwitch, TwitterShareImageLogoOverlay}
 import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, Quiz}
@@ -175,14 +175,14 @@ final case class Content(
 
   lazy val linkCounts = LinkTo.countLinks(fields.body) + fields.standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 
-  lazy val hasMultipleVideosInPage: Boolean = mainVideoCanonicalPath match {
-    case Some(_) => numberOfVideosInTheBody > 0
-    case None => numberOfVideosInTheBody > 1
+  lazy val mainMediaVideo = Jsoup.parseBodyFragment(fields.main).body.getElementsByClass("element-video")
+
+  lazy val hasMultipleVideosInPage: Boolean = mainMediaVideo.isEmpty match {
+    case true   => numberOfVideosInTheBody > 1
+    case false  => numberOfVideosInTheBody > 0
   }
 
-  lazy val mainVideoCanonicalPath: Option[String] = Jsoup.parseBodyFragment(fields.main).body.getElementsByClass("element-video").headOption.map { v =>
-    new URL(v.attr("data-canonical-url")).getPath.stripPrefix("/")
-  }
+  lazy val mainVideoCanonicalPath: String = new URL(mainMediaVideo.attr("data-canonical-url")).getPath.stripPrefix("/")
 
   lazy val numberOfVideosInTheBody: Int = Jsoup.parseBodyFragment(fields.body).body().children().select("video[class=gu-video]").size()
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -45,11 +45,12 @@
                         Video640,
                         item,
                         autoPlay = false,
-                        showControlsAtStart = false
+                        showControlsAtStart = false,
+                        path = content.metadata.id
                     )) { player =>
                         <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
                             <div class="fc-item__video-container">
-                                @video(player, false, false, showOverlay = true, showPoster = false)
+                                @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
                             </div>
                         </div>
                         <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -46,7 +46,7 @@
                         item,
                         autoPlay = false,
                         showControlsAtStart = false,
-                        path = content.metadata.id
+                        path = Some(content.metadata.id)
                     )) { player =>
                         <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
                             <div class="fc-item__video-container">

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -50,12 +50,13 @@ data-test-id="facia-card"
                     autoPlay = false,
                     showControlsAtStart = false,
                     endSlatePath,
-                    Some(false),
+                    overrideIsRatioHd = Some(false),
                     // We only pass in the ID if this is a video or audio block, as if it's a mainMedia video, the
                     // ID is actually pointing to the article, which is wrong. It would be nice to have the ID on the
                     // ContentCard, but we don't for now. Annoyingly this doesn't allow us to check for if we should
                     // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
-                    if (item.isMediaLink) item.id else None
+                    embedPath = if (item.isMediaLink) item.id else None,
+                    path = item.id.getOrElse("foo")
                 )) { player =>
                     <div class="fc-item__media-wrapper fc-item__video u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -56,7 +56,7 @@ data-test-id="facia-card"
                     // ContentCard, but we don't for now. Annoyingly this doesn't allow us to check for if we should
                     // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
                     embedPath = if (item.isMediaLink) item.id else None,
-                    path = item.id.getOrElse("foo")
+                    path = if (item.isMediaLink) item.id else None
                 )) { player =>
                     <div class="fc-item__media-wrapper fc-item__video u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -48,6 +48,7 @@
                 data-embeddable="@player.video.videos.embeddable"
                 @player.embedPath.map{ p => data-embed-path="@p" }
                 preload="none"
+                data-canonical-url="@player.path"
             >
                 @player.video.videos.encodings.map { encoding =>
                     <source src="@VideoEncodingUrlCleaner(encoding.url)" type="@encoding.format" />

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -39,7 +39,8 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
     }
 
     document.getElementsByClass("element-video").foreach { figure: Element =>
-      val canonicalUrl = figure.attr("data-canonical-url")
+      val canonicalUrl = new URL(figure.attr("data-canonical-url")).getPath.stripPrefix("/")
+
       figure.attr("data-component", "video-inbody-embed")
       figure.getElementsByClass("gu-video").foreach { element: Element =>
         element
@@ -71,9 +72,9 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         findVideoApiElement(mediaId).foreach { videoElement =>
           element.attr("data-block-video-ads", videoElement.videos.blockVideoAds.toString)
-          if (!canonicalUrl.isEmpty && videoElement.videos.embeddable) {
+          if (videoElement.videos.embeddable) {
             element.attr("data-embeddable", "true")
-            element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
+            element.attr("data-embed-path", canonicalUrl)
           } else {
             element.attr("data-embeddable", "false")
           }

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -39,7 +39,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
     }
 
     document.getElementsByClass("element-video").foreach { figure: Element =>
-      val canonicalUrl = new URL(figure.attr("data-canonical-url")).getPath.stripPrefix("/")
+      val canonicalUrl = figure.attr("data-canonical-url")
 
       figure.attr("data-component", "video-inbody-embed")
       figure.getElementsByClass("gu-video").foreach { element: Element =>
@@ -47,12 +47,14 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
           .removeClass("gu-video")
           .addClass("js-gu-media--enhance gu-media gu-media--video")
           .attr("preload", "none")
-          .attr("data-canonical-url", canonicalUrl)
           .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
+
+        if (! canonicalUrl.isEmpty) {
+          element.attr("data-canonical-url", canonicalUrl)
+        }
 
         val mediaId = element.attr("data-media-id")
 
-        val asset = findVideoFromId(mediaId)
         val video = findVideoApiElement(mediaId)
 
         element.getElementsByTag("source").remove()
@@ -72,9 +74,9 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         findVideoApiElement(mediaId).foreach { videoElement =>
           element.attr("data-block-video-ads", videoElement.videos.blockVideoAds.toString)
-          if (videoElement.videos.embeddable) {
+          if (!canonicalUrl.isEmpty && videoElement.videos.embeddable) {
             element.attr("data-embeddable", "true")
-            element.attr("data-embed-path", canonicalUrl)
+            element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
           } else {
             element.attr("data-embeddable", "false")
           }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -202,7 +202,7 @@ define([
             if (!canonicalUrl) {
                 resolve(defaultVideoInfo);
             } else {
-                var ajaxInfoUrl = config.page.ajaxUrl + urlUtils.getPath(canonicalUrl);
+                var ajaxInfoUrl = config.page.ajaxUrl + '/' + canonicalUrl;
 
                 ajax({
                     url: ajaxInfoUrl + '/info.json',

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -184,6 +184,7 @@ define([
             embedPath = $el.attr('data-embed-path'),
             // we need to look up the embedPath for main media videos
             canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? embedPath : null),
+            // the fallback to window.location.pathname should only happen for main media on fronts
             gaEventLabel = canonicalUrl || window.location.pathname,
             shouldHideAdverts = $el.attr('data-block-video-ads') !== 'false',
             player,

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -183,8 +183,9 @@ define([
             endSlateUri = $el.attr('data-end-slate'),
             embedPath = $el.attr('data-embed-path'),
             // we need to look up the embedPath for main media videos
-            canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? '/' + embedPath : null),
-            shouldHideAdverts = $el.attr('data-block-video-ads') === 'false' ? false : true,
+            canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? embedPath : null),
+            gaEventLabel = canonicalUrl || window.location.pathname,
+            shouldHideAdverts = $el.attr('data-block-video-ads') !== 'false',
             player,
             mouseMoveIdle,
             playerSetupComplete,
@@ -227,7 +228,7 @@ define([
         }));
         events.addContentEvents(player, mediaId, mediaType);
         events.addPrerollEvents(player, mediaId, mediaType);
-        events.bindGoogleAnalyticsEvents(player, canonicalUrl);
+        events.bindGoogleAnalyticsEvents(player, gaEventLabel);
 
         videoInfo.then(function(videoInfo) {
             if (videoInfo.expired) {


### PR DESCRIPTION
## What does this change?

In order to have a clear event label in the video events for GA, adds `data-canonical-url` attribute to `video` elements on:
- [x] main media
- [x] article embed
- [x] video pages
- [x] video embed pages
- [x] video cards on fronts

We cannot add this new attribute to main media embeds on fronts as the video id is not available. Rather than blocking progress (as fronts would need updating) we'll fallback to `window.location.pathname` for now as we get little traffic to these videos.

Also using named parameters for explicitness.
## What is the value of this and can you measure success?

Tracking.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots
## Request for comment

@cb372 @guardian/multimedia 
