### PR TITLE
Momentous headline leading change

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -109,21 +109,18 @@
 }
 
 .content__headline--immersive {
+    @include fs-headline(7, true);
+    line-height: 1;
     font-weight: 200;
+
+    @include mq(desktop) {
+        font-size: 4rem;
+    }
 }
 
 .immersive-main-media__headline-container--dark {
     .content__headline--immersive-article {
         color: #ffffff;
-    }
-}
-
-.content__headline--immersive-article {
-    @include fs-headline(7, true);
-    line-height: 1;
-
-    @include mq(desktop) {
-        font-size: 4rem;
     }
 }
 


### PR DESCRIPTION
Galleries and immersive templates should both have the same line-height. Now they do. 

![tight](https://cloud.githubusercontent.com/assets/14570016/18706200/ef087a56-7fe8-11e6-9b9d-fb153d010b47.png)
