### PR TITLE
GA: send internal link click events to correct tracker

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -91,7 +91,7 @@
             if (referrerVars && referrerVars.value) {
                 var d = new Date().getTime();
                 if (d - referrerVars.value.time < 60 * 1000) { // One minute
-                    ga('guardianTestPropertyTracker.send', 'event', 'Click', 'Internal', referrerVars.value.tag, {
+                    ga('@{trackerName}.send', 'event', 'Click', 'Internal', referrerVars.value.tag, {
                         dimension12: referrerVars.value.path
                     });
                 }


### PR DESCRIPTION
## What does this change?

Sends internal link click events to the correct GA tracker. 

In-page links and external links are handled elsewhere and have already been switched over to the prod tracker in #14013
## What is the value of this and can you measure success?

whatevs
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

@ajosephides @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
