### PR TITLE
Small revamp of the ELB admin dashboard

### DIFF
--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -7,8 +7,6 @@ import play.api.mvc.Action
 import tools._
 import model.NoCache
 import conf.Configuration
-import tools.CloudWatch._
-import play.api.Play.current
 
 import scala.concurrent.Future
 
@@ -19,9 +17,8 @@ class MetricsController(wsClient: WSClient) extends Controller with Logging with
 
   def renderLoadBalancers() = Action.async { implicit request =>
     for {
-      latency <- CloudWatch.fullStackLatency
-      fullStackOks <- CloudWatch.requestOkFullStack
-    } yield NoCache(Ok(views.html.lineCharts("PROD", (latency ++ fullStackOks).groupBy(_.name).flatMap(_._2).toSeq)))
+      graphs <- CloudWatch.dualOkLatencyFullStack
+    } yield NoCache(Ok(views.html.lineCharts("PROD", graphs)))
   }
 
   def renderErrors() = Action.async { implicit request =>

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -66,6 +66,7 @@ trait Chart {
   def dataset: Seq[ChartRow]
   def hasData = dataset.nonEmpty
   def format: ChartFormat
+  def dualY: Boolean = false
 
   def asDataset = s"[[$labelString], $dataString]"
 
@@ -134,6 +135,10 @@ class AwsLineChart(
 
 class AwsDailyLineChart(name: String, labels: Seq[String], format: ChartFormat, charts: GetMetricStatisticsResult*) extends AwsLineChart(name, labels, format, charts:_*) {
   override def toLabel(date: DateTime): String = date.withZone(format.timezone).toString("dd/MM")
+}
+
+class AwsDualYLineChart(name: String, labels: (String, String, String), format: ChartFormat, chartOne: GetMetricStatisticsResult, chartTwo: GetMetricStatisticsResult) extends AwsLineChart(name, Seq(labels._1, labels._2, labels._3), format, chartOne, chartTwo) {
+  override def dualY = true
 }
 
 class ABDataChart(name: String, ablabels: Seq[String], format: ChartFormat, charts: GetMetricStatisticsResult*) extends AwsLineChart(name, ablabels, format, charts:_*) {

--- a/admin/app/views/fragments/lineChart.scala.html
+++ b/admin/app/views/fragments/lineChart.scala.html
@@ -13,6 +13,12 @@
                 vAxis: {title: '@chart.labels(1)'},
             } else {
                 legend: { position: "in" },
+                @if(chart.dualY){
+                    series: {
+                        0: {targetAxisIndex: 0},
+                        1: {targetAxisIndex: 1}
+                    },
+                }
             }
             chartArea: { width: "85%" },
             titleTextStyle: {color: '#999'},


### PR DESCRIPTION
## What does this change?
1. Adding the number of healthy instances for each ELB (next to the name). _I was kind of tired to go to the AWS console and filter out the CODE elbs to know how many instances were up._
2. Grouping latency and 2xx/mins count for each ELB into a single graph. _Only one graph per ELB: Less graphs => less scrolling. I don't think having 2 lines per graph is worsening the graph readability and it makes easier to spot correlation (or non-correlation) between the two metrics._
3. Some small refactoring.
## What is the value of this and can you measure success?

Dashboard is more useful.
## Screenshots

![screen shot 2016-09-09 at 11 25 03](https://cloud.githubusercontent.com/assets/233326/18384388/25c555ac-7682-11e6-9c59-e2baa0b2df67.png)
I am open to suggestion in term of color scheme :wink:
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
