### PR TITLE
Adblocking test with ad-free offering. 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,11 +68,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ad-blocking-response2",
-    "Prominent adblocker response test",
+    "ab-ad-blocking-response3",
+    "Prominent adblocker ad-free test",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 29),   // Thursday @ 23:59 BST
+    sellByDate = new LocalDate(2016, 10, 13),   // Thursday @ 23:59 BST
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,10 +68,10 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ad-blocking-response3",
-    "Prominent adblocker ad-free test",
+    "ab-ad-blocking-response30pc",
+    "Prominent adblocker ad-free test ZERO PERCENT",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = On, //TODO: OFF!
+    safeState = Off,
     sellByDate = new LocalDate(2016, 10, 13),   // Thursday @ 23:59 BST
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "ab-ad-blocking-response3",
     "Prominent adblocker ad-free test",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
+    safeState = On, //TODO: OFF!
     sellByDate = new LocalDate(2016, 10, 13),   // Thursday @ 23:59 BST
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -40,7 +40,7 @@ define([
     surveyAdBlock.prototype.attach = function () {
         fastdom.write(function () {
             $(document.body).append(this.bannerTmpl);
-            bean.on(document, 'click', $('.survey-button-rounded__cta.whitelist'), function () {
+            bean.on(document, 'click', $('.cta-whitelist'), function () {
                 // -> state 2
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -25,36 +25,25 @@ define([
         this.config = config || {};
         this.bannerTmpl = template(surveyAdBlockTemplate,
             {
-                surveyHeader: this.config.surveyHeader,
-                surveyText: this.config.surveyText,
-                surveyTextSecond: this.config.surveyTextSecond,
-                surveyTextThird: this.config.surveyTextThird,
-                surveyTextMembership: this.config.surveyTextMembership,
-                surveyTextSubscriber: this.config.surveyTextSubscriber,
-                surveyTextUserHelp: this.config.surveyTextUserHelp,
-                signupText: this.config.signupText,
-                membershipText: this.config.membershipText,
-                signupLink: this.config.signupLink,
-                membershipLink: this.config.membershipLink,
-                signupDataLink: this.config.signupDataLink,
-                membershipDataLink: this.config.membershipDataLink,
-                subscriberLink: this.config.subscriberLink,
-                subscriberText: this.config.subscriberText,
-                subscriberDataLink: this.config.subscriberDataLink,
-                contributorLink: this.config.contributorLink,
-                contributorText: this.config.contributorText,
-                contributorDataLink: this.config.contributorDataLink,
-                showCloseBtn: this.config.showCloseBtn,
                 arrowWhiteRight: svgs('arrowWhiteRight'),
                 marque36icon: svgs('marque36icon'),
                 crossIcon: svgs('crossIcon'),
-                surveyOverlaySimple: svgs('surveyOverlaySimple')
+                surveyOverlaySimple: svgs('surveyOverlaySimple'),
+                adFreeDataLink: this.config.adFreeDataLink,
+                adFreeText: this.config.adFreeText,
+                whitelistDataLink: this.config.whitelistDataLink,
+                whitelistText: this.config.whitelistText,
+                whitelistGuideImage: this.config.whitelistGuideImage
+                adBlockIcon: this.config.adBlockIcon,
+                adBlockPlusIcon: this.config.adBlockPlusIcon,
+                variant: this.config.variant
             });
     };
 
     surveyAdBlock.prototype.attach = function () {
         fastdom.write(function () {
             $(document.body).append(this.bannerTmpl);
+            // TODO: dump the close button but wire up the other interactions
             if (this.config.showCloseBtn) {
                 bean.on(document, 'click', $('.js-survey-adblock__close-btn'), function () {
                     $('.survey-adblock').addClass('is-hidden');
@@ -71,6 +60,7 @@ define([
         fastdom.write(function () {
             $('.js-survey-adblock').removeClass('is-hidden');
         });
+        // TODO: dump the close button but wire up the other interactions
         if (this.config.showCloseBtn) {
             if (this.config.showCloseBtn === 'delayed') {
                 countdown.startTimer(5, function(seconds) {

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -40,7 +40,7 @@ define([
     surveyAdBlock.prototype.attach = function () {
         fastdom.write(function () {
             $(document.body).append(this.bannerTmpl);
-            bean.on(document, 'click', $('.survey-button__cta.whitelist'), function () {
+            bean.on(document, 'click', $('.survey-button-rounded__cta.whitelist'), function () {
                 // -> state 2
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
@@ -48,7 +48,7 @@ define([
                 $.forEachElement(('.state-2'), function(el){el.classList.remove('is-hidden');});
                 $('.survey-container').removeClass('thank-you');
             });
-            bean.on(document, 'click', $('.survey-button__cta.noads'), function () {
+            bean.on(document, 'click', $('.survey-button-rounded__cta.noads'), function () {
                 // -> state 3
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
@@ -56,7 +56,7 @@ define([
                 $.forEachElement(('.state-3'), function(el){el.classList.remove('is-hidden');});
                 $('.survey-container').removeClass('thank-you');
             });
-            bean.on(document, 'click', $('.survey-button__cta.paypal'), function () {
+            bean.on(document, 'click', $('.survey-button-rounded__cta.paypal'), function () {
                 // -> state 4
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
@@ -65,7 +65,7 @@ define([
                 $('.survey-container').addClass('thank-you');
                 storage.local.set('gu.abb3.exempt', true);
             });
-            bean.on(document, 'click', $('.survey-button__cta.ccard'), function () {
+            bean.on(document, 'click', $('.survey-button-rounded__cta.ccard'), function () {
                 // -> state 4
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
@@ -88,7 +88,7 @@ define([
                 $.forEachElement(('.state-1'), function(el){el.classList.remove('is-hidden');});
                 $('.survey-container').removeClass('thank-you');
             });
-            bean.on(document, 'click', $('.survey-button__cta.readon'), function () {
+            bean.on(document, 'click', $('.survey-button-rounded__cta.readon'), function () {
                 // -> go to article
                 $('.survey-container').removeClass('thank-you');
                 $('.js-survey-adblock').addClass('is-hidden');

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -5,7 +5,8 @@ define([
     'common/utils/template',
     'common/modules/user-prefs',
     'common/views/svgs',
-    'text!common/views/commercial/survey/survey-adblock.html'
+    'text!common/views/commercial/survey/survey-adblock.html',
+    'common/utils/storage',
 ], function (
     bean,
     fastdom,
@@ -13,7 +14,8 @@ define([
     template,
     userprefs,
     svgs,
-    surveyAdBlockTemplate
+    surveyAdBlockTemplate,
+    storage
 ) {
     var surveyAdBlock = function (config) {
         this.config = config || {};
@@ -42,25 +44,54 @@ define([
                 // -> state 2
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-4'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-2'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').removeClass('thank-you');
             });
             bean.on(document, 'click', $('.survey-button__cta.noads'), function () {
                 // -> state 3
                 $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-4'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').removeClass('thank-you');
+            });
+            bean.on(document, 'click', $('.survey-button__cta.paypal'), function () {
+                // -> state 4
+                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').addClass('thank-you');
+                storage.local.set('gu.abb3.exempt', true);
+            });
+            bean.on(document, 'click', $('.survey-button__cta.ccard'), function () {
+                // -> state 4
+                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
+                $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').addClass('thank-you');
+                storage.local.set('gu.abb3.exempt', true);
             });
             bean.on(document, 'click', $('.howto-unblock__close-btn'), function () {
                 // -> state 1
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-1'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').removeClass('thank-you');
             });
             bean.on(document, 'click', $('.pay-now__close-btn'), function () {
                 // -> state 1
                 $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-1'), function(el){el.classList.remove('is-hidden');});
+                $('.survey-container').removeClass('thank-you');
+            });
+            bean.on(document, 'click', $('.survey-button__cta.readon'), function () {
+                // -> go to article
+                $('.survey-container').removeClass('thank-you');
+                $('.js-survey-adblock').addClass('is-hidden');
             });
         }.bind(this));
     };

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -33,7 +33,7 @@ define([
                 adFreeText: this.config.adFreeText,
                 whitelistDataLink: this.config.whitelistDataLink,
                 whitelistText: this.config.whitelistText,
-                whitelistGuideImage: this.config.whitelistGuideImage
+                whitelistGuideImage: this.config.whitelistGuideImage,
                 adBlockIcon: this.config.adBlockIcon,
                 adBlockPlusIcon: this.config.adBlockPlusIcon,
                 variant: this.config.variant

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -63,7 +63,7 @@ define([
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
                 $('.survey-container').addClass('thank-you');
-                storage.local.set('gu.abb3.exempt', true);
+                storage.local.set('gu.abb30pc.exempt', true);
             });
             bean.on(document, 'click', $('.survey-button-rounded__cta.ccard'), function () {
                 // -> state 4
@@ -72,7 +72,7 @@ define([
                 $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
                 $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
                 $('.survey-container').addClass('thank-you');
-                storage.local.set('gu.abb3.exempt', true);
+                storage.local.set('gu.abb30pc.exempt', true);
             });
             bean.on(document, 'click', $('.howto-unblock__close-btn'), function () {
                 // -> state 1

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -37,61 +37,71 @@ define([
             });
     };
 
+    var greetingView = function() {
+        // -> state 1
+        $.forEachElement(('.whitelist-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.adfree-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.greeting-state'), function(el){el.classList.remove('is-hidden');});
+        $('.survey-container').removeClass('thank-you');
+    };
+
+    var whiteListInstructionView = function () {
+        // -> state 2
+        $.forEachElement(('.greeting-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.adfree-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.thankyou-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.whitelist-state'), function(el){el.classList.remove('is-hidden');});
+        $('.survey-container').removeClass('thank-you');
+    };
+
+    var adFreeOptionView = function() {
+        // -> state 3
+        $.forEachElement(('.greeting-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.whitelist-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.thankyou-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.adfree-state'), function(el){el.classList.remove('is-hidden');});
+        $('.survey-container').removeClass('thank-you');
+    };
+
+    var paymentDoneView = function() {
+        // -> state 4
+        $.forEachElement(('.greeting-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.whitelist-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.adfree-state'), function(el){el.classList.add('is-hidden');});
+        $.forEachElement(('.thankyou-state'), function(el){el.classList.remove('is-hidden');});
+        $('.survey-container').addClass('thank-you');
+        storage.local.set('gu.abb30pc.exempt', true);
+    };
+
+    var closeOverlay = function() {
+        // -> go to article
+        $('.survey-container').removeClass('thank-you');
+        $('.js-survey-adblock').addClass('is-hidden');
+    };
+
     surveyAdBlock.prototype.attach = function () {
         fastdom.write(function () {
             $(document.body).append(this.bannerTmpl);
             bean.on(document, 'click', $('.cta-whitelist'), function () {
-                // -> state 2
-                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-4'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-2'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').removeClass('thank-you');
+                whiteListInstructionView();
             });
             bean.on(document, 'click', $('.survey-button-rounded__cta.noads'), function () {
-                // -> state 3
-                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-4'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').removeClass('thank-you');
+                adFreeOptionView();
             });
             bean.on(document, 'click', $('.survey-button-rounded__cta.paypal'), function () {
-                // -> state 4
-                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').addClass('thank-you');
-                storage.local.set('gu.abb30pc.exempt', true);
+                paymentDoneView();
             });
             bean.on(document, 'click', $('.survey-button-rounded__cta.ccard'), function () {
-                // -> state 4
-                $.forEachElement(('.state-1'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-4'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').addClass('thank-you');
-                storage.local.set('gu.abb30pc.exempt', true);
+                paymentDoneView();
             });
             bean.on(document, 'click', $('.howto-unblock__close-btn'), function () {
-                // -> state 1
-                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-1'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').removeClass('thank-you');
+                greetingView();
             });
             bean.on(document, 'click', $('.pay-now__close-btn'), function () {
-                // -> state 1
-                $.forEachElement(('.state-2'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-3'), function(el){el.classList.add('is-hidden');});
-                $.forEachElement(('.state-1'), function(el){el.classList.remove('is-hidden');});
-                $('.survey-container').removeClass('thank-you');
+                greetingView();
             });
             bean.on(document, 'click', $('.survey-button-rounded__cta.readon'), function () {
-                // -> go to article
-                $('.survey-container').removeClass('thank-you');
-                $('.js-survey-adblock').addClass('is-hidden');
+                closeOverlay();
             });
         }.bind(this));
     };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -19,18 +19,24 @@ define([
 ) {
     return function () {
         this.id = 'AdBlockingResponse3';
-        this.start = '2016-09-26';
-        this.expiry = '2016-10-11'; // the test will STOP on MONDAY 10th PM. Test dates don't behave like our switches.
+        this.start = '2016-09-22';
+        this.expiry = '2016-10-14'; // this test will expire on Thurs 13th PM.
         this.author = 'Justin Pinner';
-        this.description = 'Adblocking response with ad-free 404 demand test';
+        this.description = 'Adblocking response with ad-free 404 test';
         this.audience = 0;  // TODO: audience sizing
-        this.audienceOffset = 0;
+        this.audienceOffset = 0; // exclude anyone that had been in 12% v2 test
         this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
         var variantDataLinkNames = [
-            ['adblock whitelist no-close'],
-            ['adblock supporter no-close'],
-            ['adblock subscriber no-close']
+            ['adblock whitelist 299'],
+            ['adblock supporter 299'],
+            ['adblock subscriber 299'],
+            ['adblock whitelist 499'],
+            ['adblock supporter 499'],
+            ['adblock subscriber 499'],
+            ['adblock whitelist 999'],
+            ['adblock supporter 999'],
+            ['adblock subscriber 999']
         ].map(function(_) {
             return _[0];
         }).join(', ');
@@ -42,6 +48,7 @@ define([
             return contains('chrome', detect.getUserAgent.browser.toLowerCase()) &&
                 contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint()) &&
                 config.page.edition === 'UK' &&
+                //(cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
                 detect.adblockInUseSync();
         };
 
@@ -49,7 +56,7 @@ define([
             // NOTE: async adblock detection doesn't work if the page is opened in a new tab
             return detect.adblockInUseSync() &&
                 !cookies.get('gu_abm_x') &&
-                (cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
+                //(cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
                 !config.page.isFront &&
                 !config.page.shouldHideAdverts &&
                 config.page.section !== 'childrens-books-site' &&
@@ -74,12 +81,14 @@ define([
                 if (isQualified()) {
                     var variant = '299',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeText = 'Ad free &pound;2.99/month',
+                        adFreeButtonText = 'Go ad-free for &pound;2.99/month',
+                        adFreeMessagePrefix = '&pound;2.99 per month',
                         header = 'Advertising helps fund our journalism';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
-                        adFreeText: adFreeText,
+                        adFreeButtonText: adFreeButtonText,
+                        adFreeMessagePrefix: adFreeMessagePrefix,
                         surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],
@@ -96,12 +105,14 @@ define([
                 if (isQualified()) {
                     var variant = '499',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeText = 'Ad free &pound;4.99/month',
+                        adFreeButtonText = 'Go ad-free for &pound;4.99/month',
+                        adFreeMessagePrefix = '&pound;4.99 per month',
                         header = 'Advertising helps fund our journalism';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
-                        adFreeText: adFreeText,
+                        adFreeButtonText: adFreeButtonText,
+                        adFreeMessagePrefix: adFreeMessagePrefix,
                         surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],
@@ -118,12 +129,14 @@ define([
                 if (isQualified()) {
                     var variant = '999',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeText = 'Ad free &pound;9.99/month',
+                        adFreeButtonText = 'Go ad-free for &pound;9.99/month',
+                        adFreeMessagePrefix = '&pound;4.99 per month',
                         header = 'Advertising helps fund our journalism';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
-                        adFreeText: adFreeText,
+                        adFreeButtonText: adFreeButtonText,
+                        adFreeMessagePrefix: adFreeMessagePrefix,
                         surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -79,8 +79,7 @@ define([
                     var variant = '299',
                         whitelistText = 'Allow ads and browse for free',
                         adFreeButtonText = 'Remove ads for &pound;2.99/month',
-                        adFreeMessagePrefix = '&pound;2.99 per month',
-                        header = 'Advertising helps fund our journalism';
+                        adFreeMessagePrefix = '&pound;2.99 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
@@ -102,14 +101,12 @@ define([
                     var variant = '499',
                         whitelistText = 'Allow ads and browse for free',
                         adFreeButtonText = 'Remove ads for &pound;4.99/month',
-                        adFreeMessagePrefix = '&pound;4.99 per month',
-                        header = 'Advertising helps fund our journalism';
+                        adFreeMessagePrefix = '&pound;4.99 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
                         adFreeButtonText: adFreeButtonText,
                         adFreeMessagePrefix: adFreeMessagePrefix,
-                        surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],
                         adBlockPlusIcon: config.images.commercial['abp-icon'],
@@ -126,14 +123,12 @@ define([
                     var variant = '999',
                         whitelistText = 'Allow ads and browse for free',
                         adFreeButtonText = 'Remove ads for &pound;9.99/month',
-                        adFreeMessagePrefix = '&pound;9.99 per month',
-                        header = 'Advertising helps fund our journalism';
+                        adFreeMessagePrefix = '&pound;9.99 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
                         adFreeButtonText: adFreeButtonText,
                         adFreeMessagePrefix: adFreeMessagePrefix,
-                        surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],
                         adBlockPlusIcon: config.images.commercial['abp-icon'],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -86,7 +86,6 @@ define([
                         whitelistText: whitelistText,
                         adFreeButtonText: adFreeButtonText,
                         adFreeMessagePrefix: adFreeMessagePrefix,
-                        surveyHeader: header,
                         whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
                         adBlockIcon: config.images.commercial['ab-icon'],
                         adBlockPlusIcon: config.images.commercial['abp-icon'],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -67,6 +67,7 @@ define([
                 storage.local.isStorageAvailable() &&
                 !storage.local.get('gu.subscriber') &&
                 !storage.local.get('gu.contributor') &&
+                !storage.local.get('gu.abb3.exempt') &&
                 storage.local.get('gu.alreadyVisited') > 5 &&
                 config.page.pageId !== 'contributor-email-page' &&
                 config.page.pageId !== 'contributor-email-page-submitted';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -5,8 +5,7 @@ define([
     'common/utils/storage',
     'lodash/collections/contains',
     'common/modules/commercial/user-features',
-    'common/modules/commercial/survey/survey-adblock',
-    'common/utils/cookies'
+    'common/modules/commercial/survey/survey-adblock'
 ], function (
     $,
     config,
@@ -14,8 +13,7 @@ define([
     storage,
     contains,
     userFeatures,
-    SurveyAdBlock,
-    cookies
+    SurveyAdBlock
 ) {
     return function () {
         this.id = 'AdBlockingResponse3';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -16,12 +16,12 @@ define([
     SurveyAdBlock
 ) {
     return function () {
-        this.id = 'AdBlockingResponse3';
+        this.id = 'AdBlockingResponse30pc';
         this.start = '2016-09-22';
         this.expiry = '2016-10-14'; // this test will expire on Thurs 13th PM.
         this.author = 'Justin Pinner';
-        this.description = 'Adblocking response with ad-free 404 test';
-        this.audience = 0.12;
+        this.description = 'Adblocking response with ad-free 404 test ZERO PERCENT';
+        this.audience = 0;
         this.audienceOffset = 0.12; // exclude anyone that would have been in the previous 12% v2 test
         this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
@@ -63,7 +63,7 @@ define([
                 storage.local.isStorageAvailable() &&
                 !storage.local.get('gu.subscriber') &&
                 !storage.local.get('gu.contributor') &&
-                !storage.local.get('gu.abb3.exempt') &&
+                !storage.local.get('gu.abb30pc.exempt') &&
                 storage.local.get('gu.alreadyVisited') > 5 &&
                 config.page.pageId !== 'contributor-email-page' &&
                 config.page.pageId !== 'contributor-email-page-submitted';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -18,33 +18,25 @@ define([
     cookies
 ) {
     return function () {
-        this.id = 'AdBlockingResponse2';
-        this.start = '2016-09-16';
-        this.expiry = '2016-09-23'; // the test will STOP on THURSDAY 22nd PM. Test dates don't behave like our switches!
+        this.id = 'AdBlockingResponse3';
+        this.start = '2016-09-26';
+        this.expiry = '2016-10-11'; // the test will STOP on MONDAY 10th PM. Test dates don't behave like our switches.
         this.author = 'Justin Pinner';
-        this.description = 'Adblocking response test with 30 minutes grace';
-        this.audience = 0.12;
+        this.description = 'Adblocking response with ad-free 404 demand test';
+        this.audience = 0;  // TODO: audience sizing
         this.audienceOffset = 0;
-        this.successMeasure = 'Adblocking users white-list the Guardian domain';
+        this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
         var variantDataLinkNames = [
             ['adblock whitelist no-close'],
             ['adblock supporter no-close'],
-            ['adblock subscriber no-close'],
-            ['adblock whitelist immediate-close'],
-            ['adblock supporter immediate-close'],
-            ['adblock subscriber immediate-close'],
-            ['adblock whitelist delayed-close'],
-            ['adblock supporter delayed-close'],
-            ['adblock subscriber delayed-close'],
-            ['survey adblock delayed-dismissed'],
-            ['survey adblock immediate-dismissed']
+            ['adblock subscriber no-close']
         ].map(function(_) {
             return _[0];
         }).join(', ');
         this.dataLinkNames = 'adblock response overlay: '+variantDataLinkNames+', subscriber number page: user help email';
-        this.idealOutcome = 'After whitelisting our ads, former ad-blocking users will not re-block them';
-        this.hypothesis = '30% of ad-blocking users will whitelist us when they are given a close button on a blocking pop-over window.';
+        this.idealOutcome = 'Adblock users demonstrate that they would make contributions that will completely offset lost ad display revenue';
+        this.hypothesis = 'Given the opportunity to pay for ad-free or whitelist the guardian more than 75% of adblock users choose one of these options';
 
         this.canRun = function () {
             return contains('chrome', detect.getUserAgent.browser.toLowerCase()) &&
@@ -57,10 +49,10 @@ define([
             // NOTE: async adblock detection doesn't work if the page is opened in a new tab
             return detect.adblockInUseSync() &&
                 !cookies.get('gu_abm_x') &&
+                (cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
                 !config.page.isFront &&
                 !config.page.shouldHideAdverts &&
                 config.page.section !== 'childrens-books-site' &&
-                config.page.section !== 'politics' && // because it's not https
                 !userFeatures.isPayingMember() &&
                 config.page.webTitle !== 'Subscriber number form' &&
                 config.page.webTitle !== 'How to disable your adblocker for theguardian.com' &&
@@ -77,66 +69,66 @@ define([
             id: 'control',
             test: function(){}
         }, {
-            id: 'no-close',
+            id: '299',
             test: function () {
                 if (isQualified()) {
+                    var variant = '299',
+                        whitelistText = 'Allow ads and browse for free',
+                        adFreeText = 'Ad free &pound;2.99/month',
+                        header = 'Advertising helps fund our journalism';
+
                     var surveyOverlay = new SurveyAdBlock({
-                        surveyHeader: 'Advertising helps fund our journalism',
-                        surveyText: 'We know that advertising on the Internet can be frustrating. But we\'re continually working to make sure our ads are well behaved because we want to get it right and we depend on advertising revenue.',
-                        surveyTextSecond: 'Please allow us to show you adverts.',
-                        surveyTextThird: '<hr /><p class="survey-text__info">How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_no-close">detailed instructions</a>)</p><div class="image-link-container"><img src="' + config.images.commercial['abp-whitelist-instruction-chrome'] + '"/></div><p class="survey-text__info"><strong>Ad Block:</strong> Click the <img alt="adblock" src="' + config.images.commercial['ab-icon'] + '" width="20px"/> icon &#x2794; &quot;Don\'t run on pages on this domain&quot; &#x2794; &quot;Exclude&quot;</p><p class="survey-text__info"><strong>Ad Block Plus:</strong> Click the <img alt="adblock plus" src="' + config.images.commercial['abp-icon'] + '" width="20px"/> icon &#x2794; &quot;Disable on theguardian.com&quot;</p><p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>',
-                        surveyTextMembership: 'Already paying? <a class=\"text-link\" href=\"https://profile.theguardian.com/signin?INTCMP=ADB_RESP_no-close\" data-link-name=\"adblock supporter no-close\">supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/subscriber-number" data-link-name=\"adblock subscriber no-close\">subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/contributor-email" data-link-name=\"adblock contributor no-close\">contributor validation</a>',
-                        subscriberLink: '/commercial/subscriber-number',
-                        subscriberText: 'Subscriber number',
-                        subscriberDataLink: 'adblock subscriber no-close',
-                        contributorLink: '/commercial/contributor-email',
-                        contributorText: 'Contributor email address',
-                        contributorDataLink: 'adblock contributor no-close',
-                        showCloseBtn: false
+                        whitelistText: whitelistText,
+                        adFreeText: adFreeText,
+                        surveyHeader: header,
+                        whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
+                        adBlockIcon: config.images.commercial['ab-icon'],
+                        adBlockPlusIcon: config.images.commercial['abp-icon'],
+                        variant: variant
                     });
                     surveyOverlay.attach();
                     surveyOverlay.show();
                 }
             }
         }, {
-            id: 'immediate-close',
+            id: '499',
             test: function () {
                 if (isQualified()) {
+                    var variant = '499',
+                        whitelistText = 'Allow ads and browse for free',
+                        adFreeText = 'Ad free &pound;4.99/month',
+                        header = 'Advertising helps fund our journalism';
+
                     var surveyOverlay = new SurveyAdBlock({
-                        surveyHeader: 'Advertising helps fund our journalism',
-                        surveyText: 'We know that advertising on the Internet can be frustrating. But we\'re continually working to make sure our ads are well behaved because we want to get it right and we depend on advertising revenue.',
-                        surveyTextSecond: 'Please allow us to show you adverts.',
-                        surveyTextThird: '<hr /><p class="survey-text__info">How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_immediate-close">detailed instructions</a>)</p><div class="image-link-container"><img src="' + config.images.commercial['abp-whitelist-instruction-chrome'] + '"/></div><p class="survey-text__info"><strong>Ad Block:</strong> Click the <img alt="adblock" src="' + config.images.commercial['ab-icon'] + '" width="20px"/> icon &#x2794; &quot;Don\'t run on pages on this domain&quot; &#x2794; &quot;Exclude&quot;</p><p class="survey-text__info"><strong>Ad Block Plus:</strong> Click the <img alt="adblock plus" src="' + config.images.commercial['abp-icon'] + '" width="20px"/> icon &#x2794; &quot;Disable on theguardian.com&quot;</p><p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>',
-                        surveyTextMembership: 'Already paying? <a class=\"text-link\" href=\"https://profile.theguardian.com/signin?INTCMP=ADB_RESP_immediate-close\" data-link-name=\"adblock supporter immediate-close\">supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/subscriber-number" data-link-name=\"adblock subscriber immediate-close\">subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/contributor-email" data-link-name=\"adblock contributor immediate-close\">contributor validation</a>',
-                        subscriberLink: '/commercial/subscriber-number',
-                        subscriberText: 'Subscriber number',
-                        subscriberDataLink: 'adblock subscriber immediate-close',
-                        contributorLink: '/commercial/contributor-email',
-                        contributorText: 'Contributor email address',
-                        contributorDataLink: 'adblock contributor immediate-close',
-                        showCloseBtn: true
+                        whitelistText: whitelistText,
+                        adFreeText: adFreeText,
+                        surveyHeader: header,
+                        whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
+                        adBlockIcon: config.images.commercial['ab-icon'],
+                        adBlockPlusIcon: config.images.commercial['abp-icon'],
+                        variant: variant
                     });
                     surveyOverlay.attach();
                     surveyOverlay.show();
                 }
             }
         }, {
-            id: 'delayed-close',
+            id: '999',
             test: function () {
                 if (isQualified()) {
+                    var variant = '999',
+                        whitelistText = 'Allow ads and browse for free',
+                        adFreeText = 'Ad free &pound;9.99/month',
+                        header = 'Advertising helps fund our journalism';
+
                     var surveyOverlay = new SurveyAdBlock({
-                        surveyHeader: 'Advertising helps fund our journalism',
-                        surveyText: 'We know that advertising on the Internet can be frustrating. But we\'re continually working to make sure our ads are well behaved because we want to get it right and we depend on advertising revenue.',
-                        surveyTextSecond: 'Please allow us to show you adverts.',
-                        surveyTextThird: '<hr /><p class="survey-text__info">How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_delayed-close">detailed instructions</a>)</p><div class="image-link-container"><img src="' + config.images.commercial['abp-whitelist-instruction-chrome'] + '"/></div><p class="survey-text__info"><strong>Ad Block:</strong> Click the <img alt="adblock" src="' + config.images.commercial['ab-icon'] + '" width="20px"/> icon &#x2794; &quot;Don\'t run on pages on this domain&quot; &#x2794; &quot;Exclude&quot;</p><p class="survey-text__info"><strong>Ad Block Plus:</strong> Click the <img alt="adblock plus" src="' + config.images.commercial['abp-icon'] + '" width="20px"/> icon &#x2794; &quot;Disable on theguardian.com&quot;</p><p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>',
-                        surveyTextMembership: 'Already paying? <a class=\"text-link\" href=\"https://profile.theguardian.com/signin?INTCMP=ADB_RESP_delayed-close\" data-link-name=\"adblock supporter delayed-close\">supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/subscriber-number" data-link-name=\"adblock subscriber delayed-close\">subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class=\"text-link\" href=\"/commercial/contributor-email" data-link-name=\"adblock contributor delayed-close\">contributor validation</a>',
-                        subscriberLink: '/commercial/subscriber-number',
-                        subscriberText: 'Subscriber number',
-                        subscriberDataLink: 'adblock subscriber delayed-close',
-                        contributorLink: '/commercial/contributor-email',
-                        contributorText: 'Contributor email address',
-                        contributorDataLink: 'adblock contributor delayed-close',
-                        showCloseBtn: 'delayed'
+                        whitelistText: whitelistText,
+                        adFreeText: adFreeText,
+                        surveyHeader: header,
+                        whitelistGuideImage: config.images.commercial['abp-whitelist-instruction-chrome'],
+                        adBlockIcon: config.images.commercial['ab-icon'],
+                        adBlockPlusIcon: config.images.commercial['abp-icon'],
+                        variant: variant
                     });
                     surveyOverlay.attach();
                     surveyOverlay.show();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -23,8 +23,8 @@ define([
         this.expiry = '2016-10-14'; // this test will expire on Thurs 13th PM.
         this.author = 'Justin Pinner';
         this.description = 'Adblocking response with ad-free 404 test';
-        this.audience = 0;  // TODO: audience sizing
-        this.audienceOffset = 0; // exclude anyone that had been in 12% v2 test
+        this.audience = 0.12;
+        this.audienceOffset = 0.12; // exclude anyone that would have been in the previous 12% v2 test
         this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
         var variantDataLinkNames = [
@@ -44,19 +44,17 @@ define([
         this.idealOutcome = 'Adblock users demonstrate that they would make contributions that will completely offset lost ad display revenue';
         this.hypothesis = 'Given the opportunity to pay for ad-free or whitelist the guardian more than 75% of adblock users choose one of these options';
 
+        // NOTE: async adblock detection doesn't work reliably if the page is opened in a new tab
+
         this.canRun = function () {
             return contains('chrome', detect.getUserAgent.browser.toLowerCase()) &&
                 contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint()) &&
                 config.page.edition === 'UK' &&
-                //(cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
                 detect.adblockInUseSync();
         };
 
         var isQualified = function () {
-            // NOTE: async adblock detection doesn't work if the page is opened in a new tab
             return detect.adblockInUseSync() &&
-                !cookies.get('gu_abm_x') &&
-                //(cookies.get('GU_geo_continent') && cookies.get('GU_geo_continent').toUpperCase() === 'EU') &&
                 !config.page.isFront &&
                 !config.page.shouldHideAdverts &&
                 config.page.section !== 'childrens-books-site' &&
@@ -82,7 +80,7 @@ define([
                 if (isQualified()) {
                     var variant = '299',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Go ad-free for &pound;2.99/month',
+                        adFreeButtonText = 'Remove ads for &pound;2.99/month',
                         adFreeMessagePrefix = '&pound;2.99 per month',
                         header = 'Advertising helps fund our journalism';
 
@@ -106,7 +104,7 @@ define([
                 if (isQualified()) {
                     var variant = '499',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Go ad-free for &pound;4.99/month',
+                        adFreeButtonText = 'Remove ads for &pound;4.99/month',
                         adFreeMessagePrefix = '&pound;4.99 per month',
                         header = 'Advertising helps fund our journalism';
 
@@ -130,8 +128,8 @@ define([
                 if (isQualified()) {
                     var variant = '999',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Go ad-free for &pound;9.99/month',
-                        adFreeMessagePrefix = '&pound;4.99 per month',
+                        adFreeButtonText = 'Remove ads for &pound;9.99/month',
+                        adFreeMessagePrefix = '&pound;9.99 per month',
                         header = 'Advertising helps fund our journalism';
 
                     var surveyOverlay = new SurveyAdBlock({

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -92,7 +92,7 @@
             <div class="survey-text__info">
                 <div class="pay-now__close-btn" data-link-name="survey adblock <%=variant%> pay-now closed"><%=crossIcon%></div>
                 <div class="survey-buttons">
-                    <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><%=arrowWhiteRight%></div>
+                    <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><span class="is-hidden">paypal</span><%=arrowWhiteRight%></div>
                     <div class="survey-button-rounded__cta pay ccard" data-link-name="adblock adfree <%=variant%> creditcard button" alt="Pay with debit or credit card">Pay with debit/credit card<%=arrowWhiteRight%></div>
                 </div>
                 <hr />

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -1,4 +1,4 @@
-<div class="survey-overlay survey-adblock js-survey-adblock is-hidden" data-link-name="adblock <%=variant%> response overlay" role="dialog" aria-label="take part in our survey">
+<div class="survey-overlay survey-adblock js-survey-adblock is-hidden" data-link-name="adblock response overlay <%=variant%> " role="dialog" aria-label="take part in our survey">
     <div class="survey-container">
 
         <div class="survey-content">
@@ -66,16 +66,16 @@
         </div>
 
         <div class="survey-buttons">
-            <div class="survey-button__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
-            <div class="survey-button__cta whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
-            <div class="survey-button__cta readon state-4 is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta readon state-4 is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
         </div>
 
         <div class="howto-unblock state-2 is-hidden">
             <hr />
             <div class="survey-text__info">
                 <span>
-                    How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_<%=variant%>">detailed instructions</a>)
+                    How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP3_<%=variant%>">detailed instructions</a>)
                 </span>
                 <span class="howto-unblock__close-btn" data-link-name="survey adblock howto-unblock closed">
                     <%=crossIcon%>
@@ -90,15 +90,15 @@
         <div class="howto-pay state-3 is-hidden">
             <hr />
             <div class="survey-text__info">
-                <div class="pay-now__close-btn" data-link-name="survey adblock pay-now closed"><%=crossIcon%></div>
+                <div class="pay-now__close-btn" data-link-name="survey adblock <%=variant%> pay-now closed"><%=crossIcon%></div>
                 <div class="survey-buttons">
-                    <div class="survey-button__cta paypal" data-link-name="adblock adfree paypal button">Pay with PayPal<%=arrowWhiteRight%></div>
-                    <div class="survey-button__cta ccard" data-link-name="adblock adfree creditcard button">Pay with card<%=arrowWhiteRight%></div>
+                    <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><%=arrowWhiteRight%></div>
+                    <div class="survey-button-rounded__cta pay ccard" data-link-name="adblock adfree <%=variant%> creditcard button" alt="Pay with debit or credit card">Pay with debit/credit card<%=arrowWhiteRight%></div>
                 </div>
                 <hr />
                 <div class="survey-buttons">
                     <p>Don't want to pay?</p>
-                    <div class="survey-button__cta whitelist" data-link-name="pay-now <%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+                    <div class="survey-button-rounded__cta whitelist" data-link-name="pay-now <%=variant%>"><%=whitelistText%><%=arrowWhiteRight%></div>
                 </div>
             </div>
         </div>
@@ -106,10 +106,10 @@
         <div class="survey-text__info footer state-1">
             <hr />
             <p>
-                Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
+                Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP3_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
             </p>
             <p>
-                If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP_<%=variant%>">contact us</a>
+                If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP3_<%=variant%>">contact us</a>
             </p>
         </div>
 

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -11,7 +11,7 @@
                 <%=surveyOverlaySimple%>
             </div>
             <div class="survey-header">
-                <div class="state-1 state-2">
+                <div class="greeting-state whitelist-state">
                     <div class="survey-text__header">
                         We rely on advertising revenue to fund our journalism
                     </div>
@@ -22,7 +22,7 @@
                     </div>
                 </div>
 
-                <div class="state-3 is-hidden">
+                <div class="adfree-state is-hidden">
                     <div class="survey-text__header">
                         Choose ad-free payment method
                     </div>
@@ -36,7 +36,7 @@
                     </div>
                 </div>
 
-                <div class="state-4 is-hidden">
+                <div class="thankyou-state is-hidden">
                     <div class="survey-text__header">
                         Thank you for your interest in an ad-free Guardian
                     </div>
@@ -63,12 +63,12 @@
         </div>
 
         <div class="survey-buttons">
-            <div class="survey-button-rounded__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
-            <div class="survey-button-rounded__cta cta-whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
-            <div class="survey-button-rounded__cta readon state-4 is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta noads greeting-state whitelist-state" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta cta-whitelist greeting-state" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta readon thankyou-state is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
         </div>
 
-        <div class="howto-unblock state-2 is-hidden">
+        <div class="howto-unblock whitelist-state is-hidden">
             <hr />
             <div class="survey-text__info">
                 <span class="survey-text__strong">
@@ -84,7 +84,7 @@
             <p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>
         </div>
 
-        <div class="howto-pay state-3 is-hidden">
+        <div class="howto-pay adfree-state is-hidden">
             <hr />
             <div class="survey-text__info">
                 <div class="pay-now__close-btn" data-link-name="survey adblock <%=variant%> pay-now closed"><%=crossIcon%></div>
@@ -97,7 +97,7 @@
             </div>
         </div>
 
-        <div class="survey-text__info state-1">
+        <div class="survey-text__info greeting-state">
             <hr />
             <div class="footer">
                 <p>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -1,7 +1,7 @@
 <div class="survey-overlay survey-adblock js-survey-adblock is-hidden" data-link-name="adblock <%=variant%> response overlay" role="dialog" aria-label="take part in our survey">
     <div class="survey-container">
 
-        <div class="survey-content-1 rely">
+        <div class="survey-content">
             <% if (marque36icon) { %>
             <div class="survey-logo">
                 <%=marque36icon%>
@@ -10,34 +10,68 @@
             <div class="survey-icon">
                 <%=surveyOverlaySimple%>
             </div>
-            <h3 class="survey-text__header">
-                Advertising helps fund our journalism
-            </h3>
-            <div class="survey-text">
-                <p class="survey-text__strong">
-                    Some text that explains WTF this is.
-                </p>
+            <div class="survey-header">
+                <div class="state-1 state-2">
+                    <div class="survey-text__header">
+                        Advertising helps fund our journalism
+                    </div>
+                    <div class="survey-text">
+                        <p class="survey-text__strong">
+                            Advertising revenue and direct payments from our reader base are the only ways we can maintain the Guardian in perpetuity.
+                        </p>
+                        <p class="survey-text__strong">
+                            Please choose one of the methods below to continue reading our content.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="state-3 is-hidden">
+                    <div class="survey-text__header">
+                        Choose ad-free payment method
+                    </div>
+                    <div class="survey-text">
+                        <p class="survey-text__strong">
+                            <%=adFreeMessagePrefix%> buys you an ad-free experience across theguardian.com website when you sign in.
+                        </p>
+                        <p class="survey-text__strong">
+                            There's no ongoing commitment, and you can stop your payments or take a holiday from ad-free at any time.
+                        </p>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="survey-link noads-button">
-            <a class="survey-link__takepart" href="#" data-link-name="<%=adFreeDataLink%>"><%=adFreeText%><%=arrowWhiteRight%></a>
-        </div>
-        <div class="survey-link whitelist-button">
-            <a class="survey-link__takepart" href="#" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></a>
+        <div class="survey-buttons">
+            <div class="survey-button__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
+            <div class="survey-button__cta whitelist state-1 state-3" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
         </div>
 
-        <div class="howto-unblock is-hidden">
-            <hr /><p class="survey-text__info">How to allow ads on the Guardian with AdBlock or AdBlock Plus
-            (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_<%=variant%>">detailed instructions</a>)</p>
+        <div class="howto-unblock state-2 is-hidden">
+            <hr />
+            <div class="survey-text__info">
+                <span>
+                    How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_<%=variant%>">detailed instructions</a>)
+                </span>
+                <span class="howto-unblock__close-btn" data-link-name="survey adblock howto-unblock closed">
+                    <%=crossIcon%>
+                </span>
+            </div>
             <div class="image-link-container"><img src="<%=whitelistGuideImage%>"/></div>
             <p class="survey-text__info"><strong>Ad Block:</strong> Click the <img alt="adblock" src="<%=adBlockIcon%>" width="20px"/> icon &#x2794; &quot;Don\'t run on pages on this domain&quot; &#x2794; &quot;Exclude&quot;</p>
             <p class="survey-text__info"><strong>Ad Block Plus:</strong> Click the <img alt="adblock plus" src="<%=adBlockPlusIcon%>" width="20px"/> icon &#x2794; &quot;Disable on theguardian.com&quot;</p>
             <p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>
         </div>
 
-        <div class="survey-content-2 is-hidden pay-method">
-            ! NEEDS CONTENT !
+        <div class="howto-pay state-3 is-hidden">
+            <hr />
+            <div class="survey-text__info">
+                <span>
+                   Pay now!
+                </span>
+                <span class="pay-now__close-btn" data-link-name="survey adblock pay-now closed">
+                    <%=crossIcon%>
+                </span>
+            </div>
         </div>
 
         <div class="survey-content-3 is-hidden whitelist">
@@ -48,13 +82,9 @@
             ! NEEDS CONTENT !
         </div>
 
-        <div class="survey-links paying">
-            <hr />Already paying?&nbsp;
-            <a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">supporter sign in</a>
-            &nbsp;&nbsp;|&nbsp;&nbsp;
-            <a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">subscriber sign in</a>
-            &nbsp;&nbsp;|&nbsp;&nbsp;
-            <a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">contributor validation</a>
+        <div class="survey-text__info">
+            <hr />
+            Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
         </div>
 
     </div>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -38,12 +38,37 @@
                         </p>
                     </div>
                 </div>
+
+                <div class="state-4 is-hidden">
+                    <div class="survey-text__header">
+                        Thank you for your interest in an ad-free Guardian
+                    </div>
+                    <div class="survey-text__strong">
+                        <p>
+                            We're assessing demand for an ad-free version of theguardian.com. Your interest has been counted
+                            and you won't be charged anything.
+                        </p>
+                        <p>
+                            Please email <a class="text-link" href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a> if you want to
+                            find out more.
+                        </p>
+                        <p>
+                            Help us improve your experience by doing our <a class="text-link" href="https://www.surveymonkey.net/r/Preview/?sm=M61PWayc8w23BetSmIe6mx6_2BhjqfmIRoVDQlyXtgbQJbKRAvwsLP8EnLFPrQHZvY" target="_blank">1 minute survey</a>.
+                        </p>
+                        <p>
+                            Thank you.
+                        </p>
+                    </div>
+
+                </div>
+
             </div>
         </div>
 
         <div class="survey-buttons">
             <div class="survey-button__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
-            <div class="survey-button__cta whitelist state-1 state-3" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+            <div class="survey-button__cta whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+            <div class="survey-button__cta readon state-4 is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
         </div>
 
         <div class="howto-unblock state-2 is-hidden">
@@ -65,21 +90,17 @@
         <div class="howto-pay state-3 is-hidden">
             <hr />
             <div class="survey-text__info">
-                <span>
-                   Pay now!
-                </span>
-                <span class="pay-now__close-btn" data-link-name="survey adblock pay-now closed">
-                    <%=crossIcon%>
-                </span>
+                <div class="pay-now__close-btn" data-link-name="survey adblock pay-now closed"><%=crossIcon%></div>
+                <div class="survey-buttons">
+                    <div class="survey-button__cta paypal" data-link-name="adblock adfree paypal button">Pay with PayPal<%=arrowWhiteRight%></div>
+                    <div class="survey-button__cta ccard" data-link-name="adblock adfree creditcard button">Pay with credit card<%=arrowWhiteRight%></div>
+                </div>
+                <hr />
+                <div class="survey-buttons">
+                    <p>Don't want to pay?</p>
+                    <div class="survey-button__cta whitelist" data-link-name="pay-now <%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+                </div>
             </div>
-        </div>
-
-        <div class="survey-content-3 is-hidden whitelist">
-            ! NEEDS CONTENT !
-        </div>
-
-        <div class="survey-content-4 is-hidden thank-you">
-            ! NEEDS CONTENT !
         </div>
 
         <div class="survey-text__info">

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -1,87 +1,61 @@
-<div class="survey-overlay survey-adblock js-survey-adblock is-hidden" data-link-name="adblock response overlay" role="dialog" aria-label="take part in our survey">
+<div class="survey-overlay survey-adblock js-survey-adblock is-hidden" data-link-name="adblock <%=variant%> response overlay" role="dialog" aria-label="take part in our survey">
     <div class="survey-container">
-        <% if (showCloseBtn) { %>
-        <div class="survey-adblock-close js-survey-adblock-close">
-            <%if (showCloseBtn === "delayed") { %>
-            <span class="site-message__close-btn js-survey-adblock__delayed-close is-hidden"><span class="countdown">5</span></span>
-            <button class="site-message__close-btn js-survey-adblock__close-btn is-hidden" data-link-name="survey adblock delayed-dismissed">
-                <span class="is-hidden">Close</span>
-                <%=crossIcon%>
-            </button>
-            <% } else { %>
-            <button class="site-message__close-btn js-survey-adblock__close-btn is-hidden" data-link-name="survey adblock immediate-dismissed">
-                <span class="is-hidden">Close</span>
-                <%=crossIcon%>
-            </button>
+
+        <div class="survey-content-1 rely">
+            <% if (marque36icon) { %>
+            <div class="survey-logo">
+                <%=marque36icon%>
+            </div>
             <% } %>
-        </div>
-        <% } %>
-        <% if (marque36icon) { %>
-        <div class="survey-logo">
-            <%=marque36icon%>
-        </div>
-        <% } %>
-        <div class="survey-icon">
-            <%=surveyOverlaySimple%>
-        </div>
-        <h3 class="survey-text__header">
-            <%=surveyHeader%>
-        </h3>
-        <div class="survey-content">
+            <div class="survey-icon">
+                <%=surveyOverlaySimple%>
+            </div>
+            <h3 class="survey-text__header">
+                Advertising helps fund our journalism
+            </h3>
             <div class="survey-text">
                 <p class="survey-text__strong">
-                    <%=surveyText%>
+                    Some text that explains WTF this is.
                 </p>
-                <% if (surveyTextSecond) { %>
-                    <p class="survey-text__strong">
-                        <%=surveyTextSecond%>
-                    </p>
-                <% } %>
-                <% if (surveyTextThird) { %>
-                <p class="survey-text__info">
-                    <%=surveyTextThird%>
-                </p>
-                <% } %>
-                <% if (membershipLink || signupLink) { %>
-                <div class="survey-links">
-                    <% if (membershipLink) { %>
-                    <div class="survey-link">
-                        <a class="survey-link__takepart" href="<%=membershipLink%>" target="_blank" data-link-name="<%=membershipDataLink%>"><%=membershipText%><%=arrowWhiteRight%></a>
-                    </div>
-                    <% } %>
-                    <% if (signupLink) { %>
-                    <div class="survey-link">
-                        <a class="survey-link__takepart" href="<%=signupLink%>" target="_blank" data-link-name="<%=signupDataLink%>"><%=signupText%><%=arrowWhiteRight%></a>
-                    </div>
-                    <% } %>
-                    <% if (contributorLink) { %>
-                    <div class="survey-link">
-                        <a class="survey-link__takepart" href="<%=signupLink%>" target="_blank" data-link-name="<%=contributorDataLink%>"><%=contributorText%><%=arrowWhiteRight%></a>
-                    </div>
-                    <% } %>
-                </div>
-                <% } %>
-                <% if (surveyTextUserHelp) { %>
-                <p class="survey-text__info">
-                    <%=surveyTextUserHelp%>
-                </p>
-                <% } %>
-                <% if (surveyTextMembership || surveyTextSubscriber) { %>
-                <div class="survey-links">
-                    <hr/>
-                    <% if (surveyTextMembership) { %>
-                    <p class="survey-text__info smaller">
-                        <%=surveyTextMembership%>
-                    </p>
-                    <% } %>
-                    <% if (surveyTextSubscriber) { %>
-                    <p class="survey-text__info smaller">
-                        <%=surveyTextSubscriber%>
-                    </p>
-                    <% } %>
-                </div>
-                <% } %>
             </div>
         </div>
+
+        <div class="survey-link noads-button">
+            <a class="survey-link__takepart" href="#" data-link-name="<%=adFreeDataLink%>"><%=adFreeText%><%=arrowWhiteRight%></a>
+        </div>
+        <div class="survey-link whitelist-button">
+            <a class="survey-link__takepart" href="#" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></a>
+        </div>
+
+        <div class="howto-unblock is-hidden">
+            <hr /><p class="survey-text__info">How to allow ads on the Guardian with AdBlock or AdBlock Plus
+            (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP_<%=variant%>">detailed instructions</a>)</p>
+            <div class="image-link-container"><img src="<%=whitelistGuideImage%>"/></div>
+            <p class="survey-text__info"><strong>Ad Block:</strong> Click the <img alt="adblock" src="<%=adBlockIcon%>" width="20px"/> icon &#x2794; &quot;Don\'t run on pages on this domain&quot; &#x2794; &quot;Exclude&quot;</p>
+            <p class="survey-text__info"><strong>Ad Block Plus:</strong> Click the <img alt="adblock plus" src="<%=adBlockPlusIcon%>" width="20px"/> icon &#x2794; &quot;Disable on theguardian.com&quot;</p>
+            <p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>
+        </div>
+
+        <div class="survey-content-2 is-hidden pay-method">
+            ! NEEDS CONTENT !
+        </div>
+
+        <div class="survey-content-3 is-hidden whitelist">
+            ! NEEDS CONTENT !
+        </div>
+
+        <div class="survey-content-4 is-hidden thank-you">
+            ! NEEDS CONTENT !
+        </div>
+
+        <div class="survey-links paying">
+            <hr />Already paying?&nbsp;
+            <a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">supporter sign in</a>
+            &nbsp;&nbsp;|&nbsp;&nbsp;
+            <a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">subscriber sign in</a>
+            &nbsp;&nbsp;|&nbsp;&nbsp;
+            <a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">contributor validation</a>
+        </div>
+
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -17,10 +17,10 @@
                     </div>
                     <div class="survey-text">
                         <p class="survey-text__strong">
-                            Advertising revenue and direct payments from our reader base are the only ways we can maintain the Guardian in perpetuity.
+                            The ability to display adverts is essential for us, but you're not currently seeing any.
                         </p>
                         <p class="survey-text__strong">
-                            Please choose one of the methods below to continue reading our content.
+                            Please choose how you would prefer to continue reading our content.
                         </p>
                     </div>
                 </div>
@@ -93,7 +93,7 @@
                 <div class="pay-now__close-btn" data-link-name="survey adblock pay-now closed"><%=crossIcon%></div>
                 <div class="survey-buttons">
                     <div class="survey-button__cta paypal" data-link-name="adblock adfree paypal button">Pay with PayPal<%=arrowWhiteRight%></div>
-                    <div class="survey-button__cta ccard" data-link-name="adblock adfree creditcard button">Pay with credit card<%=arrowWhiteRight%></div>
+                    <div class="survey-button__cta ccard" data-link-name="adblock adfree creditcard button">Pay with card<%=arrowWhiteRight%></div>
                 </div>
                 <hr />
                 <div class="survey-buttons">
@@ -103,9 +103,14 @@
             </div>
         </div>
 
-        <div class="survey-text__info">
+        <div class="survey-text__info footer state-1">
             <hr />
-            Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
+            <p>
+                Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
+            </p>
+            <p>
+                If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP_<%=variant%>">contact us</a>
+            </p>
         </div>
 
     </div>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -89,8 +89,8 @@
             <div class="survey-text__info">
                 <div class="pay-now__close-btn" data-link-name="survey adblock <%=variant%> pay-now closed"><%=crossIcon%></div>
                 <div class="survey-buttons">
-                    <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><span class="is-hidden">paypal</span><%=arrowWhiteRight%></div>
                     <div class="survey-button-rounded__cta pay ccard" data-link-name="adblock adfree <%=variant%> creditcard button" alt="Pay with debit or credit card">Pay with debit/credit card<%=arrowWhiteRight%></div>
+                    <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><span class="is-hidden">paypal</span><%=arrowWhiteRight%></div>
                 </div>
                 <hr />
                 <p class="survey-text__strong">Don't want to pay? <a class="text-link cta-whitelist" data-link-name="pay-now whitelist <%=variant%>">Allow ads</a>&nbsp;&#x2794;</p>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -68,8 +68,7 @@
             <div class="survey-button-rounded__cta readon thankyou-state is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
         </div>
 
-        <div class="howto-unblock whitelist-state is-hidden">
-            <hr />
+        <div class="howto-unblock whitelist-state is-hidden top-border">
             <div class="survey-text__info">
                 <span class="survey-text__strong">
                     Allow ads and browse for free. <a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP30pc_<%=variant%>"><span>More information</span></a>
@@ -84,21 +83,20 @@
             <p class="survey-text__info" style="margin-top: 25px;">After making this change, please reload the page in your browser.</p>
         </div>
 
-        <div class="howto-pay adfree-state is-hidden">
-            <hr />
+        <div class="howto-pay adfree-state is-hidden top-border">
             <div class="survey-text__info">
                 <div class="pay-now__close-btn" data-link-name="survey adblock <%=variant%> pay-now closed"><%=crossIcon%></div>
                 <div class="survey-buttons">
                     <div class="survey-button-rounded__cta pay ccard" data-link-name="adblock adfree <%=variant%> creditcard button" alt="Pay with debit or credit card">Pay with debit/credit card<%=arrowWhiteRight%></div>
                     <div class="survey-button-rounded__cta pay paypal" data-link-name="adblock adfree <%=variant%> paypal button"><span class="pp-paywith">Pay with</span><span class="is-hidden">paypal</span><%=arrowWhiteRight%></div>
                 </div>
-                <hr />
-                <p class="survey-text__strong">Don't want to pay? <a class="text-link cta-whitelist" data-link-name="pay-now whitelist <%=variant%>">Allow ads</a>&nbsp;&#x2794;</p>
+                <div class="survey-text__strong top-border">
+                    <p>Don't want to pay? <a class="text-link cta-whitelist" data-link-name="pay-now whitelist <%=variant%>">Allow ads</a>&nbsp;&#x2794;</p>
+                </div>
             </div>
         </div>
 
-        <div class="survey-text__info greeting-state">
-            <hr />
+        <div class="survey-text__info greeting-state top-border">
             <div class="footer">
                 <p>
                     Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP30pc_<%=variant%>" data-link-name="adblock supporter <%=variant%>">Supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">Print subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">Contributor sign in</a>

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -13,14 +13,11 @@
             <div class="survey-header">
                 <div class="state-1 state-2">
                     <div class="survey-text__header">
-                        Advertising helps fund our journalism
+                        We rely on advertising revenue to fund our journalism
                     </div>
                     <div class="survey-text">
-                        <p class="survey-text__strong">
-                            The ability to display adverts is essential for us, but you're not currently seeing any.
-                        </p>
-                        <p class="survey-text__strong">
-                            Please choose how you would prefer to continue reading our content.
+                        <p>
+                            Please <strong>allow ads</strong> or <strong>go ad-free</strong> so we can continue to bring you quality news into the future.
                         </p>
                     </div>
                 </div>
@@ -30,10 +27,10 @@
                         Choose ad-free payment method
                     </div>
                     <div class="survey-text">
-                        <p class="survey-text__strong">
+                        <p>
                             <%=adFreeMessagePrefix%> buys you an ad-free experience across theguardian.com website when you sign in.
                         </p>
-                        <p class="survey-text__strong">
+                        <p>
                             There's no ongoing commitment, and you can stop your payments or take a holiday from ad-free at any time.
                         </p>
                     </div>
@@ -43,7 +40,7 @@
                     <div class="survey-text__header">
                         Thank you for your interest in an ad-free Guardian
                     </div>
-                    <div class="survey-text__strong">
+                    <div>
                         <p>
                             We're assessing demand for an ad-free version of theguardian.com. Your interest has been counted
                             and you won't be charged anything.
@@ -67,15 +64,15 @@
 
         <div class="survey-buttons">
             <div class="survey-button-rounded__cta noads state-1 state-2" data-link-name="<%=adFreeDataLink%>"><%=adFreeButtonText%><%=arrowWhiteRight%></div>
-            <div class="survey-button-rounded__cta whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
+            <div class="survey-button-rounded__cta cta-whitelist state-1" data-link-name="<%=whitelistDataLink%>"><%=whitelistText%><%=arrowWhiteRight%></div>
             <div class="survey-button-rounded__cta readon state-4 is-hidden" data-link-name="adblock paymentdone continuetoarticle">Continue to article<%=arrowWhiteRight%></div>
         </div>
 
         <div class="howto-unblock state-2 is-hidden">
             <hr />
             <div class="survey-text__info">
-                <span>
-                    How to allow ads on the Guardian with AdBlock or AdBlock Plus (<a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP3_<%=variant%>">detailed instructions</a>)
+                <span class="survey-text__strong">
+                    Allow ads and browse for free. <a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP30pc_<%=variant%>"><span>More information</span></a>
                 </span>
                 <span class="howto-unblock__close-btn" data-link-name="survey adblock howto-unblock closed">
                     <%=crossIcon%>
@@ -96,21 +93,20 @@
                     <div class="survey-button-rounded__cta pay ccard" data-link-name="adblock adfree <%=variant%> creditcard button" alt="Pay with debit or credit card">Pay with debit/credit card<%=arrowWhiteRight%></div>
                 </div>
                 <hr />
-                <div class="survey-buttons">
-                    <p>Don't want to pay?</p>
-                    <div class="survey-button-rounded__cta whitelist" data-link-name="pay-now <%=variant%>"><%=whitelistText%><%=arrowWhiteRight%></div>
-                </div>
+                <p class="survey-text__strong">Don't want to pay? <a class="text-link cta-whitelist" data-link-name="pay-now whitelist <%=variant%>">Allow ads</a>&nbsp;&#x2794;</p>
             </div>
         </div>
 
-        <div class="survey-text__info footer state-1">
+        <div class="survey-text__info state-1">
             <hr />
-            <p>
-                Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP3_<%=variant%>" data-link-name="adblock supporter <%=variant%>">I am a supporter</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">I am a subscriber</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">I am a contributor</a>
-            </p>
-            <p>
-                If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP3_<%=variant%>">contact us</a>
-            </p>
+            <div class="footer">
+                <p>
+                    Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP30pc_<%=variant%>" data-link-name="adblock supporter <%=variant%>">Supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">Print subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">Contributor sign in</a>
+                </p>
+                <p>
+                    If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP30pc_<%=variant%>">contact us</a>
+                </p>
+            </div>
         </div>
 
     </div>

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -304,49 +304,45 @@
         margin-bottom: $gs-column-width/4;
         text-align: center;
         line-height: $gs-column-width/2;
-        .survey-button__cta {
-            -moz-box-shadow: inset 0px 1px 0px 0px #a4e271;
-            -webkit-box-shadow: inset 0px 1px 0px 0px #a4e271;
-            box-shadow: inset 0px 1px 0px 0px #a4e271;
-            background: -webkit-gradient(linear, left top, left bottom, color-stop(.05, #89c403), color-stop(1, #77a809));
-            background: -moz-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background: -webkit-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background: -o-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background: -ms-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background: linear-gradient(to bottom, #89c403 5%, #77a809 100%);
-            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#89c403', endColorstr='#77a809',GradientType=0);
-            background-color: #89c403;
-            -moz-border-radius: 6px;
-            -webkit-border-radius: 6px;
-            border-radius: 6px;
-            border: 1px solid #74b807;
+
+        .survey-button-rounded__cta {
+            @include clearfix;
+            @include circular;
+            border: 1px solid rgba(#ffffff, .3);
             display: inline-block;
-            cursor: pointer;
-            color: #ffffff;
-            font-weight: bold;
+            @include mq($until: mobile) {
+                margin-bottom: $gs-row-height / 2;
+            }
             padding: 6px 24px;
-            text-decoration: none;
-            text-shadow: 0px 1px 0px #528009;
             position: relative;
+            cursor: pointer;
             margin-top: 10px;
+            background-color: #2e8b3a;
             top: 25%;
             height: 50%;
             width: 250px;
         }
-        .survey-button__cta:hover {
-            background: -webkit-gradient(linear, left top, left bottom, color-stop(.05, #77a809), color-stop(1, #89c403));
-            background: -moz-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background: -webkit-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background: -o-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background: -ms-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background: linear-gradient(to bottom, #77a809 5%, #89c403 100%);
-            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#77a809', endColorstr='#89c403',GradientType=0);
+        .survey-button-rounded__cta:hover {
             background-color: #77a809;
-            text-decoration: none;
         }
-        .survey-button__cta:active {
-            position: relative;
-            top: 1px;
+
+        .survey-button-rounded__cta.pay {
+            .pp-paywith {
+                margin-left: 35px;
+            }
+            background-color: #dba500;
+        }
+
+        .survey-button-rounded__cta.pay:hover {
+            background-color: #77a809;
+        }
+
+        .survey-button-rounded__cta.pay.paypal {
+            text-align: left;
+            background-repeat: no-repeat;
+            background-size: 93px;
+            background-image: url('//contribute.theguardian.com/assets/dist/images/form/24f3c805/ppcom-white.svg');
+            background-position: left 125px center;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -132,6 +132,10 @@
     width: 100%;
     height: 100%;
 
+    .top-border {
+        border-top: 1px solid #dddddd;
+    }
+
     .countdown {
         @include fs-textSans(2);
         display: block;
@@ -244,6 +248,7 @@
         @include fs-bodyCopy(1);
         line-height: 120%;
         text-align: left;
+        margin-top: 5px;
 
         .center {
             text-align: center;

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -242,7 +242,6 @@
 
     .survey-text__info {
         @include fs-bodyCopy(1);
-        font-size: 12px;
         line-height: 120%;
         text-align: left;
 
@@ -253,6 +252,21 @@
         p {
             margin-top: 10px;
         }
+
+        .footer p {
+            font-size: 12px;
+            margin-top: 20px;
+        }
+
+    }
+
+    .survey-text__strong {
+        @include fs-textSans(4);
+        font-size: 14px;
+        font-weight: bold;
+        margin-bottom: 0;
+        padding: 6px 0 0 10px;
+        height: 44px;
     }
 
     .text-link {
@@ -296,7 +310,7 @@
     }
 
     .survey-buttons {
-        @include fs-bodyCopy(1);
+        @include fs-textSans(5);
         @include mq($until: mobile) {
             margin-bottom: $gs-row-height / 4;
         }
@@ -330,7 +344,7 @@
             .pp-paywith {
                 margin-left: 35px;
             }
-            background-color: #f5a623;
+            background-color: #f6a424;
         }
 
         .survey-button-rounded__cta.pay:hover {

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -167,7 +167,7 @@
         width: 100%;
         height: 100%;
         padding: $gs-row-height $gs-column-width*.5;
-        background-color: #01558b;
+        background-color: #175789;
         color: #ffffff;
         box-sizing: border-box;
 
@@ -181,7 +181,7 @@
     }
 
     .survey-container.thank-you {
-        background-color: #3e3e3e;
+        background-color: #3e3d3d;
     }
 
     .survey-logo {
@@ -317,24 +317,24 @@
             position: relative;
             cursor: pointer;
             margin-top: 10px;
-            background-color: #2e8b3a;
+            background-color: #2d8b3a;
             top: 25%;
             height: 50%;
             width: 250px;
         }
         .survey-button-rounded__cta:hover {
-            background-color: #77a809;
+            background-color: #3f9d4c;
         }
 
         .survey-button-rounded__cta.pay {
             .pp-paywith {
                 margin-left: 35px;
             }
-            background-color: #dba500;
+            background-color: #f5a623;
         }
 
         .survey-button-rounded__cta.pay:hover {
-            background-color: #77a809;
+            background-color: #f4b906;
         }
 
         .survey-button-rounded__cta.pay.paypal {

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -244,11 +244,14 @@
         @include fs-bodyCopy(1);
         font-size: 12px;
         line-height: 120%;
-        margin: 0 $gs-gutter $gs-column-width/4 0;
         text-align: left;
 
         .center {
             text-align: center;
+        }
+
+        p {
+            margin-top: 10px;
         }
     }
 
@@ -392,8 +395,12 @@
 
     .image-link-container {
         height: 85px;
+        margin-top: 10px;
         margin-bottom: $gs-column-width/2;
         margin-left: $gs-gutter / 2;
+        p {
+            margin-top: 10px;
+        }
     }
 
 }

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -340,9 +340,9 @@
     }
 
     .howto-unblock {
-       p {
-           text-align: left;
-       }
+        p {
+            text-align: left;
+        }
     }
 
     .howto-unblock__close-btn {

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -241,6 +241,7 @@
         font-size: 12px;
         line-height: 120%;
         margin: 0 $gs-gutter $gs-column-width/4 0;
+        text-align: center;
 
         .text-link {
             color: #ffffff;
@@ -281,6 +282,83 @@
         float: left;
         padding: 0 8px;
         line-height: $gs-column-width/2;
+    }
+
+    .survey-buttons {
+        overflow: hidden;
+        margin-bottom: $gs-column-width/4;
+        text-align: center;
+        @include fs-bodyCopy(1);
+        @include mq($until: mobile) {
+            margin-bottom: $gs-row-height / 4;
+        }
+        line-height: $gs-column-width/2;
+        .survey-button__cta {
+            -moz-box-shadow:inset 0px 1px 0px 0px #a4e271;
+            -webkit-box-shadow:inset 0px 1px 0px 0px #a4e271;
+            box-shadow:inset 0px 1px 0px 0px #a4e271;
+            background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #89c403), color-stop(1, #77a809));
+            background:-moz-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background:-webkit-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background:-o-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background:-ms-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background:linear-gradient(to bottom, #89c403 5%, #77a809 100%);
+            filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#89c403', endColorstr='#77a809',GradientType=0);
+            background-color:#89c403;
+            -moz-border-radius:6px;
+            -webkit-border-radius:6px;
+            border-radius:6px;
+            border:1px solid #74b807;
+            display:inline-block;
+            cursor:pointer;
+            color:#ffffff;
+            font-weight:bold;
+            padding:6px 24px;
+            text-decoration:none;
+            text-shadow:0px 1px 0px #528009;
+            position: relative;
+            margin-top: 10px;
+            top: 25%;
+            height: 50%;
+            width: 250px;
+        }
+        .survey-button__cta:hover {
+            background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #77a809), color-stop(1, #89c403));
+            background:-moz-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background:-webkit-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background:-o-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background:-ms-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background:linear-gradient(to bottom, #77a809 5%, #89c403 100%);
+            filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#77a809', endColorstr='#89c403',GradientType=0);
+            background-color:#77a809;
+            text-decoration: none;
+        }
+        .survey-button__cta:active {
+            position:relative;
+            top:1px;
+        }
+    }
+
+    .howto-unblock {
+       p {
+           text-align: left;
+       }
+    }
+
+    .howto-unblock__close-btn {
+        @include mq($until: tablet) {
+            position: relative;
+        }
+
+        .inline-icon {
+            svg {
+                width: 10px;
+                height: 10px;
+            }
+            color: #ffffff;
+            fill: #ffffff;
+            float: right;
+        }
     }
 
     .survey-subscriber-links {

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -180,6 +180,10 @@
         }
     }
 
+    .survey-container.thank-you {
+        background-color: #3e3e3e;
+    }
+
     .survey-logo {
         svg {
             fill: #ffffff;
@@ -241,14 +245,18 @@
         font-size: 12px;
         line-height: 120%;
         margin: 0 $gs-gutter $gs-column-width/4 0;
-        text-align: center;
+        text-align: left;
 
-        .text-link {
-            color: #ffffff;
-            text-decoration: underline;
-            &:hover {
-                text-decoration: none;
-            }
+        .center {
+            text-align: center;
+        }
+    }
+
+    .text-link {
+        color: #ffffff;
+        text-decoration: underline;
+        &:hover {
+            text-decoration: none;
         }
     }
 
@@ -345,7 +353,7 @@
         }
     }
 
-    .howto-unblock__close-btn {
+    .howto-unblock__close-btn, .pay-now__close-btn {
         @include mq($until: tablet) {
             position: relative;
         }

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -285,37 +285,37 @@
     }
 
     .survey-buttons {
-        overflow: hidden;
-        margin-bottom: $gs-column-width/4;
-        text-align: center;
         @include fs-bodyCopy(1);
         @include mq($until: mobile) {
             margin-bottom: $gs-row-height / 4;
         }
+        overflow: hidden;
+        margin-bottom: $gs-column-width/4;
+        text-align: center;
         line-height: $gs-column-width/2;
         .survey-button__cta {
-            -moz-box-shadow:inset 0px 1px 0px 0px #a4e271;
-            -webkit-box-shadow:inset 0px 1px 0px 0px #a4e271;
-            box-shadow:inset 0px 1px 0px 0px #a4e271;
-            background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #89c403), color-stop(1, #77a809));
-            background:-moz-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background:-webkit-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background:-o-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background:-ms-linear-gradient(top, #89c403 5%, #77a809 100%);
-            background:linear-gradient(to bottom, #89c403 5%, #77a809 100%);
-            filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#89c403', endColorstr='#77a809',GradientType=0);
-            background-color:#89c403;
-            -moz-border-radius:6px;
-            -webkit-border-radius:6px;
-            border-radius:6px;
-            border:1px solid #74b807;
-            display:inline-block;
-            cursor:pointer;
-            color:#ffffff;
-            font-weight:bold;
-            padding:6px 24px;
-            text-decoration:none;
-            text-shadow:0px 1px 0px #528009;
+            -moz-box-shadow: inset 0px 1px 0px 0px #a4e271;
+            -webkit-box-shadow: inset 0px 1px 0px 0px #a4e271;
+            box-shadow: inset 0px 1px 0px 0px #a4e271;
+            background: -webkit-gradient(linear, left top, left bottom, color-stop(.05, #89c403), color-stop(1, #77a809));
+            background: -moz-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background: -webkit-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background: -o-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background: -ms-linear-gradient(top, #89c403 5%, #77a809 100%);
+            background: linear-gradient(to bottom, #89c403 5%, #77a809 100%);
+            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#89c403', endColorstr='#77a809',GradientType=0);
+            background-color: #89c403;
+            -moz-border-radius: 6px;
+            -webkit-border-radius: 6px;
+            border-radius: 6px;
+            border: 1px solid #74b807;
+            display: inline-block;
+            cursor: pointer;
+            color: #ffffff;
+            font-weight: bold;
+            padding: 6px 24px;
+            text-decoration: none;
+            text-shadow: 0px 1px 0px #528009;
             position: relative;
             margin-top: 10px;
             top: 25%;
@@ -323,19 +323,19 @@
             width: 250px;
         }
         .survey-button__cta:hover {
-            background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #77a809), color-stop(1, #89c403));
-            background:-moz-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background:-webkit-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background:-o-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background:-ms-linear-gradient(top, #77a809 5%, #89c403 100%);
-            background:linear-gradient(to bottom, #77a809 5%, #89c403 100%);
-            filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#77a809', endColorstr='#89c403',GradientType=0);
-            background-color:#77a809;
+            background: -webkit-gradient(linear, left top, left bottom, color-stop(.05, #77a809), color-stop(1, #89c403));
+            background: -moz-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background: -webkit-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background: -o-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background: -ms-linear-gradient(top, #77a809 5%, #89c403 100%);
+            background: linear-gradient(to bottom, #77a809 5%, #89c403 100%);
+            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#77a809', endColorstr='#89c403',GradientType=0);
+            background-color: #77a809;
             text-decoration: none;
         }
         .survey-button__cta:active {
-            position:relative;
-            top:1px;
+            position: relative;
+            top: 1px;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -336,6 +336,7 @@
             height: 50%;
             width: 250px;
         }
+
         .survey-button-rounded__cta:hover {
             background-color: #3f9d4c;
         }
@@ -344,20 +345,25 @@
             .pp-paywith {
                 margin-left: 35px;
             }
-            background-color: #f6a424;
         }
-
-        .survey-button-rounded__cta.pay:hover {
-            background-color: #f4b906;
+        .survey-button-rounded__cta.pay.ccard {
+            background-color: #0079c1;
         }
-
+        .survey-button-rounded__cta.pay.ccard:hover {
+            background-color: #0281cc;
+        }
         .survey-button-rounded__cta.pay.paypal {
             text-align: left;
             background-repeat: no-repeat;
             background-size: 93px;
             background-image: url('//contribute.theguardian.com/assets/dist/images/form/24f3c805/ppcom-white.svg');
             background-position: left 125px center;
+            background-color: #003d61;
         }
+        .survey-button-rounded__cta.pay.paypal:hover {
+            background-color: #014a75;
+        }
+
     }
 
     .howto-unblock {


### PR DESCRIPTION
## What does this change?

This is the second iteration of the adblock engagement test (https://github.com/guardian/frontend/pull/14072). We're exploring the appetite for an ad-free offering, targeted initially at our ad-blocking readers.

**This is a ZERO PERCENT test** for validating everything prior to deploying the real deal.
## What is the value of this and can you measure success?

We're exploring the possibility that a significant proportion of ad-blocking readers are interested in paying for an ad-free experience.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![screen shot 2016-09-27 at 14 37 28](https://cloud.githubusercontent.com/assets/690395/18876054/19c54cca-84c0-11e6-8a04-8ea5986a3585.png)

![screen shot 2016-09-27 at 14 37 54](https://cloud.githubusercontent.com/assets/690395/18876064/2253b656-84c0-11e6-9e8b-9ccc187cb8a0.png)

![screen shot 2016-09-27 at 14 38 12](https://cloud.githubusercontent.com/assets/690395/18876066/27a50baa-84c0-11e6-8fb2-e9b17c3c93f1.png)
## Request for comment

@regiskuckaertz @rich-nguyen @kenlim 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
