### PR TITLE
cAPI driven hosted video page fix

### DIFF
--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -80,7 +80,7 @@ object HostedVideoPage extends Logging {
           logo = HostedLogo(
             url = sponsorship.sponsorLogo
           ),
-          cssClass = "renault",
+          cssClass = "",
           fontColour = FontColour(hostedTag.paidContentCampaignColour getOrElse ""),
           logoLink = None
         ),


### PR DESCRIPTION
## What does this change?

The wrong cssClass value should be removed because it causes wrong styling.
## Screenshots

Before:
![screen shot 2016-09-12 at 12 42 53](https://cloud.githubusercontent.com/assets/489567/18434736/c48f5c80-78e6-11e6-94cf-0b645b888282.png)

After:
![screen shot 2016-09-12 at 12 43 07](https://cloud.githubusercontent.com/assets/489567/18434745/d39860b4-78e6-11e6-992b-dce47becc48e.png)
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
