### PR TITLE
Wrap moved fabric in section

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -112,10 +112,12 @@ define([
     sizeCallbacks[adSizes.fabric] = function(event, advert) {
         var node = advert.node;
         var closestFcContainer = closest(node, '.fc-container');
+        var sectionContainer = bonzo(bonzo.create('<section>'));
 
         if (closestFcContainer) {
             fastdom.write(function () {
-                bonzo(node).insertAfter(closestFcContainer);
+                sectionContainer.append(node);
+                sectionContainer.insertAfter(closestFcContainer);
             });
         }
 


### PR DESCRIPTION
We want to make sure that the moved ad-slot is nested in a section, as the location it gets moved to has `section` as siblings.

@regiskuckaertz @rich-nguyen 
