### PR TITLE
Hosted content - js error removed

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/colours.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/colours.js
@@ -22,13 +22,17 @@ define([
     function init() {
         return new Promise(function(resolve) {
             var $nextVideo = $('.js-next-video');
-            var colour = removeHash($nextVideo.data('colour'));
+            var colour;
 
-            fastdom.write(function () {
-                $nextVideo.css({
-                    'background': 'rgba(' + hexToRGB(colour) + ', 0.1)'
+            if ($nextVideo.length) {
+                colour = removeHash($nextVideo.data('colour'));
+
+                fastdom.write(function () {
+                    $nextVideo.css({
+                        'background': 'rgba(' + hexToRGB(colour) + ', 0.1)'
+                    });
                 });
-            });
+            }
 
             resolve();
         });


### PR DESCRIPTION
## What does this change?

Currently (and temporary) we don't have the next video autoplay cards in the end of the video. But the module raises a js error if there is no `.js-next-video` element. This PR fixes that.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
