### PR TITLE
made contributions epic element

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,6 +64,18 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABContributionsEpic20160906 = Switch(
+    SwitchGroup.ABTests,
+    "ab-contributions-epic-20160906",
+    "Test whether contributions embed performs better inline and in-article than at the bottom of the article.",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 12),
+    exposeClientSide = true
+  )
+
+
+
   val ABParticipationDiscussionOrderingLiveBlogs = Switch(
     SwitchGroup.ABTests,
     "ab-participation-discussion-ordering-live-blog",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,7 +67,7 @@ trait ABTestSwitches {
   val ABContributionsEpic20160906 = Switch(
     SwitchGroup.ABTests,
     "ab-contributions-epic-20160906",
-    "Test whether contributions embed performs better inline and in-article than at the bottom of the article.",
+    "Test whether contributions embed performs better than our previous in-article component tests.",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 9, 12),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -19,7 +19,9 @@ define([
 
         var contributionsEmbed = {name: 'ContributionsEmbed20160905', variants: ['control']};
 
-        var clashingTests = [contributionsArticle, contributionsEmbed];
+        var contributionsEpic = {name: 'ContributionsEpic20160906', variants: ['control']};
+
+        var clashingTests = [contributionsArticle, contributionsEmbed, contributionsEpic];
 
         return some(clashingTests, function (test) {
             return some(test.variants, function (variant) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -67,8 +67,7 @@ define([
         new DontUpgradeMobileRichLinks(),
         new ContributionsEmbed(),
         new ContributionsEpic(),
-        new NoSocialCount(),
-        new ContributionsUserTesting()
+        new AdBlockingResponse(),
         new WeekendReadingEmail(),
         new WeekendReadingPromo(),
         new NoSocialCount()

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -19,6 +19,7 @@ define([
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/platform-dont-upgrade-mobile-rich-links',
     'common/modules/experiments/tests/contributions-embed',
+    'common/modules/experiments/tests/contributions-epic',
     'common/modules/experiments/tests/adblocking-response',
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/weekend-reading-promo',
@@ -44,6 +45,7 @@ define([
     RecommendedForYou,
     DontUpgradeMobileRichLinks,
     ContributionsEmbed,
+    ContributionsEpic,
     AdBlockingResponse,
     WeekendReadingEmail,
     WeekendReadingPromo,
@@ -64,6 +66,9 @@ define([
         new RecommendedForYou(),
         new DontUpgradeMobileRichLinks(),
         new ContributionsEmbed(),
+        new ContributionsEpic(),
+        new NoSocialCount(),
+        new ContributionsUserTesting()
         new WeekendReadingEmail(),
         new WeekendReadingPromo(),
         new NoSocialCount()

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -8,7 +8,6 @@ define([
     'common/utils/mediator',
     'text!common/views/contributions-embed.html',
     'common/utils/robust',
-    'text!common/views/giraffe-message.html',
     'inlineSvg!svgs/icon/arrow-right',
     'common/utils/config',
     'common/modules/experiments/embed',
@@ -23,7 +22,6 @@ define([
              mediator,
              contributionsEmbed,
              robust,
-             giraffeMessage,
              arrowRight,
              config,
              embed,
@@ -54,6 +52,7 @@ define([
             var $outbrain = $('.js-outbrain-container');
             return $outbrain && $outbrain.length > 0;
         }
+
         
         function getSpacefinderRules() {
             return {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
@@ -32,14 +32,14 @@ define([
         this.start = '2016-09-06';
         this.expiry = '2016-09-12';
         this.author = 'Jonathan Rankin';
-        this.description = 'Test whether the long ask performs better than _____.';
+        this.description = 'Test whether contributions embed performs better than our previous in-article component tests.';
         this.showForSensitive = false;
-        this.audience = 0.10;
+        this.audience = 0.05;
         this.audienceOffset = 0.33;
         this.successMeasure = 'Impressions to number of contributions';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'The embed performs 20% better inline and in-article than it does at the bottom of the article';
+        this.idealOutcome = 'The embed performs at least as good as our previous in-article component tests';
         this.canRun = function () {
             var pageObj = config.page;
             return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || obWidgetIsShown() || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
@@ -1,0 +1,88 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/modules/experiments/embed'
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpic,
+             robust,
+             arrowRight,
+             config,
+             embed
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsEpic20160906';
+        this.start = '2016-09-06';
+        this.expiry = '2016-09-12';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Test whether the long ask performs better than _____.';
+        this.showForSensitive = false;
+        this.audience = 0.10;
+        this.audienceOffset = 0.33;
+        this.successMeasure = 'Impressions to number of contributions';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'The embed performs 20% better inline and in-article than it does at the bottom of the article';
+        this.canRun = function () {
+            var pageObj = config.page;
+            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || obWidgetIsShown() || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+        };
+
+        function obWidgetIsShown() {
+            var $outbrain = $('.js-outbrain-container');
+            return $outbrain && $outbrain.length > 0;
+        }
+
+        var bottomWriter = function (component) {
+
+            return fastdom.write(function () {
+                var a = $('.submeta');
+                component.insertBefore(a);
+                embed.init();
+                mediator.emit('contributions-embed:insert', component);
+            });
+
+        };
+
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', function () {
+                bean.on(qwery('.js-submit-input')[0], 'click', function (){
+                    complete();
+                });
+            });
+        };
+
+
+        this.variants = [
+
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        intCMP : 'co_uk_epic'
+                    }));
+                    bottomWriter(component);
+                },
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/views/contributions-epic.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic.html
@@ -1,13 +1,15 @@
 <div class="contributions__epic">
     <div>
-        <h3 class="contributions__title">
-            Since you're here...</h3>
-        <p class="contributions__paragraph contributions__paragraph-epic">... we have a small favour to ask. More people are reading the Guardian than ever. But far fewer are paying for it. And advertising revenues are falling
+        <h2 class="contributions__title contributions__title--epic">
+            Since you're here ...</h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">... we have a small favour to ask. More people are reading the Guardian than ever. But far fewer are paying for it. And advertising revenues are falling
         fast. So you can see why we need to ask for your help. The Guardian's independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we
-        believe our perspective matters - because it might well be your perspective, too. If everyone who reads out reporting , who likes it, helps pay for it, our future would be much more secure. You can
+        believe our perspective matters - because it might well be your perspective, too. </p>
+
+        <p class="contributions__paragraph contributions__paragraph--epic">If everyone who reads our reporting, who likes it, helps pay for it, our future would be much more secure. You can
         give money to the Guardian in less than a minute.</p>
     </div>
-    <a class="contributions__option-button contributions__contribute contributions__contribute-epic" href="https://contribute.theguardian.com?<%=intCMP%>" target="_blank">
+    <a class="contributions__option-button contributions__contribute contributions__contribute--epic" href="https://contribute.theguardian.com?<%=intCMP%>" target="_blank">
         Contribute
     </a>
 </div>

--- a/static/src/javascripts/projects/common/views/contributions-epic.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic.html
@@ -1,0 +1,14 @@
+<div class="contributions__epic">
+    <div>
+        <h3 class="contributions__title">
+            Since you're here...</h3>
+        <p class="contributions__paragraph contributions__paragraph-epic">... we have a small favour to ask. More people are reading the Guardian than ever. But far fewer are paying for it. And advertising revenues are falling
+        fast. So you can see why we need to ask for your help. The Guardian's independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we
+        believe our perspective matters - because it might well be your perspective, too. If everyone who reads out reporting , who likes it, helps pay for it, our future would be much more secure. You can
+        give money to the Guardian in less than a minute.</p>
+    </div>
+    <a class="contributions__option-button contributions__contribute contributions__contribute-epic" href="https://contribute.theguardian.com?<%=intCMP%>" target="_blank">
+        Contribute
+    </a>
+</div>
+

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -6,6 +6,12 @@
     padding: 0 $gs-gutter / 4 $gs-baseline $gs-gutter / 4;
 }
 
+.contributions__epic {
+    border-top: 1px solid $multimedia-main-2;
+    background-color: #efefec;
+    padding: 0 $gs-gutter / 4 $gs-baseline $gs-gutter / 4;
+}
+
 .contributions__title {
     @include fs-header(2);
     margin: 0;
@@ -16,6 +22,10 @@
     line-height: 20px;
     font-family: $f-serif-headline;
     margin-bottom: $gs-baseline;
+}
+
+.contributions__paragraph-epic {
+    margin-top: $gs-baseline;
 }
 
 .contributions__option-button {
@@ -90,10 +100,20 @@
         background-repeat: no-repeat;
         width: 30px;
         height: 20px;
-        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="white" stroke="white" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="black" stroke="black" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
         background-size: 100%;
         float: right;
     }
+}
+
+.contributions__contribute-epic {
+    background-color: $multimedia-main-2;
+    color: $neutral-1;
+    width: 100px;
+    &:hover {
+        background-color: darken($multimedia-main-2, 5%);
+    }
+
 }
 
 @include mq($from: phablet) {

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -1,20 +1,24 @@
 @import 'svg';
 
 .contributions__embed  {
-    border-top: 1px solid #4bc6df;
-    background-color: #efefec;
+    border-top: 1px solid $news-main-2;
+    background-color: $comment-support-2;
     padding: 0 $gs-gutter / 4 $gs-baseline $gs-gutter / 4;
 }
 
 .contributions__epic {
     border-top: 1px solid $multimedia-main-2;
-    background-color: #efefec;
+    background-color: $comment-support-2;
     padding: 0 $gs-gutter / 4 $gs-baseline $gs-gutter / 4;
 }
 
 .contributions__title {
     @include fs-header(2);
     margin: 0;
+}
+
+.contributions__title--epic {
+    margin-bottom: $gs-baseline;
 }
 
 .contributions__paragraph  {
@@ -24,8 +28,8 @@
     margin-bottom: $gs-baseline;
 }
 
-.contributions__paragraph-epic {
-    margin-top: $gs-baseline;
+.contributions__paragraph--epic {
+    @include fs-bodyCopy(2);
 }
 
 .contributions__option-button {
@@ -91,6 +95,7 @@
     margin-left: 0;
     &:hover {
         background-color: darken($news-main-1, 5%);
+        text-decoration: none;
     }
 
     &:after {
@@ -106,12 +111,14 @@
     }
 }
 
-.contributions__contribute-epic {
+.contributions__contribute--epic {
+    margin-top: 0;
     background-color: $multimedia-main-2;
     color: $neutral-1;
     width: 100px;
     &:hover {
         background-color: darken($multimedia-main-2, 5%);
+        color: $neutral-1;
     }
 
 }


### PR DESCRIPTION
## What does this change?

Creates the Contributions Epic test, which is testing a longer, editorial written message for the contributions ask. 
## What is the value of this and can you measure success?

Test whether contributions embed performs better our previous in-article component tests.
## Does this affect other platforms - Amp, Apps, etc?

No 
## Screenshots

<img width="205" alt="screenshot at sep 06 12-04-24" src="https://cloud.githubusercontent.com/assets/2844554/18273386/dc9f663c-7434-11e6-95d9-04a6d0b3bd8d.png">
## Request for comment

@gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
