### PR TITLE
Extend the expiry and audience of the WR snap

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -143,7 +143,7 @@ trait ABTestSwitches {
     "Try out two formats for the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 23),
+    sellByDate = new LocalDate(2016, 10, 3),
     exposeClientSide = true
   )
 
@@ -163,7 +163,7 @@ trait ABTestSwitches {
     "Show visitors a snap banner to promote the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 12),
+    sellByDate = new LocalDate(2016, 10, 3),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-promo.js
@@ -28,10 +28,10 @@ define([
     return function () {
         this.id = 'WeekendReadingPromo';
         this.start = '2016-09-01';
-        this.expiry = '2016-09-12';
+        this.expiry = '2016-10-03';
         this.author = 'Kate Whalen';
         this.description = 'For just one pageview, show users a banner promoting the Weekend Reading email';
-        this.audience = 0.5;
+        this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Snap banner promotes the Weekend Reading email and leads to visitors signing up';
         this.audienceCriteria = 'All visitors who have not yet seen this snap banner';


### PR DESCRIPTION
- Extending the Weekend Reading snap banner (#14177), and the Weekend Reading email AB test (#14171) for a couple more weeks.
- Expanding the snap banner test to include 100% of the audience.

The snap banner still goes last, since it is waiting for the emitters to fire from other banners (#14218).
