### PR TITLE
Move new navigation from Enhanced to Standard

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -28,7 +28,6 @@ define([
     'common/modules/identity/autosignin',
     'common/modules/identity/cookierefresh',
     'common/modules/navigation/navigation',
-    'common/modules/navigation/newHeaderNavigation',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
     'common/modules/navigation/membership',
@@ -82,7 +81,6 @@ define([
     AutoSignin,
     CookieRefresh,
     navigation,
-    newHeaderNavigation,
     Profile,
     Search,
     membership,
@@ -129,7 +127,6 @@ define([
 
             initialiseNavigation: function () {
                 navigation.init();
-                newHeaderNavigation();
             },
 
             showTabs: function () {

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -119,7 +119,9 @@ define([
         //
         // Render new navigation
         //
-        newHeaderNavigation();
+        if (config.switches.abNewHeaderVariant) {
+            newHeaderNavigation();
+        }
 
         /*
          *  Interactive bootstraps.

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -25,7 +25,8 @@ define([
     'common/utils/url',
     'common/utils/cookies',
     'common/utils/robust',
-    'common/utils/user-timing'
+    'common/utils/user-timing',
+    'common/modules/navigation/newHeaderNavigation'
 ], function (
     raven,
     qwery,
@@ -40,7 +41,8 @@ define([
     url,
     cookies,
     robust,
-    userTiming
+    userTiming,
+    newHeaderNavigation
 ) {
     return function () {
         var guardian = window.guardian;
@@ -113,6 +115,11 @@ define([
                 raven.captureException(error);
             }
         });
+
+        //
+        // Render new navigation
+        //
+        newHeaderNavigation();
 
         /*
          *  Interactive bootstraps.

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -2,14 +2,12 @@ define([
     'common/utils/fastdom-promise',
     'common/utils/$',
     'common/modules/navigation/edition-picker',
-    'common/modules/navigation/editionalise-menu',
-    'common/utils/details-polyfill'
+    'common/modules/navigation/editionalise-menu'
 ], function (
     fastdomPromise,
     $,
     editionPicker,
-    editionaliseMenu,
-    detailsPolyfill
+    editionaliseMenu
 ) {
     var mainMenuId = '#main-menu';
     var html = $('html');
@@ -149,8 +147,6 @@ define([
     }
 
     function init() {
-        detailsPolyfill.init('.main-navigation__item__button');
-
         window.addEventListener('hashchange', handleHashChange);
         handleHashChange();
 


### PR DESCRIPTION
## What does this change?

This change moves the new navigation module from the Enhanced JS bundle into Standard for the duration of the new navigation's AB test.
## What is the value of this and can you measure success?

We have found that, if the user taps the menu icon when the page first loads, but before all DOM manipulation has completed, there is a ~500ms delay between the user interaction and the menu opening. Moving the navigation module from enhanced into standard reduces this delay to ~350ms. For slower connections, the improvement is more dramatic.

As part of the AB test, we will determine whether users tend to tap the menu icon while the DOM is still being loaded.

Finally, the Details polyfill is being loaded in the wrong place, and should be loaded inline. Since the new navigation is the only module that uses it, it is safe to remove the polyfill for now. In a future PR, I will add it to the correct place. 
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment
