### PR TITLE
Apply correct style to updated times in AMP live blog

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -50,6 +50,17 @@ ul {
     font-weight: bold;
 }
 
+.updated-time {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    color: #767676;
+    position: absolute;
+    right: 1.25rem;
+    bottom: 0.25rem;
+    margin: 0;
+}
+
 .block-time__absolute {
     display: none;
 }


### PR DESCRIPTION
## What does this change?

When a live blog post is updated after it is published, the time at which it was last updated is displayed at the bottom of the block. In the AMP live blog, the presentational style of the updated time is ugly and inconsistent with the non-AMP live blog. This change brings the styling of the AMP version into line with the non-AMP version
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
### Before

![amp theguardian com-business-live-2016-aug-30-reports-to-offer-latest-clues-on-brex--business-live-amp iphone 6](https://cloud.githubusercontent.com/assets/5931528/18126180/e3eeed76-6f71-11e6-91c2-4b69fba94446.png)
### After

![localhost-3000-business-live-2016-aug-30-reports-to-offer-latest-clues-on-brex--business-live-amp iphone 6 1](https://cloud.githubusercontent.com/assets/5931528/18126188/f0465866-6f71-11e6-9e47-2c0311c927cb.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
