### PR TITLE
Update facia-press to read cross account off the correct bucket

### DIFF
--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -65,4 +65,14 @@ trait FaciaSwitches {
     exposeClientSide = false
   )
 
+  val FaciaPressCrossAccountSwitch = Switch(
+    SwitchGroup.Facia,
+    "facia-press-cross-account",
+    "If this is switched on, facia-press will use the cross account FAPI client, reading from the tools bucket",
+    owners = Seq(Owner.withGithub("janua")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -10,6 +10,7 @@ import com.gu.facia.client.ApiClient
 import common._
 import common.commercial.Branding
 import conf.Configuration
+import conf.switches.Switches
 import conf.switches.Switches.FaciaInlineEmbeds
 import contentapi.{CapiHttpClient, CircuitBreakingContentApiClient, ContentApiClient, QueryDefaults}
 import fronts.FrontsApi
@@ -31,7 +32,11 @@ class LiveFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Con
     useThrift = false
   )
 
-  implicit val fapiClient: ApiClient = FrontsApi.amazonClient
+  implicit def fapiClient: ApiClient =
+    if (Switches.FaciaPressCrossAccountSwitch.isSwitchedOn)
+      FrontsApi.crossAccountClient
+    else
+      FrontsApi.amazonClient
 
   def pressByPathId(path: String): Future[Unit] =
     getPressedFrontForPath(path)
@@ -58,7 +63,11 @@ class DraftFapiFrontPress(val wsClient: WSClient, val capiClientForFrontsSeo: Co
     useThrift = false
   )
 
-  implicit val fapiClient: ApiClient = FrontsApi.amazonClient
+  implicit def fapiClient: ApiClient =
+    if (Switches.FaciaPressCrossAccountSwitch.isSwitchedOn)
+      FrontsApi.crossAccountClient
+    else
+      FrontsApi.amazonClient
 
   def pressByPathId(path: String): Future[Unit] =
     getPressedFrontForPath(path)
@@ -89,7 +98,7 @@ object EmbedJsonHtml {
 trait FapiFrontPress extends Logging with ExecutionContexts {
 
   implicit val capiClient: ContentApiClientLogic
-  implicit val fapiClient: ApiClient
+  implicit def fapiClient: ApiClient
   val capiClientForFrontsSeo: ContentApiClient
   val wsClient: WSClient
   def pressByPathId(path: String): Future[Unit]


### PR DESCRIPTION
`Facia-tool` is currently writing to two account buckets, the `tools` account bucket and the`frontend` account bucket. 

The tools team are looking to switch off writing to the `frontend` bucket. `Facia-press` still reads off the `frontend` bucket, but should be reading off the `tools` team bucket.

This adds a switch to allow switching over `facia-press` to read cross account off the tools bucket.

@Reettaphant @piuccio
