### PR TITLE
Outbrain test clashes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -121,7 +121,12 @@ define([
     function checkDependencies() {
         return Promise.all([checkEmailSignup(), checkClashingABTest()])
             .then(function(result) {
-                result.find('email');
+
+                function findEmail(value) {
+                    return value == 'email';
+                }
+
+                return result.find(findEmail);
             })
             .catch(function () {
                 return 'email';

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -121,10 +121,10 @@ define([
     function checkDependencies() {
         return Promise.all([checkEmailSignup(), checkClashingABTest()])
             .then(function(result) {
-                result.find("email");
+                result.find('email');
             })
-            .catch(function (err) {
-                return "email";
+            .catch(function () {
+                return 'email';
             });
     }
 
@@ -132,7 +132,7 @@ define([
         if (!clashingABTestPromise) {
             clashingABTestPromise = new Promise(function (resolve) {
                 if (clash.userIsInAClashingAbTest()) {
-                    resolve("email");
+                    resolve('email');
                 }
                 else {
                     resolve();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -41,7 +41,7 @@ define([
             widget: '.js-container--commercial',
             container: '.js-outbrain-container'
         },
-        email: {
+        nonCompliant: {
             widget: '.js-outbrain',
             container: '.js-outbrain-container'
         }
@@ -123,13 +123,13 @@ define([
             .then(function(result) {
 
                 function findEmail(value) {
-                    return value == 'email';
+                    return value == 'nonCompliant';
                 }
 
                 return result.find(findEmail);
             })
             .catch(function () {
-                return 'email';
+                return 'nonCompliant';
             });
     }
 
@@ -137,7 +137,7 @@ define([
         if (!clashingABTestPromise) {
             clashingABTestPromise = new Promise(function (resolve) {
                 if (clash.userIsInAClashingAbTest()) {
-                    resolve('email');
+                    resolve('nonCompliant');
                 }
                 else {
                     resolve();
@@ -155,7 +155,7 @@ define([
                     emailRunChecks.getEmailInserted()) {
                     // There is an email sign-up
                     // so load the merchandising component
-                    resolve('email');
+                    resolve('nonCompliant');
                 } else {
                     resolve();
                 }

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -11,7 +11,7 @@ define([
     'lodash/collections/contains',
     'common/modules/user-prefs',
     'common/modules/identity/api',
-    'common/modules/experiments/ab',
+    'common/modules/experiments/ab-test-clash',
     'Promise'
 ], function (
     $,
@@ -26,7 +26,7 @@ define([
     contains,
     userPrefs,
     Id,
-    ab,
+    clash,
     Promise
 ) {
     var emailInserted = false;
@@ -39,23 +39,6 @@ define([
         return page.keywordExists(['US elections 2016', 'Football']) ||
             config.page.section === 'film' ||
             config.page.seriesId === 'world/series/guardian-morning-briefing';
-    }
-
-    function userIsInAClashingAbTest() {
-        return _testABClash(ab.isInVariant);
-    }
-
-    function _testABClash(f) {
-        var contributionsArticle = {name: 'ContributionsArticle20160822', variants: ['about', 'pockets', 'like', 'love', 'truth'] };
-        var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive'] };
-
-        var clashingTests = [contributionsArticle, contributionsEmbed];
-
-        return some(clashingTests, function(test) {
-            return some(test.variants, function (variant) {
-                return f(test.name, variant);
-            });
-        });
     }
 
     function userHasRemoved(id, formType) {
@@ -168,7 +151,7 @@ define([
             !emailInserted &&
             !config.page.isFront &&
             config.switches.emailInArticle &&
-            !userIsInAClashingAbTest() &&
+            !clash.userIsInAClashingAbTest() &&
             storage.session.isAvailable() &&
             !userHasSeenThisSession() &&
             !obWidgetIsShown() &&
@@ -204,7 +187,6 @@ define([
         getEmailInserted: getEmailInserted,
         allEmailCanRun: allEmailCanRun,
         getUserEmailSubscriptions: getUserEmailSubscriptions,
-        listCanRun: listCanRun,
-        _testABClash: _testABClash // exposed for unit testing
+        listCanRun: listCanRun
     };
 });

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -1,0 +1,35 @@
+define([
+    'lodash/collections/some',
+    'common/modules/experiments/ab'
+], function (
+    some,
+    ab
+) {
+
+    function userIsInAClashingAbTest() {
+        return _testABClash(ab.isInVariant);
+    }
+
+    function _testABClash(f) {
+
+        var contributionsArticle = {
+            name: 'ContributionsArticle20160822',
+            variants: ['about', 'pockets', 'like', 'love', 'truth']
+        };
+
+        var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive']};
+
+        var clashingTests = [contributionsArticle, contributionsEmbed];
+
+        return some(clashingTests, function (test) {
+            return some(test.variants, function (variant) {
+                return f(test.name, variant);
+            });
+        });
+    }
+
+    return {
+        userIsInAClashingAbTest: userIsInAClashingAbTest,
+        _testABClash: _testABClash // exposed for unit testing
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -55,7 +55,7 @@ define([
 
         var completer = function (complete) {
             mediator.on('giraffe:insert', function () {
-                bean.on(qwery('#js-giraffe-contribute')[0], 'click', function (){
+                bean.on(qwery('#js-giraffe__contribute')[0], 'click', function (){
                     complete();
                 });
             });

--- a/static/test/javascripts/spec/common/experiments/ab-test-clash.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab-test-clash.spec.js
@@ -1,18 +1,18 @@
 define([
-    'common/modules/email/run-checks'
+    'common/modules/experiments/ab-test-clash'
 ], function (
-    RunChecks
+    Clash
 ) {
-        describe('RunChecks', function () {
+        describe('Clash', function () {
 
             it('test clash should be true with true function', function () {
                 var f = function () { return true; };
-                expect(RunChecks._testABClash(f)).toBeTruthy();
+                expect(Clash._testABClash(f)).toBeTruthy();
             });
 
             it('test clash should be false with false function', function () {
                 var f = function () { return false; };
-                expect(RunChecks._testABClash(f)).toBeFalsy();
+                expect(Clash._testABClash(f)).toBeFalsy();
             });
         });
 });


### PR DESCRIPTION
## What does this change?

Loads the correct outbrain component if the user is in a clashing ab test.  i.e. Contributions donatom.  
## What is the value of this and can you measure success?

None, this is a functional change required for compliance with the Outbrain T&C's.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
