### PR TITLE
Hide video across all Fabrics when ad collapsed

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -420,6 +420,10 @@
             float: right;
         }
     }
+
+    .slide-video:not(.slide-video__expand) .expandable-video {
+        display: none;
+    }
 }
 
 .creative--expandable-video-v2 {
@@ -448,10 +452,6 @@
         > img {
             display: block;
         }
-    }
-
-    .slide-video:not(.slide-video__expand) .expandable-video {
-        display: none;
     }
 
     .slide-video__expand .creative__cta {


### PR DESCRIPTION
I previously added this fix only to the v2 template, but it applies to the v1 as well.
