### PR TITLE
Move AMP instagram cleaner out of generic embed one

### DIFF
--- a/tools/amp-validation/endpoints.js
+++ b/tools/amp-validation/endpoints.js
@@ -24,7 +24,7 @@ module.exports = (() => {
         // TODO: enable the commented out endpoints once issues with each one have been fixed
         '/world/2016/aug/25/spain-mariano-rajoy-third-general-election-christmas-day', // Guardian Video + Interactive
         '/us-news/live/2016/aug/25/donald-trump-news-hillary-clinton-campaign-live-coverage', // Image
-        //'/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper', // Instagram + Twitter
+        '/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper', // Instagram + Twitter
         '/sport/live/2016/aug/25/county-cricket-surrey-lancashire-live-blog', // Twitter
         //'/sport/blog/2016/aug/25/baseball-olympic-games-2020-tokyo-mlb-team-selection', // Vine
         //'/stage/2016/aug/24/they-drink-it-in-the-congo-review-adam-brace', // Vimeo


### PR DESCRIPTION
## What does this change?

The AMP Instagram cleaner was looking for `element-embed` which instagram embeds no longer have, this simply separates out that instagram logic from the generic embed cleaner.

@guardian/dotcom-platform 
