### PR TITLE
New header: fix Android tap highlight position

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -334,6 +334,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     left: 0;
     line-height: 1;
     z-index: $zindex-main-menu;
+    box-shadow: 3px 0 16px rgba(0, 0, 0, .4);
 }
 
 .main-menu-container__overlay {
@@ -353,7 +354,6 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     height: 100%;
     background-color: $guardian-brand;
     color: #ffffff;
-    box-shadow: 3px 0 16px rgba(0, 0, 0, .4);
     font-family: $f-sans-serif-text;
     text-transform: lowercase;
     overflow: auto;


### PR DESCRIPTION
## What does this change?

Previously, when a user tapped an item or link within the new menu, tap highlights on Chrome for Android appeared slightly offset down and to the right. This turned out to be due to the combination of the `box-shadow` and `overflow`. 

I have moved the `box-shadow` from the menu up to the container, preserving the box shadow's visual effect, but preventing the tap highlight from being offset.
## Does this affect other platforms - Amp, Apps, etc?

Nah
## Screenshots
### Before

![android-tap-highlight-before](https://cloud.githubusercontent.com/assets/5931528/18835194/ca256bec-83f1-11e6-801c-e64572036bef.gif)
### After

![android-tap-highlight-after](https://cloud.githubusercontent.com/assets/5931528/18835197/cf7511c4-83f1-11e6-960d-8745e13afec1.gif)
## Request for comment

@NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
