### PR TITLE
Commercial metrics start and end times

### DIFF
--- a/diagnostics/app/model/diagnostics/commercial/UserReport.scala
+++ b/diagnostics/app/model/diagnostics/commercial/UserReport.scala
@@ -25,7 +25,8 @@ case class Advert(
 
 case class Baseline(
   name: Option[String],
-  time: Option[Double]
+  startTime: Option[Double],
+  endTime: Option[Double]
 )
 
 case class UserReport(

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -101,7 +101,7 @@ define([
 
     function loadModules(modules, baseline) {
 
-        ophanTracking.addBaseline(baseline);
+        ophanTracking.addStartTimeBaseline(baseline);
 
         var modulePromises = [];
 
@@ -118,7 +118,11 @@ define([
             });
         });
 
-       return Promise.all(modulePromises);
+       return Promise.all(modulePromises)
+           .then(function(moduleLoadResult){
+               ophanTracking.addEndTimeBaseline(baseline);
+               return moduleLoadResult;
+           });
     }
 
     return {

--- a/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
@@ -61,7 +61,7 @@ define([
                 var primaryBaseline = find(report.baselines, function(baseline){
                     return baseline.name === 'primary';
                 });
-                return primaryBaseline ? primaryBaseline.time : 0;
+                return primaryBaseline ? primaryBaseline.startTime : 0;
             });
 
             // Filter the times array from silly numbers, investigating why Date times are appearing in the array.

--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -168,7 +168,7 @@ define([
         var index = performanceLog.baselines
             .map(function (_) { return _.name; })
             .indexOf(baselineName);
-        return index > -1 ? performanceLog.baselines[index].time : 0;
+        return index > -1 ? performanceLog.baselines[index].startTime : 0;
     }
 
     function reportTrackingData() {

--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -159,7 +159,7 @@ define([
     function addEndTimeBaseline(baselineName) {
         performanceLog.baselines.map(function(baseline) {
             if (baseline.name === baselineName) {
-                baseline.endTime = userTiming.getCurrentTime()
+                baseline.endTime = userTiming.getCurrentTime();
             }
         });
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -149,10 +149,18 @@ define([
         }));
     }
 
-    function addBaseline(baselineName) {
+    function addStartTimeBaseline(baselineName) {
         performanceLog.baselines.push({
             name: baselineName,
-            time: userTiming.getCurrentTime()
+            startTime: userTiming.getCurrentTime()
+        });
+    }
+
+    function addEndTimeBaseline(baselineName) {
+        performanceLog.baselines.map(function(baseline) {
+            if (baseline.name === baselineName) {
+                baseline.endTime = userTiming.getCurrentTime()
+            }
         });
     }
 
@@ -177,7 +185,8 @@ define([
         trackPerformance : trackPerformance,
         moduleCheckpoint : moduleCheckpoint,
         updateAdvertMetric : updateAdvertMetric,
-        addBaseline : addBaseline,
+        addStartTimeBaseline : addStartTimeBaseline,
+        addEndTimeBaseline : addEndTimeBaseline,
         primaryBaseline : primaryBaseline,
         secondaryBaseline: secondaryBaseline,
         reportTrackingData: reportTrackingData


### PR DESCRIPTION
## What does this change?

This changes the `Baseline` type for commercial performance reports to include a `startTime` and an `endTime`. This will measure the start and end times of both baselines; `primary` and `secondary`.
## What is the value of this and can you measure success?

This will allow us to accurately measure the two main parts of the client side commercial application.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
