### PR TITLE
Change membership redirect for members only content.

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -233,7 +233,7 @@ define([
             var membershipUrl = config.page.membershipUrl,
                 membershipAccess = config.page.membershipAccess,
                 requiresPaidTier = (membershipAccess.indexOf('paid-members-only') !== -1),
-                membershipAuthUrl = membershipUrl + '/choose-tier?membershipAccess=' + membershipAccess;
+                membershipAuthUrl = membershipUrl + '/membership-content?referringContent=' + config.page.contentId + '&membershipAccess=' + membershipAccess;
 
             var redirect = function () {
                 window.location.href = membershipAuthUrl;


### PR DESCRIPTION
## What does this change?

Changes the membership endpoint to the one in https://github.com/guardian/membership-frontend/pull/1276 
## What is the value of this and can you measure success?

To support members only content. 
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![image](https://cloud.githubusercontent.com/assets/2670496/18002340/13987b92-6b7f-11e6-82ee-354c623a4fc8.png)
(from membership-frontend pr by @philwills)
## Request for comment

@philwills 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
