### PR TITLE
Hosted Article fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -96,19 +96,21 @@
                         </div>
                     </div>
                     <div class="content__secondary-column js-secondary-column">
-                        <div class="hosted__next-video">
-                            <div class="hosted__next-video--header">
-                                <div class="hosted__next-page-header--border hosted-tone-bg"></div>
-                                <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
-                                <h2 class="hosted__next-video--client-name hosted-tone">@{page.campaign.owner}</h2>
+                        @for(nextPage <- page.nextPages.headOption) {
+                            <div class="hosted__next-video">
+                                <div class="hosted__next-video--header">
+                                    <div class="hosted__next-page-header--border hosted-tone-bg"></div>
+                                    <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
+                                    <h2 class="hosted__next-video--client-name hosted-tone">@{page.campaign.owner}</h2>
+                                </div>
+                                @for(nextPage <- page.nextPages) {
+                                    <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Page: @{nextPage.title}">
+                                        <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Page: @{nextPage.title}">
+                                        <p class="hosted__next-page-title">@{nextPage.title}</p>
+                                    </a>
+                                }
                             </div>
-                            @for(nextPage <- page.nextPages) {
-                                <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Page: @{nextPage.title}">
-                                    <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Page: @{nextPage.title}">
-                                    <p class="hosted__next-page-title">@{nextPage.title}</p>
-                                </a>
-                            }
-                        </div>
+                        }
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## What does this change?

The **More from** container shouldn't be on the page if there are no other pages in the series.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/6290008/18916694/2d616296-858d-11e6-8901-3794d309d3e4.png)
## Request for comment

@guardian/labs-beta 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
