### PR TITLE
Paid interactives - logo position fixed

### DIFF
--- a/common/app/views/fragments/commercial/contentLogo.scala.html
+++ b/common/app/views/fragments/commercial/contentLogo.scala.html
@@ -1,6 +1,6 @@
 @(branding: common.commercial.Branding)
 
-<div class="brandbadge brandbadge--onside ad-slot--force-display">
+<div class="brandbadge brandbadge--onside ad-slot--force-display ad-slot--paid-for-badge--interactive">
     <div class="brandbadge__inner">
         <h3 class="brandbadge__header">@branding.label</h3>
         <a href="@branding.sponsorLink" class="brandbadge__link">


### PR DESCRIPTION
## What does this change?

The position of the logo should be on the right column. Just like the logos served via DFP. 
## Screenshots

Before:
![screen shot 2016-08-22 at 13 37 33](https://cloud.githubusercontent.com/assets/489567/17854929/a3a75218-686d-11e6-9e36-b59d464513a3.png)

After:
![screen shot 2016-08-22 at 13 37 00](https://cloud.githubusercontent.com/assets/489567/17854940/ab89060c-686d-11e6-82a9-e998f19a4556.png)
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
