### PR TITLE
Fix for sonobi in prebid environment

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
@@ -14,8 +14,8 @@ define([
         /* adSlotSelector: string. A CSS selector to query ad slots in the DOM */
         adSlotSelector: '.js-ad-slot',
 
-        /* prebidEnabled: boolean. Set to true if header bidding is enabled */
-        prebidEnabled: config.switches.headerBiddingUs && config.page.edition == 'US',
+        /* prebidEnabled: boolean. Set to true if header bidding is enabled, and the user is not participating in the sonobi test */
+        prebidEnabled: config.switches.headerBiddingUs && config.page.edition == 'US' && !('tests' in config && config.tests.commercialHbSonobi),
 
         /* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
         lazyLoadEnabled: false,

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
@@ -9,8 +9,7 @@ define([
     return shouldPrebidAdvert;
 
     function shouldPrebidAdvert(advert) {
-        return
-            dfpEnv.prebidEnabled &&
+        return dfpEnv.prebidEnabled &&
             dfpEnv.shouldLazyLoad() &&
             excludedAdvertIds.indexOf(advert.id) === -1;
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
@@ -1,6 +1,7 @@
 define([
+    'common/utils/config',
     'commercial/modules/dfp/dfp-env'
-], function (dfpEnv) {
+], function (config, dfpEnv) {
     var excludedAdvertIds = [
         'dfp-ad--pageskin-inread',
         'dfp-ad--merchandising-high'
@@ -9,7 +10,11 @@ define([
     return shouldPrebidAdvert;
 
     function shouldPrebidAdvert(advert) {
-        return dfpEnv.prebidEnabled &&
+
+        var participatingInSonobi = 'tests' in config && config.tests.commercialHbSonobi;
+
+        return !participatingInSonobi &&
+            dfpEnv.prebidEnabled &&
             dfpEnv.shouldLazyLoad() &&
             excludedAdvertIds.indexOf(advert.id) === -1;
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-prebid-advert.js
@@ -1,7 +1,6 @@
 define([
-    'common/utils/config',
     'commercial/modules/dfp/dfp-env'
-], function (config, dfpEnv) {
+], function (dfpEnv) {
     var excludedAdvertIds = [
         'dfp-ad--pageskin-inread',
         'dfp-ad--merchandising-high'
@@ -10,10 +9,7 @@ define([
     return shouldPrebidAdvert;
 
     function shouldPrebidAdvert(advert) {
-
-        var participatingInSonobi = 'tests' in config && config.tests.commercialHbSonobi;
-
-        return !participatingInSonobi &&
+        return
             dfpEnv.prebidEnabled &&
             dfpEnv.shouldLazyLoad() &&
             excludedAdvertIds.indexOf(advert.id) === -1;


### PR DESCRIPTION
Add a check to the `dfp env` to make sure that prebid is fully disabled when sonobi is active.
