### PR TITLE
Remove misleading setup.sh message

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ source_nvm() {
 check_encryption() {
 
     if linux; then
-        EXTRA_STEPS+=("Sorry, can't check if your hard disk is encryped so won't download frontend.properties.  Please check (applies to both portable and Desktop machines) and download from s3://aws-frontend-store/template-frontend.properties")
+        EXTRA_STEPS+=("Sorry, can't check if your hard disk is encrypted - please ensure that it is! (applies to both portable and Desktop machines)")
     elif mac; then
         if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
             EXTRA_STEPS+=("your hard disk is not encrypted! Encryption must be enabled on all guardian machines. Follow these instructions: https://support.apple.com/en-gb/HT204837")


### PR DESCRIPTION
The script no longer downloads a file from S3, no matter whether your disk is encrypted or not, so the message was misleading.

cc @johnduffell 
