### PR TITLE
Adding duration to the video button - AB test

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -22,6 +22,7 @@
     @defining( page.item ) { video =>
 
         <figure class="gu-video-embed" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
+          <div>hello world</div>
             <meta itemprop="name" content="@Html(video.trail.headline)"/>
             <meta itemprop="headline" content="@Html(video.trail.headline)"/>
             <meta itemprop="url" content="@video.metadata.url"/>

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -22,7 +22,6 @@
     @defining( page.item ) { video =>
 
         <figure class="gu-video-embed" itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
-          <div>hello world</div>
             <meta itemprop="name" content="@Html(video.trail.headline)"/>
             <meta itemprop="headline" content="@Html(video.trail.headline)"/>
             <meta itemprop="url" content="@video.metadata.url"/>

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 10, 3),
     exposeClientSide = true
   )
+  
+  Switch(
+    ABTests,
+    "ab-video-button-duration",
+    "Show visitors new video play button",
+    owners = Seq(Owner.withGithub("mr-mr")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 30),
+    exposeClientSide = true
+  )
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -65,7 +65,7 @@ data-test-id="facia-card"
                     </div>
                 @fallback.map { fallbackImage =>
                     <div class="fc-item__video fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                        <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                        <div data-duration="@player.video.videos.formattedDuration" data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
                         @itemImage(
                             fallbackImage.imageMedia,
                             inlineImage = containerIndex == 0 && index < 4,

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -65,7 +65,7 @@ data-test-id="facia-card"
                     </div>
                 @fallback.map { fallbackImage =>
                     <div class="fc-item__video fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                        <div data-duration="@player.video.videos.formattedDuration" data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                        <div data-formatted-duration="@player.video.videos.formattedDuration" data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
                         @itemImage(
                             fallbackImage.imageMedia,
                             inlineImage = containerIndex == 0 && index < 4,

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -41,7 +41,8 @@
                 data-auto-play="@player.autoPlay"
                 data-show-end-slate="@(player.showEndSlate && showEndSlate)"
                 @if(showPoster) { poster="@player.poster" }
-                data-duration="@player.video.videos.duration.toString()"
+                data-duration="@player.video.videos.formattedDuration.toString()"
+                data-formatted-duration="@player.video.videos.formattedDuration.toString()"
                 data-media-id="@player.video.properties.id"
                 data-end-slate="@player.endSlatePath"
                 data-block-video-ads="@player.blockVideoAds"

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -42,7 +42,6 @@
                 data-show-end-slate="@(player.showEndSlate && showEndSlate)"
                 @if(showPoster) { poster="@player.poster" }
                 data-duration="@player.video.videos.formattedDuration.toString()"
-                data-formatted-duration="@player.video.videos.formattedDuration.toString()"
                 data-media-id="@player.video.properties.id"
                 data-end-slate="@player.endSlatePath"
                 data-block-video-ads="@player.blockVideoAds"

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -41,7 +41,8 @@
                 data-auto-play="@player.autoPlay"
                 data-show-end-slate="@(player.showEndSlate && showEndSlate)"
                 @if(showPoster) { poster="@player.poster" }
-                data-duration="@player.video.videos.formattedDuration.toString()"
+                data-duration="@player.video.videos.duration.toString()"
+                data-formatted-duration="@player.video.videos.formattedDuration.toString()"
                 data-media-id="@player.video.properties.id"
                 data-end-slate="@player.endSlatePath"
                 data-block-video-ads="@player.blockVideoAds"

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -74,6 +74,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         findVideoApiElement(mediaId).foreach { videoElement =>
           element.attr("data-block-video-ads", videoElement.videos.blockVideoAds.toString)
+          element.attr("data-duration", videoElement.videos.formattedDuration.toString)
           if (!canonicalUrl.isEmpty && videoElement.videos.embeddable) {
             element.attr("data-embeddable", "true")
             element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -74,7 +74,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         findVideoApiElement(mediaId).foreach { videoElement =>
           element.attr("data-block-video-ads", videoElement.videos.blockVideoAds.toString)
-          element.attr("data-duration", videoElement.videos.formattedDuration.toString)
+          element.attr("data-formatted-duration", videoElement.videos.formattedDuration.toString)
           if (!canonicalUrl.isEmpty && videoElement.videos.embeddable) {
             element.attr("data-embeddable", "true")
             element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -108,7 +108,7 @@ define([
             if (!isNaN(duration)) {
                 player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
-                // player.controlBar.addChild('button', { text: 'hello' });
+                // Sets the duration for the Video JS button element
                 $('.vjs-big-play-button')[0].setAttribute('data-duration', $(el).attr('data-duration'));
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -98,6 +98,8 @@ define([
     function createVideoPlayer(el, options) {
         var player = videojs(el, options);
         var duration = parseInt(el.getAttribute('data-duration'), 10);
+        // $el.querySelector('.vjs-big-play-button').setAttribute('data-duration', duration);
+
 
         player.ready(function () {
             if (!isNaN(duration)) {
@@ -120,6 +122,7 @@ define([
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el) {
                 var $el = bonzo(el);
+                debugger;
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
                     container = bonzo(el).parent().parent();

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -27,9 +27,7 @@ define([
     // This must be the full path because we use curl config to change it based
     // on env
     'bootstraps/enhanced/media/video-player',
-    'text!common/views/ui/loading.html',
-    'text!common/views/media/big-play-button.html',
-    'common/utils/template'
+    'text!common/views/ui/loading.html'
 ], function (
     bean,
     bonzo,
@@ -57,9 +55,7 @@ define([
     moreInSeriesContainer,
     videojsOptions,
     videojs,
-    loadingTmpl,
-    buttonTmpl,
-    template
+    loadingTmpl
 ) {
     function getAdUrl() {
         var queryParams = {
@@ -106,7 +102,7 @@ define([
 
         player.ready(function () {
             if (!isNaN(duration)) {
-                player.duration(duration);
+                player.duration();
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
@@ -124,7 +120,7 @@ define([
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el, options, duration) {
                 function initButtonDuration() {
-                  el.getAttribute('data-duration', duration);
+                  el.getAttribute('data-duration');
                   el.classList.remove('vjs-big-play-button');
                   el.classList.add('vjs-big-play-button__duration');
                 }
@@ -163,7 +159,6 @@ define([
                   buttonElement.classList.add('vjs-big-play-button__duration');
                   var buttonDuration = el.getAttribute('data-duration');
                   buttonElement.dataset.duration = buttonDuration;
-                  console.log(buttonElement);
                 }
                 if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
                   initButtonDuration();
@@ -213,7 +208,7 @@ define([
         }
     }
 
-    function enhanceVideo(el, autoplay, shouldPreroll, duration) {
+    function enhanceVideo(el, autoplay, shouldPreroll) {
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs'),
             mediaId = $el.attr('data-media-id'),

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -142,8 +142,8 @@ define([
         });
     }
 
-    function initButtonDuration(el, duration) {
-      el.getAttribute('data-duration', duration);
+    function initButtonDuration(el) {
+      el.getAttribute('data-formatted-duration');
       el.classList.remove('vjs-big-play-button');
       el.classList.add('vjs-big-play-button__duration');
     }
@@ -166,8 +166,8 @@ define([
       var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
       buttonElement.classList.remove('vjs-big-play-button');
       buttonElement.classList.add('vjs-big-play-button__duration');
-      var buttonDuration = el.getAttribute('data-duration');
-      buttonElement.dataset.duration = buttonDuration;
+      var buttonDuration = el.getAttribute('data-formatted-duration');
+      buttonElement.dataset.formattedDuration = buttonDuration;
     }
 
     function initHeroic(){
@@ -328,7 +328,7 @@ define([
                                     var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
                                     buttonElement.classList.remove('vjs-big-play-button');
                                     buttonElement.classList.add('vjs-big-play-button__duration');
-                                    var buttonDuration = el.getAttribute('data-duration');
+                                    var buttonDuration = el.getAttribute('data-formatted-duration');
                                     buttonElement.dataset.duration = buttonDuration;
                                   }
                                   if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -27,7 +27,9 @@ define([
     // This must be the full path because we use curl config to change it based
     // on env
     'bootstraps/enhanced/media/video-player',
-    'text!common/views/ui/loading.html'
+    'text!common/views/ui/loading.html',
+    'text!common/views/media/big-play-button.html'
+    'common/utils/template'
 ], function (
     bean,
     bonzo,
@@ -55,7 +57,9 @@ define([
     moreInSeriesContainer,
     videojsOptions,
     videojs,
-    loadingTmpl
+    loadingTmpl,
+    buttonTmpl,
+    template
 ) {
     function getAdUrl() {
         var queryParams = {
@@ -104,7 +108,7 @@ define([
                 player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
             }
-
+            $('.vjs-big-play-button', player.el()).after(template(buttonTmpl, {'duration': 112}));
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
             player.guAutoplay = $(el).attr('data-auto-play') === 'true';
 
@@ -122,6 +126,8 @@ define([
                 el.getAttribute('data-duration', duration);
                 console.log(duration);
                 var $el = bonzo(el);
+                // debugger;
+                // $el.after(template(buttonTmpl, {'duration': duration}));
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
                     container = bonzo(el).parent().parent();

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -123,7 +123,11 @@ define([
     function initPlayButtons(root, duration) {
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el, options, duration) {
-                el.getAttribute('data-duration', duration);
+                function initButtonDuration() {
+                  el.getAttribute('data-duration', duration);
+                  el.classList.remove('vjs-big-play-button');
+                  el.classList.add('vjs-big-play-button__duration');
+                }
                 var $el = bonzo(el);
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
@@ -151,11 +155,17 @@ define([
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
                 enhanceVideo(el, false, withPreroll);
-                var buttonDuration = el.getAttribute('data-duration');
-                var buttonButton = el.parentElement.querySelector('button.vjs-big-play-button');
-                buttonButton.dataset.duration = buttonDuration;
-                console.log(buttonDuration);
-                console.log(buttonButton);
+                function initButtonDuration() {
+                  var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
+                  buttonElement.classList.add('vjs-big-play-button__duration');
+                  var buttonDuration = el.getAttribute('data-duration');
+                  buttonElement.dataset.duration = buttonDuration;
+                  console.log(buttonElement);
+                }
+                debugger;
+                if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
+                  initButtonDuration();
+                }
             });
         });
     }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -28,7 +28,7 @@ define([
     // on env
     'bootstraps/enhanced/media/video-player',
     'text!common/views/ui/loading.html',
-    'text!common/views/media/big-play-button.html'
+    'text!common/views/media/big-play-button.html',
     'common/utils/template'
 ], function (
     bean,
@@ -86,6 +86,7 @@ define([
     function upgradeVideoPlayerAccessibility(player) {
         // Set the video tech element to aria-hidden, and label the buttons in the videojs control bar.
         $('.vjs-tech', player.el()).attr('aria-hidden', true);
+        $('.vjs-control-text').innerHTML = 'hello';
 
         // Hide superfluous controls, and label useful buttons.
         $('.vjs-big-play-button', player.el()).attr('aria-hidden', true);
@@ -107,8 +108,9 @@ define([
             if (!isNaN(duration)) {
                 player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
+                // player.controlBar.addChild('button', { text: 'hello' });
+                $('.vjs-big-play-button')[0].setAttribute('data-duration', $(el).attr('data-duration'));
             }
-            $('.vjs-big-play-button', player.el()).after(template(buttonTmpl, {'duration': 112}));
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
             player.guAutoplay = $(el).attr('data-auto-play') === 'true';
 
@@ -124,10 +126,7 @@ define([
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el, options, duration) {
                 el.getAttribute('data-duration', duration);
-                console.log(duration);
                 var $el = bonzo(el);
-                // debugger;
-                // $el.after(template(buttonTmpl, {'duration': duration}));
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
                     container = bonzo(el).parent().parent();

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -95,14 +95,14 @@ define([
         $('.vjs-fullscreen-control', player.el()).attr('aria-label', 'video fullscreen');
     }
 
-    function createVideoPlayer(el, options, duration) {
+    function createVideoPlayer(el, options) {
         var player = videojs(el, options);
         // Commenting out line below but reluctant to delete it
         // var duration = parseInt(el.getAttribute('data-duration'), 10);
 
         player.ready(function () {
-            if (!isNaN(duration)) {
-                player.duration(duration);
+            if (!isNaN()) {
+                player.duration();
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
@@ -118,14 +118,9 @@ define([
 
     function initPlayButtons(root) {
         fastdom.read(function () {
-            $('.js-video-play-button', root).each(function (el, options, duration) {
-                function initButtonDuration() {
-                  el.getAttribute('data-duration', duration);
-                  el.classList.remove('vjs-big-play-button');
-                  el.classList.add('vjs-big-play-button__duration');
-                }
+            $('.js-video-play-button', root).each(function (el) {
                 if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
-                  initButtonDuration();
+                  initButtonDuration(el);
                 }
                 var $el = bonzo(el);
                 bean.on(el, 'click', function () {
@@ -147,6 +142,12 @@ define([
         });
     }
 
+    function initButtonDuration(el, duration) {
+      el.getAttribute('data-duration', duration);
+      el.classList.remove('vjs-big-play-button');
+      el.classList.add('vjs-big-play-button__duration');
+    }
+
     function initPlayer(withPreroll) {
         videojs.plugin('skipAd', skipAd);
         videojs.plugin('fullscreener', fullscreener);
@@ -154,18 +155,19 @@ define([
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
                 enhanceVideo(el, false, withPreroll);
-                function initArticleButtonDuration() {
-                  var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
-                  buttonElement.classList.remove('vjs-big-play-button');
-                  buttonElement.classList.add('vjs-big-play-button__duration');
-                  var buttonDuration = el.getAttribute('data-duration');
-                  buttonElement.dataset.duration = buttonDuration;
-                }
                 if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
-                  initArticleButtonDuration();
+                  initArticleButtonDuration(el);
                 }
             });
         });
+    }
+
+    function initArticleButtonDuration(el) {
+      var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
+      buttonElement.classList.remove('vjs-big-play-button');
+      buttonElement.classList.add('vjs-big-play-button__duration');
+      var buttonDuration = el.getAttribute('data-duration');
+      buttonElement.dataset.duration = buttonDuration;
     }
 
     function initHeroic(){

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -119,7 +119,8 @@ define([
     function initPlayButtons(root, duration) {
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el, options, duration) {
-                el.setAttribute('data-duration', duration);
+                el.getAttribute('data-duration', duration);
+                console.log(duration);
                 var $el = bonzo(el);
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -95,11 +95,9 @@ define([
         $('.vjs-fullscreen-control', player.el()).attr('aria-label', 'video fullscreen');
     }
 
-    function createVideoPlayer(el, options) {
+    function createVideoPlayer(el, options, duration) {
         var player = videojs(el, options);
         var duration = parseInt(el.getAttribute('data-duration'), 10);
-        // $el.querySelector('.vjs-big-play-button').setAttribute('data-duration', duration);
-
 
         player.ready(function () {
             if (!isNaN(duration)) {
@@ -118,11 +116,11 @@ define([
         return player;
     }
 
-    function initPlayButtons(root) {
+    function initPlayButtons(root, duration) {
         fastdom.read(function () {
-            $('.js-video-play-button', root).each(function (el) {
+            $('.js-video-play-button', root).each(function (el, options, duration) {
+                el.setAttribute('data-duration', duration);
                 var $el = bonzo(el);
-                debugger;
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
                     container = bonzo(el).parent().parent();

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -98,11 +98,11 @@ define([
     function createVideoPlayer(el, options) {
         var player = videojs(el, options);
         // Commenting out line below but reluctant to delete it
-        // var duration = parseInt(el.getAttribute('data-duration'), 10);
+        var duration = parseInt(el.getAttribute('data-duration'), 10);
 
         player.ready(function () {
-            if (!isNaN()) {
-                player.duration();
+            if (!isNaN(duration)) {
+                player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -108,8 +108,6 @@ define([
             if (!isNaN(duration)) {
                 player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
-                // Sets the duration for the Video JS button element
-                $('.vjs-big-play-button')[0].setAttribute('data-duration', $(el).attr('data-duration'));
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
             player.guAutoplay = $(el).attr('data-auto-play') === 'true';
@@ -153,6 +151,11 @@ define([
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
                 enhanceVideo(el, false, withPreroll);
+                var buttonDuration = el.getAttribute('data-duration');
+                var buttonButton = el.parentElement.querySelector('button.vjs-big-play-button');
+                buttonButton.dataset.duration = buttonDuration;
+                console.log(buttonDuration);
+                console.log(buttonButton);
             });
         });
     }
@@ -198,7 +201,7 @@ define([
         }
     }
 
-    function enhanceVideo(el, autoplay, shouldPreroll) {
+    function enhanceVideo(el, autoplay, shouldPreroll, duration) {
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs'),
             mediaId = $el.attr('data-media-id'),

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -98,11 +98,12 @@ define([
 
     function createVideoPlayer(el, options, duration) {
         var player = videojs(el, options);
-        var duration = parseInt(el.getAttribute('data-duration'), 10);
+        // Commenting out line below but reluctant to delete it
+        // var duration = parseInt(el.getAttribute('data-duration'), 10);
 
         player.ready(function () {
             if (!isNaN(duration)) {
-                player.duration();
+                player.duration(duration);
                 player.trigger('timeupdate'); // triggers a refresh of relevant control bar components
             }
             // we have some special autoplay rules, so do not want to depend on 'default' autoplay
@@ -116,11 +117,11 @@ define([
         return player;
     }
 
-    function initPlayButtons(root, duration) {
+    function initPlayButtons(root) {
         fastdom.read(function () {
             $('.js-video-play-button', root).each(function (el, options, duration) {
                 function initButtonDuration() {
-                  el.getAttribute('data-duration');
+                  el.getAttribute('data-duration', duration);
                   el.classList.remove('vjs-big-play-button');
                   el.classList.add('vjs-big-play-button__duration');
                 }
@@ -154,14 +155,15 @@ define([
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
                 enhanceVideo(el, false, withPreroll);
-                function initButtonDuration() {
+                function initArticleButtonDuration() {
                   var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
+                  buttonElement.classList.remove('vjs-big-play-button');
                   buttonElement.classList.add('vjs-big-play-button__duration');
                   var buttonDuration = el.getAttribute('data-duration');
                   buttonElement.dataset.duration = buttonDuration;
                 }
                 if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
-                  initButtonDuration();
+                  initArticleButtonDuration();
                 }
             });
         });
@@ -319,6 +321,20 @@ define([
                                 player.one('playing', function() {
                                     beacon.counts('video-tech-html5');
                                 });
+
+                                player.on('pause', function() {
+                                  function initPauseButtonDuration() {
+                                    var buttonElement = el.parentElement.querySelector('button.vjs-big-play-button');
+                                    buttonElement.classList.remove('vjs-big-play-button');
+                                    buttonElement.classList.add('vjs-big-play-button__duration');
+                                    var buttonDuration = el.getAttribute('data-duration');
+                                    buttonElement.dataset.duration = buttonDuration;
+                                  }
+                                  if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
+                                    initPauseButtonDuration();
+                                  }
+                                });
+
 
                                 // unglitching the volume on first load
                                 vol = player.volume();

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -82,7 +82,6 @@ define([
     function upgradeVideoPlayerAccessibility(player) {
         // Set the video tech element to aria-hidden, and label the buttons in the videojs control bar.
         $('.vjs-tech', player.el()).attr('aria-hidden', true);
-        $('.vjs-control-text').innerHTML = 'hello';
 
         // Hide superfluous controls, and label useful buttons.
         $('.vjs-big-play-button', player.el()).attr('aria-hidden', true);

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -128,6 +128,9 @@ define([
                   el.classList.remove('vjs-big-play-button');
                   el.classList.add('vjs-big-play-button__duration');
                 }
+                if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
+                  initButtonDuration();
+                }
                 var $el = bonzo(el);
                 bean.on(el, 'click', function () {
                     var placeholder, player, container;
@@ -162,7 +165,6 @@ define([
                   buttonElement.dataset.duration = buttonDuration;
                   console.log(buttonElement);
                 }
-                debugger;
                 if(ab.isInVariant('VideoButtonDuration', 'video-button-duration')) {
                   initButtonDuration();
                 }

--- a/static/src/javascripts/components/video.js/video.js
+++ b/static/src/javascripts/components/video.js/video.js
@@ -2526,7 +2526,7 @@ function forEach(list, iterator, context) {
     if (arguments.length < 3) {
         context = this
     }
-    
+
     if (toString.call(list) === '[object Array]')
         forEachArray(list, iterator, context)
     else if (typeof list === 'string')
@@ -18477,7 +18477,7 @@ var _guid = 1;
 /**
  * Get the next unique ID
  *
- * @return {String} 
+ * @return {String}
  * @function newGUID
  */
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -15,18 +15,8 @@ define([
     'common/modules/experiments/tests/contributions-epic',
     'common/modules/experiments/tests/adblocking-response',
     'common/modules/experiments/tests/weekend-reading-email',
-<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
-    'common/modules/experiments/tests/weekend-reading-promo'
-=======
     'common/modules/experiments/tests/weekend-reading-promo',
-<<<<<<< 253726bcbdd152a7a7d12ea1ff1b93e4fc907c50
-    'common/modules/experiments/tests/contributions-epic-buttons'
-=======
-    'common/modules/experiments/tests/no-social-count',
-    'common/modules/experiments/tests/contributions-epic-buttons',
     'common/modules/experiments/tests/video-button-duration'
->>>>>>> AB test structure added with bug to fix
->>>>>>> AB test structure added with bug to fix
 ], function (
     reportError,
     config,
@@ -44,18 +34,8 @@ define([
     ContributionsEpic,
     AdBlockingResponse,
     WeekendReadingEmail,
-<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
-    WeekendReadingPromo
-=======
     WeekendReadingPromo,
-<<<<<<< 253726bcbdd152a7a7d12ea1ff1b93e4fc907c50
-    ContributionsEpicButtons
-=======
-    NoSocialCount,
-    ContributionsEpicButtons,
     VideoButtonDuration
->>>>>>> AB test structure added with bug to fix
->>>>>>> AB test structure added with bug to fix
 ) {
 
     var TESTS = [
@@ -66,13 +46,8 @@ define([
         new HostedGalleryCallToAction(),
         new ContributionsEpic(),
         new WeekendReadingEmail(),
-<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
-        new WeekendReadingPromo()
-=======
         new WeekendReadingPromo(),
-        new NoSocialCount(),
         new VideoButtonDuration()
->>>>>>> AB test structure added with bug to fix
     ].concat(MembershipEngagementBannerTests);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -15,7 +15,18 @@ define([
     'common/modules/experiments/tests/contributions-epic',
     'common/modules/experiments/tests/adblocking-response',
     'common/modules/experiments/tests/weekend-reading-email',
+<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
     'common/modules/experiments/tests/weekend-reading-promo'
+=======
+    'common/modules/experiments/tests/weekend-reading-promo',
+<<<<<<< 253726bcbdd152a7a7d12ea1ff1b93e4fc907c50
+    'common/modules/experiments/tests/contributions-epic-buttons'
+=======
+    'common/modules/experiments/tests/no-social-count',
+    'common/modules/experiments/tests/contributions-epic-buttons',
+    'common/modules/experiments/tests/video-button-duration'
+>>>>>>> AB test structure added with bug to fix
+>>>>>>> AB test structure added with bug to fix
 ], function (
     reportError,
     config,
@@ -33,7 +44,18 @@ define([
     ContributionsEpic,
     AdBlockingResponse,
     WeekendReadingEmail,
+<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
     WeekendReadingPromo
+=======
+    WeekendReadingPromo,
+<<<<<<< 253726bcbdd152a7a7d12ea1ff1b93e4fc907c50
+    ContributionsEpicButtons
+=======
+    NoSocialCount,
+    ContributionsEpicButtons,
+    VideoButtonDuration
+>>>>>>> AB test structure added with bug to fix
+>>>>>>> AB test structure added with bug to fix
 ) {
 
     var TESTS = [
@@ -44,7 +66,13 @@ define([
         new HostedGalleryCallToAction(),
         new ContributionsEpic(),
         new WeekendReadingEmail(),
+<<<<<<< 75681b40cc78d673647a2bfedec39297a512f63a
         new WeekendReadingPromo()
+=======
+        new WeekendReadingPromo(),
+        new NoSocialCount(),
+        new VideoButtonDuration()
+>>>>>>> AB test structure added with bug to fix
     ].concat(MembershipEngagementBannerTests);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
@@ -1,9 +1,7 @@
 define([
-    'common/utils/config',
-    'bean'
+    'common/utils/config'
 ], function (
-    config,
-    bean
+    config
 ) {
     return function () {
         this.id = 'VideoButtonDuration';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
@@ -7,12 +7,13 @@ define([
 ) {
     return function () {
         this.id = 'VideoButtonDuration';
-        this.start = '2016-09-13';
-        this.expiry = '2016-09-30';
+        this.start = '2016-09-19';
+        this.expiry = '2016-10-07';
         this.author = 'Chris J Clarke';
         this.description = 'Test whether adding duration to the play button increases plays';
-        this.audience = 0.5;
-        this.audienceOffset = 0.5;
+        this.showForSensitive = true;
+        this.audience = 0.20;
+        this.audienceOffset = 0.15;
         this.successMeasure = 'No significant difference in clicks between the variant and control';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
@@ -1,0 +1,37 @@
+define([
+    'common/utils/config',
+    'bean'
+], function (
+    config,
+    bean
+) {
+    return function () {
+        this.id = 'VideoButtonDuration';
+        this.start = '2016-09-13';
+        this.expiry = '2016-09-30';
+        this.author = 'Chris J Clarke';
+        this.description = 'Test whether adding duration to the play button increases plays';
+        this.audience = 0.5;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'No significant difference in clicks between the variant and control';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Video plays in the control group is not more than 2% higher';
+
+        this.canRun = function () {
+          return document.getElementsByClassName('gu-media-wrapper--video').length > 0;
+        };
+
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'video-button-duration',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-button-duration.js
@@ -1,8 +1,6 @@
 define([
     'common/utils/config'
-], function (
-    config
-) {
+], function () {
     return function () {
         this.id = 'VideoButtonDuration';
         this.start = '2016-09-19';

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -155,9 +155,8 @@ $ima-controls-height: 70px;
 .vjs-big-play-button__duration {
   cursor: pointer;
   display: inline-block;
-  width: auto;
   z-index: 2;
-  padding: 0 10px 0;
+  padding: 0 10px;
   position: absolute;
   bottom: 8px;
   left: 5px;
@@ -167,7 +166,7 @@ $ima-controls-height: 70px;
   height: 44px;
   color: #161616;
   border-radius: 46px;
-  border: none;
+  border: 0;
   background-color: $media-default;
   backface-visibility: hidden;
 
@@ -176,8 +175,8 @@ $ima-controls-height: 70px;
   }
 
   &:before {
-    content: attr(data-duration);
     @include fs-textSans(4);
+    content: attr(data-duration);
     font-weight: 400;
     font-size: 15px;
     line-height: 20px;
@@ -185,14 +184,14 @@ $ima-controls-height: 70px;
     padding-right: 7px;
     padding-left: 8px;
     margin-left: 4px;
-    border-left: 1px solid rgba(51,51,51,0.6);
+    border-left: 1px solid rgba(51, 51, 51, 0.6);
     display: inline-block;
   }
   &:after {
     content: '';
     border: 1px solid;
     border-width: 8px 8px 8px 18px;
-    border-color: transparent transparent transparent #333;
+    border-color: transparent transparent transparent #333333;
     position: absolute;
     top: 50%;
     left: 14px;

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -79,80 +79,80 @@ $ima-controls-height: 70px;
     }
 }
 
-// .vjs-big-play-button {
-//     cursor: pointer;
-//     position: absolute;
-//     z-index: 1;
-//     top: 0;
-//     left: 0;
-//     width: 100%;
-//     height: 100%;
-//     box-sizing: border-box;
-//     text-align: center;
-//     border: 0;
-//     padding: 0;
-//     background-color: transparent;
-//
-//     .vjs-has-started & {
-//         padding-bottom: $vjs-control-height;
-//     }
-//
-//     &:hover .vjs-control-text {
-//         transform: translate(-50%, -50%) scale(1.15);
-//     }
-//
-//     .vjs-control-text {
-//         // Magic numbers are used here to draw the play arrow and circle as pseudo elements.
-//         @include video-play-button-size($vjs-small-button-size);
-//         position: absolute;
-//         top: 50%;
-//         left: 50%;
-//         transform: translate(-50%, -50%);
-//         transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
-//         user-select: none;
-//
-//         @include mq(mobileLandscape) {
-//             @include video-play-button-size($vjs-large-button-size);
-//         }
-//
-//         &:before {
-//             @include circular;
-//             @include video-play-button-size($vjs-small-button-size);
-//             content: '';
-//             display: block;
-//             @include mq(mobileLandscape) {
-//                 @include video-play-button-size($vjs-large-button-size);
-//             }
-//             background-color: $media-default;
-//         }
-//
-//         &:after {
-//             content: '';
-//             position: absolute;
-//             top: 50%;
-//             left: 50%;
-//             transform: translate(-40%, -50%);
-//             border-style: solid;
-//             border-width: 1em 0 1em 2.4em;
-//             border-color: transparent transparent transparent $neutral-1;
-//
-//             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
-//                 border-radius: .2em;
-//             }
-//         }
-//     }
-//
-//     .gu-media--audio &,
-//     .vjs-has-ended &,
-//     .vjs-ad-playing &,
-//     .vjs-playing &,
-//     .vjs-has-started.vjs-using-native-controls &,
-//     .vjs-ad-loading & {
-//         display: none !important;
-//     }
-// }
-
 .vjs-big-play-button {
+    cursor: pointer;
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    border: 0;
+    padding: 0;
+    background-color: transparent;
+
+    .vjs-has-started & {
+        padding-bottom: $vjs-control-height;
+    }
+
+    &:hover .vjs-control-text {
+        transform: translate(-50%, -50%) scale(1.15);
+    }
+
+    .vjs-control-text {
+        // Magic numbers are used here to draw the play arrow and circle as pseudo elements.
+        @include video-play-button-size($vjs-small-button-size);
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
+        user-select: none;
+
+        @include mq(mobileLandscape) {
+            @include video-play-button-size($vjs-large-button-size);
+        }
+
+        &:before {
+            @include circular;
+            @include video-play-button-size($vjs-small-button-size);
+            content: '';
+            display: block;
+            @include mq(mobileLandscape) {
+                @include video-play-button-size($vjs-large-button-size);
+            }
+            background-color: $media-default;
+        }
+
+        &:after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-40%, -50%);
+            border-style: solid;
+            border-width: 1em 0 1em 2.4em;
+            border-color: transparent transparent transparent $neutral-1;
+
+            @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
+                border-radius: .2em;
+            }
+        }
+    }
+
+    .gu-media--audio &,
+    .vjs-has-ended &,
+    .vjs-ad-playing &,
+    .vjs-playing &,
+    .vjs-has-started.vjs-using-native-controls &,
+    .vjs-ad-loading & {
+        display: none !important;
+    }
+}
+
+.vjs-big-play-button__duration {
   cursor: pointer;
   display: inline-block;
   width: auto;
@@ -196,10 +196,6 @@ $ima-controls-height: 70px;
   .vjs-control-text {
     display: none;
   }
-  // .l-row__item--span-1 {
-  //   top: 40%;
-  //   left: 36%;
-  // }
   .gu-media--audio &,
   .vjs-has-ended &,
   .vjs-ad-playing &,
@@ -210,9 +206,9 @@ $ima-controls-height: 70px;
   }
 }
 
-button.vjs-big-play-button {
-  top: 40%;
-  left: 36%;
+button.vjs-big-play-button__duration {
+  top: 45%;
+  left: 5%;
   &:before {
     margin-top: 0;
   }
@@ -1161,7 +1157,7 @@ button.vjs-big-play-button {
 // we had major refactoring issues.
 .gu-media--show-controls-at-start.vjs-paused {
     .vjs-control-bar {
-        bottom: 0;
+        bottom: -3.95em;
     }
 
     .vjs-big-play-button .vjs-control-text {

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -196,6 +196,10 @@ $ima-controls-height: 70px;
   .vjs-control-text {
     display: none;
   }
+  // .l-row__item--span-1 {
+  //   top: 40%;
+  //   left: 36%;
+  // }
   .gu-media--audio &,
   .vjs-has-ended &,
   .vjs-ad-playing &,
@@ -203,6 +207,14 @@ $ima-controls-height: 70px;
   .vjs-has-started.vjs-using-native-controls &,
   .vjs-ad-loading & {
       display: none !important;
+  }
+}
+
+button.vjs-big-play-button {
+  top: 40%;
+  left: 36%;
+  &:before {
+    margin-top: 0;
   }
 }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -79,77 +79,131 @@ $ima-controls-height: 70px;
     }
 }
 
+// .vjs-big-play-button {
+//     cursor: pointer;
+//     position: absolute;
+//     z-index: 1;
+//     top: 0;
+//     left: 0;
+//     width: 100%;
+//     height: 100%;
+//     box-sizing: border-box;
+//     text-align: center;
+//     border: 0;
+//     padding: 0;
+//     background-color: transparent;
+//
+//     .vjs-has-started & {
+//         padding-bottom: $vjs-control-height;
+//     }
+//
+//     &:hover .vjs-control-text {
+//         transform: translate(-50%, -50%) scale(1.15);
+//     }
+//
+//     .vjs-control-text {
+//         // Magic numbers are used here to draw the play arrow and circle as pseudo elements.
+//         @include video-play-button-size($vjs-small-button-size);
+//         position: absolute;
+//         top: 50%;
+//         left: 50%;
+//         transform: translate(-50%, -50%);
+//         transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
+//         user-select: none;
+//
+//         @include mq(mobileLandscape) {
+//             @include video-play-button-size($vjs-large-button-size);
+//         }
+//
+//         &:before {
+//             @include circular;
+//             @include video-play-button-size($vjs-small-button-size);
+//             content: '';
+//             display: block;
+//             @include mq(mobileLandscape) {
+//                 @include video-play-button-size($vjs-large-button-size);
+//             }
+//             background-color: $media-default;
+//         }
+//
+//         &:after {
+//             content: '';
+//             position: absolute;
+//             top: 50%;
+//             left: 50%;
+//             transform: translate(-40%, -50%);
+//             border-style: solid;
+//             border-width: 1em 0 1em 2.4em;
+//             border-color: transparent transparent transparent $neutral-1;
+//
+//             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
+//                 border-radius: .2em;
+//             }
+//         }
+//     }
+//
+//     .gu-media--audio &,
+//     .vjs-has-ended &,
+//     .vjs-ad-playing &,
+//     .vjs-playing &,
+//     .vjs-has-started.vjs-using-native-controls &,
+//     .vjs-ad-loading & {
+//         display: none !important;
+//     }
+// }
+
 .vjs-big-play-button {
-    cursor: pointer;
+  cursor: pointer;
+  display: inline-block;
+  width: auto;
+  z-index: 2;
+  padding: 0 10px 0;
+  position: absolute;
+  bottom: 8px;
+  left: 5px;
+  line-height: 28px;
+  padding-left: 41px;
+  width: auto;
+  height: 44px;
+  color: #161616;
+  border-radius: 46px;
+  border: none;
+  background-color: $media-default;
+  backface-visibility: hidden;
+  &:before {
+    content: attr(data-duration);
+    @include fs-textSans(4);
+    font-weight: 400;
+    font-size: 15px;
+    line-height: 20px;
+    margin-top: 14px;
+    padding-right: 7px;
+    padding-left: 8px;
+    margin-left: 4px;
+    border-left: 1px solid rgba(51,51,51,0.6);
+    display: inline-block;
+  }
+  &:after {
+    content: '';
+    border: 1px solid;
+    border-width: 8px 8px 8px 18px;
+    border-color: transparent transparent transparent #333;
     position: absolute;
-    z-index: 1;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    text-align: center;
-    border: 0;
-    padding: 0;
-    background-color: transparent;
-
-    .vjs-has-started & {
-        padding-bottom: $vjs-control-height;
-    }
-
-    &:hover .vjs-control-text {
-        transform: translate(-50%, -50%) scale(1.15);
-    }
-
-    .vjs-control-text {
-        // Magic numbers are used here to draw the play arrow and circle as pseudo elements.
-        @include video-play-button-size($vjs-small-button-size);
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
-        user-select: none;
-
-        @include mq(mobileLandscape) {
-            @include video-play-button-size($vjs-large-button-size);
-        }
-
-        &:before {
-            @include circular;
-            @include video-play-button-size($vjs-small-button-size);
-            content: '';
-            display: block;
-            @include mq(mobileLandscape) {
-                @include video-play-button-size($vjs-large-button-size);
-            }
-            background-color: $media-default;
-        }
-
-        &:after {
-            content: '';
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-40%, -50%);
-            border-style: solid;
-            border-width: 1em 0 1em 2.4em;
-            border-color: transparent transparent transparent $neutral-1;
-
-            @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
-                border-radius: .2em;
-            }
-        }
-    }
-
-    .gu-media--audio &,
-    .vjs-has-ended &,
-    .vjs-ad-playing &,
-    .vjs-playing &,
-    .vjs-has-started.vjs-using-native-controls &,
-    .vjs-ad-loading & {
-        display: none !important;
-    }
+    top: 50%;
+    left: 14px;
+    transform: translateY(-50%);
+  }
+  .vjs-control-text {
+    display: none;
+  }
+  .gu-media--audio &,
+  .vjs-has-ended &,
+  .vjs-ad-playing &,
+  .vjs-playing &,
+  .vjs-has-started.vjs-using-native-controls &,
+  .vjs-ad-loading & {
+      display: none !important;
+  }
 }
 
 .vjs-fullscreen-clickbox {

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -170,6 +170,11 @@ $ima-controls-height: 70px;
   border: none;
   background-color: $media-default;
   backface-visibility: hidden;
+
+  .vjs-has-started & {
+      padding-bottom: 0;
+  }
+
   &:before {
     content: attr(data-duration);
     @include fs-textSans(4);

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -153,72 +153,72 @@ $ima-controls-height: 70px;
 }
 
 .vjs-big-play-button__duration {
-  cursor: pointer;
-  display: inline-block;
-  z-index: 2;
-  padding: 0 10px;
-  position: absolute;
-  bottom: 8px;
-  left: 5px;
-  line-height: 28px;
-  padding-left: 41px;
-  width: auto;
-  height: 44px;
-  color: #161616;
-  border-radius: 46px;
-  border: 0;
-  background-color: $media-default;
-  backface-visibility: hidden;
-
-  .vjs-has-started & {
-      padding-bottom: 0;
-  }
-
-  &:before {
-    @include fs-textSans(4);
-    content: attr(data-duration);
-    font-weight: 400;
-    font-size: 15px;
-    line-height: 20px;
-    margin-top: 14px;
-    padding-right: 7px;
-    padding-left: 8px;
-    margin-left: 4px;
-    border-left: 1px solid rgba(51, 51, 51, 0.6);
+    cursor: pointer;
     display: inline-block;
-  }
-  &:after {
-    content: '';
-    border: 1px solid;
-    border-width: 8px 8px 8px 18px;
-    border-color: transparent transparent transparent #333333;
+    z-index: 2;
+    padding: 0 10px;
     position: absolute;
-    top: 50%;
-    left: 14px;
-    transform: translateY(-50%);
-  }
-  .vjs-control-text {
-    display: none;
-  }
-  .gu-media--audio &,
-  .vjs-has-ended &,
-  .vjs-ad-playing &,
-  .vjs-playing &,
-  .vjs-has-started.vjs-using-native-controls &,
-  .vjs-ad-loading & {
-      display: none !important;
-  }
-  .l-row__item--span-3 & {
-    top: 42%;
-    left: 5%;
-  }
+    bottom: 8px;
+    left: 5px;
+    line-height: 28px;
+    padding-left: 41px;
+    width: auto;
+    height: 44px;
+    color: #161616;
+    border-radius: 46px;
+    border: 0;
+    background-color: $media-default;
+    backface-visibility: hidden;
+
+    .vjs-has-started & {
+        padding-bottom: 0;
+    }
+
+    &:before {
+        @include fs-textSans(4);
+        content: attr(data-duration);
+        font-weight: 400;
+        font-size: 15px;
+        line-height: 20px;
+        margin-top: 14px;
+        padding-right: 7px;
+        padding-left: 8px;
+        margin-left: 4px;
+        border-left: 1px solid rgba(51, 51, 51, .6);
+        display: inline-block;
+    }
+    &:after {
+        content: '';
+        border: 1px solid;
+        border-width: 8px 8px 8px 18px;
+        border-color: transparent transparent transparent $neutral-1;
+        position: absolute;
+        top: 50%;
+        left: 14px;
+        transform: translateY(-50%);
+    }
+    .vjs-control-text {
+        display: none;
+    }
+    .gu-media--audio &,
+    .vjs-has-ended &,
+    .vjs-ad-playing &,
+    .vjs-playing &,
+    .vjs-has-started.vjs-using-native-controls &,
+    .vjs-ad-loading & {
+        display: none !important;
+    }
+    .l-row__item--span-3 & {
+        top: 42%;
+        left: 5%;
+    }
 }
 
 button.vjs-big-play-button__duration {
-  top: 45%;
-  left: 5%;
-  &:before {
-    margin-top: 0;
+    top: 45%;
+    left: 5%;
+    &:before {
+        margin-top: 0;
   }
 }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -209,6 +209,10 @@ $ima-controls-height: 70px;
   .vjs-ad-loading & {
       display: none !important;
   }
+  .l-row__item--span-3 & {
+    top: 42%;
+    left: 5%;
+  }
 }
 
 button.vjs-big-play-button__duration {

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -175,7 +175,7 @@ $ima-controls-height: 70px;
 
     &:before {
         @include fs-textSans(4);
-        content: attr(data-duration);
+        content: attr(data-formatted-duration);
         font-weight: 400;
         font-size: 15px;
         line-height: 20px;

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -171,6 +171,7 @@ $ima-controls-height: 70px;
 
     .vjs-has-started & {
         padding-bottom: 0;
+        display: none;
     }
 
     &:before {

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -156,12 +156,11 @@ $ima-controls-height: 70px;
     cursor: pointer;
     display: inline-block;
     z-index: 2;
-    padding: 0 10px;
+    padding: 0 10px 0 41px;
     position: absolute;
     bottom: 8px;
     left: 5px;
     line-height: 28px;
-    padding-left: 41px;
     width: auto;
     height: 44px;
     color: #161616;
@@ -1165,6 +1164,7 @@ button.vjs-big-play-button__duration {
 // we had major refactoring issues.
 .gu-media--show-controls-at-start.vjs-paused {
     .vjs-control-bar {
+        //Hides control bar but still shows the seeker
         bottom: -3.95em;
     }
 


### PR DESCRIPTION
## What does this change?

Adds duration to the video button across the site as an AB test.
## What is the value of this and can you measure success?

This has been tested before by showing the control bar and designs were shown in the UX lab. This is the first (small) step in implementing a new style for video cards and embeds. We've learnt from lab  and user panel testing that showing certain information up front before playing a video makes the click more valuable. 
## Does this affect other platforms - Amp, Apps, etc?

No (ran test, all pass)
## Screenshots

![image](https://cloud.githubusercontent.com/assets/2067172/18639317/50ab2060-7e8b-11e6-8a71-126c7a1c85a0.png)

![image](https://cloud.githubusercontent.com/assets/2067172/18639677/bb92c2e2-7e8c-11e6-9b36-6827578412c0.png)
## Request for comment

@akash1810 @jamespamplin @gidsg @sndrs 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
