### PR TITLE
Extend expired switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -83,7 +83,7 @@ trait ABTestSwitches {
     "Test to see whether ordering comments by recommends on live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 7), //Wednesday
+    sellByDate = new LocalDate(2016, 9, 8), //Wednesday
     exposeClientSide = true
   )
 
@@ -93,7 +93,7 @@ trait ABTestSwitches {
     "Test to see whether ordering comments by recommends on content o[ther than live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 7), //Wednesday
+    sellByDate = new LocalDate(2016, 9, 8), //Wednesday
     exposeClientSide = true
   )
 


### PR DESCRIPTION
To avoid breaking build.
