### PR TITLE
AB test: Remove share counts. 😨

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -160,7 +160,7 @@ trait ABTestSwitches {
     "Remove social count from articles",
     owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 7),   // Wednesday
+    sellByDate = new LocalDate(2016, 9, 21),   // Wednesday
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -153,4 +153,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 10, 18),   // Tuesday
     exposeClientSide = true
   )
+
+  val ABNoSocialCount = Switch(
+    SwitchGroup.ABTests,
+    "ab-no-social-count",
+    "Remove social count from articles",
+    owners = Seq(Owner.withGithub("gtrufitt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 7),   // Wednesday
+    exposeClientSide = true
+  )
 }

--- a/common/app/views/fragments/social.scala.html
+++ b/common/app/views/fragments/social.scala.html
@@ -1,9 +1,9 @@
 @(sharelinks: Seq[model.ShareLink], position: String = "bottom", iconModifier: String = "", isGallery: Boolean = false)
 
-<ul class="social social--@position u-unstyled u-cf" data-component="social">
+<ul class="social social--@position js-social--@position u-unstyled u-cf" data-component="social">
     @sharelinks.map { item: model.ShareLink =>
         <li class="social__item social__item--@item.css" data-link-name="@item.css">
-            <a  class="social__action social-icon-wrapper"
+            <a  class="social__action js-social__action--@position social-icon-wrapper"
                 data-link-name="social @position"
                 href="@item.href"
                 target="_blank"

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -21,7 +21,8 @@ define([
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',
     'common/modules/experiments/tests/minute-load-js',
     'common/modules/experiments/tests/contributions-embed',
-    'common/modules/experiments/tests/adblocking-response'
+    'common/modules/experiments/tests/adblocking-response',
+    'common/modules/experiments/tests/no-social-count'
 ], function (
     reportError,
     config,
@@ -45,7 +46,8 @@ define([
     DontUpgradeMobileRichLinks,
     MinuteLoadJs,
     ContributionsEmbed,
-    AdBlockingResponse
+    AdBlockingResponse,
+    NoSocialCount
 ) {
 
     var TESTS = [
@@ -63,7 +65,8 @@ define([
         new RecommendedForYou(),
         new DontUpgradeMobileRichLinks(),
         new MinuteLoadJs(),
-        new ContributionsEmbed()
+        new ContributionsEmbed(),
+        new NoSocialCount()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
@@ -10,7 +10,7 @@ define([
 
         this.id = 'NoSocialCount';
         this.start = '2016-08-25';
-        this.expiry = '2016-09-07';
+        this.expiry = '2016-09-21';
         this.author = 'Gareth Trufitt';
         this.description = 'Test whether the social share counts make a difference to the number of clicks on social buttons';
         this.audience = 0.5;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
@@ -12,10 +12,10 @@ define([
         this.start = '2016-08-25';
         this.expiry = '2016-09-07';
         this.author = 'Gareth Trufitt';
-        this.description = 'Test whether the social share counts increase the number of shares an article has';
+        this.description = 'Test whether the social share counts make a difference to the number of clicks on social buttons';
         this.audience = 0.5;
         this.audienceOffset = 0.5;
-        this.successMeasure = 'The control group, that shows social shares, will have 2% more clicks on sharing buttons';
+        this.successMeasure = 'No significant difference in clicks between the variant and control';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
         this.idealOutcome = 'Social share counts *do not* cause a significant increase in sharing, so we can remove them';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
@@ -1,0 +1,49 @@
+define([
+    'common/utils/config',
+    'bean'
+], function (
+    config,
+    bean
+) {
+    return function () {
+        var module = this;
+
+        this.id = 'NoSocialCount';
+        this.start = '2016-08-25';
+        this.expiry = '2016-09-07';
+        this.author = 'Gareth Trufitt';
+        this.description = 'Test whether the social share counts increase the number of shares an article has';
+        this.audience = 0.5;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'The control group, that shows social shares, will have 2% more clicks on sharing buttons';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Social share counts *do not* cause a significant increase in sharing, so we can remove them';
+
+        this.canRun = function () {
+            // We're on content and the page is commentable (so we don't have to fuss with the gap if it wasn't commentable)
+            return config.page.isContent && config.page.commentable;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: userClickedSocialShare
+            },
+            {
+                id: 'no-sharing',
+                test: function () {},
+                success: userClickedSocialShare
+            }
+        ];
+
+        function userClickedSocialShare (complete) {
+            var socialTopArr = document.querySelectorAll('.js-social--top');
+
+            if (socialTopArr.length > 0 && module.canRun()) {
+                bean.on(socialTopArr[0], 'click', document.getElementsByClassName('js-social__action--top'), complete);
+            }
+        }
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/no-social-count.js
@@ -18,7 +18,7 @@ define([
         this.successMeasure = 'No significant difference in clicks between the variant and control';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'Social share counts *do not* cause a significant increase in sharing, so we can remove them';
+        this.idealOutcome = 'Social sharing in the control group is not more than 2% higher';
 
         this.canRun = function () {
             // We're on content and the page is commentable (so we don't have to fuss with the gap if it wasn't commentable)

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -8,7 +8,8 @@ define([
     'common/utils/template',
     'common/views/svgs',
     'text!common/views/content/share-count.html',
-    'text!common/views/content/share-count-immersive.html'
+    'text!common/views/content/share-count-immersive.html',
+    'common/modules/experiments/ab'
 ], function (
     reportError,
     $,
@@ -19,7 +20,8 @@ define([
     template,
     svgs,
     shareCountTemplate,
-    shareCountImmersiveTemplate
+    shareCountImmersiveTemplate,
+    ab
 ) {
     var shareCount = 0,
         $shareCountEls = $('.js-sharecount'),
@@ -82,7 +84,8 @@ define([
         // asking for social counts in preview "leaks" upcoming URLs to social sites.
         // when they then crawl them they get 404s which affects later sharing.
         // don't call counts in preview
-        if ($shareCountEls.length && !config.page.isPreview) {
+        // AB test: No social counts - Variant: no-sharing doesn't insert share counts
+        if ($shareCountEls.length && !config.page.isPreview && !ab.isInVariant('NoSocialCount', 'no-sharing')) {
             var url = 'http://www.theguardian.com/' + config.page.pageId;
             try {
                 ajax({


### PR DESCRIPTION
## What does this change?

This adds an AB test to discover whether whether the social share counts make a difference to the number of clicks on social buttons.

The audience is 50% as the amount of share count clicks is fairly low vs PV and it'd be nice to finish the test this year. To test a 2% minimum detectable effect we need to run this high for a couple of weeks but we can rely on ABacus to do it's job RE samples.
## What is the value of this and can you measure success?

Share counts take maintenance time and degrade UX due to lazy loading. We're re-visting meta and want to prove that share counts are worth the time and effort. Facebook is periodically retiring versions of it's API which make the functionality harder to do. Twitter's API changed months ago and we've not had Twitter share counts included since then (and no-one noticed/cared). It seems to be a largely internal vanity metric that can be retrieved from other sources.
## Request for comment

@guardian/dotcom-platform 
