### PR TITLE
Hosted article - multiple inline videos tracking fixed

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -116,7 +116,8 @@ define([
 
                         player.ready(function () {
                             var vol;
-                            duration = parseInt(this.duration(), 10);
+                            var player = this;
+                            duration = parseInt(player.duration(), 10);
                             initLoadingSpinner(player);
                             upgradeVideoPlayerAccessibility(player);
 


### PR DESCRIPTION
## What does this change?

Fix for the multiple inline videos tracking issue (only the latest one was tracked correctly).
## What is the value of this and can you measure success?

We can track all of the videos now.
## Does this affect other platforms - Amp, Apps, etc?

no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

<img width="795" alt="screen shot 2016-09-28 at 10 24 41" src="https://cloud.githubusercontent.com/assets/489567/18908996/c97a15e8-8569-11e6-83bc-4293007f9c31.png">
## Request for comment

@lps88 @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
