### PR TITLE
Add keys to programmatic advert graph

### DIFF
--- a/admin/app/views/commercial/performance/programmaticDashboard.scala.html
+++ b/admin/app/views/commercial/performance/programmaticDashboard.scala.html
@@ -25,9 +25,9 @@
 
         <div class="row graph graph--commercial-app-duration">
             <div class="col-md-2">
-                <div class="graph__legend">
-                    <div class="graph__legend__label">Fastest execution:</div>
-                    <ol>
+                <div class="graph__legend panel panel-default">
+                    <h5 class="graph__legend__label">Execution times</h5>
+                    <ul class="graph__legend__keys">
                         <li>
                             <span class="legend__label--prebid">
                                 <b>— prebid</b>
@@ -46,7 +46,7 @@
                                 <span class="average--sonobi"></span>
                             </span>
                         </li>
-                    </ol>
+                    </ul>
                 </div>
                 <div class="graph__y-axis">Time (ms)</div>
             </div>

--- a/admin/app/views/commercial/performance/programmaticDashboard.scala.html
+++ b/admin/app/views/commercial/performance/programmaticDashboard.scala.html
@@ -19,15 +19,38 @@
     <div class="container-fluid">
         <h4>Time taken to execute the Commercial javascript application</h4>
 
-         <div class="row">
+        <div class="row">
             <div class="col-md-12">This is the time between the commercial system starting and completing (known as the commercial bootstrap).</div>
-         </div>
+        </div>
 
         <div class="row graph graph--commercial-app-duration">
-            <div class="col-md-1">
+            <div class="col-md-2">
+                <div class="graph__legend">
+                    <div class="graph__legend__label">Fastest execution:</div>
+                    <ol>
+                        <li>
+                            <span class="legend__label--prebid">
+                                <b>— prebid</b>
+                                <span class="average--prebid"></span>
+                            </span>
+                        </li>
+                        <li>
+                            <span class="legend__label--waterfall">
+                                <b>— waterfall</b>
+                                <span class="average--waterfall"></span>
+                            </span>
+                        </li>
+                        <li>
+                            <span class="legend__label--sonobi">
+                                <b>— sonobi</b>
+                                <span class="average--sonobi"></span>
+                            </span>
+                        </li>
+                    </ol>
+                </div>
                 <div class="graph__y-axis">Time (ms)</div>
             </div>
-            <div class="col-md-11">
+            <div class="col-md-10">
                 <div id="programmatic-live-performance-data" class="epoch category10"></div>
             </div>
         </div>

--- a/admin/public/css/commercial-programmatic-performance.css
+++ b/admin/public/css/commercial-programmatic-performance.css
@@ -27,3 +27,12 @@ commercial/performance/programmatic-dashboard
 .graph__legend {
     margin: -100px 0 40px;
 }
+
+.graph__legend__keys {
+    list-style-type: none;
+    padding-left: 6px;
+}
+
+.graph__legend__label {
+    text-align: center;
+}

--- a/admin/public/css/commercial-programmatic-performance.css
+++ b/admin/public/css/commercial-programmatic-performance.css
@@ -23,3 +23,7 @@ commercial/performance/programmatic-dashboard
 #programmatic-live-performance-data {
     height: 350px;
 }
+
+.graph__legend {
+    margin: -100px 0 40px;
+}

