### PR TITLE
Dropped margin rule that was resetting margin on focus, causing tag t…

### DIFF
--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -87,7 +87,6 @@
 
 .brand-bar__item--action,
 .brand-bar__item--action:focus {
-    margin: 0;
     cursor: pointer;
     color: $c-guardian-services-action;
     display: inline-block;


### PR DESCRIPTION
…o jump to the left.
## What does this change?

Removes a margin reset (to 0) when brand bar elements are focused.
## What is the value of this and can you measure success?

Fixes a problem where link to "become a supporter" was jumping to the left when receiving focus.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
