### PR TITLE
Add call-to-action to hosted content

### DIFF
--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -72,6 +72,9 @@ object HostedArticlePage extends Logging {
       sponsorships <- hostedTag.activeSponsorships
       sponsorship <- sponsorships.headOption
       toneTag <- tags find (_.`type` == TagType.Tone)
+      atoms <- content.atoms
+      ctaAtoms <- atoms.cta
+      ctaAtom <- ctaAtoms.headOption
     } yield {
 
       val mainImageAsset: Option[Asset] = {
@@ -102,19 +105,11 @@ object HostedArticlePage extends Logging {
         // using capi trail text instead of standfirst because we don't want the markup
         standfirst = content.fields.flatMap(_.trailText).getOrElse(""),
         body = content.fields.flatMap(_.body).getOrElse(""),
-        // todo: from cta atom
-        cta = HostedCallToAction(
-          url = "http://www.actforwildlife.org.uk/?utm_source=theguardian.com&utm_medium=referral&utm_campaign=LaunchCampaignSep2016",
-          image = Some("http://media.guim.co.uk/d723e82cdd399f013905a5ee806fea3591b4a363/0_926_3872_1666/2000.jpg"),
-          label = Some("It's time to act for wildlife"),
-          trackingCode = Some("act-for-wildlife-button"),
-          btnText = Some("Act for wildlife")
-        ),
+        cta = HostedCallToAction.fromAtom(ctaAtom),
         mainPicture = mainImageAsset.flatMap(_.file) getOrElse "",
         mainPictureCaption = mainImageAsset.flatMap(_.typeData.flatMap(_.caption)).getOrElse(""),
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
-        // todo: related content
         nextPagesList = HostedPages.nextPages(campaignName = campaignId, pageName = content.webUrl.split(campaignId + "/")(1))
       )
     }

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -72,9 +72,9 @@ object HostedArticlePage extends Logging {
       sponsorships <- hostedTag.activeSponsorships
       sponsorship <- sponsorships.headOption
       toneTag <- tags find (_.`type` == TagType.Tone)
-      atoms <- content.atoms
-      ctaAtoms <- atoms.cta
-      ctaAtom <- ctaAtoms.headOption
+//      atoms <- content.atoms
+//      ctaAtoms <- atoms.cta
+//      ctaAtom <- ctaAtoms.headOption
     } yield {
 
       val mainImageAsset: Option[Asset] = {
@@ -105,7 +105,15 @@ object HostedArticlePage extends Logging {
         // using capi trail text instead of standfirst because we don't want the markup
         standfirst = content.fields.flatMap(_.trailText).getOrElse(""),
         body = content.fields.flatMap(_.body).getOrElse(""),
-        cta = HostedCallToAction.fromAtom(ctaAtom),
+        // todo: from cta atom
+//        cta = HostedCallToAction.fromAtom(ctaAtom),
+        cta = HostedCallToAction(
+          url = "http://www.actforwildlife.org.uk/?utm_source=theguardian.com&utm_medium=referral&utm_campaign=LaunchCampaignSep2016",
+          image = Some("http://media.guim.co.uk/d723e82cdd399f013905a5ee806fea3591b4a363/0_926_3872_1666/2000.jpg"),
+          label = Some("It's time to act for wildlife"),
+          trackingCode = Some("act-for-wildlife-button"),
+          btnText = Some("Act for wildlife")
+        ),
         mainPicture = mainImageAsset.flatMap(_.file) getOrElse "",
         mainPictureCaption = mainImageAsset.flatMap(_.typeData.flatMap(_.caption)).getOrElse(""),
         socialShareText = content.fields.flatMap(_.socialShareText),

--- a/common/app/common/commercial/hosted/HostedCallToAction.scala
+++ b/common/app/common/commercial/hosted/HostedCallToAction.scala
@@ -1,0 +1,25 @@
+package common.commercial.hosted
+
+import com.gu.contentatom.thrift.{Atom, AtomData}
+
+case class HostedCallToAction(
+  url: String,
+  image: Option[String],
+  label: Option[String],
+  trackingCode: Option[String],
+  btnText: Option[String]
+)
+
+object HostedCallToAction {
+
+  def fromAtom(ctaAtom: Atom): HostedCallToAction = {
+    val cta = ctaAtom.data.asInstanceOf[AtomData.Cta].cta
+    HostedCallToAction(
+      url = cta.url,
+      image = cta.backgroundImage,
+      label = cta.label,
+      trackingCode = cta.trackingCode,
+      btnText = cta.btnText
+    )
+  }
+}

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -41,6 +41,8 @@ object HostedVideoPage extends Logging {
       atoms <- content.atoms
       videoAtoms <- atoms.media
       videoAtom <- videoAtoms.headOption
+      ctaAtoms <- atoms.cta
+      ctaAtom <- ctaAtoms.headOption
     } yield {
 
       val video = videoAtom.data.asInstanceOf[AtomData.Media].media
@@ -113,17 +115,9 @@ object HostedVideoPage extends Logging {
           srcUrlOgg = videoUrl("video/ogg"),
           srcM3u8 = videoUrl("video/m3u8")
         ),
-        // todo: from cta atom
-        cta = HostedCallToAction(
-          url = "http://www.actforwildlife.org.uk/?utm_source=theguardian.com&utm_medium=referral&utm_campaign=LaunchCampaignSep2016",
-          image = Some("http://media.guim.co.uk/d723e82cdd399f013905a5ee806fea3591b4a363/0_926_3872_1666/2000.jpg"),
-          label = Some("It's time to act for wildlife"),
-          trackingCode = Some("act-for-wildlife-button"),
-          btnText = Some("Act for wildlife")
-        ),
+        cta = HostedCallToAction.fromAtom(ctaAtom),
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
-        // todo: related content
         nextPage = HostedPages.nextPages(campaignName = campaignId, pageName = content.webUrl.split(campaignId + "/")(1)).headOption,
         nextVideo = HostedPages.nextPages(campaignName = campaignId, pageName = content.webUrl.split(campaignId + "/")(1), contentType = Some(HostedContentType.Video)).headOption,
         metadata
@@ -147,25 +141,3 @@ case class HostedVideo(
   srcUrlOgg: String,
   srcM3u8: String
 )
-
-case class HostedCallToAction(
-  url: String,
-  image: Option[String] = None,
-  label: Option[String] = None,
-  trackingCode: Option[String] = None,
-  btnText: Option[String] = None
-)
-
-object HostedCallToAction {
-
-  def fromAtom(ctaAtom: Atom): HostedCallToAction = {
-    val cta = ctaAtom.data.asInstanceOf[AtomData.Cta].cta
-    HostedCallToAction(
-      url = cta.url,
-      image = cta.backgroundImage,
-      label = cta.label,
-      trackingCode = cta.trackingCode,
-      btnText = cta.btnText
-    )
-  }
-}

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -1,7 +1,7 @@
 package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.{Content, TagType}
-import com.gu.contentatom.thrift.AtomData
+import com.gu.contentatom.thrift.{Atom, AtomData}
 import common.Logging
 import common.commercial.hosted.hardcoded.HostedPages
 import model.GuardianContentTypes._
@@ -155,3 +155,17 @@ case class HostedCallToAction(
   trackingCode: Option[String] = None,
   btnText: Option[String] = None
 )
+
+object HostedCallToAction {
+
+  def fromAtom(ctaAtom: Atom): HostedCallToAction = {
+    val cta = ctaAtom.data.asInstanceOf[AtomData.Cta].cta
+    HostedCallToAction(
+      url = cta.url,
+      image = cta.backgroundImage,
+      label = cta.label,
+      trackingCode = cta.trackingCode,
+      btnText = cta.btnText
+    )
+  }
+}

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -90,7 +90,9 @@ object ChesterZooHostedPages {
   private val cta = HostedCallToAction(
     label = Some("We won't stand back and we won't give up."),
     btnText = Some("It's time to act for wildlife"),
-    url = "http://www.actforwildlife.org.uk/?utm_source=theguardian.com&utm_medium=referral&utm_campaign=LaunchCampaignSep2016"
+    url = "http://www.actforwildlife.org.uk/?utm_source=theguardian.com&utm_medium=referral&utm_campaign=LaunchCampaignSep2016",
+    image = None,
+    trackingCode = None
   )
 
 

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -22,7 +22,8 @@ object RenaultHostedPages {
     url = "https://www.renault.co.uk/vehicles/new-vehicles/zoe.html",
     label = Some("Discover Zoe"),
     image = Some(Static("images/commercial/ren_commercial_banner.jpg")),
-    trackingCode = Some("explore-renault-zoe-button")
+    trackingCode = Some("explore-renault-zoe-button"),
+    btnText = None
   )
 
   private val teaserWithoutNextPage: HostedVideoPage = {

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -193,7 +193,9 @@ object VisitBritainHostedPages {
   private def cta(pageName: String) = HostedCallToAction(
     label = Some("Explore our collection of unique experiences from all over Great Britain & Northern Ireland"),
     btnText = Some("Find more inspiration"),
-    url = s"http://www.homeofamazing.com/?utm_source=guardianpartnership&utm_medium=hostedgalleries$pageName&utm_campaign=display"
+    url = s"http://www.homeofamazing.com/?utm_source=guardianpartnership&utm_medium=hostedgalleries$pageName&utm_campaign=display",
+    image = None,
+    trackingCode = None
   )
 
   val activitiesGallery: HostedGalleryPage = HostedGalleryPage(

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -19,7 +19,8 @@ object ZootropolisHostedPages {
     url = "https://ad.doubleclick.net/ddm/clk/307882423;133964630;h",
     image = Some("https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis_cta.jpg"),
     trackingCode = Some("disney-zootropolis"),
-    btnText = Some("Out now on digital download")
+    btnText = Some("Out now on digital download"),
+    label = None
   )
 
   private lazy val videoPageWithoutNextPage: HostedVideoPage = {


### PR DESCRIPTION
Builds the CTA in hosted content from the CTA atom in capi response.

Will have to add CTAs to all the Chester Zoo campaign content before merging this, otherwise we'll get 404s.

/cc @guardian/labs-beta @DiegoVazquezNanini 
