### PR TITLE
Hosted article inline videos

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -73,41 +73,43 @@ define([
                         }
                     }
 
-                    player = videojs($videoEl.get(0), videojsOptions());
-                    player.guMediaType = 'video';
-                    videojs.plugin('fullscreener', fullscreener);
+                    $videoEl.each(function(el){
+                        player = videojs(el, videojsOptions());
+                        player.guMediaType = 'video';
+                        videojs.plugin('fullscreener', fullscreener);
 
-                    player.ready(function () {
-                        var vol;
-                        initLoadingSpinner(player);
-                        upgradeVideoPlayerAccessibility(player);
+                        player.ready(function () {
+                            var vol;
+                            initLoadingSpinner(player);
+                            upgradeVideoPlayerAccessibility(player);
 
-                        // unglitching the volume on first load
-                        vol = player.volume();
-                        if (vol) {
-                            player.volume(0);
-                            player.volume(vol);
-                        }
-
-                        player.fullscreener();
-
-                        var mediaId = $videoEl.attr('data-media-id');
-                        deferToAnalytics(function () {
-                            events.initOmnitureTracking(player);
-                            events.initOphanTracking(player, mediaId);
-
-                            events.bindGlobalEvents(player);
-                            events.bindContentEvents(player);
-                        });
-
-                        player.on('error', function () {
-                            var err = player.error();
-                            if (err && 'message' in err && 'code' in err) {
-                                reportError(new Error(err.message), {
-                                    feature: 'hosted-player',
-                                    vjsCode: err.code
-                                }, false);
+                            // unglitching the volume on first load
+                            vol = player.volume();
+                            if (vol) {
+                                player.volume(0);
+                                player.volume(vol);
                             }
+
+                            player.fullscreener();
+
+                            var mediaId = $videoEl.attr('data-media-id');
+                            deferToAnalytics(function () {
+                                events.initOmnitureTracking(player);
+                                events.initOphanTracking(player, mediaId);
+
+                                events.bindGlobalEvents(player);
+                                events.bindContentEvents(player);
+                            });
+
+                            player.on('error', function () {
+                                var err = player.error();
+                                if (err && 'message' in err && 'code' in err) {
+                                    reportError(new Error(err.message), {
+                                        feature: 'hosted-player',
+                                        vjsCode: err.code
+                                    }, false);
+                                }
+                            });
                         });
                     });
 

--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -62,10 +62,15 @@ define([
             require(['bootstraps/enhanced/media/main'], function () {
                 require(['bootstraps/enhanced/media/video-player'], function (videojs) {
                     var $videoEl = $('.vjs-hosted__video');
+                    var $inlineVideoEl = $('video');
 
                     if ($videoEl.length === 0) {
-                        // halt execution
-                        return resolve();
+                        if ($inlineVideoEl.length === 0) {
+                            // halt execution
+                            return resolve();
+                        } else {
+                            $videoEl = $inlineVideoEl;
+                        }
                     }
 
                     player = videojs($videoEl.get(0), videojsOptions());

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -109,7 +109,7 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             }
         }
 
-        video { //inline video element
+        .vjs_video_3-dimensions { //inline video element
             width: 100%;
 
             @include mq(desktop) {
@@ -119,6 +119,10 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             @include mq(wide) {
                 width: gs-span(11) + $gs-gutter;
                 margin-left: gs-span(-3);
+            }
+
+            video {
+                width: 100%;
             }
         }
     }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -108,6 +108,19 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
                 margin-top: 1px;
             }
         }
+
+        video { //inline video element
+            width: 100%;
+
+            @include mq(desktop) {
+                width: gs-span(8);
+            }
+
+            @include mq(wide) {
+                width: gs-span(11) + $gs-gutter;
+                margin-left: gs-span(-3);
+            }
+        }
     }
     .hosted__standfirst {
         padding: 0;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -109,8 +109,10 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             }
         }
 
-        .vjs_video_3-dimensions { //inline video element
+        //inline video element
+        .vjs-controls-enabled { //this is temporary solution, we don't have other common class on every inline videos
             width: 100%;
+            height: auto;
 
             @include mq(desktop) {
                 width: gs-span(8);
@@ -123,6 +125,20 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
 
             video {
                 width: 100%;
+            }
+
+            .vjs-poster,
+            .vjs-big-play-button {
+                width: 100%;
+
+                @include mq(desktop) {
+                    width: gs-span(8);
+                }
+
+                @include mq(wide) {
+                    width: gs-span(11) + $gs-gutter;
+                    margin-left: gs-span(-3);
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Hosted article inline videos look and work much better now.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-15 at 15 39 15](https://cloud.githubusercontent.com/assets/489567/18553991/a01ad110-7b5a-11e6-8271-4ab561c795b2.png)

After:
![screen shot 2016-09-15 at 15 39 29](https://cloud.githubusercontent.com/assets/489567/18554002/a7d6ab54-7b5a-11e6-918e-a0a3ccc6e5f8.png)
## Request for comment

@lps88 @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
