### PR TITLE
Extend AMP live blog switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -384,7 +384,7 @@ trait FeatureSwitches {
     "If this switch is on, amp live blog articles have an itemtype of NewsArticle, and thus appear in Google's AMP carousel",
     owners = Seq(Owner.withGithub("SiAdcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 9),
+    sellByDate = new LocalDate(2016, 10, 26),
     exposeClientSide = false
   )
 
@@ -394,7 +394,7 @@ trait FeatureSwitches {
     "If this switch is on, amp-live-list will be included in live blogs",
     owners = Seq(Owner.withGithub("SiAdcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 2),
+    sellByDate = new LocalDate(2016, 10, 26),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extend all AMP live blog switches until October. We are still unsure what the impact of future changes to `<amp-live-list>` and Google's AMP blue links will be, so we'd still like to have granular control over AMP support for live blogs for the foreseeable future. 
