### PR TITLE
Update docs to allow successfully running `identity`

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -31,19 +31,6 @@ So the required steps are:
 
 * configure and run nginx (see `/nginx`)
 * update your hosts file (also described in `/nginx`)
-* make sure that your `~/.gu/frontend.conf` file contains
-
-
-
-```
-# ID
-id.apiRoot=https://id.code.dev-guardianapis.com
-id.apiClientToken=frontend-code-client-token
-```
-
-This configures the locally running identity module with the Identity API 
-on the CODE environment.
-
 * run the Identity subproject on port 9009
 
 With these in place, you'll be able to browse Identity on
@@ -57,6 +44,8 @@ following properties in `~/.gu/frontend.conf`.
 
 ```
 # ID
-id.apiRoot=https://idapi.thegulocal.com
-id.apiClientToken=frontend-dev-client-token
+devOverrides {
+  id.apiRoot=https://idapi.thegulocal.com
+  id.apiClientToken=frontend-dev-client-token
+}
 ```

--- a/identity/README.md
+++ b/identity/README.md
@@ -31,7 +31,7 @@ So the required steps are:
 
 * configure and run nginx (see `/nginx`)
 * update your hosts file (also described in `/nginx`)
-* make sure that your frontend.properties file contains
+* make sure that your `~/.gu/frontend.conf` file contains
 
 
 
@@ -53,7 +53,7 @@ With these in place, you'll be able to browse Identity on
 ## Configuration of local Identity API
 
 The Identity site can be configured to use the local Identity API with the
-following properties in `frontend.properties`.
+following properties in `~/.gu/frontend.conf`.
 
 ```
 # ID

--- a/identity/README.md
+++ b/identity/README.md
@@ -43,9 +43,9 @@ The Identity site can be configured to use the local Identity API with the
 following properties in `~/.gu/frontend.conf`.
 
 ```
-# ID
 devOverrides {
-  id.apiRoot=https://idapi.thegulocal.com
+  # ID
+  id.apiRoot="https://idapi.thegulocal.com"
   id.apiClientToken=frontend-dev-client-token
 }
 ```


### PR DESCRIPTION
## What does this change?

Update the docs for the identity app. `frontend.properties` [is no longer used](https://github.com/guardian/frontend/blob/a61225df3b211b638aeef3d7bfd676d5456231ef/common/app/common/configuration.scala#L41-L47)
## What is the value of this and can you measure success?

Devs get up and running more easily
## Request for comment

cc/ @guardian/dotcom-platform 
