### PR TITLE
Add AMP data-loading-strategy attribute, "prefer-viewability-over-views"

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -14,9 +14,9 @@
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
         @if(blockGroup.length == 5 && index < 8) {
             <div @if(LiveUpdateAmpSwitch.isSwitchedOn) { id="amp-ad-@index" data-sort-time="1" } class="block amp-ad-container amp-ad-container--live-blog">
-                <amp-ad width="300" height="250" type="doubleclick"
-                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
-                data-slot=@AmpAdDataSlot(article).toString()>
+                <amp-ad width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
+                    json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
+                    data-slot=@AmpAdDataSlot(article).toString()>
                 </amp-ad>
             </div>
         }

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -88,7 +88,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
 
   def adAfter(element: Element) = {
     val ampAd = <div class="amp-ad-container">
-          <amp-ad width="300" height="250" type="doubleclick"
+          <amp-ad width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
                   json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
                   data-slot={AmpAdDataSlot(article).toString()}>
           </amp-ad>


### PR DESCRIPTION
This adds an additional attribute to `amp-ad` tags on AMP pages. The data loading strategy affects how the amp platform loads adverts. More info [here](https://www.ampproject.org/docs/reference/extended/amp-ad.html).

Note, we expect viewability to increase, but as the docs state, we understand that ads may load so late they fail to generate a view (impression). Stephan says this is like moving from lazy-load to lazy-lazy-load.
