### PR TITLE
Add retry to page fetching for amp validation

### DIFF
--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -1,27 +1,32 @@
 'use strict';
 
 const https = require('https');
+const promiseRetry = require('promise-retry');
 
 const hostname = 'https://amp.theguardian.com';
 
 exports.get = endpoint => makeRequest(endpoint).then(getBody);
 
 function makeRequest(endpoint) {
-    return new Promise((resolve, reject) => {
-        const errorMessage = `Unable to fetch ${endpoint}`;
+    return promiseRetry(retry => {
+        return new Promise((resolve, reject) => {
+            const errorMessage = `Unable to fetch ${endpoint}`;
 
-        const req = https.get(hostname + endpoint, res => {
-            if (res.statusCode !== 200) {
-                res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
-                reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
-            } else {
-                resolve(res);
-            }
-        });
-        req.on('error', error => {
-            reject(new Error(errorMessage + ` ${error.message}`));
-        });
-        req.end();
+            const req = https.get(hostname + endpoint, res => {
+                if (res.statusCode !== 200) {
+                    res.resume(); // must consume data, see https://nodejs.org/api/http.html#http_class_http_clientrequest
+                    reject(new Error(errorMessage + ` Status code was ${res.statusCode}`));
+                } else {
+                    resolve(res);
+                }
+            });
+            req.on('error', error => {
+                reject(new Error(errorMessage + ` ${error.message}`));
+            });
+            req.end();
+        }).catch(retry);
+    }, {
+        retries: 2
     });
 }
 

--- a/tools/amp-validation/package.json
+++ b/tools/amp-validation/package.json
@@ -15,7 +15,8 @@
   },
   "homepage": "https://github.com/guardian/frontend#readme",
   "dependencies": {
-    "amphtml-validator": "^1.0.10"
+    "amphtml-validator": "^1.0.10",
+    "promise-retry": "^1.1.1"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
## What does this change?

Adds retry functionality to the fetching of pages in the amp validator.  We were getting a couple of errors from the teamcity job that appear to just be occasional network issues.  They always clear up by the next time the job is run, so I've added a couple of retries on failure just to see if we can avoid the noisy warning email.
## What is the value of this and can you measure success?

Less annoying emails for non-issues.
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
