### PR TITLE
Extend sports surging switch for one week

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -302,7 +302,7 @@ trait CommercialSwitches {
     "If on email will be sent to Rio Olympic surging content team every 30 minutes with update on surging content.",
     owners = Seq(Owner.withGithub("Calum Campbell")),
     safeState = Off,
-    sellByDate = new LocalDate(2016,8,31),
+    sellByDate = new LocalDate(2016,9,6),
     exposeClientSide = false
   )
 }


### PR DESCRIPTION
This feature is no longer needed but @Calum-Campbell is currently on annual leave.

I'm extending it for a week when Calum will be back and can remove the feature (and the switch).
