### PR TITLE
Inject contentApiClient PR #2 (mostly in controllers)

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -1,16 +1,17 @@
-import app.{LifecycleComponent, FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
-import common.dfp.DfpAgentLifecycle
+import dfp.{CapiLookupAgent, DfpAgentLifecycle}
 import conf.switches.SwitchboardLifecycle
 import conf.{AdminFilters, CachedHealthCheckLifeCycle, CommonGzipFilter}
 import controllers.{AdminControllers, HealthCheck}
-import _root_.dfp.DfpDataCacheLifecycle
+import _root_.dfp.{DfpDataCacheLifecycle, DfpDataCacheJob}
+import contentapi.{CapiHttpClient, ContentApiClient}
 import http.AdminHttpErrorHandler
 import dev.DevAssetsController
 import football.feed.MatchDayRecorder
-import jobs.{FastlyCloudwatchLoadJob, R2PagePressJob, VideoEncodingsJob, AnalyticsSanityCheckJob}
+import jobs.{AnalyticsSanityCheckJob, FastlyCloudwatchLoadJob, R2PagePressJob, VideoEncodingsJob}
 import model.{AdminLifecycle, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
@@ -29,6 +30,8 @@ class AppLoader extends FrontendApplicationLoader {
 trait AdminServices {
   def wsClient: WSClient
   def akkaAsync: AkkaAsync
+  lazy val capiHttpClient = wire[CapiHttpClient]
+  lazy val contentApiClient = wire[ContentApiClient]
   lazy val ophanApi = wire[OphanApi]
   lazy val emailService = wire[EmailService]
   lazy val fastlyStatisticService = wire[FastlyStatisticService]
@@ -37,6 +40,8 @@ trait AdminServices {
   lazy val videoEncodingsJob = wire[VideoEncodingsJob]
   lazy val matchDayRecorder = wire[MatchDayRecorder]
   lazy val analyticsSanityCheckJob = wire[AnalyticsSanityCheckJob]
+  lazy val capiLookupAgent = wire[CapiLookupAgent]
+  lazy val dfpDataCacheJob = wire[DfpDataCacheJob]
 }
 
 trait Controllers extends AdminControllers {

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -5,6 +5,7 @@ import common.AkkaAsync
 import controllers.admin._
 import controllers.admin.commercial.{DfpDataController, SlotController, TakeoverWithEmptyMPUsController}
 import controllers.cache.{ImageDecacheController, PageDecacheController}
+import dfp.DfpDataCacheJob
 import jobs.VideoEncodingsJob
 import play.api.libs.ws.WSClient
 import play.api.Mode
@@ -16,6 +17,7 @@ trait AdminControllers {
   def videoEncodingsJob: VideoEncodingsJob
   def mode: Mode.Mode
   def ophanApi: OphanApi
+  def dfpDataCacheJob: DfpDataCacheJob
   lazy val oAuthLoginController = wire[OAuthLoginAdminController]
   lazy val uncachedWebAssets = wire[UncachedWebAssets]
   lazy val uncachedAssets = wire[UncachedAssets]

--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -7,14 +7,14 @@ import dfp.DfpDataCacheJob
 import model.NoCache
 import play.api.mvc.{Action, AnyContent, Controller}
 
-class DfpDataController extends Controller with ExecutionContexts {
+class DfpDataController(dfpDataCacheJob: DfpDataCacheJob) extends Controller with ExecutionContexts {
 
   def renderCacheFlushPage(): Action[AnyContent] = Action { implicit request =>
     NoCache(Ok(views.html.commercial.dfpFlush(environment.stage)))
   }
 
   def flushCache(): Action[AnyContent] = Action { implicit request =>
-    DfpDataCacheJob.refreshAllDfpData()
+    dfpDataCacheJob.refreshAllDfpData()
     NoCache(Redirect(routes.DfpDataController.renderCacheFlushPage()))
       .flashing("triggered" -> "true")
   }

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -10,7 +10,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class DfpDataCacheLifecycle(
   appLifecycle: ApplicationLifecycle,
   jobScheduler: JobScheduler,
-  akkaAsync: AkkaAsync)(implicit ec: ExecutionContext) extends LifecycleComponent with ExecutionContexts {
+  akkaAsync: AkkaAsync,
+  dfpDataCacheJob: DfpDataCacheJob)(implicit ec: ExecutionContext) extends LifecycleComponent with ExecutionContexts {
 
   appLifecycle.addStopHook { () => Future {
     jobs foreach { job =>
@@ -65,7 +66,7 @@ class DfpDataCacheLifecycle(
     new Job[Unit] {
       val name: String = "DFP-Cache"
       val interval: Int = 2
-      def run(): Future[Unit] = DfpDataCacheJob.run()
+      def run(): Future[Unit] = dfpDataCacheJob.run()
     },
 
     new Job[Unit] {
@@ -109,7 +110,7 @@ class DfpDataCacheLifecycle(
     }
 
     akkaAsync.after1s {
-      DfpDataCacheJob.refreshAllDfpData()
+      dfpDataCacheJob.refreshAllDfpData()
       CreativeTemplateAgent.refresh()
       DfpTemplateCreativeCacheJob.run()
       CustomTargetingKeyValueJob.run()

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -1,10 +1,18 @@
 package dfp
 
-import common.dfp.{GuLineItem, GuTargeting}
+import common.dfp.{CapiLookupAgent, GuLineItem, GuTargeting}
 import org.joda.time.DateTime
 import org.scalatest._
+import test.{WithTestContentApiClient, WithTestWsClient}
 
-class DfpDataCacheJobTest extends FlatSpec with Matchers {
+class DfpDataCacheJobTest
+  extends FlatSpec
+  with Matchers
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
+
+  lazy val dfpDataCacheJob = new DfpDataCacheJob(new CapiLookupAgent(testContentApiClient))
 
   private def lineItem(id: Long, name: String, completed: Boolean = false): GuLineItem = {
     GuLineItem(id,
@@ -35,7 +43,7 @@ class DfpDataCacheJobTest extends FlatSpec with Matchers {
       lineItem(3, "c")
     )
 
-    val lineItems = DfpDataCacheJob.loadLineItems(
+    val lineItems = dfpDataCacheJob.loadLineItems(
       cachedLineItems,
       lineItemsModifiedSince,
       allReadyOrDeliveringLineItems
@@ -56,7 +64,7 @@ class DfpDataCacheJobTest extends FlatSpec with Matchers {
       lineItem(4, "f")
     )
 
-    val lineItems = DfpDataCacheJob.loadLineItems(
+    val lineItems = dfpDataCacheJob.loadLineItems(
       cachedLineItems,
       lineItemsModifiedSince,
       allReadyOrDeliveringLineItems
@@ -82,7 +90,7 @@ class DfpDataCacheJobTest extends FlatSpec with Matchers {
       lineItem(4, "f")
     )
 
-    val lineItems = DfpDataCacheJob.loadLineItems(
+    val lineItems = dfpDataCacheJob.loadLineItems(
       cachedLineItems,
       lineItemsModifiedSince,
       allReadyOrDeliveringLineItems

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -4,7 +4,6 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import common.Edition.defaultEdition
 import common.{Edition, ExecutionContexts, Logging}
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import implicits.{Dates, ItemResponses}
 import model.Cached.{WithoutRevalidationResult, RevalidatableResult}
 import model._
@@ -93,7 +92,7 @@ class AllIndexController(contentApiClient: ContentApiClient) extends Controller 
 
   // this is simply the latest by date. No lead content, editors picks, or anything else
   private def loadLatest(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[IndexPage]] = {
-    val result = getResponse(
+    val result = contentApiClient.getResponse(
       contentApiClient.item(s"/$path", Edition(request)).pageSize(50).toDate(date).orderBy("newest")
     ).map{ item =>
       item.section.map( section =>
@@ -117,7 +116,7 @@ class AllIndexController(contentApiClient: ContentApiClient) extends Controller 
   }
 
   private def findByDate(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[DateTime]] = {
-    val result = getResponse(
+    val result = contentApiClient.getResponse(
       contentApiClient.item(s"/$path", Edition(request))
         .pageSize(1)
         .fromDate(date)

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import conf._
 import common._
 import model.Cached.{WithoutRevalidationResult, RevalidatableResult}
 import model._
@@ -9,8 +8,7 @@ import play.api.mvc._
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 
-
-class EmbedController extends Controller with Logging with ExecutionContexts {
+class EmbedController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
 
   def render(path: String) = Action.async { implicit request =>
     lookup(path) map {
@@ -24,7 +22,7 @@ class EmbedController extends Controller with Logging with ExecutionContexts {
 
     log.info(s"Fetching video: $path for edition $edition")
 
-    val response: Future[ItemResponse] = ContentApiClient.getResponse(ContentApiClient.item(path, edition)
+    val response: Future[ItemResponse] = contentApiClient.getResponse(contentApiClient.item(path, edition)
       .showFields("all")
     )
 
@@ -50,5 +48,3 @@ class EmbedController extends Controller with Logging with ExecutionContexts {
     Cached(600)(RevalidatableResult.Ok(views.html.videoEmbed(model)))
   }
 }
-
-object EmbedController extends EmbedController

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -11,7 +11,7 @@ import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 
-class GalleryController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class GalleryController(contentApiClient: ContentApiClient) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }
@@ -39,7 +39,7 @@ class GalleryController extends Controller with RendersItemResponse with Logging
                     (implicit request: RequestHeader) = {
     val edition = Edition(request)
     log.info(s"Fetching gallery: $path for edition $edition")
-    ContentApiClient.getResponse(ContentApiClient.item(path, edition)
+    contentApiClient.getResponse(contentApiClient.item(path, edition)
       .showFields("all")
     ).map { response =>
       val gallery = response.content.map(Content(_))
@@ -61,5 +61,3 @@ class GalleryController extends Controller with RendersItemResponse with Logging
   private def isSupported(c: ApiContent) = c.isGallery
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
-
-object GalleryController extends GalleryController

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -15,7 +15,7 @@ case class InteractivePage (interactive: Interactive, related: RelatedContent) e
   override lazy val item = interactive
 }
 
-class InteractiveController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class InteractiveController(contentApiClient: ContentApiClient) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   def renderInteractiveJson(path: String): Action[AnyContent] = renderInteractive(path)
   def renderInteractive(path: String): Action[AnyContent] = Action.async { implicit request => renderItem(path) }
@@ -24,8 +24,8 @@ class InteractiveController extends Controller with RendersItemResponse with Log
                     (implicit request: RequestHeader): Future[Either[InteractivePage, Result]] = {
     val edition = Edition(request)
     log.info(s"Fetching interactive: $path for edition $edition")
-    val response: Future[ItemResponse] = ContentApiClient.getResponse(
-      ContentApiClient.item(path, edition)
+    val response: Future[ItemResponse] = contentApiClient.getResponse(
+      contentApiClient.item(path, edition)
         .showFields("all")
     )
 
@@ -54,5 +54,3 @@ class InteractiveController extends Controller with RendersItemResponse with Log
 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
 }
-
-object InteractiveController extends InteractiveController

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import common._
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import contentapi.Paths
 import model.Cached.WithoutRevalidationResult
 import model._
@@ -12,7 +11,7 @@ import services.{IndexPage, IndexPageItem}
 
 import scala.concurrent.Future
 
-class LatestIndexController extends Controller with ExecutionContexts with implicits.ItemResponses with Logging {
+class LatestIndexController(contentApiClient: ContentApiClient) extends Controller with ExecutionContexts with implicits.ItemResponses with Logging {
   def latest(path: String) = Action.async { implicit request =>
     loadLatest(path).map { _.map { index =>
       index.page match {
@@ -34,8 +33,8 @@ class LatestIndexController extends Controller with ExecutionContexts with impli
 
   // this is simply the latest by date. No lead content, editors picks, or anything else
   private def loadLatest(path: String)(implicit request: RequestHeader): Future[Option[IndexPage]] = {
-    val result = getResponse(
-      ContentApiClient.item(s"/$path", Edition(request))
+    val result = contentApiClient.getResponse(
+      contentApiClient.item(s"/$path", Edition(request))
         .pageSize(1)
         .orderBy("newest")
     ).map{ item =>
@@ -64,5 +63,3 @@ class LatestIndexController extends Controller with ExecutionContexts with impli
     }
   }
 }
-
-object LatestIndexController extends LatestIndexController

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -40,7 +40,7 @@ case class QuizAnswersPage(
   val shares: Seq[ShareLink] = if (results.isKnowledge) knowledgeShares else personalityShares
 }
 
-class QuizController extends Controller with ExecutionContexts with Logging {
+class QuizController(contentApiClient: ContentApiClient) extends Controller with ExecutionContexts with Logging {
 
   def submit(quizId: String, path: String) = Action.async { implicit request =>
     form.playForm.bindFromRequest.fold(
@@ -58,8 +58,8 @@ class QuizController extends Controller with ExecutionContexts with Logging {
     val edition = Edition(request)
 
     log.info(s"Fetching quiz atom: $quizId from content id: $path: ${RequestLog(request)}")
-    val capiQuery = ContentApiClient.item(path, edition).showAtoms("all")
-    val result = ContentApiClient.getResponse(capiQuery) map { itemResponse =>
+    val capiQuery = contentApiClient.item(path, edition).showAtoms("all")
+    val result = contentApiClient.getResponse(capiQuery) map { itemResponse =>
       val maybePage: Option[QuizAnswersPage] = itemResponse.content.flatMap { content =>
 
         val quiz = Atoms.make(content).flatMap(_.quizzes.find(_.id == quizId))
@@ -75,5 +75,3 @@ class QuizController extends Controller with ExecutionContexts with Logging {
   }
 
 }
-
-object QuizController extends QuizController

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -7,7 +7,7 @@ import contentapi.ContentApiClient
 import model.Cached
 import play.api.mvc.{RequestHeader, Action, Controller}
 
-class ShortUrlsController extends Controller with Logging with ExecutionContexts {
+class ShortUrlsController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
     log.info(s"Redirecting short url $shortUrl")
@@ -15,7 +15,7 @@ class ShortUrlsController extends Controller with Logging with ExecutionContexts
   }
 
   private def redirectUrl(shortUrl: String, queryString: Map[String, Seq[String]])(implicit request: RequestHeader) = {
-    ContentApiClient.getResponse(ContentApiClient.item(shortUrl)).map { response =>
+    contentApiClient.getResponse(contentApiClient.item(shortUrl)).map { response =>
       response.content.map(_.id).map { id =>
         Redirect(LinkTo(s"/$id"), queryString = queryString, status = MOVED_PERMANENTLY)
       }.getOrElse(NotFound)
@@ -28,5 +28,3 @@ class ShortUrlsController extends Controller with Logging with ExecutionContexts
     redirectUrl(shortUrl, queryString)
   }
 }
-
-object ShortUrlsController extends ShortUrlsController

--- a/applications/test/CrosswordDataTest.scala
+++ b/applications/test/CrosswordDataTest.scala
@@ -7,11 +7,18 @@ import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
 
-@DoNotDiscover class CrosswordDataTest extends FreeSpec with ShouldMatchers with ConfiguredTestSuite with ScalaFutures {
+@DoNotDiscover class CrosswordDataTest
+  extends FreeSpec
+  with ShouldMatchers
+  with ConfiguredTestSuite
+  with ScalaFutures
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   "CrosswordData" - {
 
-    val crosswordPageController = new CrosswordPageController
+    val crosswordPageController = new CrosswordPageController(testContentApiClient)
 
     "fromCrossword should normalize separators for grouped entries" in {
 

--- a/applications/test/CrosswordPageMetaDataTest.scala
+++ b/applications/test/CrosswordPageMetaDataTest.scala
@@ -2,12 +2,18 @@ package test
 
 import controllers.CrosswordPageController
 import metadata.MetaDataMatcher
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class CrosswordPageMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CrosswordPageMetaDataTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val crosswordUrl = "crosswords/cryptic/26697"
-  val crosswordPageController = new CrosswordPageController
+  val crosswordPageController = new CrosswordPageController(testContentApiClient)
 
   it should "not include the ios deep link" in {
     val result = crosswordPageController.crossword("cryptic", 26697)(TestRequest(crosswordUrl))

--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -2,13 +2,19 @@ package test
 
 import controllers.GalleryController
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class GalleryControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class GalleryControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient{
 
   val galleryUrl = "news/gallery/2012/may/02/picture-desk-live-kabul-burma"
 
-  val galleryController = new GalleryController
+  val galleryController = new GalleryController(testContentApiClient)
 
   "Gallery Controller" should "200 when content type is gallery" in {
     val result = galleryController.render(galleryUrl)(TestRequest(s"/$galleryUrl"))

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -2,13 +2,20 @@ package test
 
 import controllers.InteractiveController
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+
 import scala.collection.JavaConversions._
 
-@DoNotDiscover class InteractiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class InteractiveControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val url = "lifeandstyle/ng-interactive/2016/mar/12/stephen-collins-cats-cartoon"
-  val interactiveController = new InteractiveController
+  val interactiveController = new InteractiveController(testContentApiClient)
 
   "Interactive Controller" should "200 when content type is 'interactive'" in {
     val result = interactiveController.renderInteractive(url)(TestRequest(url))

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -1,14 +1,20 @@
 package test
 
 import controllers.LatestIndexController
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 
-@DoNotDiscover class LatestIndexControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class LatestIndexControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   private val MovedPermanently = 301
   private val Found = 302
-  val latestIndexController = new LatestIndexController
+  val latestIndexController = new LatestIndexController(testContentApiClient)
 
   it should "redirect to latest for a series" in {
     val result = latestIndexController.latest("football/series/thefiver")(TestRequest())

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -2,13 +2,18 @@ package test
 
 import controllers.MediaController
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class MediaControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MediaControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll with WithTestWsClient
+  with WithTestContentApiClient {
 
   val videoUrl = "uk/video/2012/jun/26/queen-enniskillen-northern-ireland-video"
   val videoUrlWithDodgyOctpusUrl = "football/video/2015/feb/10/manchester-united-louis-van-gaal-long-ball-video"
-  val mediaController = new MediaController
+  val mediaController = new MediaController(testContentApiClient)
 
   "Media Controller" should "200 when content type is video" in {
     val result = mediaController.render(videoUrl)(TestRequest(videoUrl))

--- a/applications/test/TestAppLoader.scala
+++ b/applications/test/TestAppLoader.scala
@@ -1,0 +1,13 @@
+import app.FrontendComponents
+import play.api.ApplicationLoader.Context
+import play.api.BuiltInComponentsFromContext
+import test.WithTestContentApiClient
+
+trait TestComponents extends WithTestContentApiClient {
+  self: ApplicationsServices =>
+  override lazy val contentApiClient = testContentApiClient
+}
+
+class TestAppLoader extends AppLoader {
+  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents with TestComponents
+}

--- a/common/app/common/dfp/CapiLookupAgent.scala
+++ b/common/app/common/dfp/CapiLookupAgent.scala
@@ -2,10 +2,9 @@ package common.dfp
 
 import common.{AkkaAgent, ExecutionContexts, Logging}
 import contentapi.ContentApiClient
-
 import scala.concurrent.Future
 
-object CapiLookupAgent extends ExecutionContexts with Logging {
+class CapiLookupAgent(contentApiClient: ContentApiClient) extends ExecutionContexts with Logging {
 
   private val agent = AkkaAgent[Map[(TagType, String), Seq[String]]](Map.empty)
 
@@ -21,8 +20,8 @@ object CapiLookupAgent extends ExecutionContexts with Logging {
   private def lookup(paidForTags: Seq[PaidForTag]): Future[Map[(TagType, String), Seq[String]]] = {
 
     def lookup(tagType: TagType, tagName: String): Future[((TagType, String), Seq[String])] = {
-      val query = ContentApiClient.tags.q(tagName).tagType(tagType.name).pageSize(50)
-      val lookupResult = ContentApiClient.getResponse(query) map { response =>
+      val query = contentApiClient.tags.q(tagName).tagType(tagType.name).pageSize(50)
+      val lookupResult = contentApiClient.getResponse(query) map { response =>
         response.results
       } recover {
         case e: Exception =>

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -141,7 +141,7 @@ case class PaidForTag(targetedName: String,
                       lineItems: Seq[GuLineItem]) {
 }
 
-object PaidForTagFormat {
+object PaidForTag {
 
   implicit val pftWrites: Writes[PaidForTag] = new Writes[PaidForTag] {
     override def writes(tag: PaidForTag): JsValue = {
@@ -217,7 +217,7 @@ case class PaidForTagsReport(updatedTimeStamp: String, paidForTags: Seq[PaidForT
 
 object PaidForTagsReport {
 
-  import common.dfp.PaidForTagFormat._
+  import common.dfp.PaidForTag._
 
   implicit val jsonWrites = new Writes[PaidForTagsReport] {
     override def writes(report: PaidForTagsReport): JsValue = {

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -162,6 +162,7 @@ final case class CircuitBreakingContentApiClient(
     }
   }
 }
+
 //TODO: Do not use. For legacy reason only.
 //To delete once all references to ContentApiClient are via the class
 object ContentApiClient extends ContentApiClient(WSCapiHttpClient)

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -6,6 +6,7 @@ import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters}
+import contentapi.{CapiHttpClient, ContentApiClient}
 import controllers.{HealthCheck, OnwardControllers}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import feed._
@@ -27,6 +28,8 @@ class AppLoader extends FrontendApplicationLoader {
 trait OnwardServices {
   def wsClient: WSClient
   def environment: Environment
+  lazy val capiHttpClient = wire[CapiHttpClient]
+  lazy val contentApiClient = wire[ContentApiClient]
   lazy val ophanApi = wire[OphanApi]
   lazy val stocksData = wire[StocksData]
   lazy val weatherApi = wire[WeatherApi]

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -4,7 +4,6 @@ import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import layout.{CollectionEssentials, FaciaContainer}
 import model._
@@ -15,7 +14,7 @@ import slices.{Fixed, FixedContainers}
 
 import scala.concurrent.Future
 
-class MediaInSectionController extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class MediaInSectionController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
   // These exist to work around the absence of default values in Play routing.
   def renderSectionMediaWithSeries(mediaType: String, sectionId: String, seriesId: String) =
     renderMedia(mediaType, sectionId, Some(seriesId))
@@ -38,7 +37,7 @@ class MediaInSectionController extends Controller with Logging with Paging with 
     def isCurrentStory(content: ApiContent) =
       content.fields.flatMap(_.shortUrl).exists(!_.equals(currentShortUrl))
 
-    val promiseOrResponse = getResponse(ContentApiClient.search(edition)
+    val promiseOrResponse = contentApiClient.getResponse(contentApiClient.search(edition)
       .section(sectionId)
       .tag(tags)
       .showTags("all")
@@ -92,5 +91,3 @@ class MediaInSectionController extends Controller with Logging with Paging with 
     renderFormat(response, response, 900)
   }
 }
-
-object MediaInSectionController extends MediaInSectionController

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -10,7 +10,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 import views.support.FaciaToMicroFormat2Helpers._
 import scala.concurrent.Future
 
-class MostPopularController(geoMostPopularAgent: GeoMostPopularAgent, dayMostPopularAgent: DayMostPopularAgent) extends Controller with Logging with ExecutionContexts {
+class MostPopularController(contentApiClient: ContentApiClient, geoMostPopularAgent: GeoMostPopularAgent, dayMostPopularAgent: DayMostPopularAgent) extends Controller with Logging with ExecutionContexts {
   val page = SimplePage(MetaData.make(
     "most-read",
     Some(SectionSummary.fromId("most-read")),
@@ -101,7 +101,7 @@ class MostPopularController(geoMostPopularAgent: GeoMostPopularAgent, dayMostPop
 
   private def lookup(edition: Edition, path: String)(implicit request: RequestHeader) = {
     log.info(s"Fetching most popular: $path for edition $edition")
-    ContentApiClient.getResponse(ContentApiClient.item(path, edition)
+    contentApiClient.getResponse(contentApiClient.item(path, edition)
       .tag(None)
       .showMostViewed(true)
     ).map{response =>

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -13,7 +13,7 @@ import slices.Fixed
 
 import scala.concurrent.Future.{successful => unit}
 
-class MostViewedSocialController(mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh) extends Controller with ExecutionContexts {
+class MostViewedSocialController(contentApiClient: ContentApiClient, mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh) extends Controller with ExecutionContexts {
   def renderMostViewed(socialContext: String) = Action.async { implicit request =>
     val mostPopularSocial = mostPopularSocialAutoRefresh.get
 
@@ -25,8 +25,8 @@ class MostViewedSocialController(mostPopularSocialAutoRefresh: MostPopularSocial
 
     articles match {
       case Some(articleIds) if articleIds.nonEmpty =>
-        ContentApiClient.getResponse(
-          ContentApiClient
+        contentApiClient.getResponse(
+          contentApiClient
             .search(Edition(request))
             .ids(articleIds.take(7).map(item => feed.urlToContentPath(item.url)).mkString(","))
         ) map { response =>

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -5,16 +5,15 @@ import feed.MostViewedVideoAgent
 import model.{Content, Video, Cached}
 import play.api.mvc.{Action, Controller}
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 
-class MostViewedVideoController(mostViewedVideoAgent: MostViewedVideoAgent) extends Controller with Logging with ExecutionContexts {
+class MostViewedVideoController(contentApiClient: ContentApiClient, mostViewedVideoAgent: MostViewedVideoAgent) extends Controller with Logging with ExecutionContexts {
 
   // Move this out of here if the test is successful
   def renderInSeries(series: String) = Action.async { implicit request =>
     val page = (request.getQueryString("page") getOrElse "1").toInt
     val edition = Edition(request)
 
-    getResponse(ContentApiClient.search(edition)
+    contentApiClient.getResponse(contentApiClient.search(edition)
       .tag(series)
       .contentType("video")
       .showTags("series")

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -3,6 +3,7 @@ package controllers
 import com.softwaremill.macwire._
 import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData
+import contentapi.ContentApiClient
 import feed._
 import play.api.libs.ws.WSClient
 import weather.WeatherApi
@@ -10,6 +11,7 @@ import weather.WeatherApi
 trait OnwardControllers {
 
   def wsClient: WSClient
+  def contentApiClient: ContentApiClient
   def stocksData: StocksData
   def weatherApi: WeatherApi
   def geoMostPopularAgent: GeoMostPopularAgent

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -8,9 +8,8 @@ import scala.concurrent.Future
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.ItemResponse
 import play.twirl.api.HtmlFormat
-import ContentApiClient.getResponse
 
-class RichLinkController extends Controller with Paging with Logging with ExecutionContexts with Requests   {
+class RichLinkController(contentApiClient: ContentApiClient) extends Controller with Paging with Logging with ExecutionContexts with Requests   {
 
   def renderHtml(path: String) = render(path)
 
@@ -24,8 +23,8 @@ class RichLinkController extends Controller with Paging with Logging with Execut
     val edition = Edition(request)
     log.info(s"Fetching article: $path for edition: ${edition.id}:")
 
-    val response: Future[ItemResponse] = getResponse(
-      ContentApiClient.item(path, edition)
+    val response: Future[ItemResponse] = contentApiClient.getResponse(
+      contentApiClient.item(path, edition)
         .showFields("headline,standfirst,shortUrl,webUrl,byline,starRating,trailText,liveBloggingNow")
         .showTags("all")
         .showElements("all")
@@ -45,5 +44,3 @@ class RichLinkController extends Controller with Paging with Logging with Execut
     }
   }
 }
-
-object RichLinkController extends RichLinkController

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -5,7 +5,6 @@ import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.facia.client.models.Backfill
 import common._
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import layout.{CollectionEssentials, DescriptionMetaHeader, FaciaContainer}
 import model.Cached.WithoutRevalidationResult
@@ -27,7 +26,7 @@ case class Series(id: String, tag: Tag, trails: RelatedContent) {
  }
 }
 
-class SeriesController extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class SeriesController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
   def renderSeriesStories(seriesId: String) = Action.async { implicit request =>
     lookup(Edition(request), seriesId) map { series =>
       series.map(renderSeriesTrails).getOrElse(NotFound)
@@ -49,7 +48,7 @@ class SeriesController extends Controller with Logging with Paging with Executio
     def isCurrentStory(content: ApiContent) =
       content.fields.flatMap(_.shortUrl).exists(_.equals(currentShortUrl))
 
-    val seriesResponse: Future[Option[Series]] = getResponse(ContentApiClient.item(seriesId, edition)
+    val seriesResponse: Future[Option[Series]] = contentApiClient.getResponse(contentApiClient.item(seriesId, edition)
       .showFields("all")
     ).map { response =>
         response.tag.flatMap { tag =>
@@ -111,5 +110,3 @@ class SeriesController extends Controller with Logging with Paging with Executio
     renderFormat(response, response, 900)
   }
 }
-
-object SeriesController extends SeriesController

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -3,7 +3,6 @@ package controllers
 import com.gu.contentapi.client.GuardianContentApiError
 import common._
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import feed.MostReadAgent
 import model._
 import play.api.libs.json.{JsArray, Json}
@@ -12,7 +11,7 @@ import services._
 
 import scala.concurrent.Future
 
-class TaggedContentController(val mostReadAgent: MostReadAgent) extends Controller with Related with Logging with ExecutionContexts {
+class TaggedContentController(contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent) extends Controller with Related with Logging with ExecutionContexts {
 
   def renderJson(tag: String) = Action.async { implicit request =>
     tagWhitelist.find(_ == tag).map { tag =>
@@ -46,7 +45,7 @@ class TaggedContentController(val mostReadAgent: MostReadAgent) extends Controll
 
   private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[List[ContentType]] = {
     log.info(s"Fetching tagged stories for edition ${edition.id}")
-    getResponse(ContentApiClient.search(edition)
+    contentApiClient.getResponse(contentApiClient.search(edition)
       .tag(tag)
       .pageSize(3)
     ).map { response =>

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -10,7 +10,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 
 import scala.concurrent.Future
 
-class TopStoriesController extends Controller with Logging with Paging with ExecutionContexts {
+class TopStoriesController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts {
 
   def renderTopStoriesHtml = renderTopStories()
   def renderTopStories() = Action.async { implicit request =>
@@ -31,7 +31,7 @@ class TopStoriesController extends Controller with Logging with Paging with Exec
 
   private def lookup(edition: Edition)(implicit request: RequestHeader): Future[Option[RelatedContent]] = {
     log.info(s"Fetching top stories for edition ${edition.id}")
-    ContentApiClient.getResponse(ContentApiClient.item("/", edition)
+    contentApiClient.getResponse(contentApiClient.item("/", edition)
       .showEditorsPicks(true)
     ).map { response =>
         response.editorsPicks.getOrElse(Seq.empty).toList map { item =>
@@ -77,5 +77,3 @@ class TopStoriesController extends Controller with Logging with Paging with Exec
     renderFormat(response, response, 900)
   }
 }
-
-object TopStoriesController extends TopStoriesController

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -4,14 +4,13 @@ import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
-import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import model._
 import play.api.mvc.{Action, Controller, RequestHeader}
 
 import scala.concurrent.Future
 
-class VideoEndSlateController extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class VideoEndSlateController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
 
   def renderSection(sectionId: String) = Action.async { implicit request =>
     val response = lookupSection(Edition(request), sectionId) map { seriesItems =>
@@ -26,7 +25,7 @@ class VideoEndSlateController extends Controller with Logging with Paging with E
 
     def isCurrentStory(content: ApiContent) = content.fields.flatMap(_.shortUrl).exists(_ == currentShortUrl)
 
-    val promiseOrResponse = getResponse(ContentApiClient.search(edition)
+    val promiseOrResponse = contentApiClient.getResponse(contentApiClient.search(edition)
       .section(sectionId)
       .tag("type/video")
       .showTags("all")
@@ -66,7 +65,7 @@ class VideoEndSlateController extends Controller with Logging with Paging with E
 
     def isCurrentStory(content: ApiContent) = content.fields.flatMap(_.shortUrl).exists(_ == currentShortUrl)
 
-    val promiseOrResponse = getResponse(ContentApiClient.item(seriesId, edition)
+    val promiseOrResponse = contentApiClient.getResponse(contentApiClient.item(seriesId, edition)
       .tag("type/video")
       .showTags("all")
       .showFields("all")
@@ -89,5 +88,3 @@ class VideoEndSlateController extends Controller with Logging with Paging with E
     renderFormat(response, response, 900)
   }
 }
-
-object VideoEndSlateController extends VideoEndSlateController

--- a/onward/test/ContentCardControllerTest.scala
+++ b/onward/test/ContentCardControllerTest.scala
@@ -1,15 +1,23 @@
 package test
 
-import org.scalatest.{Matchers, FlatSpec, DoNotDiscover}
+import controllers.RichLinkController
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test._
 import play.api.test.Helpers._
 
-@DoNotDiscover class RichLinkControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite  {
+@DoNotDiscover class RichLinkControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val article = "/world/2014/nov/18/hereford-hospital-patient-tested-for-ebola"
+  lazy val richLinkController = new RichLinkController(testContentApiClient)
 
   "Content Card Controller" should "200 when the content is found" in {
-      val result = controllers.RichLinkController.render(article)(TestRequest())
+      val result = richLinkController.render(article)(TestRequest())
       status(result) should be(200)
   }
 
@@ -18,7 +26,7 @@ import play.api.test.Helpers._
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = controllers.RichLinkController.render(article)(fakeRequest)
+    val result = richLinkController.render(article)(fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -12,12 +12,13 @@ import services.OphanApi
   with Matchers
   with ConfiguredTestSuite
   with BeforeAndAfterAll
-  with WithTestWsClient {
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   val tag = "technology"
 
   lazy val ophanApi = new OphanApi(wsClient)
-  lazy val mostPopularController = new MostPopularController(new GeoMostPopularAgent(ophanApi), new DayMostPopularAgent(ophanApi))
+  lazy val mostPopularController = new MostPopularController(testContentApiClient, new GeoMostPopularAgent(ophanApi), new DayMostPopularAgent(ophanApi))
 
   "Most Popular Controller" should "200 when content type is tag" in {
     val result = mostPopularController.render(tag)(TestRequest())

--- a/onward/test/MostViewedVideoTest.scala
+++ b/onward/test/MostViewedVideoTest.scala
@@ -11,9 +11,10 @@ import services.OphanApi
   with Matchers
   with ConfiguredTestSuite
   with BeforeAndAfterAll
-  with WithTestWsClient {
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
-  lazy val mostViewedVideoController = new MostViewedVideoController(new MostViewedVideoAgent(new OphanApi(wsClient)))
+  lazy val mostViewedVideoController = new MostViewedVideoController(testContentApiClient, new MostViewedVideoAgent(new OphanApi(wsClient)))
 
   "Most Viewed Video Controller" should "200 when content type is tag" in {
     val result = mostViewedVideoController.renderMostViewed()(TestRequest())

--- a/onward/test/SeriesControllerTest.scala
+++ b/onward/test/SeriesControllerTest.scala
@@ -1,14 +1,22 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import controllers.SeriesController
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 
-@DoNotDiscover class SeriesControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class SeriesControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
   var series = "news/series/pass-notes"
+  lazy val seriesController = new SeriesController(testContentApiClient)
 
   "Series Controller" should "200 when content type is a tag" in {
-    val result = controllers.SeriesController.renderSeriesStories(series)(TestRequest())
+    val result = seriesController.renderSeriesStories(series)(TestRequest())
     status(result) should be (200)
   }
 

--- a/onward/test/TestAppLoader.scala
+++ b/onward/test/TestAppLoader.scala
@@ -1,0 +1,13 @@
+import app.FrontendComponents
+import play.api.ApplicationLoader.Context
+import play.api.BuiltInComponentsFromContext
+import test.WithTestContentApiClient
+
+trait TestComponents extends WithTestContentApiClient {
+  self: OnwardServices =>
+  override lazy val contentApiClient = testContentApiClient
+}
+
+class TestAppLoader extends AppLoader {
+  override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents with TestComponents
+}

--- a/onward/test/TopStoriesControllerTest.scala
+++ b/onward/test/TopStoriesControllerTest.scala
@@ -1,13 +1,22 @@
 package test
 
+import controllers.TopStoriesController
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
-@DoNotDiscover class TopStoriesControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class TopStoriesControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
+
+  lazy val topStoriesController = new TopStoriesController(testContentApiClient)
 
   "Top Stories" should "should return 200" in {
-    val result = controllers.TopStoriesController.renderTopStories()(TestRequest())
+    val result = topStoriesController.renderTopStories()(TestRequest())
     status(result) should be(200)
   }
 
@@ -16,14 +25,14 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = controllers.TopStoriesController.renderTopStories()(fakeRequest)
+    val result = topStoriesController.renderTopStories()(fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")
   }
 
   it should "should return 200 for trails" in {
-    val result = controllers.TopStoriesController.renderTrails()(TestRequest())
+    val result = topStoriesController.renderTrails()(TestRequest())
     status(result) should be(200)
   }
 }

--- a/onward/test/VideoInSectionTest.scala
+++ b/onward/test/VideoInSectionTest.scala
@@ -1,19 +1,28 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import controllers.MediaInSectionController
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 
-@DoNotDiscover class VideoInSectionTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class VideoInSectionTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
+
+  lazy val mediaInSectionController = new MediaInSectionController(testContentApiClient)
 
   "Video In Section controller" should "provide a tag combiner link" in {
-    val result = controllers.MediaInSectionController.renderSectionMedia("video", "football")(TestRequest())
+    val result = mediaInSectionController.renderSectionMedia("video", "football")(TestRequest())
     status(result) should be (200)
     contentAsString(result) should include ("href=\"/football/football+content/video\"")
     contentAsString(result) should include ("more football videos")
   }
 
   "Video In Section controller" should "exclude videos in the series specified" in {
-    val result = controllers.MediaInSectionController.renderSectionMediaWithSeries("video", "fashion", "theguardian/series/how-to-dress")(TestRequest())
+    val result = mediaInSectionController.renderSectionMediaWithSeries("video", "fashion", "theguardian/series/how-to-dress")(TestRequest())
     status(result) should be (200)
     contentAsString(result) should not include ("fashion-tips")
   }

--- a/sport/app/football/controllers/FootballControllers.scala
+++ b/sport/app/football/controllers/FootballControllers.scala
@@ -2,11 +2,13 @@ package football.controllers
 
 import com.softwaremill.macwire._
 import conf.FootballClient
+import contentapi.ContentApiClient
 import feed.CompetitionsService
 
 trait FootballControllers {
   def competitionsService: CompetitionsService
   def footballClient: FootballClient
+  def contentApiClient: ContentApiClient
   lazy val fixturesController = wire[FixturesController]
   lazy val resultsController = wire[ResultsController]
   lazy val matchDayController = wire[MatchDayController]

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -2,6 +2,7 @@ package football.controllers
 
 import common._
 import conf.Configuration
+import contentapi.ContentApiClient
 import feed.CompetitionsService
 import football.model.FootballMatchTrail
 import implicits.{Football, Requests}
@@ -14,7 +15,7 @@ import pa.FootballMatch
 import play.api.libs.json._
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import play.twirl.api.Html
-import contentapi.ContentApiClient
+
 import scala.concurrent.Future
 
 case class Report(trail: FootballMatchTrail, name: String)
@@ -34,7 +35,7 @@ case class MatchNav(
   lazy val hasPreview = preview.isDefined
 }
 
-class MoreOnMatchController(val competitionsService: CompetitionsService) extends Controller with Football with Requests with Logging with ExecutionContexts with implicits.Dates {
+class MoreOnMatchController(val competitionsService: CompetitionsService, contentApiClient: ContentApiClient) extends Controller with Football with Requests with Logging with ExecutionContexts with implicits.Dates {
   def interval(contentDate: LocalDate) = new Interval(contentDate.toDateTimeAtStartOfDay - 2.days, contentDate.toDateTimeAtStartOfDay + 3.days)
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMdd").withZone(DateTimeZone.forID("Europe/London"))
@@ -94,7 +95,7 @@ class MoreOnMatchController(val competitionsService: CompetitionsService) extend
   def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[List[ContentType]] = {
     val matchDate = theMatch.date.toLocalDate
 
-    ContentApiClient.getResponse(ContentApiClient.search(Edition(request))
+    contentApiClient.getResponse(contentApiClient.search(Edition(request))
       .section("football")
       .tag("tone/minutebyminute|tone/matchreports|football/series/squad-sheets|football/series/match-previews|football/series/saturday-clockwatch")
       .fromDate(matchDate.minusDays(2).toDateTimeAtStartOfDay)

--- a/sport/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/sport/test/controllers/MoreOnMatchFeatureTest.scala
@@ -9,9 +9,13 @@ import play.api.test.FakeRequest
   extends FeatureSpec
   with GivenWhenThen
   with Matchers
-  with FootballTestData with WithTestFootballClient with BeforeAndAfterAll with WithTestWsClient {
+  with FootballTestData
+  with WithTestFootballClient
+  with BeforeAndAfterAll
+  with WithTestWsClient
+  with WithTestContentApiClient {
 
-  val moreOnMatchController = new MoreOnMatchController(testCompetitionsService)
+  val moreOnMatchController = new MoreOnMatchController(testCompetitionsService, testContentApiClient)
 
   feature("Match Nav") {
 

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -1,10 +1,11 @@
-import app.{LifecycleComponent, FrontendComponents}
+import app.{FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
 import common.Logback.LogstashLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
 import conf.FootballLifecycle
 import conf.switches.SwitchboardLifecycle
+import contentapi.{CapiHttpClient, ContentApiClient}
 import cricket.conf.CricketLifecycle
 import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
@@ -12,6 +13,11 @@ import services.ConfigAgentLifecycle
 
 trait StandaloneLifecycleComponents extends SportServices with CommercialServices with FapiServices with OnwardServices {
   self: FrontendComponents =>
+
+  //Override conflicting members
+  override lazy val capiHttpClient = wire[CapiHttpClient]
+  override lazy val contentApiClient = wire[ContentApiClient]
+
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],
     wire[CommercialLifecycle],

--- a/standalone/app/controllers/ItemController.scala
+++ b/standalone/app/controllers/ItemController.scala
@@ -10,7 +10,7 @@ class ItemController(articleController: ArticleController,
   articleController,
   new GalleryController(contentApiClient),
   MediaController,
-  InteractiveController,
+  new InteractiveController(contentApiClient),
   ImageContentController,
   faciaDraftController
 )

--- a/standalone/app/controllers/ItemController.scala
+++ b/standalone/app/controllers/ItemController.scala
@@ -5,12 +5,14 @@ import contentapi.ContentApiClient
 // If you add to this, don't forget the one in dev-build
 class ItemController(articleController: ArticleController,
                      faciaDraftController: FaciaDraftController,
-                     contentApiClient: ContentApiClient
+                     galleryController: GalleryController,
+                     mediaController: MediaController,
+                     interactiveController: InteractiveController
                     ) extends ItemResponseController(
   articleController,
-  new GalleryController(contentApiClient),
-  new MediaController(contentApiClient),
-  new InteractiveController(contentApiClient),
+  galleryController,
+  mediaController,
+  interactiveController,
   ImageContentController,
   faciaDraftController
 )

--- a/standalone/app/controllers/ItemController.scala
+++ b/standalone/app/controllers/ItemController.scala
@@ -9,7 +9,7 @@ class ItemController(articleController: ArticleController,
                     ) extends ItemResponseController(
   articleController,
   new GalleryController(contentApiClient),
-  MediaController,
+  new MediaController(contentApiClient),
   new InteractiveController(contentApiClient),
   ImageContentController,
   faciaDraftController

--- a/standalone/app/controllers/ItemController.scala
+++ b/standalone/app/controllers/ItemController.scala
@@ -1,9 +1,14 @@
 package controllers
 
+import contentapi.ContentApiClient
+
 // If you add to this, don't forget the one in dev-build
-class ItemController(articleController: ArticleController, faciaDraftController: FaciaDraftController) extends ItemResponseController(
+class ItemController(articleController: ArticleController,
+                     faciaDraftController: FaciaDraftController,
+                     contentApiClient: ContentApiClient
+                    ) extends ItemResponseController(
   articleController,
-  GalleryController,
+  new GalleryController(contentApiClient),
   MediaController,
   InteractiveController,
   ImageContentController,

--- a/standalone/app/controllers/StandaloneControllerComponents.scala
+++ b/standalone/app/controllers/StandaloneControllerComponents.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.softwaremill.macwire._
+import contentapi.{CapiHttpClient, ContentApiClient}
 import controllers.commercial.CommercialControllers
 import controllers.front.FrontJsonFapiDraft
 import cricket.controllers.CricketControllers


### PR DESCRIPTION
## What does this change?

Inject contentApiClient in all necessary controllers (and one agent)
I am trying to keep the size of those PR manageable because it is quite repetitive at this point.
## What is the value of this and can you measure success?

➡️ Play 2.5

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
