### PR TITLE
Send media and discussion events to the prod GA property

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -31,9 +31,7 @@ define([
     track.seen = false;
 
     var ga = window.ga;
-    // When ready to go live, change to:
-    // var gaTracker = config.googleAnalytics.trackers.editorial;
-    var gaTracker = 'guardianTestPropertyTracker';
+    var gaTracker = config.googleAnalytics.trackers.editorial;
 
     function sendToGA(label, customDimensions) {
         var fieldsObject = assign({

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -39,7 +39,8 @@ define([
             'content:play',
             'content:end'
         ],
-        ga = window.ga;
+        ga = window.ga,
+        gaTracker = config.googleAnalytics.trackers.editorial;
 
 
     /**
@@ -153,7 +154,7 @@ define([
             return 'media:' + eventName;
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
-                ga('guardianTestPropertyTracker.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
+                ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
             });
         });
     }


### PR DESCRIPTION
## What does this change?

Send media events (video/audio playback events) and the "scrolled down to comments" event to the production GA property.

We have been sending these events to the test property for a while and they look fine.
## What is the value of this and can you measure success?

Really running out of things to write here.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@ajosephides @akash1810 @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
