### PR TITLE
Avoid transition on closing ad

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -447,7 +447,7 @@
         position: absolute;
         right: 10px;
         opacity: 0;
-        transition: opacity .2s 3s;
+        transition: none;
 
         > img {
             display: block;
@@ -455,6 +455,7 @@
     }
 
     .slide-video__expand .creative__cta {
+        transition: opacity .2s 3s;
         opacity: 1;
     }
 


### PR DESCRIPTION
This will fix the issue where advert copy is overlaid with the CTA when the Fabric video is getting collapsed.
