### PR TITLE
Show more useful message for dev config problems

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -71,7 +71,16 @@ devOverrides {
     lazy val test = ClassPathConfigurationSource(s"env/DEVINFRA.properties")
     lazy val testConfig = new CM(List(test), PlayDefaultLogger).load.resolve
 
-    val appConfig = if (installVars.guStage == "DEVINFRA") testConfig else config.getConfig(identity.app + "." + identity.stage)
+    val appConfig =
+      if (installVars.guStage == "DEVINFRA") testConfig
+      else {
+        try {
+          config.getConfig(identity.app + "." + identity.stage)
+        } catch {
+          case e: ConfigException if installVars.guStage == "DEV" =>
+            throw new RuntimeException(s"${e.getMessage}.  You probably need to refresh your credentials.", e)
+        }
+      }
     appConfig
   }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -30,7 +30,7 @@ object GuardianConfiguration extends Logging {
 
     val installVars = {
       val p = new JavaProperties()
-      p.load(new FileInputStream(s"/etc/gu/install_vars"))
+      p.load(new FileInputStream("/etc/gu/install_vars"))
       val stack = p.getProperty("stack", "frontend")
       // if got config at app startup, we wouldn't need to configure it
       val app = p.getProperty("app", "dev-build")
@@ -62,13 +62,13 @@ devOverrides {
     val s3ConfigVersion = 3
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
-    lazy val runtimeOnly = FileConfigurationSource(s"/etc/gu/frontend.conf")
+    lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")
     lazy val identity = new AwsApplication(installVars.stack, installVars.app, installVars.guStage, installVars.awsRegion)
     lazy val commonS3Config = S3ConfigurationSource(identity, installVars.configBucket, Configuration.aws.mandatoryCredentials, Some(s3ConfigVersion))
     lazy val config = new CM(List(userPrivate, runtimeOnly, commonS3Config), PlayDefaultLogger).load.resolve
 
     // test mode is self contained and won't need to use anything secret
-    lazy val test = ClassPathConfigurationSource(s"env/DEVINFRA.properties")
+    lazy val test = ClassPathConfigurationSource("env/DEVINFRA.properties")
     lazy val testConfig = new CM(List(test), PlayDefaultLogger).load.resolve
 
     val appConfig =


### PR DESCRIPTION
This is what you see in the dev environment if your credentials are out of date:

![image](https://cloud.githubusercontent.com/assets/1722550/18311059/29d6a3f0-74fa-11e6-847f-1169e4685a2c.png)

If app config fails it's probably because credentials need refreshing, but that's not immediately obvious.  So this change gives you a hint:

![image](https://cloud.githubusercontent.com/assets/1722550/18311027/000704e8-74fa-11e6-9bbe-04b604c79fa3.png)
