### PR TITLE
Fix concat on undefined bug for coverage task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,8 +162,9 @@ module.exports = function (grunt) {
     grunt.registerTask('test', ['test:unit']);
     grunt.registerTask('coverage', function () {
         var target = this.args.length ? ':' + this.args.join(':') : '';
+        var reporters = grunt.config.get('karma.options.reporters');
         grunt.config.set('karma.options.reporters',
-            grunt.config.get('karma.options.reporters').concat('coverage')
+            typeof(reporters) == 'undefined' ? ['coverage'] : reporters.concat('coverage')
         );
         grunt.config.set('karma.options.preprocessors',
             grunt.config.get('coverage.preprocessors')


### PR DESCRIPTION
## What does this change?

I kept getting concat on undefined when running grunt:coverage, as the grunt config for reporters was never set. This just introduces the check
## What is the value of this and can you measure success?

Can run coverage
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
