### PR TITLE
Fix MPU width in containers

### DIFF
--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -233,7 +233,10 @@ Hence why a greater depth of selector specificity is needed.
         width: gs-span(4);
         padding-bottom: $gs-baseline / 2;
         @include mq(tablet) {
-            width: gs-span(9);
+            width: gs-span(5);
+        }
+        @include mq(desktop) {
+            width: gs-span(4);
         }
     }
     .ad-slot__label {


### PR DESCRIPTION
Since I [removed the flex layout](https://github.com/guardian/frontend/commit/1b2a7aa073117bd5de3b400cb8eaa213a1e95804#diff-5c2a5857bc9011c98390faace79197d9R33) for the slice MPU candidate, this happens:

![picture 4](https://cloud.githubusercontent.com/assets/629976/18634306/4bf0c1dc-7e78-11e6-8314-f92ee4a27e6b.jpg)

There is no reason for flex in the first place, but the problem was that the size of the slot was too much, so this fix just reduces it to a normal value.

**After:**

![picture 3](https://cloud.githubusercontent.com/assets/629976/18634343/6bcd2b26-7e78-11e6-9617-2148146457a8.jpg)

![picture 2](https://cloud.githubusercontent.com/assets/629976/18634345/6e497c74-7e78-11e6-90e3-9e8225c0084f.jpg)
