### PR TITLE
Add check for childrens books site when asking for contribution

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -42,6 +42,8 @@ define([
 
         var isMatchReport = config.hasTone('Match reports');
 
+        var isChildrensSection = config.page.blogIds === 'childrens-books-site/childrens-books-site' || config.page.section === 'childrens-books-site' || config.page.pageId === 'childrens-books-site';
+
         var isIdentityPage =
             config.page.contentType === 'Identity' ||
             config.page.section === 'identity'; // needed for pages under profile.* subdomain
@@ -128,7 +130,7 @@ define([
             switches.liveblogAdverts;
 
         this.canReasonablyAskForMoney = // eg become a supporter, give a contribution
-            !(userFeatures.isPayingMember() || config.page.isSensitive || config.page.isAdvertisementFeature);
+            !(userFeatures.isPayingMember() || config.page.isSensitive || config.page.isAdvertisementFeature || isChildrensSection);
 
         this.canAskForAContribution =
             this.canReasonablyAskForMoney && config.page.edition === 'UK'; // Contributions only testing in UK so far


### PR DESCRIPTION
## What does this change?

We don't show ads on Children's Books articles, so nor should we ask for money. This PR ads a check to the 'canReasonablyAskForMoney' function that the contribution's abTests check before displaying contributions asks. 
## What is the value of this and can you measure success?

We won't advertise to children 
## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
