### PR TITLE
Remove spinny sharecount

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -1,4 +1,5 @@
 define([
+    'fastdom',
     'common/utils/report-error',
     'common/utils/$',
     'common/utils/ajax',
@@ -10,6 +11,7 @@ define([
     'text!common/views/content/share-count.html',
     'text!common/views/content/share-count-immersive.html'
 ], function (
+    fastdom,
     reportError,
     $,
     ajax,
@@ -36,8 +38,10 @@ define([
             var displayCount = shareCount.toFixed(0),
                 formattedDisplayCount = formatters.integerCommas(displayCount),
                 shortDisplayCount = displayCount > 10000 ? Math.round(displayCount / 1000) + 'k' : displayCount;
-            $fullValueEls.text(formattedDisplayCount);
-            $shortValueEls.text(shortDisplayCount);
+            fastdom.write(function() {
+                $fullValueEls.text(formattedDisplayCount);
+                $shortValueEls.text(shortDisplayCount);
+            });
         }
     }
 
@@ -61,21 +65,7 @@ define([
         $shortValueEls = $('.sharecount__value--short', $shareCountEls[0]); // limited to 1 el
         $fullValueEls = $('.sharecount__value--full', $shareCountEls[0]); // limited to 1 el
 
-        if (detect.isBreakpoint({min: 'tablet'})) {
-            var duration = 250,
-                updateStep = 25,
-                slices = duration / updateStep,
-                amountPerStep = val / slices,
-                currentSlice = 0,
-                interval = window.setInterval(function () {
-                    incrementShareCount(amountPerStep);
-                    if (++currentSlice === slices) {
-                        window.clearInterval(interval);
-                    }
-                }, updateStep);
-        } else {
-            incrementShareCount(val);
-        }
+        incrementShareCount(val);
     }
 
     return function () {


### PR DESCRIPTION
## What does this change?

Doesn't do the ol' count up to the number re-paint re-paint re-paint malarkey. Just sticks the number in.
## What is the value of this and can you measure success?

No re-paints. Uses fastdom. 
## Request for comment

@guardian/dotcom-platform 
