### PR TITLE
Revealer: Use absolute units for the fixed background

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -1,9 +1,10 @@
 define([
     'common/utils/fastdom-promise',
     'common/utils/template',
+    'common/utils/detect',
     'common/modules/commercial/creatives/add-tracking-pixel',
     'text!common/views/commercial/creatives/revealer.html'
-], function(fastdom, template, addTrackingPixel, revealerStr) {
+], function(fastdom, template, detect, addTrackingPixel, revealerStr) {
     var revealerTpl;
 
     function Revealer($adSlot, params) {
@@ -24,11 +25,14 @@ define([
                 }
             }).then(function () {
                 return fastdom.read(function () {
-                    return $adSlot[0].getBoundingClientRect();
+                    return detect.getViewport();
                 });
-            }).then(function (adSlotRect) {
+            }).then(function (viewport) {
                 var background = $adSlot[0].getElementsByClassName('creative__background')[0];
-                background.style.left = (adSlotRect.left + adSlotRect.width / 2) + 'px';
+                background.style.width = viewport.width + 'px';
+                // for the height, we need to account for the height of the location bar, which
+                // may or may not be there. 70px padding is not too much.
+                background.style.height = (viewport.height + 70) + 'px';
                 return true;
             });
         }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -28,12 +28,14 @@ define([
                     return detect.getViewport();
                 });
             }).then(function (viewport) {
-                var background = $adSlot[0].getElementsByClassName('creative__background')[0];
-                background.style.width = viewport.width + 'px';
-                // for the height, we need to account for the height of the location bar, which
-                // may or may not be there. 70px padding is not too much.
-                background.style.height = (viewport.height + 70) + 'px';
-                return true;
+                return fastdom.write(function () {
+                    var background = $adSlot[0].getElementsByClassName('creative__background')[0];
+                    background.style.width = viewport.width + 'px';
+                    // for the height, we need to account for the height of the location bar, which
+                    // may or may not be there. 70px padding is not too much.
+                    background.style.height = (viewport.height + 70) + 'px';
+                    return true;
+                });
             });
         }
     }

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -3,17 +3,19 @@
     position: relative;
 
     .creative__cta {
-        position: absolute;;
+        position: absolute;
         height: 100%;
         width: 100%;
         clip: rect(0, auto, auto, 0);
+        overflow: hidden;
     }
 
     .creative__background {
         position: fixed;
-        height: 100%;
         top: 0;
-        transform: translate(-50%, 0);
+        left: 0;
+        background-size: cover;
+        backface-visibility: hidden;
     }
 
     .creative__button {


### PR DESCRIPTION
It turns out that using % to set the dimensions of a fixed positioned element is a bad idea, especially if this element has a background image. Even using the shiny `vh` and `vw` units doesn't provide smooth scrolling.

I had to instead use absolute units and set the dimensions in pixels once and for all, at runtime.

cc  @guardian/commercial-dev 
