### PR TITLE
Add publisher metadata to AMP live blog

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -30,14 +30,12 @@
         itemscope itemtype="@schemaType(model)" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
-        @if(isAmpAndStructuredAsNewsArticle()) {
-            <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
-                <meta itemprop="name" content="The Guardian">
-                <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-                    <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
-                </div>
+        <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+            <meta itemprop="name" content="The Guardian">
+            <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+                <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
             </div>
-        }
+        </div>
 
         <header class="content__head tonal__head tonal__head--@toneClass(article)
                       @if(ArticleBadgesSwitch.isSwitchedOn) {


### PR DESCRIPTION
## What does this change?

According to Google's [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/), only pages with a schema type of `NewsArticle` require `publisher` metadata. However, in an email exchange with Eric Lindley at Google, we have discovered that pages with a schema type of `LiveBlogPosting` also require `publisher` metadata.

> W/r/t your question, `LiveBlogPosting` schema should be eligible for the Top Stories carousel. However, we've determined that the reason your liveblogs aren't showing up in Top Stories is that two additional structured data properties are required: `publisher.name` and `publisher.logo`. Apologies for the late notice—we are currently fixing an inconsistency in the guidelines and structured data testing tool, as these resources don't currently call out these requirements.

This change adds the `publisher` metadata to `LiveBlogPosting` articles, regardless of whether the article is an AMP article.
