### PR TITLE
Remove unused import

### DIFF
--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -1,7 +1,5 @@
 package common
 
-import play.api.{Application, GlobalSettings}
-
 import scala.concurrent.duration.FiniteDuration
 import akka.agent.Agent
 import akka.actor.{ActorSystem, Cancellable}

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -1,11 +1,12 @@
 package common
 
 import model.Cached.RevalidatableResult
+
 import model._
 import play.api.libs.json._
 import play.api.libs.json.Json.toJson
 import conf.switches.Switches.AutoRefreshSwitch
-import play.api.mvc.{ RequestHeader, Results, Result }
+import play.api.mvc.{ RequestHeader, Results }
 import play.twirl.api.Html
 import play.api.http.ContentTypes._
 

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -3,8 +3,6 @@ package common
 import common.editions.{Au, Us, International}
 import common.Edition.editionRegex
 import conf.Configuration
-import conf.switches.Switches
-import implicits.Requests
 import layout.ContentCard
 import model.Trail
 import org.jsoup.Jsoup

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -2,7 +2,6 @@ package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
 import conf.Configuration.site.host
-import conf.switches.Switches
 
 object Formula1HostedPages {
 

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -2,7 +2,6 @@ package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
 import conf.Configuration.site.host
-import conf.switches.Switches
 
 object VisitBritainHostedPages {
 

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -3,7 +3,6 @@ package common.editions
 import java.util.Locale
 
 import common._
-import conf.switches.Switches
 import org.joda.time.DateTimeZone
 
 object International extends Edition(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -3,7 +3,6 @@ package common.editions
 import java.util.Locale
 
 import common._
-import conf.switches.Switches
 import org.joda.time.DateTimeZone
 
 object Uk extends Edition(

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -7,7 +7,7 @@ import org.quartz._
 import play.api.Mode.Test
 
 import scala.collection.mutable
-import play.api.{Environment, Play}
+import play.api.Environment
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -4,7 +4,7 @@ import app.LifecycleComponent
 import common._
 import org.joda.time.DateTime
 import play.api.{Mode, Play}
-import play.api.libs.ws.{WS, WSClient, WSResponse}
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc._
 
 import scala.concurrent.Future

--- a/common/app/conf/PanicSheddingFilter.scala
+++ b/common/app/conf/PanicSheddingFilter.scala
@@ -4,7 +4,6 @@ import java.lang.management.ManagementFactory
 
 import akka.agent.Agent
 import common.{ExecutionContexts, RequestMetrics, Logging}
-import conf.switches.Switches
 import org.joda.time.DateTime
 import play.api.mvc.Results._
 import play.api.mvc.{Result, RequestHeader, Filter}

--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -1,7 +1,6 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import org.joda.time.LocalDate
 
 trait FaciaSwitches {
   // Facia

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -1,7 +1,6 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import org.joda.time.LocalDate
 
 trait MonitoringSwitches {
   // Monitoring

--- a/common/app/contentapi/SectionTagLookUp.scala
+++ b/common/app/contentapi/SectionTagLookUp.scala
@@ -1,8 +1,6 @@
 package contentapi
 
 import common.Maps.RichMap
-import conf.switches.Switches
-import Function.const
 
 object SectionTagLookUp {
   private val ExceptionsMap = Map(

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -3,7 +3,6 @@ package contentapi
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
-import com.gu.contentapi.client.ContentApiClientLogic
 import common.ContentApiMetrics.{ContentApiErrorMetric, ContentApi404Metric}
 import common.{Logging, ExecutionContexts}
 import conf.Configuration
@@ -12,7 +11,7 @@ import metrics.{CountMetric, TimingMetric}
 import play.api.libs.ws.{WS, WSAuthScheme}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.{Success, Failure, Try}
 
 case class Response(body: Array[Byte], status: Int, statusText: String)

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -1,7 +1,6 @@
 package model
 
-import conf.switches.Switches
-import conf.{Configuration, Static}
+import conf.Static
 import layout.FaciaContainer
 import java.security.MessageDigest
 import java.math.BigInteger

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -1,7 +1,5 @@
 package model
 
-import java.net.URLEncoder
-
 import campaigns.ShortCampaignCodes
 import common.`package`._
 import conf.Configuration.facebook.{ appId => facebookAppId }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -22,7 +22,6 @@ import play.api.libs.json._
 import views.support._
 
 import scala.collection.JavaConversions._
-import scala.language.postfixOps
 import scala.util.Try
 
 sealed trait ContentType {

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -2,7 +2,7 @@ package model.liveblog
 
 import java.util.Locale
 
-import com.gu.contentapi.client.model.v1.{BlockAttributes => ApiBlockAttributes, BlockElement => ApiBlockElement, Blocks => ApiBlocks, Block, VideoElementFields, Asset}
+import com.gu.contentapi.client.model.v1.{BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks, Block}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import model.liveblog.BodyBlock._
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -8,7 +8,7 @@ import common.dfp._
 import common.{Edition, ManifestData, NavItem, Pagination}
 import conf.Configuration
 import cricketPa.CricketTeams
-import model.liveblog.{Blocks, BodyBlock}
+import model.liveblog.Blocks
 import model.meta.{Guardian, LinkedData, PotentialAction, WebPage}
 import ophan.SurgingContentAgent
 import org.apache.commons.lang3.StringUtils

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,7 +1,6 @@
 package model.meta
 
 import conf.Static
-import org.joda.time.DateTime
 
 class LinkedData(
   val `@type`: String,

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -7,7 +7,6 @@ import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{ConfigJson => Config, FrontJson => Front}
 import common._
 import conf.Configuration
-import conf.switches.Switches
 import fronts.FrontsApi
 import model.pressed.CollectionConfig
 import model.{FrontProperties, SeoDataJson}

--- a/common/app/services/IndexPageGrouping.scala
+++ b/common/app/services/IndexPageGrouping.scala
@@ -1,6 +1,5 @@
 package services
 
-import com.gu.facia.api.models.FaciaContent
 import common.JodaTime._
 import common.Maps.RichMapSeq
 import implicits.Collections

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -1,6 +1,6 @@
 package services
 
-import java.net.{URL, URLEncoder}
+import java.net.URLEncoder
 
 import common.{BadConfigurationException, ExecutionContexts, Logging}
 import conf.Configuration._

--- a/common/app/services/TagIndexesS3.scala
+++ b/common/app/services/TagIndexesS3.scala
@@ -6,8 +6,6 @@ import play.api.Play
 import play.api.Play.current
 import play.api.libs.json._
 
-import scala.collection.JavaConversions._
-
 sealed trait TagIndexError
 
 case object TagIndexNotFound extends TagIndexError

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -5,8 +5,6 @@ import common.Edition
 import conf.Configuration
 import conf.Configuration.environment
 import model._
-import implicits.Dates.DateTime2ToCommonDateFormats
-import org.joda.time.DateTime
 import play.api.Play
 import play.api.Play.current
 import play.api.libs.json.{JsValue, JsBoolean, JsString, Json}

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import org.jsoup.nodes.{ Element, Document }
+import org.jsoup.nodes.Document
 import scala.collection.JavaConversions._
 
 case class TimestampCleaner(article: model.Article) extends HtmlCleaner {

--- a/common/app/views/support/OmnitureAnalyticsData.scala
+++ b/common/app/views/support/OmnitureAnalyticsData.scala
@@ -3,7 +3,7 @@ package views.support
 import java.net.URLEncoder._
 
 import conf.Configuration
-import model.{ContentPage, MetaData, Page, EmbedPage}
+import model.{ContentPage,Page, EmbedPage}
 import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html

--- a/router/app/controllers/Application.scala
+++ b/router/app/controllers/Application.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.Logging
-import play.api.mvc._
+import play.api.mvc.{Controller, Action}
 
 class Application extends Controller with Logging {
   // Management doesn't start in DEV until an application URL is hit


### PR DESCRIPTION
## What does this change?

Removing unused import. Used the `-Ywarn-unused-import` to detect those.

I wanted to enable the `-Ywarn-unused-import` scalac option but Play 2.4
seems to have an issue and detect false positive in routes files. See
https://github.com/playframework/playframework/issues/6131 for more
details.
We'll need to wait until after the upgrade to Play 2.5 to enable this
option 😢 
## What is the value of this and can you measure success?

Less unecessary code
## Does this affect other platforms - Amp, Apps, etc?

It could affect amp I guess 😁 
## Request for comment

@jfsoul @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
