### PR TITLE
Add CAPI container fronts to glossary

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -62,11 +62,10 @@ devOverrides {
     val s3ConfigVersion = 1
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
-    lazy val devinfra = FileConfigurationSource(s"/etc/gu/frontend.properties")
     lazy val runtimeOnly = FileConfigurationSource(s"/etc/gu/frontend.conf")
     lazy val identity = new AwsApplication(installVars.stack, installVars.app, installVars.guStage, installVars.awsRegion)
     lazy val commonS3Config = S3ConfigurationSource(identity, installVars.configBucket, Configuration.aws.mandatoryCredentials, Some(s3ConfigVersion))
-    lazy val config = new CM(List(userPrivate, runtimeOnly, devinfra, commonS3Config), PlayDefaultLogger).load.resolve
+    lazy val config = new CM(List(userPrivate, runtimeOnly, commonS3Config), PlayDefaultLogger).load.resolve
 
     // test mode is self contained and won't need to use anything secret
     lazy val test = ClassPathConfigurationSource(s"env/DEVINFRA.properties")

--- a/docs/01-start-here/02-guardian-visual-glossary.md
+++ b/docs/01-start-here/02-guardian-visual-glossary.md
@@ -78,6 +78,8 @@
 
 [All combinations](http://preview.gutools.co.uk/all-dynamic-fast#)
 
+[List of fronts containing containers built from CAPI queries and no curation](https://docs.google.com/spreadsheets/d/1x5JcqR33tnFCjd83mzBxmQONH5xeDkmeQNEjT_MUz0I/edit#gid=374412710)
+
 ## Rich Links
 
 [Lots of examples](http://preview.gutools.co.uk/info/developer-blog/2014/dec/12/rich-link-testing)


### PR DESCRIPTION
## What does this change?

Adds https://docs.google.com/spreadsheets/d/1x5JcqR33tnFCjd83mzBxmQONH5xeDkmeQNEjT_MUz0I/edit#gid=374412710 to the glossary

@guardian/dotcom-platform 
