### PR TITLE
Don't let imgix auto-choose format for email images

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -17,6 +17,7 @@ sealed trait ElementProfile {
   def hidpi: Boolean
   def compression: Int
   def isPng: Boolean
+  def autoFormat: Boolean
 
   def elementFor(image: ImageMedia): Option[ImageAsset] = {
     val sortedCrops = image.imageCrops.sortBy(-_.width)
@@ -38,7 +39,7 @@ sealed trait ElementProfile {
 
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
   val qualityparam = if (hidpi) {"q=20"} else {"q=55"}
-  val autoParam = "auto=format"
+  val autoParam = if (autoFormat) "auto=format" else ""
   val sharpParam = "usm=12"
   val fitParam = "fit=max"
   val dprParam = if (hidpi) {
@@ -66,7 +67,8 @@ case class Profile(
   override val height: Option[Int] = None,
   override val hidpi: Boolean = false,
   override val compression: Int = 95,
-  override val isPng: Boolean = false) extends ElementProfile
+  override val isPng: Boolean = false,
+  override val autoFormat: Boolean = true) extends ElementProfile
 
 object VideoProfile {
   lazy val ratioHD = new Fraction(16,9)
@@ -77,7 +79,8 @@ case class VideoProfile(
   override val height: Some[Int],
   override val hidpi: Boolean = false,
   override val compression: Int = 95,
-  override val isPng: Boolean = false) extends ElementProfile {
+  override val isPng: Boolean = false,
+  override val autoFormat: Boolean = true) extends ElementProfile {
 
   lazy val isRatioHD: Boolean = Precision.compareTo(VideoProfile.ratioHD.doubleValue, aspectRatio.doubleValue, 0.1d) == 0
 
@@ -122,7 +125,7 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
   override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
 }
 
-object EmailImage extends Profile(width = Some(640))
+object EmailImage extends Profile(width = Some(640), autoFormat = false)
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))


### PR DESCRIPTION
Outlook wasn't displaying main image in articles like [this one](https://www.theguardian.com/media/2016/sep/02/itv-news-daily-mail-eamonn-holmes/email) because of imgix's automatic content negotiation. We were passing `auto=format` as a parameter to imgix, which according to [imgix's documentation](https://docs.imgix.com/tutorials/improved-compression-auto-content-negotiation) does the following:

> Behind the scenes, these are the steps we take during content negotiation:
> 1. Check if your browser supports WebP. If it does, we serve back a WebP image and return. 
> 2. Check if your browser supports JPEG XR. If it does, we serve back a JPEG XR image and return.
> 3. Check if the request has a fallback format. If it does, we serve back the image in the fallback format.
> 4. If we hit this point, serve back the image in its original format. 

When Outlook requests images for emails it sends the following User Agent string:

`User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; Microsoft Outlook 16.0.7167; ms-office; MSOffice 16)`

This causes imgix to return [JPEG XR](https://en.wikipedia.org/wiki/JPEG_XR) format with content-type `image/vnd.ms-photo`, which is [Microsoft-specific](http://caniuse.com/#feat=jpegxr). Ironically, Outlook can't render it!

So for email images, we now omit `auto=format` which means the image is always returned as a JPEG, which Outlook can render.

@desbo 
