### PR TITLE
Prevent Ophan request when new header is clicked

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -11,10 +11,9 @@
     >
             @sectionName
     </label>
-
 }
 
-<header class="@Atomise("New-header")" role="banner" data-link-name="global navigation: new header">
+<header class="@Atomise("New-header")" role="banner">
     <div class="new-header__inner gs-container">
         <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0">
             <h1 class="u-h">The Guardian</h1>
@@ -37,4 +36,3 @@
         </nav>
     </div>
 </header>
-


### PR DESCRIPTION
## What does this change?

Currently, whenever the new header is clicked, an Ophan request is fired. I can see no good reason for this; it appears the behaviour was simply [copied across from the old header](https://github.com/guardian/frontend/commit/f7a7f0b3cf62f524cdf26991c1d51a46aff5bc27#diff-9dfb20850d870ccfce099272fcb25286R9).

We are now using Ophan to track whether a primary or secondary link item is clicked, so tracking all clicks on the new header is redundant and just adds noise.
## Request for comment

@NataliaLKB @stephanfowler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
