### PR TITLE
Move become a supporter copy into subscribe link don't show to members

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -15,17 +15,6 @@
         <div class="gs-container l-header__inner">
             <div class="l-header-pre u-cf">
                 <div class="brand-bar">
-                    <div class="brand-bar__item brand-bar__item--profile
-                                    brand-bar__item--has-control brand-bar__item--register
-                                    popup-container has-popup js-profile-register
-                                    hide-until-mobile-landscape">
-                        <a href="@Configuration.id.membershipUrl/supporter?INTCMP=DOTCOM_HEADER_BECOMEMEMBER_@Edition(request).id"
-                        data-link-name="Register link"
-                        class="brand-bar__item--action">
-                            @fragments.inlineSvg("profile-add-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                            <span class="control__info js-control-info control__info--supporting">become a supporter</span>
-                        </a>
-                    </div>
                     @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                         <div class="brand-bar__item brand-bar__item--profile popup-container
                                     has-popup js-profile-nav"
@@ -63,12 +52,17 @@
                     }
 
                     <div class="brand-bar__item has-popup brand-bar__item--has-control
-                                popup-container brand-bar__item--subscribe desktop-only hide-on-slim-header"
+                                popup-container brand-bar__item--subscribe
+                                 hide-on-slim-header hide-on-tablet"
                          data-component="subscribe">
-                        <a href="@SubscribeLink(Edition(request))" class="brand-bar__item--action"
+                        @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
+                        <a href="@Configuration.id.membershipUrl/supporter?INTCMP=DOTCOM_HEADER_BECOMEMEMBER_@Edition(request).id"
+                        data-link-name="Register link"
+                        class="brand-bar__item--action brand-bar__item--split--first js-become-member">
+                            <span class="control__info js-control-info control__info--supporting">become a supporter</span>
+                        </a><a href="@SubscribeLink(Edition(request))" class="brand-bar__item--action brand-bar__item--split--last js-subscribe"
                         data-link-name="@Edition(request).id.toLowerCase : topNav : subscribe">
