### PR TITLE
Point Football API at a CDN

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -207,4 +207,14 @@ trait PerformanceSwitches {
     sellByDate = new LocalDate(2016, 10, 10),
     exposeClientSide = false
   )
+
+  val CachedFootballStats = Switch(
+    SwitchGroup.Performance,
+    "cached-football-stats",
+    "If this switch is on then calls to the football API will be via a cdn",
+    owners = Seq(Owner.withGithub("gklopper")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 10, 10),
+    exposeClientSide = false
+  )
 }

--- a/sport/app/conf/SportConfiguration.scala
+++ b/sport/app/conf/SportConfiguration.scala
@@ -8,7 +8,7 @@ object SportConfiguration {
   import GuardianConfiguration._
 
   object pa {
-    lazy val footballHost = PaClientConfig.baseUrl
+    lazy val footballHost = "http://football-api.gu-web.net/v1.5"
     lazy val footballKey = configuration.getMandatoryStringProperty("pa.api.key")
     lazy val cricketKey = configuration.getStringProperty("pa.cricket.api.key")
   }

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -2,9 +2,10 @@ package conf
 
 import app.LifecycleComponent
 import common._
+import conf.switches.Switches
 import feed.CompetitionsService
 import model.{LiveBlogAgent, TeamMap}
-import pa.{Http, PaClient, PaClientErrorsException}
+import pa.{PaClientConfig, Http, PaClient, PaClientErrorsException}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
 
@@ -75,7 +76,19 @@ class FootballLifecycle(
 
 class FootballClient(wsClient: WSClient) extends PaClient with Http with Logging with ExecutionContexts {
 
+
+    // TODO - once we have proved this works with the switch, we can simply remove the switch and
+    // uncomment this line to make it permanent
+    //override lazy val base: String = "http://football-api.gu-web.net/v1.5"
+
+    private val cachedBase: String = "http://football-api.gu-web.net/v1.5"
+
     override def GET(urlString: String): Future[pa.Response] = {
+
+        val url = if (Switches.CachedFootballStats.isSwitchedOn)
+          urlString.replace(PaClientConfig.baseUrl, cachedBase)
+        else
+          urlString
 
         val promiseOfResponse = wsClient.url(urlString).withRequestTimeout(2000).get()
 


### PR DESCRIPTION
## What does this change?

Has a switch which proxies the 3rd party football api through a CDN.
## What is the value of this and can you measure success?

We are hitting the 3rd party too often and they are complaining. Our architecture means we need to make a lot of calls as we do not maintain our own database.

Success is a happy 3rd party.
## Does this affect other platforms - Amp, Apps, etc?

No, but once it is proved working it could be used by apps too.
