### PR TITLE
Better control of overflow for fabrics

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
@@ -95,6 +95,10 @@ define([
                 addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
             }
             $fabricExpandableVideo.appendTo(this.$adSlot);
+            this.$adSlot.addClass('ad-slot--fabric');
+            if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {
+                this.$adSlot.parent().addClass('top-banner-ad-container--fabric');
+            }
             return true;
         }, this);
     };

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -231,6 +231,11 @@ define([
             }
 
             $fabricExpandingV1.appendTo(this.$adSlot);
+            this.$adSlot.addClass('ad-slot--fabric');
+
+            if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {
+                this.$adSlot.parent().addClass('top-banner-ad-container--fabric');
+            }
             return true;
         }, this);
     };

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
@@ -39,8 +39,6 @@ define([
     };
 
     FabricV1.prototype.create = function () {
-        this.$adSlot.addClass('ad-slot--fabric-v1 content__mobile-full-width');
-
         if (!fabricV1Tpl) {
             fabricV1Tpl = template(fabricV1Html);
             iframeVideoTpl = template(iframeVideoStr);
@@ -94,6 +92,11 @@ define([
 
             if (this.scrollType === 'fixed' && hasBackgroundFixedSupport) {
                 bonzo(this.scrollingBg).css('background-attachment', 'fixed');
+            }
+
+            this.$adSlot.addClass('ad-slot--fabric-v1 ad-slot--fabric content__mobile-full-width');
+            if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {
+                this.$adSlot.parent().addClass('top-banner-ad-container--fabric');
             }
 
             return true;

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
@@ -41,6 +41,10 @@ define([
                     addTrackingPixel(bonzo(adSlot), params.Trackingpixel + params.cacheBuster);
                 }
                 adSlot.insertAdjacentHTML('beforeend', fabricVideoTpl({ data: params }));
+                adSlot.classList.add('ad-slot--fabric');
+                if( adSlot.parentNode.classList.contains('top-banner-ad-container') ) {
+                    adSlot.parentNode.classList.add('top-banner-ad-container--fabric');
+                }
             }).then(function () {
                 layer2 = qwery('.creative__layer2', adSlot);
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -66,6 +66,10 @@
     background-color: $neutral-8;
 }
 
+.top-banner-ad-container--fabric {
+    overflow: hidden;
+}
+
 .sticky-top-banner-ad {
     z-index: $zindex-popover;
     width: 100%;
@@ -656,6 +660,10 @@
 
 .ad-slot--revealer {
     min-width: 300px;
+}
+
+.ad-slot--fabric {
+    overflow: hidden;
 }
 
 .ad-slot--fabric-v1,

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -151,7 +151,7 @@
         @include fs-textSans(1);
         position: absolute;
         z-index: 11;
-        bottom: -10px;
+        bottom: 0;
         left: 50%;
         border: 1px solid #ffffff;
         border-width: 1px 1px 0;


### PR DESCRIPTION
This is ugly but we'll get rid of this when we move to native ads. Currently the Fabric templates overflow their container and this creates [a jarring and ugly flicker effect](https://www.theguardian.com/uk?adtest=demo_responsive).

Now:
![fabric-jump](https://cloud.githubusercontent.com/assets/629976/18246438/a4abd250-7363-11e6-854a-7c0fbdeb3946.gif)

And:
![fabric-jump-2](https://cloud.githubusercontent.com/assets/629976/18246422/8266f01c-7363-11e6-8950-5902dc33bd67.gif)
