### PR TITLE
Adding link to the new Troubleshooting google doc

### DIFF
--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -115,7 +115,7 @@
                         <li><a href="https://kibana.gu-web.net/goto/1955d282a7b6cc452b673cdb9c27f1af">
                             Failing Commercial Feeds
                         </a></li>
-                        <li><a href="https://docs.google.com/a/guardian.co.uk/document/d/1Imf0MN9Gx_tWMgQBk21LyDZsKz6DVLEyJyOPLveJ_Gk/edit?usp=sharing">
+                        <li><a href="https://docs.google.com/a/guardian.co.uk/document/d/1Imf0MN9Gx_tWMgQBk21LyDZsKz6DVLEyJyOPLveJ_Gk">
                             Troubleshooting Guide</a></li>
                     </ul>
                 </div>

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -115,6 +115,8 @@
                         <li><a href="https://kibana.gu-web.net/goto/1955d282a7b6cc452b673cdb9c27f1af">
                             Failing Commercial Feeds
                         </a></li>
+                        <li><a href="https://docs.google.com/a/guardian.co.uk/document/d/1Imf0MN9Gx_tWMgQBk21LyDZsKz6DVLEyJyOPLveJ_Gk/edit?usp=sharing">
+                            Troubleshooting Guide</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## What does this change?

Adds link to the new commercial troubleshooting guide to the admin page for ease of location and access
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
