### PR TITLE
Update grunt-eslint & turn on cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ screenshots
 common/conf/assets
 atomic-map.json
 
+.eslintcache
+
 dev/gems
 dev/casperjs
 integration-tests/target/*

--- a/grunt-configs/eslint.js
+++ b/grunt-configs/eslint.js
@@ -2,7 +2,8 @@
 module.exports = function () {
     return {
         options: {
-            rulePaths: ['./dev/eslint-rules']
+            rulePaths: ['./dev/eslint-rules'],
+            cache: true
         },
         'Gruntfile.js': [
             'Gruntfile.js'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -529,6 +529,9 @@
     "chokidar": {
       "version": "1.5.1"
     },
+    "circular-json": {
+      "version": "0.3.1"
+    },
     "clap": {
       "version": "1.1.1"
     },
@@ -1601,7 +1604,36 @@
       }
     },
     "grunt-eslint": {
-      "version": "18.0.0"
+      "version": "19.0.0",
+      "dependencies": {
+        "eslint": {
+          "version": "3.4.0"
+        },
+        "file-entry-cache": {
+          "version": "2.0.0"
+        },
+        "flat-cache": {
+          "version": "1.2.1"
+        },
+        "globals": {
+          "version": "9.9.0"
+        },
+        "ignore": {
+          "version": "3.1.5"
+        },
+        "lodash": {
+          "version": "4.15.0"
+        },
+        "shelljs": {
+          "version": "0.6.1"
+        },
+        "strip-bom": {
+          "version": "3.0.0"
+        },
+        "user-home": {
+          "version": "2.0.0"
+        }
+      }
     },
     "grunt-frequency-graph": {
       "version": "0.1.6",
@@ -2780,6 +2812,9 @@
     },
     "nan": {
       "version": "2.4.0"
+    },
+    "natural-compare": {
+      "version": "1.4.0"
     },
     "negotiator": {
       "version": "0.5.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-css-metrics": "0.1.2",
-    "grunt-eslint": "18.0.0",
+    "grunt-eslint": "19.0.0",
     "grunt-frequency-graph": "^0.1.6",
     "grunt-karma": "^2.0.0",
     "grunt-mkdir": "0.1.2",


### PR DESCRIPTION
## What does this change?

Housekeeping and turning on the cache functionality in eslint to speed up linting times.

Terribly un-random sample:

Before: W/ grunt-eslint 18, no cache

```
Execution Time (2016-09-07 13:59:37 UTC)
loading tasks         309ms  ▇ 2%
loading grunt-eslint  311ms  ▇ 2%
eslint:Gruntfile.js   650ms  ▇ 5%
eslint:grunt-configs  328ms  ▇ 2%
eslint:st...ascripts   4.7s  ▇▇▇▇▇▇▇ 34%
eslint:static/src      7.8s  ▇▇▇▇▇▇▇▇▇▇▇▇ 55%
Total 14.1s
```

After: W/ grunt-eslint 19, cache turned on

```
Execution Time (2016-09-07 16:09:54 UTC)
loading tasks         763ms  ▇▇▇▇ 16%
loading grunt-eslint  564ms  ▇▇▇ 12%
eslint:Gruntfile.js   923ms  ▇▇▇▇ 20%
eslint:grunt-configs  268ms  ▇▇ 6%
eslint:st...ascripts   1.3s  ▇▇▇▇▇▇ 27%
eslint:static/src     897ms  ▇▇▇▇ 19%
Total 4.7s
```

⚡ 

@guardian/dotcom-platform 
