### PR TITLE
Move comments avatar to discussion frontend

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -363,7 +363,7 @@ class GuardianConfiguration extends Logging {
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
-    lazy val frontendAssetsVersion = "v1.1.0"
+    lazy val frontendAssetsVersion = "v1.2.0"
   }
 
   object witness {

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -125,7 +125,7 @@ CommentBox.prototype.prerender = function() {
 
     if (this.options.state === 'response') {
         this.getElem('submit').innerHTML = 'Post reply';
-    } else {
+    } else if (this.options.shouldRenderMainAvatar) {
         var avatar = this.getElem('avatar-wrapper');
         avatar.setAttribute('userid', userData.id);
         UserAvatars.avatarify(avatar);

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -128,6 +128,7 @@ CommentBox.prototype.prerender = function() {
     } else if (this.options.shouldRenderMainAvatar) {
         var avatar = this.getElem('avatar-wrapper');
         avatar.setAttribute('userid', userData.id);
+        avatar.setAttribute('data-userid', userData.id);
         UserAvatars.avatarify(avatar);
     }
 

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -335,7 +335,8 @@ Loader.prototype.renderCommentBox = function(elem) {
     return new CommentBox({
         discussionId: this.getDiscussionId(),
         premod: this.user.privateFields.isPremoderated,
-        newCommenter: !this.user.privateFields.hasCommented
+        newCommenter: !this.user.privateFields.hasCommented,
+        shouldRenderMainAvatar: !discussionFrontend.canRun(ab, window.curlConfig)
     }).render(elem).on('post:success', this.commentPosted.bind(this));
 };
 
@@ -379,6 +380,7 @@ Loader.prototype.renderCommentCount = function () {
     if (discussionFrontend.canRun(ab, window.curlConfig)) {
         return discussionFrontend.load(ab, this, {
             apiHost: config.page.discussionApiUrl,
+            avatarImagesHost: config.page.avatarImagesUrl,
             closed: this.getDiscussionClosed(),
             discussionId: this.getDiscussionId(),
             element: document.getElementsByClassName('js-discussion-external-frontend')[0],


### PR DESCRIPTION
## What does this change?

The user avatar is now part of discussion-frontend. It appears to me that the image is broken. It's always showing the anonymous image even when logged in.
There is some logic to render the actual avatar but it doesn't work. I've fixed that.

The code was implemented in guardian/discussion-frontend#8 and it's the first time I'm bundling CSS as well. Some of the styles are now in `discussion-frontend` and injected in the `head` during rendering. I'm using CSS modules so they shouldn't conflict with what's already in the page.
## What is the value of this and can you measure success?

Part 3 of migrating to discussion frontend.
## Does this affect other platforms - Amp, Apps, etc?

No, all checks `PASS`
## Screenshots

![screen shot 2016-09-16 at 11 25 50](https://cloud.githubusercontent.com/assets/680284/18583137/9b0b5c20-7c00-11e6-9b7c-347f66b69d1f.png)
