### PR TITLE
Enable sticky ads when opted in to new header

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -81,8 +81,7 @@ define([
     }
 
     if ((config.switches.disableStickyAdBannerOnMobile && detect.getBreakpoint() === 'mobile') ||
-         config.page.disableStickyTopBanner ||
-         config.tests.abNewHeaderVariant
+         config.page.disableStickyTopBanner
     ) {
         config.page.hasStickyAdBanner = false;
     } else {


### PR DESCRIPTION
## What does this change?

The sticky ad banner was disabled if the user participating in the header test. This was [originally disabled](https://github.com/guardian/frontend/pull/12439#r58707823) due to uncertainty around how the sticky banner would interact with the new header navigation.

However, in the meanwhile, it was decided that the new header navigation would not be implemented on desktop, meaning it will not interfere with the sticky banner, which applies to desktop only. 

Therefore the sticky banner can be enabled even when the user has opted in to the new header.
## Request for comment

@NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
