### PR TITLE
Change doc generator to use bin/bash

### DIFF
--- a/docs/generate-toc.sh
+++ b/docs/generate-toc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cleanDirectoryName() {
     # Remove leading number 


### PR DESCRIPTION
The bash script doesn't work for me on Linux using `#!/bin/sh`, but does with `#!/bin/bash`.

Could someone try it with bash on OSX to see if it stays working there?

@gtrufitt @TBonnin 
