### PR TITLE
Bump frontend configuration version to 5

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 4
+    val s3ConfigVersion = 5
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
The URL of the Jobs feed property is wrong in the current configuration for the DEV environment:

```
jobs.api.url.template="http://jobs.theguardian.com/feeds/GuardianLiveJobsForWebComponents_yyyy-MM-dd_.xml"
```

It should be identical to the PROD-CODE environment, i.e.

```
jobs.api.url = "http://jobs.theguardian.com/feeds/GuardianLiveJobsForWebComponents.xml"
```

... which is what I changed in v5.

cc @johnduffell 
