### PR TITLE
Change colour of headline on immersive articles

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -112,15 +112,10 @@
     font-weight: 200;
 }
 
-.immersive-main-media__headline-container--dark {
-    .content__headline--immersive-article {
-        color: #ffffff;
-    }
-}
-
 .content__headline--immersive-article {
     @include fs-headline(7, true);
     line-height: 1;
+    color: #ffffff;
 
     @include mq(desktop) {
         font-size: 4rem;


### PR DESCRIPTION
I'm pretty sure we would always want these headlines to be white on immersive articles.
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/1607666/17861837/a0c6731a-6860-11e6-83d0-1c210041ee48.png)

After:
![image](https://cloud.githubusercontent.com/assets/1607666/17861823/968dcfb0-6860-11e6-8427-0fcf50db8230.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
