### PR TITLE
Extend ab test expiry

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -22,7 +22,7 @@ define([
 
         this.id = 'ContributionsArticle20160822';
         this.start = '2016-08-22';
-        this.expiry = '2016-08-25';
+        this.expiry = '2016-08-26';
         this.author = 'Mark Butler';
         this.description = 'Add a button allowing readers to contribute money.';
         this.showForSensitive = false;


### PR DESCRIPTION
## What does this change?

Extending ab test expiry as we are still short on data.
## What is the value of this and can you measure success?

None it s a functional change.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
