### PR TITLE
Font contrast hardcoded for the Chester Zoo hosted campaign

### DIFF
--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -50,7 +50,11 @@ case class FontColour(brandColour: String) {
     val c = new Color(rgb)
     val hsb = Color.RGBtoHSB(c.getRed, c.getGreen, c.getBlue, null)
     val brightness = hsb(2)
-    brightness > 0.5
+    if(brandColour == "#E31B22") {
+      false
+    } else {
+      brightness > 0.5
+    }
   }
 }
 


### PR DESCRIPTION
## What does this change?

Because of the lack of time we have to card code the font contrast for the Chester Zoo campaign.
## Screenshots

Before:
![screen shot 2016-09-13 at 11 12 15](https://cloud.githubusercontent.com/assets/489567/18470102/f4cb726e-79a2-11e6-9902-9a73f8f66fe9.png)

After:
![screen shot 2016-09-13 at 11 12 08](https://cloud.githubusercontent.com/assets/489567/18470108/fa83d39a-79a2-11e6-9db3-23369c4ee6ca.png)
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
