### PR TITLE
Remove cssClass field from HostedCampaign

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -33,7 +33,7 @@
     }
     </style>
         <!--<![endif]-->
-    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @{page.campaign.cssClass} @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
+    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
         @guardianHostedHeader("hosted-gallery-page", page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -40,7 +40,7 @@
     </style>
     <!--<![endif]-->
     @guardianHostedHeader(if(page.campaign.fontColour.shouldHaveBrightFont) "hosted-video-page hosted-page--bright" else "hosted-video-page", page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
-    <div class="hosted-page l-side-margins hosted__side hosted-video-page @{page.campaign.cssClass} @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
+    <div class="hosted-page l-side-margins hosted__side hosted-video-page @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
         <section class="hosted-tone--dark">
             <div class="host hosted__container--full">
                 <div class="u-responsive-ratio u-responsive-ratio--hd">

--- a/commercial/app/views/hosted/zootropolisPage.scala.html
+++ b/commercial/app/views/hosted/zootropolisPage.scala.html
@@ -61,7 +61,7 @@
     </style>
     <!--<![endif]-->
     @guardianHostedHeader("hosted-article-page", page.campaign.logo.url, page.campaign.owner, page.campaign.logoLink.getOrElse(page.cta.url))
-    <div class="hosted-page l-side-margins hosted__side hosted-article-page @{page.campaign.cssClass}">
+    <div class="hosted-page l-side-margins hosted__side hosted-article-page zootropolis">
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">
             <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">
                 <div class="gs-container">

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -93,7 +93,6 @@ object HostedArticlePage extends Logging {
           logo = HostedLogo(
             url = sponsorship.sponsorLogo
           ),
-          cssClass = "", //TODO remove this variable later
           fontColour = FontColour(hostedTag.paidContentCampaignColour getOrElse ""),
           logoLink = None
         ),

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -38,7 +38,6 @@ case class HostedCampaign(
   name: String,
   owner: String,
   logo: HostedLogo,
-  cssClass: String,
   fontColour: FontColour,
   logoLink: Option[String] = None
 )

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -94,7 +94,6 @@ object HostedVideoPage extends Logging {
           logo = HostedLogo(
             url = sponsorship.sponsorLogo
           ),
-          cssClass = "",
           fontColour = FontColour(hostedTag.paidContentCampaignColour getOrElse ""),
           logoLink = None
         ),

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -11,9 +11,7 @@ object ChesterZooHostedPages {
     name = "What we fight for",
     owner = "Chester Zoo",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png"),
-    cssClass = "chester-zoo",
-    fontColour = FontColour("#E31B22"),
-    logoLink = None
+    fontColour = FontColour("#E31B22")
   )
 
   private val images: List[HostedGalleryImage] = List(

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -10,9 +10,7 @@ object Formula1HostedPages {
     name = "Singapore Grand Prix",
     owner = "First Stop Singapore",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg"),
-    cssClass = "f1-singapore",
-    fontColour = FontColour("#063666"),
-    logoLink = None
+    fontColour = FontColour("#063666")
   )
 
   private def cta(pageName: String) = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -17,9 +17,7 @@ object LeffeHostedPages {
     name = "Leffe - Rediscover Time",
     owner = "Leffe",
     logo = HostedLogo(Static("images/commercial/leffe.jpg")),
-    cssClass = "leffe",
-    fontColour = FontColour("#dec190"),
-    logoLink = None
+    fontColour = FontColour("#dec190")
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -15,9 +15,7 @@ object RenaultHostedPages {
     name = "Discover your Renault Zoe",
     owner = "Renault",
     logo = HostedLogo(Static("images/commercial/logo_renault.jpg")),
-    cssClass = "renault",
-    fontColour = FontColour("#ffc421"),
-    logoLink = None
+    fontColour = FontColour("#ffc421")
   )
 
   private val cta = HostedCallToAction(

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -14,9 +14,7 @@ object VisitBritainHostedPages {
     name = "#OMGB. Home of Amazing Moments. Great Britain & Northern Ireland",
     owner = "OMGB",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg"),
-    cssClass = "visit-britain",
-    fontColour = FontColour("#E41F13"),
-    logoLink = None
+    fontColour = FontColour("#E41F13")
   )
 
   private val activityImages: List[HostedGalleryImage] = List(

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -12,9 +12,7 @@ object ZootropolisHostedPages {
     name = "Zootropolis",
     owner = "Disney",
     logo = HostedLogo("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis-logo.jpg"),
-    cssClass = "zootropolis",
-    fontColour = FontColour("#2ec869"),
-    logoLink = None
+    fontColour = FontColour("#2ec869")
   )
 
   private val cta = HostedCallToAction(

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -17,14 +17,3 @@
         }
     }
 }
-
-.leffe {
-    .hosted-tone-btn {
-        &.hosted-tone-btn,
-        &:focus,
-        &:hover {
-            background-color: #ffffff;
-            border-color: #ffffff;
-        }
-    }
-}

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -731,6 +731,10 @@ $hosted-video-height: 540px;
             height: 20px;
         }
     }
+    .hosted-page:not(.hosted-page--bright) & {
+        background-color: #ffffff;
+        border-color: #ffffff;
+    }
 }
 
 .hosted__cta-link {


### PR DESCRIPTION
## What does this change?

Remove a field which was used to set a campaign-specific css class on hosted pages.
## What is the value of this and can you measure success?

All the styling should be the same across the campaigns. The brand-specific colours are now driven from capi, so we don't need it any more.
## Request for comment

@guardian/labs-beta 
