### PR TITLE
Extend the ad feedback test and rename the test js file.

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -17,7 +17,7 @@ define([
     'common/modules/experiments/tests/hosted-gallery-cta',
     'common/modules/experiments/tests/membership-messages',
     'common/modules/experiments/tests/contributions-header',
-    'common/modules/experiments/tests/ad-feedback',
+    'common/modules/experiments/tests/commercial-feedback',
     'common/modules/experiments/tests/minute',
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-feedback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-feedback.js
@@ -7,7 +7,7 @@ define([
     return function () {
         this.id = 'AdFeedback';
         this.start = '2016-07-21';
-        this.expiry = '2016-08-25';
+        this.expiry = '2016-09-14';
         this.author = 'Justin Pinner';
         this.description = 'Learn which ads attract user feedback.';
         this.audience = 0.02;


### PR DESCRIPTION
## What does this change?

Extends the ad feedback test expiry date. Also renames a javascript file because it's currently breaking another test we're building.
## What is the value of this and can you measure success?

We've been receiving good feedback, and want to collect more. The test should have been defined to run until September 14th, but the actual test file declared an earlier termination date.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

As per original PR (https://github.com/guardian/frontend/pull/13879)
## Request for comment

@regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
