### PR TITLE
Track web notifications follow button attention

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -8,9 +8,9 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-live-blog-chrome-notifications-prod2",
     "Live blog chrome notifications - prod",
-    owners = Seq(Owner.withGithub("NathanielBennett")),
+    owners = Seq(Owner.withGithub("janua")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 31),
+    sellByDate = new LocalDate(2016, 9, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -53,9 +53,19 @@ define([
         },
 
         init: function() {
-            modules.configureSubscribeButton();
+            var $followElement = modules.configureSubscribeButton();
             if(!modules.hasSubscribed() && !modules.hasDismissedExplainer()) {
                 modules.showExplainer();
+            }
+
+            modules.trackFollowButtonAttention($followElement.get(0));
+        },
+
+        trackFollowButtonAttention: function (followElement) {
+            if (followElement) {
+                require(['ophan/ng'], function (ophan) {
+                    ophan.trackComponentAttention('web-notifications--follow-button', followElement);
+                });
             }
         },
 
@@ -72,6 +82,8 @@ define([
                 $follow.html(src);
                 bean.one($follow[0], 'click', '.js-notifications__button', handler);
             });
+
+            return $follow;
         },
 
         showExplainer: function() {


### PR DESCRIPTION
## What does this change?

This adds attention tracking to the follow button for web notifications. Currently, we don't truly know how many people have seen the button as it depends on lots of different variables; On Chrome, on HTTPS, on a liveblog and in the AB test (for now).
## What is the value of this and can you measure success?

This will allow us to track how many people actually seen the button, but also allow us to see how long the button was on screen for the user if we need that.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@stephanfowler @zeftilldeath @joelochlann @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
