### PR TITLE
Remove unused import

### DIFF
--- a/onward/app/controllers/CardController.scala
+++ b/onward/app/controllers/CardController.scala
@@ -13,8 +13,6 @@ import scala.concurrent.Future
 
 class CardController(wsClient: WSClient) extends Controller with Logging with ExecutionContexts {
 
-  import play.api.Play.current
-
   def opengraph(resource: String) = Action.async { implicit request =>
     val myUri = new URI(resource)
     val r = myUri.getPath


### PR DESCRIPTION
## What does this change?

Removes an unused import in the opengraph CardController (route tagged as experimental). Doing this as an example change to test out the deployment infra.
## What is the value of this and can you measure success?

No value. Tests/compile works
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

n/a
