### PR TITLE
Add Comscore tracking to AMP

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -59,6 +59,10 @@
 
         @fragments.amp.googleAnalytics(content)
 
+        <amp-analytics id="comscore" type="comscore">
+          <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
+        </amp-analytics>
+
         <div class="main-body">
 
             @fragments.amp.header()


### PR DESCRIPTION
## What does this change?

Currently Comscore is piggybacking on Omniture, but that is going away soon.

See the [amp-analytics docs](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md#comscore)
## What is the value of this and can you measure success?

Comscore tracking of AMP pages won't disappear when we switch off Omniture.
## Does this affect other platforms - Amp, Apps, etc?

This has already been done in non-AMP.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

n/a
## Request for comment

@dominickendrick @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
