### PR TITLE
Fix related content container on paid content

### DIFF
--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -1,13 +1,14 @@
 package views.support
 
-import common.Maps.RichMap
 import common.Edition
+import common.Maps.RichMap
 import conf.Configuration
 import conf.Configuration.environment
+import conf.switches.Switches.staticBadgesSwitch
 import model._
 import play.api.Play
 import play.api.Play.current
-import play.api.libs.json.{JsValue, JsBoolean, JsString, Json}
+import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
@@ -25,7 +26,13 @@ object JavaScriptPage {
 
     val config = (Configuration.javascript.config ++ pageData).mapValues(JsString.apply)
     val isInappropriateForSponsorship = content.exists(_.commercial.isInappropriateForSponsorship)
-    val sponsorshipType = content.flatMap(_.commercial.sponsorshipType).map("sponsorshipType" -> JsString(_))
+    val sponsorshipType = {
+      val maybeSponsorshipType = {
+        if (staticBadgesSwitch.isSwitchedOn) page.branding(edition).map(_.sponsorshipType.name)
+        else content.flatMap(_.commercial.sponsorshipType)
+      }
+      maybeSponsorshipType.map("sponsorshipType" -> JsString(_))
+    }
     val sponsorshipTag = content.flatMap(_.commercial.sponsorshipTag).map( tag => "sponsorshipTag" -> JsString(tag.name))
     val allowUserGeneratedContent = content.map(_.allowUserGeneratedContent).getOrElse(false)
     val requiresMembershipAccess = content.map(_.metadata.requiresMembershipAccess).getOrElse(false)

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -66,7 +66,8 @@ define([
                 };
 
                 // exclude ad features from non-ad feature content
-                if (config.page.sponsorshipType !== 'advertisement-features') {
+                if ((!config.switches.staticBadges && config.page.sponsorshipType !== 'advertisement-features') ||
+                    (config.switches.staticBadges && config.page.sponsorshipType !== 'paid-content')) {
                     opts.excludeTags.push('tone/advertisement-features');
                 }
                 // don't want to show professional network content on videos or interactives


### PR DESCRIPTION
The sponsorship type wasn't being set client-side since the logo migration, which meant the related content container was bringing in obscure content on paid pages.  This should fix it.

Eg. https://www.theguardian.com/discover-cool-canada/2016/sep/09/magnifique-montreal-at-a-glance

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/18629133/924c0a64-7e5b-11e6-8a84-d414e42d95e6.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/18629142/9dd214dc-7e5b-11e6-90a9-9937fae4a89f.png)
