### PR TITLE
Remove the annoying and redundant .json suffix from soulmates routes.

### DIFF
--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -18,8 +18,8 @@ GET         /commercial/jobs.json                                         contro
 GET         /commercial/masterclasses.json                                controllers.commercial.MasterclassesController.renderMasterclasses
 
 # Soulmates merchandising components
-GET        /commercial/soulmates/$subgroup<\w+>.json                     controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
-GET        /commercial/soulmates/api/$subgroup<\w+>.json                 controllers.commercial.SoulmatesController.getSoulmates(subgroup)
+GET        /commercial/soulmates/$subgroup<\w+>.json                      controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
+GET        /commercial/soulmates/$subgroup<\w+>                           controllers.commercial.SoulmatesController.getSoulmates(subgroup)
 
 # Book merchandising components
 GET         /commercial/books/book.json                                   controllers.commercial.BookOffersController.renderBook

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -288,6 +288,7 @@ GET            /commercial/travel/api/offers.json                               
 GET            /commercial/jobs.json                                                                                             controllers.commercial.JobsController.renderJobs
 GET            /commercial/masterclasses.json                                                                                    controllers.commercial.MasterclassesController.renderMasterclasses
 GET            /commercial/soulmates/$subgroup<\w+>.json                                                                         controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
+GET            /commercial/soulmates/$subgroup<\w+>                                                                              controllers.commercial.SoulmatesController.getSoulmates(subgroup)
 GET            /commercial/books/book.json                                                                                       controllers.commercial.BookOffersController.renderBook
 GET            /commercial/books/books.json                                                                                      controllers.commercial.BookOffersController.renderBooks
 GET            /commercial/books/api/books.json                                                                                  controllers.commercial.BookOffersController.getBooks


### PR DESCRIPTION
Makes the Native Templates code a bit nicer as we can store the URL in the config file.

@regiskuckaertz 
