### PR TITLE
Promote comments in (p)react

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,7 +18,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-discussion-external-frontend-count",
+    "ab-discussion-external-frontend-avatar",
     "Standalone frontend discussion",
     owners = Seq(Owner.withGithub("piuccio")),
     safeState = On,

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -8,12 +8,12 @@ define([
     reportError
 ) {
     function canRun(ab, curlConfig) {
-        return (ab.isInVariant('DiscussionExternalFrontendCount', 'react') && curlConfig.paths['discussion-frontend-react']) ||
-            (ab.isInVariant('DiscussionExternalFrontendCount', 'preact') && curlConfig.paths['discussion-frontend-preact']);
+        return (ab.isInVariant('DiscussionExternalFrontendAvatar', 'react') && curlConfig.paths['discussion-frontend-react']) ||
+            (ab.isInVariant('DiscussionExternalFrontendAvatar', 'preact') && curlConfig.paths['discussion-frontend-preact']);
     }
 
     function load(ab, loader, opts) {
-        var requireVariant = ab.isInVariant('DiscussionExternalFrontendCount', 'react') ? 'react' : 'preact';
+        var requireVariant = ab.isInVariant('DiscussionExternalFrontendAvatar', 'react') ? 'react' : 'preact';
         return require('discussion-frontend-' + requireVariant, function (frontend) {
             // Preact works in a slightly different way
             // https://github.com/developit/preact-compat/issues/145

--- a/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/discussion-external-frontend.js
@@ -5,16 +5,16 @@ define([
 ) {
     return function () {
 
-        this.id = 'DiscussionExternalFrontendCount';
-        this.start = '2016-09-06';
+        this.id = 'DiscussionExternalFrontendAvatar';
+        this.start = '2016-09-20';
         this.expiry = '2016-09-30';
         this.author = 'Fabio Crisci';
         this.description = 'Load discussion frontend from an external location';
-        this.audience = 0.05;
-        this.audienceOffset = 0.45;
-        this.successMeasure = 'Comment count loads correctly';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Comments count and avatar load correctly';
         this.showForSensitive = true;
-        this.audienceCriteria = 'Browsers with Promise';
+        this.audienceCriteria = 'Modern browsers';
         this.dataLinkNames = '';
         this.idealOutcome = '';
 
@@ -25,15 +25,6 @@ define([
         };
 
         this.variants = [
-            {
-                id: 'control',
-                test: function () {},
-                success: function (complete) {
-                    if (this.canRun()) {
-                        mediator.on('comments-count-loaded', complete);
-                    }
-                }.bind(this)
-            },
             {
                 id: 'react',
                 test: function () {},


### PR DESCRIPTION
## What does this change?

Remove control and split users 50-50 among react and preact
## What is the value of this and can you measure success?

The initial test shows that external comments don't affect page load. As of this morning the complete ratio (number of people that stay long enough for the comments count to load) is:

| Variant | Completion |
| --- | --- |
| control | 61.61% |
| preact | 61.49% |
| react | 61.37% |

The test ran only on 5% so the results are not statistically significant and are subject to little variations but at least they show that there's no evident negative effect in rendering comments in (p)react.

This PR modifies the test to always use the external `discussion-frontend` and split users in two groups, react and preact. It should give statistical significance more easily.

Because of browsers constraints (you need `fetch` and `Promise`) some users will be `not-in-test`. This test should tell us how many they are and track the count over time.
## Does this affect other platforms - Amp, Apps, etc?

No
