### PR TITLE
Fix race condition with Facia healthcheck

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -23,6 +23,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   implicit val alterTimeout: Timeout = Configuration.faciatool.configBeforePressTimeout.millis
   private lazy val configAgent = AkkaAgent[Option[Config]](None)
 
+  def isLoaded() = configAgent.get().isDefined
+
   def getClient: ApiClient = {
     FrontsApi.crossAccountClient
   }

--- a/facia/app/controllers/HealthCheck.scala
+++ b/facia/app/controllers/HealthCheck.scala
@@ -2,8 +2,21 @@ package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
+import play.api.mvc.{Action, AnyContent}
+import services.ConfigAgent
+
+import scala.concurrent.Future
 
 class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
   wsClient,
   9008,
-  NeverExpiresSingleHealthCheck("/uk/business"))
+  NeverExpiresSingleHealthCheck("/uk/business")) {
+
+  override def healthCheck(): Action[AnyContent] = Action.async { request =>
+    if (!ConfigAgent.isLoaded()) {
+      Future.successful(InternalServerError("Facia config has not been loaded yet"))
+    } else {
+      super.healthCheck()(request)
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Facia doesn't server fronts before the Facia config has been downloaded
(done by an agent) and return a 200 with X-Acccel-Redirect (internal
redirect) in this case.
Fetching the Healthcheck endpoint before the config was downloaded was
therefore returned with a 200 and considered successful, which allows
ELB to mark instances as healthy even though there might be issue with
underlying fronts rendering
This PR checks the config has been fetched before to return proper healthcheck result

Note:
I didn't go for a different endpoint specific to healthcheck or adding a condition in the logic of front rendering because it defeats the principle that code executed by the healthcheck should be identical to the one executed to reply to real-user requests. 
Also, right now we are testing only one endpoint (`/uk/business`) but we might several in the future and I didn't want to have to modify multiple endpoints then.
Last, it keeps the additional logic self contained with the healthcheck code
## What is the value of this and can you measure success?

Facia healtcheck is actually working and Facia instances are not marked as healthy and added in the rotation if there is an underlying problem with front rendering
## Request for comment

@jfsoul @janua 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
