### PR TITLE
Inject http client into ContentApiClient

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -16,7 +16,7 @@ import views.support.PreviousAndNext
 
 import scala.concurrent.Future
 
-class AllIndexController extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
+class AllIndexController(contentApiClient: ContentApiClient) extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
 
   // no need to set the zone here, it gets it from the date.
   private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
@@ -94,7 +94,7 @@ class AllIndexController extends Controller with ExecutionContexts with ItemResp
   // this is simply the latest by date. No lead content, editors picks, or anything else
   private def loadLatest(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[IndexPage]] = {
     val result = getResponse(
-      ContentApiClient.item(s"/$path", Edition(request)).pageSize(50).toDate(date).orderBy("newest")
+      contentApiClient.item(s"/$path", Edition(request)).pageSize(50).toDate(date).orderBy("newest")
     ).map{ item =>
       item.section.map( section =>
         IndexPage(
@@ -118,7 +118,7 @@ class AllIndexController extends Controller with ExecutionContexts with ItemResp
 
   private def findByDate(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[DateTime]] = {
     val result = getResponse(
-      ContentApiClient.item(s"/$path", Edition(request))
+      contentApiClient.item(s"/$path", Edition(request))
         .pageSize(1)
         .fromDate(date)
         .orderBy("oldest")
@@ -133,5 +133,3 @@ class AllIndexController extends Controller with ExecutionContexts with ItemResp
 
   private def urlFormat(date: DateTime) = date.toString(dateFormatUTC).toLowerCase
 }
-
-object AllIndexController extends AllIndexController

--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -1,8 +1,12 @@
 package controllers
 
 import com.softwaremill.macwire._
+import contentapi.ContentApiClient
 
 trait ApplicationsControllers {
+
+  def contentApiClient: ContentApiClient
+
   lazy val siteMapController = wire[SiteMapController]
   lazy val crosswordPageController = wire[CrosswordPageController]
   lazy val crosswordSearchController = wire[CrosswordSearchController]

--- a/applications/test/AllIndexControllerTest.scala
+++ b/applications/test/AllIndexControllerTest.scala
@@ -1,12 +1,18 @@
 package test
 
-import common.Logging
-import controllers.{IndexController, AllIndexController}
+import contentapi.ContentApiClient
+import controllers.AllIndexController
 import org.joda.time.DateTimeZone
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 
-@DoNotDiscover class AllIndexControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class AllIndexControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   private val PermanentRedirect = 301
   private val TemporaryRedirect = 302
@@ -46,7 +52,7 @@ import play.api.test.Helpers._
     }
   }
 
-  lazy val allIndexController = new AllIndexController
+  lazy val allIndexController = new AllIndexController(testContentApiClient)
 
   it should "redirect dated tag pages to the equivalent /all page" in {
     val result = allIndexController.on("football/series/thefiver/2014/jan/23")(TestRequest())

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -7,6 +7,7 @@ import common.Logback.LogstashLifecycle
 import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters}
+import contentapi.{CapiHttpClient, ContentApiClient}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import model.ApplicationIdentity
@@ -22,6 +23,12 @@ import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
+}
+
+trait ArticleServices {
+  def wsClient: WSClient
+  lazy val capiHttpClient = wire[CapiHttpClient]
+  lazy val contentApiClient = wire[ContentApiClient]
 }
 
 trait Controllers extends ArticleControllers {
@@ -46,7 +53,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with ArticleServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -30,7 +30,7 @@ case class ArticlePage(article: Article, related: RelatedContent) extends PageWi
 case class LiveBlogPage(article: Article, currentPage: LiveBlogCurrentPage, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-class ArticleController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class ArticleController(contentApiClient: ContentApiClient) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
@@ -194,7 +194,7 @@ class ArticleController extends Controller with RendersItemResponse with Logging
     val edition = Edition(request)
 
     log.info(s"Fetching article: $path for edition ${edition.id}: ${RequestLog(request)}")
-    val capiItem = ContentApiClient.item(path, edition)
+    val capiItem = contentApiClient.item(path, edition)
       .showTags("all")
       .showFields("all")
       .showReferences("all")
@@ -204,7 +204,7 @@ class ArticleController extends Controller with RendersItemResponse with Logging
       val blocksParam = blockRange.query.map(_.mkString(",")).getOrElse("body")
       capiItem.showBlocks(blocksParam)
     }.getOrElse(capiItem)
-    ContentApiClient.getResponse(capiItemWithBlocks)
+    contentApiClient.getResponse(capiItemWithBlocks)
 
   }
 

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -1,11 +1,13 @@
 package controllers
 
 import com.softwaremill.macwire._
+import contentapi.ContentApiClient
 import play.api.BuiltInComponents
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
 trait ArticleControllers {
   self: BuiltInComponents =>
+  def contentApiClient: ContentApiClient
   lazy val bookAgent: NewspaperBookTagAgent = wire[NewspaperBookTagAgent]
   lazy val bookSectionAgent: NewspaperBookSectionTagAgent = wire[NewspaperBookSectionTagAgent]
   lazy val publicationController = wire[PublicationController]

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -4,16 +4,23 @@ import controllers.ArticleController
 import org.apache.commons.codec.digest.DigestUtils
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+
 import scala.collection.JavaConversions._
 
-@DoNotDiscover class ArticleControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ArticleControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
   val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
   val sudokuUrl = "lifeandstyle/2013/sep/09/sudoku-2599-easy"
 
-  lazy val articleController = new ArticleController
+  lazy val articleController = new ArticleController(testContentApiClient)
 
   "Article Controller" should "200 when content type is article" in {
     val result = articleController.renderArticle(articleUrl)(TestRequest(articleUrl))

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -1,14 +1,21 @@
 package test
 
+import contentapi.ContentApiClient
 import controllers.ArticleController
 import metadata.MetaDataMatcher
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class ArticleMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ArticleMetaDataTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
 
-  lazy val articleController = new ArticleController
+  lazy val articleController = new ArticleController(testContentApiClient)
 
   it should "Include organisation metadata" in {
     val result = articleController.renderArticle(articleUrl)(TestRequest(articleUrl))

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -1,17 +1,22 @@
 package test
 
+import contentapi.ContentApiClient
 import controllers.{ArticleController, PublicationController}
 import model.TagDefinition
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
-@DoNotDiscover class PublicationControllerTest extends FlatSpec
-                                                with Matchers
-                                                with ConfiguredTestSuite
-                                                with MockitoSugar {
+@DoNotDiscover class PublicationControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with MockitoSugar
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   private val PermanentRedirect = 301
   private val TemporaryRedirect = 302
@@ -20,7 +25,7 @@ import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
   val emptySeq: Seq[TagDefinition] = Seq.empty
   val bookAgent = mock[NewspaperBookTagAgent]
   val bookSectionAgent = mock[NewspaperBookSectionTagAgent]
-  val articleController = new ArticleController
+  val articleController = new ArticleController(testContentApiClient)
   val publicationController = new PublicationController(bookAgent, bookSectionAgent, articleController)
 
   "Publication Controller" should "redirect to an /all page when an observer dated book url is requested" in {

--- a/article/test/TestAppLoader.scala
+++ b/article/test/TestAppLoader.scala
@@ -3,10 +3,11 @@ import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import test.WithTestContentApiClient
 
-trait TestComponents extends AppComponents with WithTestContentApiClient {
+trait TestComponents extends WithTestContentApiClient {
+  self: ArticleServices =>
   override lazy val contentApiClient = testContentApiClient
 }
 
 class TestAppLoader extends AppLoader {
-  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with TestComponents
+  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents with TestComponents
 }

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -10,11 +10,10 @@ import common._
 import conf.Configuration
 import conf.Configuration.contentApi
 import conf.switches.Switches.{CircuitBreakerSwitch, ContentApiUseThrift}
-import metrics.{CountMetric, TimingMetric}
 import model.{Content, Trail}
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
-
+import play.api.libs.ws.WS
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future}
@@ -113,13 +112,11 @@ trait ApiQueryDefaults extends Logging {
 // the average response time, and the number of timeouts, from Content Api.
 trait MonitoredContentApiClientLogic extends ContentApiClientLogic with ApiQueryDefaults with Logging {
 
-  def httpTimingMetric: TimingMetric
-  def httpTimeoutMetric: CountMetric
-
-  var _http: Http = new WsHttp(httpTimingMetric, httpTimeoutMetric)
+  val httpClient: HttpClient
+  var _httpClient = httpClient //TODO: to delete once ContentApiClient fully uses DI
 
   override def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext): Future[HttpResponse] = {
-    val futureContent = _http.GET(url, headers) map { response: Response =>
+    val futureContent = _httpClient.GET(url, headers) map { response: Response =>
       HttpResponse(response.body, response.status, response.statusText)
     }
     futureContent.onFailure{ case t =>
@@ -130,11 +127,10 @@ trait MonitoredContentApiClientLogic extends ContentApiClientLogic with ApiQuery
 }
 
 final case class CircuitBreakingContentApiClient(
-  override val httpTimingMetric: TimingMetric,
-  override val httpTimeoutMetric: CountMetric,
+  override val httpClient: HttpClient,
   override val targetUrl: String,
-  override val apiKey: String,
-  override val useThrift: Boolean) extends MonitoredContentApiClientLogic {
+  val apiKey: String,
+  val useThrift: Boolean) extends MonitoredContentApiClientLogic {
 
   private val circuitBreakerActorSystem = ActorSystem("content-api-client-circuit-breaker")
 
@@ -166,21 +162,29 @@ final case class CircuitBreakingContentApiClient(
     }
   }
 }
+//TODO: Do not use. For legacy reason only.
+//To delete once all references to ContentApiClient are via the class
+object ContentApiClient extends ContentApiClient(WSCapiHttpClient)
+object WSCapiHttpClient extends HttpClient {
+  import play.api.Play.current
+  lazy val httpClient = new CapiHttpClient(WS.client)
+  def GET(url: String, headers: Iterable[(String, String)]): Future[Response] = {
+    httpClient.GET(url, headers)
+  }
+}
 
-object ContentApiClient extends ApiQueryDefaults {
+class ContentApiClient(httpClient: HttpClient) extends ApiQueryDefaults {
 
   // Public val for test.
   val jsonClient = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    httpClient = httpClient,
     targetUrl = contentApi.contentApiHost,
     apiKey = contentApi.key.getOrElse(""),
     useThrift = false)
 
   // Public val for test.
   val thriftClient = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    httpClient = httpClient,
     targetUrl = contentApi.contentApiHost,
     apiKey = contentApi.key.getOrElse(""),
     useThrift = true)
@@ -204,30 +208,13 @@ object ContentApiClient extends ApiQueryDefaults {
   def getResponse(sectionsQuery: SectionsQuery)(implicit context: ExecutionContext) = getClient.getResponse(sectionsQuery)
 
   def getResponse(editionsQuery: EditionsQuery)(implicit context: ExecutionContext) = getClient.getResponse(editionsQuery)
-
-  // Used for testing, and training preview.
-  def setHttp(http: Http): Unit ={
-    thriftClient._http = http
-    jsonClient._http = http
-  }
-}
-
-object DraftContentApi {
-  val client = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
-    targetUrl = Configuration.contentApi.contentApiDraftHost,
-    apiKey = contentApi.key.getOrElse(""),
-    useThrift = false
-  )
 }
 
 // The Admin server uses this PreviewContentApi to check the preview environment.
 // The Preview server uses the standard ContentApiClient object, configured with preview settings.
-object PreviewContentApi {
+class PreviewContentApi(httpClient: HttpClient) {
   val client = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    httpClient = httpClient,
     targetUrl = Configuration.contentApi.previewHost,
     apiKey = contentApi.key.getOrElse(""),
     useThrift = false

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -3,28 +3,27 @@ package contentapi
 import java.net.InetAddress
 import java.util.concurrent.TimeoutException
 
-import common.ContentApiMetrics.{ContentApiErrorMetric, ContentApi404Metric}
-import common.{Logging, ExecutionContexts}
+import common.ContentApiMetrics.{ContentApi404Metric, ContentApiErrorMetric}
+import common.{ContentApiMetrics, ExecutionContexts, Logging}
 import conf.Configuration
 import conf.Configuration.contentApi.previewAuth
 import metrics.{CountMetric, TimingMetric}
-import play.api.libs.ws.{WS, WSAuthScheme}
+import play.api.libs.ws.{WSAuthScheme, WSClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Success, Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 case class Response(body: Array[Byte], status: Int, statusText: String)
 
-trait Http {
+trait HttpClient {
   def GET(url: String, headers: Iterable[(String, String)]): Future[Response]
 }
 
-class WsHttp(val httpTimingMetric: TimingMetric, val httpTimeoutMetric: CountMetric)
-  extends Http with ExecutionContexts with Logging {
+class CapiHttpClient(wsClient: WSClient)
+  extends HttpClient with ExecutionContexts with Logging {
 
   import java.lang.System.currentTimeMillis
-  import play.api.Play.current
 
   def GET(url: String, headers: Iterable[(String, String)]): Future[Response] = {
     //append with a & as there are always params in there already
@@ -34,21 +33,21 @@ class WsHttp(val httpTimingMetric: TimingMetric, val httpTimeoutMetric: CountMet
 
     val start = currentTimeMillis
 
-    val baseRequest = WS.url(urlWithDebugInfo)
+    val baseRequest = wsClient.url(urlWithDebugInfo)
     val request = previewAuth.fold(baseRequest)(auth => baseRequest.withAuth(auth.user, auth.password, WSAuthScheme.BASIC))
     val response = request.withHeaders(headers.toSeq: _*).withRequestTimeout(contentApiTimeout).get()
 
     // record metrics
     response.onSuccess {
       case r if r.status == 404 => ContentApi404Metric.increment()
-      case r if r.status == 200 => httpTimingMetric.recordDuration(currentTimeMillis - start)
+      case r if r.status == 200 => ContentApiMetrics.HttpLatencyTimingMetric.recordDuration(currentTimeMillis - start)
       case _ =>
     }
 
     response.onFailure {
       case e: TimeoutException =>
         log.warn(s"Content API TimeoutException for $url in ${currentTimeMillis - start}: $e")
-        httpTimeoutMetric.increment()
+        ContentApiMetrics.HttpTimeoutCountMetric.increment()
       case e: Exception =>
         log.warn(s"Content API client exception for $url in ${currentTimeMillis - start}: $e")
     }

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -66,7 +66,8 @@ trait AppComponents
   with AdminJobsServices
   with OnwardServices {
 
-  override lazy val ophanApi = wire[OphanApi] // ophanApi is already defined in AdminServices and OnwardServices. Overriding it here to avoid conflict
+  //Overriding conflicting members
+  override lazy val ophanApi = wire[OphanApi]
 
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -11,7 +11,7 @@ import common._
 import common.commercial.Branding
 import conf.Configuration
 import conf.switches.Switches.FaciaInlineEmbeds
-import contentapi.{CircuitBreakingContentApiClient, ContentApiClient, QueryDefaults}
+import contentapi.{CapiHttpClient, CircuitBreakingContentApiClient, ContentApiClient, QueryDefaults}
 import fronts.FrontsApi
 import model._
 import model.facia.PressedCollection
@@ -25,8 +25,7 @@ import scala.concurrent.Future
 class LiveFapiFrontPress(val wsClient: WSClient) extends FapiFrontPress {
 
   override implicit val capiClient: ContentApiClientLogic = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    httpClient = new CapiHttpClient(wsClient),
     targetUrl = Configuration.contentApi.contentApiHost,
     apiKey = Configuration.contentApi.key.getOrElse("facia-press"),
     useThrift = false
@@ -53,8 +52,7 @@ class LiveFapiFrontPress(val wsClient: WSClient) extends FapiFrontPress {
 class DraftFapiFrontPress(val wsClient: WSClient) extends FapiFrontPress {
 
   override implicit val capiClient: ContentApiClientLogic = CircuitBreakingContentApiClient(
-    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
-    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    httpClient = new CapiHttpClient(wsClient),
     targetUrl = Configuration.contentApi.contentApiDraftHost,
     apiKey = Configuration.contentApi.key.getOrElse("facia-press"),
     useThrift = false

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -26,7 +26,8 @@ trait AppComponents
   with StandaloneControllerComponents
   with Controllers
   with StandaloneLifecycleComponents
-  with AdminJobsServices {
+  with AdminJobsServices
+  with OnwardServices {
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -5,6 +5,7 @@ import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters, FootballClient, FootballLifecycle}
+import contentapi.{CapiHttpClient, ContentApiClient}
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import cricketPa.PaFeed
@@ -23,7 +24,7 @@ import play.api.libs.ws.WSClient
 import rugby.conf.RugbyLifecycle
 import router.Routes
 import rugby.controllers.RugbyControllers
-import rugby.feed.OptaFeed
+import rugby.feed.{CapiFeed, OptaFeed}
 import rugby.jobs.RugbyStatsJob
 
 class AppLoader extends FrontendApplicationLoader {
@@ -32,6 +33,8 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait SportServices {
   def wsClient: WSClient
+  lazy val capiHttpClient = wire[CapiHttpClient]
+  lazy val contentApiClient = wire[ContentApiClient]
   lazy val footballClient = wire[FootballClient]
   lazy val competitionDefinitions = CompetitionsProvider.allCompetitions
   lazy val competitionsService = wire[CompetitionsService]
@@ -39,6 +42,7 @@ trait SportServices {
   lazy val cricketStatsJob = wire[CricketStatsJob]
   lazy val rugbyFeed = wire[OptaFeed]
   lazy val rugbyStatsJob = wire[RugbyStatsJob]
+  lazy val capiFeed = wire[CapiFeed]
 }
 
 trait Controllers extends FootballControllers with CricketControllers with RugbyControllers {
@@ -62,7 +66,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with SportServices{
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with SportServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -13,7 +13,8 @@ class RugbyLifecycle(
   appLifeCycle: ApplicationLifecycle,
   jobs: JobScheduler,
   akkaAsync: AkkaAsync,
-  rugbyStatsJob: RugbyStatsJob
+  rugbyStatsJob: RugbyStatsJob,
+  capiFeed: CapiFeed
 )(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   protected val initializationTimeout: FiniteDuration = 10.seconds
@@ -43,7 +44,7 @@ class RugbyLifecycle(
 
     jobs.deschedule("MatchNavArticles")
     jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
-      val refreshedNavContent = CapiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
+      val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }
 
@@ -57,7 +58,7 @@ class RugbyLifecycle(
       rugbyStatsJob.fetchPastScoreEvents
       rugbyStatsJob.fetchPastMatchesStat
 
-      val refreshedNavContent = CapiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
+      val refreshedNavContent = capiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
       rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }
   }

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -14,7 +14,7 @@ case class MatchNavigation(
   minByMin: ContentType
 )
 
-object CapiFeed extends ExecutionContexts with Logging {
+class CapiFeed(contentApiClient: ContentApiClient) extends ExecutionContexts with Logging {
 
   def getMatchArticles(matches: Seq[Match]) : Future[Map[String, MatchNavigation]] = {
     Future.sequence(
@@ -31,7 +31,7 @@ object CapiFeed extends ExecutionContexts with Logging {
 
     log.info(s"Looking for ${rugbyMatch.toString}")
 
-    ContentApiClient.getResponse(ContentApiClient.search(Edition.defaultEdition)
+    contentApiClient.getResponse(contentApiClient.search(Edition.defaultEdition)
       .section("sport")
       .tag(searchTags)
       .fromDate(matchDate.toDateTimeAtStartOfDay)

--- a/training-preview/app/AppLoader.scala
+++ b/training-preview/app/AppLoader.scala
@@ -18,7 +18,6 @@ class AppLoader extends FrontendApplicationLoader {
 trait Controllers {
   def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
-  ContentApiClient.setHttp(wire[TrainingHttp]) // adds auth as a side effect - can be fixed when ContentApiClient uses DI instead of setHttp
 }
 
 trait AppComponents
@@ -27,6 +26,9 @@ trait AppComponents
   with Controllers
   with StandaloneLifecycleComponents
   with AdminJobsServices {
+
+  lazy val trainingCapiHttpClient = wire[TrainingHttp]
+  override lazy val contentApiClient = wire[ContentApiClient]
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/training-preview/app/controllers/HealthCheck.scala
+++ b/training-preview/app/controllers/HealthCheck.scala
@@ -5,11 +5,11 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import dispatch.{FunctionHandler, Http}
 
 import scala.concurrent.Future
-import contentapi.{ContentApiClient, Response}
+import contentapi.{ContentApiClient, HttpClient, Response}
 import conf.Configuration.contentApi.previewAuth
 import play.api.libs.ws.WSClient
 
-class TrainingHttp extends contentapi.Http with ExecutionContexts {
+class TrainingHttp extends HttpClient with ExecutionContexts {
 
   // Play 2.4.2 has problems passing the any certificate flag through play.ws.ssl.loose.acceptAnyCertificate
   // This is a workaround. Forum here (called 'Play 2.4 disable certification check'):

--- a/training-preview/test/TestAppLoader.scala
+++ b/training-preview/test/TestAppLoader.scala
@@ -1,9 +1,12 @@
-
 import app.FrontendComponents
-import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
-import test.TestSettings
+import play.api.ApplicationLoader.Context
+import test.WithTestContentApiClient
+
+trait TestComponents extends AppComponents with WithTestContentApiClient {
+  override lazy val contentApiClient = testContentApiClient
+}
 
 class TestAppLoader extends AppLoader {
-  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents with TestSettings
+  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with TestComponents
 }


### PR DESCRIPTION
## What does this change?

First PR to remove WS reference within ContentApiClient. 👊 
Create a contentApiClass but keep a ContentApiClient object around for legacy purpose. I started to move to using the class so I can inject the http client but I am far from being done. More PRs to come
## What is the value of this and can you measure success?

=> Play 2.5
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
