### PR TITLE
Fix failing line of setup.sh script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -145,7 +145,6 @@ main() {
   check_encryption
   create_aws_config
   install_homebrew
-  install_awscli
   install_jdk
   install_node
   install_gcc


### PR DESCRIPTION
## What does this change?

Fixes the setup.sh to allow it to run, by removing the accidentally left-in awscli install call (the function for which was removed in a previous commit)
## What is the value of this and can you measure success?

success measured by the script not failing to run
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

The awscli install function was removed in a previous commit, but
the call was left in - and causes the script to fail. This change
removes the call
