### PR TITLE
Chester Zoo - styling fixes for gallery captions, etc

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -51,8 +51,12 @@
                     <div class="hosted-gallery__captions">
                         @for(i <- page.images.indices) {
                             <div class="hosted-gallery__caption js-hosted-gallery-caption @{if (i == 0) "current-caption" else ""}">
-                                @fragments.inlineSvg("camera", "icon", List("inline-camera inline-icon "))
-                                <span>@page.images(i).title</span>
+                                <div class="hosted-gallery__image-title">
+                                    <span>
+                                        @fragments.inlineSvg("camera", "icon", List("inline-camera inline-icon "))
+                                        @page.images(i).title
+                                    </span>
+                                </div>
                                 <div class="hosted-gallery__caption-text">
                                     @page.images(i).caption
                                     @if(page.images(i).caption.nonEmpty && page.images(i).credit.nonEmpty) {<br/>}

--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -10,7 +10,7 @@
                 <div class="js-hosted-gallery-container hosted-gallery__gallery-container">
                     <div class="js-hosted-gallery-images hosted-gallery__images-container">
                         @guardianHostedGalleryImage(page.images.head, {
-                            <div class="hosted-gallery__meta">
+                            <div class="hosted-gallery__meta js-hosted-gallery-meta">
                                 <div class="content__main-column">
                                     <h1 class="hosted-gallery__heading">{page.title}</h1>
                                     <h3 class="hosted-gallery__sub-heading">{page.standfirst}</h3>

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -267,7 +267,7 @@ define([
         var ctaIndex = this.ctaIndex();
         fastdom.write(function () {
             this.$images.each(function (image, index) {
-                var opacity = (progress - index + 1) * 4 / 3;
+                var opacity = ((progress - index + 1) * 16 / 11) - 0.0625;
                 bonzo(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
             });
 
@@ -279,6 +279,7 @@ define([
 
             bonzo(this.$progress).toggleClass('first-half', fractionProgress && fractionProgress < 0.5);
 
+            bonzo(this.$meta).css('opacity', progress != 0 ? 0 : 1);
         }.bind(this));
 
         if (newIndex && newIndex !== this.index) {

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -59,6 +59,7 @@ define([
         this.$counter = $('.js-hosted-gallery-image-count', this.$progress);
         this.$ctaFloat = $('.js-hosted-gallery-cta', this.$galleryEl)[0];
         this.$ojFloat = $('.js-hosted-gallery-oj', this.$galleryEl)[0];
+        this.$meta = $('.js-hosted-gallery-meta', this.$galleryEl)[0];
 
         if (this.$galleryEl.length) {
             this.resize = this.trigger.bind(this, 'resize');
@@ -240,7 +241,8 @@ define([
 
     HostedGallery.prototype.translateContent = function (imgIndex, offset, duration) {
         var px = -1 * (imgIndex - 1) * this.swipeContainerWidth,
-            galleryEl = this.$imagesContainer[0];
+            galleryEl = this.$imagesContainer[0],
+            $meta = this.$meta;
         galleryEl.style.webkitTransitionDuration = duration + 'ms';
         galleryEl.style.mozTransitionDuration = duration + 'ms';
         galleryEl.style.msTransitionDuration = duration + 'ms';
@@ -249,6 +251,9 @@ define([
         galleryEl.style.mozTransform = 'translate(' + (px + offset) + 'px,0)';
         galleryEl.style.msTransform = 'translate(' + (px + offset) + 'px,0)';
         galleryEl.style.transform = 'translate(' + (px + offset) + 'px,0)' + 'translateZ(0)';
+        fastdom.write(function () {
+            bonzo($meta).css('opacity', offset != 0 ? 0 : 1);
+        });
     };
 
     HostedGallery.prototype.fadeContent = function (e) {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -99,7 +99,7 @@
         font-size: 30px;
         line-height: 32px;
     }
-    &:hover {
+    &:hover, &:active {
         text-decoration: none;
     }
 }
@@ -154,7 +154,7 @@
     flex-wrap: wrap-reverse;
     align-items: flex-end;
     align-content: flex-end;
-    &:hover {
+    &:hover, &:active {
         text-decoration: none;
     }
     &:nth-child(3) {
@@ -166,7 +166,7 @@
 
 .hosted-gallery__next-gallery-title {
     flex: 1;
-    min-width: 90px;
+    min-width: 100px;
 }
 
 .hosted-gallery__next-gallery-image {
@@ -202,7 +202,8 @@
     margin: 16px 0;
     color: #ffffff;
     font-weight: bold;
-    &:hover {
+    text-align: center;
+    &:hover, &:active {
         text-decoration: none;
     }
 
@@ -382,7 +383,7 @@ $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
 .hosted-gallery__caption {
     @include f-headlineSans;
     font-size: 13px;
-    line-height: 39px;
+    height: 40px;
     color: $neutral-7;
     position: absolute;
     right: 50px;
@@ -395,6 +396,18 @@ $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
     &.current-caption {
         opacity: 1;
         visibility: visible;
+    }
+}
+
+.hosted-gallery__image-title {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    line-height: 20px;
+    height: 100%;
+    padding-top: 2px;
+    span {
+        max-height: 40px;
     }
 }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -269,6 +269,7 @@
     right: 0;
     color: #ffffff;
     padding: 20px;
+    transition: opacity 300ms ease;
     background: linear-gradient(to top, rgba(51, 51, 51, .7) 0%, rgba(51, 51, 51, .5) 50%, transparent 100%);
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColor=0, endColorstr='#B4333333');
     @include mq($until: tablet) {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -599,11 +599,6 @@ $hosted-video-height: 540px;
     @include mq(desktop) {
         padding-top: 270px;
     }
-
-    a {
-        // hack stop the link underline
-        color: transparent;
-    }
 }
 
 .hosted__cta-btn-wrapper {
@@ -707,6 +702,9 @@ $hosted-video-height: 540px;
     display: block;
     width: 100%;
     height: 100%;
+    // hack stop the link underline
+    color: transparent;
+    outline: none;
 
     &:hover {
         background-color: rgba(#333333, .2);
@@ -715,7 +713,7 @@ $hosted-video-height: 540px;
 
 .hosted__cta-link,
 .hosted__next-video--tile {
-    &:hover {
+    &:hover, &:active {
         text-decoration: none;
     }
 }


### PR DESCRIPTION
## What does this change?
1. the onward journeys text shouldn't crash into the image on gallery
2. the article cta shouldn't have a link underline
3. the gallery captions should wrap onto two lines if long enough
4. the gallery title and standfirst fade out when you start scrolling
## Screenshots
1. before:
   ![image](https://cloud.githubusercontent.com/assets/6290008/18512381/c1b8d3b0-7a80-11e6-9365-3dd0fc7f7f46.png)
2. before:
   ![image](https://cloud.githubusercontent.com/assets/6290008/18512408/e1225c1c-7a80-11e6-85a1-7ec02735a96b.png)
3. after:
   ![image](https://cloud.githubusercontent.com/assets/6290008/18512443/13398b9e-7a81-11e6-8836-2b9634a4628e.png)
## Request for comment

@Calanthe 
