### PR TITLE
Hosted video tone fix

### DIFF
--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -53,6 +53,9 @@ object HostedVideoPage extends Logging {
       val owner = sponsorship.sponsorName
       val standfirst = content.fields flatMap (_.standfirst) getOrElse ""
 
+      val toneId = toneTag.id
+      val toneName = toneTag.webTitle
+
       val keywordId = s"${campaignId}/${campaignId}"
       val keywordName = campaignId
 

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -54,7 +54,8 @@ object HostedVideoPage extends Logging {
       val standfirst = content.fields flatMap (_.standfirst) getOrElse ""
 
       val toneId = toneTag.id
-      val toneName = toneTag.webTitle
+      //val toneName = toneTag.webTitle //TODO the toneTag.webTitle value should be Hosted not Advertisement Feature
+      val toneName = "Hosted"
 
       val keywordId = s"${campaignId}/${campaignId}"
       val keywordName = campaignId

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -6,6 +6,7 @@ import common.Logging
 import conf.Static
 import model.GuardianContentTypes._
 import model.{MetaData, SectionSummary}
+import play.api.libs.json.JsString
 
 case class HostedVideoPage(
   campaign: HostedCampaign,
@@ -52,6 +53,9 @@ object HostedVideoPage extends Logging {
       val owner = sponsorship.sponsorName
       val standfirst = content.fields flatMap (_.standfirst) getOrElse ""
 
+      val keywordId = s"${campaignId}/${campaignId}"
+      val keywordName = campaignId
+
       val metadata = MetaData.make(
         id = pageId,
         section = content.sectionId map SectionSummary.fromId,
@@ -61,6 +65,12 @@ object HostedVideoPage extends Logging {
         description = Some(standfirst),
         contentType = Video,
         iosType = Some(Video),
+        javascriptConfigOverrides = Map(
+          "keywordIds" -> JsString(keywordId),
+          "keywords" -> JsString(keywordName),
+          "toneIds" -> JsString(toneId),
+          "tones" -> JsString(toneName)
+        ),
         opengraphPropertiesOverrides = Map(
           "og:url" -> pageUrl,
           "og:title" -> pageTitle,


### PR DESCRIPTION
## What does this change?

Because of the wrong tone `guardian.config.page.tones` on the hosted video page, js wasn't initialised at all. Now everything works (including 'About' link and video) but this is temporary solution.
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
