### PR TITLE
Only enhance menu checkboxes if menus not open

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -65,12 +65,11 @@ define([
     }
 
     function enhanceCheckboxesToButtons() {
-        var checkboxes = [
-            qwery('#main-menu-toggle')[0],
-            qwery('#edition-picker')[0]
-        ];
+        var checkboxIds = ['main-menu-toggle', 'edition-picker'];
 
-        checkboxes.forEach(function (checkbox) {
+        checkboxIds.forEach(function (checkboxId) {
+            var checkbox = document.getElementById(checkboxId);
+
             if (!checkbox) {
                 return;
             }
@@ -87,7 +86,7 @@ define([
 
     function veggieBurgerClickHandler(event) {
         var button = event.target;
-        var mainMenu = qwery('#main-menu')[0];
+        var mainMenu = document.getElementById('main-menu');
         var veggieBurgerLink = qwery('.js-change-link')[0];
 
         function menuIsOpen() {
@@ -162,7 +161,7 @@ define([
             primaryItem.addEventListener('click', function () {
                 fastdom.read(function () {
                     var id = primaryItem.getAttribute('aria-controls');
-                    var menuToOpen = qwery('#' + id)[0];
+                    var menuToOpen = document.getElementById(id);
                     var menuButton = qwery('.js-navigation-button', menuToOpen)[0];
 
                     fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -3,10 +3,12 @@ define([
     'fastdom',
     'common/modules/navigation/edition-picker',
     'common/modules/navigation/editionalise-menu'
-], function (qwery,
-             fastdom,
-             editionPicker,
-             editionaliseMenu) {
+], function (
+    qwery,
+    fastdom,
+    editionPicker,
+    editionaliseMenu
+) {
     var html = qwery('html')[0];
     var menuItems = qwery('.js-close-nav-list');
     var buttonClickHandlers = {
@@ -15,8 +17,8 @@ define([
     };
     var enhanced = {};
 
-    function weShouldEnhance(toggle) {
-        return !enhanced[toggle.id] && toggle && !toggle.checked;
+    function weShouldEnhance(checkbox) {
+        return !enhanced[checkbox.id] && checkbox && !checkbox.checked;
     }
 
 
@@ -63,21 +65,21 @@ define([
     }
 
     function enhanceCheckboxesToButtons() {
-        var toggles = [
+        var checkboxes = [
             qwery('#main-menu-toggle')[0],
             qwery('#edition-picker')[0]
         ];
 
-        toggles.forEach(function (toggle) {
-            if (!toggle) {
+        checkboxes.forEach(function (checkbox) {
+            if (!checkbox) {
                 return;
             }
-            if (weShouldEnhance(toggle)) {
-                applyEnhancementsTo(toggle);
+            if (weShouldEnhance(checkbox)) {
+                applyEnhancementsTo(checkbox);
             } else {
-                toggle.addEventListener('click', function closeMenuHandler() {
-                    applyEnhancementsTo(toggle);
-                    toggle.removeEventListener('click', closeMenuHandler);
+                checkbox.addEventListener('click', function closeMenuHandler() {
+                    applyEnhancementsTo(checkbox);
+                    checkbox.removeEventListener('click', closeMenuHandler);
                 });
             }
         });


### PR DESCRIPTION
## What does this change?

Users can interact with the new header menu before JavaScript has loaded. It uses a CSS solution that tracks the state of a hidden checkbox.

If the user opens the menu before the JavaScript is loaded, then when the JavaScript loads, the checkbox is replaced with a button. As a result, the menu automatically closes itself as soon as the JavaScript loads, which is an annoying experience.

![menu-close-enhancement](https://cloud.githubusercontent.com/assets/5931528/18718724/68c2a960-801c-11e6-8070-9041f8aa454d.gif)

This change ensures the JavaScript enhancements are not applied while the menu is open. The enhancements are applied later, if the user closes the menu.

This functionality is applied to the main menu and the edition picker.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@NataliaLKB @gtrufitt 
