### PR TITLE
Add dimensions to logo amp-img elements

### DIFF
--- a/common/app/common/commercial/Branding.scala
+++ b/common/app/common/commercial/Branding.scala
@@ -59,10 +59,24 @@ object SponsorshipTargeting {
   }
 }
 
+case class Dimensions(width: Int, height: Int)
+
+object Dimensions {
+
+  implicit val dimensionsFormat = Json.format[Dimensions]
+}
+
+case class Logo(url: String, dimensions: Option[Dimensions])
+
+object Logo {
+
+  implicit val logoFormat = Json.format[Logo]
+}
+
 case class Branding(
   sponsorshipType: SponsorshipType,
   sponsorName: String,
-  sponsorLogo: String,
+  sponsorLogo: Logo,
   sponsorLink: String,
   aboutThisLink: String,
   targeting: Option[SponsorshipTargeting],
@@ -109,7 +123,8 @@ object Branding {
         case _ => Sponsored
       },
       sponsorName = sponsorship.sponsorName,
-      sponsorLogo = sponsorship.sponsorLogo,
+      sponsorLogo =
+        Logo(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions map (d => Dimensions(d.width, d.height))),
       sponsorLink = sponsorship.sponsorLink,
       aboutThisLink = sponsorship.aboutLink getOrElse "/sponsored-content",
       targeting = sponsorship.targeting map SponsorshipTargeting.make,

--- a/common/app/views/fragments/commercial/contentLogo.scala.html
+++ b/common/app/views/fragments/commercial/contentLogo.scala.html
@@ -7,13 +7,15 @@
         <h3 class="brandbadge__header">@branding.label</h3>
         <a href="@branding.sponsorLink" class="brandbadge__link ad-slot--paid-for-badge__link">
             @if(request.isAmp) {
-                <amp-img src="@branding.sponsorLogo.url"
-                    @for(dim <- branding.sponsorLogo.dimensions) {
+                @branding.sponsorLogo.dimensions.map { dim =>
+                    <amp-img src="@branding.sponsorLogo.url"
                         width="@dim.width"
                         height="@dim.height"
-                    }
-                    alt="@{branding.sponsorName}'s logo"
-                    class="brandbadge__logo"></amp-img>
+                        alt="@{branding.sponsorName}'s logo"
+                        class="brandbadge__logo"></amp-img>
+                }.getOrElse {
+                    <p>@branding.sponsorName</p>
+                }
             } else {
                 <img src="@branding.sponsorLogo.url"
                     @for(dim <- branding.sponsorLogo.dimensions) {

--- a/common/app/views/fragments/commercial/contentLogo.scala.html
+++ b/common/app/views/fragments/commercial/contentLogo.scala.html
@@ -7,9 +7,21 @@
         <h3 class="brandbadge__header">@branding.label</h3>
         <a href="@branding.sponsorLink" class="brandbadge__link ad-slot--paid-for-badge__link">
             @if(request.isAmp) {
-                <amp-img class="brandbadge__logo" src="@branding.sponsorLogo" />
+                <amp-img src="@branding.sponsorLogo.url"
+                    @for(dim <- branding.sponsorLogo.dimensions) {
+                        width="@dim.width"
+                        height="@dim.height"
+                    }
+                    alt="@{branding.sponsorName}'s logo"
+                    class="brandbadge__logo"></amp-img>
             } else {
-                <img class="brandbadge__logo" src="@branding.sponsorLogo">
+                <img src="@branding.sponsorLogo.url"
+                    @for(dim <- branding.sponsorLogo.dimensions) {
+                        width="@dim.width"
+                        height="@dim.height"
+                    }
+                    alt="@{branding.sponsorName}'s logo"
+                    class="brandbadge__logo">
             }
         </a>
         @if(branding.sponsorshipType != PaidContent) {

--- a/common/test/common/commercial/BrandingTest.scala
+++ b/common/test/common/commercial/BrandingTest.scala
@@ -9,7 +9,10 @@ class BrandingTest extends FlatSpec with Matchers {
     val branding = Branding(
       sponsorshipType = Foundation,
       sponsorName = "Bill and Melinda Gates Foundation",
-      sponsorLogo = "https://static.theguardian.com/commercial/sponsor/world/series/united-nations-70-years/logo.png",
+      sponsorLogo = Logo(
+        "https://static.theguardian.com/commercial/sponsor/world/series/united-nations-70-years/logo.png",
+        None
+      ),
       sponsorLink = "http://www.theguardian.com/global-development",
       aboutThisLink = "/sponsored-content",
       targeting = None,

--- a/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
@@ -3,14 +3,13 @@ package views.support.commercial
 import common.commercial._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import play.api.test.FakeRequest
-import views.support.SponsorDataAttributes
 
 class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   private def mkBranding(sponsorName: String) = Branding(
     sponsorshipType = Sponsored,
     sponsorName,
-    sponsorLogo = "",
+    sponsorLogo = Logo("", None),
     sponsorLink = "",
     aboutThisLink = "",
     targeting = None,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
   val faciaVersion = "2.0.2"
-  val capiModelsVersion = "9.21"
+  val capiModelsVersion = "9.24"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"


### PR DESCRIPTION
This change adds width and height parameters to amp-img element for branded logos.
