### PR TITLE
Hosted video pages - logo fixes

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -60,7 +60,9 @@
                             <h1 class="hosted__heading @{page.brandColourCssClass}">@{page.video.title}</h1>
                         </div>
                         <div class="hostedbadge hostedbadge--shouldscale">
+                            <a href="@page.campaign.logoLink.getOrElse(page.cta.url)" data-link-name="hosted-logo-top-left" target="_blank">
                                 <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -22,6 +22,10 @@
         border-color: @{page.campaign.fontColour.brandColour};
     }
 
+    .hosted-page .hosted__heading {
+        color: @{page.campaign.fontColour.brandColour};
+    }
+
     .hosted-page .hosted__next-video--tile {
         border-top-color: @{page.campaign.fontColour.brandColour};
     }

--- a/static/src/stylesheets/module/commercial/_hostedbadge.scss
+++ b/static/src/stylesheets/module/commercial/_hostedbadge.scss
@@ -22,21 +22,25 @@
 
 .hostedbadge__info {
     @include f-headlineSans;
-    @include font-size(13, 11);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .5px;
+    line-height: 16px;
 
     height: auto;
-    padding: 3px 0 2px;
+    padding-top: $gs-gutter / 4;
+    padding-bottom: $gs-gutter / 2.5;
     color: $neutral-1;
     margin: 0;
     text-align: center;
 
-    @include mq(desktop) {
+    /*@include mq(desktop) {
         .hostedbadge--shouldscale & {
             padding: 0;
             font-size: 16px;
             line-height: 28px;
         }
-    }
+    }*/
 }
 
 .hostedbadge .hostedbadge__logo {

--- a/static/src/stylesheets/module/commercial/_hostedbadge.scss
+++ b/static/src/stylesheets/module/commercial/_hostedbadge.scss
@@ -33,14 +33,6 @@
     color: $neutral-1;
     margin: 0;
     text-align: center;
-
-    /*@include mq(desktop) {
-        .hostedbadge--shouldscale & {
-            padding: 0;
-            font-size: 16px;
-            line-height: 28px;
-        }
-    }*/
 }
 
 .hostedbadge .hostedbadge__logo {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -233,17 +233,6 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             text-align: center;
         }
     }
-    p.hostedbadge__info, p.hosted__glogotext {
-        font-size: 14px;
-        font-weight: 600;
-        letter-spacing: .5px;
-        line-height: 16px;
-    }
-
-    p.hostedbadge__info {
-        padding-top: $gs-gutter / 4;
-        padding-bottom: $gs-gutter / 2.5;
-    }
 
     .gu-image {
         height: auto;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -10,7 +10,7 @@
             }
         }
         .hostedbadge__logo {
-            @include mq($until: tablet) {
+            @include mq($until: wide) {
                 // use fading one
                 display: none;
             }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -524,7 +524,7 @@ $hosted-video-height: 540px;
     .hostedbadge__logo.hostedbadge__logo {
         position: relative;
         display: none;
-        @include mq($until: tablet) {
+        @include mq($until: wide) {
             display: block;
         }
     }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -222,7 +222,10 @@ $hosted-video-height: 540px;
 
 .hosted__glogotext {
     @include f-headlineSans;
-    @include font-size(14);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .5px;
+    line-height: 16px;
 
     margin: 0;
     text-align: left;
@@ -520,6 +523,10 @@ $hosted-video-height: 540px;
 
     .hostedbadge {
         position: absolute;
+
+        @include mq(desktop) {
+            margin-left: $gs-gutter / 2;
+        }
     }
     .hostedbadge__logo.hostedbadge__logo {
         position: relative;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -556,6 +556,14 @@ $hosted-video-height: 540px;
     }
 }
 
+.hosted-page .hosted-fading { //this needs to overwrite inline styles
+    .hosted__heading {
+        @include mq(tablet) {
+            color: #ffffff;
+        }
+    }
+}
+
 .hosted__heading--small {
     @include f-headlineSans;
 


### PR DESCRIPTION
## What does this change?

A few fixes on the video pages:
- fading in/out logo is now clickable
- logo fades in/out also on desktop and leftCol breakpoint
- label above the logo has smaller font (like it was done by @blongden73 only on article pages before)
- fading header is white on desktop and tablet breakpoints and has brand colour on mobile bp

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-16 at 12 10 41](https://cloud.githubusercontent.com/assets/489567/18584439/a8f81bfe-7c08-11e6-9b91-82046acaac1b.png)

After:
![screen shot 2016-09-16 at 12 10 35](https://cloud.githubusercontent.com/assets/489567/18584462/cec46054-7c08-11e6-9e02-252425d61fa1.png)

Logo fades out during video play
<img width="525" alt="screen shot 2016-09-16 at 12 11 15" src="https://cloud.githubusercontent.com/assets/489567/18584491/07faa3f6-7c09-11e6-84bb-7f0dd35dc3a6.png">

White header colour on desktop
![screen shot 2016-09-16 at 12 47 49](https://cloud.githubusercontent.com/assets/489567/18584986/348bd144-7c0c-11e6-858c-13158f80b719.png)
## Request for comment

@lps88 @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
