### PR TITLE
Remove remnant polyfill code from matches

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/get-stylesheet.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/get-stylesheet.js
@@ -4,11 +4,11 @@ define([
     var aProto = Array.prototype;
 
     messenger.register('get-styles', function(specs) {
-        return getStyles(specs, document.styleSheets, 'matches');
+        return getStyles(specs, document.styleSheets);
     });
     return getStyles;
 
-    function getStyles(specs, styleSheets, matches) {
+    function getStyles(specs, styleSheets) {
         if (!specs || typeof specs.selector !== 'string') {
             return null;
         }
@@ -18,11 +18,11 @@ define([
         var result = [];
         while (i < ii) {
             var sheet = styleSheets[i++];
-            if (!sheet.ownerNode || !sheet.ownerNode[matches]) {
+            if (!sheet.ownerNode || !sheet.ownerNode.matches) {
                 continue;
             }
 
-            if (!sheet.ownerNode[matches](specs.selector)) {
+            if (!sheet.ownerNode.matches(specs.selector)) {
                 continue;
             }
 

--- a/static/test/javascripts/spec/common/commercial/dfp/get-stylesheet.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/get-stylesheet.spec.js
@@ -55,20 +55,20 @@ define([
         });
 
         it('should return all webfonts available', function () {
-            var result = getStyles({ selector: '.webfont' }, styleSheets, 'matches');
+            var result = getStyles({ selector: '.webfont' }, styleSheets);
             expect(result).not.toBeNull();
             expect(result.length).toBe($('.webfont').length);
         });
 
         it('should return only the GuardianSansWeb webfont', function () {
-            var result = getStyles({ selector: '.webfont[data-cache-name="GuardianSansWeb"]' }, styleSheets, 'matches');
+            var result = getStyles({ selector: '.webfont[data-cache-name="GuardianSansWeb"]' }, styleSheets);
             expect(result).not.toBeNull();
             expect(result.length).toBe($('.webfont[data-cache-name="GuardianSansWeb"]').length);
         });
 
         it('should return only the GuardianSansWeb and GuardianSansTextWeb webfonts', function () {
             var selector = '.webfont[data-cache-name="GuardianSansWeb"], .webfont[data-cache-name="GuardianSansWeb"]';
-            var result = getStyles({ selector: selector }, styleSheets, 'matches');
+            var result = getStyles({ selector: selector }, styleSheets);
             expect(result).not.toBeNull();
             expect(result.length).toBe($(selector).length);
         });


### PR DESCRIPTION
Slight tidy up for code which used to use `matches` or `msMatchesSelector`. This can now use `matches` thanks to the polyfill, but still checks the function is defined.
