### PR TITLE
Messenger: id calling iframe

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -55,8 +55,10 @@ define([
 
     function setListeners() {
         ophanTracking.trackPerformance(window.googletag);
-        window.googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
-        window.googletag.pubads().addEventListener('slotOnload', raven.wrap(onSlotLoad));
+
+        var pubads = window.googletag.pubads();
+        pubads.addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
+        pubads.addEventListener('slotOnload', raven.wrap(onSlotLoad));
     }
 
     function setPageTargeting() {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/init.js
@@ -8,12 +8,13 @@ define([
     'common/modules/commercial/build-page-targeting',
     'common/modules/commercial/dfp/private/dfp-env',
     'common/modules/commercial/dfp/private/on-slot-render',
+    'common/modules/commercial/dfp/private/on-slot-load',
     'common/modules/commercial/dfp/private/PrebidService',
     'common/modules/commercial/dfp/private/ophan-tracking',
 
     // These are cross-frame protocol messaging routines:
     'common/modules/commercial/dfp/private/get-stylesheet'
-], function (Promise, qwery, bonzo, raven, fastdom, commercialFeatures, buildPageTargeting, dfpEnv, onSlotRender, PrebidService, ophanTracking) {
+], function (Promise, qwery, bonzo, raven, fastdom, commercialFeatures, buildPageTargeting, dfpEnv, onSlotRender, onSlotLoad, PrebidService, ophanTracking) {
 
 
     return init;
@@ -55,6 +56,7 @@ define([
     function setListeners() {
         ophanTracking.trackPerformance(window.googletag);
         window.googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
+        window.googletag.pubads().addEventListener('slotOnload', raven.wrap(onSlotLoad));
     }
 
     function setPageTargeting() {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -1,11 +1,9 @@
 define([
     'Promise',
-    'common/utils/report-error'
-], function (Promise, reportError) {
-    var allowedHosts = [
-        location.protocol + '//tpc.googlesyndication.com',
-        location.protocol + '//' + location.host
-    ];
+    'common/utils/report-error',
+    'common/modules/commercial/dfp/private/post-message'
+], function (Promise, reportError, postMessage) {
+    var allowedHost = location.protocol + '//tpc.googlesyndication.com';
     var listeners = {};
     var registeredListeners = 0;
 
@@ -56,7 +54,7 @@ define([
 
     function onMessage(event) {
         // We only allow communication with ads created by DFP
-        if (allowedHosts.indexOf(event.origin) === -1) {
+        if (allowedHost !== event.origin) {
             return;
         }
 
@@ -109,7 +107,7 @@ define([
         });
 
         function respond(error, result) {
-            event.source.postMessage(JSON.stringify({ id: data.id, error: error, result: result }), event.origin);
+            postMessage({ id: data.id, error: error, result: result }, event.source);
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/dfp-origin.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/dfp-origin.js
@@ -1,0 +1,3 @@
+define(function () {
+    return location.protocol + '//tpc.googlesyndication.com';
+});

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
@@ -2,11 +2,14 @@ define([
     'common/modules/commercial/dfp/private/get-advert-by-id',
     'common/modules/commercial/dfp/private/post-message'
 ], function (getAdvertById, postMessage) {
+    var nativeAdName = /^\d+-\d+-\d+;\d+;<!DOCTYPE/;
     return onLoad;
 
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
         var iframe = advert.node.querySelector('iframe');
-        postMessage({ id: iframe.id }, iframe.contentWindow);
+        if (nativeAdName.test(iframe.name)) {
+            postMessage({ id: iframe.id }, iframe.contentWindow);
+        }
     }
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
@@ -1,0 +1,12 @@
+define([
+    'common/modules/commercial/dfp/private/get-advert-by-id',
+    'common/modules/commercial/dfp/private/post-message'
+], function (getAdvertById, postMessage) {
+    return onLoad;
+
+    function onLoad(event) {
+        var advert = getAdvertById(event.slot.getSlotElementId());
+        var iframe = advert.node.querySelector('iframe');
+        postMessage({ id: iframe.id }, iframe.contentWindow);
+    }
+});

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-load.js
@@ -8,6 +8,9 @@ define([
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
         var iframe = advert.node.querySelector('iframe');
+        /* We don't have (yet) a means to identify a native creative, so we
+           resort to that heuristic for now, which tests whether the iframe[name]
+           starts with a special string such as 1-0-4;33540;<!DOCTYPE */
         if (nativeAdName.test(iframe.name)) {
             postMessage({ id: iframe.id }, iframe.contentWindow);
         }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/post-message.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/post-message.js
@@ -1,0 +1,7 @@
+define(function () {
+    return postMessage;
+
+    function postMessage(message, targetWindow) {
+        targetWindow.postMessage(JSON.stringify(message), location.protocol + '//tpc.googlesyndication.com');
+    }
+});

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/post-message.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/post-message.js
@@ -1,7 +1,9 @@
-define(function () {
+define([
+    'common/modules/commercial/dfp/private/dfp-origin'
+], function (dfpOrigin) {
     return postMessage;
 
     function postMessage(message, targetWindow) {
-        targetWindow.postMessage(JSON.stringify(message), location.protocol + '//tpc.googlesyndication.com');
+        targetWindow.postMessage(JSON.stringify(message), dfpOrigin);
     }
 });

--- a/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
@@ -111,8 +111,8 @@ define([
                     .html('body:after{ content: "' + breakpoint + '"}')
                     .appendTo('head');
                 var pubAds = {
-                    listener: undefined,
-                    addEventListener: sinon.spy(function (eventName, callback) { this.listener = callback; }),
+                    listeners: [],
+                    addEventListener: sinon.spy(function (eventName, callback) { this.listeners[eventName] = callback; }),
                     setTargeting: sinon.spy(),
                     enableSingleRequest: sinon.spy(),
                     collapseEmptyDivs: sinon.spy(),
@@ -266,8 +266,8 @@ define([
             fakeEventTwo.creativeId = '2';
 
             dfp.init().then(dfp.load).then(function () {
-                window.googletag.pubads().listener(fakeEventOne);
-                window.googletag.pubads().listener(fakeEventTwo);
+                window.googletag.pubads().listeners.slotRenderEnded(fakeEventOne);
+                window.googletag.pubads().listeners.slotRenderEnded(fakeEventTwo);
 
                 var result = dfp.getCreativeIDs();
 

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -23,8 +23,12 @@ define([
         injector.mock('common/utils/report-error', routines.noop);
 
         beforeEach(function (done) {
-            injector.require(['common/modules/commercial/dfp/messenger'], function($1) {
+            injector.require([
+                'common/modules/commercial/dfp/messenger',
+                'common/modules/commercial/dfp/private/dfp-origin'
+            ], function($1, $2) {
                 messenger = $1;
+                dfpOrigin = $2;
                 mockWindow = jasmine.createSpyObj('window', ['addEventListener', 'removeEventListener', 'postMessage']);
                 mockWindow.addEventListener.and.callFake(function(_, _onMessage) {
                     onMessage = _onMessage;
@@ -58,7 +62,7 @@ define([
         });
 
         it('should not respond when sending malformed JSON', function () {
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: '{', source: mockFrame });
+            onMessage({ origin: dfpOrigin, data: '{', source: mockFrame });
             expect(mockFrame.postMessage).not.toHaveBeenCalled();
         });
 
@@ -68,11 +72,11 @@ define([
                 { value: 'missing type' },
                 { type: 'unregistered', value: 'type' }
             ];
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payloads[0]), source: mockFrame });
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payloads[0]), source: mockFrame });
             expect(mockFrame.postMessage).not.toHaveBeenCalled();
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payloads[1]), source: mockFrame });
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payloads[1]), source: mockFrame });
             expect(mockFrame.postMessage).not.toHaveBeenCalled();
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payloads[2]), source: mockFrame });
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payloads[2]), source: mockFrame });
             expect(mockFrame.postMessage).not.toHaveBeenCalled();
         });
 
@@ -81,7 +85,7 @@ define([
             messenger.register('this', routines.noop, mockWindow);
             messenger.register('that', routines.noop, mockWindow);
             messenger.unregister('that', routines.noop, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame });
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame });
             expect(mockFrame.postMessage).toHaveBeenCalled();
             expect(response.error.code).toBe(405);
             expect(response.error.message).toBe('Service that not implemented');
@@ -91,7 +95,7 @@ define([
         it('should throw when the listener fails', function (done) {
             var payload = { id: '01234567-89ab-cdef-fedc-ba9876543210', type: 'this', value: 'hello' };
             messenger.register('this', routines.thrower, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.error.code).toBe(500);
@@ -105,7 +109,7 @@ define([
         it('should respond with the routine\'s return value', function (done) {
             var payload = { id: '01234567-89ab-cdef-fedc-ba9876543210', type: 'this', value: 'hello' };
             messenger.register('this', routines.respond, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe('hello johnny!');
@@ -119,7 +123,7 @@ define([
             var payload = { id: '01234567-89ab-cdef-fedc-ba9876543210', type: 'this', value: 1 };
             messenger.register('this', routines.add1, mockWindow);
             messenger.register('this', routines.add2, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe(4);
@@ -133,7 +137,7 @@ define([
         it('should respond to Rubicon messages with no IDs', function (done) {
             var payload = { type: 'set-ad-height', value: { id: 'test', height: '20px' } };
             messenger.register('set-ad-height', routines.rubicon, mockWindow);
-            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe('rubicon');

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -4,7 +4,7 @@ define([
     Injector
 ) {
     describe('Cross-frame messenger', function () {
-        var messenger, mockWindow, mockFrame, onMessage, response;
+        var messenger, dfpOrigin, mockWindow, mockFrame, onMessage, response;
 
         var routines = {
             noop: function() {},

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -133,7 +133,7 @@ define([
         it('should respond to Rubicon messages with no IDs', function (done) {
             var payload = { type: 'set-ad-height', value: { id: 'test', height: '20px' } };
             messenger.register('set-ad-height', routines.rubicon, mockWindow);
-            onMessage({ origin: location.protocol + '//' + location.host, data: JSON.stringify(payload), source: mockFrame })
+            onMessage({ origin: 'http://tpc.googlesyndication.com', data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe('rubicon');


### PR DESCRIPTION
## What does this change?

Sends a nonce to an embedded view as soon as it has loaded, with the ID of the iframe into which it is loaded—only if the embedded view is a native ad.
## What is the value of this and can you measure success?

Native ads heavily rely on `window.postMessage`. Sadly, there is standard way to link an incoming message to the corresponding `iframe`. But we need this information though, as in some scenarios we might want to manipulate that frame. Fortunately, DFP gives us a means to know when the `load` event of a slot has fired. We will use that as our way in and send some information that will allow us to create that link later on.

cc @guardian/commercial-dev 
