### PR TITLE
Make Revealer full-width in articles

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/revealer.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/revealer.js
@@ -19,7 +19,7 @@ define([
 
             return fastdom.write(function () {
                 $adSlot[0].insertAdjacentHTML('beforeend', markup);
-                $adSlot.addClass('ad-slot--revealer');
+                $adSlot.addClass('ad-slot--revealer content__mobile-full-width');
                 if (params.trackingPixel) {
                     addTrackingPixel($adSlot, params.trackingPixel + params.cacheBuster);
                 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -106,7 +106,7 @@ define([
     /**
      * Mobile adverts with fabric sizes get 'fluid' full-width design
      */
-    sizeCallbacks[adSizes.fabric] = addFluid(['ad-slot--mobile', 'ad-slot--top-banner-ad']);
+    sizeCallbacks[adSizes.fabric] = addFluid(['ad-slot--top-banner-ad']);
 
     /**
      * Commercial components with merch sizing get fluid-250 styling

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -665,6 +665,7 @@
 
 .ad-slot--revealer {
     min-width: 300px;
+    width: auto;
 }
 
 .ad-slot--fabric {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -670,6 +670,7 @@
 
 .ad-slot--fabric {
     overflow: hidden;
+    width: auto;
 }
 
 .ad-slot--fabric-v1,


### PR DESCRIPTION
Although it is already full-width on fronts, revealer are not f-w on articles:

![picture 4](https://cloud.githubusercontent.com/assets/629976/18666661/f83ff604-7f24-11e6-98a2-f52da6653aa7.jpg)

Fixed:

![picture 5](https://cloud.githubusercontent.com/assets/629976/18666664/fc249ce8-7f24-11e6-93e1-7725e5bdbcbd.jpg)
