### PR TITLE
Fix ad targeting bug with paid-content tags

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -134,7 +134,8 @@ object TagProperties {
       bylineImageUrl = tag.bylineImageUrl,
       podcast = tag.podcast.map(Podcast.make),
       references = tag.references.map(Reference.make),
-      activeBrandings = tag.activeSponsorships.map(_.map(Branding.make(tag.webTitle)))
+      activeBrandings = tag.activeSponsorships.map(_.map(Branding.make(tag.webTitle))),
+      paidContentType = tag.paidContentType
     )
   }
 }
@@ -155,7 +156,8 @@ case class TagProperties(
                           bylineImageUrl: Option[String],
                           podcast: Option[Podcast],
                           references: Seq[Reference],
-                          activeBrandings: Option[Seq[Branding]]
+                          activeBrandings: Option[Seq[Branding]],
+                          paidContentType: Option[String]
 ) {
  val footballBadgeUrl = references.find(_.`type` == "pa-football-team")
       .map(_.id.split("/").drop(1).mkString("/"))

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -579,15 +579,25 @@ final case class Tags(
 
   private def tagsOfType(tagType: String): List[Tag] = tags.filter(_.properties.tagType == tagType)
 
-  lazy val keywords: List[Tag] = tagsOfType("Keyword")
-  lazy val nonKeywordTags: List[Tag] = tags.filterNot(_.properties.tagType == "Keyword")
+  private def tagsOfTypeOrPaidContentSubtype(tagType: String, paidContentSubType: String): List[Tag] = {
+    tags.filter { tag =>
+      tag.properties.tagType == tagType ||
+      (tag.properties.tagType == "PaidContent" && tag.properties.paidContentType == Some(paidContentSubType))
+    }
+  }
+
+  lazy val keywords: List[Tag] = tagsOfTypeOrPaidContentSubtype("Keyword", "Topic")
+
+  lazy val nonKeywordTags: List[Tag] = tags.diff(keywords)
+
   lazy val contributors: List[Tag] = tagsOfType("Contributor")
   lazy val isContributorPage: Boolean = contributors.nonEmpty
-  lazy val series: List[Tag] = tagsOfType("Series")
+  lazy val series: List[Tag] = tagsOfTypeOrPaidContentSubtype("Series", "Series")
   lazy val blogs: List[Tag] = tagsOfType("Blog")
   lazy val tones: List[Tag] = tagsOfType("Tone")
   lazy val types: List[Tag] = tagsOfType("Type")
   lazy val tracking: List[Tag] = tagsOfType("Tracking")
+  lazy val paidContent: List[Tag] = tagsOfType("PaidContent")
 
   lazy val richLink: Option[String] = tags.flatMap(_.richLinkId).headOption
   lazy val openModule: Option[String] = tags.flatMap(_.openModuleId).headOption

--- a/common/test/common/dfp/HighMerchandisingLineItemTest.scala
+++ b/common/test/common/dfp/HighMerchandisingLineItemTest.scala
@@ -70,8 +70,8 @@ class HighMerchandisingLineItemTest extends FlatSpec with Matchers {
         None,
         None,
         Seq.empty,
+        None,
         None
-
       ),None,None,None
     ))
     TestAgent.isTargetedByHighMerch("sport", testTagsSeq, editions.Us,"/commentisfree/2016/may/25/greek-bailout-eu-on-best-behaviour-until-referendum-over-brexit") should be(true)

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -101,7 +101,7 @@ object FootballTestData {
   val teamTags: Map[String, Tag] = Map(
     "Liverpool" -> Tag(
       TagProperties("football/liverpool", "/football/liverpool", "Keyword", "football", "Football", "Liverpool",
-        "https://www.theguardian.com/football/liverpool", None, None, None, None, None, None, None, Seq(), None),
+        "https://www.theguardian.com/football/liverpool", None, None, None, None, None, None, None, Seq(), None, None),
       None,
       None,
       None)


### PR DESCRIPTION
Some tags that were previously keywords are now paid-content tags of subtype topic, and this meant some _k_ parameters were being missed out in ad calls.

Eg. 

```
id: "cook-with-leisure/cook-with-leisure",
type: "paid-content",
webTitle: "Cook with Leisure",
webUrl: "https://www.theguardian.com/cook-with-leisure/cook-with-leisure",
apiUrl: "https://content.guardianapis.com/cook-with-leisure/cook-with-leisure",
paidContentType: "Topic"
```
