### PR TITLE
YANK: Reserve space for comments and save for later

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -39,7 +39,7 @@
                 }
             </div>
 
-            <div class="meta__numbers modern-visible">
+            <div class="meta__numbers">
                 <div class="u-h meta__number js-sharecount">
                 </div>
                 <div class="u-h meta__number" data-discussion-id="@item.content.discussionId" data-commentcount-format="content" data-discussion-closed="@{

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -113,8 +113,7 @@
 }
 
 .meta__save-for-later {
-    // Shown with test
-    display: none;
+    height: 30px;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline / 2;
     margin-bottom: 0;


### PR DESCRIPTION
## What does this change?

It makes sure that comments, shares and SFL don't jump the page.
## What is the value of this and can you measure success?

Instead of this:

![jumping-meta-before](https://cloud.githubusercontent.com/assets/638051/17890656/4cea3946-692f-11e6-8d2e-60dfe54d9f1c.gif)

You get this:

![jumping-meta](https://cloud.githubusercontent.com/assets/638051/17890659/51961f50-692f-11e6-86dd-d2aee3842213.gif)

_Note:_ This does mean that no-js and non-modern browsers get some space that is never filled... but this is far better than the alternative.
## Request for comment

@guardian/dotcom-platform 
