### PR TITLE
AMP: Bugfix: Check for amp for default rich-link styles

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -55,7 +55,7 @@ object BodyCleaner {
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,
-      RichLinkCleaner,
+      RichLinkCleaner(amp),
       MembershipEventCleaner,
       BlockquoteCleaner,
       ChaptersLinksCleaner,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -549,7 +549,7 @@ object MainFigCaptionCleaner extends HtmlCleaner {
   }
 }
 
-object RichLinkCleaner extends HtmlCleaner {
+case class RichLinkCleaner(amp: Boolean = false) extends HtmlCleaner {
   override def clean(document: Document): Document = {
 
     val richLinks = document.getElementsByClass("element-rich-link")
@@ -558,13 +558,17 @@ object RichLinkCleaner extends HtmlCleaner {
       .addClass("element-rich-link--not-upgraded")
       .attr("data-component", "rich-link")
       .zipWithIndex.map{ case (el, index) => el.attr("data-link-name", s"rich-link-${richLinks.length} | ${index+1}") }
-      .map( richLink => {
-          val link = richLink.getElementsByTag("a").first()
-          val href = link.attr("href")
-          val html = views.html.fragments.richLinkDefault(link.text(), href).toString()
-          richLink.empty().prepend(html);
-        }
-      )
+
+    if (!amp) {
+      richLinks
+        .map( richLink => {
+            val link = richLink.getElementsByTag("a").first()
+            val href = link.attr("href")
+            val html = views.html.fragments.richLinkDefault(link.text(), href).toString()
+            richLink.empty().prepend(html);
+          }
+        )
+    }
     document
   }
 }


### PR DESCRIPTION
## What does this change?

Bugfix caused by #14032
## What is the value of this and can you measure success?

Richlinks look right on AMP again.
## Screenshots

Broken: 

![screen shot 2016-08-23 at 13 22 19](https://cloud.githubusercontent.com/assets/638051/17891635/0b1b74e8-6935-11e6-93c8-f7a580f92566.jpg)

Fixed:

![screen shot 2016-08-23 at 13 21 54](https://cloud.githubusercontent.com/assets/638051/17891644/1a9dc376-6935-11e6-98d5-d0257c4bd468.jpg)
## Request for comment

@guardian/dotcom-platform 
