### PR TITLE
cApi merchandising spacing fixed

### DIFF
--- a/common/app/views/commercial/cards/itemCard.scala.html
+++ b/common/app/views/commercial/cards/itemCard.scala.html
@@ -16,7 +16,7 @@
 <div class="@CssClassBuilder.linkFromStandardCard(item, optAdvertClassNames, optClassNames, useCardBranding)">
     <a href="@item.targetUrl"
        data-link-name="@omnitureId"
-       class="advert advert--branded">
+       class="advert @if(useCardBranding) {advert--branded}">
         <h2 class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
             @item.headline


### PR DESCRIPTION
## What does this change?

Fix for the merchandising items. There should be spacing (additional `advert--branded` class) only when there is badge inside item.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-26 at 14 32 53](https://cloud.githubusercontent.com/assets/489567/18836050/2b420846-83f6-11e6-906b-ee2e1b8e53f0.png)

After:
![screen shot 2016-09-26 at 14 32 58](https://cloud.githubusercontent.com/assets/489567/18836056/3128ab0c-83f6-11e6-96c3-07e47b0cedad.png)
## Request for comment

@lps88 @kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
