### PR TITLE
Change ad-slot--container-inline for mobileLandscape to not have a

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -183,6 +183,12 @@
         background-color: transparent;
     }
 }
+
+.ad-slot--container-inline {
+    @include mq(mobileLandscape) {
+        margin-top: 0;
+    }
+}
 .ad-slot--gallery-inline {
     background-color: $media-background;
 


### PR DESCRIPTION
This reduces some of the spacing above `.ad-slot--container-inline` which is the container for ads on mobile that get inserted between the containers. There is still a bit of space but this lessens the gap.

@regiskuckaertz @rich-nguyen 
