### PR TITLE
Fix for Logo Contrast Issues on Media Tone Content

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -58,17 +58,19 @@
         }
     }
 
-    .brandbadge__header,
-    .brandbadge__help,
     .brandbadge__logo {
         filter: invert(50%);
     }
+
+    .brandbadge__header,
+    .brandbadge__help,
 
 
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;
     },
+
     .caption {
         color: $neutral-4;
 

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -65,7 +65,6 @@
     .brandbadge__header,
     .brandbadge__help,
 
-
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -60,10 +60,10 @@
 
     .brandbadge__header,
     .brandbadge__help,
-
     .brandbadge__logo {
         filter: invert(50%);
-    }
+    },
+
 
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -69,7 +69,7 @@
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;
-    },
+    }
 
     .caption {
         color: $neutral-4;

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -62,7 +62,7 @@
     .brandbadge__help,
     .brandbadge__logo {
         filter: invert(50%);
-    },
+    }
 
 
     .ad-slot--paid-for-badge__header,

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -60,10 +60,15 @@
 
     .brandbadge__header,
     .brandbadge__help,
+
+    .brandbadge__logo {
+        filter: invert(50%);
+    }
+
     .ad-slot--paid-for-badge__header,
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;
-    }
+    },
 
     .caption {
         color: $neutral-4;

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -69,7 +69,6 @@
     .ad-slot--paid-for-badge__help {
         color: $neutral-6;
     },
-
     .caption {
         color: $neutral-4;
 


### PR DESCRIPTION
## What does this change?

Now that the logos have moved over, when a dark logo is being displayed on the editorial media tone (foundation stuff mainly) it hides away in the dark. This used to be solved by targeting two slots to the same place and having the client provide a white version, this is no longer going to work as tag manager can only manage one logo per tag. This looks to solve this issue via CSS (hopefully).
## What is the value of this and can you measure success?

No more contrast issues, happy Bill Gates.
## Does this affect other platforms - Amp, Apps, etc?

@GHaberis as discussed it would be good to do this on apps as well
Ran the AMP test suite and all looks tickety boo

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before

![image](https://cloud.githubusercontent.com/assets/11922253/18551282/a02dd180-7b4f-11e6-98df-62c41f50dfd9.png)

After

![image](https://cloud.githubusercontent.com/assets/11922253/18551497/884f9a5c-7b50-11e6-99e1-6ae35e44ec38.png)
## Request for comment

@kelvin-chappell @regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
