### PR TITLE
Sonobi 50 percent

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -64,7 +64,7 @@ object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     ABNewHeaderVariant,
     CommercialClientLoggingVariant,
-    CommercialHeaderBiddingSonobiVariant,
+    CommercialHeaderBiddingSonobiVariant
   )
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -49,28 +49,6 @@ object CommercialHeaderBiddingSonobiVariant extends TestDefinition(
   }
 }
 
-object CommercialHeaderBiddingPrebidVariant extends TestDefinition(
-  name = "commercial-hb-prebid",
-  description = "A test variant for the prebid header-bidding integration",
-  owners = Seq(Owner.withGithub("rich-nguyen"), Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2016, 11, 1)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-comm-hb-test").contains("prebid")
-  }
-}
-
-object CommercialHeaderBiddingControl extends TestDefinition(
-  name = "commercial-hb-control",
-  description = "A control group for the header bidding test",
-  owners = Seq(Owner.withGithub("rich-nguyen"), Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2016, 11, 1)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-comm-hb-test").contains("control")
-  }
-}
-
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -87,8 +65,6 @@ object ActiveTests extends ServerSideABTests {
     ABNewHeaderVariant,
     CommercialClientLoggingVariant,
     CommercialHeaderBiddingSonobiVariant,
-    CommercialHeaderBiddingPrebidVariant,
-    CommercialHeaderBiddingControl
   )
 }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/ophan-tracking.js
@@ -173,10 +173,7 @@ define([
     }
 
     function reportTrackingData() {
-        if (config.tests.commercialClientLogging ||
-            config.tests.commercialHbSonobi ||
-            config.tests.commercialHbPrebid ||
-            config.tests.commercialHbControl) {
+        if (config.tests.commercialClientLogging) {
             require(['ophan/ng'], function (ophan) {
                 performanceLog.viewId = ophan.viewId;
 


### PR DESCRIPTION
This removes the multi variant tests around `Sonobi` which currently has a `sonobi` test, a `control` test and a `prebid` test group.
I have removed both `control` and `prebid` as they aren't currently used for anything.

We are leaving `sonobi` to be used as a switch with a new percentage of test users. See referenced PR.

@rich-nguyen 
