### PR TITLE
hosted article various fixes

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle2.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle2.scala.html
@@ -83,7 +83,7 @@
                             </div>
                         </div>
                         <div class="hosted__standfirst">
-                            <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser Find out more with our
+                            <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
                                 <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
                                     <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about @{page.brandColourCssClass}" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
                                 </div>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -78,9 +78,9 @@
                 </div>
                 <div class="hosted__standfirst">
                     <p class="hosted__text">@Html(page.standfirst)</p>
-                    <div class="hosted__terms">​This content was paid for and produced by @{page.campaign.owner}. For more information click
+                    <div class="hosted__terms">Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
                         <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
-                            <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about" data-link-name="terms-and-conditions-text-link">here @fragments.inlineSvg("arrow-down", "icon")</button>
+                            <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
                         </div>
                     </div>
                 </div>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -191,7 +191,7 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             display: inline-block;
             float: left;
             color: #000000;
-            padding: 12px 20px 4px;
+            padding: 12px 16px 4px;
             font-size: 480%;
             line-height: 4.25rem;
             width: 4.8125rem;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -111,7 +111,6 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
     }
     .hosted__standfirst {
         padding: 0;
-        margin: 50px 0 0;
 
         .hosted__terms {
             margin-top: 0;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -229,9 +229,11 @@ $hosted-video-height: 540px;
     color: rgba(255, 255, 255, .5);
 }
 
-.hosted-page {
+.hosted-page ~ .survey-overlay-simple {
     .survey-container {
-        top: 40%;
+        @include mq(tablet) {
+            top: 40%;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -764,11 +764,8 @@ $hosted-video-height: 540px;
 
 .hosted__standfirst {
     width: auto;
-    padding: $gs-baseline / 2 $gs-gutter 0;
-
-    @include mq(desktop) {
-        margin-bottom: $gs-gutter * 1.5;
-    }
+    padding: $gs-baseline $gs-gutter 0;
+    margin: 30px 0 0;
 }
 
 .hosted__social.host__header {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -229,6 +229,12 @@ $hosted-video-height: 540px;
     color: rgba(255, 255, 255, .5);
 }
 
+.hosted-page {
+    .survey-container {
+        top: 40%;
+    }
+}
+
 .hosted-video-page {
     .hosted__container.host {
         position: relative;
@@ -711,6 +717,11 @@ $hosted-video-height: 540px;
     &:hover {
         background-color: rgba(#333333, .2);
     }
+
+    &:active,
+    &:visited {
+        text-decoration: none;
+    }
 }
 
 .hosted__cta-link,
@@ -751,7 +762,7 @@ $hosted-video-height: 540px;
 
 .hosted__standfirst {
     width: auto;
-    padding: $gs-baseline $gs-gutter 0;
+    padding: $gs-baseline / 2 $gs-gutter 0;
 
     @include mq(desktop) {
         margin-bottom: $gs-gutter * 1.5;


### PR DESCRIPTION
## What does this change?

A few styling fixes on the hosted pages:
- The 'About' popup is positioned little lower now.
- Disclaimer text is the same on every page.
- Less space between disclaimer and CTA banner
- Less padding on drop cap letter.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
<img width="697" alt="screen shot 2016-09-14 at 16 37 18" src="https://cloud.githubusercontent.com/assets/489567/18519497/120dd61a-7a9c-11e6-80a2-9d9733e823d1.png">

![screen shot 2016-09-14 at 16 56 49](https://cloud.githubusercontent.com/assets/489567/18519579/5e9132e8-7a9c-11e6-9e46-adbdc5db2c8e.png)

![screen shot 2016-09-14 at 16 58 21](https://cloud.githubusercontent.com/assets/489567/18519609/7a0897c8-7a9c-11e6-9df4-001edbcc9c2e.png)

After:
<img width="707" alt="screen shot 2016-09-14 at 16 37 28" src="https://cloud.githubusercontent.com/assets/489567/18519505/1a42b328-7a9c-11e6-8cfc-af537ecd1865.png">

![screen shot 2016-09-14 at 16 57 05](https://cloud.githubusercontent.com/assets/489567/18519586/65eadea4-7a9c-11e6-8722-924542deec4e.png)

![screen shot 2016-09-14 at 16 58 14](https://cloud.githubusercontent.com/assets/489567/18519621/8384121e-7a9c-11e6-9831-2dd2ae080fb8.png)
## Request for comment

@clloyd 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
