### PR TITLE
Add the world cup qualifiers to the tables

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -41,6 +41,7 @@ class LeagueTableController(val competitionsService: CompetitionsService) extend
         "Community Shield",
         "Scottish Cup",
         "Scottish League Cup",
+        "World Cup 2018 Qualifiers",
         "International friendlies"
     )
 


### PR DESCRIPTION
## What does this change?

Adds the world cup qualifiers table to football.

![image](https://cloud.githubusercontent.com/assets/638051/18249307/61de0f9e-7375-11e6-8c28-e0e21f5f4832.png)

@guardian/dotcom-platform 
