### PR TITLE
Init US survey banner

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -392,7 +392,7 @@ define([
                 ['c-pinterest', modules.initPinterest],
                 ['c-save-for-later', modules.saveForLater],
                 ['c-email', modules.initEmail],
-                ['c-us-survey-banner', modules.USSurveyBanner],
+                ['c-us-survey-banner', USSurveyBanner],
                 ['c-user-features', userFeatures.refresh.bind(userFeatures)],
                 ['c-membership',membership]
 

--- a/static/src/javascripts/projects/common/modules/onward/us-survey-banner.js
+++ b/static/src/javascripts/projects/common/modules/onward/us-survey-banner.js
@@ -69,6 +69,6 @@ define([
         }
     }
 
-    return init();
+    return init;
 
 });


### PR DESCRIPTION
I'm not sure how this ever worked, @sammorrisdesign. We are seeing a JS error on every page since https://github.com/guardian/frontend/pull/14255 was merged. I'm fixing forwards, the messaging code looks fine to enable.
