### PR TITLE
Font contrast added to the gallery page

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -3,7 +3,7 @@
 @import views.html.hosted._
 
 @main(page, Some("commercial"))  { }  {
-    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @{page.campaign.cssClass}">
+    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @{page.campaign.cssClass} @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
         @guardianHostedHeader("hosted-gallery-page", page.campaign.cssClass, page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">


### PR DESCRIPTION
## What does this change?

The `hosted-page--bright` is added to the `hosted-gallery-page` `<div/>` so the correct font contrast is applied.
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
