### PR TITLE
New size for pageskins: 2x2

### DIFF
--- a/common/app/views/fragments/commercial/pageSkin.scala.html
+++ b/common/app/views/fragments/commercial/pageSkin.scala.html
@@ -1,7 +1,7 @@
 @fragments.commercial.standardAd(
     "pageskin-inread",
     Seq("page-skin"),
-    Map("wide" -> Seq("1,1")),
+    Map("wide" -> Seq("1,1", "2,2")),
     showLabel=false,
     refresh=false,
     outOfPage=true

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -72,7 +72,8 @@ define([
      * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
      * and their containers closed up.
      */
-    sizeCallbacks[adSizes.outOfPage] = function (event, advert) {
+    sizeCallbacks[adSizes.outOfPage] =
+    sizeCallbacks[adSizes.empty] = function (event, advert) {
         if (!event.slot.getOutOfPage()) {
             var $parent = bonzo(advert.node.parentNode);
             return fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
@@ -18,7 +18,8 @@ define(function () {
         inlineMerchandising:    AdSize(88, 85),
         fabric:                 AdSize(88, 71),
         fluid250:               AdSize(88, 70),
-        outOfPage:              AdSize(1, 1)
+        outOfPage:              AdSize(2, 2),
+        empty:                  AdSize(1, 1)
     };
     adSizes['970x250'] = adSizes.billboard;
     adSizes['728x90'] = adSizes.leaderboard;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
@@ -11,19 +11,19 @@ define([
         label: false,
         refresh: false,
         sizeMappings: {
-            mobile: compile(adSizes.outOfPage, adSizes.badge)
+            mobile: compile(adSizes.empty, adSizes.badge)
         }
     };
 
     var inlineDefinition = {
         sizeMappings: {
-            mobile: compile(adSizes.outOfPage, adSizes.mpu, adSizes.fluid)
+            mobile: compile(adSizes.empty, adSizes.mpu, adSizes.fluid)
         }
     };
 
     var rightMappings = {
         mobile: compile(
-            adSizes.outOfPage,
+            adSizes.empty,
             adSizes.mpu,
             adSizes.halfPage,
             config.page.edition === 'US' ? adSizes.portrait : null,
@@ -42,14 +42,14 @@ define([
         'right-small': {
             name: 'right',
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.mpu, adSizes.fluid)
+                mobile: compile(adSizes.empty, adSizes.mpu, adSizes.fluid)
             }
         },
         im: {
             label: false,
             refresh: false,
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.inlineMerchandising)
+                mobile: compile(adSizes.empty, adSizes.inlineMerchandising)
             }
         },
         inline: inlineDefinition,
@@ -58,7 +58,7 @@ define([
             label: false,
             refresh: false,
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.merchandisingHigh, adSizes.fluid)
+                mobile: compile(adSizes.empty, adSizes.merchandisingHigh, adSizes.fluid)
             }
         },
         'merchandising-high-ad-feature': {
@@ -66,7 +66,7 @@ define([
             label: false,
             refresh: false,
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.merchandisingHighAdFeature, adSizes.fluid)
+                mobile: compile(adSizes.empty, adSizes.merchandisingHighAdFeature, adSizes.fluid)
             }
         },
         spbadge: badgeDefinition,
@@ -76,7 +76,7 @@ define([
         'top-above-nav': {
             sizeMappings: {
                 mobile: compile(
-                    adSizes.outOfPage,
+                    adSizes.empty,
                     adSizes.mpu,
                     adSizes.fluid250,
                     adSizes.fabric,
@@ -117,7 +117,7 @@ define([
         name = definition.name || name;
 
         if (config.page.hasPageSkin && slotName === 'merchandising-high') {
-            definition.sizeMappings.wide = adSizes.outOfPage;
+            definition.sizeMappings.wide = adSizes.empty;
         }
 
         assign(attributes, definition.sizeMappings);


### PR DESCRIPTION
So, 1x1 is used for two things:
- deliver page skins
- close unwanted slots on roadblocks

That's a problem because this is what happens when a roadblock with a pageskin is targeted to a whole section:

![picture 2](https://cloud.githubusercontent.com/assets/629976/18638721/1ac25f2e-7e89-11e6-9a0a-bd7ced3a1295.jpg)

Note: pageskins should only appear on fronts

To solve this issue, we're introducing a new size. This is a transitory phase where both sizes will still be used; this gives AdOps time to test and move line items.
