### PR TITLE
Update Media Briefing and Opinion US email listings

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -62,14 +62,15 @@ object EmailSubscriptions {
 
     ),
     EmailSubscription(
-      "Media briefing",
+      "MediaGuardian Briefing",
       "news",
       "Media",
-      "An indispensable summary of what the papers are saying about media on your desktop before 9am. We summarise the media headlines in every newspaper from the Wall Street Journal to the Daily Star.",
+      "An indispensable summary of the media industry headlines in your inbox before 9am. We dig out the most important stories from every and any newspaper, broadcaster and website.",
       "Weekday mornings",
       "217",
       7,
-      subscribedTo = subscribedListIds.exists{ x => x == "217" }
+      subscribedTo = subscribedListIds.exists{ x => x == "217" },
+      exampleUrl = Some("http://www.theguardian.com/media/series/mediaguardian-briefing/latest/email")
     ),
     EmailSubscription(
       "Brexit briefing",
@@ -306,7 +307,7 @@ object EmailSubscriptions {
       "Best of Guardian Opinion - US",
       "comment",
       "Opinion's daily email newsletter",
-      "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
+      "Keep up on today’s pressing issues with the Guardian’s Best of Opinion US email. We’ll send the most shared opinion, analysis and editorial articles from the last 24 hours, every weekday, direct to your inbox.",
       "Weekday afternoons",
       "3228",
       subscribedTo = subscribedListIds.exists{ x => x == "3228" }


### PR DESCRIPTION
## What does this change?
- Update copy and for listings
- Rename for MediaGuardian Briefing
- Add example URL to MediaGuardian Briefing
## What is the value of this and can you measure success?
- Example emails and better copy will hopefully entice page viewers to sign up
- Keep the Email Prefs page in sync with current Editorial offerings

For Editorial. With love, DigDev ❤️ 
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

<img width="833" alt="picture 236" src="https://cloud.githubusercontent.com/assets/8607683/18521705/28fe4306-7aa5-11e6-9d50-e328fbe1d4cc.png">
## Request for comment