--- a/static/src/javascripts/projects/admin/bootstraps/commercial-programmatic-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-programmatic-performance.js
@@ -1,4 +1,4 @@
-/*global $, Epoch*/
+/*global $, Epoch, d3*/
 define([
     'common/utils/config',
     'common/utils/fetch-json',
@@ -22,6 +22,7 @@ define([
     var FETCH_INTERVAL = 1000; // The frequency that we poll for report data.
     var FETCH_DELAY = 10; // The delay which we wait before we ask for a time-based datapoint, eg. 10 seconds before the present moment.
     var reportTemplateUrl = '/commercial-reports/<%=isoDate%>';
+    var colors = d3.scale.category10().range();
 
     function initialise() {
 
@@ -50,6 +51,11 @@ define([
         });
 
        window.setInterval(fetchData, FETCH_INTERVAL);
+
+       // Add key colours to the legend rows, based on d3.
+       $('.legend__label--prebid').css('color', colors[0]);
+       $('.legend__label--waterfall').css('color', colors[1]);
+       $('.legend__label--sonobi').css('color', colors[2]);
     }
 
     function getProgrammaticReports(reports, deliveryMethod) {

--- a/static/src/javascripts/projects/admin/bootstraps/commercial-programmatic-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-programmatic-performance.js
@@ -23,6 +23,11 @@ define([
     var FETCH_DELAY = 10; // The delay which we wait before we ask for a time-based datapoint, eg. 10 seconds before the present moment.
     var reportTemplateUrl = '/commercial-reports/<%=isoDate%>';
     var colors = d3.scale.category10().range();
+    var programmaticExecutionTimes = {      // Store the 1000 most recently fetched datapoints.
+        prebid: [],
+        waterfall: [],
+        sonobi: []
+    };
 
     function initialise() {
 
@@ -62,7 +67,33 @@ define([
         return filter(reports, function(report) { return report.tags.indexOf(deliveryMethod) !== -1; });
     }
 
-    function getAverageStartTime(reports) {
+    // Returns a number formatted as a string giving the average of the dataset.
+    function calculateAverage(dataset) {
+        var sum = reduce(dataset, function(sum, num) { return sum + num; });
+        var average = (sum / dataset.length);
+        return Number.isFinite(average) ? average.toFixed([2]) : '0.0';
+    }
+
+    function storeAverageStartTime(startTimes, deliveryMethod) {
+        // Find the corresponding array to store these start times.
+        var globalTimeValues = programmaticExecutionTimes[deliveryMethod];
+
+        // Push the new start times into the stored array to find an average.
+        Array.prototype.push.apply(globalTimeValues, startTimes);
+        // Limit the size of the array to 1000.
+        if (globalTimeValues.length > 1000) {
+            globalTimeValues.splice(0, globalTimeValues.length - 1000);
+        }
+
+        if (!globalTimeValues.length) {
+            return;
+        }
+
+        $('.average--' + deliveryMethod).text(calculateAverage(globalTimeValues));
+    }
+
+    // Stores the start time values, and returns the average start time for this batch of reports.
+    function processAverageStartTime(reports, deliveryMethod) {
         var startTimes = map(reports, function(report){
             var primaryBaseline = find(report.baselines, function(baseline){
                 return baseline.name === 'primary';
@@ -73,9 +104,11 @@ define([
         // Filter the times array from silly numbers.
         var validStartTimes = filter(startTimes, function(startTime) { return startTime < 20000; });
 
-        var sum = reduce(validStartTimes, function(sum, num) { return sum + num; });
-        var average = (sum / validStartTimes.length);
-        return Number.isFinite(average) ? average.toFixed([2]) : 0;
+        // Store the start times too, to display global dataset averages.
+        storeAverageStartTime(validStartTimes, deliveryMethod);
+
+        // Return the average for this specific timestamped dataset.
+        return calculateAverage(validStartTimes);
     }
 
     function fetchData() {
@@ -93,9 +126,9 @@ define([
             var waterfallReports = getProgrammaticReports(logs.reports, 'waterfall');
             var sonobiReports = getProgrammaticReports(logs.reports, 'sonobi');
             
-            var prebidStartTime = getAverageStartTime(prebidReports);
-            var waterfallStartTime = getAverageStartTime(waterfallReports);
-            var sonobiStartTime = getAverageStartTime(sonobiReports);
+            var prebidStartTime = processAverageStartTime(prebidReports, 'prebid');
+            var waterfallStartTime = processAverageStartTime(waterfallReports, 'waterfall');
+            var sonobiStartTime = processAverageStartTime(sonobiReports, 'sonobi');
 
             chart.push([
                 {


### PR DESCRIPTION
Adds a component to show the average execution time for each programmatic delivery method, and to help distinguish the three lines in the multi-line graph.

![programmatic_advert_performance](https://cloud.githubusercontent.com/assets/4549425/18584404/75faf0b4-7c08-11e6-9dc4-d006ade0a858.jpg)
