### PR TITLE
GA discussion events

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -92,6 +92,7 @@
                 var d = new Date().getTime();
                 if (d - referrerVars.value.time < 60 * 1000) { // One minute
                     ga('@{trackerName}.send', 'event', 'Click', 'Internal', referrerVars.value.tag, {
+                        nonInteraction: true, // to avoid affecting bounce rate
                         dimension12: referrerVars.value.path
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -35,11 +35,11 @@ define([
     // var gaTracker = config.googleAnalytics.trackers.editorial;
     var gaTracker = 'guardianTestPropertyTracker';
 
-    function sendToGA(action, label, customDimensions) {
+    function sendToGA(label, customDimensions) {
         var fieldsObject = assign({
             nonInteraction: true // to avoid affecting bounce rate
         }, (customDimensions || {}));
-        ga(gaTracker + '.send', 'event', 'Discussion', action, label, fieldsObject);
+        ga(gaTracker + '.send', 'event', 'ElementView', 'Onpage item', label, fieldsObject);
     }
 
     /**
@@ -56,10 +56,6 @@ define([
         var commentType = comment.replyTo ? 'response' : 'comment';
         var parentCommentAuthorId = comment.replyTo ? comment.replyTo.authorId : null;
 
-        sendToGA('Post comment', commentType, {
-           dimension22: parentCommentAuthorId
-        });
-
         // Add extra variables for discussion.
         omniture.populateEventProperties('comment');
         s.events += ',event51';
@@ -73,8 +69,6 @@ define([
     };
 
     track.recommend = function (e) {
-        sendToGA('Engage with comment', 'recommend');
-
         omniture.populateEventProperties('Recommend a comment');
         s.events += ',event72';
         s.linkTrackVars += this.getLinkTrackVars(['eVar65', 'eVar67']);
@@ -88,8 +82,6 @@ define([
 
     track.jumpedToComments = function () {
         if (!track.seen) {
-            sendToGA('Click comments link');
-
             omniture.populateEventProperties('seen jump-to-comments');
             s.events += ',event72';
             s.linkTrackVars += this.getLinkTrackVars(['eVar65']);
@@ -104,8 +96,6 @@ define([
 
     track.commentPermalink = function () {
         if (!track.seen) {
-            sendToGA('Follow permalink');
-
             omniture.populateEventProperties('seen comment-permalink');
             s.events += ',event72';
             s.linkTrackVars += this.getLinkTrackVars(['eVar65']);

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -86,11 +86,6 @@ Loader.prototype.initMainComments = function() {
     var self = this,
         commentId = this.getCommentIdFromHash();
 
-
-    if (commentId) {
-        mediator.emit('discussion:seen:comment-permalink');
-    }
-
     //We want to test the effect of comment ordering, but not mess with users who have already re-ordered their comments
     var order = userPrefs.get('discussion.order') || userPrefs.get('discussion.order.test') || (this.getDiscussionClosed() ? 'oldest' : 'newest');
     var threading = userPrefs.get('discussion.threading') || 'collapsed';
@@ -277,6 +272,8 @@ Loader.prototype.ready = function() {
     // More for analytics than anything
     if (window.location.hash === '#comments') {
         mediator.emit('discussion:seen:comments-anchor');
+    } else if (this.getCommentIdFromHash()) {
+        mediator.emit('discussion:seen:comment-permalink');
     }
 
     mediator.on('discussion:commentbox:post:success', this.removeState.bind(this, 'empty'));


### PR DESCRIPTION
## What does this change?

Send discussion events to GA as well as Omniture.

Also fix a bug that meant the "followed a permalink" event was never sent. The event was being emitted by `loader.js` before the analytics module had been initialised and started listening for it.

~~Note: we don't quite have parity with Omniture because we don't yet send the logged in user's ID as a custom dimension. That's a little involved, and not only relevant to discussion, so I'll do it in a separate PR.~~ This has been done in #14137.
## What is the value of this and can you measure success?

~~Dunno. Waiting for @crifmulholland to come back from holiday so I can check which events are actually needed.~~ Checked with Chris M, decided we only need the "scrolled to comments" event. Other events are already covered by the generic click tracking.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@nicl @ajosephides 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
