### PR TITLE
Fix liveblog updated timestamp

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -87,14 +87,18 @@ $block-padding-right: $gs-gutter;
     padding: $gs-baseline/3 0;
     margin-top: ($gs-baseline/3)*2;
 
-    @include mq($from: tablet) {
-        width: gs-span(1);
-    }
-
     time {
         display: inline-block;
         margin-bottom: $gs-baseline/2;
     }
+}
+
+.published-time {
+
+    @include mq($from: tablet) {
+        width: gs-span(1);
+    }
+
 }
 
 .block-time {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -87,6 +87,10 @@ $block-padding-right: $gs-gutter;
     padding: $gs-baseline/3 0;
     margin-top: ($gs-baseline/3)*2;
 
+    @include mq($from: tablet) {
+        width: gs-span(1);
+    }
+
     time {
         display: inline-block;
         margin-bottom: $gs-baseline/2;
@@ -97,10 +101,6 @@ $block-padding-right: $gs-gutter;
     line-height: 15px;
     padding: $gs-baseline/4 0 $gs-baseline $gs-gutter/2;
     position: relative;
-
-    @include mq($from: tablet) {
-        width: gs-span(1);
-    }
 
     &.published-time {
         @include fs-textSans(2);


### PR DESCRIPTION
## What does this change?

Reduces the scope of the width rule used to make timestamps wrap on liveblogs; now only applies to published timestamps. It was previously unintentionally also affecting updated timestamps.
## What is the value of this and can you measure success?

Fixes a problem with liveblog updated timestamps caused by PR #14211 (sorry, my bad!).
## Screenshots

![updated-before-after](https://cloud.githubusercontent.com/assets/5131341/18315177/f942b58a-750d-11e6-81d3-fef2da67fd43.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
