### PR TITLE
Hosted pages - choose contrasting colour using HSL

### DIFF
--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -51,13 +51,12 @@ case class FontColour(brandColour: String) {
     val hexColour = brandColour.stripPrefix("#")
     val rgb = Integer.parseInt(hexColour, 16)
     val c = new Color(rgb)
-    val hsb = Color.RGBtoHSB(c.getRed, c.getGreen, c.getBlue, null)
-    val brightness = hsb(2)
-    if(brandColour == "#E31B22" || brandColour == "#E41F13") {
-      false
-    } else {
-      brightness > 0.5
-    }
+    // the conversion in java.awt.Color uses HSB colour space, whereas we want HSL here
+    // see http://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/
+    val min: Float = Math.min(Math.min(c.getRed, c.getGreen), c.getBlue)
+    val max: Float = Math.max(Math.max(c.getRed, c.getGreen), c.getBlue)
+    val lightness = (min + max) / 510
+    lightness > 0.5
   }
 }
 

--- a/common/test/common/commercial/hosted/FontColourTest.scala
+++ b/common/test/common/commercial/hosted/FontColourTest.scala
@@ -8,12 +8,12 @@ import org.scalatest.{FlatSpec, Matchers}
  */
 class FontColourTest extends FlatSpec with Matchers {
 
-  "shouldHaveBrightFont" should "be false for a bright brandColour" in {
+  "shouldHaveBrightFont" should "be true for Zootropolis green" in {
     val colour = FontColour("#2ec869") //Zootropolis
-    colour.shouldHaveBrightFont should be(false)
+    colour.shouldHaveBrightFont should be(true)
   }
 
-  it should "be false for another bright brandColour" in {
+  it should "be false for a bright brandColour e.g Renault Yellow" in {
     val colour = FontColour("#ffc421") //Renault
     colour.shouldHaveBrightFont should be(false)
   }
@@ -30,6 +30,15 @@ class FontColourTest extends FlatSpec with Matchers {
 
   it should "be true for black brandColour" in {
     val colour = FontColour("#000000") //black
+    colour.shouldHaveBrightFont should be(true)
+  }
+
+  it should "be true for Visit Britain colour" in {
+    val colour = FontColour("#E41F13") //red
+    colour.shouldHaveBrightFont should be(true)
+  }
+  it should "be true for Chester Zoo colour" in {
+    val colour = FontColour("#E31B22") //red
     colour.shouldHaveBrightFont should be(true)
   }
 }


### PR DESCRIPTION
## What does this change?

Instead of using the B (brightness) of HSB colour space to choose a contrasting colour to the brand colour for each Hosted By campaign, calculate the lightness (using HSL colour space) and use that instead.

![image](https://cloud.githubusercontent.com/assets/6290008/18666553/4cec5ad6-7f24-11e6-942b-5fd7ea9f9299.png)
### Interesting links on the topic:
- http://colorizer.org/
- https://en.wikipedia.org/wiki/HSL_and_HSV
- http://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/
## What is the value of this and can you measure success?

We had to hard code some exceptions to the previous rule, it categorised Visit Britain and Chester Zoo reds as very bright, which forced the text colour to be black, which looked bad! Now the same algorithm works for all the current campaigns.

![image](https://cloud.githubusercontent.com/assets/6290008/18666225/97c38f9a-7f22-11e6-9a77-e5b92f366937.png)
## Request for comment

@guardian/labs-beta 
