### PR TITLE
Set a width on the toast container so we don't cover pagination buttons

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -620,6 +620,9 @@ $timeline-width: 15px;
 /* prevent toast from dropping behind first post when not fixed */
 .toast__container:not(.is-sticky) {
     position: absolute;
+    // Make sure we're not covering the pagination buttons
+    width: 50%;
+    left: 25%;
 }
 
 .toast__container--open {


### PR DESCRIPTION
## What does this change?

The pagination buttons are being covered by the update toast, preventing them from being clicked on > the first page of the liveblog.
## What is the value of this and can you measure success?

Can navigate through the liveblog.

@guardian/dotcom-platform 
