### PR TITLE
Promote comments with a sticky banner

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -363,7 +363,7 @@ class GuardianConfiguration extends Logging {
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
-    lazy val frontendAssetsVersion = "v1.2.0"
+    lazy val frontendAssetsVersion = "v1.3.0"
   }
 
   object witness {

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,7 +22,17 @@ trait ABTestSwitches {
     "Standalone frontend discussion",
     owners = Seq(Owner.withGithub("piuccio")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 9, 30),
+    sellByDate = new LocalDate(2016, 11, 3),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-discussion-promote-comments",
+    "Promote the comments with a sticky bottom banner",
+    owners = Seq(Owner.withGithub("piuccio")),
+    safeState = On,
+    sellByDate = new LocalDate(2016, 10, 12),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -29,6 +29,13 @@ define([
             //     json: fetchJson
             // };
 
+            // Show the sticky banner only if we are in the AB test and other banners are not visible
+            var noOtherBanners = !otherBannersVisible();
+            opts.featureStickyBanner = ab.isInVariant('DiscussionPromoteComments', 'bottom-banner') && noOtherBanners;
+            opts.featureTopBanner = ab.isInVariant('DiscussionPromoteComments', 'top-banner') && noOtherBanners;
+            opts.featureStickyBadge = ab.isInVariant('DiscussionPromoteComments', 'bubble') && noOtherBanners;
+            opts.featureStickyBannerDismissable = true;
+
             frontend(opts)
             .then(function (emitter) {
                 emitter.on('error', function (feature, error) {
@@ -47,6 +54,20 @@ define([
         }, function (error) {
             reportError(error, { feature: 'discussion' });
         });
+    }
+
+    function otherBannersVisible () {
+        var siteMessage = document.getElementsByClassName('js-site-message');
+        if (siteMessage.length && !siteMessage[0].classList.contains('is-hidden')) {
+            // Contribution banner is visible
+            return true;
+        }
+        var breakingNews = document.getElementsByClassName('js-breaking-news-placeholder');
+        if (breakingNews.length && !breakingNews[0].classList.contains('breaking-news--hidden')) {
+            // Breaking news alert is visible
+            return true;
+        }
+        return false;
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -102,8 +102,8 @@ Loader.prototype.initMainComments = function() {
 
     this.comments.on('untruncate-thread', this.removeTruncation.bind(this));
 
-    this.on('click,', '.js-discussion-author-link, .js-discussion-change-page', this.removeTruncation.bind(this));
-    this.on('click', '.js-discussion-show-button, .d-show-more-replies__button', function () {
+    this.on('click,', '.js-discussion-author-link', this.removeTruncation.bind(this));
+    this.on('click', '.js-discussion-change-page, .js-discussion-show-button, .d-show-more-replies__button', function () {
         mediator.emit('discussion:comments:get-more-replies');
         self.removeTruncation();
     });

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -8,6 +8,7 @@ define([
     'lodash/functions/memoize',
     'lodash/utilities/noop',
     'common/modules/experiments/tests/discussion-external-frontend',
+    'common/modules/experiments/tests/discussion-promote-bottom-banner',
     'common/modules/experiments/tests/live-blog-chrome-notifications-prod',
     'common/modules/experiments/tests/hosted-article-onward-journey',
     'common/modules/experiments/tests/hosted-gallery-cta',
@@ -27,6 +28,7 @@ define([
     memoize,
     noop,
     DiscussionExternalFrontend,
+    DiscussionPromoteBottomBanner,
     LiveBlogChromeNotificationsProd,
     HostedArticleOnwardJourney,
     HostedGalleryCallToAction,
@@ -40,6 +42,7 @@ define([
 
     var TESTS = [
         new DiscussionExternalFrontend(),
+        new DiscussionPromoteBottomBanner(),
         new AdBlockingResponse(),
         new LiveBlogChromeNotificationsProd(),
         new HostedArticleOnwardJourney(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/discussion-promote-bottom-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/discussion-promote-bottom-banner.js
@@ -1,0 +1,73 @@
+define([
+    'common/utils/config',
+    'common/utils/detect',
+    'common/utils/mediator'
+], function (
+    config,
+    detect,
+    mediator
+) {
+    return function () {
+
+        this.id = 'DiscussionPromoteComments';
+        this.start = '2016-09-23';
+        this.expiry = '2016-10-12';
+        this.author = 'Fabio Crisci';
+        this.description = 'Test different ways to promote comments';
+        this.audience = 0.1;
+        this.audienceOffset = 0.35;
+        this.successMeasure = 'Users interact more with comments';
+        this.showForSensitive = true;
+        this.audienceCriteria = 'Modern browsers, mobile only on articles and live blogs';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            var type = config.page.contentType;
+            return 'fetch' in window && 'Promise' in window &&
+                window.curlConfig.paths['discussion-frontend-react'] &&
+                window.curlConfig.paths['discussion-frontend-preact'] &&
+                (type === 'Article' || type === 'LiveBlog') &&
+                detect.isBreakpoint({ max: 'tablet' });
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }.bind(this)
+            },
+            {
+                id: 'bottom-banner',
+                test: function () {},
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }.bind(this)
+            },
+            {
+                id: 'top-banner',
+                test: function () {},
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }.bind(this)
+            },
+            {
+                id: 'bubble',
+                test: function () {},
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('discussion:comments:get-more-replies', complete);
+                    }
+                }.bind(this)
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

Add a new AB test to measure the effect of a sticky banner prompting to join the discussion in the comments.

I'm trying not to be too annoying, so the banner is only visible while the main content is in view. (it doesn't appear immediately on page load and goes away when you scroll to related content, outbrain, comments, footer and so on).

Slightly contrary to what I just said, the banner is not dismissable, it comes in and goes away at its own will. Clicking on it takes you down to the comments without expanding it.

The related PR on discussion frontend is guardian/discussion-frontend#10
## What is the value of this and can you measure success?

People should interact more with comments (go to next page, toggle more comments, change sort order, stuff like that). We don't care much about posting (at least in this test).
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![out](https://cloud.githubusercontent.com/assets/680284/18708303/2548d968-7ff2-11e6-9d2f-f4620cf00d9e.gif)
