### PR TITLE
Set the adblock with ad-free test live.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,7 +65,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 10, 6),
     exposeClientSide = true
   )
-  
+
   for (edition <- Edition.all) Switch(
     ABTests,
     "ab-membership-engagement-banner-"+edition.id.toLowerCase,
@@ -78,8 +78,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ad-blocking-response30pc",
-    "Prominent adblocker ad-free test ZERO PERCENT",
+    "ab-ad-blocking-response3",
+    "Prominent adblocker ad-free test",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 10, 13),   // Thursday @ 23:59 BST

--- a/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/survey/survey-adblock.js
@@ -70,7 +70,7 @@ define([
         $.forEachElement(('.adfree-state'), function(el){el.classList.add('is-hidden');});
         $.forEachElement(('.thankyou-state'), function(el){el.classList.remove('is-hidden');});
         $('.survey-container').addClass('thank-you');
-        storage.local.set('gu.abb30pc.exempt', true);
+        storage.local.set('gu.abb3.exempt', true);
     };
 
     var closeOverlay = function() {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -16,13 +16,13 @@ define([
     SurveyAdBlock
 ) {
     return function () {
-        this.id = 'AdBlockingResponse30pc';
-        this.start = '2016-09-22';
+        this.id = 'AdBlockingResponse3';
+        this.start = '2016-09-28';
         this.expiry = '2016-10-14'; // this test will expire on Thurs 13th PM.
         this.author = 'Justin Pinner';
-        this.description = 'Adblocking response with ad-free 404 test ZERO PERCENT';
-        this.audience = 0;
-        this.audienceOffset = 0.12; // exclude anyone that would have been in the previous 12% v2 test
+        this.description = 'Adblocking response test with ad-free option';
+        this.audience = 0.12;
+        this.audienceOffset = 0.13; // exclude anyone that would have been in the previous 12% v2 test
         this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
         var variantDataLinkNames = [
@@ -63,7 +63,7 @@ define([
                 storage.local.isStorageAvailable() &&
                 !storage.local.get('gu.subscriber') &&
                 !storage.local.get('gu.contributor') &&
-                !storage.local.get('gu.abb30pc.exempt') &&
+                !storage.local.get('gu.abb3.exempt') &&
                 storage.local.get('gu.alreadyVisited') > 5 &&
                 config.page.pageId !== 'contributor-email-page' &&
                 config.page.pageId !== 'contributor-email-page-submitted';
@@ -73,13 +73,13 @@ define([
             id: 'control',
             test: function(){}
         }, {
-            id: '299',
+            id: '300',
             test: function () {
                 if (isQualified()) {
-                    var variant = '299',
+                    var variant = '300',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Remove ads for &pound;2.99/month',
-                        adFreeMessagePrefix = '&pound;2.99 per month';
+                        adFreeButtonText = 'Remove ads for &pound;3/month',
+                        adFreeMessagePrefix = '&pound;3 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
@@ -95,13 +95,13 @@ define([
                 }
             }
         }, {
-            id: '499',
+            id: '500',
             test: function () {
                 if (isQualified()) {
-                    var variant = '499',
+                    var variant = '500',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Remove ads for &pound;4.99/month',
-                        adFreeMessagePrefix = '&pound;4.99 per month';
+                        adFreeButtonText = 'Remove ads for &pound;5/month',
+                        adFreeMessagePrefix = '&pound;5 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,
@@ -117,13 +117,13 @@ define([
                 }
             }
         }, {
-            id: '999',
+            id: '1000',
             test: function () {
                 if (isQualified()) {
-                    var variant = '999',
+                    var variant = '1000',
                         whitelistText = 'Allow ads and browse for free',
-                        adFreeButtonText = 'Remove ads for &pound;9.99/month',
-                        adFreeMessagePrefix = '&pound;9.99 per month';
+                        adFreeButtonText = 'Remove ads for &pound;10/month',
+                        adFreeMessagePrefix = '&pound;10 per month';
 
                     var surveyOverlay = new SurveyAdBlock({
                         whitelistText: whitelistText,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -26,15 +26,15 @@ define([
         this.successMeasure = 'Adblocking users show genuine interest in a paid ad-free service';
         this.audienceCriteria = 'Chrome desktop users with active adblocking software';
         var variantDataLinkNames = [
-            ['adblock whitelist 299'],
-            ['adblock supporter 299'],
-            ['adblock subscriber 299'],
-            ['adblock whitelist 499'],
-            ['adblock supporter 499'],
-            ['adblock subscriber 499'],
-            ['adblock whitelist 999'],
-            ['adblock supporter 999'],
-            ['adblock subscriber 999']
+            ['adblock whitelist 300'],
+            ['adblock supporter 300'],
+            ['adblock subscriber 300'],
+            ['adblock whitelist 500'],
+            ['adblock supporter 500'],
+            ['adblock subscriber 500'],
+            ['adblock whitelist 1000'],
+            ['adblock supporter 1000'],
+            ['adblock subscriber 1000']
         ].map(function(_) {
             return _[0];
         }).join(', ');

--- a/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
+++ b/static/src/javascripts/projects/common/views/commercial/survey/survey-adblock.html
@@ -46,11 +46,7 @@
                             and you won't be charged anything.
                         </p>
                         <p>
-                            Please email <a class="text-link" href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a> if you want to
-                            find out more.
-                        </p>
-                        <p>
-                            Help us improve your experience by doing our <a class="text-link" href="https://www.surveymonkey.net/r/Preview/?sm=M61PWayc8w23BetSmIe6mx6_2BhjqfmIRoVDQlyXtgbQJbKRAvwsLP8EnLFPrQHZvY" target="_blank">1 minute survey</a>.
+                            Help us improve your experience by doing our <a class="text-link" href="https://www.surveymonkey.co.uk/r/YR9LMZC" target="_blank">1 minute survey</a>.
                         </p>
                         <p>
                             Thank you.
@@ -71,7 +67,7 @@
         <div class="howto-unblock whitelist-state is-hidden top-border">
             <div class="survey-text__info">
                 <span class="survey-text__strong">
-                    Allow ads and browse for free. <a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP30pc_<%=variant%>"><span>More information</span></a>
+                    Allow ads and browse for free. <a class="text-link" href="/info/2016/mar/21/how-to-disable-your-adblocker-for-theguardiancom?INTCMP=ADB_RESP3_<%=variant%>"><span>More information</span></a>
                 </span>
                 <span class="howto-unblock__close-btn" data-link-name="survey adblock howto-unblock closed">
                     <%=crossIcon%>
@@ -99,10 +95,10 @@
         <div class="survey-text__info greeting-state top-border">
             <div class="footer">
                 <p>
-                    Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP30pc_<%=variant%>" data-link-name="adblock supporter <%=variant%>">Supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">Print subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">Contributor sign in</a>
+                    Already paying?&nbsp;<a class="text-link" href="https://profile.theguardian.com/signin?INTCMP=ADB_RESP3_<%=variant%>" data-link-name="adblock supporter <%=variant%>">Supporter sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/subscriber-number" data-link-name="adblock subscriber <%=variant%>">Print subscriber sign in</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a class="text-link" href="/commercial/contributor-email" data-link-name="adblock contributor <%=variant%>">Contributor sign in</a>
                 </p>
                 <p>
-                    If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP30pc_<%=variant%>">contact us</a>
+                    If you don't know why you are seeing this message, please <a class="text-link" href="https://www.theguardian.com/help/contact-us?INTCMP=ADB_RESP3_<%=variant%>">contact us</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## What does this change?

Set the ad block with ad-free experiment live. See https://github.com/guardian/frontend/pull/14471 for more info.

**We're planning to activate this tomorrow morning (28th)**.
## What is the value of this and can you measure success?

As described in the previous PR (above). This now picks up an offset audience of 12% spread over 4 test categories.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

See previous PR (https://github.com/guardian/frontend/pull/14471)
## Request for comment

@dominickendrick @desbo @ScottPainterGNM @regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
