### PR TITLE
Fix sign in link when register with phone number is off

### DIFF
--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -9,8 +9,8 @@
             <h2 class="container__meta__title">comments <span class="discussion__comment-count js-discussion-comment-count"></span></h2>
 
             <p class="container__meta__item discussion__meta discussion__meta--open-signed-out">
-                <a class="u-underline" href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN@if(RegisterWithPhoneNumber.isSwitchedOn){&clientId=comments"}>Sign in</a>
-                or <a class="u-underline" href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG@if(RegisterWithPhoneNumber.isSwitchedOn){&clientId=comments"}">create your Guardian account</a> to join the discussion.
+                <a class="u-underline" href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN@if(RegisterWithPhoneNumber.isSwitchedOn){&clientId=comments}">Sign in</a>
+                or <a class="u-underline" href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG@if(RegisterWithPhoneNumber.isSwitchedOn){&clientId=comments}">create your Guardian account</a> to join the discussion.
             </p>
 
             <p class="container__meta__item discussion__meta discussion__meta--closed">This discussion is closed for comments.</p>


### PR DESCRIPTION
## What does this change?

Sign in currently looks like this

![screen shot 2016-09-05 at 15 54 34](https://cloud.githubusercontent.com/assets/680284/18251497/5607497c-7381-11e6-9144-9ddae8a41dda.png)
## What is the value of this and can you measure success?

Links  are back to normal
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@NathanielBennett hopefully I didn't break the case `RegisterWithPhoneNumber.isSwitchedOn: true` 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
