### PR TITLE
Amp bluelinks AB test tracking

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -56,7 +56,8 @@ class DevParametersHttpRequestHandler(
     "k", // keywords in commercial component requests
     "s", // section in commercial component requests
     "seg", // user segments in commercial component requests
-    "t" // specific item targetting
+    "t", // specific item targetting
+    "0p19G" // Google AMP AB test parameter
   )
 
   val allowedParams = CanonicalLink.significantParams ++ commercialParams ++ insignificantParams

--- a/facia/public/amp_remote.html
+++ b/facia/public/amp_remote.html
@@ -108,6 +108,34 @@
             return window.context.isMaster && config.type == 'doubleclick';
         }
 
+        function stripUrlToQueryString(url) {
+            return url.replace(/.*\?/, '');
+        }
+
+        function getUrlVars(originalUrl) {
+            return stripUrlToQueryString(originalUrl).split('&')
+                .filter(Boolean)
+                .map(function (query) {
+                    return query.indexOf('=') > -1 ? query.split('=') : [query, true];
+                })
+                .reduce(function (result, input) {
+                    result[input[0]] = input[1];
+                    return result;
+                }, {});
+        }
+
+        function attachQueryParams(config) {
+            //Google AMP AB test query parameter
+            var whitelist = ['0p19G'];
+            var paramsMap = getUrlVars(config.targeting.url);
+            Object.keys(paramsMap).map(function(value, index){
+                if(whitelist.indexOf(value) > -1) {
+                    config.targeting[value] = paramsMap[value];
+                }
+            });
+            return config;
+        }
+
         // this is the big AMP callback
         draw3p(function (config, done) {
 
@@ -117,7 +145,8 @@
             }
 
             if (configIsValid(config)) {
-                var configWithAdTestParam = attachAdTestParam(config);
+                var configWithAttachedQueryParams = attachQueryParams(config);
+                var configWithAdTestParam = attachAdTestParam(configWithAttachedQueryParams);
                 var result = attachKruxSegments(configWithAdTestParam);
                 done(result);
             } else {

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -3,6 +3,7 @@ define([
     'common/utils/cookies',
     'common/utils/detect',
     'common/utils/storage',
+    'common/utils/url',
     'commercial/modules/third-party-tags/audience-science-pql',
     'commercial/modules/third-party-tags/krux',
     'common/modules/identity/api',
@@ -21,6 +22,7 @@ define([
     cookies,
     detect,
     storage,
+    url,
     audienceScienceGateway,
     krux,
     identity,
@@ -142,6 +144,9 @@ define([
                 })[0] || {};
 
             return matchedRef.id;
+        }, getWhitelistedQueryParams = function() {
+            var whiteList = ['0p19G'];
+            return pick(url.getUrlVars(), whiteList);
         };
 
     return function (opts) {
@@ -171,7 +176,8 @@ define([
                 tn:      uniq(compact([page.sponsorshipType].concat(parseIds(page.tones)))),
                 // round video duration up to nearest 30 multiple
                 vl:      page.videoDuration ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
-            }, audienceScienceGateway.getSegments());
+            }, audienceScienceGateway.getSegments()
+            , getWhitelistedQueryParams());
 
         // filter out empty values
         return pick(pageTargets, function (target) {


### PR DESCRIPTION
## What does this change?

This adds the tracking of the query parameter `0p19G` in DFP. For normal pages, this uses `setTargeting` using `googletag`, and for AMP pages, it uses the `config` object of `draw3p` and adds the targeting via `config.targeting`.
## What is the value of this and can you measure success?

This means we can measure the impact of the bluelinks AB test run by google.
## Does this affect other platforms - Amp, Apps, etc?

This affects AMP and normal pages, by adding the white-listed query parameters to the DFP call.
## Request for comment

@kenlim @JamieKMorrison @NataliaLKB @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
