### PR TITLE
Stop this fix from touching paid content

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -58,8 +58,7 @@
         }
     }
 
-    &:not(.content--advertisement-feature)
-    .brandbadge__logo {
+    &:not(.content--advertisement-feature).brandbadge__logo {
         filter: invert(50%);
     }
 

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -58,6 +58,7 @@
         }
     }
 
+    &:not(.content--advertisement-feature)
     .brandbadge__logo {
         filter: invert(50%);
     }


### PR DESCRIPTION
## What does this change?

Stops my other fix from having any impact on the paid content styled media pages
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?

Nopers, checked amp tests and all good.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

@regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
