### PR TITLE
Provide profile details when serializing Soulmates (Members) to JSON.

### DIFF
--- a/commercial/app/model/commercial/soulmates/Member.scala
+++ b/commercial/app/model/commercial/soulmates/Member.scala
@@ -31,7 +31,19 @@ object Member {
         (JsPath \ "location").read[String].map(locations => locations.split(",").head)
       ) (Member.apply _)
 
-  implicit val writesMember: Writes[Member] = Json.writes[Member]
+  implicit val writesMember: Writes[Member] = new Writes[Member] {
+    def writes(member: Member): JsValue = {
+      Json.obj(
+        "username" -> member.username,
+        "gender" -> member.gender.name,
+        "age" -> member.age,
+        "profile_photo" -> member.profilePhoto,
+        "location" -> member.location,
+        "profile_id" -> member.profileId,
+        "profile_url" -> member.profileUrl
+      )
+    }
+  }
 
   // based on play.api.libs.json.LowPriorityDefaultReads.traversableReads
   implicit val readsMembers: Reads[Seq[Member]] = new Reads[Seq[Member]] {


### PR DESCRIPTION
The native templates need a few extra vals that aren't provided for free by Play. Cue manual JSON `Writes`.

@guardian/commercial-dev 
