### PR TITLE
Update mobile apps api when changing competitions

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -89,6 +89,9 @@ object Competitions {
     val competitions = comps
   }
 }
+ 
+// when updating this code, think about whether the mobile apps api needs to be updated too 
+// (https://github.com/guardian/mobile-apps-api/blob/master/mobile-football/app/data/pa/Competitions.scala)
 
 object CompetitionsProvider {
   val allCompetitions: Seq[Competition] = Seq(


### PR DESCRIPTION
## What does this change?

When changes to competitions are required in frontend they are always required in mobile apps api too.  The change will be really similar - e.g. https://github.com/guardian/frontend/pull/14093 vs https://github.com/guardian/mobile-apps-api/pull/828.  This PR just adds a comment pointing this out.
## What is the value of this and can you measure success?

Mobile football won't be updated 30 days after frontend, two developers won't have to make the same trivial change.  @rcrphillips will smile.
## Does this affect other platforms - Amp, Apps, etc?

YES.  I've added the same note to mobile apps repo

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

@gtrufitt

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
