### PR TITLE
Make the Weekend Reading Signup sample link to the latest email

### DIFF
--- a/applications/app/views/signup/weekendReading.scala.html
+++ b/applications/app/views/signup/weekendReading.scala.html
@@ -75,7 +75,7 @@
             <div class="content__main-column">
 
                 <div class="email-signup-sample"  data-component="weekend-reading">
-                    <a href="/info/2016/jul/20/weekend-round-up-no10s-revolving-door/email">
+                    <a href="/membership/series/weekend-reading/latest/email">
                         <button class="email-signup-sample__button"  data-link-name="weekend-reading-sample">
                             View a sample
                             @fragments.inlineSvg("arrow-right", "icon")


### PR DESCRIPTION
## What does this change?

No longer link to the [example](https://www.theguardian.com/info/2016/jul/20/weekend-round-up-no10s-revolving-door/email) Weekend Reading email. Now that the email is being curated each week we can use the `/latest/email` convention to show a more [recent example](https://www.theguardian.com/membership/series/weekend-reading/latest/email)
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment
