### PR TITLE
Subscribe everyone to the WR variant, until AB buckets are balanced

### DIFF
--- a/applications/app/views/signup/weekendReading.scala.html
+++ b/applications/app/views/signup/weekendReading.scala.html
@@ -25,7 +25,7 @@
                     </div>
 
                     <div class="email-signup" data-component="weekend-reading">
-                        <form action="https://www.theguardian.com/email" method="post" class="email-sub__form js-email-sub__form email-sub__form--article" data-email-form-type="article" data-email-list-id="3744" data-link-name="referrer-unknown">
+                        <form action="https://www.theguardian.com/email" method="post" class="email-sub__form js-email-sub__form email-sub__form--article" data-email-form-type="article" data-email-list-id="3743" data-link-name="referrer-unknown">
                           <div class="email-sub__form-wrapper">
                             <div class="email-sub__inline-label js-email-sub__inline-label">
                               <label class="email-sub__label js-email-sub__label" for="article-email-sub-input">
@@ -38,7 +38,7 @@
                               </label>
                               <input class="email-sub__lozenge email-sub__text-input js-email-sub__text-input"
                               data-link-name="weekend-reading-input" type="email" name="email" required/>
-                              <input class="js-email-sub__listid-input" type="hidden" name="listId" value="3744"/>
+                              <input class="js-email-sub__listid-input" type="hidden" name="listId" value="3743"/>
                               <input class="js-email-sub__referrer-input" type="hidden" name="referrer" value="unknown"/>
                               <button type="submit" class="email-sub__lozenge email-sub__submit-input js-email-sub__submit-input button button--tertiary"
                               data-link-name="weekend-reading-submit">

--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -56,7 +56,7 @@ object EmailSubscriptions {
       "News",
       "The best stuff you didn't have time to read during the week - from features and news analysis to lifestyle and culture.",
       "Every Saturday",
-      "3744",
+      "3743",
       subscribedTo = subscribedListIds.exists{ x => x == "3743" || x == "3744" },
       exampleUrl = Some("http://www.theguardian.com/membership/series/weekend-reading/latest/email")
 

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -155,8 +155,9 @@ define([
                 buttonString += 'addEmailSubscriptions[]=' + encodeURIComponent(value) + '&';
             }
             // deal with the AB test running on Weekend Reading (there are two listIDs)
-            if (config.switches.abWeekendReadingEmail && value === 'unsubscribe-3744') {
-                buttonString += 'removeEmailSubscriptions[]=' + encodeURIComponent('3743') + '&';
+            // delete me after 2016-10-01!
+            if (config.switches.abWeekendReadingEmail && value === 'unsubscribe-3743') {
+                buttonString += 'removeEmailSubscriptions[]=' + encodeURIComponent('3744') + '&';
             }
 
         }


### PR DESCRIPTION
## What does this change?

Add all Weekend Reading subscriptions to `version 2` until balance is restored (and this PR can be reverted)

Temporarily puts all Weekend Reading subscriptions into ListID **3743**.
## What is the value of this and can you measure success?

We a currently running a site-wide AB test to subscribe users to two different email formats. Randomisation seems to be favouring `version 1` (ListID **3744**) significantly.

(Randomisation occurs when the user visits the Guardian, irrespective of if they sign up to the email, or visit the email page)

We now have twice as many people signed up to `version 1` as to `version 2` of the Weekend Reading email. This PR aims to balance the groups.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@joelochlann 
