### PR TITLE
New header design pedantry

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -1,3 +1,10 @@
+// Specific values for menu button breakpoints
+$veggie-burger-small: 42px;
+$veggie-burger-medium: 52px;
+$gutter-small: 29px;
+$gutter-medium: 37px;
+$gutter-large: 55px;
+
 $mobile-medium: 375px; // Breakpoint for our most common device sizes
 
 .new-header__inner {
@@ -42,10 +49,9 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 
 .new-header__nav {
     @include fs-textSans(5);
-    line-height: 1.6;
+    line-height: $gs-baseline * 2.5;
     width: 100%;
-    padding-left: 10px;
-    // Position after pseudo element which forces line break
+    margin-left: $gs-gutter / 2;
 
     @include mq($until: mobile) {
         font-size: 16px;
@@ -55,22 +61,20 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         font-size: 5.2vw;
     }
 
+    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+        line-height: $gs-baseline * 3;
+    }
+
     @include mq(mobileLandscape) {
         font-size: 24px;
+        line-height: $gs-baseline * 3.5;
+        margin-left: $gs-gutter;
     }
 }
-
-// Specific values for menu button breakpoints
-$veggie-burger-small: 42px;
-$veggie-burger-medium: 52px;
-$gutter-small: 29px;
-$gutter-medium: 37px;
-$gutter-large: 55px;
 
 .new-header__nav__menu-button {
     // Override button from user agent stylesheet
     position: absolute;
-    right: 0px;
     // Unset button from user agent stylesheet
     border: 0;
     outline: none;
@@ -79,6 +83,7 @@ $gutter-large: 55px;
     z-index: 1071;
     background-color: $news-main-2;
     cursor: pointer;
+    bottom: -$gs-baseline / 2;
 
     &--open:before {
         // Extended hit area for veggie burger close state, for fat fingers
@@ -90,10 +95,8 @@ $gutter-large: 55px;
         //Smaller menu button
         height: $veggie-burger-small;
         min-width: $veggie-burger-small;
-        margin-top: -$gs-baseline / 1.5;
-        margin-bottom: -$gs-baseline / 2;
         //Align with the 'i' in 'theguardian'
-        margin-right: $gutter-small;
+        right: $gutter-small;
 
         &--open:before {
             height: $veggie-burger-small * 2;
@@ -107,10 +110,8 @@ $gutter-large: 55px;
     @include mq($mobile-medium) {
         height: $veggie-burger-medium;
         width: $veggie-burger-medium;
-        margin-top: -$gs-baseline / 1.5;
-        margin-bottom: -$gs-baseline / 2;
         //Align with the 'i' in 'theguardian'
-        margin-right: $gutter-medium;
+        right: $gutter-medium;
 
         &--open:before {
             height: $veggie-burger-medium * 2;
@@ -123,7 +124,7 @@ $gutter-large: 55px;
 
     @include mq(mobileLandscape) {
         //Align with the 'i' in 'theguardian'
-        margin-right: $gutter-large;
+        right: $gutter-large;
     }
 }
 
@@ -135,7 +136,6 @@ $gutter-large: 55px;
     right: 0;
     margin-left: auto;
     margin-right: auto;
-    cursor: pointer;
 
     &,
     &:before,
@@ -188,7 +188,7 @@ $gutter-large: 55px;
     white-space: nowrap;
     position: relative;
 
-    &:first-child .new-header__nav__link {
+    &:first-child {
         padding-left: 0;
     }
 
@@ -267,7 +267,7 @@ $gutter-large: 55px;
         width: 0;
         height: 0;
         border-style: solid;
-        border-width: 0 10px 10px;
+        border-width: 0 $gs-gutter / 2 $gs-gutter / 2;
         border-color: transparent transparent $guardian-brand-dark;
     }
 }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -310,6 +310,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         & ~ .edition-picker__dropdown {
             display: block;
             background-color: $guardian-brand-dark;
+            box-shadow: 0 0 $gs-baseline * 2.5 0 rgba(0,0,0,0.2);
         }
 
         & ~ .edition-picker__current-edition {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -313,7 +313,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         & ~ .edition-picker__dropdown {
             display: block;
             background-color: $guardian-brand-dark;
-            box-shadow: 0 0 $gs-baseline * 2.5 0 rgba(0,0,0,0.2);
+            box-shadow: 0 0 $gs-baseline * 2.5 0 rgba(0, 0, 0, .2);
         }
 
         & ~ .edition-picker__current-edition {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -55,6 +55,9 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 
     @include mq($until: mobile) {
         font-size: 16px;
+        // Menu squishes gracefully
+        height: $gs-baseline * 2.5;
+        margin-right: $gutter-small + $veggie-burger-small + $gs-gutter / 3;
     }
 
     @include mq($from: mobile, $until: mobileLandscape) {


### PR DESCRIPTION
The new header has gone through some skeletal reconstructive surgery, and in the process had its nose knocked out of joint. Consider this PR the chisel and hammer that get that nose looking good again.

Font size increased previously:
![screen shot 2016-09-21 at 14 24 47](https://cloud.githubusercontent.com/assets/14570016/18712870/403799ce-8008-11e6-9497-38107daf6783.png)

Font size increased now:
![screen shot 2016-09-21 at 14 27 57](https://cloud.githubusercontent.com/assets/14570016/18712874/456e2836-8008-11e6-9987-76883a986c43.png)

Graceful squishing:
![squishy](https://cloud.githubusercontent.com/assets/14570016/18712876/487043de-8008-11e6-9632-1bbc1f8a2002.gif)

Got it all nice and pixel perfect.

CC @stephanfowler @SiAdcock @NataliaLKB 🌵 
