### PR TITLE
Prepare adblock test for live deployment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -99,11 +99,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ad-blocking-response",
+    "ab-ad-blocking-response2",
     "Prominent adblocker response test",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 16),   // Friday @ 23:59 BST
+    sellByDate = new LocalDate(2016, 9, 22),   // Thursday @ 23:59 BST
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -18,12 +18,12 @@ define([
     cookies
 ) {
     return function () {
-        this.id = 'AdBlockingResponse';
+        this.id = 'AdBlockingResponse2';
         this.start = '2016-09-16';
-        this.expiry = '2016-09-17';
+        this.expiry = '2016-09-23'; // the test will STOP on THURSDAY 22nd PM. Test dates don't behave like our switches!
         this.author = 'Justin Pinner';
-        this.description = 'Adblocking response ZERO PERCENT test with 30 minutes grace';
-        this.audience = 0;
+        this.description = 'Adblocking response test with 30 minutes grace';
+        this.audience = 0.12;
         this.audienceOffset = 0;
         this.successMeasure = 'Adblocking users white-list the Guardian domain';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';


### PR DESCRIPTION
## What does this change?

We're using a new switch and AB test name, so we can close down the test version used in development, thus closing and removing anyone and everyone from the original zero percent test.
## What is the value of this and can you measure success?

We're going to switch this on and put it in front of actual readers now.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

See https://github.com/guardian/frontend/pull/14072, https://github.com/guardian/frontend/pull/14230 and  https://github.com/guardian/frontend/pull/14334
## Request for comment

@kenlim @regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
