### PR TITLE
Remove deprecated keyIdentifier

### DIFF
--- a/static/src/javascripts/components/bean/bean.js
+++ b/static/src/javascripts/components/bean/bean.js
@@ -106,7 +106,7 @@
               'fromElement offsetX offsetY pageX pageY screenX screenY toElement'))
           , mouseWheelProps = mouseProps.concat(str2arr('wheelDelta wheelDeltaX wheelDeltaY wheelDeltaZ ' +
               'axis')) // 'axis' is FF specific
-          , keyProps     = commonProps.concat(str2arr('char charCode key keyCode keyIdentifier '          +
+          , keyProps     = commonProps.concat(str2arr('char charCode key keyCode '          +
               'keyLocation location'))
           , textProps    = commonProps.concat(str2arr('data'))
           , touchProps   = commonProps.concat(str2arr('touches targetTouches changedTouches scale rotation'))

--- a/static/src/javascripts/components/bean/bean.js
+++ b/static/src/javascripts/components/bean/bean.js
@@ -2,6 +2,10 @@
   * Bean - copyright (c) Jacob Thornton 2011-2012
   * https://github.com/fat/bean
   * MIT license
+  * 
+  *  Changes from upstream:
+  *      - Removed 'keyIdentitfier' until https://github.com/fat/bean/issues/128 is fixed 
+  *
   */
 (function (name, context, definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()


### PR DESCRIPTION
## What does this change?

Remove `keyIdentifier` as a property from `bean.js` as this is [now deprecated and will be removed soon](https://www.chromestatus.com/features/5316065118650368).

Currently console display a warning on every page:

```
'KeyboardEvent.keyIdentifier' is deprecated and will be removed in M53, around September 2016. See https://www.chromestatus.com/features/5316065118650368 for more details.
```

As `bean.js` seems to be copied, I don't know if we should diverge or wait for [the upstream issue](https://github.com/fat/bean/issues/128) being fixed and then update to the latest version.  
## What is the value of this and can you measure success?

Prevent breaking frontend (throwing an client side error potentially breaking other features) when latest `chrome` will remove `keyIdentifier`.
## Does this affect other platforms - Amp, Apps, etc?

`keyIdentifier` does not seems to be used on `frontend` so I don't think it should break anything or anyone.
