### PR TITLE
CSS-only header navigation

### DIFF
--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -4,7 +4,7 @@
 
 <div class="edition-picker js-edition-picker-container">
 
-    <input class="edition-picker__checkbox js-enhance-checkbox"
+    <input class="edition-picker__button js-enhance-checkbox js-edition-picker-button"
         type="checkbox"
         id="edition-picker"
         aria-controls="edition-picker__dropdown">

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -4,7 +4,7 @@
 
 <div class="edition-picker js-edition-picker-container">
 
-    <input class="edition-picker__button js-enhance-checkbox js-edition-picker-button"
+    <input class="edition-picker__button js-enhance-checkbox"
         type="checkbox"
         id="edition-picker"
         aria-controls="edition-picker__dropdown">

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -3,10 +3,10 @@
 @import common.{ NewNavigation, LinkTo, Edition }
 
 @sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection) = {
-    <li class="main-navigation__item navigation-border">
+    <li class="main-navigation__item navigation-border js-navigation-item">
             <!-- TODO: Firefox -->
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name" open>
-            <summary class="main-navigation__item__button">
+            <summary class="main-navigation__item__button js-navigation-button">
                 <i class="main-navigation__icon"></i>
                 @topLevelSection.name
             </summary>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -5,7 +5,7 @@
 @sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection) = {
     <li class="main-navigation__item navigation-border">
             <!-- TODO: Firefox -->
-        <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name">
+        <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name" open>
             <summary class="main-navigation__item__button">
                 <i class="main-navigation__icon"></i>
                 @topLevelSection.name
@@ -16,6 +16,7 @@
                     navigation-group
                     navigation-group--@{edition.id.toLowerCase}
                     js-editionlise-secondary-nav"
+                    data-edition="@{edition.id.toLowerCase}"
                     @if(edition.id.toLowerCase != "uk") { hidden }> @* Our default edition is UK *@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
@@ -29,11 +30,12 @@
     </li>
 }
 
-<div class="main-menu-container" id="main-menu">
-        <!-- TODO: Provide tabbable alternative -->
-    <a href="#" class="main-menu-container__overlay" aria-hidden="true"></a>
+<div href="#" class="main-menu-container__overlay" aria-hidden="true"></div>
 
-    <div class="main-menu-container__menu js-reset-scroll-on-menu">
+<div class="main-menu-container">
+        <!-- TODO: Provide tabbable alternative -->
+
+    <div class="main-menu-container__menu js-reset-scroll-on-menu" id="main-menu" aria-hidden="true">
         <ul class="main-navigation">
             @NewNavigation.topLevelSections.map { section =>
                 @sectionList(section)

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -30,9 +30,10 @@
     </li>
 }
 
-<div href="#" class="main-menu-container__overlay" aria-hidden="true"></div>
+<label for="main-menu-toggle" class="main-menu-container__overlay" aria-hidden="true"></label>
 
 <div class="main-menu-container">
+
         <!-- TODO: Provide tabbable alternative -->
 
     <div class="main-menu-container__menu js-reset-scroll-on-menu" id="main-menu" aria-hidden="true">
@@ -78,3 +79,4 @@
         </ul>
     </div>
 </div>
+

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -34,9 +34,9 @@
 
 <div class="main-menu-container">
 
-        <!-- TODO: Provide tabbable alternative -->
+    <!-- TODO: Provide tabbable alternative -->
 
-    <div class="main-menu-container__menu js-reset-scroll-on-menu" id="main-menu" aria-hidden="true">
+    <div class="main-menu-container__menu js-main-menu" id="main-menu" aria-hidden="true">
         <ul class="main-navigation">
             @NewNavigation.topLevelSections.map { section =>
                 @sectionList(section)

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -27,7 +27,7 @@
                 @primaryLinks(section.name)
             }
             <label for="main-menu-toggle" class="new-header__nav__menu-button js-change-link" tabindex="0">
-                <i class="new-header__veggie-burger-icon"></i>
+                <span class="new-header__veggie-burger-icon"></span>
                 <span class="u-h">Menu</span>
             </label>
             <input type="checkbox" id="main-menu-toggle" class="new-header__nav__button js-enhance-checkbox" aria-controls="main-menu">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,17 +4,14 @@
 @import common.{LinkTo, NewNavigation}
 
 @primaryLinks(sectionName: String) = {
-    <li class="new-header__nav__primary-item">
-        <a class="new-header__nav__link js-open-section-in-menu"
-            tabindex="0"
-            aria-controls="primary-list-@sectionName"
-            href="@LinkTo{#main-menu}">
-                @sectionName
-        </a>
-    </li>
-}
+    <label for="main-menu-toggle" class="new-header__nav__link js-open-section-in-menu"
+        tabindex="0"
+        aria-controls="primary-list-@sectionName"
+    >
+            @sectionName
+    </label>
 
