### PR TITLE
Remove dimensions from logos

### DIFF
--- a/common/app/views/fragments/commercial/contentLogo.scala.html
+++ b/common/app/views/fragments/commercial/contentLogo.scala.html
@@ -18,10 +18,6 @@
                 }
             } else {
                 <img src="@branding.sponsorLogo.url"
-                    @for(dim <- branding.sponsorLogo.dimensions) {
-                        width="@dim.width"
-                        height="@dim.height"
-                    }
                     alt="@{branding.sponsorName}'s logo"
                     class="brandbadge__logo">
             }


### PR DESCRIPTION
They get used in different sizes on the site depending on context.

/cc @Calanthe 
