### PR TITLE
Add AMP ad script to avoid future errors

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -21,6 +21,7 @@
         <script custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
+        <script custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js" async></script>
         @if(content.tags.isLiveBlog) {
             <script custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js" async></script>
             @if(LiveUpdateAmpSwitch.isSwitchedOn) {


### PR DESCRIPTION
## What does this change?

Adds the ad script required for AMP.

https://trello.com/c/zbReISlR/100-amp-ad-warnings-will-soon-be-errors-and-cause-validation-failures-everywhere
