### PR TITLE
Clashing tests embed

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -41,7 +41,7 @@ define([
             config.page.seriesId === 'world/series/guardian-morning-briefing';
     }
 
-    function userIsInAClashingAbTest(f) {
+    function userIsInAClashingAbTest() {
         return checkTestClash(ab.isInVariant);
     }
 

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -41,7 +41,11 @@ define([
             config.page.seriesId === 'world/series/guardian-morning-briefing';
     }
 
-    function userIsInAClashingAbTest() {
+    function userIsInAClashingAbTest(f) {
+        return checkTestClash(ab.isInVariant);
+    }
+
+    function checkTestClash(f) {
         var contributionsArticle = {name: 'ContributionsArticle20160822', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
         var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive'] };
 
@@ -49,7 +53,7 @@ define([
 
         return some(clashingTests, function(test) {
             return some(test.variants, function (variant) {
-                return ab.isInVariant(test.name, variant);
+                return f(test.name, variant);
             });
         });
     }
@@ -200,6 +204,7 @@ define([
         getEmailInserted: getEmailInserted,
         allEmailCanRun: allEmailCanRun,
         getUserEmailSubscriptions: getUserEmailSubscriptions,
-        listCanRun: listCanRun
+        listCanRun: listCanRun,
+        checkTestClash: checkTestClash
     };
 });

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,9 +42,15 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        var clashingTests = {name: 'ContributionsArticle20160822', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
-        return some(clashingTests.variants, function(variant) {
-            return ab.isInVariant(clashingTests.name, variant);
+        var contributionsArticle = {name: 'ContributionsArticle20160822', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
+        var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive'] };
+
+        var clashingTests = [contributionsArticle, contributionsEmbed];
+
+        return some(clashingTests, function(test) {
+            return some(test.variants, function (variant) {
+                return ab.isInVariant(test.name, variant);
+            });
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -42,10 +42,10 @@ define([
     }
 
     function userIsInAClashingAbTest() {
-        return checkTestClash(ab.isInVariant);
+        return _testABClash(ab.isInVariant);
     }
 
-    function checkTestClash(f) {
+    function _testABClash(f) {
         var contributionsArticle = {name: 'ContributionsArticle20160822', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
         var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive'] };
 
@@ -205,6 +205,6 @@ define([
         allEmailCanRun: allEmailCanRun,
         getUserEmailSubscriptions: getUserEmailSubscriptions,
         listCanRun: listCanRun,
-        checkTestClash: checkTestClash
+        _testABClash: _testABClash // exposed for unit testing
     };
 });

--- a/static/test/javascripts/spec/common/email/run-checks.spec.js
+++ b/static/test/javascripts/spec/common/email/run-checks.spec.js
@@ -1,0 +1,18 @@
+define([
+    'common/modules/email/run-checks'
+], function (
+    RunChecks
+) {
+        describe('RunChecks', function () {
+
+            it('test clash should be true with true function', function () {
+                var f = function () { return true; };
+                expect(RunChecks.checkTestClash(f)).toBeTruthy();
+            });
+
+            it('test clash should be false with false function', function () {
+                var f = function () { return false; };
+                expect(RunChecks.checkTestClash(f)).toBeFalsy();
+            });
+        });
+});

--- a/static/test/javascripts/spec/common/email/run-checks.spec.js
+++ b/static/test/javascripts/spec/common/email/run-checks.spec.js
@@ -7,12 +7,12 @@ define([
 
             it('test clash should be true with true function', function () {
                 var f = function () { return true; };
-                expect(RunChecks.checkTestClash(f)).toBeTruthy();
+                expect(RunChecks._testABClash(f)).toBeTruthy();
             });
 
             it('test clash should be false with false function', function () {
                 var f = function () { return false; };
-                expect(RunChecks.checkTestClash(f)).toBeFalsy();
+                expect(RunChecks._testABClash(f)).toBeFalsy();
             });
         });
 });


### PR DESCRIPTION
## What does this change?

Add ability to check multiple ab tests for clashes with email sign-in component.  
## What is the value of this and can you measure success?

None, its a functional change to prevent test clashing.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
