### PR TITLE
Contributions embed abtest

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,6 +64,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABContributionsEmbed20160822 = Switch(
+    SwitchGroup.ABTests,
+    "ab-contributions-embed-20160822",
+    "Test contributions embed with amount picker.",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 8, 26),
+    exposeClientSide = true
+  )
+
   val ABParticipationDiscussionOrderingLiveBlogs = Switch(
     SwitchGroup.ABTests,
     "ab-participation-discussion-ordering-live-blog",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -70,7 +70,7 @@ trait ABTestSwitches {
     "Test contributions embed with amount picker.",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 26),
+    sellByDate = new LocalDate(2016, 8, 27),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,13 +64,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABContributionsEmbed20160822 = Switch(
+  val ABContributionsEmbed20160823= Switch(
     SwitchGroup.ABTests,
-    "ab-contributions-embed-20160822",
+    "ab-contributions-embed-20160823",
     "Test contributions embed with amount picker.",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 27),
+    sellByDate = new LocalDate(2016, 8, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -22,6 +22,7 @@ define([
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',
     'common/modules/experiments/tests/minute-load-js'
+    'common/modules/experiments/tests/contributions-embed'
 ], function (
     reportError,
     config,
@@ -41,11 +42,12 @@ define([
     HostedGalleryCallToAction,
     MembershipMessages,
     ContributionsHeader,
-    AdFeedback,
+   	AdFeedback,
     Minute,
     RecommendedForYou,
     DontUpgradeMobileRichLinks,
     MinuteLoadJs
+    ContributionsEmbed
 ) {
 
     var TESTS = [
@@ -59,11 +61,14 @@ define([
         new HostedGalleryCallToAction(),
         new MembershipMessages(),
         new ContributionsHeader(),
-        new AdFeedback(),
+     //   new AdFeedback(),
         new Minute(),
         new RecommendedForYou(),
+        new MinuteLoadJs()
         new DontUpgradeMobileRichLinks(),
         new MinuteLoadJs()
+        new MinuteLoadJs(),
+        new ContributionsEmbed()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -21,7 +21,7 @@ define([
     'common/modules/experiments/tests/minute',
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',
-    'common/modules/experiments/tests/minute-load-js'
+    'common/modules/experiments/tests/minute-load-js',
     'common/modules/experiments/tests/contributions-embed'
 ], function (
     reportError,
@@ -42,11 +42,11 @@ define([
     HostedGalleryCallToAction,
     MembershipMessages,
     ContributionsHeader,
-   	AdFeedback,
+    AdFeedback,
     Minute,
     RecommendedForYou,
     DontUpgradeMobileRichLinks,
-    MinuteLoadJs
+    MinuteLoadJs,
     ContributionsEmbed
 ) {
 
@@ -61,12 +61,10 @@ define([
         new HostedGalleryCallToAction(),
         new MembershipMessages(),
         new ContributionsHeader(),
-     //   new AdFeedback(),
+        new AdFeedback(),
         new Minute(),
         new RecommendedForYou(),
-        new MinuteLoadJs()
         new DontUpgradeMobileRichLinks(),
-        new MinuteLoadJs()
         new MinuteLoadJs(),
         new ContributionsEmbed()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -1,0 +1,95 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-embed.html',
+    'text!common/views/contributions-header.html',
+    'common/views/svgs',
+    'common/modules/article/space-filler'
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEmbed,
+             contributionsHeader,
+             svgs,
+             spaceFiller
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsEmbed20160822';
+        this.start = '2016-08-22';
+        this.expiry = '2016-08-26';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Test contributions embed with amount picker.';
+        this.showForSensitive = false;
+        this.audience = 0.13;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Determine the effectivness of allowing user to pick contribution amount in the cta';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.canRun = function () {
+            var pageObj = window.guardian.config.page;
+            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+        };
+
+        var getSpacefinderRules = function () {
+            return {
+                bodySelector: '.js-article__body',
+                slotSelector: ' > p',
+                minAbove: 200,
+                minBelow: 150,
+                clearContentMeta: 50,
+                fromBottom: true,
+                selectors: {
+                    ' .element-rich-link': {minAbove: 100, minBelow: 100},
+                    ' > h2': {minAbove: 200, minBelow: 0},
+                    ' > *:not(p):not(h2):not(blockquote)': {minAbove: 35, minBelow: 200},
+                    ' .ad-slot': {minAbove: 150, minBelow: 200}
+                }
+            };
+        };
+
+        var writer = function () {
+            var $embed = $.create(template(contributionsEmbed, {
+                linkText : 'give to the Guardian',
+                linkHref : 'https://contribute.theguardian.com/uk?INTCMP=co_uk_head_give_coin',
+                coinSvg: svgs('contributionsCoin', ['rounded-icon', 'control__icon-wrapper'])
+            }));
+
+           return spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
+                    $embed.insertBefore(paras[0]);
+                    mediator.emit('contributions-embed:insert');
+            });
+
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-header:insert', function () {
+                bean.on(qwery('#contributions__header-contribute-link')[0], 'click', complete);
+            });
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    writer();
+                },
+                success: function (complete) {
+                    completer(complete);
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -24,13 +24,13 @@ define([
     return function () {
 
         this.id = 'ContributionsEmbed20160822';
-        this.start = '2016-08-22';
-        this.expiry = '2016-08-26';
+        this.start = '2016-08-23';
+        this.expiry = '2016-08-27';
         this.author = 'Jonathan Rankin';
         this.description = 'Test contributions embed with amount picker.';
         this.showForSensitive = false;
         this.audience = 0.13;
-        this.audienceOffset = 0;
+        this.audienceOffset = 0.13;
         this.successMeasure = 'Determine the effectivness of allowing user to pick contribution amount in the cta';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -31,10 +31,10 @@ define([
         this.showForSensitive = false;
         this.audience = 0.13;
         this.audienceOffset = 0.05;
-        this.successMeasure = 'Determine the effectivness of allowing user to pick contribution amount in the cta';
+        this.successMeasure = 'Impressions to number of contributions';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = '';
+        this.idealOutcome = 'The component performs 3x better than the ContributionsArticle20160818 test (like variant)';
         this.canRun = function () {
             var pageObj = window.guardian.config.page;
             return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -30,7 +30,7 @@ define([
         this.description = 'Test contributions embed with amount picker.';
         this.showForSensitive = false;
         this.audience = 0.13;
-        this.audienceOffset = 0.13;
+        this.audienceOffset = 0.05;
         this.successMeasure = 'Determine the effectivness of allowing user to pick contribution amount in the cta';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -23,9 +23,9 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEmbed20160822';
+        this.id = 'ContributionsEmbed20160823';
         this.start = '2016-08-23';
-        this.expiry = '2016-08-27';
+        this.expiry = '2016-08-30';
         this.author = 'Jonathan Rankin';
         this.description = 'Test contributions embed with amount picker.';
         this.showForSensitive = false;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -55,7 +55,7 @@ define([
 
         var completer = function (complete) {
             mediator.on('giraffe:insert', function () {
-                bean.on(qwery('#giraffe__contribute')[0], 'click', function (){
+                bean.on(qwery('#js-giraffe-contribute')[0], 'click', function (){
                     complete();
                 });
             });

--- a/static/src/javascripts/projects/common/views/contributions-embed.html
+++ b/static/src/javascripts/projects/common/views/contributions-embed.html
@@ -1,0 +1,3 @@
+<figure class="element element-interactive interactive element--supporting" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Bacon">
+    <a href="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-link-name="in body link" class="u-underline">Hello</a>
+</figure>

--- a/static/src/javascripts/projects/common/views/contributions-embed.html
+++ b/static/src/javascripts/projects/common/views/contributions-embed.html
@@ -1,3 +1,3 @@
-<figure class="element element-interactive interactive element--supporting" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Bacon">
-    <a href="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-link-name="in body link" class="u-underline">Hello</a>
+<figure class="element element-interactive contribute-embed interactive element--inline" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Bacon">
+    <a id="giraffe__contribute-button" href="<%=linkHref%>" data-link-name="in body link" class="u-underline"></a>
 </figure>

--- a/static/src/javascripts/projects/common/views/contributions-embed.html
+++ b/static/src/javascripts/projects/common/views/contributions-embed.html
@@ -1,3 +1,3 @@
 <figure class="element element-interactive contribute-embed interactive element--inline" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Contribute">
-    <a id="giraffe__contribute-button" href="<%=linkHref%>" data-link-name="in body link" class="u-underline"></a>
+    <a id="js-giraffe__contribute-button" href="<%=linkHref%>" data-link-name="in body link" class="u-underline"></a>
 </figure>

--- a/static/src/javascripts/projects/common/views/contributions-embed.html
+++ b/static/src/javascripts/projects/common/views/contributions-embed.html
@@ -1,3 +1,3 @@
-<figure class="element element-interactive contribute-embed interactive element--inline" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Bacon">
+<figure class="element element-interactive contribute-embed interactive element--inline" data-interactive="https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js" data-canonical-url="https://interactive.guim.co.uk/contributions-embeds/embed/embed.html" data-alt="Contribute">
     <a id="giraffe__contribute-button" href="<%=linkHref%>" data-link-name="in body link" class="u-underline"></a>
 </figure>

--- a/static/src/javascripts/projects/common/views/giraffe-message.html
+++ b/static/src/javascripts/projects/common/views/giraffe-message.html
@@ -5,5 +5,5 @@
             <%= copy %>
         </p>
     </div>
-    <a id="giraffe__contribute" href="<%=linkHref%>" class="button button--primary button--large button--giraffe" data-link-name="<%=linkName%>">Give today <%= svg %></a>
+    <a id="js-giraffe__contribute" href="<%=linkHref%>" class="button button--primary button--large button--giraffe" data-link-name="<%=linkName%>">Give today <%= svg %></a>
 </div>


### PR DESCRIPTION
## What does this change?

This is a test which adds the contributions interactive embed at the end of articles. This embed is inserted as an interactive. The way it is implemented is as follows:
1. If the user is in the test, insert the following <figure> element to the end of the article, which is invisible until explicitly rendered: 
2. Run a script which looks for this specific interactive and renders it. 

What makes this contributions ad different from those previous is that it asks the user to select their contribution amount in the ad itself, which propagates through to the contributions form 
## What is the value of this and can you measure success?

The value is we can evaluate the effectiveness of asking for the contribution amount in the ad. We are measuring the success by looking at the impression to contribution rate. 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

The embed on desktop

![screenshot at aug 23 13-55-02](https://cloud.githubusercontent.com/assets/2844554/17892688/7c993286-693a-11e6-8f36-f3ca8aab8223.png)

The embed on mobile
![screenshot at aug 23 13-59-13](https://cloud.githubusercontent.com/assets/2844554/17892690/7e8941c6-693a-11e6-9ea7-e06617f74370.png)

Note: the design is set to change, but this doesn't affect this pull request as the interactive embed is built and deployed separately from frontend. 
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
