### PR TITLE
Keep stacktrace when capi lookup fails

### DIFF
--- a/commercial/app/model/commercial/Lookup.scala
+++ b/commercial/app/model/commercial/Lookup.scala
@@ -34,7 +34,7 @@ object Lookup extends ExecutionContexts with Logging {
                 .showAtoms("all")
     val result = ContentApiClient.getResponse(query) map { response => response.content flatMap transform }
     result.onFailure {
-      case NonFatal(e) => log.warn(s"Capi lookup of item '$itemId' failed: ${e.getMessage}")
+      case NonFatal(e) => log.warn(s"Capi lookup of item '$itemId' failed: ${e.getMessage}", e)
     }
     result
   }


### PR DESCRIPTION
Then we can see cause:

```
WARN  model.commercial.Lookup - Capi lookup of item 'advertiser-content/chester-zoo-act-for-wildlife/saving-orangutans-from-extinction' failed: / by zero
java.lang.ArithmeticException: / by zero
    at common.commercial.hosted.hardcoded.ChesterZooHostedPages$.nextPages(ChesterZooHostedPages.scala:238)
```

/cc @guardian/labs-beta 
