### PR TITLE
Fluid ads in liveblogs

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -18,6 +18,7 @@ define([
     'commercial/modules/hosted/gallery',
     'commercial/modules/hosted/colours',
     'commercial/modules/slice-adverts',
+    'commercial/modules/liveblog-adverts',
     'commercial/modules/sticky-top-banner',
     'commercial/modules/third-party-tags',
     'commercial/modules/paidfor-band',
@@ -44,6 +45,7 @@ define([
     hostedGallery,
     hostedColours,
     sliceAdverts,
+    liveblogAdverts,
     stickyTopBanner,
     thirdPartyTags,
     paidforBand,
@@ -57,6 +59,7 @@ define([
         ['cm-articleBodyAdverts', articleBodyAdverts.init],
         ['cm-sliceAdverts', sliceAdverts.init],
         ['cm-galleryAdverts', galleryAdverts.init],
+        ['cm-liveblogAdverts', liveblogAdverts.init],
         ['cm-frontCommercialComponents', frontCommercialComponents.init],
         ['cm-closeDisabledSlots', closeDisabledSlots.init]
     ];

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -3,7 +3,6 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/modules/article/rich-links',
-    'commercial/modules/liveblog-adverts',
     'common/modules/experiments/affix',
     'common/modules/ui/autoupdate',
     'common/modules/ui/notification-counter',
@@ -18,7 +17,6 @@ define([
     detect,
     mediator,
     richLinks,
-    liveblogAdverts,
     Affix,
     AutoUpdate,
     NotificationCounter,
@@ -34,10 +32,6 @@ define([
     var modules;
 
     modules = {
-        initAdverts: function () {
-            return liveblogAdverts.init();
-        },
-
         affixTimeline: function () {
             var topMarker;
             if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0 && config.page.keywordIds.indexOf('sport/rugby-union') < 0) {
@@ -78,7 +72,6 @@ define([
 
     function ready() {
         robust.catchErrorsAndLogAll([
-            ['lb-adverts',    modules.initAdverts],
             ['lb-autoupdate', modules.createAutoUpdate],
             ['lb-timeline',   modules.affixTimeline],
             ['lb-timestamp',  modules.keepTimestampsCurrent],

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -58,7 +58,7 @@ define([
     /**
      * DFP fluid ads should use existing fluid-250 styles in the top banner position
      */
-    sizeCallbacks[adSizes.fluid] = addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad']);
+    sizeCallbacks[adSizes.fluid] = addFluid(['ad-slot']);
 
     /**
      * Trigger sticky scrolling for MPUs in the right-hand article column

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -1,6 +1,7 @@
 define([
     'bonzo',
     'common/utils/fastdom-promise',
+    'common/utils/detect',
     'common/utils/config',
     'common/utils/mediator',
     'common/modules/commercial/dfp/add-slot',
@@ -11,6 +12,7 @@ define([
 ], function (
     bonzo,
     fastdom,
+    detect,
     config,
     mediator,
     addSlot,
@@ -23,7 +25,7 @@ define([
     var OFFSET = 1.5;      // ratio of the screen height from which ads are loaded
     var MAX_ADS = 8;       // maximum number of ads to display
 
-    var slotCounter = 0, windowHeight, firstSlot;
+    var slotCounter = 0, isMobile, windowHeight, firstSlot;
 
     function startListening() {
         mediator.on('modules:autoupdate:updates', onUpdate);
@@ -64,9 +66,14 @@ define([
 
     function insertAds(slots) {
         for (var i = 0; i < slots.length && slotCounter < MAX_ADS; i++) {
-            var $adSlot = bonzo(createSlot('inline1' + slotCounter++, 'liveblog-inline block'));
+            var slotName = isMobile && slotCounter === 0 ?
+                'top-above-nav' : isMobile ?
+                'inline' + slotCounter :
+                'inline' + (slotCounter + 1);
+            var $adSlot = bonzo(createSlot(slotName, 'liveblog-inline block'));
             $adSlot.insertAfter(slots[i]);
             addSlot($adSlot);
+            slotCounter += 1;
         }
     }
 
@@ -89,8 +96,10 @@ define([
 
     function init() {
         if (!commercialFeatures.liveblogAdverts) {
-            return null;
+            return Promise.resolve();
         }
+
+        isMobile = detect.getBreakpoint() === 'mobile';
 
         return fastdom.read(function () {
             return windowHeight = document.documentElement.clientHeight;

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -123,6 +123,7 @@ define([
             (!isLiveBlog || isWidePage);
 
         this.liveblogAdverts =
+            isLiveBlog &&
             this.dfpAdvertising &&
             switches.liveblogAdverts;
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -637,6 +637,17 @@
     padding-left: 0;
     padding-right: 0;
     padding-bottom: 0;
+
+    &.ad-slot--liveblog-inline {
+        @include mq(mobile) {
+            margin-left: $gs-gutter / -2;
+            margin-right: $gs-gutter / -2;
+        }
+        @include mq(mobileLandscape, $until: tablet) {
+            margin-left: -$gs-gutter;
+            margin-right: -$gs-gutter;
+        }
+    }
 }
 
 .ad-slot--fabric-v1 {


### PR DESCRIPTION
## What does this change?

In liveblogs, inserts slots during the commercial bootstrap rather than the enhanced one. Also harmonises the slot naming scheme with the rest of the site. And makes sure a fluid ad expands to fill the width of the screen on mobile.

![picture 1](https://cloud.githubusercontent.com/assets/629976/18011654/f4d657a4-6bad-11e6-8e88-aebd5b83066f.jpg)

cc @guardian/commercial-dev 
