### PR TITLE
Chester Zoo cta changes

### DIFF
--- a/common/app/common/commercial/hosted/HostedArticlePage2.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage2.scala
@@ -109,7 +109,7 @@ object HostedArticlePage2 extends Logging {
           image = Some("http://media.guim.co.uk/d723e82cdd399f013905a5ee806fea3591b4a363/0_926_3872_1666/2000.jpg"),
           label = Some("It's time to act for wildlife"),
           trackingCode = Some("act-for-wildlife-button"),
-          btnText = None
+          btnText = Some("Act for wildlife")
         ),
         mainPicture = mainImageAsset.flatMap(_.file) getOrElse "",
         mainPictureCaption = mainImageAsset.flatMap(_.typeData.flatMap(_.caption)).getOrElse(""),


### PR DESCRIPTION
## What does this change?

Different, white CTA for the Chester Zoo

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-15 at 16 00 22](https://cloud.githubusercontent.com/assets/489567/18554856/86e81bb4-7b5d-11e6-8a4e-d910407578d4.png)

After:
![screen shot 2016-09-15 at 16 00 15](https://cloud.githubusercontent.com/assets/489567/18554861/8d980140-7b5d-11e6-8b09-374a97afa953.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
