### PR TITLE
[not ready to merge] Always redirect to https for redirects defined in dynamo

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -64,7 +64,7 @@ class ArchiveController(dynamoDB: DynamoDB) extends Controller with Logging with
         Some(path)
       case _ => None
     }
-    s"http://${normalised.getOrElse(path)}"
+    s"https://${normalised.getOrElse(path)}"
   }
 
   def linksToItself(path: String, destination: String): Boolean = path match {
@@ -134,7 +134,7 @@ class ArchiveController(dynamoDB: DynamoDB) extends Controller with Logging with
 
   private def redirectTo(path: String, identifier: String)(implicit request: RequestHeader): Result = {
     log.info(s"301, $identifier, ${RequestLog(request)}")
-    Cached(300)(WithoutRevalidationResult(Redirect(s"http://$path", 301)))
+    Cached(300)(WithoutRevalidationResult(Redirect(s"https://$path", 301)))
   }
 
   private def logDestination(path: String, msg: String, destination: String) {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -19,10 +19,10 @@ import services.DynamoDB
 
   it should "return a normalised r1 path" in {
     val tests = List(
-      "www.theguardian.com/books/reviews/travel/0,,343395,00.html" -> "http://www.theguardian.com/books/reviews/travel/0,,343395,.html",
-      "www.theguardian.com/books/reviews/travel/0,,343395,.html" -> "http://www.theguardian.com/books/reviews/travel/0,,343395,.html",
-      "www.theguardian.com/books/review/story/0,034,908973,00.html" -> "http://www.theguardian.com/books/review/story/0,,908973,.html",
-      "www.theguardian.com/books/reviews/travel/foo" -> "http://www.theguardian.com/books/reviews/travel/foo"
+      "www.theguardian.com/books/reviews/travel/0,,343395,00.html" -> "https://www.theguardian.com/books/reviews/travel/0,,343395,.html",
+      "www.theguardian.com/books/reviews/travel/0,,343395,.html" -> "https://www.theguardian.com/books/reviews/travel/0,,343395,.html",
+      "www.theguardian.com/books/review/story/0,034,908973,00.html" -> "https://www.theguardian.com/books/review/story/0,,908973,.html",
+      "www.theguardian.com/books/reviews/travel/foo" -> "https://www.theguardian.com/books/reviews/travel/foo"
     )
     tests foreach {
       case (key, value) => archiveController.normalise(key) should be (value)
@@ -32,14 +32,14 @@ import services.DynamoDB
   // r1 curio (all the redirects have their 00's removed, all the s3 archived files don't)
   it should "return a normalised r1 path with suffixed zeros" in {
     val path = "www.theguardian.com/books/reviews/travel/0,,343395,.html"
-    val expectedPath = "http://www.theguardian.com/books/reviews/travel/0,,343395,00.html"
+    val expectedPath = "https://www.theguardian.com/books/reviews/travel/0,,343395,00.html"
     archiveController.normalise(path , zeros = "00") should be (expectedPath)
   }
 
   it should "return a normalised short url path" in {
     val tests = List(
-      "www.theguardian.com/p/dfas/stw" -> "http://www.theguardian.com/p/dfas",
-      "www.theguardian.com/p/dfas" -> "http://www.theguardian.com/p/dfas"
+      "www.theguardian.com/p/dfas/stw" -> "https://www.theguardian.com/p/dfas",
+      "www.theguardian.com/p/dfas" -> "https://www.theguardian.com/p/dfas"
     )
     tests foreach {
       case (key, value) => archiveController.normalise(key) should be (value)
@@ -63,37 +63,37 @@ import services.DynamoDB
   it should "redirect old style galleries" in {
     val result = archiveController.lookup("www.theguardian.com/arts/gallery/0,")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/arts/pictures/0,")
+    location(result) should be ("https://www.theguardian.com/arts/pictures/0,")
   }
 
   it should "test a redirect doesn't link to itself" in {
     val path = "www.theguardian.com/books/worldliteraturetour/page/0,,2021886,.html"
-    val dest = "http://books.theguardian.com/worldliteraturetour/page/0,,2021886,.html"
+    val dest = "https://books.theguardian.com/worldliteraturetour/page/0,,2021886,.html"
     archiveController.linksToItself(path, dest) should be (true)
   }
 
   it should "lowercase the section of the url" in {
     val result = archiveController.lookup("www.theguardian.com/Football/News_Story/0,1563,1655638,00.html")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/football/News_Story/0,1563,1655638,00.html")
+    location(result) should be ("https://www.theguardian.com/football/News_Story/0,1563,1655638,00.html")
   }
 
   it should "redirect century urls correctly" in {
     val result = archiveController.lookup("www.theguardian.com/century")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
+    location(result) should be ("https://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
   }
 
   it should "redirect century decade urls correctly" in {
     val result = archiveController.lookup("www.theguardian.com/1899-1909")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
+    location(result) should be ("https://www.theguardian.com/world/2014/jul/31/-sp-how-the-guardian-covered-the-20th-century")
   }
 
   it should "redirect an R1 century article to a corrected decade story endpoint" in {
     val result = archiveController.lookup("www.theguardian.com/1899-1909/Story/0,,126404,00.html")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/century/1899-1909/Story/0,,126404,00.html")
+    location(result) should be ("https://www.theguardian.com/century/1899-1909/Story/0,,126404,00.html")
   }
 
   it should "not redirect a random URL that contains the word century" in {
@@ -104,17 +104,17 @@ import services.DynamoDB
   it should "redirect failed combiners to the section" in {
     val result = archiveController.lookup("www.theguardian.com/tv-and-radio/tvandradioblog+media/chris-evans")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/tv-and-radio")
+    location(result) should be ("https://www.theguardian.com/tv-and-radio")
 
     val result2 = archiveController.lookup("www.theguardian.com/tv-and-radio+media/chris-evans")(TestRequest())
     status(result2) should be (301)
-    location(result2) should be ("http://www.theguardian.com/tv-and-radio")
+    location(result2) should be ("https://www.theguardian.com/tv-and-radio")
   }
 
   it should "redirect paths that start with /Guardian/" in {
     val result = archiveController.lookup("www.theguardian.com/Guardian/world/2005/jun/21/hearafrica05.development3")(TestRequest())
     status(result) should be (301)
-    location(result) should be ("http://www.theguardian.com/world/2005/jun/21/hearafrica05.development3")
+    location(result) should be ("https://www.theguardian.com/world/2005/jun/21/hearafrica05.development3")
   }
 
   it should "redirect failed combiners RSS to the section RSS" in {
@@ -198,14 +198,14 @@ import services.DynamoDB
 
   it should "redirect short urls with campaign codes" in {
 
-    val result = archiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", "http://www.theguardian.com/p/new")
-    result should be("http://www.theguardian.com/p/new?CMP=share_btn_tw")
+    val result = archiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", "https://www.theguardian.com/p/new")
+    result should be("https://www.theguardian.com/p/new?CMP=share_btn_tw")
   }
 
   it should "redirect short urls with campaign codes and allow for overrides" in {
     val shortRedirectWithCMP = services.Redirect("http://www.theguardian.com/p/new?CMP=existing-cmp")
-    val result = archiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", "http://www.theguardian.com/p/new?CMP=existing-cmp")
-    result should be ("http://www.theguardian.com/p/new?CMP=existing-cmp")
+    val result = archiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", "https://www.theguardian.com/p/new?CMP=existing-cmp")
+    result should be ("https://www.theguardian.com/p/new?CMP=existing-cmp")
   }
 
   it should "not perform a redirect loop check on Archive objects" in {


### PR DESCRIPTION
## What does this change?

Ensure that all redirection defined in dynamo table (so not the one in `fastly`) are done with `https` scheme.

This prevent additional roundtrips.
## Does this affect other platforms - Amp, Apps, etc?

No
