### PR TITLE
Returing 404 when cannot retrieve a discussion from DAPI

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -146,8 +146,9 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
       }
     } recover {
       case NonFatal(e) =>
-        log.error(s"Discussion $key cannot be retrieved", e)
-        InternalServerError(s"Discussion $key cannot be retrieved")
+        val errorMessage = s"Discussion $key cannot be retrieved"
+        log.error(errorMessage, e)
+        NotFound(errorMessage)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Previous commit https://github.com/guardian/frontend/commit/a524158f7616b0a04e14f4e8e4614b4746d19a5d
explicitely changed 404 to 500 (in addition to add logging).
This patch revert the change of response type.
## What is the value of this and can you measure success?

Stop returning 500 for non-existing discussions which should be used when an error happens and not when content doesn't exist
## Request for comment

@nicl @jfsoul 
