### PR TITLE
Badges floating fix

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -72,23 +72,20 @@
     border-bottom: 1px dotted $neutral-5;
 
     @include mq(tablet) {
-        float: right;
+        float: left;
     }
 
     @include mq(leftCol) {
+        float: none;
         clear: left;
-        float: left;
         width: $left-column;
+        min-height: 0;
+        border-bottom-width: 0;
+        border-top: 1px dotted $neutral-5;
     }
 
     @include mq(wide) {
         width: $left-column-wide;
-    }
-
-    @include mq(leftCol) {
-        min-height: 0;
-        border-bottom-width: 0;
-        border-top: 1px dotted $neutral-5;
     }
 
     @include mq(mobile, $until: leftCol) {


### PR DESCRIPTION
## What does this change?

Fix for the badges in the left column. They weren't clickable because of the `float: left` style.
Now this should be fixed. I also tested `/commercial-containers`, interactive and other article pages.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-15 at 11 44 41](https://cloud.githubusercontent.com/assets/489567/18547219/31055bf8-7b3a-11e6-9f2b-5e1f6963ed39.png)

After:
![screen shot 2016-09-15 at 11 44 51](https://cloud.githubusercontent.com/assets/489567/18547229/36fb3a0a-7b3a-11e6-9470-5b10afc619f4.png)
## Request for comment

@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
