### PR TITLE
Move mobile ad-slot to outside of containers

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -53,27 +53,12 @@ define([
     var addFluid250 = addClassIfHasClass(['ad-slot--fluid250']);
     var addFluid    = addClassIfHasClass(['ad-slot--fluid']);
 
-    function onFluidAd(event, advert) {
-        var node = advert.node;
-        var closestFcContainer = closest(node, '.fc-container');
-        var sectionContainer = bonzo(bonzo.create('<section>'));
-
-        if (closestFcContainer) {
-            fastdom.write(function () {
-                sectionContainer.append(node);
-                sectionContainer.insertAfter(closestFcContainer);
-            });
-        }
-
-        addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad'])(event, advert);
-    }
-
     var sizeCallbacks = {};
 
     /**
      * DFP fluid ads should use existing fluid-250 styles in the top banner position
      */
-    sizeCallbacks[adSizes.fluid] = onFluidAd;
+    sizeCallbacks[adSizes.fluid] = addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad']);
 
     /**
      * Trigger sticky scrolling for MPUs in the right-hand article column
@@ -124,7 +109,7 @@ define([
     /**
      * Mobile adverts with fabric sizes get 'fluid' full-width design
      */
-    sizeCallbacks[adSizes.fabric] = onFluidAd;
+    sizeCallbacks[adSizes.fabric] = addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad']);
 
     /**
      * Commercial components with merch sizing get fluid-250 styling

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -108,8 +108,11 @@ define([
             adSlots.forEach(isMobile ? insertOnMobile : insertOnTabletPlus);
 
             function insertOnMobile(item) {
+                var sectionContainer = bonzo(bonzo.create('<section>'));
+                sectionContainer.append(item.adSlot);
+
                 // add a mobile advert after the container
-                item.anchor.lastElementChild.appendChild(item.adSlot);
+                bonzo(sectionContainer).insertAfter(item.anchor);
             }
 
             function insertOnTabletPlus(item) {


### PR DESCRIPTION
## What does this change?

This moves the ad-slots on mobile on fronts to appear outside the container instead of being the last child of the container. This uses `insertAfter` instead of `append` on the `anchor`.

This will also move all the `inline` ads to their own section in between containers.

This seems to causes spacing issues above the ad where a show more button would have appeared. We can fix these as we go along.

We no longer need `onFluidAd` as we are no longer manipulating the DOM after the ad-slot has been added.
## Screenshots
### Fluid

![fluidad](https://cloud.githubusercontent.com/assets/445472/17936923/4f4db12e-6a18-11e6-9428-bb996c69a6b9.png)
### Fabric

![fabricad](https://cloud.githubusercontent.com/assets/445472/17936928/53bb2eb2-6a18-11e6-8d6b-0acd365862cb.png)
### MPU

![mpu](https://cloud.githubusercontent.com/assets/445472/17936920/4d8bca24-6a18-11e6-924d-95abb4c0321b.png)
## Request for comment

@regiskuckaertz @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
