### PR TITLE
Added width of 1 gs-span to date block from tablet upwards, to force …

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -98,6 +98,10 @@ $block-padding-right: $gs-gutter;
     padding: $gs-baseline/4 0 $gs-baseline $gs-gutter/2;
     position: relative;
 
+    @include mq($from: tablet) {
+        width: gs-span(1);
+    }
+
     &.published-time {
         @include fs-textSans(2);
         margin: 0;


### PR DESCRIPTION
## What does this change?

Adds a width of 1 gs-span to the date block on a liveblog, to force long dates to wrap.
## What is the value of this and can you measure success?

Fixes a problem where the full dates displayed on old liveblogs were overlapping with the content.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

…wrap of full dates.
