### PR TITLE
Don't brand a container unless tagged 'branded'

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -279,7 +279,8 @@ object FaciaContainer {
     showTimestamps = false,
     None,
     useShowMore = true,
-    hasShowMoreEnabled = !config.config.hideShowMore
+    hasShowMoreEnabled = !config.config.hideShowMore,
+    showBranding = config.config.showBranding
   )
 
   def forStoryPackage(dataId: String, items: Seq[PressedContent], title: String, href: Option[String] = None) = {
@@ -311,7 +312,8 @@ case class FaciaContainer(
   showTimestamps: Boolean,
   dateLinkPath: Option[String],
   useShowMore: Boolean,
-  hasShowMoreEnabled: Boolean
+  hasShowMoreEnabled: Boolean,
+  showBranding: Boolean
 ) {
   def transformCards(f: ContentCard => ContentCard) = copy(
     containerLayout = containerLayout.map(_.transformCards(f))

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -111,10 +111,13 @@ object Commercial {
         isPaidContainer || isAllPaidContent
       }
 
-      !isPaidFront && (
-        (containerBrandingFromCapi.isSwitchedOff && container.commercialOptions.isPaidContainer)
-          || optContainerModel.exists(isPaid)
-        )
+      lazy val isPaidContainerInDfp =
+        containerBrandingFromCapi.isSwitchedOff && container.commercialOptions.isPaidContainer
+
+      lazy val isPaidContainerInCapi =
+        containerBrandingFromCapi.isSwitchedOn && container.showBranding && optContainerModel.exists(isPaid)
+
+      !isPaidFront && (isPaidContainerInDfp || isPaidContainerInCapi)
     }
 
     def mkSponsorDataAttributes(config: CollectionConfig): Option[SponsorDataAttributes] = {

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -112,7 +112,8 @@ class FixturesAndResults(competitions: Competitions) extends Football {
           showTimestamps = false,
           dateLinkPath = None,
           useShowMore = false,
-          hasShowMoreEnabled = true
+          hasShowMoreEnabled = true,
+          showBranding = false
         )
       }
     }).flatten


### PR DESCRIPTION
Some containers that haven't got the 'branded' tag in the fronts tool look like this, because we think they're paid containers:
![image](https://cloud.githubusercontent.com/assets/1722550/18590810/2730c2ea-7c28-11e6-8aca-65f7d1717724.png)

But with this change, they look like this, which is correct:
![image](https://cloud.githubusercontent.com/assets/1722550/18590896/65a69680-7c28-11e6-9244-dff952cf9aa8.png)
