### PR TITLE
Remove immersiveMainMediaEmbedSwitch

### DIFF
--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -1,11 +1,9 @@
 @(article: model.Article)(implicit request: RequestHeader)
 
 @import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches.immersiveMainEmbedSwitch
 
 <header class="content__head tonal__head tonal__head--@toneClass(article) @if(article.isUSMinute) { content__head--minute-article }">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@
     <h1 class="is-hidden" itemprop="headline">@Html(article.trail.headline)</h1>
-
 </header>

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -28,7 +28,6 @@ object MainCleaner {
       withJsoup(BulletCleaner(html))(
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
-        ImmersiveMainEmbed(article.isImmersive),
         MainFigCaptionCleaner
       )
   }

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -28,7 +28,7 @@ object MainCleaner {
       withJsoup(BulletCleaner(html))(
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
-        ImmersiveMainEmbed(article.isImmersive, article.isSixtyDaysModified),
+        ImmersiveMainEmbed(article.isImmersive),
         MainFigCaptionCleaner
       )
   }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -4,16 +4,6 @@ import conf.switches.Expiry.never
 import org.joda.time.LocalDate
 
 trait FeatureSwitches {
-  val immersiveMainEmbedSwitch = Switch(
-    SwitchGroup.Feature,
-    "immersive-main-media",
-    "If this switch is on, main media embeds won't be iframed",
-    owners = Seq(Owner.withGithub("sammorrisdesign")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 22),
-    exposeClientSide = false
-  )
-
   // see https://github.com/guardian/frontend/pull/13446
   val HeroicTemplateSwitch = Switch(
     SwitchGroup.Feature,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -514,7 +514,6 @@ final case class Article (
   val isUSMinute: Boolean = content.tags.isUSMinuteSeries
   val isImmersive: Boolean = content.isImmersive
   val isHeroic: Boolean = content.isHeroic
-  val isSixtyDaysModified: Boolean = fields.lastModified.isAfter(DateTime.now().minusDays(60))
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -450,13 +450,11 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
 
 case class ImmersiveMainEmbed(isImmersive: Boolean, isSixtyDaysModified: Boolean) extends HtmlCleaner {
   override def clean(document: Document): Document = {
-      if(immersiveMainEmbedSwitch.isSwitchedOn && isSixtyDaysModified && isImmersive) {
-        val srcdoc = document.getElementsByTag("iframe").attr("srcdoc")
-        if(srcdoc != null) {
-            document.getElementsByTag("body").html(srcdoc)
-        }
-      }
-      document
+    val srcdoc = document.getElementsByTag("iframe").attr("srcdoc")
+    if(srcdoc != null) {
+        document.getElementsByTag("body").html(srcdoc)
+    }
+    document
   }
 }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -448,18 +448,6 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
   }
 }
 
-case class ImmersiveMainEmbed(isImmersive: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
-    if(isImmersive) {
-      val srcdoc = document.getElementsByTag("iframe").attr("srcdoc")
-      if(srcdoc != null) {
-          document.getElementsByTag("body").html(srcdoc)
-      }
-    }
-    document
-  }
-}
-
 case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
   override def clean(document: Document): Document = {
     if(isImmersive) {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -448,11 +448,13 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
   }
 }
 
-case class ImmersiveMainEmbed(isImmersive: Boolean, isSixtyDaysModified: Boolean) extends HtmlCleaner {
+case class ImmersiveMainEmbed(isImmersive: Boolean) extends HtmlCleaner {
   override def clean(document: Document): Document = {
-    val srcdoc = document.getElementsByTag("iframe").attr("srcdoc")
-    if(srcdoc != null) {
-        document.getElementsByTag("body").html(srcdoc)
+    if(isImmersive) {
+      val srcdoc = document.getElementsByTag("iframe").attr("srcdoc")
+      if(srcdoc != null) {
+          document.getElementsByTag("body").html(srcdoc)
+      }
     }
     document
   }


### PR DESCRIPTION
## What does this change?

This removes the `immersiveMainMediaEmbedSwitch` that is due to expire in a week or so.
## Does this affect other platforms - Amp, Apps, etc?

Nah

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
