### PR TITLE
Remove the double avatar message in discussion frontend

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -130,6 +130,11 @@ CommentBox.prototype.prerender = function() {
         avatar.setAttribute('userid', userData.id);
         avatar.setAttribute('data-userid', userData.id);
         UserAvatars.avatarify(avatar);
+    } else {
+        var container = document.getElementsByClassName('d-comment-box__meta')[0];
+        if (container) {
+            container.parentNode.removeChild(container);
+        }
     }
 
     if (this.options.replyTo) {


### PR DESCRIPTION
## What does this change?

When discussion frontend AB test is active, the avatar is rendered by the external code, however the text `sign in as` is displayed twice.
If the test is active, remove the duplicate text
## What is the value of this and can you measure success?

Fix for #14339
## Does this affect other platforms - Amp, Apps, etc?

No
