### PR TITLE
Retrieve original location href via iframe hash

### DIFF
--- a/facia/public/amp_remote.html
+++ b/facia/public/amp_remote.html
@@ -127,13 +127,23 @@
         function attachQueryParams(config) {
             //Google AMP AB test query parameter
             var whitelist = ['0p19G'];
-            var paramsMap = getUrlVars(config.targeting.url);
+            var originalLocationHref = getOriginalLocationHref();
+            var paramsMap = originalLocationHref ? getUrlVars(originalLocationHref) : {};
             Object.keys(paramsMap).map(function(value, index){
                 if(whitelist.indexOf(value) > -1) {
                     config.targeting[value] = paramsMap[value];
                 }
             });
             return config;
+        }
+
+        function getOriginalLocationHref() {
+            try {
+                var configString = window.location.hash.substr(1);
+                var config = JSON.parse(configString);
+                return config._context.location.href;
+            } catch(e){}
+            return "";
         }
 
         // this is the big AMP callback


### PR DESCRIPTION
## What does this change?

This changes the AMP Bluelinks AB test tracking so that we get the query parameter from the JSON object that is included on the `window.location.hash` of the iframe. This is in `JSON` format and includes the original context through `_context`.
## Request for comment

@NataliaLKB @JamieKMorrison 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
