### PR TITLE
deploy.json: Set publicReadAcl to false and remove not needed parameters

### DIFF
--- a/admin-jobs/deploy.json
+++ b/admin-jobs/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/admin/deploy.json
+++ b/admin/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/applications/deploy.json
+++ b/applications/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/archive/deploy.json
+++ b/archive/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/article/deploy.json
+++ b/article/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/commercial/deploy.json
+++ b/commercial/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/diagnostics/deploy.json
+++ b/diagnostics/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/discussion/deploy.json
+++ b/discussion/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/facia-press/deploy.json
+++ b/facia-press/deploy.json
@@ -5,13 +5,10 @@
             "type": "autoscaling",
             "data": {
                 "secondsToWait": 1200,
-                "port": 18080,
                 "healthcheckGrace": 20,
                 "warmupGrace":30,
                 "bucket": "aws-frontend-artifacts",
-                "healthcheck_paths": [
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/facia/deploy.json
+++ b/facia/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/identity/deploy.json
+++ b/identity/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/onward/deploy.json
+++ b/onward/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
 

--- a/preview/deploy.json
+++ b/preview/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/router/deploy.json
+++ b/router/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
 

--- a/rss/deploy.json
+++ b/rss/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/sport/deploy.json
+++ b/sport/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },

--- a/training-preview/deploy.json
+++ b/training-preview/deploy.json
@@ -5,13 +5,10 @@
             "type":"autoscaling",
             "data":{
                 "secondsToWait":1200,
-                "port":18080,
                 "healthcheckGrace":20,
                 "warmupGrace":30,
                 "bucket":"aws-frontend-artifacts",
-                "healthcheck_paths":[
-                    "/management/healthcheck"
-                ]
+                "publicReadAcl" : false
             }
         }
     },


### PR DESCRIPTION
## What does this change?

Set publicReadAcl to false and remove not needed parameters in deploy.json files
## What is the value of this and can you measure success?
- App is downloaded using `aws s3 cp` so no need for public read permission
- `port` and `healthcheck_paths` are not supported params of autoscaling
  deploy type (https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling)
## Request for comment

@sihil @guardian/dotcom-platform 
