### PR TITLE
Define size mappings for out of page slots too

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -14,13 +14,14 @@ define([
         var adUnit = adUnitOverride ?
             '/' + config.page.dfpAccountId + '/' + adUnitOverride :
             config.page.adUnit;
+        var sizeOpts = getSizeOpts(sizes);
         var id = adSlotNode.id;
         var slot;
 
         if (adSlotNode.getAttribute('data-out-of-page')) {
-            slot = window.googletag.defineOutOfPageSlot(adUnit, id);
+            slot = window.googletag.defineOutOfPageSlot(adUnit, sizeOpts.size, id).defineSizeMapping(sizeOpts.sizeMapping);
         } else {
-            slot = createInPageSlot(adUnit, id, sizes);
+            slot = window.googletag.defineSlot(adUnit, sizeOpts.size, id).defineSizeMapping(sizeOpts.sizeMapping);
         }
 
         setTargeting(adSlotNode, slot, 'data-series', 'se');
@@ -32,7 +33,7 @@ define([
         return slot;
     }
 
-    function createInPageSlot(adUnit, id, sizes) {
+    function getSizeOpts(sizes) {
         var sizeMapping = buildSizeMapping(sizes);
         // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
         var size = uniq(
@@ -40,7 +41,10 @@ define([
             function (size) { return size[0] + '-' + size[1]; }
         );
 
-        return window.googletag.defineSlot(adUnit, size, id).defineSizeMapping(sizeMapping);
+        return {
+            sizeMapping: sizeMapping,
+            size: size
+        };
     }
 
     function setTargeting(adSlotNode, slot, attribute, targetKey) {

--- a/static/test/javascripts/spec/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts/spec/commercial/dfp/dfp-api.spec.js
@@ -256,7 +256,7 @@ define([
         it('should be able to create "out of page" ad slot', function (done) {
             $('.js-ad-slot').first().attr('data-out-of-page', true);
             dfp.init().then(dfp.load).then(function () {
-                expect(window.googletag.defineOutOfPageSlot).toHaveBeenCalledWith('/123456/theguardian.com/front', 'dfp-ad-html-slot');
+                expect(window.googletag.defineOutOfPageSlot).toHaveBeenCalled();
                 done();
             });
         });


### PR DESCRIPTION
Although I added the 2x2 size to the pageskin slot, the information was not carried over to DFP. That is because out of page slots don't have a size mapping:

![picture 2](https://cloud.githubusercontent.com/assets/629976/18670912/edb5fb60-7f39-11e6-97c5-96142909bd91.jpg)

Except that now they do:

![picture 1](https://cloud.githubusercontent.com/assets/629976/18670921/f49cce9a-7f39-11e6-9076-c12cfd056b06.jpg)
