### PR TITLE
Media tone icon bug in *drumroll* IE

### DIFF
--- a/static/src/stylesheets/module/content/_media.head.scss
+++ b/static/src/stylesheets/module/content/_media.head.scss
@@ -29,6 +29,6 @@
 
     svg {
         width: .86em;
-        height: 100%;
+        height: .60em;
     }
 }

--- a/static/src/stylesheets/module/content/_media.head.scss
+++ b/static/src/stylesheets/module/content/_media.head.scss
@@ -29,6 +29,6 @@
 
     svg {
         width: .86em;
-        height: .60em;
+        height: .6em;
     }
 }


### PR DESCRIPTION
@blongden73 It's your fault for spotting this bug so you have to plus one it.

This is how cool it looked:
![screen shot 2016-09-02 at 16 22 42](https://cloud.githubusercontent.com/assets/14570016/18208973/9fffe886-7129-11e6-87a6-58593060b706.png)
