### PR TITLE
Updates routes for soulmates JSON and caches Nil rendered result.

### DIFF
--- a/commercial/app/controllers/commercial/BookOffersController.scala
+++ b/commercial/app/controllers/commercial/BookOffersController.scala
@@ -57,8 +57,7 @@ class BookOffersController(bookFinder: BookFinder, bestsellersAgent: Bestsellers
   def renderBooks = Action.async { implicit request =>
 
     def result(books: Seq[Book]): Result = books match {
-      case Nil =>
-        NoCache(jsonFormat.nilResult.result)
+      case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
       case someBooks =>
         Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")

--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -3,7 +3,7 @@ package controllers.commercial
 import common.JsonComponent
 import model.commercial.soulmates.SoulmatesAgent.{menAgent, newMenAgent, newWomenAgent, womenAgent}
 import model.commercial.soulmates._
-import model.{Cached, NoCache}
+import model.Cached
 import play.api.mvc._
 
 import scala.concurrent.duration._
@@ -29,7 +29,7 @@ class SoulmatesController extends Controller with implicits.Requests {
 
   def renderSoulmates(groupName: String) = Action { implicit request =>
     soulmatesSample(groupName).toList match {
-      case Nil => NoCache(jsonFormat.nilResult.result)
+      case Nil => Cached(componentMaxAge){ jsonFormat.nilResult }
       case soulmates => Cached(componentMaxAge) {
         val clickMacro = request.getParameter("clickMacro")
         val omnitureId = request.getParameter("omnitureId")
@@ -40,8 +40,6 @@ class SoulmatesController extends Controller with implicits.Requests {
 
   def getSoulmates(groupName: String) = Action { implicit request =>
 
-    Cached(60.seconds){
-      JsonComponent(soulmatesSample(groupName))
-    }
+    Cached(60.seconds){ JsonComponent(soulmatesSample(groupName)) }
   }
 }

--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -29,7 +29,7 @@ class SoulmatesController extends Controller with implicits.Requests {
 
   def renderSoulmates(groupName: String) = Action { implicit request =>
     soulmatesSample(groupName).toList match {
-      case Nil => Cached(componentMaxAge){ jsonFormat.nilResult }
+      case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
       case soulmates => Cached(componentMaxAge) {
         val clickMacro = request.getParameter("clickMacro")
         val omnitureId = request.getParameter("omnitureId")

--- a/commercial/app/controllers/commercial/TravelOffersController.scala
+++ b/commercial/app/controllers/commercial/TravelOffersController.scala
@@ -17,7 +17,7 @@ class TravelOffersController(travelOffersAgent: TravelOffersAgent) extends Contr
   def renderTravel = Action { implicit request =>
 
     travelSample(specificIds, segment) match {
-      case Nil => NoCache(jsonFormat.nilResult.result)
+      case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
       case offers => Cached(componentMaxAge) {
         val clickMacro = request.getParameter("clickMacro")
         val omnitureId = request.getParameter("omnitureId")

--- a/commercial/app/controllers/commercial/package.scala
+++ b/commercial/app/controllers/commercial/package.scala
@@ -11,6 +11,11 @@ package object commercial {
 
   val componentMaxAge = 15.minutes
 
+  /*  if a service goes down or an agent becomes unavailable, we don't want each user request to
+      hit frontend; allow Fastly to briefly cache Nil results
+   */
+  val componentNilMaxAge = 5.seconds
+
   def segment(implicit request: RequestHeader) = {
     val params = request.queryString
     val section = params.get("s") map (_.head)

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -19,7 +19,7 @@ GET         /commercial/masterclasses.json                                contro
 
 # Soulmates merchandising components
 GET        /commercial/soulmates/$subgroup<\w+>.json                      controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
-GET        /commercial/soulmates/$subgroup<\w+>                           controllers.commercial.SoulmatesController.getSoulmates(subgroup)
+GET        /commercial/soulmates/api/$subgroup<\w+>.json                  controllers.commercial.SoulmatesController.getSoulmates(subgroup)
 
 # Book merchandising components
 GET         /commercial/books/book.json                                   controllers.commercial.BookOffersController.renderBook

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -288,7 +288,7 @@ GET            /commercial/travel/api/offers.json                               
 GET            /commercial/jobs.json                                                                                             controllers.commercial.JobsController.renderJobs
 GET            /commercial/masterclasses.json                                                                                    controllers.commercial.MasterclassesController.renderMasterclasses
 GET            /commercial/soulmates/$subgroup<\w+>.json                                                                         controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
-GET            /commercial/soulmates/$subgroup<\w+>                                                                              controllers.commercial.SoulmatesController.getSoulmates(subgroup)
+GET            /commercial/soulmates/api/$subgroup<\w+>.json                                                                     controllers.commercial.SoulmatesController.getSoulmates(subgroup)
 GET            /commercial/books/book.json                                                                                       controllers.commercial.BookOffersController.renderBook
 GET            /commercial/books/books.json                                                                                      controllers.commercial.BookOffersController.renderBooks
 GET            /commercial/books/api/books.json                                                                                  controllers.commercial.BookOffersController.getBooks


### PR DESCRIPTION
This brings the soulmates JSON endpoint into line with the convention of the other soulmates components. It also ensures we are caching the `Nil` result when we render it, which was previously being explicitly uncached...
