### PR TITLE
Each Header-Bidding test variant should be logging commercial reports

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -173,7 +173,10 @@ define([
     }
 
     function reportTrackingData() {
-        if (config.tests.commercialClientLogging) {
+        if (config.tests.commercialClientLogging ||
+            config.tests.commercialHbSonobi ||
+            config.tests.commercialHbPrebid ||
+            config.tests.commercialHbControl) {
             require(['ophan/ng'], function (ophan) {
                 performanceLog.viewId = ophan.viewId;
 


### PR DESCRIPTION
These variants should be logging commercial reports.
