### PR TITLE
fix bug where arrow was black for contributions embed test

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -105,7 +105,7 @@
         background-repeat: no-repeat;
         width: 30px;
         height: 20px;
-        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="black" stroke="black" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="white" stroke="white" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
         background-size: 100%;
         float: right;
     }
@@ -121,6 +121,9 @@
         color: $neutral-1;
     }
 
+    &:after {
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="$neutral-1" stroke="$neutral-1" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
+    }
 }
 
 @include mq($from: phablet) {


### PR DESCRIPTION
## What does this change?

Fixed a bug where the arrow in the contributions emed test was black.
## What is the value of this and can you measure success?

It fixes the bug. Doesn't look wrong any more. More clicks, more contributions. 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

A screenshot showing that both arrows are now the correct color
![screenshot at sep 06 17-18-57](https://cloud.githubusercontent.com/assets/2844554/18281792/2615bf0c-7456-11e6-997c-b11c3b577641.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
