### PR TITLE
Add world cup qualifiers 2018

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -115,7 +115,8 @@ object CompetitionsProvider {
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
-    Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2))
+    Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2)),
+    Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true)
   )
 }
 

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -116,7 +116,7 @@ object CompetitionsProvider {
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
     Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2)),
-    Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true)
+    Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true, tableDividers = List(2))
   )
 }
 


### PR DESCRIPTION
## What does this change?

Adds the world cup qualifier matches to the football section:

![image](https://cloud.githubusercontent.com/assets/638051/18246243/607f487e-7362-11e6-8317-2703db0a6580.png)

@guardian/dotcom-platform 
