### PR TITLE
Added Ophan attributes for new header

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -21,7 +21,7 @@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                         <li class="navigation-group__item">
-                            <a href="@LinkTo { @sectionItem.url }">@sectionItem.name</a>
+                            <a href="@LinkTo { @sectionItem.url }" data-link-name="nav : secondary : @sectionItem.name">@sectionItem.name</a>
                         </li>
                     }
                 </ul>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -21,7 +21,7 @@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                         <li class="navigation-group__item">
-                            <a href="@LinkTo { @sectionItem.url }" data-link-name="nav : secondary : @sectionItem.name">@sectionItem.name</a>
+                            <a href="@LinkTo { @sectionItem.url }" data-link-name="@sectionItem.name">@sectionItem.name</a>
                         </li>
                     }
                 </ul>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -7,6 +7,7 @@
     <label for="main-menu-toggle" class="new-header__nav__link js-open-section-in-menu"
         tabindex="0"
         aria-controls="primary-list-@sectionName"
+        data-link-name="nav : primary : @sectionName"
     >
             @sectionName
     </label>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -23,7 +23,7 @@
 
         @fragments.nav.editionPicker()
 
-        <nav class="new-header__nav">
+        <nav class="new-header__nav" data-component="nav">
             @NewNavigation.topLevelSections.map { section =>
                 @primaryLinks(section.name)
             }

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -7,7 +7,7 @@
     <label for="main-menu-toggle" class="new-header__nav__link js-open-section-in-menu"
         tabindex="0"
         aria-controls="primary-list-@sectionName"
-        data-link-name="nav : primary : @sectionName"
+        data-link-name="@sectionName"
     >
             @sectionName
     </label>
@@ -23,7 +23,7 @@
 
         @fragments.nav.editionPicker()
 
-        <nav class="new-header__nav" data-component="nav">
+        <nav class="new-header__nav" data-component="main-navigation">
             @NewNavigation.topLevelSections.map { section =>
                 @primaryLinks(section.name)
             }


### PR DESCRIPTION
## What does this change?

Identifies the `nav` component and link names in the new header navigation.
## What is the value of this and can you measure success?

This will allow us to identify in Ophan whether and how users are using the new menu.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@NataliaLKB 
