### PR TITLE
cAPI driven hosted article - inline styles added

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle2.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle2.scala.html
@@ -3,8 +3,38 @@
 @import views.html.hosted._
 
 @main(page, Some("commercial")) { } {
-    @guardianHostedHeader("hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
-    <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
+    <!--[if (gt IE 9)|(IEMobile)]><!-->
+    <style>
+    .hosted-tone {
+    color: @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted-tone-bg {
+    background-color: @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted-tone-btn,
+    .hosted-tone-btn:focus,
+    .hosted-tone-btn:hover {
+    background-color: @{page.campaign.fontColour.brandColour};
+    border-color: @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted-page .hosted__next-video--tile {
+    border-top-color: @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted-page .hosted__link {
+    color: @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted-page ~ .survey-overlay-simple .survey-text__header {
+    background-color: @{page.campaign.fontColour.brandColour};
+    }
+    </style>
+    <!--<![endif]-->
+    @guardianHostedHeader(if(page.campaign.fontColour.shouldHaveBrightFont) "hosted-article-page hosted-page--bright" else "hosted-article-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
+    <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
 
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">
             <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">

--- a/common/app/common/commercial/hosted/HostedArticlePage2.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage2.scala
@@ -82,7 +82,7 @@ object HostedArticlePage2 extends Logging {
           logo = HostedLogo(
             url = sponsorship.sponsorLogo
           ),
-          cssClass = "renault",
+          cssClass = "", //TODO remove this variable later
           fontColour = FontColour(hostedTag.paidContentCampaignColour getOrElse ""),
           logoLink = None
         ),


### PR DESCRIPTION
## What does this change?

Similar to the hosted video pages https://github.com/guardian/frontend/pull/14018 we have to include inline styles with brand specific colour. This PR adds those styles into template.

I am aware that the red colour does not look right. The contrast font is calculated correctly, because based on the http://www.colorhexa.com/e31b22, the brightness value in the `HSB` format is equal to 89 therefore font should be dark. We may have to change that.

The work on this page is still in progress. We need to upload correct CTA and top banner images. We also have to think about adding some padding around the brand logo.
## Screenshots

![screen shot 2016-09-09 at 17 14 18](https://cloud.githubusercontent.com/assets/489567/18394276/01f1bcae-76b1-11e6-9517-1ddedaf1250f.png)

![screen shot 2016-09-09 at 17 14 29](https://cloud.githubusercontent.com/assets/489567/18394281/05fecc7e-76b1-11e6-9532-88b0e1a0143e.png)
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
