### PR TITLE
Add back in some mistakenly commented out passing amp tests

### DIFF
--- a/tools/amp-validation/endpoints.js
+++ b/tools/amp-validation/endpoints.js
@@ -36,8 +36,8 @@ module.exports = (() => {
         '/lifeandstyle/2016/jun/04/dont-talk-politics-sex-ex-10-ways-ruin-a-date',  // gif
         '/football/2016/jun/20/ngolo-kante-france-euro-2016-caen-jose-saez', // guardian audio
         '/science/2016/may/25/neanderthals-built-mysterious-cave-structures-175000-years-ago', // dailymotion
-        //'/cities/2015/feb/24/private-london-exposed-thames-path-riverside-walking-route', // google maps
-        //'/news/2016/may/09/how-mossack-fonseca-missed-warning-signs-of-70-million-boiler-room-scam-panama-papers', // scribd
+        '/cities/2015/feb/24/private-london-exposed-thames-path-riverside-walking-route', // google maps
+        '/news/2016/may/09/how-mossack-fonseca-missed-warning-signs-of-70-million-boiler-room-scam-panama-papers', // scribd
         '/sport/2015/nov/18/jonah-lomu-interview-2015-world-cup-audio', // soundcloud
         '/music/musicblog/2016/jul/21/yello-swiss-pop-pioneers-return-with-new-video-limbo', // vevo
         //'/tv-and-radio/2014/nov/07/shelter-refuses-to-take-donations-from-itv-star-dapper-laughs', // vine #2


### PR DESCRIPTION
## What does this change?

I was too eager in my commenting out - these tests were passing after all.
## What is the value of this and can you measure success?

More tests!
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
