### PR TITLE
Amp liveblog - bug fix

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -38,14 +38,14 @@
                 _root_.liveblog.LatestBlock(article.blocks)
             }" data-test-id="live-blog-blocks"
             itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
-                <div update on="tap:live-list.update" class="toast__space-reserver">
+                <button update on="tap:live-list.update" class="toast__space-reserver">
                     <div id="toast__tofix" class="toast__container is-sticky">
-                        <button class="toast__button toast__button--closed button button--large">
+                        <span class="toast__button toast__button--closed button button--large">
                             <span class="toast__text">New updates</span>
                             @fragments.inlineSvg("refresh", "icon", List(""))
-                        </button>
+                        </span>
                     </div>
-                </div>
+                </button>
                 <div items>
                     @liveBlogBlocksAMP(article, timezone)
                 </div>

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -232,6 +232,8 @@
 
 .toast__space-reserver {
     height: 36px;
+    border: 0 none;
+    background: transparent;
     margin-bottom: -36px;
     display: block;
 }

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -249,6 +249,7 @@
     position: relative;
     display: inline-block;
     box-sizing: border-box;
+    cursor: pointer;
     overflow: hidden;
     height: 36px;
     width: auto;
@@ -271,6 +272,7 @@
     display: inline-block;
     font-weight: 700;
     float: right;
+    line-height: 36px;
     opacity: 1;
     padding-left: 25px;
     transition: opacity .3s ease-in-out;


### PR DESCRIPTION
## What does this change?

Fixes a validation error where the element with `on="tap:live-list.update"` is expected to have the semantics of a button. Misleadingly the validator suggests adding a role and tabindex to the element, but instead making the element a `button` fixes the validation error. This required some minor CSS fixes.
## What is the value of this and can you measure success?

Fixes AMP liveblog validation errors.
## Does this affect other platforms - Amp, Apps, etc?

AMP only.
## CC

@stephanfowler

@SiAdcock @NataliaLKB - Lets review this when you get back!
