### PR TITLE
Stop AWS environment variables from breaking dev - remove `EnvironmentVariableCredentialsProvider`!

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -552,8 +552,6 @@ class GuardianConfiguration extends Logging {
     def mandatoryCredentials: AWSCredentialsProvider = credentials.getOrElse(throw new BadConfigurationException("AWS credentials are not configured"))
     val credentials: Option[AWSCredentialsProvider] = {
       val provider = new AWSCredentialsProviderChain(
-        new EnvironmentVariableCredentialsProvider(),
-        new SystemPropertiesCredentialsProvider(),
         new ProfileCredentialsProvider("frontend"),
         new InstanceProfileCredentialsProvider
       )


### PR DESCRIPTION
I had a puzzling time trying to work out why I couldn't get DotCom Frontend to work on my dev box after
https://github.com/guardian/frontend/pull/13749 was merged, a change that meant frontend config is now pulled from AWS S3.

In the logs, I saw S3 was saying 'ACCESS DENIED' - despite my having up-to-date Janus `frontend` credentials.

It turned out that I had some `AWS_ACCESS_KEY` & `AWS_SECRET_KEY` environment variables lying around in my bash profile from some random awful non-Frontend thing.

Although those are awful, they shouldn't have broke Frontend! Ever since https://github.com/guardian/frontend/pull/5428 we shouldn't have needed anything in dev but Profile credentials - and in Prod just Instance Profile credentials - but useless little `EnvironmentVariableCredentialsProvider` was overriding those credentials on my dev instance, and now it must go :)

cc @johnduffell
