### PR TITLE
Fluid/native ads are 250px high by default

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -626,6 +626,7 @@
  * Fluid ad slots don't have widths
  */
 .ad-slot--fluid {
+    min-height: 250px;
     width: auto;
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
Until we find a reliable way to link an IFRAME to an incoming message, dynamic resizing of native ads will not happen. So we might provide a sensible default in the meantime.

cc @guardian/commercial-dev 
