### PR TITLE
Native fluid ads behave like Fabrics

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -50,6 +50,21 @@ define([
         };
     }
 
+    function onFluidAd(event, advert) {
+        var node = advert.node;
+        var closestFcContainer = closest(node, '.fc-container');
+        var sectionContainer = bonzo(bonzo.create('<section>'));
+
+        if (closestFcContainer) {
+            fastdom.write(function () {
+                sectionContainer.append(node);
+                sectionContainer.insertAfter(closestFcContainer);
+            });
+        }
+
+        addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad'])(event, advert);
+    }
+
     var addFluid250 = addClassIfHasClass(['ad-slot--fluid250']);
     var addFluid    = addClassIfHasClass(['ad-slot--fluid']);
 
@@ -58,7 +73,7 @@ define([
     /**
      * DFP fluid ads should use existing fluid-250 styles in the top banner position
      */
-    sizeCallbacks[adSizes.fluid] = addFluid250(['ad-slot--top-banner-ad']);
+    sizeCallbacks[adSizes.fluid] = onFluidAd;
 
     /**
      * Trigger sticky scrolling for MPUs in the right-hand article column
@@ -109,20 +124,7 @@ define([
     /**
      * Mobile adverts with fabric sizes get 'fluid' full-width design
      */
-    sizeCallbacks[adSizes.fabric] = function(event, advert) {
-        var node = advert.node;
-        var closestFcContainer = closest(node, '.fc-container');
-        var sectionContainer = bonzo(bonzo.create('<section>'));
-
-        if (closestFcContainer) {
-            fastdom.write(function () {
-                sectionContainer.append(node);
-                sectionContainer.insertAfter(closestFcContainer);
-            });
-        }
-
-        addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad'])(event, advert);
-    };
+    sizeCallbacks[adSizes.fabric] = onFluidAd;
 
     /**
      * Commercial components with merch sizing get fluid-250 styling

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -50,6 +50,9 @@ define([
         };
     }
 
+    var addFluid250 = addClassIfHasClass(['ad-slot--fluid250']);
+    var addFluid    = addClassIfHasClass(['ad-slot--fluid']);
+
     function onFluidAd(event, advert) {
         var node = advert.node;
         var closestFcContainer = closest(node, '.fc-container');
@@ -64,9 +67,6 @@ define([
 
         addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad'])(event, advert);
     }
-
-    var addFluid250 = addClassIfHasClass(['ad-slot--fluid250']);
-    var addFluid    = addClassIfHasClass(['ad-slot--fluid']);
 
     var sizeCallbacks = {};
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -151,6 +151,9 @@ define([
 
             function callSizeCallback() {
                 var size = slotRenderEvent.size.join(',');
+                if (size === '0,0') {
+                    size = 'fluid';
+                }
                 if (sizeCallbacks[size]) {
                     return sizeCallbacks[size](slotRenderEvent, advert);
                 }


### PR DESCRIPTION
## What does this change?

When DFP returns a native/fluid ad, it needs to expand to fill its container. This is the current behaviour of the Fabrics format (with one insidious use case where we have to move the ad slot out of its `.fc-container`)

Anyway, this is so native ads are 100% by default.

cc @guardian/commercial-dev 
