### PR TITLE
Small styling fix on the paid video page

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -764,6 +764,11 @@
             }
         }
 
+        .brandbadge__header,
+        .brandbadge__help {
+            color: $neutral-2;
+        }
+
         .most-viewed-container--media,
         .meta__number {
             .inline-icon {


### PR DESCRIPTION
## What does this change?

A fix for the font colour around the logos on the paid video page.
## Screenshots

Before:
![screen shot 2016-08-22 at 10 56 50](https://cloud.githubusercontent.com/assets/489567/17850879/258fb296-6857-11e6-91d6-c816d7d54b37.png)

After:
![screen shot 2016-08-22 at 10 56 35](https://cloud.githubusercontent.com/assets/489567/17850882/2d77892a-6857-11e6-8f16-376c6cfa2ba4.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
