### PR TITLE
Update quiz question to inline-block instead of block style

### DIFF
--- a/static/src/stylesheets/module/atoms/_quiz.scss
+++ b/static/src/stylesheets/module/atoms/_quiz.scss
@@ -23,7 +23,7 @@
 // fieldset > legend
 .atom-quiz__question-text {
     margin-bottom: $gs-baseline;
-    display: block;
+    display: inline-block;
 
     &:before {
         counter-increment: quiz-question;


### PR DESCRIPTION
## What does this change?

Fixes this in IE11:

![image](https://cloud.githubusercontent.com/assets/638051/18090011/ae2e8e2e-6eba-11e6-97f9-fc6326841510.png)

@guardian/dotcom-platform 
