### PR TITLE
Contributions: Fixed sizing on desktop

### DIFF
--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -157,6 +157,14 @@
     width: 170px;
 }
 
+.contributions__contribute--no-buttons--control {
+    width: 130px;
+}
+
+.contributions__contribute--no-buttons--give {
+    width: 130px;
+}
+
 @include mq($from: phablet) {
     .contributions__option-button--bottom {
         width: 70px;
@@ -165,7 +173,6 @@
     .contributions__contribute--bottom {
         margin-left: $gs-gutter / 2;
         margin-top: 0;
-        width: 130px;
     }
 
     .contributions__amount-field--bottom {


### PR DESCRIPTION
## What does this change?

Fixed sizing on desktop after I accidently broke it when fixing mobile in this [PR](https://github.com/guardian/frontend/pull/14358)
## What is the value of this and can you measure success?

See previous PR.
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
