### PR TITLE
Allow the engagement banner to appear on all pages, not just Articles

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -128,7 +128,6 @@ define([
             switches.liveblogAdverts;
 
         this.syncMembershipMessages =
-            isArticle &&
             !userFeatures.isPayingMember();
 
         this.async = {

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -340,15 +340,6 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
                 });
             });
 
-            it('Does not display messages outside articles', function (done) {
-                config.page.contentType = 'Network Front';
-                features = new CommercialFeatures;
-                features.async.membershipMessages.then(function (flag) {
-                    expect(flag).toBe(false);
-                    done();
-                });
-            });
-
             it('Does not display messages to existing members', function (done) {
                 userFeatures.isPayingMember = function () {return true;};
                 features = new CommercialFeatures;


### PR DESCRIPTION
## What does this change?

The engagement banner was restricted to Article pages as far back as it's origins in https://github.com/guardian/frontend/pull/9367 in June 2015, but having checked with Charles Minty, @paulbrown1982  and @JuliaBellis, we can't find any solid reason why. The banner will now show everywhere, including the Network Front.

Everyone is happy to try enabling it! The banner appears to work fine on fronts, and does not obscure full-screen video on video pages like http://localhost:9000/world/video/2016/jul/21/nice-attack-planned-for-months-involved-accomplices-says-prosecutor-video:
## What is the value of this and can you measure success?

Simplifying the codebase. Will also increase exposure to the banner...
## Does this affect other platforms - Amp, Apps, etc?

Nope. Apps already show the Membership peaking-message on fronts.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/52038/18481744/3b4a81da-79d5-11e6-9d28-e79b839389c3.png)
## Request for comment

@paulbrown1982 @JuliaBellis 
