### PR TITLE
Show series links on paid content

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -174,14 +174,17 @@ case class Tag (
 
   override val metadata: MetaData = Tag.makeMetadata(properties, pagination)
 
+  def isOfType(typeName: String): Boolean = properties.tagType == typeName || isOfPaidType(typeName)
+  def isOfPaidType(typeName: String): Boolean = properties.paidContentType.contains(typeName)
+
   val isContributor: Boolean = metadata.id.startsWith("profile/")
   val id: String = metadata.id
   val name: String = metadata.webTitle
-  val isSeries: Boolean = properties.tagType == "Series"
-  val isBlog: Boolean = properties.tagType == "Blog"
+  val isSeries: Boolean = isOfType("Series")
+  val isBlog: Boolean = isOfType("Blog")
   val isSectionTag: Boolean = SectionTagLookUp.sectionId(metadata.id).contains(metadata.sectionId)
   val showSeriesInMeta = metadata.id != "childrens-books-site/childrens-books-site"
-  val isKeyword = properties.tagType == "Keyword"
+  val isKeyword = isOfType("Keyword") || isOfPaidType("Topic")
   val isFootballTeam = properties.references.exists(_.`type` == "pa-football-team")
   val isFootballCompetition = properties.references.exists(_.`type` == "pa-football-competition")
   val contributorImagePath = properties.bylineImageUrl.map(ImgSrc(_, Contributor))


### PR DESCRIPTION
This changes the way tag types are identified.  It inspects paid content types as well as standard types.  And that makes series links reappear on paid content!

eg. https://www.theguardian.com/inside-seat/2016/sep/05/smart-cities-future-transport-technologies-revolution-carnet-vehicles-urban-planning

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/18630386/31dac194-7e64-11e6-8d80-f464526d545a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/18630390/3a8acb0e-7e64-11e6-8433-20857f6b24e4.png)
