### PR TITLE
Hosted article - figcaption fixed

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -96,6 +96,18 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
         h1 {
             line-height: 28px;
         }
+        figcaption {
+            font-size: 12px;
+            line-height: 16px;
+            color: $neutral-2;
+
+            &:before {
+                @include icon(image);
+                content: '';
+                vertical-align: top;
+                margin-top: 1px;
+            }
+        }
     }
     .hosted__standfirst {
         padding: 0;


### PR DESCRIPTION
## What does this change?

This PR fixes the caption styling on hosted article pages.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-14 at 13 06 30](https://cloud.githubusercontent.com/assets/489567/18511515/1bc41162-7a7c-11e6-8a6d-59826c6aca67.png)

After:
![screen shot 2016-09-14 at 13 06 36](https://cloud.githubusercontent.com/assets/489567/18511528/23727890-7a7c-11e6-8fe2-15ffd15e7be7.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
