### PR TITLE
Update switch expiry dates.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 31),
+    sellByDate = new LocalDate(2016, 9, 6),
     exposeClientSide = true
   )
 
@@ -60,7 +60,7 @@ trait ABTestSwitches {
     "Test contributions embed with amount picker.",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 30),
+    sellByDate = new LocalDate(2016, 9, 6),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -31,7 +31,7 @@ define([
 
         this.id = 'ContributionsEmbed20160823';
         this.start = '2016-08-23';
-        this.expiry = '2016-08-30';
+        this.expiry = '2016-09-06';
         this.author = 'Jonathan Rankin';
         this.description = 'Test contributions embed with amount picker.';
         this.showForSensitive = false;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -22,7 +22,7 @@ define([
 
         this.id = 'ContributionsArticle20160822';
         this.start = '2016-08-22';
-        this.expiry = '2016-08-26';
+        this.expiry = '2016-09-06';
         this.author = 'Mark Butler';
         this.description = 'Add a button allowing readers to contribute money.';
         this.showForSensitive = false;


### PR DESCRIPTION
## What does this change?

Extends switch expiry to fix the build.  We will soon be re-launching these tests so I have not removed them in this PR.
## What is the value of this and can you measure success?

None, its a functional test.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
