### PR TITLE
Extend surging content email switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -302,7 +302,7 @@ trait CommercialSwitches {
     "If on email will be sent to Rio Olympic surging content team every 30 minutes with update on surging content.",
     owners = Seq(Owner.withGithub("Calum Campbell")),
     safeState = Off,
-    sellByDate = new LocalDate(2016,8,23),
+    sellByDate = new LocalDate(2016,8,31),
     exposeClientSide = false
   )
 }


### PR DESCRIPTION
Expired switch extension until next Wed.

@guardian/commercial-dev 
