### PR TITLE
Badges - bylines fixed on mobile

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -282,9 +282,8 @@
 }
 
 .badge--alt {
-    float: left;
-    clear: left;
-    border-top: 1px dotted $neutral-5;
+    float: none;
+    border-top: 0;
     margin-top: $gs-baseline / 3;
     padding-top: $gs-baseline / 6;
     text-align: left;
@@ -292,6 +291,9 @@
 
     @include mq(leftCol) {
         width: $left-column;
+        float: left;
+        clear: left;
+        border-top: 1px dotted $neutral-5;
     }
 
     @include mq(wide) {
@@ -317,6 +319,16 @@
         @include font-size(11);
         color: $paid-article-icon;
         font-weight: normal;
+    }
+}
+
+.fc-container {
+    .badge--alt {
+        @include mq(tablet) {
+            float: left;
+            clear: left;
+            border-top: 1px dotted $neutral-5;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

Fix for the mobile version of badges (in articles and commercial containers - in the left column).
## What is the value of this and can you measure success?

Badges look better when not floated and without the redundant top border.
## Does this affect other platforms - Amp, Apps, etc?

no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-27 at 12 52 45](https://cloud.githubusercontent.com/assets/489567/18872240/52b5d2f2-84b1-11e6-8934-0a180ccfed5d.png)

After:
![screen shot 2016-09-27 at 12 53 29](https://cloud.githubusercontent.com/assets/489567/18872256/6a14c5ac-84b1-11e6-8766-00bd4b9dac10.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
