### PR TITLE
Restrict all Contributions CTAs to not show to paying members

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -127,12 +127,15 @@ define([
             this.dfpAdvertising &&
             switches.liveblogAdverts;
 
-        this.syncMembershipMessages =
-            !userFeatures.isPayingMember();
+        this.canReasonablyAskForMoney = // eg become a supporter, give a contribution
+            !(userFeatures.isPayingMember() || config.page.isSensitive || config.page.isAdvertisementFeature);
 
+        this.canAskForAContribution =
+            this.canReasonablyAskForMoney && config.page.edition === 'UK'; // Contributions only testing in UK so far
+        
         this.async = {
-            membershipMessages : detect.adblockInUse.then(function (adblockUsed) {
-                return !adblockUsed && self.syncMembershipMessages;
+            canDisplayMembershipEngagementBanner : detect.adblockInUse.then(function (adblockUsed) {
+                return !adblockUsed && self.canReasonablyAskForMoney;
             })
         };
     }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-embed.js
@@ -10,6 +10,7 @@ define([
     'common/utils/robust',
     'inlineSvg!svgs/icon/arrow-right',
     'common/utils/config',
+    'common/modules/commercial/commercial-features',
     'common/modules/experiments/embed',
     'common/modules/article/space-filler'
 
@@ -24,6 +25,7 @@ define([
              robust,
              arrowRight,
              config,
+             commercialFeatures,
              embed,
              spaceFiller
 ) {
@@ -44,8 +46,8 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'The embed performs 20% better inline and in-article than it does at the bottom of the article';
         this.canRun = function () {
-            var pageObj = config.page;
-            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || obWidgetIsShown() || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return commercialFeatures.canAskForAContribution && worksWellWithPageTemplate && !obWidgetIsShown();
         };
 
         function obWidgetIsShown() {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-buttons.js
@@ -10,6 +10,7 @@ define([
     'common/utils/robust',
     'inlineSvg!svgs/icon/arrow-right',
     'common/utils/config',
+    'common/modules/commercial/commercial-features',
     'common/modules/experiments/embed'
 ], function (bean,
              qwery,
@@ -22,6 +23,7 @@ define([
              robust,
              arrowRight,
              config,
+             commercialFeatures,
              embed
 ) {
 
@@ -41,8 +43,8 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'The buttons improve the conversion rate by 50%';
         this.canRun = function () {
-            var pageObj = config.page;
-            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || obWidgetIsShown() || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return commercialFeatures.canAskForAContribution && worksWellWithPageTemplate && !obWidgetIsShown();
         };
 
         function obWidgetIsShown() {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
@@ -10,6 +10,7 @@ define([
     'common/utils/robust',
     'inlineSvg!svgs/icon/arrow-right',
     'common/utils/config',
+    'common/modules/commercial/commercial-features',
     'common/modules/experiments/embed'
 ], function (bean,
              qwery,
@@ -22,6 +23,7 @@ define([
              robust,
              arrowRight,
              config,
+             commercialFeatures,
              embed
 ) {
 
@@ -41,8 +43,8 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'The embed performs at least as good as our previous in-article component tests';
         this.canRun = function () {
-            var pageObj = config.page;
-            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || obWidgetIsShown() || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return commercialFeatures.canAskForAContribution && worksWellWithPageTemplate && !obWidgetIsShown();
         };
 
         function obWidgetIsShown() {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner.js
@@ -42,8 +42,10 @@ define([
         // Required by the A/B testing framework - can not be async, unfortunately
         this.canRun = function () {
             var matchesEdition = config.page.edition.toLowerCase() == edition;
-            return matchesEdition && commercialFeatures.syncMembershipMessages &&
-                minVisited <= (storage.local.get('gu.alreadyVisited') || 0);
+
+            var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= minVisited;
+
+            return userHasMadeEnoughVisits && commercialFeatures.canReasonablyAskForMoney && matchesEdition;
         };
 
         this.completer = function (complete) {
@@ -64,7 +66,7 @@ define([
             id: id,
             test: function () {
                 // async check to see if user has an ad-blocker enabled
-                commercialFeatures.async.membershipMessages.then(function (canShow) {
+                commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
                     if (canShow && self.canRun()) {
                         var renderedBanner = template(messageTemplate, { messageText: messageText, linkHref: linkHref });
                         var messageShown = new Message(

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -315,7 +315,7 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
         describe('Membership messages', function () {
             it('Displays messages by default', function (done) {
                 features = new CommercialFeatures;
-                features.async.membershipMessages.then(function (flag) {
+                features.async.canDisplayMembershipEngagementBanner.then(function (flag) {
                     expect(flag).toBe(true);
                     done();
                 });
@@ -325,28 +325,16 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
                 // i.e. we want to show the adblock message instead
                 detect.adblockInUse = Promise.resolve(true);
                 features = new CommercialFeatures;
-                features.async.membershipMessages.then(function (flag) {
+                features.async.canDisplayMembershipEngagementBanner.then(function (flag) {
                     expect(flag).toBe(false);
                     done();
                 });
             });
 
-            it('Does display messages on mobile', function (done) {
-                detect.getBreakpoint = function () { return 'mobile'; };
-                features = new CommercialFeatures;
-                features.async.membershipMessages.then(function (flag) {
-                    expect(flag).toBe(true);
-                    done();
-                });
-            });
-
-            it('Does not display messages to existing members', function (done) {
+            it('Does not display messages to existing members because they are already giving us money', function () {
                 userFeatures.isPayingMember = function () {return true;};
                 features = new CommercialFeatures;
-                features.async.membershipMessages.then(function (flag) {
-                    expect(flag).toBe(false);
-                    done();
-                });
+                expect(features.canReasonablyAskForMoney).toBe(false);
             });
         });
     });

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -331,7 +331,7 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
                 });
             });
 
-            it('Does not display messages to existing members because they are already giving us money', function () {
+            it('Does not ask paying members for money - because they are *already* giving us money, we do not want to hassle them', function () {
                 userFeatures.isPayingMember = function () {return true;};
                 features = new CommercialFeatures;
                 expect(features.canReasonablyAskForMoney).toBe(false);


### PR DESCRIPTION
We weren't checking on the Contributions Epic/Embed CTAs if the users were paying members, which was obviously irritating for those users.

This is a small refactor to introduce `canReasonablyAskForMoney` and `canAskForAContribution` - which we should be able to apply to all our tests.

cc @markjamesbutler @jranks123 
