### PR TITLE
Add GA tracking to 404 page

### DIFF
--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -101,13 +101,23 @@
         </script>
         <script src="http://image.guardian.co.uk/omni/omniture.js"></script>
         <script>
-            s.pageType ="errorPage"
+            s.pageType ="errorPage";
             s.prop19 = "frontend";
             s.t();
         </script>
         <noscript>
             <img src="http://hits.guardian.co.uk/b/ss/guardiangu-network/1/H.24.2/?v19=frontend&v7=404&ns=guardian&c19=frontend&c9=404&c30=non-content&c6=&c13=&pageType=errorPage&pageName=404&g=http%3A%2F%2Fm.guardian.co.uk%2F/404&" alt="" style="display: none;" />
         </noscript>
+
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+            ga('create', 'UA-78705427-1', 'auto');
+            ga('set', 'dimension14', '404');
+            ga('send', 'pageview');
+        </script>
 
         <script src="https://pasteup.guim.co.uk/js/lib/requirejs/2.1.5/require.min.js"></script>
 


### PR DESCRIPTION
## What does this change?

Add a GA snippet to the 404 page

See also guardian/platform#1053 and guardian/fastly-edge-cache#671

Thomas explained the 404 page flow to me:
1. The router routes a request to `article`
2. If `article` responds with 404, router falls back to `archive`
3. `archive` looks in S3, Dynamo, etc. If it can't find the requested page anywhere, it returns a 404, using the `notFound.scala.html` view

So the 404 page in the router is probably not used for anything, except for very rare (impossible?) cases when it can't work out which backend to route a request to.
## What is the value of this and can you measure success?

Track broken links
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@TBonnin @ajosephides 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
