### PR TITLE
Radiator: Fix missing charts css class

### DIFF
--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -64,7 +64,7 @@
     <br clear="all"/>
     <div>
         <h2>Pageviews <span class="pageviews-per-second"></span> / Errors</h2>
-        <div id="pageviews" class="chart"></div>
+        <div id="pageviews" class="chart charts"></div>
         @errorCharts.map{ chart => @fragments.lineChart(chart) }
     </div>
 


### PR DESCRIPTION
## What does this change?

Following up on https://github.com/guardian/frontend/pull/14435
Radiator: I forgot one of the css class which cause this layout issue:
![screen shot 2016-09-23 at 13 19 54](https://cloud.githubusercontent.com/assets/233326/18785507/7a0ab5da-8190-11e6-995c-dc74c12b4fe5.png)
## What is the value of this and can you measure success?

Proper layout where pageviews and errors graphs sit side by side rather than on top of each other
## Request for comment

@NataliaLKB @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
