### PR TITLE
AMP - Increase Maximum No. of Ads to 8

### DIFF
--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -8,7 +8,7 @@ import views.support.{AmpAd, AmpAdDataSlot, HtmlCleaner}
 import scala.collection.JavaConversions._
 
 object AmpAdCleaner {
-  val AD_LIMIT = 2
+  val AD_LIMIT = 8
   val CHARS_BETWEEN_ADS = 700
   val DONT_INTERLEAVE_SMALL_PARA = 50
 

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -39,8 +39,17 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   }
 
-  "AmpAdCleaner" should "only add 8 ads in total" in {
+  "AmpAdCleaner" should "only add 2 ads for short article" in {
     val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 4}</body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-ad").size should be(2)
+
+  }
+
+  "AmpAdCleaner" should "only add 8 ads in total" in {
+    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 25}</body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -39,17 +39,8 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   }
 
-  "AmpAdCleaner" should "only add 2 ads for short article" in {
-    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 4}</body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
-    result.getElementsByTag("amp-ad").size should be(2)
-
-  }
-
   "AmpAdCleaner" should "only add 8 ads in total" in {
-    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 25}</body></html>"""
+    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 30}</body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -39,7 +39,7 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   }
 
-  "AmpAdCleaner" should "include ads at defined, regular intervals" in {
+  "AmpAdCleaner" should "not have changed ad intervals without someone checking the tests are still valid" in {
     AmpAdCleaner.AD_LIMIT should be(8)
     AmpAdCleaner.CHARS_BETWEEN_ADS should be(700)
     AmpAdCleaner.DONT_INTERLEAVE_SMALL_PARA should be(50)

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -39,6 +39,13 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   }
 
+  "AmpAdCleaner" should "include ads at defined, regular intervals" in {
+    AmpAdCleaner.AD_LIMIT should be(8)
+    AmpAdCleaner.CHARS_BETWEEN_ADS should be(700)
+    AmpAdCleaner.DONT_INTERLEAVE_SMALL_PARA should be(50)
+
+  }
+
   "AmpAdCleaner" should "only add 8 ads in total" in {
     val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 30}</body></html>"""
     val document: Document = Jsoup.parse(doc)

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -39,12 +39,12 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   }
 
-  "AmpAdCleaner" should "only add 2 ads in total" in {
+  "AmpAdCleaner" should "only add 8 ads in total" in {
     val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 4}</body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 
-    result.getElementsByTag("amp-ad").size should be(2)
+    result.getElementsByTag("amp-ad").size should be(8)
 
   }
 


### PR DESCRIPTION
## What does this change?

Ups the maximum number of ads on AMP pages from 2 to 8. **Note**: 8 is the maximum, but the number of ads shown is proportional to the length of the article, so shorter pieces won't necessarily show as many as this.
## What is the value of this and can you measure success?

Allows more ads to display on AMP versions of articles, bringing the tally closer to the number on the standard versions.
## Does this affect other platforms - Amp, Apps, etc?

AMP.
## Screenshots
## Request for comment

@kenlim 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
