### PR TITLE
Fix proxied call to PA API

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -90,7 +90,7 @@ class FootballClient(wsClient: WSClient) extends PaClient with Http with Logging
         else
           urlString
 
-        val promiseOfResponse = wsClient.url(urlString).withRequestTimeout(2000).get()
+        val promiseOfResponse = wsClient.url(url).withRequestTimeout(2000).get()
 
         promiseOfResponse.map{ r =>
 


### PR DESCRIPTION
## What does this change?

Minor fix to the recent change for proxying PA API through fastly.
## What is the value of this and can you measure success?

The PA API caching works (with any luck)
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @gklopper 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
