### PR TITLE
Fix radiator graphs (Fastly, googlebot-errors)

### DIFF
--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -162,7 +162,7 @@ object CloudWatch extends Logging with ExecutionContexts {
       .withPeriod(120)
       .withStatistics("Average")
       .withNamespace("Fastly")
-      .withDimensions(new Dimension().withName("Stage").withValue("prod"))
+      .withDimensions(stage)
       .withMetricName(metric))) map { metricsResult =>
       new AwsLineChart(graphTitle, Seq("Time", metric), ChartFormat(Colour.`tone-features-2`), metricsResult)
     }
@@ -186,9 +186,7 @@ object CloudWatch extends Logging with ExecutionContexts {
         .withStatistics("Average")
         .withNamespace("Fastly")
         .withMetricName(s"$region-hits")
-        .withDimensions(
-          new Dimension().withName("Stage").withValue("prod")
-        ))
+        .withDimensions(stage))
       )
 
       misses <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
@@ -198,10 +196,8 @@ object CloudWatch extends Logging with ExecutionContexts {
         .withStatistics("Average")
         .withNamespace("Fastly")
         .withMetricName(s"$region-miss")
-        .withDimensions(
-          new Dimension().withName("Stage").withValue("prod")
-        )
-      ))
+        .withDimensions(stage))
+      )
     } yield new AwsLineChart(graphTitle, Seq("Time", "Hits", "Misses"), ChartFormat(Colour.success, Colour.error), hits, misses)
   }
 
@@ -291,7 +287,7 @@ object CloudWatch extends Logging with ExecutionContexts {
         .withEndTime(now.toDate)
         .withPeriod(900)
         .withStatistics("Sum")
-        .withDimensions(new Dimension().withName("Stage").withValue("prod"))))
+        .withDimensions(stage)))
     }
 
     def compare(pvCount: GetMetricStatisticsResult,

--- a/admin/app/tools/errors.scala
+++ b/admin/app/tools/errors.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.cloudwatch.model.{Dimension, GetMetricStatisticsRe
 import common.ExecutionContexts
 import org.joda.time.DateTime
 import awswrappers.cloudwatch._
+import conf.Configuration._
 
 import scala.concurrent.Future
 
@@ -13,18 +14,18 @@ object HttpErrors extends ExecutionContexts {
     new AwsLineChart("Global 4XX", Seq("Time", "4xx/min"), ChartFormat.SingleLineBlue, metric)
   }
 
-  private val prod = new Dimension().withName("Stage").withValue("prod")
+  private val stage = new Dimension().withName("Stage").withValue(environment.stage)
 
   def googlebot404s = withErrorLogging(Future.sequence(Seq(
     euWestClient.getMetricStatisticsFuture(
       metric("googlebot-404s").withStartTime(new DateTime().minusHours(12).toDate)
-        .withNamespace("ArchiveMetrics").withDimensions(prod)
+        .withNamespace("ArchiveMetrics").withDimensions(stage)
     ) map { metric =>
       new AwsLineChart("12 hours", Seq("Time", "404/min"), ChartFormat(Colour.`tone-live-1`), metric)
     },
     euWestClient.getMetricStatisticsFuture(
       metric("googlebot-404s").withNamespace("ArchiveMetrics")
-        .withDimensions(prod).withPeriod(900)
+        .withDimensions(stage).withPeriod(900)
         .withStartTime(new DateTime().minusDays(14).toDate)
     ) map { metric =>
       new AwsLineChart("2 weeks", Seq("Time", "404/15min"), ChartFormat(Colour.`tone-live-2`), metric)


### PR DESCRIPTION
## What does this change?

A recent change of configuration class modifed the current stage case ('prod' -> 'PROD')
This patch remove the hardcoded 'prod' and replaces them with the proper
configuraton stage value
## What is the value of this and can you measure success?

Graph in admin are working 📈 
## Request for comment

@gtrufitt @guardian/dotcom-platform 
