### PR TITLE
Docs: Initial documentation for current JS architecture

### DIFF
--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -16,7 +16,7 @@ And then specific Javascript bootstraps used on different pages and required int
 
 See below for quick descriptions.
 
-- [main.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html)
+- [- main.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html)
 	- [head.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/head.scala.html)
 		- [inlineJsBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSBlocking.scala.html) - Scripts required to render the page correctly on first paint.
 			- Polyfills for json2, es5-html5, RAF, classlist
@@ -53,7 +53,7 @@ There are ways to force enhancement, so take a look at the JS, but something of 
 
 #### pageConfig
 
-If you put `guardian.config` in your console, you will see the JS config containing information about analytics, modules, switches, tests and the page. This config object is initally populated serverside and topped-up client side (ie: information about the user is only available client-side)
+If you put `guardian.config` in your console, you will see the JS config containing information about analytics, modules, switches, tests and the page. This config object is initially populated serverside and topped-up client side (i.e.: information about the user is only available client-side)
 
 The initial config structure is defined in [config.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/config.scala.js) and [javaScriptConfig.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/javaScriptConfig.scala.js). 
 
@@ -122,7 +122,7 @@ Gets the [Ophan browserId](https://github.com/guardian/frontend/blob/master/comm
 
 In javascripts/bootstraps we define all the entry points for each bundle described in [requirejs.js](). 
 
-The top level entry points which call the bootstrap initalisation of all other bundles are [enhanced/main.js](), [standard/main.js](), [admin.js]() (for frontend.gutools, not theguardian.com), [commercial.js]() and [video-embed.js]() (initalised when there is a video embed from [videoEmbed.scala.html]()).
+The top level entry points which call the bootstrap initialisation of all other bundles are [enhanced/main.js](), [standard/main.js](), [admin.js]() (for frontend.gutools, not theguardian.com), [commercial.js]() and [video-embed.js]() (initialised when there is a video embed from [videoEmbed.scala.html]()).
 
 ### app.js
 
@@ -175,7 +175,7 @@ The [standard main.js](https://github.com/guardian/frontend/blob/master/static/s
 
 - Sets-up error handling
 - Bootstraps interactives immediately as they're content
-- Initalises A/B tests (so be **very** careful about what you require into AB tests as they're bundled with the standard JS)
+- Initialises A/B tests (so be **very** careful about what you require into AB tests as they're bundled with the standard JS)
 - Upgrades images
 - Adds some event listeners for use elsewhere in the app (throttled scroll)
 - Initialises membership and identity
@@ -217,7 +217,7 @@ The commercial JS is it's own bundle and is executed immediately after the stand
 
 The main entry point for enhanced JS is in [bootstraps/enhanced/main.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/enhanced/main.js)
 
-Here we initalise the rest of our Javascript application, requiring the bundles expected by the current page.
+Here we initialise the rest of our Javascript application, requiring the bundles expected by the current page.
 
 For example, we use the page config property of `isFront` to load `facia.js`:
 
@@ -240,7 +240,7 @@ if ((config.isMedia || qwery('video, audio').length) && !config.isHosted) {
 }
 ```
 
-Each bundle is created via the [requirejs config](https://github.com/guardian/frontend/blob/master/grunt-configs/requirejs.js), eg:
+Each bundle is created via the [requirejs config](https://github.com/guardian/frontend/blob/master/grunt-configs/requirejs.js), e.g.:
 
 ```js
 facia: {
@@ -274,8 +274,8 @@ There are five projects in the Javascript architecture:
 - Admin - This is the Javascript for the admin tools at frontend.gutools (not guardian.com related)
 - Commercial - The modules and js views for the commercial Javascript
 - Common - The largest of the projects, common contains the modules, utilities and js views for much of the application. 
-	- In modules you will find the Javascript for everything from articles to crosswords, identitity to sport.
-	- Utils contains the reusable utilities we use across the site for dom querying, fastdom promises, array methods, fetch, inlineSvg, event listeners, localStorage methods etc. Take some to familairise yourself with these methods as you will likely end up finding what you need here.
+	- In modules you will find the Javascript for everything from articles to crosswords, identity to sport.
+	- Utils contains the reusable utilities we use across the site for dom querying, fastdom promises, array methods, fetch, inlineSvg, event listeners, localStorage methods etc. Take some to familiarise yourself with these methods as you will likely end up finding what you need here.
 	- The Javascript views for the JS loaded content including a/b test experiments, breaking news, share buttons etc.
 - Facia - Contains JS modules and views for the weather, snaps and fronts containers
 - Membership - Contains the formatters, payment and stripe javascripts

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -36,6 +36,7 @@ See below for quick descriptions.
 			- getUserData.js
 			- detectAdblock 
 			- showUserName
+			- editionaliseMenu
 			- ophanConfig
 		- [Analytics](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/base.scala.html)
 			- Google
@@ -131,6 +132,10 @@ Secrets.
 #### showUserName
 
 [Puts the user's username](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js) into the header (increases perceived rendering speed as their username is there before the app.js has to download and parse).
+
+#### editionaliseMenu
+
+The [editonaliseMenu JS](https://github.com/guardian/frontend/blob/d4bc1349f981cdc8f2508b3f0df61b00420ca219/common/app/templates/inlineJS/nonBlocking/editionaliseMenu.scala.js) updates the menu to show and hide the sub-menus in the current edition.
 
 #### Ophan config
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -60,7 +60,20 @@ There are ways to force enhancement, so take a look at the JS, but something of 
 
 If you put `guardian.config` in your console, you will see the JS config containing information about analytics, modules, switches, tests and the page. This config object is initially populated serverside and topped-up client side (i.e.: information about the user is only available client-side)
 
-The initial config structure is defined in [config.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/config.scala.js) and [javaScriptConfig.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/javaScriptConfig.scala.js). 
+The initial config structure is defined in [config.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/config.scala.js) and [javaScriptConfig.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/javaScriptConfig.scala.js).
+
+In [config.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/config.scala.js) we also set the `isModernBrowser` flag which is our 'cuts the mustard test' comprising of:
+
+```
+ 	"querySelector" in document
+    && "addEventListener" in window
+    && "localStorage" in window
+    && "sessionStorage" in window
+    && "bind" in Function
+    && (("XMLHttpRequest" in window && "withCredentials" in new XMLHttpRequest())|| "XDomainRequest" in window)
+```
+
+The commercial JS will only run if `isModernBrowser` is true.
 
 You'll most likely be using the page config the most often which is defined in [JavascriptPage.scala](https://github.com/guardian/frontend/blob/master/common/app/views/support/JavaScriptPage.scala). Be aware that the metadata for a particular page may be [overridden with MetaData.make](https://github.com/guardian/frontend/blob/master/common/app/common/commercial/hosted/HostedGalleryPage.scala#L35).
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -300,7 +300,7 @@ All the enhanced bootstraps are in [bootstraps/enhanced](https://github.com/guar
 
 There are five projects in the Javascript architecture:
 
-- [Admin](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/admin) - This is the Javascript for the admin tools at frontend.gutools (not guardian.com related)
+- [Admin](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/admin) - This is the Javascript for the frontend admin tools gutools (ask your neighbour what these are). It is the only JS file not related to theguardian.com.
 - [Commercial](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/commercial) - The modules and js views for the commercial Javascript
 - [Common](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/common) - The largest of the projects, common contains the modules, utilities and js views for much of the application. 
 	- In modules you will find the Javascript for everything from articles to crosswords, identity to sport.

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -77,7 +77,7 @@ The commercial JS will only run if `isModernBrowser` is true.
 
 You'll most likely be using the page config the most often which is defined in [JavascriptPage.scala](https://github.com/guardian/frontend/blob/master/common/app/views/support/JavaScriptPage.scala). Be aware that the metadata for a particular page may be [overridden with MetaData.make](https://github.com/guardian/frontend/blob/master/common/app/common/commercial/hosted/HostedGalleryPage.scala#L35).
 
-*Note that if you want to use config in a JS module, you shouldn't use the window object, but include it directly in your module via the config.js utility.*
+*Note that if you want to use config in a JS module, you shouldn't use the window object, but include it directly in your module via the [config.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/utils/config.js) utility.*
 
 #### applyRenderConditions
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -54,7 +54,7 @@ Contains the [config](https://github.com/guardian/frontend/blob/master/common/ap
 
 The [shouldEnhance JS](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js) defines whether we should run the enhanced Javascript. 
 
-There are ways to force enhancement, so take a look at the JS, but something of note is that we don't enhance devices running iOS < 8 on all pages or on all iPads on Fronts.
+There are ways to force enhancement, so take a look at the JS, but something of note is that we don't enhance devices running iOS < 8 on any pages and don't enhance iPads on Fronts.
 
 #### pageConfig
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -2,7 +2,34 @@
 
 ### Quick Overview
 
-The Javascript app is split into 
+The JS app can be split into distinct parts:
+
+- Inline blocking JS
+- Inline Non-blocking JS
+- app.js - curl module loader, the bundle booter and the standard Javascript
+- Commercial Javascript
+- Enhanced Javascript
+
+And then specific Javascripts used on different pages and required into the app when needed:
+
+- Article
+- Article Minute
+- Crosswords
+- Liveblog
+- Gallery
+- Trail
+- Profile
+- Sudoku
+- Image content
+- Facia
+- Football
+- Preferences
+- Membership
+- Ophan
+- Admin
+- Main Media
+- Video Embed
+- Accessibility
 
 ### General structure
 
@@ -18,7 +45,10 @@ See below for quick descriptions.
 			- applyRenderConditions
 			- loadFonts
 			- enable non blocking stylesheets
-			- Load the main app async
+			- **Load the main app async**
+				- app.js
+				- commercial.js
+				- enhanced/main.js
 			- Cloudwatch beacon
 		- [inlineJSNonBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSNonBlocking.scala.html)
 			- getUserData.js

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -6,6 +6,7 @@ The JS app can be split into distinct parts:
 
 - Inline blocking JS
 - Inline Non-blocking JS
+- Analytics
 - app.js - curl module loader, the bundle booter and the standard Javascript
 - Commercial Javascript
 - Enhanced Javascript
@@ -36,6 +37,10 @@ See below for quick descriptions.
 			- detectAdblock 
 			- showUserName
 			- ophanConfig
+		- [Analytics](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/base.scala.html)
+			- Google
+			- Omniture
+			- Comscore
 		
 ### Inline blocking JS 
 
@@ -117,6 +122,12 @@ Secrets.
 #### Ophan config
 
 Gets the [Ophan browserId](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js) which is used across analytics to tie data together.
+
+### Analytics
+
+The analytics for Dotcom are defined in [analytics/base.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/base.scala.html). It contains [Google Analytics](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/google.scala.html), [Omniture](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/omniture.scala.html) and [Comscore](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/comscore.scala.html). 
+
+[Read more about the Google Analytics implementation](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/14-implement-google-analytics.md).
 
 ### Bootstraps
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -131,9 +131,9 @@ The analytics for Dotcom are defined in [analytics/base.scala.html](https://gith
 
 ### Bootstraps
 
-In javascripts/bootstraps we define all the entry points for each bundle described in [requirejs.js](). 
+In [javascripts/bootstraps](b.com/guardian/frontend/tree/master/static/src/javascripts/bootstraps) we define all the entry points for each bundle described in [requirejs.js](https://github.com/guardian/frontend/blob/master/grunt-configs/requirejs.js). 
 
-The top level entry points which call the bootstrap initialisation of all other bundles are [enhanced/main.js](), [standard/main.js](), [admin.js]() (for frontend.gutools, not theguardian.com), [commercial.js]() and [video-embed.js]() (initialised when there is a video embed from [videoEmbed.scala.html]()).
+The top level entry points which call the bootstrap initialisation of all other bundles are [enhanced/main.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/enhanced/main.js), [standard/main.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/standard/main.js), [admin.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/admin.js) (for frontend.gutools, not theguardian.com), [commercial.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/commercial.js) and [video-embed.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/video-embed.js) (initialised when there is a video embed from [videoEmbed.scala.html](https://github.com/guardian/frontend/blob/master/applications/app/views/videoEmbed.scala.html)).
 
 ### app.js
 
@@ -282,15 +282,15 @@ All the enhanced bootstraps are in [bootstraps/enhanced](https://github.com/guar
 
 There are five projects in the Javascript architecture:
 
-- Admin - This is the Javascript for the admin tools at frontend.gutools (not guardian.com related)
-- Commercial - The modules and js views for the commercial Javascript
-- Common - The largest of the projects, common contains the modules, utilities and js views for much of the application. 
+- [Admin](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/admin) - This is the Javascript for the admin tools at frontend.gutools (not guardian.com related)
+- [Commercial](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/commercial) - The modules and js views for the commercial Javascript
+- [Common](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/common) - The largest of the projects, common contains the modules, utilities and js views for much of the application. 
 	- In modules you will find the Javascript for everything from articles to crosswords, identity to sport.
 	- Utils contains the reusable utilities we use across the site for dom querying, fastdom promises, array methods, fetch, inlineSvg, event listeners, localStorage methods etc. Take some to familiarise yourself with these methods as you will likely end up finding what you need here.
 	- The Javascript views for the JS loaded content including a/b test experiments, breaking news, share buttons etc.
-- Facia - Contains JS modules and views for the weather, snaps and fronts containers
-- Membership - Contains the formatters, payment and stripe javascripts
+- [Facia](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/facia) - Contains JS modules and views for the weather, snaps and fronts containers
+- [Membership](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/membership) - Contains the formatters, payment and stripe javascripts
 
 ### Vendor
 
-Contains vendor JS from the likes of forsee, formstack, prebid and stripe.
+Contains [vendor JS](https://github.com/guardian/frontend/tree/master/static/src/javascripts/vendor) from the likes of forsee, formstack, prebid and stripe.

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -20,7 +20,7 @@ See below for quick descriptions.
 - [- main.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html)
 	- [head.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/head.scala.html)
 		- [inlineJsBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSBlocking.scala.html) - Scripts required to render the page correctly on first paint.
-			- Polyfills for json2, es5-html5, RAF, classlist
+			- Polyfills for json2, es5-html5, RAF, classlist, matches and details
 			- Curl config
 			- shouldEnhance
 			- pageConfig

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -1,0 +1,152 @@
+## Javascript
+
+### Quick Overview
+
+The Javascript app is split into 
+
+### General structure
+
+See below for quick descriptions.
+
+- [main.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html)
+	- [head.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/head.scala.html)
+		- [inlineJsBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSBlocking.scala.html) - Scripts required to render the page correctly on first paint.
+			- Polyfills for json2, es5-html5, RAF, classlist
+			- Curl config
+			- shouldEnhance
+			- pageConfig
+			- applyRenderConditions
+			- loadFonts
+			- enable non blocking stylesheets
+			- Load the main app async
+			- Cloudwatch beacon
+		- [inlineJSNonBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSNonBlocking.scala.html)
+			- getUserData.js
+			- detectAdblock 😨
+			- showUserName
+			- ophanConfig
+		
+### Inline blocking JS 
+
+The inline blocking JS is in the head of the document and will block render until it has finished executing. Each of these scripts are required to render the page correctly on first paint.
+		
+#### Curl config
+
+Contains the [config](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/curlConfig.scala.js) for the [curl AMD module loader](https://github.com/cujojs/curl). You can find the aliases for certain JS modules in here such as `fastdom` which helps you avoid having to add the full path for certain modules.
+
+#### shouldEnhance
+
+The [shouldEnhance JS](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js) defines whether we should run the enhanced Javascript. 
+
+There are ways to force enhancement, so take a look at the JS, but something of note is that we don't enhance devices running iOS < 8 on all pages or on all iPads on Fronts.
+
+#### pageConfig
+
+If you put `guardian.config` in your console, you will see the JS config containing information about analytics, modules, switches, tests and the page. This config object is initally populated serverside and topped-up client side (ie: information about the user is only available client-side)
+
+The initial config structure is defined in [config.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/config.scala.js) and [javaScriptConfig.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/javaScriptConfig.scala.js). 
+
+You'll most likely be using the page config the most often which is defined in [JavascriptPage.scala](https://github.com/guardian/frontend/blob/master/common/app/views/support/JavaScriptPage.scala). Be aware that the metadata for a particular page may be [overridden with MetaData.make](https://github.com/guardian/frontend/blob/master/common/app/common/commercial/hosted/HostedGalleryPage.scala#L35).
+
+*Note that if you want to use config in a JS module, you shouldn't use the window object, but include it directly in your module via the config.js utility.*
+
+#### applyRenderConditions
+
+Choose how the browser should render the page before any painting begins. [applyRenderConditions.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js).
+
+Applies classes to the document based on support including svg, flexbox and replaces `js-off` with `js-on`.
+
+#### loadFonts
+
+Described at the top of the loadFonts.scala.js:
+
+**bypass normal browser font-loading to avoid the FOIT.**
+
+works like this:
+
+do you have fonts in localStorage?
+
+- **yes** – inject them (minimises 2nd layout as fonts are loaded before DOM is created)
+- **no**  – did the localStorage check go ok?
+	- **yes** – ajax them in as JSON immediately, inject them and save them to localStorage
+	- **no**  – load font files async using @@font-face
+	
+#### Enable non-blocking stylesheets
+
+A util that borrows heavily from [loadCSS](https://github.com/filamentgroup/loadCSS), it loads CSS async so that non-critical CSS doesn't block rendering.
+
+#### Load the main app async
+
+We polyfill the `async` attribute to prevent parser blocking by creating a script element and inserting it into the page. This is the main app.js which contains standard and enhanced JS.
+
+*Note that in Dev we get curl and require [boot.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/boot.js) immediately here but on Prod we concatenate curl and boot.js with bootstraps/standard*
+
+*Double Note: in head.scala.html we use a link element with prefetch attr and href set to app.js so that we head off and fetch it as early as possible*
+
+`<link rel="prefetch" href="@Static("javascripts/app.js")">`
+
+#### Cloudwatch beacon
+
+This is where we would ping cloudwatch.. if we had anything to ping about..
+
+### Inline non-blocking JS
+
+#### getUserData
+
+The [getUserData](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js) util puts the current logged-in user's data in the JS config ready to be used by other JS.
+
+#### detectAdblock
+
+Secrets.
+
+#### showUserName
+
+[Puts the user's username](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js) into the header (increases perceived rendering speed as their username is there before the app.js has to download and parse).
+
+#### Ophan config
+
+Gets the [Ophan browserId](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js) which is used across analytics to tie data together.
+
+## (S)CSS
+
+WIP..
+
+Inline SCSS
+
+	- head.scala.html
+		-stylesheets.scala.html
+			- @Html(head(project))
+			
+			
+Project refers to one of:
+
+```
+private def cssHead(project: String): String =
+    project match {
+      case "footballSnaps" => "head.footballSnaps"
+      case "facia" => "head.facia"
+      case "identity" => "head.identity"
+      case "football" => "head.football"
+      case "index" => "head.index"
+      case "rich-links" => "head.rich-links"
+      case "email" => "head.email"
+      case "commercial" => "head.commercial"
+      case "survey" => "head.survey"
+      case _ => "head.content"
+    }
+ ```
+ 
+ 
+in [assets.scala](https://github.com/guardian/frontend/blob/master/common/app/assets/assets.scala#L105)
+
+		
+## Build pipeline
+
+WIP..
+
+### Assets
+
+#### CSS
+
+#### JS
+

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -185,15 +185,15 @@ app: {
 
 To quote the file:
 
-> // This file is intended to be downloaded and run ASAP on all pages by all readers.
+> This file is intended to be downloaded and run ASAP on all pages by all readers.
 
-> // While it's ok to run code from here that requires specific host capabilities, it should manage failing gracefully by itself.
+> While it's ok to run code from here that requires specific host capabilities, it should manage failing gracefully by itself.
 
->// Assume *nothing* about the host...
+> Assume *nothing* about the host...
 
-> // This also means you should think *very hard* before adding modules to it, in particular 3rd party modules.
+> This also means you should think *very hard* before adding modules to it, in particular 3rd party modules.
 
-> // For this file, performance and breadth of support should take priority over *anything*…
+> For this file, performance and breadth of support should take priority over *anything*…
 
 The [standard main.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/standard/main.js) does a few core things:
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -238,7 +238,7 @@ It uses promises to require and init, in blocking order, standard JS, commercial
 
 ### Commercial JS
 
-The commercial JS is it's own bundle and is executed immediately after the standard JS.
+The commercial JS is its own bundle and is executed immediately after the standard JS.
 
 [Read about the commercial JS](https://github.com/guardian/frontend/blob/master/docs/05-commercial/03-commercial-javascript.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,6 @@
 - [How to deploy](01-start-here/03-how-to-deploy.md)
 - [Troubleshooting](01-start-here/04-troubleshooting.md)
 - [Development tips](01-start-here/05-development-tips.md)
-- [](01-start-here/06-faqs.md)
 
 ##[Architecture](02-architecture/)
 - [The different applications composing the Guardian website](02-architecture/01-applications-architecture.md)
@@ -16,9 +15,6 @@
 - [Archiving](02-architecture/04-archiving.md)
 - [Architecture principles for CSS](02-architecture/05-architecture-principles-for-css.md)
 - [Javascript](02-architecture/06-client-side-architecture.md)
-
-##[Dev how tos](03-dev-how-tos/)
-- [](03-dev-how-tos/*.md)
 
 ##[Dev howtos](03-dev-howtos/)
 - [How to setup and run A/B tests](03-dev-howtos/01-ab-testing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - [How to deploy](01-start-here/03-how-to-deploy.md)
 - [Troubleshooting](01-start-here/04-troubleshooting.md)
 - [Development tips](01-start-here/05-development-tips.md)
+- [](01-start-here/06-faqs.md)
 
 ##[Architecture](02-architecture/)
 - [The different applications composing the Guardian website](02-architecture/01-applications-architecture.md)
@@ -14,6 +15,10 @@
 - [Libraries we use](02-architecture/03-libraries-we-use.md)
 - [Archiving](02-architecture/04-archiving.md)
 - [Architecture principles for CSS](02-architecture/05-architecture-principles-for-css.md)
+- [Javascript](02-architecture/06-client-side-architecture.md)
+
+##[Dev how tos](03-dev-how-tos/)
+- [](03-dev-how-tos/*.md)
 
 ##[Dev howtos](03-dev-howtos/)
 - [How to setup and run A/B tests](03-dev-howtos/01-ab-testing.md)


### PR DESCRIPTION
## What does this change?

Adds a document describing the current architecture of our Javascript.

@guardian/dotcom-platform 
