### PR TITLE
Modify references to teamcity host

### DIFF
--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -45,7 +45,7 @@
         Note, it will not show unless you enable the "External status widget" for the build in Teamcity
             for some reason the &js=1 hangs waiting for a http resp so just using the iframe version for now
         *@
-        <iframe src="http://teamcity.gu-web.net:8111/externalStatus.html?buildTypeId=dotcom_master"></iframe>
+        <iframe src="https://teamcity.gu-web.net/externalStatus.html?buildTypeId=dotcom_master"></iframe>
     </div>
 
 

--- a/docs/03-dev-howtos/10-testing-platform.md
+++ b/docs/03-dev-howtos/10-testing-platform.md
@@ -28,7 +28,7 @@ The simplest way to do that is to spin up a new Auto scaling Group in environmen
 1. delete the ASG and Launch config
 
 ## Building a branch with frontend
-1. click the ... icon next to Run in [dotcom master](http://teamcity.gu-web.net:8111/viewType.html?buildTypeId=dotcom_master) build
+1. click the ... icon next to Run in [dotcom master](https://teamcity.gu-web.net/viewType.html?buildTypeId=dotcom_master) build
 1. change the BranchName in the parameters screen to your branch
 1. run the build - it will create the build and upload to riffraff
 1. deploy the build with riffraff to TEST

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,6 @@
 - [Archiving](02-architecture/04-archiving.md)
 - [Architecture principles for CSS](02-architecture/05-architecture-principles-for-css.md)
 
-##[Dev how tos](03-dev-how-tos/)
-- [](03-dev-how-tos/*.md)
-
 ##[Dev howtos](03-dev-howtos/)
 - [How to setup and run A/B tests](03-dev-howtos/01-ab-testing.md)
 - [What to do when a deployment breaks](03-dev-howtos/02-deployment-errors.md)

--- a/static/src/deploys-radiator/app/render.js
+++ b/static/src/deploys-radiator/app/render.js
@@ -10,7 +10,7 @@ const ih = (tagName, options, children) => (h(tagName, options, children.toJS())
 // Used in hyperscript because children cannot be booleans
 // https://github.com/Matt-Esch/virtual-dom/issues/326
 const exp = (condition) => condition ? true : undefined;
-const teamCityHost = 'http://teamcity.gu-web.net:8111';
+const teamCityHost = 'https://teamcity.gu-web.net';
 const createBuildLink = (build) => (`${teamCityHost}/viewLog.html?buildNumber=${build}&buildTypeId=dotcom_master&tab=buildResultsDiv`);
 const riffRaffHost = 'https://riffraff.gutools.co.uk';
 const createRiffRaffDeployLink = (uuid) => (`${riffRaffHost}/deployment/view/${uuid}`);


### PR DESCRIPTION
## What does this change?

Change reference to `http://teamcity.gu-web.net:8111` to `https://teamcity.gu-web.net`
It also requires a change of config
## What is the value of this and can you measure success?

TLS for Teamcity 🔒 
## Request for comment

@johnduffell @jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

To merge once teamcity.gu-web.net domain has been moved to https
Also requiring a change of the conf/properties file
