### PR TITLE
Extend link preconnect switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -204,7 +204,7 @@ trait PerformanceSwitches {
     "If this switch is on then link preconnect hints will be on the page",
     owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 5),
+    sellByDate = new LocalDate(2016, 10, 10),
     exposeClientSide = false
   )
 }


### PR DESCRIPTION
Extending this switch, we still haven't confirmed what the impact is of using `link-preconnect`
