### PR TITLE
Contributions Epic button text AB Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
     "Test variants of the button text to drive contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 21),
+    sellByDate = new LocalDate(2016, 9, 27),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,11 +48,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-20160906",
-    "Test whether contributions embed performs better than our previous in-article component tests.",
-    owners = Seq(Owner.withGithub("jranks123")),
+    "ab-contributions-epic-20160916",
+    "Test variants of the button text to drive contributions.",
+    owners = Seq(Owner.withGithub("markjamesbutler")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 20),
+    sellByDate = new LocalDate(2016, 9, 21),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -12,7 +12,7 @@ define([
 
     function _testABClash(f) {
 
-        var contributionsEpic = {name: 'ContributionsEpic20160906', variants: ['control']};
+        var contributionsEpic = {name: 'ContributionsEpic20160916', variants: ['control', 'give', 'today', 'make']};
 
         var contributionsEpicButtons = {name: 'ContributionsEpicButtons20160907', variants: ['control', 'buttons']};
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
@@ -32,7 +32,7 @@ define([
 
         this.id = 'ContributionsEpic20160916';
         this.start = '2016-09-16';
-        this.expiry = '2016-09-21';
+        this.expiry = '2016-09-27';
         this.author = 'Mark Butler';
         this.description = 'Test variants of the button text to drive contributions.';
         this.showForSensitive = false;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic.js
@@ -30,14 +30,14 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEpic20160906';
-        this.start = '2016-09-06';
-        this.expiry = '2016-09-13';
-        this.author = 'Jonathan Rankin';
-        this.description = 'Test whether contributions embed performs better than our previous in-article component tests.';
+        this.id = 'ContributionsEpic20160916';
+        this.start = '2016-09-16';
+        this.expiry = '2016-09-21';
+        this.author = 'Mark Butler';
+        this.description = 'Test variants of the button text to drive contributions.';
         this.showForSensitive = false;
         this.audience = 0.05;
-        this.audienceOffset = 0.33;
+        this.audienceOffset = 0.23;
         this.successMeasure = 'Impressions to number of contributions';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
@@ -79,7 +79,51 @@ define([
                 id: 'control',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl : 'https://contribute.theguardian.com?INTCMP=co_uk_epic',
+                        id: 'control',
+                        linkUrl : 'https://contribute.theguardian.com?INTCMP=co_uk_epic_cta_control',
+                        linkName: 'Contribute',
+                        position: 'bottom',
+                        variant: 'no-buttons'
+                    }));
+                    bottomWriter(component);
+                },
+                success: completer
+            },
+            {
+                id: 'give',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        id: 'give',
+                        linkUrl : 'https://contribute.theguardian.com?INTCMP=co_uk_epic_cta_give',
+                        linkName: 'Give today',
+                        position: 'bottom',
+                        variant: 'no-buttons'
+                    }));
+                    bottomWriter(component);
+                },
+                success: completer
+            },
+            {
+                id: 'today',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        id: 'today',
+                        linkUrl : 'https://contribute.theguardian.com?INTCMP=co_uk_epic_cta_today',
+                        linkName: 'Contribute today',
+                        position: 'bottom',
+                        variant: 'no-buttons'
+                    }));
+                    bottomWriter(component);
+                },
+                success: completer
+            },
+            {
+                id: 'make',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        id: 'make',
+                        linkUrl : 'https://contribute.theguardian.com?INTCMP=co_uk_epic_cta_make',
+                        linkName: 'Make a contribution',
                         position: 'bottom',
                         variant: 'no-buttons'
                     }));

--- a/static/src/javascripts/projects/common/views/contributions-epic.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic.html
@@ -23,8 +23,8 @@
             </div>
         </div>
         <div >
-            <a class="js-submit-input contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--<%=position%> contributions__contribute--<%=variant%>" href="<%=linkUrl%>" target="_blank">
-                Contribute
+            <a class="js-submit-input contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--<%=position%> contributions__contribute--<%=variant%>--<%=id%>" href="<%=linkUrl%>" target="_blank">
+                <%=linkName%>
             </a>
         </div>
     </div>

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -172,6 +172,13 @@
         margin-left: 0;
     }
 
+    .contributions__contribute--no-buttons--today {
+        width: 150px;
+    }
+
+    .contributions__contribute--no-buttons--make {
+        width: 170px;
+    }
 
 }
 

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -149,6 +149,14 @@
     display: none;
 }
 
+.contributions__contribute--no-buttons--today {
+    width: 150px;
+}
+
+.contributions__contribute--no-buttons--make {
+    width: 170px;
+}
+
 @include mq($from: phablet) {
     .contributions__option-button--bottom {
         width: 70px;
@@ -171,15 +179,6 @@
     .contributions__contribute--no-buttons {
         margin-left: 0;
     }
-
-    .contributions__contribute--no-buttons--today {
-        width: 150px;
-    }
-
-    .contributions__contribute--no-buttons--make {
-        width: 170px;
-    }
-
 }
 
 


### PR DESCRIPTION
## What does this change?

Test variants of the button text to drive contributions.
## What is the value of this and can you measure success?

Determine the best button text to use to drive contributions.
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![screen shot 2016-09-16 at 17 06 27](https://cloud.githubusercontent.com/assets/406099/18592842/a782d796-7c30-11e6-998e-e16a4e1106da.png)
![screen shot 2016-09-16 at 17 06 41](https://cloud.githubusercontent.com/assets/406099/18592843/a78361ca-7c30-11e6-93d7-eb6f0776d945.png)
![screen shot 2016-09-16 at 17 06 54](https://cloud.githubusercontent.com/assets/406099/18592845/a785cd0c-7c30-11e6-85b9-381dab9a7bff.png)
![screen shot 2016-09-16 at 17 07 46](https://cloud.githubusercontent.com/assets/406099/18592844/a7848b72-7c30-11e6-9133-0730d50dbb3c.png)

Mobile:

![screen shot 2016-09-16 at 17 27 44](https://cloud.githubusercontent.com/assets/406099/18593403/1e8fa100-7c33-11e6-9741-14c9bd467206.png)
![screen shot 2016-09-16 at 17 28 13](https://cloud.githubusercontent.com/assets/406099/18593401/1e8d59e0-7c33-11e6-9b88-a898713ad5b7.png)
![screen shot 2016-09-16 at 17 28 22](https://cloud.githubusercontent.com/assets/406099/18593402/1e8d6304-7c33-11e6-8ca0-66217334958f.png)
![screen shot 2016-09-16 at 17 28 31](https://cloud.githubusercontent.com/assets/406099/18593404/1e9d88c4-7c33-11e6-8a4d-6e4deb9ac255.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
