### PR TITLE
Commercial: revealer on desktop/tablet

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -16,7 +16,6 @@ define([
 
         function create() {
             var markup = revealerTpl(params);
-            var isDesktop = detect.isBreakpoint({ min: 'desktop' });
 
             return fastdom.write(function () {
                 $adSlot[0].insertAdjacentHTML('beforeend', markup);
@@ -29,10 +28,8 @@ define([
                     return $adSlot[0].getBoundingClientRect();
                 });
             }).then(function (adSlotRect) {
-                if( isDesktop ) {
-                    var background = $adSlot[0].getElementsByClassName('creative__background')[0];
-                    background.style.left = adSlotRect.left + 'px';
-                }
+                var background = $adSlot[0].getElementsByClassName('creative__background')[0];
+                background.style.left = (adSlotRect.left + adSlotRect.width / 2) + 'px';
                 return true;
             });
         }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -1,9 +1,10 @@
 define([
     'common/utils/fastdom-promise',
     'common/utils/template',
+    'common/utils/detect',
     'common/modules/commercial/creatives/add-tracking-pixel',
     'text!common/views/commercial/creatives/revealer.html'
-], function(fastdom, template, addTrackingPixel, revealerStr) {
+], function(fastdom, template, detect, addTrackingPixel, revealerStr) {
     var revealerTpl;
 
     function Revealer($adSlot, params) {
@@ -15,6 +16,7 @@ define([
 
         function create() {
             var markup = revealerTpl(params);
+            var isDesktop = detect.isBreakpoint({ min: 'desktop' });
 
             return fastdom.write(function () {
                 $adSlot[0].insertAdjacentHTML('beforeend', markup);
@@ -22,6 +24,16 @@ define([
                 if (params.trackingPixel) {
                     addTrackingPixel($adSlot, params.trackingPixel + params.cacheBuster);
                 }
+            }).then(function () {
+                return fastdom.read(function () {
+                    return $adSlot[0].getBoundingClientRect();
+                });
+            }).then(function (adSlotRect) {
+                if( isDesktop ) {
+                    var background = $adSlot[0].getElementsByClassName('creative__background')[0];
+                    background.style.left = adSlotRect.left + 'px';
+                }
+                return true;
             });
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -1,10 +1,9 @@
 define([
     'common/utils/fastdom-promise',
     'common/utils/template',
-    'common/utils/detect',
     'common/modules/commercial/creatives/add-tracking-pixel',
     'text!common/views/commercial/creatives/revealer.html'
-], function(fastdom, template, detect, addTrackingPixel, revealerStr) {
+], function(fastdom, template, addTrackingPixel, revealerStr) {
     var revealerTpl;
 
     function Revealer($adSlot, params) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -636,6 +636,10 @@
     min-height: 250px;
 }
 
+.ad-slot--revealer {
+    min-width: 300px;
+}
+
 .ad-slot--fabric-v1,
 .ad-slot--fluid250 {
     width: auto;

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -13,13 +13,7 @@
         position: fixed;
         height: 100%;
         top: 0;
-        left: $gs-gutter / 2;
-        right: $gs-gutter / 2;
-
-        @include mq(mobileLandscape) {
-            left: $gs-gutter;
-            right: $gs-gutter;
-        }
+        transform: translate(-50%, 0);
     }
 
     .creative__button {


### PR DESCRIPTION
So, the position of the revealer creatives on desktop is a little bit off:

![picture 6](https://cloud.githubusercontent.com/assets/629976/17852600/f244a79e-685f-11e6-9cc6-38a1ed9fd891.jpg)

This is fixed by moving the fixed positioned image closer to the adslot expanded `DOMRect`.

![picture 7](https://cloud.githubusercontent.com/assets/629976/17852627/1b87cdc0-6860-11e6-9935-d0eddb6a2f85.jpg)

cc @guardian/commercial-dev 
