### PR TITLE
Modify container choice for series container

### DIFF
--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -98,7 +98,7 @@ class SeriesController(contentApiClient: ContentApiClient) extends Controller wi
     val response = () => views.html.fragments.containers.facia_cards.container(
       FaciaContainer(
         1,
-        Fixed(visuallyPleasingContainerForStories(series.trails.faciaItems.length)),
+        Fixed(visuallyPleasingContainerForStories(math.min(series.trails.faciaItems.length, 4))),
         CollectionConfigWithId(dataId, config),
         CollectionEssentials(series.trails.faciaItems take 4, Nil, displayName, None, None, None),
         componentId


### PR DESCRIPTION
So that it takes account of the actual number of stories that will appear in the container.

This fixes the strange layout of the series container in https://www.theguardian.com/inside-seat/2016/sep/05/smart-cities-future-transport-technologies-revolution-carnet-vehicles-urban-planning

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/18674370/e9d26d64-7f46-11e6-8929-1019a0682c8a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/18674358/db3d5bf6-7f46-11e6-963d-774bcacc382f.png)
