### PR TITLE
Extend AB test switch while we prepare the next iteration

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Prominent adblocker response test",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 22),   // Thursday @ 23:59 BST
+    sellByDate = new LocalDate(2016, 9, 29),   // Thursday @ 23:59 BST
     exposeClientSide = true
   )
 
@@ -95,7 +95,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 10, 3),
     exposeClientSide = true
   )
-  
+
   Switch(
     ABTests,
     "ab-video-button-duration",


### PR DESCRIPTION
## What does this change?

Extends the adblock test master switch for another week. The test itself expires tonight but rather than remove all the code only to re-add it again almost immediately for the next iteration, we'll let the switch live on until we replace it with its v3 incarnation. 
## What is the value of this and can you measure success?

Builds won't break.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

N/A
## Request for comment

@TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
