### PR TITLE
Extend AMP live blog switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -373,7 +373,7 @@ trait FeatureSwitches {
     "If this switch is on, link to amp pages will be in the metadata for live blogs",
     owners = Seq(Owner.withGithub("SiAdcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 26),
+    sellByDate = new LocalDate(2016, 10, 26),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extends the AMP live blog switch by two months. There are still a number of changes that Google have promised over the next few months that could break AMP live blogs or make them otherwise untenable. It is therefore desirable for us to continue to control AMP live blogs independently of AMP articles in general.
