### PR TITLE
Audience for comments in react

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -16,7 +16,7 @@ trait ABTestSwitches {
 
   val ABDiscussionExternalFrontend = Switch(
     SwitchGroup.ABTests,
-    "ab-discussion-external-frontend",
+    "ab-discussion-external-frontend-count",
     "Standalone frontend discussion",
     owners = Seq(Owner.withGithub("piuccio")),
     safeState = On,
@@ -53,7 +53,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 9, 6),
     exposeClientSide = true
   )
-  
+
   val ABContributionsEmbed20160905= Switch(
     SwitchGroup.ABTests,
     "ab-contributions-embed-20160905",

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -370,6 +370,7 @@ Loader.prototype.renderBonzoCommentCount = function() {
             } else {
                 this.setState('empty');
             }
+            mediator.emit('comments-count-loaded');
         }
     }.bind(this))
     .catch(this.logError.bind(this, 'CommentCount'));

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -384,7 +384,8 @@ Loader.prototype.renderCommentCount = function () {
             discussionId: this.getDiscussionId(),
             element: document.getElementsByClassName('js-discussion-external-frontend')[0],
             userFromCookie: !!Id.getUserFromCookie(),
-            profileUrl: config.page.idUrl
+            profileUrl: config.page.idUrl,
+            profileClientId: config.switches.registerWithPhone ? 'comments' : ''
         });
     } else {
         return this.renderBonzoCommentCount();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
@@ -1,21 +1,25 @@
-define([], function () {
+define([
+    'common/utils/mediator'
+], function (
+    mediator
+) {
     return function () {
 
-        this.id = 'DiscussionExternalFrontend';
-        this.start = '2016-08-14';
+        this.id = 'DiscussionExternalFrontendCount';
+        this.start = '2016-09-06';
         this.expiry = '2016-09-30';
         this.author = 'Fabio Crisci';
         this.description = 'Load discussion frontend from an external location';
-        this.audience = 0;
-        this.audienceOffset = 0.0;
-        this.successMeasure = '';
+        this.audience = 0.05;
+        this.audienceOffset = 0.45;
+        this.successMeasure = 'Comment count loads correctly';
         this.showForSensitive = true;
-        this.audienceCriteria = 'Modern browsers only';
+        this.audienceCriteria = 'Browsers with Promise';
         this.dataLinkNames = '';
         this.idealOutcome = '';
 
         this.canRun = function () {
-            return 'fetch' in window && 'Promise' in window &&
+            return 'Promise' in window &&
                 window.curlConfig.paths['discussion-frontend-react'] &&
                 window.curlConfig.paths['discussion-frontend-preact'];
         };
@@ -24,17 +28,29 @@ define([], function () {
             {
                 id: 'control',
                 test: function () {},
-                success: function () {}
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('comments-count-loaded', complete);
+                    }
+                }.bind(this)
             },
             {
                 id: 'react',
                 test: function () {},
-                success: function () {}
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('comments-count-loaded', complete);
+                    }
+                }.bind(this)
             },
             {
                 id: 'preact',
                 test: function () {},
-                success: function () {}
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('comments-count-loaded', complete);
+                    }
+                }.bind(this)
             }
         ];
     };


### PR DESCRIPTION
## What does this change?

Start showing the react/preact version of comment count to users.
## What is the value of this and can you measure success?

The test is measuring the correct loading of comments count. I don't expect the variants to perform better, but I want to see if (p)react breaks on some of the browsers in the wild.

It's quite possible that the ratio of comments count loaded is lower for (p)react simply because it takes longer to load the assets and people leave the page in the mean time.
Assets are loaded asynchronously so they won't affect page load.
## Does this affect other platforms - Amp, Apps, etc?

No
