### PR TITLE
Add campaign code for the smart app banner

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -91,7 +91,7 @@
 <meta name="msapplication-TileImage" content="@Static("images/favicons/windows_tile_144_b.png")" />
 
 @if(SmartAppBanner.isSwitchedOn) {
-    <meta name="apple-itunes-app" content="app-id=@Configuration.ios.ukAppId, app-argument=@page.metadata.webUrl">
+    <meta name="apple-itunes-app" content="app-id=@Configuration.ios.ukAppId, app-argument=@page.metadata.webUrl, affiliate-data=ct=newsmartappbanner&pt=304191">
 }
 
 @*


### PR DESCRIPTION
## What does this change?

Adds a campaign code to the Apple's smart app banner.
## What is the value of this and can you measure success?

We will see in iTunes analytics how many people install our app by clicking on the smart app banner.
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
