### PR TITLE
Fix clashing tests bug for Contributions Embed test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -17,7 +17,7 @@ define([
             variants: ['about', 'pockets', 'like', 'love', 'truth']
         };
 
-        var contributionsEmbed = {name: 'ContributionsEmbed20160823', variants: ['control']};
+        var contributionsEmbed = {name: 'ContributionsEmbed20160905', variants: ['control']};
 
         var contributionsUserTesting = {name: 'ContributionsUserTesting20160831', variants: ['control']};
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -54,7 +54,6 @@ define([
             var $outbrain = $('.js-outbrain-container');
             return $outbrain && $outbrain.length > 0;
         }
-
         
         function getSpacefinderRules() {
             return {


### PR DESCRIPTION
## What does this change?

Fixes a bug where the name of the Contributions Embed test was not updated in the clashing tests when the test was launched.
## What is the value of this and can you measure success?

It means that we will be contractually compliant with Outbrain.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
