### PR TITLE
Radiator tweaks

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -32,7 +32,6 @@
                     <ul>
                         <li><a href="/dev/switchboard">Switchboard</a></li>
                         <li><a href="@controllers.admin.routes.RadiatorController.renderRadiator()">Radiator</a></li>
-                        <li><a href="@controllers.admin.routes.RadiatorController.renderRadiator()?features=external">Radiator (external)</a></li>
                         @if(R2PagePressServiceSwitch.isSwitchedOn) {
                             <li><a href="@controllers.admin.routes.R2PressController.pressForm()">Press-a-page</a></li>
                         }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -29,7 +29,7 @@
 
     <header>
         <span id="logo">the<span class="white">guardian</span>.com dashboard</span>
-        <div class="cost"><strong>$@cost.max.toLong</strong> this month</div>
+        <div class="cost"><a href="https://console.aws.amazon.com/billing/home"><strong>$@cost.max.toLong</strong> this month</a></div>
     </header>
 
     <div class="pingdom-wrapper">

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -51,6 +51,9 @@ ul {
 #pingdom li.down, .riffraff li.Failed {
     background-color: red;
 }
+#pingdom li.paused {
+    background-color: lightgrey;
+}
 
 .riffraff li.Behind {
     background-color: #21fa41;

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -98,7 +98,7 @@ li.Not.running {
     background-color: lightgrey;
 }
 
-h2, .cost {
+h2, .cost a {
     font-family: Georgia, serif;
     color: #999;
     clear: both;

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -74,7 +74,19 @@ define([
             }
 
             function renderDeploys(stage, target) {
-                Object.keys(latestDeployments[stage]).forEach(function (deployment)  {
+                var sortedDeployments = Object.keys(latestDeployments[stage])
+                    .sort(function(firstDeployment, secondDeployment) {
+                        //sorting by build number (higher first) and then project name (alphabetical)
+                        var d1 = latestDeployments[stage][firstDeployment];
+                        var d2 = latestDeployments[stage][secondDeployment];
+                        var buildDiff = d1.build - d2.build;
+                        if (buildDiff !== 0) {
+                            return buildDiff;
+                        }
+                        return d1.projectName.localeCompare(d2.projectName);
+                    });
+
+                sortedDeployments.forEach(function (deployment) {
                     var d  = latestDeployments[stage][deployment];
                     var nameAbbreviation = d.projectName.substr(7, 4); //start at 7 to drop 'dotcom: '
 


### PR DESCRIPTION
## What does this change?

Small tweaks to Radiator:
- Make the aws cost a link to the aws billing console
- sort deploys per build and project name
- add grey color for pingdom paused checks (I have to find out why one would be paused 😁 )
- Removing unused Radiator external link on admin dashboard
## What is the value of this and can you measure success?

Link to find more info, consistent ordering, no blank squares, ...
## Screenshots

![screen shot 2016-08-23 at 11 50 29](https://cloud.githubusercontent.com/assets/233326/17889380/d622ae12-6927-11e6-979a-5b5e6958865f.png)
## Request for comment

@johnduffell @gtrufitt @sihil @jfsoul @NataliaLKB @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
