### PR TITLE
AMPify soundcloud embeds in AMP articles

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -18,6 +18,7 @@
         <script custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js" async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
+        <script custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
         @if(content.tags.isLiveBlog) {

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -80,13 +80,12 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
       for {
         audioElement <- document.getElementsByClass("element-audio")
         iframeElement <- audioElement.getElementsByTag("iframe")
-        soundcloudUrl = iframeElement.attr("src")
-        trackId <- getTrackIdFromUrl(soundcloudUrl) filterNot { _.isEmpty }
-        soundcloudElement = createElement(document, trackId)
-      } yield (audioElement, iframeElement, soundcloudElement, {
+        trackId <- getTrackIdFromUrl(iframeElement.attr("src"))
+      } yield {
+        val soundcloudElement = createElement(document, trackId)
         audioElement.appendChild(soundcloudElement)
         iframeElement.remove()
-      })
+      }
     }
   }
 

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -73,7 +73,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
       }.foreach { audioElementWithIframe: Element =>
         audioElementWithIframe.getElementsByTag("iframe").foreach { iframeElement: Element =>
           val soundcloudUrl = iframeElement.attr("src")
-          val pattern = ".*%2Ftracks%2F(\\d+).*".r
+          val pattern = ".*soundcloud.com%2Ftracks%2F(\\d+).*".r
           soundcloudUrl match {
             case pattern(trackId) =>
               val soundcloud = createElement(document, trackId)

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -71,7 +71,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
     def getTrackIdFromUrl(soundcloudUrl: String): Option[String] = {
       val pattern = ".*soundcloud.com%2Ftracks%2F(\\d+).*".r
       soundcloudUrl match {
-        case pattern(trackId) => Option(trackId)
+        case pattern(trackId) => Some(trackId)
         case _ => None
       }
     }

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -61,8 +61,8 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
   }
 
   def cleanAmpSoundcloud(document: Document) = {
-    document.getElementsByClass("element-audio").filter { audioElement: Element =>
-      audioElement.getElementsByTag("iframe").length != 0
+    document.getElementsByClass("element-audio").filterNot { audioElement: Element =>
+      audioElement.getElementsByTag("iframe").isEmpty
     }.foreach { audioElementWithIframe: Element =>
       audioElementWithIframe.getElementsByTag("iframe").foreach { iframeElement: Element =>
         val soundcloudUrl = iframeElement.attr("src")

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -69,10 +69,11 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
     }
 
     def getTrackIdFromUrl(soundcloudUrl: String): Option[String] = {
-      val pattern = "soundcloud.com%2Ftracks%2F(\\d+)".r
-      val trackId = pattern.findAllIn(soundcloudUrl).matchData.map { matches => matches.group(1) }.mkString
-
-      Option(trackId)
+      val pattern = ".*soundcloud.com%2Ftracks%2F(\\d+).*".r
+      soundcloudUrl match {
+        case pattern(trackId) => Option(trackId)
+        case _ => None
+      }
     }
 
     def clean(document: Document) = {

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -1,0 +1,57 @@
+package views.support.cleaner
+
+import com.gu.contentapi.client.model.v1.{Content => ApiContent}
+import model.{Article, Content}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.{FlatSpec, Matchers}
+
+class AmpEmbedCleanerTest extends FlatSpec with Matchers {
+
+  private def clean(document: Document): Document = {
+    val cleaner = AmpEmbedCleaner(article())
+    cleaner.clean(document)
+    document
+  }
+
+ "AmpEmbedCleaner" should "replace an iframe in an audio-element with an amp-soundcloud element" in {
+   val soundcloudUrl = "http://www.soundcloud.com/%2Ftracks%2F1234"
+   val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
+   val document: Document = Jsoup.parse(doc)
+   val result: Document = clean(document)
+
+   result.getElementsByTag("amp-soundcloud").size should be(1)
+ }
+
+  "AmpEmbedCleaner" should "not add a amp-soundcloud element if an audio element does not contain an iframe" in {
+    val doc = s"""<html><body><figure class="element-audio"></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-soundcloud").size should be(0)
+  }
+
+  "AmpEmbedCleaner" should "create an amp-soundcloud element with a trackid from the iframe src" in {
+    val trackId = "1234"
+    val soundcloudUrl = s"http://www.soundcloud.com/%2Ftracks%2F$trackId"
+    val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-soundcloud").first.attr("data-trackid") should be(trackId)
+  }
+
+  private def article() = {
+    val contentApiItem = contentApi()
+    val content = Content.make(contentApiItem)
+
+    Article.make(content)
+  }
+
+  private def contentApi() = ApiContent(
+    id = "foo/2012/jan/07/bar",
+    webTitle = "Some article",
+    webUrl = "http://www.guardian.co.uk/foo/2012/jan/07/bar",
+    apiUrl = "http://content.guardianapis.com/foo/2012/jan/07/bar"
+  )
+}

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -41,6 +41,15 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-soundcloud").first.attr("data-trackid") should be(trackId)
   }
 
+  "AmpEmbedCleaner" should "not create an amp-soundcloud element if trackid missing from iframe src" in {
+    val soundcloudUrl = s"http://www.soundcloud.com/"
+    val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-soundcloud").size should be(0)
+  }
+
   private def article() = {
     val contentApiItem = contentApi()
     val content = Content.make(contentApiItem)

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -15,7 +15,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
  "AmpEmbedCleaner" should "replace an iframe in an audio-element with an amp-soundcloud element" in {
-   val soundcloudUrl = "http://www.soundcloud.com/%2Ftracks%2F1234"
+   val soundcloudUrl = "http://www.soundcloud.com%2Ftracks%2F1234"
    val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
    val document: Document = Jsoup.parse(doc)
    val result: Document = clean(document)
@@ -33,7 +33,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
   "AmpEmbedCleaner" should "create an amp-soundcloud element with a trackid from the iframe src" in {
     val trackId = "1234"
-    val soundcloudUrl = s"http://www.soundcloud.com/%2Ftracks%2F$trackId"
+    val soundcloudUrl = s"http://www.soundcloud.com%2Ftracks%2F$trackId"
     val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)


### PR DESCRIPTION
## What does this change?

Vanilla Soundcloud embeds are not supported by AMP. Luckily, AMP provide an `amp-soundcloud` component that we can use instead.

This change adds an cleaner that finds Soundcloud embeds in AMP articles and replaces them with their `amp-soundcloud` counterparts
## What is the value of this and can you measure success?

AMP articles that contain Soundcloud embeds will validate successfully
## Does this affect other platforms - Amp, Apps, etc?

Only AMP articles
## Screenshots
### News article

![localhost-3000-healthcare-network-2016-aug-25-look-soundcloud-amp iphone 6](https://cloud.githubusercontent.com/assets/5931528/17974651/cbc7fdd8-6ade-11e6-888d-fa0f63355a4f.png)
### Live blog

![localhost-3000-sport-live-2016-aug-23-team-gb-return-home-from-rio-olympics-live-updates-amp iphone 6](https://cloud.githubusercontent.com/assets/5931528/17974721/1839aacc-6adf-11e6-808c-c4629eb85b70.png)
## Request for comment

@guardian/dotcom-platform 
