### PR TITLE
Radiator refresh

### DIFF
--- a/admin/app/controllers/DeploysNotifyController.scala
+++ b/admin/app/controllers/DeploysNotifyController.scala
@@ -62,11 +62,8 @@ trait DeploysNotifyController extends Controller with ApiKeyAuthenticationSuppor
   //
 
   def notifyStep(number: String) = ApiKeyAuthenticatedAction.async(BodyJson[NotifyRequestBody]) { implicit request =>
-    teamcity.getTeamCityBuild(number).flatMap { teamcityBuild =>
-      val notices = for {
-        build <- teamcityBuild.right
-        ns <- allNotices(build, request).right
-      } yield ns
+    teamcity.getBuild(number).flatMap { build =>
+      val notices = allNotices(build, request)
       notices match {
         case Right(ns) => notifyAll(request.body.step, ns).map(ApiResults(_))
         case Left(errors) => Future.successful(ApiResults(notices))

--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -37,13 +37,13 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
     val apiKey = Configuration.riffraff.apiKey
 
     for {
-      user50x <- CloudWatch.user50x
+      router50x <- CloudWatch.routerBackend50x
       latencyGraphs <- CloudWatch.shortStackLatency
       fastlyErrors <- CloudWatch.fastlyErrors
       fastlyHitMiss <- CloudWatch.fastlyHitMissStatistics
       cost <- CloudWatch.cost
     } yield {
-      val errorGraphs = Seq(user50x)
+      val errorGraphs = Seq(router50x)
       val fastlyGraphs = fastlyErrors ++ fastlyHitMiss
       NoCache(Ok(views.html.radiator(
         errorGraphs, latencyGraphs, fastlyGraphs, cost, switchesExpiringSoon,

--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -10,6 +10,8 @@ import play.api.libs.json.Json
 import conf.Configuration
 import model.NoCache
 import conf.switches.{Switch, Switches}
+import model.deploys.{HttpClient, TeamCityBuild, TeamcityService}
+import scala.concurrent.Future
 
 class RadiatorController(wsClient: WSClient) extends Controller with Logging with Requests{
 
@@ -19,6 +21,7 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
   // but realise it is a PERSONAL token setup against YOUR github account
   // put it in your properties file as github.token=XXXXXXX
   lazy val githubAccessToken = Configuration.github.token.map{ token => s"?access_token=$token" }.getOrElse("")
+  lazy val teamcityService = new TeamcityService(new HttpClient(wsClient))
 
   def switchesExpiringSoon = {
     Switches.all.filter(Switch.expiry(_).hasExpired) ++ // already expired
@@ -36,7 +39,16 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
   def renderRadiator() = Action.async { implicit request =>
     val apiKey = Configuration.riffraff.apiKey
 
+    def mostRecentBuildForProjects(projects: String*): Future[Seq[TeamCityBuild]] = {
+      Future.sequence(projects.map { project =>
+        teamcityService
+          .getBuilds(project, 1)
+          .map(_.head)
+      })
+    }
+
     for {
+      ciBuilds <- mostRecentBuildForProjects("dotcom_master", "dotcom_ampValidation")
       router50x <- CloudWatch.routerBackend50x
       latencyGraphs <- CloudWatch.shortStackLatency
       fastlyErrors <- CloudWatch.fastlyErrors
@@ -46,7 +58,7 @@ class RadiatorController(wsClient: WSClient) extends Controller with Logging wit
       val errorGraphs = Seq(router50x)
       val fastlyGraphs = fastlyErrors ++ fastlyHitMiss
       NoCache(Ok(views.html.radiator(
-        errorGraphs, latencyGraphs, fastlyGraphs, cost, switchesExpiringSoon,
+        ciBuilds, errorGraphs, latencyGraphs, fastlyGraphs, cost, switchesExpiringSoon,
         Configuration.environment.stage, apiKey
       )))
     }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -54,7 +54,7 @@
             @switches.map{ switch =>
                 @Switch.expiry(switch).daysToExpiry.map { days =>
                     <li title="@switch.name - expires in @days days">
-                        <span class="expiry-days-@days">@switch.name</span> - <span>@showOwners(switch)</span>
+                        <span class="@if(days < 0) { expired } else { expiry-days-@days }">@switch.name</span> - <span>@showOwners(switch)</span>
                     </li>
                 }
             }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -33,11 +33,6 @@
         <div class="cost"><a href="https://console.aws.amazon.com/billing/home"><strong>$@cost.max.toLong</strong> this month</a></div>
     </header>
 
-    <div class="pingdom-wrapper">
-        <h2>Pingdom <small>(external monitoring of our host names)</small></h2>
-        <ul id="pingdom"></ul>
-    </div>
-
     <div class="build-wrapper">
         <h2>Teamcity builds</h2>
         @*
@@ -62,10 +57,19 @@
             }
         </ul>
     </div>
+
     <br clear="all"/>
-    <div class="pageviews-wrapper">
-        <h2>Pageviews <span class="pageviews-per-second"></span></h2>
-        <div id="pageviews"></div>
+    <div>
+        <h2>Pageviews <span class="pageviews-per-second"></span> / Errors</h2>
+        <div id="pageviews" class="chart"></div>
+        @errorCharts.map{ chart => @fragments.lineChart(chart) }
+    </div>
+
+    <br clear="all"/>
+
+    <div class="pingdom-wrapper">
+        <h2>Pingdom <small>(external monitoring of our host names)</small></h2>
+        <ul id="pingdom"></ul>
     </div>
 
     <div class="monitoring-wrapper">
@@ -82,15 +86,16 @@
             <ul class="riffraff" id="riffraffPROD"></ul>
             <ul class="deployers" id="deployersPROD"></ul>
         </div>
+        <a href="/deploys-radiator"> Go to Deploys-Radiator</a>
     </div>
 
-    @graph_group("Errors", errorCharts)
     @graph_group("Latencies", latencyCharts)
+    <a href="/metrics/loadbalancers"> More Latencies</a>
+
     @graph_group("Fastly", fastlyCharts)
 }
 
 @graph_group(title: String, graphs: Seq[tools.AwsLineChart]) = {
-    <br clear="all"/>
     <div>
         <h2>@title</h2>
         @graphs.map{ chart => @fragments.lineChart(chart) }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -1,5 +1,6 @@
 @import conf.switches.Switch
-@(  errorCharts: Seq[tools.AwsLineChart],
+@(  ciBuilds: Seq[model.deploys.TeamCityBuild],
+    errorCharts: Seq[tools.AwsLineChart],
     latencyCharts: Seq[tools.AwsLineChart],
     fastlyCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
@@ -33,14 +34,16 @@
         <div class="cost"><a href="https://console.aws.amazon.com/billing/home"><strong>$@cost.max.toLong</strong> this month</a></div>
     </header>
 
-    <div class="build-wrapper">
+    <div id="build-wrapper">
         <h2>Teamcity builds</h2>
-        @*
-        To add another build just append another &buildTypeId=XXXXXX
-        Note, it will not show unless you enable the "External status widget" for the build in Teamcity
-            for some reason the &js=1 hangs waiting for a http resp so just using the iframe version for now
-        *@
-        <iframe src="https://teamcity.gu-web.net/externalStatus.html?buildTypeId=dotcom_master"></iframe>
+        <ul>
+        @ciBuilds.map { build =>
+            <li>
+                <a class="@if(build.isSuccess) { succeeded } else { failed }"
+                href="@conf.Configuration.teamcity.host/viewLog.html?buildId=@build.id&buildTypeId=@build.projectName">@build.projectName (@build.number)</a>
+            </li>
+        }
+        </ul>
     </div>
 
 

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -168,21 +168,28 @@ a {
     }
 }
 
-/* Teamcity widget */
-.build-wrapper {
+/* Teamcity */
+#build-wrapper {
     float: left;
     width: 50%;
 }
 
-/*(we do not have control over these class names) */
-.buildNumberDate, .buildResults, .tcTD_projectName {
-    display: none;
+#build-wrapper ul {
+    padding: 0;
+    list-style-type: none;
 }
 
-.tcTable, .tcTable tr {
-    display: inline-block;
+#build-wrapper a {
+    display:inline-block;
+    padding: 10px;
+    margin: 2px 0 2px 0;
 }
 
-.buildTypeIcon {
-   width: 32px;
+#build-wrapper .succeeded {
+    background-color: #B8FAA0;
+}
+
+#build-wrapper .failed {
+    background-color: red;
+    color: white;
 }


### PR DESCRIPTION
## What does this change?

Slightly modify the radiator page:
- Move pingdom and deployments down
- Show router 50x rather than user facing 50x errors
- Ditch Teamcity widget and replace it with request to TC api and a simple html list. Also, adding the AmpValidation project build status
- Add links to deploys-radiator and loadbalancers dashboards
## What is the value of this and can you measure success?

Better readibility of Teamcity build statuses.
Focus on the most important things: build status, switch status, pageviews and errors
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots

![screen shot 2016-09-23 at 11 30 20](https://cloud.githubusercontent.com/assets/233326/18783118/fc40c8aa-8181-11e6-81fe-069a54e7fe3c.png)
## Request for comment

@gtrufitt @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
