### PR TITLE
Render fronts as email-friendly HTML

### DIFF
--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -12,12 +12,13 @@ class IndexController extends IndexControllerCommon {
       if (request.isRss) {
         val body = TrailsToRss(model.page.metadata, model.trails.map(_.trail))
         RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)
-      } else if (request.isJson)
+      } else if (request.isJson) {
         JsonComponent(
           "html" -> views.html.fragments.indexBody(model)
         )
-      else
+      } else {
         RevalidatableResult.Ok(views.html.index(model))
+      }
     }
   }
 }

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -1,18 +1,18 @@
 @(page: PageWithStoryPackage)(implicit request: RequestHeader)
 
-@import views.support.EmailArticleImage
+@import views.support.EmailImage
 @import views.support.EmailHelpers._
 @import model.liveblog._
 @import model.EmailAddons.EmailContentType
 
 @defining(page.article) { article =>
     @fullRow {
-        <a href="@article.metadata.webUrl" @page.item.email.map { email => title="View @email.name online"}>
-            <img width="580" src="@article.banner" @page.item.email.map { email => alt="View @email.name online"}>
+        <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
+            <img width="580" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
         </a>
     }
 
-    @article.fallbackSeriesText.map { seriesName =>
+    @page.fallbackSeriesText.map { seriesName =>
         @paddedRow {
             <h3 class="text--brand">@seriesName</h3>
             <hr class="rule--compact" />
@@ -81,7 +81,7 @@
                     }
 
                     case ImageBlockElement(media, data, showCredit) => {
-                        @EmailArticleImage.bestFor(media).map { url =>
+                        @EmailImage.bestFor(media).map { url =>
                             @fullRow {
                                 <img width="580" class="media--main" src="@url" @data.get("alt").map { alt => alt="@alt" }>
                             }
@@ -107,7 +107,7 @@
                     case GuVideoBlockElement(video, media, data) => {
                         @data.get("url").map { url =>
                             @fullRowWithBackground(media) {
-                                <a class="play--button" href="@url"><img class="play--icon" src="@Images.play"></a>
+                                <a class="play--button" href="@url"><img class="float-left play--icon" src="@Images.play"></a>
                             }
                         }
                     }

--- a/article/app/views/fragments/emailMainMedia.scala.html
+++ b/article/app/views/fragments/emailMainMedia.scala.html
@@ -1,11 +1,11 @@
 @(article: model.Article)(implicit request: RequestHeader)
 
-@import views.support.{ImgSrc, EmailArticleImage}
+@import views.support.{ImgSrc, EmailImage}
 @import views.support.EmailHelpers._
 
 @if(!article.elements.hasMainEmbed) {
     @article.elements.mainPicture.map { picture =>
-        @EmailArticleImage.bestFor(picture.images).map { url =>
+        @EmailImage.bestFor(picture.images).map { url =>
             @fullRow {
                 <img width="580" class="media--main" src="@url" alt="@ImgSrc.getFallbackAsset(picture.images).flatMap(_.altText).getOrElse("")" />
             }

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -45,7 +45,8 @@ class DevParametersHttpRequestHandler(
     "amp", // used in dev to request the amp version of a specific url
     "__amp_source_origin", // used by amp-live-list to enforce CORS
     "amp_latest_update_time", // used by amp-live-list to check for latest updates
-    "heatmap" // used by ophan javascript to enable the heatmap
+    "heatmap", // used by ophan javascript to enable the heatmap
+    "format" // used to determine whether HTML should be served in email-friendly format or not
   )
 
   val commercialParams = Seq(

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -24,7 +24,7 @@ trait Requests {
 
     lazy val isAmp: Boolean = r.getQueryString("amp").isDefined || (!r.host.isEmpty && r.host == Configuration.amp.host)
 
-    lazy val isEmail: Boolean = (r.getQueryString("format") == Some("email")) || r.path.endsWith(EMAIL_SUFFIX)
+    lazy val isEmail: Boolean = r.getQueryString("format").contains("email") || r.path.endsWith(EMAIL_SUFFIX)
 
     lazy val isModified = isJson || isRss || isEmail
 

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -2,108 +2,121 @@ package model
 
 import conf.Static
 
-sealed trait EmailContent extends Product with Serializable {
+
+sealed trait EmailMetadata[T] extends Product with Serializable {
   def name: String
-  def banner: String
-  def test(c: ContentType): Boolean
+  def banner: Option[String] = None
   def address: Option[String] = None
+  def test(c: T): Boolean
 }
 
-case object ArtWeekly extends EmailContent {
+sealed trait ArticleEmailMetadata extends EmailMetadata[ContentPage] {
+  def test(c: ContentPage): Boolean
+}
+
+sealed trait FrontEmailMetadata extends EmailMetadata[PressedPage] {
+  def test(p: PressedPage) = p.metadata.webTitle == this.name
+}
+
+case object ArtWeekly extends ArticleEmailMetadata {
   val name = "Art Weekly"
-  val banner = "art-weekly.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "artanddesign/series/art-weekly")
+  override val banner = Some("art-weekly.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "artanddesign/series/art-weekly")
 }
 
-case object GreenLight extends EmailContent {
+case object GreenLight extends ArticleEmailMetadata {
   val name = "Green Light"
-  val banner = "green-light.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "environment/series/green-light")
+  override val banner = Some("green-light.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "environment/series/green-light")
 }
 
-case object MoneyTalks extends EmailContent {
+case object MoneyTalks extends ArticleEmailMetadata {
   val name = "Money Talks"
-  val banner = "money-talks.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "money/series/money-talks")
+  override val banner = Some("money-talks.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "money/series/money-talks")
 }
 
-case object PovertyMatters extends EmailContent {
+case object PovertyMatters extends ArticleEmailMetadata {
   val name = "Poverty Matters"
-  val banner = "poverty-matters.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "global-development/series/poverty-matters")
+  override val banner = Some("poverty-matters.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "global-development/series/poverty-matters")
 }
 
-case object TheBreakdown extends EmailContent {
+case object TheBreakdown extends ArticleEmailMetadata {
   val name = "The Breakdown"
-  val banner = "the-breakdown.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "sport/series/breakdown")
+  override val banner = Some("the-breakdown.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "sport/series/breakdown")
 }
 
-case object TheFiver extends EmailContent {
+case object TheFiver extends ArticleEmailMetadata {
   val name = "The Fiver"
-  val banner = "the-fiver.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "football/series/thefiver")
+  override val banner = Some("the-fiver.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "football/series/thefiver")
 }
 
-case object TheSpin extends EmailContent {
+case object TheSpin extends ArticleEmailMetadata {
   val name = "The Spin"
-  val banner = "the-spin.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "sport/series/thespin")
+  override val banner = Some("the-spin.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "sport/series/thespin")
 }
 
-case object MorningBriefing extends EmailContent {
+case object MorningBriefing extends ArticleEmailMetadata {
   val name = "Morning Briefing"
-  val banner = "morning-briefing.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "world/series/guardian-morning-briefing")
+  override val banner = Some("morning-briefing.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "world/series/guardian-morning-briefing")
 }
 
-case object TheUSMinute extends EmailContent {
+case object TheUSMinute extends ArticleEmailMetadata {
   val name = "The campaign minute 2016"
-  val banner = "the-us-minute.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "us-news/series/the-campaign-minute-2016")
+  override val banner = Some("the-us-minute.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "us-news/series/the-campaign-minute-2016")
 }
 
-case object USBriefing extends EmailContent {
+case object USBriefing extends ArticleEmailMetadata {
   val name = "Guardian US Briefing"
-  val banner = "guardian-us-briefing.png"
+  override val banner = Some("guardian-us-briefing.png")
   override val address = Some("222 Broadway, 22nd and 23rd Floors, New York, New York, 10038")
-  def test(c: ContentType) = c.tags.series.exists(_.id == "us-news/series/guardian-us-briefing")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "us-news/series/guardian-us-briefing")
 }
 
-case object AusBriefing extends EmailContent {
+case object AusBriefing extends ArticleEmailMetadata {
   val name = "Australian election briefing"
-  val banner = "australian-election-briefing.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "australia-news/series/australian-election-briefing")
+  override val banner = Some("australian-election-briefing.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "australia-news/series/australian-election-briefing")
 }
 
-case object EuReferendum extends EmailContent {
+case object EuReferendum extends ArticleEmailMetadata {
   val name = "EU Referendum Morning Briefing"
-  val banner = "eu-referendum.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "politics/series/eu-referendum-morning-briefing")
+  override val banner = Some("eu-referendum.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "politics/series/eu-referendum-morning-briefing")
 }
 
-case object LabNotes extends EmailContent {
+case object LabNotes extends ArticleEmailMetadata {
   val name = "Lab Notes"
-  val banner = "lab-notes.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "science/series/lab-notes")
+  override val banner = Some("lab-notes.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "science/series/lab-notes")
 }
 
-case object OlympicsDailyBriefing extends EmailContent {
+case object OlympicsDailyBriefing extends ArticleEmailMetadata {
   val name = "Olympics Daily Briefing"
-  val banner = "olympics-daily-briefing.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "sport/series/olympics-2016-daily-briefing")
+  override val banner = Some("olympics-daily-briefing.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "sport/series/olympics-2016-daily-briefing")
 }
 
-case object MediaBriefing extends EmailContent {
+case object MediaBriefing extends ArticleEmailMetadata {
   val name = "Media Briefing"
-  val banner = "media-briefing.png"
-  def test(c: ContentType) = c.tags.series.exists(_.id == "media/series/mediaguardian-briefing")
+  override val banner = Some("media-briefing.png")
+  def test(c: ContentPage) = c.item.tags.series.exists(_.id == "media/series/mediaguardian-briefing")
+}
+
+case object TheFlyer extends FrontEmailMetadata {
+  val name = "The Flyer"
 }
 
 object EmailAddons {
   private val defaultAddress = "Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396"
   private val defaultBanner = "generic.png"
-  private val allEmails     = Seq(
+  private val articleEmails     = Seq(
     ArtWeekly,
     GreenLight,
     MoneyTalks,
@@ -119,14 +132,22 @@ object EmailAddons {
     LabNotes,
     OlympicsDailyBriefing,
     MediaBriefing)
+  private val frontEmails = Seq(
+    TheFlyer
+  )
 
-  implicit class EmailContentType(c: ContentType) {
-    val email = allEmails.find(_.test(c))
+  implicit class EmailContentType(p: Page) {
+    val email = p match {
+      case c: ContentPage => articleEmails.find(_.test(c))
+      case p: PressedPage => frontEmails.find(_.test(p))
+    }
 
-    val fallbackSeriesText = if (email.isEmpty) c.content.seriesName else None
+    val fallbackSeriesText = PartialFunction.condOpt(p) {
+      case c: ContentPage if email.isEmpty => c.item.content.seriesName
+    }
 
     lazy val banner = {
-      val banner = email map (_.banner) getOrElse defaultBanner
+      val banner = email flatMap (_.banner) getOrElse defaultBanner
       Static(s"images/email/banners/$banner")
     }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -105,7 +105,7 @@ final case class Content(
     cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1
 
   lazy val signedArticleImage: String = {
-    ImgSrc(rawOpenGraphImage, EmailArticleImage)
+    ImgSrc(rawOpenGraphImage, EmailImage)
   }
 
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images

--- a/common/app/views/fragments/email/ampScript.scala.html
+++ b/common/app/views/fragments/email/ampScript.scala.html
@@ -1,14 +1,16 @@
-@(page: model.ContentPage)
+@(page: model.Page)
 
 @import views.support.StripHtmlTagsAndUnescapeEntities
+@import views.support.EmailHelpers.{subjectFromPage, introFromPage}
+
 
 <!--
 %%[
     Var @@subject, @@intro
-    Set @@subject = "@Html(StripHtmlTagsAndUnescapeEntities(page.item.trail.headline))"
+    Set @@subject = "@Html(StripHtmlTagsAndUnescapeEntities(subjectFromPage(page)))"
 
 
-    @page.item.trail.fields.trailText.map { byline =>
+    @introFromPage(page).map { byline =>
     Set @@intro = "@Html(StripHtmlTagsAndUnescapeEntities(byline))"
     }
 ]%%

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -1,4 +1,4 @@
-@(page: model.ContentPage)(implicit request: RequestHeader)
+@(page: model.Page)(implicit request: RequestHeader)
 
 @import views.support.EmailHelpers._
 @import model.EmailAddons.EmailContentType
@@ -10,10 +10,10 @@
 
 @fullRow(Seq("disclaimer")) {
     <p>
-    @page.item.email.map { email =>
+    @page.email.map { email =>
         You are receiving this email because you are a subscriber to @{email.name}.
     }
 
-    Guardian News & Media Limited - a member of Guardian Media Group PLC. Registered Office: @page.item.address
+    Guardian News & Media Limited - a member of Guardian Media Group PLC. Registered Office: @page.address
     </p>
 }

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -1,0 +1,61 @@
+@()
+
+<style>
+    body, .body {
+        background: #e5e5e5;
+    }
+
+    .media--main {
+        width: 100%;
+    }
+
+    .container,
+    .panel {
+        background: #eaeaea;
+    }
+
+    .panel {
+        padding: 5px 10px !important;
+        border: none;
+    }
+
+    .container-title {
+        color: #005689;
+        padding-top: 4px;
+    }
+    .container-title--not-first {
+        border-top: 3px solid #4bc6df;
+    }
+
+    .facia-card {
+        display: block;
+        text-decoration: none;
+    }
+
+    .headline, .trail-text {
+        font-weight: bold;
+        font-size: 16px;
+        line-height: 20px;
+        margin: 0;
+        color: inherit;
+    }
+
+    .facia-card .headline {
+        padding: 5px 10px;
+    }
+
+    .facia-card--large .headline {
+        font-size: 20px;
+        line-height: 24px;
+        color: inherit;
+        padding: 5px 10px;
+    }
+
+    .facia-card--large .trail-text {
+        padding: 5px 10px 20px;
+    }
+
+    .kicker-separator {
+        font-weight: normal;
+    }
+</style>

--- a/common/app/views/fragments/email/stylesheets/ink.scala.html
+++ b/common/app/views/fragments/email/stylesheets/ink.scala.html
@@ -48,9 +48,18 @@ img {
     -ms-interpolation-mode: bicubic;
     width: auto;
     max-width: 100%;
-    float: left;
     clear: both;
     display: block;
+}
+
+img.float-left {
+    float: left;
+    text-align: left;
+}
+
+img.float-right {
+    float: right;
+    text-align: right;
 }
 
 center {

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -93,7 +93,7 @@
     }
 
     .media--main {
-        width: 100% ;
+        width: 100%;
     }
 
     .row.background--image {

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -1,0 +1,200 @@
+@()
+
+<style>
+    .tone-news {
+        border-top: 1px solid #4bc6df;
+        background-color: #f6f6f6;
+    }
+    .tone-news .headline {
+        color: #333333;
+    }
+    .tone-news .fc-item__kicker {
+        color: #005689;
+    }
+    .tone-news .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-news .trail-text {
+        color: #767676;
+    }
+
+
+    .tone-feature {
+        border-top: 1px solid pink;
+        background-color: #951c55;
+    }
+    .tone-feature .headline {
+        color: #fff;
+    }
+    .tone-feature .fc-item__kicker {
+        color: #fdadba;
+    }
+    .tone-feature .kicker-separator {
+        color: #aa4977;
+    }
+    .tone-feature .trail-text {
+        color: #ead2dd;
+    }
+
+
+    .tone-media {
+        border-top: 1px solid #ffbb00;
+        background-color: #333;
+    }
+    .tone-media .headline {
+        color: #fff;
+    }
+    .tone-media .fc-item__kicker {
+        color: #ffbb00;
+    }
+    .tone-media .kicker-separator {
+        color: #737373;
+    }
+    .tone-media .trail-text {
+        color: #bdbdbd;
+    }
+
+
+    .tone-review {
+        border-top: 1px solid pink;
+        background-color: #7d7569;
+    }
+    .tone-review .headline {
+        color: #fff;
+    }
+    .tone-review .fc-item__kicker {
+        color: #ffce4b;
+    }
+    .tone-review .kicker-separator {
+        color: #979187;
+    }
+    .tone-review .trail-text {
+        color: #cbc8c3;
+    }
+
+
+    .tone-editorial {
+        border-top: 1px solid #aad8f1;
+        background-color: #005689;
+    }
+    .tone-editorial .headline {
+        color: #fff;
+    }
+    .tone-editorial .fc-item__kicker {
+        color: #aad8f1;
+    }
+    .tone-editorial .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-editorial .trail-text {
+        color: #aad8f1;
+    }
+
+
+    .tone-external {
+        border-top: 1px solid #4bc6df;
+        background-color: #f6f6f6;
+    }
+    .tone-external .headline {
+        color: #333333;
+    }
+    .tone-external .fc-item__kicker {
+        color: #005689;
+    }
+    .tone-external .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-external .trail-text {
+        color: #767676;
+    }
+
+
+    .tone-live {
+        border-top: 1px solid #fdadba;
+        background-color: #b51800;
+    }
+    .tone-live .headline {
+        color: #fff;
+    }
+    .tone-live .fc-item__kicker {
+        color: #fdadba;
+    }
+    .tone-live .kicker-separator {
+        color: #c44633;
+    }
+    .tone-live .trail-text {
+        color: #f0d1cc;
+    }
+
+
+    .tone-analysis {
+        border-top: 1px solid #4bc6df;
+        background-color: #f6f6f6;
+    }
+    .tone-analysis .headline {
+        color: #005689;
+    }
+    .tone-analysis .fc-item__kicker {
+        color: #767676;
+    }
+    .tone-analysis .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-analysis .trail-text {
+        color: #767676;
+    }
+
+
+    .tone-special-report {
+        border-top: 1px solid #fce800;
+        background-color: #63717a;
+    }
+    .tone-special-report .headline {
+        color: #fff;
+    }
+    .tone-special-report .fc-item__kicker {
+        color: #fce800;
+    }
+    .tone-special-report .kicker-separator {
+        color: #828d95;
+    }
+    .tone-special-report .trail-text {
+        color: #e0e3e4;
+    }
+
+
+    .tone-comment {
+        border-top: 1px solid #e6711b;
+        background-color: #e3e3de;
+    }
+    .tone-comment .headline {
+        color: #333333;
+    }
+    .tone-comment .fc-item__kicker {
+        color: #e6711b;
+    }
+    .tone-comment .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-comment .trail-text {
+        color: #767676;
+    }
+
+
+    .tone-dead {
+        border-top: 1px solid pink;
+        background-color: #f6f6f6;
+    }
+    .tone-dead .headline {
+        color: #333333;
+    }
+    .tone-dead .fc-item__kicker {
+        color: #cc2b12;
+    }
+    .tone-dead .kicker-separator {
+        color: #d6d6d6;
+    }
+    .tone-dead .trail-text {
+        color: #767676;
+    }
+</style>

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -1,4 +1,4 @@
-@(page: model.ContentPage)(body: Html)(implicit request: RequestHeader)
+@(page: model.Page)(body: Html)(implicit request: RequestHeader)
 
 @import common.{LinkTo, CanonicalLink}
 
@@ -16,6 +16,11 @@
         @fragments.email.stylesheets.fonts()
         @fragments.email.stylesheets.main()
         @fragments.email.stylesheets.footer()
+
+        @if(page.metadata.isFront) {
+            @fragments.email.stylesheets.front()
+            @fragments.email.stylesheets.tones()
+        }
     </head>
 
     <body>
@@ -29,7 +34,6 @@
                             <tr>
                                 <td>@body</td>
                             </tr>
-
                             <tr>
                                 <td class="footer">@fragments.email.footer(page)</td>
                             </tr>

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -1,7 +1,8 @@
 package views.support
 
 import conf.Static
-import model.ImageMedia
+import model._
+import model.pressed.PressedContent
 import play.twirl.api.Html
 
 object EmailHelpers {
@@ -31,18 +32,35 @@ object EmailHelpers {
   def paddedRow(inner: Html): Html = row(columns(12, Seq("panel"))(inner))
   def paddedRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(columns(12, classes ++ Seq("panel"))(inner))
 
+  def imageUrlFromPressedContent(pressedContent: PressedContent): Option[String] = {
+    for {
+      InlineImage(imageMedia) <- InlineImage.fromFaciaContent(pressedContent)
+      url <- EmailImage.bestFor(imageMedia)
+    } yield url
+  }
+
+  def subjectFromPage(page: Page): String = page match {
+    case c: ContentPage => c.item.trail.headline
+    case p: PressedPage => p.metadata.description.getOrElse(p.metadata.webTitle)
+  }
+
+  def introFromPage(page: Page): Option[String] = page match {
+    case c: ContentPage => c.item.trail.byline
+    case p: PressedPage => p.frontProperties.onPageDescription
+  }
+
   def fullRowWithBackground(media: ImageMedia)(inner: Html): Html = {
-    EmailArticleImage.bestFor(media).map { url =>
+    EmailImage.bestFor(media).map { url =>
       Html {
         s"""<table style="background-image: url($url)" class="row background--image">
           <tr>${columns(12)(inner)}</tr>
         </table>"""
       }
-    } getOrElse(fullRow(inner))
+    } getOrElse (fullRow(inner))
   }
 
   def icon(name: String) = Html {
-    s"""<img src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
+    s"""<img src="${Static(s"images/email/icons/$name.png")}" class="float-left icon icon-$name">"""
   }
 
   object Images {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -122,7 +122,7 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
   override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
 }
 
-object EmailArticleImage extends Profile(width = Some(640))
+object EmailImage extends Profile(width = Some(640))
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -116,6 +116,11 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           }
           else if (request.isJson)
             Cached(CacheTime.Facia)(JsonFront(faciaPage))
+          else if (request.isEmail) {
+            Cached(CacheTime.Facia) {
+              RevalidatableResult.Ok(InlineStyles(views.html.frontEmail(faciaPage)))
+            }
+          }
           else {
             Cached(CacheTime.Facia) {
               RevalidatableResult.Ok(views.html.front(faciaPage))

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -1,0 +1,85 @@
+@import layout.{FaciaCard, FaciaCardHeader}
+@import model.pressed.PressedContent
+@import layout.EditionalisedLink
+@(page: model.PressedPage)(implicit request: RequestHeader)
+
+@import conf.Static
+@import views.support.EmailHelpers._
+@import views.support.TrailCssClasses.toneClass
+@import views.html.fragments.items.elements.facia_cards.kicker
+@import model.pressed.{FreeHtmlKicker, ItemKicker, KickerProperties}
+
+@headline(pressedContent: PressedContent) = {
+    <h3 class="headline">
+        @defining(FaciaCardHeader.fromTrail(pressedContent, None)) { header =>
+            @kicker(header, Seq())
+            @if(header.kicker.isDefined) {
+                <span class="kicker-separator">/</span>
+            }
+        }
+        @pressedContent.header.headline
+    </h3>
+}
+
+@faciaCardLarge(pressedContent: PressedContent) = {
+    @paddedRow {
+        @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
+            <a @Html(href) class="facia-card facia-card--large @toneClass(pressedContent)">
+                @imageUrlFromPressedContent(pressedContent).map { url =>
+                    <img width="580" class="media--main" src="@url" />
+                }
+                @headline(pressedContent)
+                @pressedContent.card.trailText.map { trailText =>
+                    <h4 class="trail-text">@trailText</h4>
+                }
+            </a>
+        }
+    }
+}
+
+@faciaCardSmall(pressedContent: PressedContent) = {
+    @paddedRow(Seq("sub-grid")) {
+        @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
+            <a @Html(href) class="facia-card @toneClass(pressedContent)">
+                <table>
+                    <tr>
+                        <td class="seven sub-columns">
+                            @headline(pressedContent)
+                        </td>
+                        <td class="five sub-columns last">
+                            @imageUrlFromPressedContent(pressedContent).map { url =>
+                                <img width="580" class="media--main" src="@url" />
+                            }
+                        </td>
+                    </tr>
+                </table>
+            </a>
+        }
+    }
+}
+
+@fullRow {
+    <img width="580" src="@Static("images/email/banners/generic.png")">
+}
+
+@page.frontProperties.onPageDescription.map { description =>
+    @paddedRow {
+        <p>@description</p>
+    }
+}
+
+@page.collections.zipWithIndex.map { case (collection, collectionIndex) =>
+    @paddedRow {
+        <h2 class="container-title @if(collectionIndex > 0) { container-title--not-first }">
+            @collection.displayName
+        </h2>
+    }
+
+    @collection.curatedPlusBackfillDeduplicated.zipWithIndex.map { case (pressedContent, cardIndex) =>
+        @if(cardIndex == 0) {
+            @faciaCardLarge(pressedContent)
+        } else {
+            @faciaCardSmall(pressedContent)
+        }
+    }
+}

--- a/facia/app/views/frontEmail.scala.html
+++ b/facia/app/views/frontEmail.scala.html
@@ -1,0 +1,5 @@
+@(page: model.PressedPage)(implicit request: RequestHeader)
+
+@mainEmail(page) {
+    @fragments.emailFrontBody(page)
+}


### PR DESCRIPTION
## What does this change?

Extends @desbo's work on rendering articles with email-friendly HTML, which began in #11673. Now fronts can also be rendered as emails with either the `/email` slug or `?format=email` parameter. e.g. http://www.theguardian.com/politics?format=email
## What is the value of this and can you measure success?

Currently, emails which consist mainly of links ("email collections") are generated by the [gu-email-renderer](https://github.com/guardian/gu-email-renderer). This has two main limitations:
- Emails are rendered in an old R2 design
- Changes to the structure & contents of certain emails require developer involvement

Rendering fronts as emails gives us an opportunity to reskin our link-based emails while also giving control back to editorial via the fronts tool. Editorial staff can now apply all the flexibility of fronts to emails, including:
- Determine what sections appear in an email
- Choose specific articles to appear in those sections
- Autopopulate sections with CAPI queries (via backfill)
- Override kickers, headlines, trail text etc if desired
- Choose external links to populate certain sections
- Add custom text to the top of the email
- etc...

The metrics that we're hoping to ultimately influence with all this control are:
- Click-To-Open rate of our link-based emails (proportion of people that read an email who click on at least one link in it)
- therefore web traffic from email products
- ...therefore visit frequency for non-regulars
## Does this affect other platforms - Amp, Apps, etc?

Just web
## Screenshots
### The front

![screencapture-m-thegulocal-email-the-flyer-1473337874565](https://cloud.githubusercontent.com/assets/5122968/18349310/a4041224-75c8-11e6-9e7c-7229ecebbb55.png)
### The email

![screencapture-m-thegulocal-email-the-flyer-1473337825739](https://cloud.githubusercontent.com/assets/5122968/18349307/a2b38eae-75c8-11e6-926a-0549c9b6c6f1.png)
## Request for comment

@desbo @katebee 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
