### PR TITLE
Update clashing tests with new ContributionsUserTesting test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -19,7 +19,9 @@ define([
 
         var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive']};
 
-        var clashingTests = [contributionsArticle, contributionsEmbed];
+        var contributionsUserTesting = {name: 'ContributionsUserTesting20160831', variants: ['control']}
+
+        var clashingTests = [contributionsArticle, contributionsEmbed, contributionsUserTesting];
 
         return some(clashingTests, function (test) {
             return some(test.variants, function (variant) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -19,7 +19,7 @@ define([
 
         var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control', 'interactive']};
 
-        var contributionsUserTesting = {name: 'ContributionsUserTesting20160831', variants: ['control']}
+        var contributionsUserTesting = {name: 'ContributionsUserTesting20160831', variants: ['control']};
 
         var clashingTests = [contributionsArticle, contributionsEmbed, contributionsUserTesting];
 


### PR DESCRIPTION
## What does this change?

Ensures that the email component doesn't run when the ContributionsUserTesting20160831 is running.
## What is the value of this and can you measure success?

None, its a functional change.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
