### PR TITLE
Remove AMP live blog switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -367,16 +367,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val LiveBlogAmpSwitch = Switch(
-    SwitchGroup.Feature,
-    "live-blog-amp",
-    "If this switch is on, link to amp pages will be in the metadata for live blogs",
-    owners = Seq(Owner.withGithub("SiAdcock")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 26),
-    exposeClientSide = false
-  )
-
   // see https://github.com/guardian/frontend/pull/13916
   val AmpLiveBlogNewsArticleSwitch = Switch(
     SwitchGroup.Feature,

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -45,16 +45,10 @@
 
     @Page.getContentPage(page).map { page =>
         @if(
-            (
-                page.item.tags.isArticle &&
-                !page.item.tags.isLiveBlog &&
-                !page.item.content.isImmersive &&
-                !page.item.tags.isQuiz &&
-                AmpSwitch.isSwitchedOn
-            ) || (
-                page.item.tags.isLiveBlog &&
-                LiveBlogAmpSwitch.isSwitchedOn
-            )
+            page.item.tags.isArticle &&
+            !page.item.content.isImmersive &&
+            !page.item.tags.isQuiz &&
+            AmpSwitch.isSwitchedOn
         ) {
             <link rel="amphtml" href="@AmpLinkTo{/@page.metadata.id}">
         }


### PR DESCRIPTION
## What does this change?

Now that AMP live blogs are relatively stable, this change removes the ability to easily turn AMP on and off for live blogs.
## Request for comment

@stephanfowler @guardian/dotcom-platform 
