### PR TITLE
Radiator: grouping graphs

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -38,14 +38,15 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
 
     for {
       user50x <- CloudWatch.user50x
-      shortLatency <- CloudWatch.shortStackLatency
+      latencyGraphs <- CloudWatch.shortStackLatency
       fastlyErrors <- CloudWatch.fastlyErrors
-      multiLineGraphs <- CloudWatch.fastlyHitMissStatistics
+      fastlyHitMiss <- CloudWatch.fastlyHitMissStatistics
       cost <- CloudWatch.cost
     } yield {
-      val graphs = Seq(user50x) ++ shortLatency ++ fastlyErrors
+      val errorGraphs = Seq(user50x)
+      val fastlyGraphs = fastlyErrors ++ fastlyHitMiss
       NoCache(Ok(views.html.radiator(
-        graphs, multiLineGraphs, cost, switchesExpiringSoon,
+        errorGraphs, latencyGraphs, fastlyGraphs, cost, switchesExpiringSoon,
         Configuration.environment.stage, apiKey
       )))
     }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -1,6 +1,7 @@
 @import conf.switches.Switch
-@(  charts: Seq[tools.AwsLineChart],
-    hitMissCharts: Seq[tools.AwsLineChart],
+@(  errorCharts: Seq[tools.AwsLineChart],
+    latencyCharts: Seq[tools.AwsLineChart],
+    fastlyCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
     switches: Seq[conf.switches.Switch],
     env: String,
@@ -82,6 +83,15 @@
         </div>
     </div>
 
-    @charts.map{ chart => @fragments.lineChart(chart)  }
-    @hitMissCharts.map{ chart => @fragments.lineChart(chart) }
+    @graph_group("Errors", errorCharts)
+    @graph_group("Latencies", latencyCharts)
+    @graph_group("Fastly", fastlyCharts)
+}
+
+@graph_group(title: String, graphs: Seq[tools.AwsLineChart]) = {
+    <br clear="all"/>
+    <div>
+        <h2>@title</h2>
+        @graphs.map{ chart => @fragments.lineChart(chart) }
+    </div>
 }


### PR DESCRIPTION
## What does this change?

Tiny tweak of Radiator: Group error graphs, latency graphs and fastly graphs together
## What is the value of this and can you measure success?

Easier to visually understand what graph is showing what
## Screenshots

![screen shot 2016-08-23 at 13 55 13](https://cloud.githubusercontent.com/assets/233326/17892451/413da128-6939-11e6-97dc-195e60a65a4c.png)
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