-                            @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                            <span class="control__info">subscribe</span>
+                            <span class="control__info js-control-info">subscribe</span>
                         </a>
                     </div>
 

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,6 +31,7 @@ define([
     'common/modules/navigation/newHeaderNavigation',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
+    'common/modules/navigation/membership',
     'common/modules/onward/history',
     'common/modules/onward/more-tags',
     'common/modules/onward/tech-feedback',
@@ -83,6 +84,7 @@ define([
     newHeaderNavigation,
     Profile,
     Search,
+    membership,
     history,
     MoreTags,
     techFeedback,
@@ -334,7 +336,6 @@ define([
                 });
             }
         };
-
     return {
         init: function () {
             forEach(robust.makeBlocks([
@@ -378,7 +379,8 @@ define([
                 ['c-pinterest', modules.initPinterest],
                 ['c-save-for-later', modules.saveForLater],
                 ['c-email', modules.initEmail],
-                ['c-user-features', userFeatures.refresh.bind(userFeatures)]
+                ['c-user-features', userFeatures.refresh.bind(userFeatures)],
+                ['c-membership',membership]
 
             ]), function (fn) {
                 fn();

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -2,28 +2,14 @@ define(['common/modules/commercial/user-features', 'common/utils/fastdom-promise
     var LAST_CLASS = 'brand-bar__item--split--last';
 
     function init() {
-        var refreshUser = new Promise(function (resolve) {
-            userFeatures.refresh();
-            resolve(userFeatures.isPayingMember());
-        });
-        refreshUser.then(function (isMember) {
-            if (isMember) {
-                hideSupporterLink();
-            }
-       });
-    }
-
-    function hideSupporterLink() {
-
-        var $becomeMemberLink = $('.js-become-member');
-        var $subscriberLink = $('.js-subscribe');
-
-        fastdom.write(function () {
-            $becomeMemberLink.attr('hidden', 'hidden');
-            $subscriberLink.removeClass(LAST_CLASS);
-        });
-
-
+        if (userFeatures.isPayingMember()) {
+            var $becomeMemberLink = $('.js-become-member');
+            var $subscriberLink = $('.js-subscribe');
+            fastdom.write(function () {
+                $becomeMemberLink.attr('hidden', 'hidden');
+                $subscriberLink.removeClass(LAST_CLASS);
+            });
+        }
     }
 
     return init;

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -1,0 +1,31 @@
+define(['common/modules/commercial/user-features', 'common/utils/fastdom-promise', 'Promise', 'common/utils/$'], function (userFeatures, fastdom, Promise, $) {
+    var LAST_CLASS = 'brand-bar__item--split--last';
+
+    function init() {
+        var refreshUser = new Promise(function (resolve) {
+            userFeatures.refresh();
+            resolve(userFeatures.isPayingMember());
+        });
+        refreshUser.then(function (isMember) {
+            if (isMember) {
+                hideSupporterLink();
+            }
+       });
+    }
+
+    function hideSupporterLink() {
+
+        var $becomeMemberLink = $('.js-become-member');
+        var $subscriberLink = $('.js-subscribe');
+
+        fastdom.write(function () {
+            $becomeMemberLink.attr('hidden', 'hidden');
+            $subscriberLink.removeClass(LAST_CLASS);
+        });
+
+
+    }
+
+    return init;
+
+});

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -45,21 +45,21 @@
 }
 .brand-bar__item .brand-bar__item--split--first {
     margin-left: $gs-gutter/4;
-    height: 34px;
+    height: 36px; //36px = svg button size
 }
 .brand-bar__item--split--first::after {
     content: '\200B'; //zero width space
     border-right: 1px solid rgba(255, 255, 255, .2);
-    left: 11px;
+    left: $gs-gutter/2;
     position: relative;
-    height: 24px;
-    bottom: -5px;
+    height:  $gs-baseline * 2;
+    bottom: -(36px - ($gs-baseline *2))/2; //36px = svg button size
     display: block;
 }
 
 .brand-bar__item--split--last {
-    padding-left: 11px;
-    height: 34px;
+    padding-left: $gs-gutter / 2;
+    height: 36px;
 }
 
 .brand-bar__item--action {

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -43,6 +43,24 @@
         margin-left: $gs-gutter / 2;
     }
 }
+.brand-bar__item .brand-bar__item--split--first {
+    margin-left: $gs-gutter/4;
+    height: 34px;
+}
+.brand-bar__item--split--first::after {
+    content: '\200B'; //zero width space
+    border-right: 1px solid rgba(255, 255, 255, .2);
+    left: 11px;
+    position: relative;
+    height: 24px;
+    bottom: -5px;
+    display: block;
+}
+
+.brand-bar__item--split--last {
+    padding-left: 11px;
+    height: 34px;
+}
 
 .brand-bar__item--action {
     &:active,

--- a/static/src/stylesheets/module/nav/_control.scss
+++ b/static/src/stylesheets/module/nav/_control.scss
@@ -40,10 +40,6 @@ $control-size: 36px;
     }
 }
 
-.control__info--supporting {
-    margin-left: $gs-gutter/4;
-}
-
 
 /* Control icon
    ========================================================================== */


### PR DESCRIPTION
## What does this change?

This adds the become a supporter link to the subscribe button, so that both may be shown. Previously, the become a supporter link was only shown to signed out users. This also hides the supporter link if the user is a paying member. I don't think we can do the same with the subscriber link presently. (I don't think the content authorisation proxy would handle the load)
## What is the value of this and can you measure success?

This should increase membership supporter sign ups without impacting subscriptions. 
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots

![image](https://cloud.githubusercontent.com/assets/2670496/17970857/2cbb7066-6ad0-11e6-82e4-001620ecfa69.png)
## Request for comment

@SiAdcock @samdesborough would appreciate comment on the js, and when we should handle hiding the membership link.
@tomverran for subs
@markjamesbutler for membership

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
