### PR TITLE
Reqwest doesn't work with discussion API

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -22,9 +22,12 @@ define([
             }
             // Inject the net module to work around the lack of a global fetch
             // It can be removed once all browsers have window.fetch
-            opts.net = {
-                json: fetchJson
-            };
+            // Well, it turns out that fetchJson uses reqwest which sends X-Requested-With
+            // which is not allowed by Access-Control-Allow-Headers, so don't use reqwest
+            // until discussion API is fixed
+            // opts.net = {
+            //     json: fetchJson
+            // };
 
             frontend(opts)
             .then(function (emitter) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
@@ -19,7 +19,7 @@ define([
         this.idealOutcome = '';
 
         this.canRun = function () {
-            return 'Promise' in window &&
+            return 'fetch' in window && 'Promise' in window &&
                 window.curlConfig.paths['discussion-frontend-react'] &&
                 window.curlConfig.paths['discussion-frontend-preact'];
         };


### PR DESCRIPTION
## What does this change?

`reqwest` works now because we're proxying requests through `discussion` app. However `discussion-frontend` talks directly to discussion API which is not configured to handle `X-Requested-With`.
Until we fix the API, use global fetch when available.
## What is the value of this and can you measure success?

I can start the AB test which would otherwise always fail loading comment count
## Does this affect other platforms - Amp, Apps, etc?

No
