### PR TITLE
Inject `wsClient` into `OphanApi` rather than calling `WS`

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -10,7 +10,7 @@ import _root_.dfp.DfpDataCacheLifecycle
 import http.AdminHttpErrorHandler
 import dev.DevAssetsController
 import football.feed.MatchDayRecorder
-import jobs.{FastlyCloudwatchLoadJob, R2PagePressJob, VideoEncodingsJob}
+import jobs.{FastlyCloudwatchLoadJob, R2PagePressJob, VideoEncodingsJob, AnalyticsSanityCheckJob}
 import model.{AdminLifecycle, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
@@ -19,7 +19,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
-import services.{ConfigAgentLifecycle, FastlyStatisticService, EmailService}
+import services.{ConfigAgentLifecycle, EmailService, FastlyStatisticService, OphanApi}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -29,12 +29,14 @@ class AppLoader extends FrontendApplicationLoader {
 trait AdminServices {
   def wsClient: WSClient
   def akkaAsync: AkkaAsync
+  lazy val ophanApi = wire[OphanApi]
   lazy val emailService = wire[EmailService]
   lazy val fastlyStatisticService = wire[FastlyStatisticService]
   lazy val fastlyCloudwatchLoadJob = wire[FastlyCloudwatchLoadJob]
   lazy val r2PagePressJob = wire[R2PagePressJob]
   lazy val videoEncodingsJob = wire[VideoEncodingsJob]
   lazy val matchDayRecorder = wire[MatchDayRecorder]
+  lazy val analyticsSanityCheckJob = wire[AnalyticsSanityCheckJob]
 }
 
 trait Controllers extends AdminControllers {

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -8,12 +8,14 @@ import controllers.cache.{ImageDecacheController, PageDecacheController}
 import jobs.VideoEncodingsJob
 import play.api.libs.ws.WSClient
 import play.api.Mode
+import services.OphanApi
 
 trait AdminControllers {
   def akkaAsync: AkkaAsync
   def wsClient: WSClient
   def videoEncodingsJob: VideoEncodingsJob
   def mode: Mode.Mode
+  def ophanApi: OphanApi
   lazy val oAuthLoginController = wire[OAuthLoginAdminController]
   lazy val uncachedWebAssets = wire[UncachedWebAssets]
   lazy val uncachedAssets = wire[UncachedAssets]

--- a/admin/app/controllers/OphanApiController.scala
+++ b/admin/app/controllers/OphanApiController.scala
@@ -5,19 +5,18 @@ import play.api.mvc._
 import services.OphanApi
 import model.NoCache
 
-
-class OphanApiController extends Controller with ExecutionContexts {
+class OphanApiController(ophanApi: OphanApi) extends Controller with ExecutionContexts {
 
   def pageViews(path: String) = Action.async { request =>
-    OphanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
+    ophanApi.getBreakdown(path) map (body => NoCache(Ok(body) as "application/json"))
   }
 
   def platformPageViews = Action.async { request =>
-    OphanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
+    ophanApi.getBreakdown(platform = "next-gen", hours = 2) map (body => NoCache(Ok(body) as "application/json"))
   }
 
   def adsRenderTime = Action.async { request =>
-    OphanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
+    ophanApi.getAdsRenderTime(request.queryString) map (body => NoCache(Ok(body) as "application/json"))
   }
 
 }

--- a/admin/app/jobs/AnalyticsSanityCheckJob.scala
+++ b/admin/app/jobs/AnalyticsSanityCheckJob.scala
@@ -12,7 +12,7 @@ import services.{CloudWatchStats, OphanApi}
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
-object AnalyticsSanityCheckJob extends ExecutionContexts with Logging {
+class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends ExecutionContexts with Logging {
 
   private val rawPageViews = new AtomicLong(0L)
   private val omniturePageViews = new AtomicLong(0L)
@@ -76,7 +76,7 @@ object AnalyticsSanityCheckJob extends ExecutionContexts with Logging {
 
   private def ophanViews: Future[Long] = {
     val now = new DateTime().minusMinutes(15).getMillis
-    OphanApi.getBreakdown("next-gen", hours = 1).map { json =>
+    ophanApi.getBreakdown("next-gen", hours = 1).map { json =>
       (json \\ "data").flatMap {
         line =>
           val recent = line.asInstanceOf[play.api.libs.json.JsArray].value.filter {

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -23,7 +23,8 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
                      fastlyCloudwatchLoadJob: FastlyCloudwatchLoadJob,
                      r2PagePressJob: R2PagePressJob,
                      videoEncodingsJob: VideoEncodingsJob,
-                     matchDayRecorder: MatchDayRecorder)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+                     matchDayRecorder: MatchDayRecorder,
+                     analyticsSanityCheckJob: AnalyticsSanityCheckJob)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
 
   appLifecycle.addStopHook { () => Future {
     descheduleJobs()
@@ -60,7 +61,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
 
     //every 2, 17, 32, 47 minutes past the hour, on the 12th second past the minute (e.g 13:02:12, 13:17:12)
     jobs.schedule("AnalyticsSanityCheckJob", "12 2/15 * * * ?") {
-      AnalyticsSanityCheckJob.run()
+      analyticsSanityCheckJob.run()
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobHighFrequency", adminPressJobHighPushRateInMinutes) {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -13,7 +13,6 @@ import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, Quiz}
 import model.pressed._
-import ophan.SurgingContentAgent
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
@@ -69,7 +68,6 @@ final case class Content(
   showFooterContainers: Boolean = false
 ) {
 
-  lazy val isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(metadata.id)
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
   lazy val isSeries: Boolean = tags.series.nonEmpty
   lazy val isFromTheObserver: Boolean = publication == "The Observer"

--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -1,7 +1,6 @@
 @(page: model.Page)(implicit request: RequestHeader)
 @import common.{Edition, StringEncodings}
 @import conf.Static
-@import views.support.{JavaScriptPage, CamelCase}
 @import play.api.libs.json.Json
 
 var isModernBrowser =

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import http.CorsHttpErrorHandler
 import app.{FrontendApplicationLoader, FrontendComponents}
-import business.StocksDataLifecycle
+import business.{StocksData, StocksDataLifecycle}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
@@ -8,7 +8,7 @@ import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.{HealthCheck, OnwardControllers}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
-import feed.{MostPopularFacebookAutoRefreshLifecycle, MostReadLifecycle, OnwardJourneyLifecycle}
+import feed._
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
@@ -17,9 +17,26 @@ import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
 import router.Routes
+import services.OphanApi
+import weather.WeatherApi
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
+}
+
+trait OnwardServices {
+  def wsClient: WSClient
+  def environment: Environment
+  lazy val ophanApi = wire[OphanApi]
+  lazy val stocksData = wire[StocksData]
+  lazy val weatherApi = wire[WeatherApi]
+  lazy val geoMostPopularAgent = wire[GeoMostPopularAgent]
+  lazy val dayMostPopularAgent = wire[DayMostPopularAgent]
+  lazy val mostReadAgent = wire[MostReadAgent]
+  lazy val mostPopularSocialAutoRefresh = wire[MostPopularSocialAutoRefresh]
+  lazy val mostViewedAudioAgent = wire[MostViewedAudioAgent]
+  lazy val mostViewedGalleryAgent = wire[MostViewedGalleryAgent]
+  lazy val mostViewedVideoAgent = wire[MostViewedVideoAgent]
 }
 
 trait Controllers extends OnwardControllers {
@@ -29,7 +46,7 @@ trait Controllers extends OnwardControllers {
 }
 
 trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
+  self: FrontendComponents with Controllers with OnwardServices =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -43,7 +60,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with OnwardServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -8,10 +8,9 @@ import model._
 import play.api.libs.json._
 import play.api.mvc.{Action, Controller, RequestHeader}
 import views.support.FaciaToMicroFormat2Helpers._
-
 import scala.concurrent.Future
 
-class MostPopularController extends Controller with Logging with ExecutionContexts {
+class MostPopularController(geoMostPopularAgent: GeoMostPopularAgent, dayMostPopularAgent: DayMostPopularAgent) extends Controller with Logging with ExecutionContexts {
   val page = SimplePage(MetaData.make(
     "most-read",
     Some(SectionSummary.fromId("most-read")),
@@ -59,7 +58,7 @@ class MostPopularController extends Controller with Logging with ExecutionContex
     val headers = request.headers.toSimpleMap
     val countryCode = headers.getOrElse("X-GU-GeoLocation","country:row").replace("country:","")
 
-    val countryPopular = MostPopular("across the guardian", "", GeoMostPopularAgent.mostPopular(countryCode).map(_.faciaContent))
+    val countryPopular = MostPopular("across the guardian", "", geoMostPopularAgent.mostPopular(countryCode).map(_.faciaContent))
 
     Cached(900) {
       JsonComponent(
@@ -73,7 +72,7 @@ class MostPopularController extends Controller with Logging with ExecutionContex
   def renderPopularDay(countryCode: String) = Action { implicit request =>
     Cached(900) {
       JsonComponent(
-        "trails" -> JsArray(DayMostPopularAgent.mostPopular(countryCode).map{ trail =>
+        "trails" -> JsArray(dayMostPopularAgent.mostPopular(countryCode).map{ trail =>
           Json.obj(
             ("url", trail.content.metadata.url),
             ("headline", trail.content.trail.headline)
@@ -112,5 +111,3 @@ class MostPopularController extends Controller with Logging with ExecutionContex
     }
   }
 }
-
-object MostPopularController extends MostPopularController

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
-class MostViewedAudioController extends Controller with Logging with ExecutionContexts {
+class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent) extends Controller with Logging with ExecutionContexts {
   def renderMostViewed() = Action { implicit request =>
     getMostViewedAudio match {
       case Nil => Cached(60) { JsonNotFound() }
@@ -26,12 +26,12 @@ class MostViewedAudioController extends Controller with Logging with ExecutionCo
 
   private def getMostViewedAudio()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("4").toInt
-    MostViewedAudioAgent.mostViewedAudio().take(size).toList
+    mostViewedAudioAgent.mostViewedAudio().take(size).toList
   }
 
   private def getMostViewedPodcast()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("4").toInt
-    MostViewedAudioAgent.mostViewedPodcast().take(size).toList
+    mostViewedAudioAgent.mostViewedPodcast().take(size).toList
   }
 
   private def renderMostViewedAudio(audios: Seq[RelatedContentItem], mediaType: String)(implicit request: RequestHeader) = Cached(900) {
@@ -54,5 +54,3 @@ class MostViewedAudioController extends Controller with Logging with ExecutionCo
     )
   }
 }
-
-object MostViewedAudioController extends MostViewedAudioController

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
-class MostViewedGalleryController extends Controller with Logging with ExecutionContexts {
+class MostViewedGalleryController(mostViewedGalleryAgent: MostViewedGalleryAgent) extends Controller with Logging with ExecutionContexts {
 
   private val page = SimplePage(MetaData.make(
     "more galleries",
@@ -40,7 +40,7 @@ class MostViewedGalleryController extends Controller with Logging with Execution
 
   private def getMostViewedGallery()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("6").toInt
-    MostViewedGalleryAgent.mostViewedGalleries().take(size).toList
+    mostViewedGalleryAgent.mostViewedGalleries().take(size).toList
   }
 
   private def renderMostViewedGallery(galleries: Seq[RelatedContentItem])(implicit request: RequestHeader) = {
@@ -60,5 +60,3 @@ class MostViewedGalleryController extends Controller with Logging with Execution
     renderFormat(htmlResponse, jsonResponse, 900)
   }
 }
-
-object MostViewedGalleryController extends MostViewedGalleryController

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -13,9 +13,9 @@ import slices.Fixed
 
 import scala.concurrent.Future.{successful => unit}
 
-class MostViewedSocialController extends Controller with ExecutionContexts {
+class MostViewedSocialController(mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh) extends Controller with ExecutionContexts {
   def renderMostViewed(socialContext: String) = Action.async { implicit request =>
-    val mostPopularSocial = MostPopularSocialAutoRefresh.get
+    val mostPopularSocial = mostPopularSocialAutoRefresh.get
 
     val articles = socialContext match {
       case "twitter" => mostPopularSocial.map(_.twitter)
@@ -68,5 +68,3 @@ class MostViewedSocialController extends Controller with ExecutionContexts {
     }
   }
 }
-
-object MostViewedSocialController extends MostViewedSocialController

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{Action, Controller}
 import contentapi.ContentApiClient
 import contentapi.ContentApiClient.getResponse
 
-class MostViewedVideoController extends Controller with Logging with ExecutionContexts {
+class MostViewedVideoController(mostViewedVideoAgent: MostViewedVideoAgent) extends Controller with Logging with ExecutionContexts {
 
   // Move this out of here if the test is successful
   def renderInSeries(series: String) = Action.async { implicit request =>
@@ -44,7 +44,7 @@ class MostViewedVideoController extends Controller with Logging with ExecutionCo
   def renderMostViewed() = Action { implicit request =>
 
     val size = request.getQueryString("size").getOrElse("6").toInt
-    val videos = MostViewedVideoAgent.mostViewedVideo().take(size)
+    val videos = mostViewedVideoAgent.mostViewedVideo().take(size)
 
     if (videos.nonEmpty) {
       Cached(900) {
@@ -59,5 +59,3 @@ class MostViewedVideoController extends Controller with Logging with ExecutionCo
     }
   }
 }
-
-object MostViewedVideoController extends MostViewedVideoController

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -3,18 +3,23 @@ package controllers
 import com.softwaremill.macwire._
 import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData
-import weather.WeatherApi
+import feed._
 import play.api.libs.ws.WSClient
-import play.api.Environment
+import weather.WeatherApi
 
-trait OnwardServices {
+trait OnwardControllers {
+
   def wsClient: WSClient
-  def environment: Environment
-  lazy val stocksData = wire[StocksData]
-  lazy val weatherApi = wire[WeatherApi]
-}
+  def stocksData: StocksData
+  def weatherApi: WeatherApi
+  def geoMostPopularAgent: GeoMostPopularAgent
+  def dayMostPopularAgent: DayMostPopularAgent
+  def mostReadAgent: MostReadAgent
+  def mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh
+  def mostViewedVideoAgent: MostViewedVideoAgent
+  def mostViewedGalleryAgent: MostViewedGalleryAgent
+  def mostViewedAudioAgent: MostViewedAudioAgent
 
-trait OnwardControllers extends OnwardServices {
   lazy val navigationController = wire[NavigationController]
   lazy val weatherController = wire[WeatherController]
   lazy val locationsController = wire[LocationsController]

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -2,11 +2,12 @@ package controllers
 
 import common._
 import containers.Containers
+import feed.MostReadAgent
 import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import services._
 
-class PopularInTag extends Controller with Related with Containers with Logging with ExecutionContexts {
+class PopularInTag(val mostReadAgent: MostReadAgent) extends Controller with Related with Containers with Logging with ExecutionContexts {
   def render(tag: String) = Action.async { implicit request =>
     val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
@@ -27,5 +28,3 @@ class PopularInTag extends Controller with Related with Containers with Logging 
     )
   }
 }
-
-object PopularInTag extends PopularInTag

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import common._
 import containers.Containers
+import feed.MostReadAgent
 import model.Cached.RevalidatableResult
 import model._
 import play.api.libs.json._
@@ -11,7 +12,7 @@ import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
 
 import scala.concurrent.duration._
 
-class RelatedController extends Controller with Related with Containers with Logging with ExecutionContexts {
+class RelatedController(val mostReadAgent: MostReadAgent) extends Controller with Related with Containers with Logging with ExecutionContexts {
 
   private val page = SimplePage(MetaData.make(
     "related-content",
@@ -61,5 +62,3 @@ class RelatedController extends Controller with Related with Containers with Log
     )
   }
 }
-
-object RelatedController extends RelatedController

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -4,6 +4,7 @@ import com.gu.contentapi.client.GuardianContentApiError
 import common._
 import contentapi.ContentApiClient
 import contentapi.ContentApiClient.getResponse
+import feed.MostReadAgent
 import model._
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc.{Action, Controller, RequestHeader}
@@ -11,7 +12,7 @@ import services._
 
 import scala.concurrent.Future
 
-class TaggedContentController extends Controller with Related with Logging with ExecutionContexts {
+class TaggedContentController(val mostReadAgent: MostReadAgent) extends Controller with Related with Logging with ExecutionContexts {
 
   def renderJson(tag: String) = Action.async { implicit request =>
     tagWhitelist.find(_ == tag).map { tag =>
@@ -56,5 +57,3 @@ class TaggedContentController extends Controller with Related with Logging with 
     }
   }
 }
-
-object TaggedContentController extends TaggedContentController

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -31,7 +31,7 @@ object MostPopularAgent extends Logging with ExecutionContexts {
 
 }
 
-object GeoMostPopularAgent extends Logging with ExecutionContexts {
+class GeoMostPopularAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   private val ophanPopularAgent = AkkaAgent[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
@@ -47,7 +47,7 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
   }
 
   def update(countryCode: String) {
-    val ophanQuery = OphanApi.getMostRead(hours = 3, count = 10, country = countryCode.toLowerCase)
+    val ophanQuery = ophanApi.getMostRead(hours = 3, count = 10, country = countryCode.toLowerCase)
 
     ophanQuery.map { ophanResults =>
 
@@ -85,7 +85,7 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
   }
 }
 
-object DayMostPopularAgent extends Logging with ExecutionContexts {
+class DayMostPopularAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   private val ophanPopularAgent = AkkaAgent[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
@@ -99,7 +99,7 @@ object DayMostPopularAgent extends Logging with ExecutionContexts {
   }
 
   def update(countryCode: String) {
-    val ophanQuery = OphanApi.getMostRead(hours = 24, count = 10, country = countryCode)
+    val ophanQuery = ophanApi.getMostRead(hours = 24, count = 10, country = countryCode)
 
     ophanQuery.map { ophanResults =>
 

--- a/onward/app/feed/MostPopularSocialAutoRefresh.scala
+++ b/onward/app/feed/MostPopularSocialAutoRefresh.scala
@@ -11,24 +11,26 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class MostReadSocial(twitter: Seq[MostReadItem], facebook: Seq[MostReadItem])
 
-object MostPopularSocialAutoRefresh extends AutoRefresh[MostReadSocial](0.seconds, 3.minutes) {
+class MostPopularSocialAutoRefresh(ophanApi: OphanApi) extends AutoRefresh[MostReadSocial](0.seconds, 3.minutes) {
   val Hours = 3
 
   override protected def refresh(): Future[MostReadSocial] = {
     for {
-      facebookMostRead <- OphanApi.getMostReadFacebook(Hours)
-      twitterMostRead <- OphanApi.getMostReadTwitter(Hours)
+      facebookMostRead <- ophanApi.getMostReadFacebook(Hours)
+      twitterMostRead <- ophanApi.getMostReadTwitter(Hours)
     } yield MostReadSocial(twitterMostRead, facebookMostRead)
   }
 }
 
-class MostPopularFacebookAutoRefreshLifecycle(appLifeCycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent {
+class MostPopularFacebookAutoRefreshLifecycle(appLifeCycle: ApplicationLifecycle,
+                                              mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh)
+                                             (implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () => Future {
-    MostPopularSocialAutoRefresh.stop()
+    mostPopularSocialAutoRefresh.stop()
   }}
 
   override def start(): Unit = {
-    MostPopularSocialAutoRefresh.start()
+    mostPopularSocialAutoRefresh.start()
   }
 }

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -2,10 +2,9 @@ package feed
 
 import common._
 import play.api.libs.json.{JsArray, JsValue}
-import java.net.URL
 import services.OphanApi
 
-object MostReadAgent extends Logging with ExecutionContexts {
+class MostReadAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   private val agent = AkkaAgent[Map[String, Int]](Map.empty)
 
@@ -13,7 +12,7 @@ object MostReadAgent extends Logging with ExecutionContexts {
     log.info("Refreshing most read.")
 
     // limiting to sport/football section for now as this is only used by popular-in-tag component
-    val ophanQuery = OphanApi.getMostReadInSection("sport,football", 2, 1000)
+    val ophanQuery = ophanApi.getMostReadInSection("sport,football", 2, 1000)
 
     ophanQuery.map{ ophanResults =>
 

--- a/onward/app/feed/MostReadLifecycle.scala
+++ b/onward/app/feed/MostReadLifecycle.scala
@@ -9,7 +9,8 @@ import scala.concurrent.{Future, ExecutionContext}
 class MostReadLifecycle(
   appLifecycle: ApplicationLifecycle,
   jobs: JobScheduler,
-  akkaAsync: AkkaAsync
+  akkaAsync: AkkaAsync,
+  mostReadAgent: MostReadAgent
 )(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () => Future {
@@ -21,11 +22,11 @@ class MostReadLifecycle(
 
     // update every 30 min
     jobs.schedule("MostReadAgentRefreshJob",  "0 0/30 * * * ?") {
-      MostReadAgent.update()
+      mostReadAgent.update()
     }
 
     akkaAsync.after1s {
-      MostReadAgent.update()
+      mostReadAgent.update()
     }
   }
 }

--- a/onward/app/feed/MostViewedAudioAgent.scala
+++ b/onward/app/feed/MostViewedAudioAgent.scala
@@ -4,10 +4,12 @@ import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem
 import play.api.libs.json.{JsArray, JsValue}
+
 import scala.concurrent.Future
 import ContentApiClient.getResponse
+import services.OphanApi
 
-object MostViewedAudioAgent extends Logging with ExecutionContexts {
+class MostViewedAudioAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   private val audioAgent = AkkaAgent[Seq[RelatedContentItem]](Nil)
   private val podcastAgent = AkkaAgent[Seq[RelatedContentItem]](Nil)
@@ -18,7 +20,7 @@ object MostViewedAudioAgent extends Logging with ExecutionContexts {
   def refresh() = {
     log.info("Refreshing most viewed audio.")
 
-    val ophanResponse = services.OphanApi.getMostViewedAudio(hours = 3, count = 100)
+    val ophanResponse = ophanApi.getMostViewedAudio(hours = 3, count = 100)
 
     ophanResponse.map { result =>
 

--- a/onward/app/feed/MostViewedGalleryAgent.scala
+++ b/onward/app/feed/MostViewedGalleryAgent.scala
@@ -4,10 +4,12 @@ import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem
 import play.api.libs.json.{JsArray, JsValue}
+
 import scala.concurrent.Future
 import ContentApiClient.getResponse
+import services.OphanApi
 
-object MostViewedGalleryAgent extends Logging with ExecutionContexts {
+class MostViewedGalleryAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   private val agent = AkkaAgent[Seq[RelatedContentItem]](Nil)
 
@@ -16,7 +18,7 @@ object MostViewedGalleryAgent extends Logging with ExecutionContexts {
   def refresh() = {
     log.info("Refreshing most viewed galleries.")
 
-    val ophanResponse = services.OphanApi.getMostViewedGalleries(hours = 3, count = 12)
+    val ophanResponse = ophanApi.getMostViewedGalleries(hours = 3, count = 12)
 
     ophanResponse.map { result =>
 

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -7,10 +7,11 @@ import contentapi.ContentApiClient
 import contentapi.ContentApiClient.getResponse
 import model.{Video, _}
 import play.api.libs.json._
+import services.OphanApi
 
 import scala.concurrent.Future
 
-object MostViewedVideoAgent extends Logging with ExecutionContexts {
+class MostViewedVideoAgent(ophanApi: OphanApi) extends Logging with ExecutionContexts {
 
   case class QueryResult(id: String, count: Double, paths: Seq[String])
 
@@ -23,7 +24,7 @@ object MostViewedVideoAgent extends Logging with ExecutionContexts {
   def refresh(): Unit = {
     log.info("Refreshing most viewed video.")
 
-    val ophanResponse = services.OphanApi.getMostViewedVideos(hours = 3, count = 20)
+    val ophanResponse = ophanApi.getMostViewedVideos(hours = 3, count = 20)
 
     ophanResponse.map { result =>
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -3,13 +3,17 @@ package feed
 import app.LifecycleComponent
 import common.{JobScheduler, AkkaAsync}
 import play.api.inject.ApplicationLifecycle
-
 import scala.concurrent.{Future, ExecutionContext}
 
 class OnwardJourneyLifecycle(
   appLifecycle: ApplicationLifecycle,
   jobs: JobScheduler,
-  akkaAsync: AkkaAsync)(implicit ec: ExecutionContext) extends LifecycleComponent {
+  akkaAsync: AkkaAsync,
+  geoMostPopularAgent: GeoMostPopularAgent,
+  dayMostPopularAgent: DayMostPopularAgent,
+  mostViewedAudioAgent: MostViewedAudioAgent,
+  mostViewedGalleryAgent: MostViewedGalleryAgent,
+  mostViewedVideoAgent: MostViewedVideoAgent)(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () => Future {
     stop()
@@ -23,25 +27,25 @@ class OnwardJourneyLifecycle(
     jobs.schedule("OnwardJourneyAgentsRefreshJob", "0 * * * * ?") {
       MostPopularAgent.refresh()
       MostPopularExpandableAgent.refresh()
-      GeoMostPopularAgent.refresh()
-      MostViewedVideoAgent.refresh()
-      MostViewedAudioAgent.refresh()
-      MostViewedGalleryAgent.refresh()
+      geoMostPopularAgent.refresh()
+      mostViewedVideoAgent.refresh()
+      mostViewedAudioAgent.refresh()
+      mostViewedGalleryAgent.refresh()
     }
 
     // fire every hour
     jobs.schedule("OnwardJourneyAgentsRefreshHourlyJob", "0 0 * * * ?") {
-      DayMostPopularAgent.refresh()
+      dayMostPopularAgent.refresh()
     }
 
     akkaAsync.after1s {
       MostPopularAgent.refresh()
       MostPopularExpandableAgent.refresh()
-      GeoMostPopularAgent.refresh()
-      MostViewedVideoAgent.refresh()
-      MostViewedAudioAgent.refresh()
-      MostViewedGalleryAgent.refresh()
-      DayMostPopularAgent.refresh()
+      geoMostPopularAgent.refresh()
+      mostViewedVideoAgent.refresh()
+      mostViewedAudioAgent.refresh()
+      mostViewedGalleryAgent.refresh()
+      dayMostPopularAgent.refresh()
     }
   }
 

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -9,6 +9,9 @@ import conf.switches.Switches.RelatedContentSwitch
 import ContentApiClient.getResponse
 
 trait Related extends ConciergeRepository {
+
+  def mostReadAgent: MostReadAgent
+
   def related(edition: Edition, path: String, excludeTags: Seq[String] = Nil): Future[RelatedContent] = {
 
     if (RelatedContentSwitch.isSwitchedOff) {
@@ -52,7 +55,7 @@ trait Related extends ConciergeRepository {
         RelatedContentItem(item)
       }
       RelatedContent(items.sortBy(content =>
-        - MostReadAgent.getViewCount(content.content.metadata.id).getOrElse(0)).take(10))
+        - mostReadAgent.getViewCount(content.content.metadata.id).getOrElse(0)).take(10))
     }
 
     trails

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -1,15 +1,26 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import controllers.MostPopularController
+import feed.{DayMostPopularAgent, GeoMostPopularAgent}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test._
 import play.api.test.Helpers._
+import services.OphanApi
 
-@DoNotDiscover class MostPopularControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MostPopularControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   val tag = "technology"
 
+  lazy val ophanApi = new OphanApi(wsClient)
+  lazy val mostPopularController = new MostPopularController(new GeoMostPopularAgent(ophanApi), new DayMostPopularAgent(ophanApi))
+
   "Most Popular Controller" should "200 when content type is tag" in {
-    val result = controllers.MostPopularController.render(tag)(TestRequest())
+    val result = mostPopularController.render(tag)(TestRequest())
     status(result) should be(200)
   }
 
@@ -18,7 +29,7 @@ import play.api.test.Helpers._
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = controllers.MostPopularController.render(tag)(fakeRequest)
+    val result = mostPopularController.render(tag)(fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")

--- a/onward/test/MostViewedVideoTest.scala
+++ b/onward/test/MostViewedVideoTest.scala
@@ -1,12 +1,22 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import controllers.MostViewedVideoController
+import feed.MostViewedVideoAgent
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
+import services.OphanApi
 
-@DoNotDiscover class MostViewedVideoTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MostViewedVideoTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
+
+  lazy val mostViewedVideoController = new MostViewedVideoController(new MostViewedVideoAgent(new OphanApi(wsClient)))
 
   "Most Viewed Video Controller" should "200 when content type is tag" in {
-    val result = controllers.MostViewedVideoController.renderMostViewed()(TestRequest())
+    val result = mostViewedVideoController.renderMostViewed()(TestRequest())
     status(result) should be(200)
   }
 }

--- a/onward/test/RelatedControllerTest.scala
+++ b/onward/test/RelatedControllerTest.scala
@@ -1,14 +1,24 @@
 package test
 
+import controllers.RelatedController
+import feed.MostReadAgent
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import services.OphanApi
 
-@DoNotDiscover class RelatedControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class RelatedControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   val article = "uk/2012/aug/07/woman-torture-burglary-waterboard-surrey"
   val badArticle = "i/am/not/here"
   val articleWithoutRelated = "childrens-books-site/2016/may/17/picasso-ed-vere"
+
+  lazy val relatedController = new RelatedController(new MostReadAgent(new OphanApi(wsClient)))
 
   it should "serve JSON when .json format is supplied" in {
     val fakeRequest = FakeRequest(GET, s"/related/${article}.json")
@@ -22,12 +32,12 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
   }
 
   it should "404 when article does not exist" in {
-    val result = controllers.RelatedController.render(badArticle)(TestRequest())
+    val result = relatedController.render(badArticle)(TestRequest())
     status(result) should be(404)
   }
 
   it should "404 when article does not have related content" in {
-    val result = controllers.RelatedController.render(articleWithoutRelated)(TestRequest())
+    val result = relatedController.render(articleWithoutRelated)(TestRequest())
     status(result) should be(404)
   }
 }

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -10,7 +10,7 @@ import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
 import services.ConfigAgentLifecycle
 
-trait StandaloneLifecycleComponents extends SportServices with CommercialServices with FapiServices {
+trait StandaloneLifecycleComponents extends SportServices with CommercialServices with FapiServices with OnwardServices {
   self: FrontendComponents =>
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],


### PR DESCRIPTION
## What does this change?

Inject `wsClient` into `OphanApi` rather than calling `WS` in preparation of Play 2.5 upgrade where global object `WS` has been deprecated

One caveat though: `OphanApi` object is called from `SurgingContentAgent` which is itself called from Page `meta` in order to populate some Javascript config value.
Until I find an elegant way to inject `OphanApi` into the `SurgingContentAgent`, I have kept the `OphanApi` object. 😢 
## What is the value of this and can you measure success?

=> Play 2.5
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
