### PR TITLE
Extending participation tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -80,7 +80,7 @@ trait ABTestSwitches {
     "Test to see whether ordering comments by recommends on live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 31),
+    sellByDate = new LocalDate(2016, 9, 7), //Wednesday
     exposeClientSide = true
   )
 
@@ -90,7 +90,7 @@ trait ABTestSwitches {
     "Test to see whether ordering comments by recommends on content o[ther than live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 8, 31),
+    sellByDate = new LocalDate(2016, 9, 7), //Wednesday
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-live-blog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-live-blog.js
@@ -14,7 +14,7 @@ define([
 
         this.id = 'ParticipationDiscussionOrderingLiveBlog';
         this.start = '2016-08-05';
-        this.expiry = '2016-08-28';
+        this.expiry = '2016-09-07';
         this.author = 'Nathaniel Bennett';
         this.description = 'Changes the default ordering of comments on live-blogs so we can determine whether sorting by recommended causes more users to view comments';
         this.audience = 0.1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-non-live.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-ordering-non-live.js
@@ -14,7 +14,7 @@ define([
 
         this.id = 'ParticipationDiscussionOrderingNonLive';
         this.start = '2016-08-05';
-        this.expiry = '2016-08-28';
+        this.expiry = '2016-09-07';
         this.author = 'Nathaniel Bennett';
         this.description = 'Changes the default ordering of comments on non live-blog content so we can determine whether sorting by recommended causes more users to view comments';
         this.audience = 0.1;


### PR DESCRIPTION
## What does this change?

Extends tests
## Request for comment

@gtrufitt @NathanielBennett 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
