### PR TITLE
Remove superfluous variable names from `ABTestSwitches`

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -1,12 +1,13 @@
 package conf.switches
 
 import common.Edition
+import conf.switches.SwitchGroup.ABTests
 import org.joda.time.LocalDate
 
 trait ABTestSwitches {
 
-  val ABLiveBlogChromeNotificationsProd2 = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-live-blog-chrome-notifications-prod2",
     "Live blog chrome notifications - prod",
     owners = Seq(Owner.withGithub("janua")),
@@ -15,8 +16,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABDiscussionExternalFrontend = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-discussion-external-frontend-count",
     "Standalone frontend discussion",
     owners = Seq(Owner.withGithub("piuccio")),
@@ -25,8 +26,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABHostedArticleOnwardJourney = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-hosted-article-onward-journey",
     "Vertical positioning of the onward journey links",
     owners = Seq(Owner.withGithub("lps88")),
@@ -35,8 +36,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABHostedGalleryCallToAction = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-hosted-gallery-cta",
     "Test which gallery image to put the call to action link on",
     owners = Seq(Owner.withGithub("lps88")),
@@ -47,7 +48,7 @@ trait ABTestSwitches {
 
 
   val ABContributionsEmbed20160905= Switch(
-    SwitchGroup.ABTests,
+    ABTests,
     "ab-contributions-embed-20160905",
     "Test whether contributions embed performs better inline and in-article than at the bottom of the article.",
     owners = Seq(Owner.withGithub("jranks123")),
@@ -56,8 +57,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABContributionsEpic20160906 = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-contributions-epic-20160906",
     "Test whether contributions embed performs better than our previous in-article component tests.",
     owners = Seq(Owner.withGithub("jranks123")),
@@ -66,8 +67,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABContributionsEpicButtons20160907 = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-contributions-epic-buttons-20160907",
     "Test whether adding the amount buttons to the epic increases the impressions to conversions rate.",
     owners = Seq(Owner.withGithub("jranks123")),
@@ -76,8 +77,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABParticipationDiscussionOrderingLiveBlogs = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-participation-discussion-ordering-live-blog",
     "Test to see whether ordering comments by recommends on live blogs increases the number oof people who read them",
     owners = Seq(Owner.withGithub("NathanielBennett")),
@@ -87,7 +88,7 @@ trait ABTestSwitches {
   )
 
   for (edition <- Edition.all) Switch(
-    SwitchGroup.ABTests,
+    ABTests,
     "ab-membership-engagement-banner-"+edition.id.toLowerCase,
     "Test effectiveness of header for driving contributions vs membership.",
     owners = Seq(Owner.withGithub("rtyley")),
@@ -96,8 +97,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABAdFeedback = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-ad-feedback",
     "Solicit feedback for ad impressions",
     owners = Seq(Owner.withGithub("justinpinner")),
@@ -106,8 +107,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABRecommendedForYou = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-recommended-for-you",
     "Test demand for a personalised container on fronts",
     owners = Seq(Owner.withGithub("joelochlann")),
@@ -116,8 +117,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABDontUpgradeMobileRichLinks = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-dont-upgrade-mobile-rich-links",
     "Test whether the loyalty of users decreases with non-enhanced rich links",
     owners = Seq(Owner.withGithub("gtrufitt")),
@@ -126,8 +127,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABAdBlockingResponse = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-ad-blocking-response",
     "Prominent adblocker response test",
     owners = Seq(Owner.withGithub("justinpinner")),
@@ -136,8 +137,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABWeekendReadingEmail = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-weekend-reading-email",
     "Try out two formats for the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),
@@ -146,8 +147,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABNoSocialCount = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-no-social-count",
     "Remove social count from articles",
     owners = Seq(Owner.withGithub("gtrufitt")),
@@ -156,8 +157,8 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABWeekendReadingPromo = Switch(
-    SwitchGroup.ABTests,
+  Switch(
+    ABTests,
     "ab-weekend-reading-promo",
     "Show visitors a snap banner to promote the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),


### PR DESCRIPTION
The names don't help anything:
- no individual reference is made server-side to any of these A/B switches
- the `Switch()` constructor [automatically registers itself](https://github.com/guardian/frontend/blob/08649d62/common/app/conf/switches/Switches.scala#L107) in a full list of switches in the JVM, so the switch appears in https://frontend.gutools.co.uk/dev/switchboard

... and the additional Scala `val` identifiers duplicate the name already given within the switch, which just adds noise.

cc @desbo
