### PR TITLE
Tiny Bugfix: Avoid displaying non-upgraded tag rich-links

### DIFF
--- a/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
@@ -1,4 +1,4 @@
-.element-rich-link--not-upgraded .element-rich-link--tag {
+.element-rich-link--not-upgraded.element-rich-link--tag {
     // only display tag based rich links when they are fully upgraded (as we have no link text)
     // not using `display: none` here so spacefinder still sees it
     height: 0;


### PR DESCRIPTION
## What does this change?

I bungled the selector in my previous change, this prevents showing non-upgraded rich-links.
## What is the value of this and can you measure success?

Don't get an odd plain link.

@guardian/dotcom-platform 
