### PR TITLE
New header: don't show the nav in the footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf">
+                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }


### PR DESCRIPTION
## What does this change?

This adds the class `hide-on-mobile` when you are in the new header test. What this means is that on mobile (when you also see the new header) you don't have access to the old navigation in the footer.

However, when you are on desktop you still do.
## What is the value of this and can you measure success?

When you are in the new header test, you don't have access to the current header
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/18879492/62fa1090-84cc-11e6-83d6-d0fe0cb07628.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/18879509/74eb3496-84cc-11e6-8b95-2e2e951949fa.png)
## Request for comment

@SiAdcock @zeftilldeath 
