### PR TITLE
Head space

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -40,6 +40,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
+            ("has-new-header", mvt.ABNewHeaderVariant.isParticipating),
             ("is-immersive", getContent(page).exists(_.content.isImmersive)),
             ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">

--- a/onward/app/views/weatherFragments/cityWeather.scala.html
+++ b/onward/app/views/weatherFragments/cityWeather.scala.html
@@ -5,6 +5,7 @@
 
 <div class="weather js-weather">
     <div class="u-unstyled weather__current js-weather-current">
+        @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon","js-weather-icon"), Some(weatherResponse.WeatherText))<span class="u-h">@weatherResponse.WeatherText</span>
         <p class="weather__desc">
             <span class="u-h">The temperature</span>
             <span class="weather__time">Now</span>
@@ -13,7 +14,6 @@
                 <span class="weather__temp js-weather-temp">@math.round(temp.Value)°@temp.Unit</span>
             }
         </p>
-        @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon","js-weather-icon"), Some(weatherResponse.WeatherText))<span class="u-h">@weatherResponse.WeatherText</span>
     </div>
     <button class="weather__toggle-forecast meta-button js-toggle-forecast mobile-only" data-link-name="weather-toggle-forecast"
     href="#toggle-forecast"><span class="u-h">Toggle forecast</span>@fragments.inlineSvg("arrow", "icon", List("weather__toggle-icon"))

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -633,3 +633,20 @@ $navigation-horizontal-padding: $gs-gutter * 2;
 .no-text-transform {
     text-transform: none;
 }
+
+//
+@include mq($until: tablet) {
+    .has-new-header {
+        .weather {
+            padding-top: 1px;
+        }
+
+        .fc-container--first .fc-container__inner {
+            padding-top: $gs-baseline / 2 + $gs-baseline / 4;
+        }
+
+        .content__labels {
+            padding: ($gs-baseline / 2 + $gs-baseline / 4) 0;
+        }
+    }
+}

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -634,14 +634,15 @@ $navigation-horizontal-padding: $gs-gutter * 2;
     text-transform: none;
 }
 
-//
+// Breathing space between header and content
 @include mq($until: tablet) {
     .has-new-header {
         .weather {
             padding-top: 1px;
         }
 
-        .fc-container--first .fc-container__inner {
+        .fc-container--first .fc-container__inner,
+        .index-page-header {
             padding-top: $gs-baseline / 2 + $gs-baseline / 4;
         }
 

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -529,10 +529,8 @@ $header-image-size-desktop: 100px;
     background-color: #ffffff;
 }
 .index-page-header {
-    border-top: 1px solid $news-accent;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
-    margin-top: $gs-baseline;
 
     .has-page-skin & {
         width: gs-span(12);


### PR DESCRIPTION
A few tweaks to prevent page content from getting too intimate with the new header.

eg: 
![screen shot 2016-09-26 at 14 16 00](https://cloud.githubusercontent.com/assets/14570016/18869643/140470c4-84a5-11e6-97a4-ba192f264577.png)

![screen shot 2016-09-27 at 11 29 38](https://cloud.githubusercontent.com/assets/14570016/18869771/b6e2fae0-84a5-11e6-93df-35041107f72b.png) 

Sure there may be more out there but this is as much as I can find at the moment. 

CC @NataliaLKB 
