### PR TITLE
Implement ignored sentry action tags

### DIFF
--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -7,7 +7,7 @@ import conf.Configuration.environment
 import model._
 import play.api.Play
 import play.api.Play.current
-import play.api.libs.json.{JsValue, JsBoolean, JsString, Json}
+import play.api.libs.json.{JsBoolean, JsString, JsArray, JsValue, Json}
 import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
@@ -53,6 +53,10 @@ object JavaScriptPage {
       case _ => Map()
     }
 
+    val ignoredSentryActions : Seq[JsString] = Seq(
+      JsString("ads")
+    )
+
     javascriptConfig ++ config ++ commercialMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
@@ -67,7 +71,8 @@ object JavaScriptPage {
       ("requiresMembershipAccess", JsBoolean(requiresMembershipAccess)),
       ("membershipAccess", JsString(membershipAccess)),
       ("idWebAppUrl", JsString(Configuration.id.oauthUrl)),
-      ("cardStyle", JsString(cardStyle))
+      ("cardStyle", JsString(cardStyle)),
+      ("ignoredSentryActions", JsArray(ignoredSentryActions) )
     )
   }
 }

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -7,7 +7,7 @@ import conf.Configuration.environment
 import model._
 import play.api.Play
 import play.api.Play.current
-import play.api.libs.json.{JsBoolean, JsString, JsArray, JsValue, Json}
+import play.api.libs.json.{JsValue, JsBoolean, JsString, Json}
 import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
@@ -53,10 +53,6 @@ object JavaScriptPage {
       case _ => Map()
     }
 
-    val ignoredSentryActions : Seq[JsString] = Seq(
-      JsString("ads")
-    )
-
     javascriptConfig ++ config ++ commercialMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
@@ -71,8 +67,7 @@ object JavaScriptPage {
       ("requiresMembershipAccess", JsBoolean(requiresMembershipAccess)),
       ("membershipAccess", JsString(membershipAccess)),
       ("idWebAppUrl", JsString(Configuration.id.oauthUrl)),
-      ("cardStyle", JsString(cardStyle)),
-      ("ignoredSentryActions", JsArray(ignoredSentryActions) )
+      ("cardStyle", JsString(cardStyle))
     )
   }
 }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -443,7 +443,7 @@ define([
                 require(['js!//imasdk.googleapis.com/js/sdkloader/ima3.js']).then(function () {
                     initWithRaven(true);
                 }, function (e) {
-                    raven.captureException(e, { tags: { feature: 'media', action: 'ads' } });
+                    raven.captureException(e, { tags: { feature: 'media', action: 'ads', ignored: true } });
                     initWithRaven();
                 });
             } else {

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -75,9 +75,7 @@ define([
                 },
                 shouldSendCallback: function (data) {
                     var isDev = config.page.isDev;
-
-                    var isIgnored = typeof(data.tags.action) !== 'undefined' &&
-                        config.page.ignoredSentryActions.indexOf(data.tags.action) != -1;
+                    var isIgnored = typeof(data.tags.ignored) !== 'undefined' && data.tags.ignored;
 
                     if (isDev && !isIgnored) {
                         // Some environments don't support or don't always expose the console object

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -75,7 +75,11 @@ define([
                 },
                 shouldSendCallback: function (data) {
                     var isDev = config.page.isDev;
-                    if (isDev) {
+
+                    var isIgnored = typeof(data.tags.action) !== 'undefined' &&
+                        config.page.ignoredSentryActions.indexOf(data.tags.action) != -1;
+
+                    if (isDev && !isIgnored) {
                         // Some environments don't support or don't always expose the console object
                         if (window.console && window.console.warn) {
                             window.console.warn('Raven captured error.', data);
@@ -84,6 +88,7 @@ define([
 
                     return config.switches.enableSentryReporting &&
                         Math.random() < 0.1 &&
+                        !isIgnored &&
                         !isDev; // don't actually notify sentry in dev mode
                 }
             }


### PR DESCRIPTION
## What does this change?
- Implements a new configuration value for ignored sentry actions (action is a tag set on some errors before passing them to raven-js for logging out to sentry)
- Alters the raven-js shouldSendCallback hook to check the action tag of the exception before sending to Sentry.

This could also have been implemented as a special "ignored" tag which may have been cleaner as it would require no config changes on the scala side, but it would have meant this change would not be retroactive and we'd have to go back and put the ignored tag on all the existing ads code.
## What is the value of this and can you measure success?

Should reduce the number of crashes being sent to sentry due to ad-blocker related exceptions by several hundred thousand a month.
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
