### PR TITLE
Extend recommended for you feature switch by a week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -112,7 +112,7 @@ trait ABTestSwitches {
     "Test demand for a personalised container on fronts",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 9),
+    sellByDate = new LocalDate(2016, 9, 16),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -30,11 +30,11 @@ define([
     return function () {
         this.id = 'RecommendedForYou';
         this.start = '2016-08-02';
-        this.expiry = '2016-09-09';
+        this.expiry = '2016-09-16';
         this.author = 'Joseph Smith';
         this.description = 'Add a personalised container to fronts';
-        this.audience = 0.1;
-        this.audienceOffset = 0.1;
+        this.audience = 0;
+        this.audienceOffset = 0;
         this.successMeasure = 'Number of clicks to turn on this section';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';


### PR DESCRIPTION
Extend #13965 by a week - we're not still gathering data from users but we'll be demoing some of the tests we've run to Kate on Monday I want to still be able to switch this on for CODE frontend.
