### PR TITLE
Override User Agent style for lists

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -1,3 +1,8 @@
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
 .content__main {
     background: rgba(200,200,200,0.26);
 }


### PR DESCRIPTION
## What does this change?

User Agent styles for `<ul>` elements were sneaking into AMP live blogs. This change overrides those styles, removing the list style type and the default padding. 
## What is the value of this and can you measure success?

The change makes lists look consistent with those on non-AMP live blogs.
## Does this affect other platforms - Amp, Apps, etc?

Nope 
## Screenshots
### Before

![amp theguardian com-business-live-2016-aug-30-reports-to-offer-latest-clues-on-brex--business-live iphone 6](https://cloud.githubusercontent.com/assets/5931528/18098443/1e3f32d0-6eda-11e6-86cf-c2d8b6f31653.png)
### After

![localhost-3000-business-live-2016-aug-30-reports-to-offer-latest-clues-on-brex--business-live-amp iphone 6](https://cloud.githubusercontent.com/assets/5931528/18098428/141e0380-6eda-11e6-9f0e-12c61ed74669.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
