### PR TITLE
strip domain from canonical url for video embeds

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -50,7 +50,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
           .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
 
         if (! canonicalUrl.isEmpty) {
-          element.attr("data-canonical-url", canonicalUrl)
+          element.attr("data-canonical-url", new URL(canonicalUrl).getPath.stripPrefix("/"))
         }
 
         val mediaId = element.attr("data-media-id")


### PR DESCRIPTION
## What does this change?

The canonical url path is used to make a request to api.nextgen for an info.json blob containing up-to-date video information. Currently, some requests are 404ing as the request to api.nextgen is invalid, e.g. https://www.theguardian.com/football/2016/sep/05/paul-scholes-non-league-football-premier-league and https://api.nextgen.guardianapps.co.uk/https://www.theguardian.com/sport/video/2016/sep/04/spennymoor-town-goalkeeper-scores-80-yard-free-kick-in-fa-cup-qualifier-video/info.json.

This fixes this issue.

Related to https://github.com/guardian/frontend/pull/14058.
## What is the value of this and can you measure success?

Fewer 404s, better tracking.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

n/a
## Request for comment

@gidsg @cb372 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
