### PR TITLE
Update capital one cup to efl cup

### DIFF
--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -17,7 +17,7 @@ object PA extends Collections {
     ("123", "Scottish League Two"),
     ("300", "FA Cup"),
     ("320", "Scottish Cup"),
-    ("301", "Capital One Cup"),
+    ("301", "EFL Cup"),
     ("400", "Community Shield"),
     ("500", "Champions League"),
     ("510", "Europa League"),

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -37,7 +37,7 @@ class LeagueTableController(val competitionsService: CompetitionsService) extend
         "Europa League",
         "Champions League",
         "FA Cup",
-        "Capital One Cup",
+        "EFL Cup",
         "Community Shield",
         "Scottish Cup",
         "Scottish League Cup",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -110,7 +110,7 @@ object CompetitionsProvider {
     Competition("751", "/football/euro-2016-qualifiers", "Euro 2016 qualifying", "Euro 2016 qual.", "Internationals"),
     Competition("501", "/football/champions-league-qualifying", "Champions League qualifying", "Champions League qual.", "European"),
     Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
-    Competition("301", "/football/capital-one-cup", "Capital One Cup", "Capital One Cup", "English"),
+    Competition("301", "/football/efl-cup", "EFL Cup", "EFL Cup", "English"),
     Competition("400", "/football/community-shield", "Community Shield", "Community Shield", "English", showInTeamsList = true),
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),


### PR DESCRIPTION
## What does this change?

The capital one cup is now called the EFL cup. Update our naming.

Once out, need to redirect with the redirect tool:

/football/capital-one-cup > /football/efl-cup/
/football/capital-one-cup/live > /football/efl-cup/live
/football/capital-one-cup/fixtures > /football/efl-cup/fixtures
/football/capital-one-cup/results > /football/efl-cup/results

There is no /table or /group/table for efl cup it seems.
## Request for comment

@guardian/dotcom-platform 
