### PR TITLE
Return error during get comment process

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -144,11 +144,11 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
           RevalidatableResult.Ok(views.html.discussionComments.discussionPage(page))
         }
       }
+    } recover {
+      case NonFatal(e) =>
+        log.error(s"Discussion $key cannot be retrieved", e)
+        InternalServerError(s"Discussion $key cannot be retrieved")
     }
-      .recover {
-        case NonFatal(e) =>
-          NotFound(s"Discussion ${key} cannot be retrieved")
-      }
   }
 
   private def getTopComments(key: DiscussionKey)(implicit request: RequestHeader): Future[Result] = {


### PR DESCRIPTION
Previously errors were simply swallowed, making it hard to debug prod issues.

(The specific motivation here is a prod issue that we have been unable to replicate locally - relating to braces in comments.)

@johnduffell 
