### PR TITLE
Badges floating fix

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -139,7 +139,7 @@
     }
 }
 
-.content__main-column--article {
+.content__main-column {
     .brandbadge--onside {
         @include mq(leftCol) {
             float: none;

--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -141,7 +141,7 @@
 
 .content__main-column {
     .brandbadge--onside {
-        @include mq(leftCol) {
+        @include mq(tablet) {
             float: none;
         }
     }


### PR DESCRIPTION
## What does this change?

Proper (I think ;)) solution of the https://github.com/guardian/frontend/pull/14316 bug. I need to get rid of badge's float style on every content page not only article. 

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before (liveblog):
tablet:
![screen shot 2016-09-20 at 11 39 15](https://cloud.githubusercontent.com/assets/489567/18667512/cc1f930a-7f28-11e6-9764-bef49fcca7f5.png)

desktop:
![screen shot 2016-09-20 at 11 39 07](https://cloud.githubusercontent.com/assets/489567/18667515/d2f46b1a-7f28-11e6-8aff-40871a8038ed.png)

After (both tablet and desktop):
![screen shot 2016-09-20 at 11 46 10](https://cloud.githubusercontent.com/assets/489567/18667519/dda37bd2-7f28-11e6-8251-c0eece41bb44.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
