### PR TITLE
Add plain dark form style

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -35,7 +35,7 @@ POST           /notification/delete                                             
 
 # Email paths
 GET        /email                                                               controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain|plainDark>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plaindark>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -35,7 +35,7 @@ POST           /notification/delete                                             
 
 # Email paths
 GET        /email                                                               controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain>/:listId                 controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plainDark>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -111,6 +111,7 @@ object EmailTypes {
   val article = "article"
   val landing = "landing"
   val plain = "plain"
+  val plainDark = "plainDark"
 }
 
 class EmailFormService(wsClient: WSClient) {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -44,7 +44,7 @@ GET            /crosswords/lookup                                               
 
 # Email paths
 GET            /email                                                                                                            controllers.EmailSignupController.renderPage()
-GET            /email/form/$emailType<article|footer|plain|plainDark>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET            /email/form/$emailType<article|footer|plain|plaindark>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()
 OPTIONS        /email                                                                                                            controllers.EmailSignupController.options()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -44,7 +44,7 @@ GET            /crosswords/lookup                                               
 
 # Email paths
 GET            /email                                                                                                            controllers.EmailSignupController.renderPage()
-GET            /email/form/$emailType<article|footer|plain>/:listId                                                              controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET            /email/form/$emailType<article|footer|plain|plainDark>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()
 OPTIONS        /email                                                                                                            controllers.EmailSignupController.options()

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -175,7 +175,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    
 
 # Email paths
 GET        /email                                                                              controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain|plainDark>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plaindark>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -175,7 +175,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    
 
 # Email paths
 GET        /email                                                                              controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain>/:listId                                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plainDark>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -312,7 +312,7 @@
     .email-sub__submit-input {
         background-color: #DDDBD7;
         border-color: #DDDBD7;
-        color: #000000;
+        color: #333;
     }
 
     .email-sub__message {

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -310,8 +310,8 @@
     padding: 0;
 
     .email-sub__submit-input {
-        background-color: #DDDBD7;
-        border-color: #DDDBD7;
+        background-color: $neutral-4;
+        border-color: $neutral-4;
         color: $neutral-1;
     }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -268,7 +268,7 @@
 
 .email-sub__form--article,
 .email-sub__form--plain,
-.email-sub__form--plainDark
+.email-sub__form--plaindark
 {
     .label__icon {
         display: inline-block;
@@ -306,7 +306,7 @@
 }
 
 // PLAIN-DARK MODS
-.email-sub__form--plainDark {
+.email-sub__form--plaindark {
     padding: 0;
 
     .email-sub__submit-input {

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -267,7 +267,9 @@
 }
 
 .email-sub__form--article,
-.email-sub__form--plain {
+.email-sub__form--plain,
+.email-sub__form--plainDark
+{
     .label__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;
@@ -299,6 +301,26 @@
 
     .email-sub__text-input {
         border-color: $guardian-brand;
+    }
+
+}
+
+// PLAIN-DARK MODS
+.email-sub__form--plainDark {
+    padding: 0;
+
+    .email-sub__submit-input {
+        background-color: #DDDBD7;
+        border-color: #DDDBD7;
+        color: #000000;
+    }
+
+    .email-sub__message {
+        color: #ffffff;
+    }
+
+    .email-sub__message__headline {
+        color: #ffffff;
     }
 }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -312,7 +312,7 @@
     .email-sub__submit-input {
         background-color: #DDDBD7;
         border-color: #DDDBD7;
-        color: #333;
+        color: $neutral-1;
     }
 
     .email-sub__message {

--- a/static/src/stylesheets/module/email/_header.scss
+++ b/static/src/stylesheets/module/email/_header.scss
@@ -83,3 +83,15 @@
     }
 }
 
+// PLAIN DARK MODS
+.email-sub--plainDark {
+    .email-sub__message__description {
+        display: none;
+    }
+
+    .email-sub__message__headline {
+        color: #ffffff;
+        line-height: 2rem;
+    }
+}
+

--- a/static/src/stylesheets/module/email/_header.scss
+++ b/static/src/stylesheets/module/email/_header.scss
@@ -84,7 +84,7 @@
 }
 
 // PLAIN DARK MODS
-.email-sub--plainDark {
+.email-sub--plaindark {
     .email-sub__message__description {
         display: none;
     }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -51,7 +51,8 @@ body {
 @include mq($from: 184px) {
     .email-sub__form--footer,
     .email-sub__form--article,
-    .email-sub__form--plain {
+    .email-sub__form--plain,
+    .email-sub__form--plainDark {
         // Rounded inline input
         .email-sub__text-input {
             border-right: 0;
@@ -85,7 +86,8 @@ body {
     }
 
     .email-sub__form--footer,
-    .email-sub__form--plain {
+    .email-sub__form--plain,
+    .email-sub__form--plainDark {
         .email-sub__submit-input {
             padding-left: $gs-gutter / 2;
         }
@@ -95,7 +97,8 @@ body {
 // It's a fixed layout so only at this width do we want to apply these styles
 @include mq(183px, 183px) {
     .email-sub__form--footer,
-    .email-sub__form--plain {
+    .email-sub__form--plain,
+    .email-sub__form--plainDark {
         padding-right: $gs-gutter / 2;
 
         .email-sub__text-input {
@@ -142,6 +145,14 @@ body {
 * IFRAME PLAIN MODS
 */
 .email-sub--plain {
+    .email-sub__header,
+    .email-sub__label,
+    .email-sub__small {
+        display: none;
+    }
+}
+
+.email-sub--plainDark {
     .email-sub__header,
     .email-sub__label,
     .email-sub__small {

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -144,15 +144,9 @@ body {
 /**
 * IFRAME PLAIN MODS
 */
-.email-sub--plain {
-    .email-sub__header,
-    .email-sub__label,
-    .email-sub__small {
-        display: none;
-    }
-}
-
-.email-sub--plaindark {
+.email-sub--plain,
+.email-sub--plaindark
+{
     .email-sub__header,
     .email-sub__label,
     .email-sub__small {

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -52,7 +52,7 @@ body {
     .email-sub__form--footer,
     .email-sub__form--article,
     .email-sub__form--plain,
-    .email-sub__form--plainDark {
+    .email-sub__form--plaindark {
         // Rounded inline input
         .email-sub__text-input {
             border-right: 0;
@@ -87,7 +87,7 @@ body {
 
     .email-sub__form--footer,
     .email-sub__form--plain,
-    .email-sub__form--plainDark {
+    .email-sub__form--plaindark {
         .email-sub__submit-input {
             padding-left: $gs-gutter / 2;
         }
@@ -98,7 +98,7 @@ body {
 @include mq(183px, 183px) {
     .email-sub__form--footer,
     .email-sub__form--plain,
-    .email-sub__form--plainDark {
+    .email-sub__form--plaindark {
         padding-right: $gs-gutter / 2;
 
         .email-sub__text-input {
@@ -152,7 +152,7 @@ body {
     }
 }
 
-.email-sub--plainDark {
+.email-sub--plaindark {
     .email-sub__header,
     .email-sub__label,
     .email-sub__small {


### PR DESCRIPTION
## What does this change?

Add 'plain dark' email form mod for use on interactives with dark backgrounds
## What is the value of this and can you measure success?

Allows us to add email subscribe functionality to interactives (which are still on HTTP)
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="1279" alt="screen shot 2016-08-30 at 09 59 32" src="https://cloud.githubusercontent.com/assets/1764158/18083051/4758e210-6e99-11e6-9a19-aca9edc57b9b.png">
## Request for comment

CC @duarte @akash1810 @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
