### PR TITLE
Add tags to the commercial report

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/init.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/init.js
@@ -43,6 +43,8 @@ define([
             if ('tests' in config && config.tests.commercialHbSonobi) {
                 // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
                 require(['js!googletag.js']);
+
+                ophanTracking.addTag('sonobi');
             } else {
                 if (!window.googletag) {
                     window.googletag = {cmd: []};
@@ -53,6 +55,9 @@ define([
 
                 if (dfpEnv.prebidEnabled) {
                     dfpEnv.prebidService = new PrebidService();
+                    ophanTracking.addTag('prebid');
+                } else {
+                    ophanTracking.addTag('waterfall');
                 }
             }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/init.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/init.js
@@ -43,7 +43,6 @@ define([
             if ('tests' in config && config.tests.commercialHbSonobi) {
                 // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
                 require(['js!googletag.js']);
-
                 ophanTracking.addTag('sonobi');
             } else {
                 if (!window.googletag) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -8,6 +8,7 @@ define([
 
     var performanceLog = {
             viewId: 'unknown',
+            tags: [],
             modules: [],
             adverts: [],
             baselines: []
@@ -173,6 +174,10 @@ define([
         }
     }
 
+    function addTag(tag) {
+        performanceLog.tags.push(tag);
+    }
+
     return {
         trackPerformance : trackPerformance,
         moduleCheckpoint : moduleCheckpoint,
@@ -180,6 +185,6 @@ define([
         addBaseline : addBaseline,
         primaryBaseline : primaryBaseline,
         secondaryBaseline: secondaryBaseline,
-        reportTrackingData: reportTrackingData
+        addTag: addTag
     };
 });


### PR DESCRIPTION
Adds some useful tags to help us distinguish commercial reports that are using different methods of ad delivery.

If we do this, we can easily bucket our client logs into categories, which makes makes for easy comparison of performance between "branches" of our system. For example, how is prebid performing compared to waterfall? 

I've identified a list of things which we can tag up later, to enable us to diagnose commercial sub-features:

**Interesting page-level commercial tags**
- Which programmatic services are being used?
  - Is header-bidding used (exposed in this pr)
- Lazy loaded?
- Has page skin?

**Interesting advert-level tags**
- Inside facia container?
- Fluid?
- Template-rendered? (ie, is it rendered with our js templating system)
- Was advert disabled/empty/hidden?
- Was the slot provided by the server or through JS? 
