### PR TITLE
Fix fixed positioned element overflow by clipping

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/revealer.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/revealer.html
@@ -1,5 +1,5 @@
 <aside class="creative creative--revealer">
-    <a class="creative__cta" href="%%CLICK_URL_ESC%%<%=link%>" target="_blank">
+    <a class="creative__cta" href="%%CLICK_URL_UNESC%%<%=link%>" target="_blank">
         <img class="creative__background" src="<%=backgroundImage%>" alt>
         <img class="creative__button creative__button--<%=buttonVPos%> creative__button--<%=buttonHPos%>" src="<%=button%>" alt>
     </a>

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -3,9 +3,10 @@
     position: relative;
 
     .creative__cta {
-        background-attachment: fixed;
-        background-size: cover;
-        height: 250px;
+        position: absolute;;
+        height: 100%;
+        width: 100%;
+        clip: rect(0, auto, auto, 0);
     }
 
     .creative__background {


### PR DESCRIPTION
## What does this change?

The Revealer template uses a fixed positioned element inside a canvas. The problem is, the container of fixed positioned elements is the viewport, and so the element overflows its container:

![picture 2](https://cloud.githubusercontent.com/assets/629976/17816590/cdecbfb0-6631-11e6-9604-4c32bd41c3df.jpg)

Yeah, not cool. Although I really don't know why it worked [in the first instance](https://github.com/guardian/frontend/pull/13692). Anyway, by using the `clip` property on the parent of this element, we can achieve the desired result:

![picture 4](https://cloud.githubusercontent.com/assets/629976/17816621/fc42b0d6-6631-11e6-991d-45eeac0e68fe.jpg)

And _voila!_

cc @guardian/commercial-dev 
