### PR TITLE
Badge in the immersive article fix

### DIFF
--- a/common/app/views/fragments/contentMetaImmersive.scala.html
+++ b/common/app/views/fragments/contentMetaImmersive.scala.html
@@ -1,4 +1,4 @@
-@(item: model.ContentType, showBadge: Boolean = true)(implicit request: RequestHeader)
+@(item: model.ContentType)(implicit request: RequestHeader)
 @import model._
 
 @byline() = {

--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -347,6 +347,21 @@
     }
 }
 
+.content--immersive-article {
+    .badge--alt {
+        @include mq(leftCol) {
+            position: absolute;
+            left: ($gs-column-width * -3 + $gs-gutter);
+            top: 10px;
+        }
+        @include mq(wide) {
+            position: absolute;
+            left: ($gs-column-width * -4);
+            top: 10px;
+        }
+    }
+}
+
 .content--media--video:not(.paid-content--advertisement-feature),
 .content--media--audio:not(.paid-content--advertisement-feature),
 .content--gallery:not(.paid-content--advertisement-feature) {


### PR DESCRIPTION
## What does this change?

Fix for the wrong located badge in the immersive articles.
## What is the value of this and can you measure success?

Badge is in the correct position.
## Does this affect other platforms - Amp, Apps, etc?

no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![screen shot 2016-09-28 at 12 29 55](https://cloud.githubusercontent.com/assets/489567/18911927/8d3bd4b4-8577-11e6-8196-23ea50ce48c4.png)

After:
![screen shot 2016-09-28 at 12 28 51](https://cloud.githubusercontent.com/assets/489567/18911929/93f80b74-8577-11e6-894c-fa0824a8a5bb.png)
## Request for comment

@kelvin-chappell @lps88 @regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
