### PR TITLE
Move the comments state to discussion frontend

### DIFF
--- a/common/app/assets/DiscussionAssets.scala
+++ b/common/app/assets/DiscussionAssets.scala
@@ -28,11 +28,12 @@ class DiscussionExternalAssetsLifecycle (config: GuardianConfiguration, wsClient
   def refresh(): Future[Map[String, String]] = {
     config.discussion.frontendAssetsMap match {
       case Some(url) if Switches.DiscussionFetchExternalAssets.isSwitchedOn =>
-        fetchAssetsMap(url, wsClient).map(
-          parseResponse(_, url) match {
-            case Some(parsed) => DiscussionAssetsMap.alter(parsed, URI.create(url))
+        val versionedUrl = url.replace("{VERSION}", config.discussion.frontendAssetsVersion)
+        fetchAssetsMap(versionedUrl, wsClient).map(
+          parseResponse(_, versionedUrl) match {
+            case Some(parsed) => DiscussionAssetsMap.alter(parsed, URI.create(versionedUrl))
             case None =>
-              val errMsg = "Impossible to parse discussion assets map"
+              val errMsg = s"Impossible to parse discussion assets map from $versionedUrl"
               log.warn(errMsg)
               Future.failed(new RuntimeException(errMsg))
           }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -59,7 +59,7 @@ devOverrides {
     }
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 1
+    val s3ConfigVersion = 2
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource(s"/etc/gu/frontend.conf")
@@ -349,6 +349,7 @@ class GuardianConfiguration extends Logging {
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
+    lazy val frontendAssetsVersion = "v1.1.0"
   }
 
   object witness {

--- a/common/app/conf/switches/DiscussionSwitches.scala
+++ b/common/app/conf/switches/DiscussionSwitches.scala
@@ -28,7 +28,7 @@ trait DiscussionSwitches {
     "discussion-fetch-external-assets",
     "if this is switched on, discussion external assets map is fetched regularly",
     owners = Seq(Owner.withGithub("piuccio")),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false
   )

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -3,7 +3,7 @@
 
 @sectionHeading = {
 
-    <div class="discussion__heading">
+    <div class="discussion__heading js-discussion-external-frontend">
 
         <div class="container__meta">
             <h2 class="container__meta__title">comments <span class="discussion__comment-count js-discussion-comment-count"></span></h2>

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -379,8 +379,11 @@ Loader.prototype.renderCommentCount = function () {
     if (discussionFrontend.canRun(ab, window.curlConfig)) {
         return discussionFrontend.load(ab, this, {
             apiHost: config.page.discussionApiUrl,
+            closed: this.getDiscussionClosed(),
             discussionId: this.getDiscussionId(),
-            element: document.querySelector('.js-discussion-comment-count').parentNode
+            element: document.getElementsByClassName('js-discussion-external-frontend')[0],
+            userFromCookie: !!Id.getUserFromCookie(),
+            profileUrl: config.page.idUrl
         });
     } else {
         return this.renderBonzoCommentCount();

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -49,18 +49,16 @@ define([
     };
 
     /**
-     * The array returned from the cookie is in the format;
+     * The object returned from the cookie has the keys:
      *
-     * [
-     *    id,
-     *    email,
-     *    displayname,
-     *    userGroupBitmask,
-     *    expiryDate,
-     *    persist,
-     *    accountCreatedDate,
+     * {
+     *    id
+     *    primaryEmailAddress
+     *    displayName
+     *    accountCreatedDate
      *    emailVerified
-     * ];
+     *    rawResponse
+     * };
      *
      * @return {?Object} the user information
      */


### PR DESCRIPTION
## What does this change?

![screen shot 2016-08-31 at 18 13 19](https://cloud.githubusercontent.com/assets/680284/18167363/16933828-7048-11e6-8d57-189720874a3c.png)

The status text is now part of discussion frontend.
## What is the value of this and can you measure success?

Second part of standalone comments (part 1: #13992)
Everything is still behind a 0 audience test, but once merge I'll start circulating the link to opt in
## Does this affect other platforms - Amp, Apps, etc?

No
