### PR TITLE
Prevents users from scrolling when the menu is open on IOS

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -104,7 +104,7 @@ define([
                 removeOrderingFromLists();
 
                 // Users should be able to scroll again
-                html.style.overflow = '';
+                html.classList.remove('nav-is-open');
             });
         } else {
             fastdom.write(function () {
@@ -120,7 +120,7 @@ define([
                 // No targetItem to put in as the parameter. All lists should close.
                 closeAllOtherPrimaryLists();
                 // Prevents scrolling on the body
-                html.style.overflow = 'hidden';
+                html.classList.add('nav-is-open');
             });
         }
     }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -7,6 +7,13 @@ $gutter-large: 55px;
 
 $mobile-medium: 375px; // Breakpoint for our most common device sizes
 
+
+// When the menu is open this class is added to the html to prevent users from scrolling
+.nav-is-open {
+    overflow: hidden;
+    position: fixed;
+}
+
 .new-header__inner {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## What does this change?

On IOS there is bug where scrolling is still enabled when the new header menu is open. This just adds `position: fixed` which completes the code and fixes the bug.
## What is the value of this and can you measure success?

This is the expected behaviour when you have a sidebar menu. 
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

Everything should look the same :)
## Request for comment

@SiAdcock 
