### PR TITLE
Radiator: show name and owner of expiring switches

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -21,9 +21,9 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
   lazy val githubAccessToken = Configuration.github.token.map{ token => s"?access_token=$token" }.getOrElse("")
 
   def switchesExpiringSoon = {
-    Switches.all.filter { switch =>
-      Switch.expiry(switch).expiresSoon
-    }
+    Switches.all.filter(Switch.expiry(_).hasExpired) ++ // already expired
+    Switches.all.filter(Switch.expiry(_).daysToExpiry.exists(_ == 0)) ++ // expiring today
+    Switches.all.filter(Switch.expiry(_).daysToExpiry.exists(_ == 1)) // expiring tomorrow
   }
 
   // proxy call to github so we do not leak the access key

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -8,6 +8,21 @@
 
 @import org.joda.time.{DateTime, Days}
 
+@showOwners(switch: conf.switches.Switch) = {
+    @for(owner <- switch.owners) { @showOwner(owner) }
+}
+@showOwner(owner: conf.switches.Owner) = {
+    @if(!owner.github.isEmpty) {
+        <a href="https://github.com/@{owner.github.get}">@{owner.name.getOrElse(owner.github)}</a>
+    } else {
+        @if(!owner.email.isEmpty) {
+            <a href="mailto:@{owner.email.get}">@{owner.name.getOrElse(owner.email)}</a>
+        } else {
+            @owner.name
+        }
+    }
+}
+
 @admin_main("theguardian.com radiator", env, isAuthed = true, hasCharts = true, autoRefresh = true) {
 
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/radiator.css")">
@@ -35,11 +50,11 @@
 
     <div class="expiring-wrapper">
         <h2>Expiring features</h2>
-        <ul id="sell-by-date">
+        <ul id="switches">
             @switches.map{ switch =>
                 @Switch.expiry(switch).daysToExpiry.map { days =>
-                    <li class="Expiring expiry-days-@days @if(Switch.expiry(switch).hasExpired){expired}" title="@switch.name - expires in @days days">
-                        @switch.name
+                    <li title="@switch.name - expires in @days days">
+                        <span class="expiry-days-@days">@switch.name</span> - <span>@showOwners(switch)</span>
                     </li>
                 }
             }

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -12,7 +12,7 @@ header {
     font-size: 18px;
 }
 .navbar { display: none; }
-#pingdom li, #riffraff li, #sell-by-date li { font-size: 30px; line-height: 30px; }
+#pingdom li, #riffraff li { font-size: 30px; line-height: 30px; }
 #pingdom small, #riffraff small { font-size: 20px; }
 
 .down, .Failed { color: red; }
@@ -27,8 +27,7 @@ ul {
 }
 
 #pingdom li,
-.riffraff li,
-#sell-by-date li {
+.riffraff li {
     width: 30px;
     height: 30px;
     font-size: 0;
@@ -53,21 +52,34 @@ ul {
     background-color: red;
 }
 
-.Expiring {
-    background-color: orange;
-}
-
 .riffraff li.Behind {
     background-color: #21fa41;
 }
 
-.expired, .expiry-days-0, .expiry-days-1, .expiry-days-2 {
+#switches {
+    list-style-type: none;
+    padding: 0px;
+}
+#switches li {
+    margin: 3px;
+}
+#switches li span {
+    color: white;
+    padding: 2px;
+    margin: 2px;
+}
+#switches .expired {
     background-color: red;
+}
+#switches .expiry-days-0 {
+    background-color: orangered;
+}
+#switches .expiry-days-1 {
+    background-color: orange;
 }
 
 .riffraff,
-#pingdom,
-#sell-by-date {
+#pingdom {
     overflow: hidden;
     padding: 0;
     margin-bottom: 20px;


### PR DESCRIPTION
## What does this change?

Show name and owner of expiring switches
## What is the value of this and can you measure success?

Displaying red and orange squares for expiring switches doesn't bring much value.
This patch would show the name of the switch and who is owning it. It is limited to the switches expiring on or before tomorrow, sorted by expiration date ascending.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

BEFORE 
![screen shot 2016-08-22 at 17 02 28](https://cloud.githubusercontent.com/assets/233326/17861752/38b1025c-688a-11e6-9960-cc8ae1f18317.png)

AFTER
![screen shot 2016-08-22 at 16 55 32](https://cloud.githubusercontent.com/assets/233326/17861728/1a791720-688a-11e6-8bff-d1446f0283d3.png)
## Request for comment

@gtrufitt @jfsoul @johnduffell @SiAdcock 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
