### PR TITLE
Extended new header opt in switch for another 3 months

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -20,7 +20,7 @@ object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
   description = "Feature switch (0% test) for the new header",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 9, 8) // Thursday
+  sellByDate = new LocalDate(2016, 12, 8) // Thursday
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variant")


### PR DESCRIPTION
## What does this change?

New header opt in switch expired in a couple days. Just extending it 😄 
## What is the value of this and can you measure success?

People can opt in and continue to use the new header!
## Does this affect other platforms - Amp, Apps, etc?

Nope!

@guardian/dotcom-platform 
