### PR TITLE
Update grunt-svgmin

### DIFF
--- a/grunt-configs/svgmin.js
+++ b/grunt-configs/svgmin.js
@@ -6,7 +6,14 @@ module.exports = function () {
                 cwd: 'common/conf/assets/inline-svgs',
                 src: ['**/*.svg'],
                 dest: 'common/conf/assets/inline-svgs'
-            }]
+            }],
+            options: {
+                plugins: [
+                    {
+                        removeXMLNS: true
+                    }
+                ]
+            }
         }
     };
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1767,13 +1767,10 @@
       }
     },
     "grunt-svgmin": {
-      "version": "2.0.1",
+      "version": "4.0.0",
       "dependencies": {
-        "esprima": {
-          "version": "2.2.0"
-        },
-        "js-yaml": {
-          "version": "3.3.1"
+        "csso": {
+          "version": "2.2.1"
         },
         "minimist": {
           "version": "0.0.8"
@@ -1781,11 +1778,11 @@
         "mkdirp": {
           "version": "0.5.1"
         },
-        "sax": {
-          "version": "1.1.6"
+        "pretty-bytes": {
+          "version": "4.0.2"
         },
         "svgo": {
-          "version": "0.5.6"
+          "version": "0.7.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-sass": "1.0.0",
     "grunt-sass-lint": "^0.1.0",
     "grunt-shell": "1.1.1",
-    "grunt-svgmin": "^2.0.0",
+    "grunt-svgmin": "^4.0.0",
     "grunt-text-replace": "0.3.12",
     "grunt-webfontjson": "0.0.4",
     "gulp": "^3.9.0",


### PR DESCRIPTION
## What does this change?

This updates grunt-svgmin to the latest which uses the [latest svgo](https://github.com/svg/svgo/releases/tag/0.7.0)

Also added the `removeXMLNS` option which strips the many accidently left in xmlns attrs from inline-svgs.
## Request for comment

@paperboyo - What was it you were excited about? 
@guardian/dotcom-platform 