-@fragments.nav.newHeaderMenu()
+}
 
 <header class="@Atomise("New-header")" role="banner" data-link-name="global navigation: new header">
     <div class="new-header__inner gs-container">
@@ -26,16 +23,17 @@
         @fragments.nav.editionPicker()
 
         <nav class="new-header__nav">
-            <a href="#main-menu" class="new-header__nav__menu-button js-change-link" tabindex="0">
-                <i class="new-header__veggie-burger-icon">
-                </i>
+            @NewNavigation.topLevelSections.map { section =>
+                @primaryLinks(section.name)
+            }
+            <label for="main-menu-toggle" class="new-header__nav__menu-button js-change-link" tabindex="0">
+                <i class="new-header__veggie-burger-icon"></i>
                 <span class="u-h">Menu</span>
-            </a>
-            <ul class="new-header__nav__list">
-                @NewNavigation.topLevelSections.map { section =>
-                    @primaryLinks(section.name)
-                }
-            </ul>
+            </label>
+            <input type="checkbox" id="main-menu-toggle" class="new-header__nav__button js-enhance-checkbox" aria-controls="main-menu">
+
+            @fragments.nav.newHeaderMenu()
         </nav>
     </div>
 </header>
+

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -28,7 +28,6 @@ define([
     'common/modules/identity/autosignin',
     'common/modules/identity/cookierefresh',
     'common/modules/navigation/navigation',
-    'common/modules/navigation/newHeaderNavigation',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
     'common/modules/navigation/membership',
@@ -85,7 +84,6 @@ define([
     AutoSignin,
     CookieRefresh,
     navigation,
-    newHeaderNavigation,
     Profile,
     Search,
     membership,
@@ -135,7 +133,6 @@ define([
 
             initialiseNavigation: function () {
                 navigation.init();
-                newHeaderNavigation();
             },
 
             showTabs: function () {

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -25,7 +25,8 @@ define([
     'common/utils/url',
     'common/utils/cookies',
     'common/utils/robust',
-    'common/utils/user-timing'
+    'common/utils/user-timing',
+    'common/modules/navigation/newHeaderNavigation'
 ], function (
     raven,
     qwery,
@@ -40,7 +41,8 @@ define([
     url,
     cookies,
     robust,
-    userTiming
+    userTiming,
+    newHeaderNavigation
 ) {
     return function () {
         var guardian = window.guardian;
@@ -291,6 +293,11 @@ define([
         } catch (e) {
             // do nothing
         }
+
+        /**
+         *  New Header Navigation
+         */
+        newHeaderNavigation();
 
         userTiming.mark('standard end');
     };

--- a/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
+++ b/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
@@ -11,7 +11,7 @@ define([
         var editionPickerDropdown = qwery('.js-edition-picker-dropdown')[0];
 
         function menuIsOpen() {
-            return (button.getAttribute('aria-expanded') === 'true');
+            return button.getAttribute('aria-expanded') === 'true';
         }
 
         function closeEditionPickerAndRemoveListener() {

--- a/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
+++ b/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
@@ -1,84 +1,41 @@
 define([
-    'common/utils/fastdom-promise',
-    'common/utils/$'
+    'fastdom',
+    'qwery'
 ], function (
-    fastdomPromise,
-    $
+    fastdom,
+    qwery
 ) {
-    var dropdown = $('.js-edition-picker-dropdown');
-    var button;
+    function editionPickerClickHandler(event) {
+        event.stopPropagation();
+        var button = event.target;
+        var editionPickerDropdown = qwery('.js-edition-picker-dropdown')[0];
 
-    function enhanceToButton() {
-        var container = $('.js-edition-picker-container');
-        var checkBox = $('.js-enhance-checkbox');
+        function menuIsOpen() {
+            return (button.getAttribute('aria-expanded') === 'true');
+        }
 
-        button = $.create('<button>');
-        button.addClass('edition-picker__button js-open-edition-picker');
-        button.attr('id', 'edition-picker');
-        button.attr('aria-controls', 'edition-picker__dropdown');
-        button.attr('aria-expanded', 'false');
+        function closeEditionPickerAndRemoveListener() {
+            closeMenu();
+            document.removeEventListener('click', closeEditionPickerAndRemoveListener, false);
+        }
 
-        fastdomPromise.write(function() {
-            checkBox.remove();
-            container.prepend(button);
-            bindClickEvents();
-        });
-    }
+        function closeMenu() {
+            fastdom.write(function () {
+                button.setAttribute('aria-expanded', 'false');
+                editionPickerDropdown.setAttribute('aria-hidden', 'true');
+            });
+        }
 
-    function bindClickEvents() {
-        if (button.length > 0) {
-            button[0].addEventListener('click', function() {
-                if (button.hasClass('open')) {
-                    closeMenuAndRemoveListener();
-                } else {
-                    openMenu().then(function() {
-                        document.addEventListener('click', closeMenuAndRemoveListener, false);
-                    });
-                }
+        if (menuIsOpen()) {
+            closeEditionPickerAndRemoveListener();
+        } else {
+            fastdom.write(function () {
+                button.setAttribute('aria-expanded', 'true');
+                editionPickerDropdown.setAttribute('aria-hidden', 'false');
+                document.addEventListener('click', closeEditionPickerAndRemoveListener, false);
             });
         }
     }
 
-    function openMenu() {
-        return fastdomPromise.write(function() {
-            button.addClass('open');
-            button.attr('aria-expanded', 'true');
-            dropdown.attr('aria-hidden', 'false');
-        });
-    }
-
-    function closeMenu() {
-        return fastdomPromise.write(function() {
-            button.removeClass('open');
-            button.attr('aria-expanded', 'false');
-            dropdown.attr('aria-hidden', 'true');
-        });
-    }
-
-    function closeMenuAndRemoveListener() {
-        return closeMenu().then(function() {
-            document.removeEventListener('click', closeMenuAndRemoveListener, false);
-        });
-    }
-
-    function clickMenuOnEnter() {
-        var label = document.getElementsByClassName('js-on-enter-click');
-
-        if (label.length > 0) {
-            label[0].onkeypress =  function clickOnEnter(event) {
-                if((event.keyCode ? event.keyCode : event.which) === 13) {
-                    fastdomPromise.write(function() {
-                        label[0].click();
-                    });
-                }
-            };
-        }
-    }
-
-    function init() {
-        clickMenuOnEnter();
-        enhanceToButton();
-    }
-
-    return init;
+    return editionPickerClickHandler;
 });

--- a/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
+++ b/static/src/javascripts/projects/common/modules/navigation/edition-picker.js
@@ -22,7 +22,9 @@ define([
         function closeMenu() {
             fastdom.write(function () {
                 button.setAttribute('aria-expanded', 'false');
-                editionPickerDropdown.setAttribute('aria-hidden', 'true');
+                if (editionPickerDropdown) {
+                    editionPickerDropdown.setAttribute('aria-hidden', 'true');
+                }
             });
         }
 
@@ -31,7 +33,9 @@ define([
         } else {
             fastdom.write(function () {
                 button.setAttribute('aria-expanded', 'true');
-                editionPickerDropdown.setAttribute('aria-hidden', 'false');
+                if (editionPickerDropdown) {
+                    editionPickerDropdown.setAttribute('aria-hidden', 'false');
+                }
                 document.addEventListener('click', closeEditionPickerAndRemoveListener, false);
             });
         }

--- a/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
+++ b/static/src/javascripts/projects/common/modules/navigation/editionalise-menu.js
@@ -1,40 +1,35 @@
 define([
-    'common/utils/fastdom-promise',
-    'common/utils/$',
+    'fastdom',
+    'qwery',
     'common/utils/config'
 ], function (
-    fastdomPromise,
-    $,
+    fastdom,
+    qwery,
     config
 ) {
 
     function editionaliseMenu() {
         var edition = config.page.edition.toLowerCase();
-        var editionLists = $('.js-editionlise-secondary-nav');
+        var editionLists = qwery('.js-editionlise-secondary-nav');
 
         // UK is our default edition so we don't have to change it
         if (edition !== 'uk') {
 
-            editionLists.each(function (navList) {
+            editionLists.forEach(function (navList) {
 
-                fastdomPromise.read(function() {
+                fastdom.read(function() {
+                    var isListCurrentEdition = (navList.getAttribute('data-edition') === edition);
 
-                    return navList.classList.contains('navigation-group--' + edition);
-
-                }).then(function (isListCurrentEdition) {
-
-                   fastdomPromise.write(function () {
-
-                       if (isListCurrentEdition) {
-                           navList.removeAttribute('hidden');
-                       } else {
-                           navList.setAttribute('hidden', '');
-                       }
-                   });
+                    fastdom.write(function () {
+                        if (isListCurrentEdition) {
+                            navList.removeAttribute('hidden');
+                        } else {
+                            navList.setAttribute('hidden', '');
+                        }
+                    });
                 });
             });
         }
     }
-
     return editionaliseMenu;
 });

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -60,7 +60,7 @@ define([
         var veggieBurgerLink = qwery('.js-change-link')[0];
 
         function menuIsOpen() {
-            return (button.getAttribute('aria-expanded') === 'true');
+            return button.getAttribute('aria-expanded') === 'true';
         }
 
         if (!mainMenu || !veggieBurgerLink) {

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -24,6 +24,14 @@ define([
         });
     }
 
+    function removeOrderingFromLists() {
+        var mainListItems = qwery('.js-navigation-item');
+
+        mainListItems.forEach(function (item) {
+            item.style.order = '';
+        });
+    }
+
     function enhanceToButton() {
         var checkboxes = qwery('.js-enhance-checkbox');
         fastdom.read(function () {
@@ -68,16 +76,11 @@ define([
         }
         if (menuIsOpen()) {
             fastdom.write(function () {
-                var mainListItems = qwery('.js-main-navigation-item');
-
                 button.setAttribute('aria-expanded', 'false');
                 mainMenu.setAttribute('aria-hidden', 'true');
                 veggieBurgerLink.classList.remove('new-header__nav__menu-button--open');
+                removeOrderingFromLists();
 
-                // Remove possible ordering for the lists
-                mainListItems.forEach(function (item) {
-                    item.style.order = '';
-                });
                 // Users should be able to scroll again
                 html.style.overflow = '';
             });

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -10,7 +10,6 @@ define([
     editionaliseMenu
 ) {
     var html = qwery('html')[0];
-    var veggieBurgerLink = qwery('.js-change-link');
     var menuItems = qwery('.js-close-nav-list');
     var buttonClickHandlers = {
         'main-menu-toggle': veggieBurgerClickHandler,
@@ -58,12 +57,13 @@ define([
     function veggieBurgerClickHandler(event) {
         var button = event.target;
         var mainMenu = qwery('#main-menu')[0];
+        var veggieBurgerLink = qwery('.js-change-link')[0];
 
         function menuIsOpen() {
             return (button.getAttribute('aria-expanded') === 'true');
         }
 
-        if (!mainMenu) {
+        if (!mainMenu || !veggieBurgerLink) {
             return;
         }
         if (menuIsOpen()) {
@@ -72,7 +72,7 @@ define([
 
                 button.setAttribute('aria-expanded', 'false');
                 mainMenu.setAttribute('aria-hidden', 'true');
-                veggieBurgerLink[0].classList.remove('new-header__nav__menu-button--open');
+                veggieBurgerLink.classList.remove('new-header__nav__menu-button--open');
 
                 // Remove possible ordering for the lists
                 mainListItems.forEach(function (item) {
@@ -87,7 +87,7 @@ define([
 
                 button.setAttribute('aria-expanded', 'true');
                 mainMenu.setAttribute('aria-hidden', 'false');
-                veggieBurgerLink[0].classList.add('new-header__nav__menu-button--open');
+                veggieBurgerLink.classList.add('new-header__nav__menu-button--open');
 
                 if (firstButton) {
                     firstButton.focus();

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -33,9 +33,7 @@ define([
                 var checkboxControls = checkbox.getAttribute('aria-controls');
                 var forEachClass = Array.prototype.forEach.bind(checkbox.classList);
 
-                forEachClass(function (c) {
-                    button.classList.add(c);
-                });
+                forEachClass(button.classList.add);
                 button.setAttribute('id', checkboxId);
                 button.setAttribute('aria-controls', checkboxControls);
                 button.setAttribute('aria-expanded', 'false');

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -1,159 +1,160 @@
 define([
-    'common/utils/fastdom-promise',
-    'common/utils/$',
+    'qwery',
+    'fastdom',
     'common/modules/navigation/edition-picker',
     'common/modules/navigation/editionalise-menu'
 ], function (
-    fastdomPromise,
-    $,
+    qwery,
+    fastdom,
     editionPicker,
     editionaliseMenu
 ) {
-    var mainMenuId = '#main-menu';
-    var html = $('html');
-    var mainMenuEl = $(mainMenuId);
-    var veggieBurgerLink = $('.js-change-link');
-    var primaryItems = $('.js-close-nav-list');
+    var html = qwery('html')[0];
+    var veggieBurgerLink = qwery('.js-change-link');
+    var menuItems = qwery('.js-close-nav-list');
+    var buttonClickHandlers = {
+        'main-menu-toggle': veggieBurgerClickHandler,
+        'edition-picker': editionPicker
+    };
 
     function closeAllOtherPrimaryLists(targetItem) {
-        primaryItems.each(function (item) {
-
+        menuItems.forEach(function (item) {
             if (item !== targetItem) {
                 item.removeAttribute('open');
             }
         });
     }
 
-    function animateMenuOpen() {
-        return fastdomPromise.write(function () {
-            mainMenuEl.addClass('off-screen shown');
+    function enhanceToButton() {
+        var checkboxes = qwery('.js-enhance-checkbox');
+        fastdom.read(function () {
+            var buttons = checkboxes.map(function (checkbox) {
+                var button = document.createElement('button');
+                var checkboxId = checkbox.id;
+                var checkboxControls = checkbox.getAttribute('aria-controls');
+                var forEachClass = Array.prototype.forEach.bind(checkbox.classList);
 
-            veggieBurgerLink.addClass('new-header__nav__menu-button--open');
-            veggieBurgerLink.attr('href', '#');
-        }).then(function () {
-            return fastdomPromise.write(function () {
-                mainMenuEl.removeClass('off-screen');
+                forEachClass(function (c) {
+                    button.classList.add(c);
+                });
+                button.setAttribute('id', checkboxId);
+                button.setAttribute('aria-controls', checkboxControls);
+                button.setAttribute('aria-expanded', 'false');
+
+                return button;
             });
-        }).then(function () {
-            var firstButton = $('.main-navigation__item__button')[0];
+            fastdom.write(function () {
+                buttons.forEach(function (button, index) {
+                    var checkbox = checkboxes[index];
+                    var eventHandler = buttonClickHandlers[button.id];
 
-            return fastdomPromise.write(function () {
-                if (firstButton) {
-                    firstButton.focus();
-                }
-                // Prevents scrolling on the body
-                html.css('overflow', 'hidden');
-            });
-        });
-    }
-
-    function animateMenuClose() {
-        return fastdomPromise.write(function () {
-            if (mainMenuEl.hasClass('shown')) {
-                mainMenuEl.addClass('off-screen');
-
-                veggieBurgerLink.removeClass('new-header__nav__menu-button--open');
-                veggieBurgerLink.attr('href', mainMenuId);
-
-                // TODO: Support browsers that don't have transitions
-                // We still want to hide this
-                if (mainMenuEl.length > 0) {
-
-                    mainMenuEl[0].addEventListener('transitionend', function handler() {
-
-                        mainMenuEl[0].removeEventListener('transitionend', handler);
-
-                        return fastdomPromise.write(function () {
-                            mainMenuEl.removeClass('off-screen');
-                            mainMenuEl.removeClass('shown');
-                        }).then(function () {
-                            return fastdomPromise.write(function () {
-                                var mainListItems = $('.main-navigation__item');
-                                // Remove possible ordering for the lists
-                                mainListItems.removeAttr('style');
-                                // No targetItem to put in as the parameter. All lists should close.
-                                closeAllOtherPrimaryLists();
-
-                                $('.new-header__nav__menu-button').focus();
-                                // Users should be able to scroll again
-                                html.css('overflow', '');
-                            });
-                        });
-                    });
-                }
-            }
-        });
-    }
-
-    function moveTargetListToTop(targetListId) {
-        primaryItems.each(function (listItem, index) {
-
-            fastdomPromise.read(function () {
-                return listItem.getAttribute('id');
-            }).then(function (itemId) {
-
-                if (itemId === targetListId) {
-                    fastdomPromise.write(function () {
-                        var parent = listItem.parentNode;
-                        var menuContainer = $('.js-reset-scroll-on-menu');
-
-                        // Using flexbox to reorder lists based on what is clicked.
-                        parent.style.order = '-' + index;
-
-                        // Make sure when the menu is open, the user is always scrolled to the top
-                        menuContainer[0].scrollTop = 0;
-                    });
-                }
-            });
-        });
-    }
-
-    function openTargetListOnClick() {
-        var primaryLinks = $('.js-open-section-in-menu');
-
-        primaryLinks.each(function (primaryLink) {
-
-            primaryLink.addEventListener('click', function () {
-
-                fastdomPromise.read(function () {
-                    return primaryLink.getAttribute('aria-controls');
-                }).then(function (id) {
-                    var menuToOpen = $('#' + id);
-
-                    fastdomPromise.write(function () {
-                        menuToOpen.attr('open', '');
-                        return id;
-                    }).then(moveTargetListToTop.bind(id));
+                    checkbox.parentNode.replaceChild(button, checkbox);
+                    button.addEventListener('click', eventHandler);
                 });
             });
         });
     }
 
-    function bindPrimaryItemClickEvents() {
-        primaryItems.each(function (item) {
+    function veggieBurgerClickHandler(event) {
+        var button = event.target;
+        var mainMenu = qwery('#main-menu')[0];
+
+        function menuIsOpen() {
+            return (button.getAttribute('aria-expanded') === 'true');
+        }
+
+        if (!mainMenu) {
+            return;
+        }
+        if (menuIsOpen()) {
+            fastdom.write(function () {
+                var mainListItems = qwery('.main-navigation__item');
+
+                button.setAttribute('aria-expanded', 'false');
+                mainMenu.setAttribute('aria-hidden', 'true');
+                veggieBurgerLink[0].classList.remove('new-header__nav__menu-button--open');
+
+                // Remove possible ordering for the lists
+                mainListItems.forEach(function (item) {
+                    item.style.order = '';
+                });
+                // Users should be able to scroll again
+                html.style.overflow = '';
+            });
+        } else {
+            fastdom.write(function () {
+                var firstButton = qwery('.main-navigation__item__button')[0];
+
+                button.setAttribute('aria-expanded', 'true');
+                mainMenu.setAttribute('aria-hidden', 'false');
+                veggieBurgerLink[0].classList.add('new-header__nav__menu-button--open');
+
+                if (firstButton) {
+                    firstButton.focus();
+                }
+                // No targetItem to put in as the parameter. All lists should close.
+                closeAllOtherPrimaryLists();
+                // Prevents scrolling on the body
+                html.style.overflow = 'hidden';
+            });
+        }
+    }
+
+    function moveTargetListToTop(targetListId) {
+        menuItems.forEach(function (listItem, index) {
+
+            fastdom.read(function () {
+                var itemId = listItem.getAttribute('id');
+
+                if (itemId === targetListId) {
+                    fastdom.write(function () {
+                        var parent = listItem.parentNode;
+                        var menuContainer = qwery('.js-reset-scroll-on-menu')[0];
+
+                        // Using flexbox to reorder lists based on what is clicked.
+                        parent.style.order = '-' + index;
+
+                        // Make sure when the menu is open, the user is always scrolled to the top
+                        menuContainer.scrollTop = 0;
+                    });
+                }
+            });
+        });
+    }
+
+    function bindMenuItemClickEvents() {
+        menuItems.forEach(function (item) {
             item.addEventListener('click', closeAllOtherPrimaryLists.bind(null, item));
         });
     }
 
-    function handleHashChange () {
-        var shouldShowMenu = window.location.hash === mainMenuId;
-        var shouldHideMenu = window.location.hash === '';
+    function bindPrimaryItemsClickEvents() {
+        var primaryItems = qwery('.js-open-section-in-menu');
 
-        if (shouldShowMenu) {
-            animateMenuOpen();
-        } else if (shouldHideMenu) {
-            animateMenuClose();
-        }
+        primaryItems.forEach(function (primaryItem) {
+
+            primaryItem.addEventListener('click', function () {
+                fastdom.read(function () {
+                    var id = primaryItem.getAttribute('aria-controls');
+                    var menuToOpen = qwery('#' + id)[0];
+                    var menuButton = qwery('.main-navigation__item__button', menuToOpen)[0];
+
+                    fastdom.write(function () {
+                        menuToOpen.setAttribute('open', '');
+                        moveTargetListToTop(id);
+                        menuButton.focus();
+                        // Prevents scrolling on the body
+                        html.style.overflow = 'hidden';
+                    });
+                });
+            });
+        });
     }
 
     function init() {
-        window.addEventListener('hashchange', handleHashChange);
-        handleHashChange();
-
-        bindPrimaryItemClickEvents();
-        openTargetListOnClick();
-
-        editionPicker();
+        enhanceToButton();
+        bindMenuItemClickEvents();
+        bindPrimaryItemsClickEvents();
         editionaliseMenu();
     }
 

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -31,9 +31,11 @@ define([
                 var button = document.createElement('button');
                 var checkboxId = checkbox.id;
                 var checkboxControls = checkbox.getAttribute('aria-controls');
-                var forEachClass = Array.prototype.forEach.bind(checkbox.classList);
+                var checkboxClasses = Array.prototype.slice.call(checkbox.classList);
 
-                forEachClass(button.classList.add);
+                checkboxClasses.forEach(function (c) {
+                    button.classList.add(c);
+                });
                 button.setAttribute('id', checkboxId);
                 button.setAttribute('aria-controls', checkboxControls);
                 button.setAttribute('aria-expanded', 'false');

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -68,7 +68,7 @@ define([
         }
         if (menuIsOpen()) {
             fastdom.write(function () {
-                var mainListItems = qwery('.main-navigation__item');
+                var mainListItems = qwery('.js-main-navigation-item');
 
                 button.setAttribute('aria-expanded', 'false');
                 mainMenu.setAttribute('aria-hidden', 'true');
@@ -83,7 +83,7 @@ define([
             });
         } else {
             fastdom.write(function () {
-                var firstButton = qwery('.main-navigation__item__button')[0];
+                var firstButton = qwery('.js-navigation-button')[0];
 
                 button.setAttribute('aria-expanded', 'true');
                 mainMenu.setAttribute('aria-hidden', 'false');
@@ -137,7 +137,7 @@ define([
                 fastdom.read(function () {
                     var id = primaryItem.getAttribute('aria-controls');
                     var menuToOpen = qwery('#' + id)[0];
-                    var menuButton = qwery('.main-navigation__item__button', menuToOpen)[0];
+                    var menuButton = qwery('.js-navigation-button', menuToOpen)[0];
 
                     fastdom.write(function () {
                         menuToOpen.setAttribute('open', '');

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -107,7 +107,7 @@ define([
                 if (itemId === targetListId) {
                     fastdom.write(function () {
                         var parent = listItem.parentNode;
-                        var menuContainer = qwery('.js-reset-scroll-on-menu')[0];
+                        var menuContainer = qwery('.js-main-menu')[0];
 
                         // Using flexbox to reorder lists based on what is clicked.
                         parent.style.order = '-' + index;

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -229,4 +229,5 @@ $zindex-sticky: 1020;  // Sticky header
 $zindex-modal: 1030;   // Search modal
 $zindex-popover: 1040; // Breaking news
 $zindex-overlay: 1050; // Lightbox
-$zindex-notifications-permissions-warning: 1060;
+$zindex-notifications-permissions-warning: 1060; //Chrome Live Blog notifications
+$zindex-main-menu: 1070; // New header navigation dropdown

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -357,7 +357,6 @@ $gutter-large: 55px;
     transition: transform .2s cubic-bezier(.23, 1, .32, 1);
 
     @include mq($until: $mobile-medium) {
-        margin-right: $gutter-small + ($veggie-burger-small / 2);
         padding-top: $gs-baseline / 3;
     }
 
@@ -365,14 +364,6 @@ $gutter-large: 55px;
         //Larger font/icon size for larger devices
         font-size: 24px;
         padding-top: $gs-baseline;
-    }
-
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
-        margin-right: $gutter-medium + ($veggie-burger-medium / 2);
-    }
-
-    @include mq(mobileLandscape) {
-        margin-right: $gutter-large + ($veggie-burger-medium / 2);
     }
 
     .main-menu-container.off-screen & {
@@ -388,6 +379,18 @@ $gutter-large: 55px;
 .main-menu-container {
     transform: translateX(-110%);
     transition: transform .4s cubic-bezier(.23, 1, .32, 1);
+
+    @include mq($until: $mobile-medium) {
+        margin-right: $gutter-small + ($veggie-burger-small / 2);
+    }
+
+    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+        margin-right: $gutter-medium + ($veggie-burger-medium / 2);
+    }
+
+    @include mq(mobileLandscape) {
+        margin-right: $gutter-large + ($veggie-burger-medium / 2);
+    }
 }
 
 .new-header__nav__button {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -23,18 +23,18 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     @include mq($until: $mobile-medium) {
         width: 170px;
         // height: auto doesn't work in Safari
-        height: calc(3/16 * 170px);
+        height: calc(3 / 16 * 170px);
     }
 
     @include mq($from: $mobile-medium, $until: mobileLandscape) {
         width: 225px;
-        height: calc(3/16 * 225px);
+        height: calc(3 / 16 * 225px);
     }
 
     @include mq(mobileLandscape) {
         width: 260px;
         // height: auto doesn't work in Safari
-        height: calc(3/16 * 260px);
+        height: calc(3 / 16 * 260px);
         padding: ($gs-baseline / 2) ($gs-gutter / 2) 0;
         margin-right: $gs-gutter / 2;
     }
@@ -43,12 +43,9 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 .new-header__nav {
     @include fs-textSans(5);
     line-height: 1.6;
-    display: flex;
-    align-items: center;
     width: 100%;
+    padding-left: 10px;
     // Position after pseudo element which forces line break
-    order: 1;
-    justify-content: space-between;
 
     @include mq($until: mobile) {
         font-size: 16px;
@@ -72,14 +69,16 @@ $gutter-large: 55px;
 
 .new-header__nav__menu-button {
     // Override button from user agent stylesheet
-    position: relative;
+    position: absolute;
+    right: 0px;
     // Unset button from user agent stylesheet
     border: 0;
     outline: none;
     // Override button from user agent stylesheet
     border-radius: 100%;
-    z-index: $zindex-modal;
+    z-index: 1031;
     background-color: $news-main-2;
+    cursor: pointer;
 
     &--open:before {
         // Extended hit area for veggie burger close state, for fat fingers
@@ -136,6 +135,7 @@ $gutter-large: 55px;
     right: 0;
     margin-left: auto;
     margin-right: auto;
+    cursor: pointer;
 
     &,
     &:before,
@@ -170,28 +170,20 @@ $gutter-large: 55px;
     }
 }
 
-.new-header__nav__list {
-    display: flex;
-    flex-wrap: wrap;
-    // Unset ul from user agent stylesheet
-    margin-top: 0;
-    // Unset ul from user agent stylesheet
-    margin-bottom: 0;
-    order: -1;
-    margin-left: $gs-gutter / 2;
 
-    @include mq($until: mobile) {
-        overflow: hidden;
-        height: 1.6em;
+.new-header__nav__link {
+    // Override a from _lists.scss
+    color: #ffffff;
+    padding-left: .3em;
+    padding-right: .07em;
+    display: inline-block;
+    cursor: pointer;
+
+    &:focus,
+    &:hover {
+        text-decoration: none;
     }
 
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter;
-    }
-}
-
-.new-header__nav__primary-item {
-    // Override inherited nav ul from _lists.scss
     list-style: none;
     white-space: nowrap;
     position: relative;
@@ -208,21 +200,8 @@ $gutter-large: 55px;
         color: $news-main-2;
     }
 
-    &:first-child:before {
+    &:first-of-type:before {
         content: none;
-    }
-}
-
-.new-header__nav__link {
-    // Override a from _lists.scss
-    color: #ffffff;
-    padding-left: .3em;
-    padding-right: .3em;
-    display: inline-block;
-
-    &:focus,
-    &:hover {
-        text-decoration: none;
     }
 }
 
@@ -323,10 +302,10 @@ $gutter-large: 55px;
     }
 }
 
-.edition-picker__checkbox, .edition-picker__button {
+.edition-picker__button {
     display: none;
 
-    &:checked, &.open {
+    &:checked, &[aria-expanded='true'] {
         & ~ .edition-picker__dropdown {
             display: block;
             background-color: $guardian-brand-dark;
@@ -350,35 +329,19 @@ $gutter-large: 55px;
     left: 0;
     line-height: 1;
     z-index: $zindex-modal;
-
-    .js-on & {
-        &:not(.shown) {
-            display: none;
-        }
-    }
-
-    .js-off & {
-        &:not(:target) {
-            display: none;
-        }
-    }
 }
 
 .main-menu-container__overlay {
     background-color: hsla(0, 0%, 0%, .5);
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     transition: opacity .2s cubic-bezier(.23, 1, .32, 1);
     // Without this, in Safari/IOS this element appears above the menu
-    z-index: -1;
-
-    .main-menu-container.off-screen & {
-        opacity: 0;
-        transition: opacity .4s cubic-bezier(.23, 1, .32, 1);
-    }
+    z-index: 2;
+    display: none;
 }
 
 .main-menu-container__menu {
@@ -415,6 +378,31 @@ $gutter-large: 55px;
     .main-menu-container.off-screen & {
         transform: translateX(-110%);
         transition: transform .4s cubic-bezier(.23, 1, .32, 1);
+    }
+}
+
+.new-header__nav__button {
+    display: none;
+}
+
+.main-menu-container {
+    transform: translateX(-110%);
+    transition: transform .4s cubic-bezier(.23, 1, .32, 1);
+}
+
+.new-header__nav__button {
+    &:checked, &[aria-expanded='true']  {
+        & ~ .main-menu-container {
+            transform: translateX(0%);
+            transition: transform .4s cubic-bezier(.23, 1, .32, 1);
+        }
+    }
+    &:checked, &[aria-expanded='true'] {
+        & ~ .main-menu-container__overlay {
+            opacity: 1;
+            transition: opacity .4s cubic-bezier(.23, 1, .32, 1);
+            display: block;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -76,7 +76,7 @@ $gutter-large: 55px;
     outline: none;
     // Override button from user agent stylesheet
     border-radius: 100%;
-    z-index: 1031;
+    z-index: 1071;
     background-color: $news-main-2;
     cursor: pointer;
 
@@ -328,7 +328,7 @@ $gutter-large: 55px;
     bottom: 0;
     left: 0;
     line-height: 1;
-    z-index: $zindex-modal;
+    z-index: $zindex-main-menu;
 }
 
 .main-menu-container__overlay {
@@ -340,7 +340,7 @@ $gutter-large: 55px;
     left: 0;
     transition: opacity .2s cubic-bezier(.23, 1, .32, 1);
     // Without this, in Safari/IOS this element appears above the menu
-    z-index: 2;
+    z-index: $zindex-overlay;
     display: none;
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -305,7 +305,8 @@ $gutter-large: 55px;
 .edition-picker__button {
     display: none;
 
-    &:checked, &[aria-expanded='true'] {
+    &:checked,
+    &[aria-expanded='true'] {
         & ~ .edition-picker__dropdown {
             display: block;
             background-color: $guardian-brand-dark;
@@ -394,13 +395,15 @@ $gutter-large: 55px;
 }
 
 .new-header__nav__button {
-    &:checked, &[aria-expanded='true']  {
+    &:checked,
+    &[aria-expanded='true']  {
         & ~ .main-menu-container {
             transform: translateX(0%);
             transition: transform .4s cubic-bezier(.23, 1, .32, 1);
         }
     }
-    &:checked, &[aria-expanded='true'] {
+    &:checked,
+    &[aria-expanded='true'] {
         & ~ .main-menu-container__overlay {
             opacity: 1;
             transition: opacity .4s cubic-bezier(.23, 1, .32, 1);


### PR DESCRIPTION
## What does this change?
- implemented a CSS-only version of the new header navigation. This is available as soon as the HTML and CSS has loaded
- stripped most of the JavaScript functionality of the header; JS now provides only accessibility and user experience enhancements. Also removed most of its third party dependency libraries, with the exception of `fastdom` and `qwery`
- moved the JavaScript from enhanced into standard
## What is the value of this and can you measure success?

Currently, the new header navigation does not respond to user interaction until all enhanced JavaScript has been loaded. There is an unacceptable delay between user interaction and perceived response from the header UI. Implementing a CSS-only version of the navigation ensures there will be no such delay.

The CSS-only version of the navigation is not accessible, and the user experience is sub-optimal. Therefore we will still need to maintain minimal JavaScript that addresses these issues.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@NataliaLKB @gtrufitt @rich-nguyen @TBonnin @zeftilldeath @regiskuckaertz 
