### PR TITLE
Contributions User Testing 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,6 +54,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABContributionsUserTesting20160831 = Switch(
+    SwitchGroup.ABTests,
+    "ab-contributions-user-testing-20160831",
+    "User testing effectiveness of inline CTA for contributions.",
+    owners = Seq(Owner.withGithub("markjamesbutler")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 6),
+    exposeClientSide = true
+  )
+
   val ABContributionsEmbed20160823= Switch(
     SwitchGroup.ABTests,
     "ab-contributions-embed-20160823",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -20,7 +20,8 @@ define([
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',
     'common/modules/experiments/tests/contributions-embed',
     'common/modules/experiments/tests/adblocking-response',
-    'common/modules/experiments/tests/no-social-count'
+    'common/modules/experiments/tests/no-social-count',
+    'common/modules/experiments/tests/contributions-user-testing'
 ], function (
     reportError,
     config,
@@ -43,7 +44,8 @@ define([
     DontUpgradeMobileRichLinks,
     ContributionsEmbed,
     AdBlockingResponse,
-    NoSocialCount
+    NoSocialCount,
+    ContributionsUserTesting
 ) {
 
     var TESTS = [
@@ -60,7 +62,8 @@ define([
         new RecommendedForYou(),
         new DontUpgradeMobileRichLinks(),
         new ContributionsEmbed(),
-        new NoSocialCount()
+        new NoSocialCount(),
+        new ContributionsUserTesting()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-user-testing.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-user-testing.js
@@ -1,0 +1,76 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/giraffe-message.html',
+    'inlineSvg!svgs/icon/arrow-right'
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             giraffeMessage,
+             arrowRight
+) {
+    return function () {
+
+        this.id = 'ContributionsUserTesting20160831';
+        this.start = '2016-08-31';
+        this.expiry = '2016-09-06';
+        this.author = 'Mark Butler';
+        this.description = 'In article component to for lab testing event.';
+        this.showForSensitive = false;
+        this.audience = 0;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Lab testing of in-article component to understand its effectiveness.';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.canRun = function () {
+            var pageObj = window.guardian.config.page;
+            return (pageObj.pageId === 'science/2016/aug/29/russian-radio-telescope-strong-signal-hd164595-seti' && pageObj.edition === 'UK');
+        };
+
+        var writer = function (linkText, copy, cmpCode) {
+            var $newThing = $.create(template(giraffeMessage, {
+                linkText: linkText,
+                linkName: 'contribute',
+                linkHref: 'https://contribute.theguardian.com?INTCMP=' + cmpCode,
+                copy: copy,
+                svg: svg(arrowRight, ['button--giraffe__icon'])
+            }));
+
+            return fastdom.write(function () {
+                var a = $('.submeta');
+                $newThing.insertBefore(a);
+                mediator.emit('giraffe:insert');
+            });
+        };
+
+        var completer = function (complete) {
+            mediator.on('giraffe:insert', function () {
+                bean.on(qwery('#js-giraffe__contribute')[0], 'click', function (){
+                    complete();
+                });
+            });
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    writer('If you use it, if you like it, why not pay for it? It’s only fair. ', 'Give to the Guardian', 'co_uk_inarticle_like_usertesting');
+                },
+                success: function (complete) {
+                    completer(complete);
+                }
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

This change enables the in-line component on a single page thus allowing us to conduct user testing on this tomorrow.
## What is the value of this and can you measure success?

None, its simply to allow user testing of the inline component.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
