### PR TITLE
Show logos on immersive articles

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -33,13 +33,10 @@
 
                         @fragments.chapterHeadings(article)
 
-                        <div class="content__article-body from-content-api js-article__body" itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
-                            data-test-id="article-review-body">
-
-                            @if(isPaidContent || article.commercial.isSponsored(None) || article.commercial.isFoundationSupported) {
-                                @fragments.commercial.badge(article, model)
-                            }
-
+                        <div class="content__article-body from-content-api js-article__body"
+                             itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
+                             data-test-id="article-review-body">
+                            @fragments.commercial.badge(article, model)
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 


### PR DESCRIPTION
Condition for showing logos is wrong on immersive articles.
This should fix it.

/cc @guardian/commercial-dev
