### PR TITLE
give ContributionsStory it's correct name in ab-test-clash.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -13,7 +13,7 @@ define([
     function _testABClash(f) {
 
         var contributionsEpic = {name: 'ContributionsEpic20160916', variants: ['control', 'give', 'today', 'make']};
-        var contributionsStory = {name: 'ContributionsStory20160922', variants: ['control', 'story']};
+        var contributionsStory = {name: 'ContributionsStory', variants: ['control', 'story']};
         var clashingTests = [contributionsEpic, contributionsStory];
 
         return some(clashingTests, function (test) {


### PR DESCRIPTION
## What does this change?

Fixes a bug whereby ContributionsStory was incorrectly named in ab-test-clash.js. The result of this bug is that we may not be compliant with OutBrain
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
