### PR TITLE
Removed expiring switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,17 +65,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 10, 6),
     exposeClientSide = true
   )
-
-  Switch(
-    ABTests,
-    "ab-contributions-epic-20160916",
-    "Test variants of the button text to drive contributions.",
-    owners = Seq(Owner.withGithub("markjamesbutler")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 27),
-    exposeClientSide = true
-  )
-
+  
   for (edition <- Edition.all) Switch(
     ABTests,
     "ab-membership-engagement-banner-"+edition.id.toLowerCase,


### PR DESCRIPTION
## What does this change?

Removed the switch that I missed when removing the test.
## What is the value of this and can you measure success?

None, its a functional change.
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
