### PR TITLE
Parameterise edit profile footer by userhelp

### DIFF
--- a/identity/app/model/Userhelp.scala
+++ b/identity/app/model/Userhelp.scala
@@ -1,0 +1,25 @@
+package model
+
+sealed trait Userhelp {
+  val name: String
+  val faq: String
+  val email: String
+}
+
+case object IdentityUserhelp extends Userhelp {
+  val name = "Account"
+  val faq = "http://www.theguardian.com/help/identity-faq"
+  val email = "userhelp@theguardian.com?subject=Account%20help"
+}
+
+case object MembershipUserhelp extends Userhelp {
+  val name = "Membership"
+  val faq = "https://membership.theguardian.com/help"
+  val email = "membershipsupport@theguardian.com"
+}
+
+case object DigitalPackUserhelp extends Userhelp {
+  val name = "Subscriptions"
+  val faq = "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+  val email = "digitalpack@theguardian.com"
+}

--- a/identity/app/views/emailVerified.scala.html
+++ b/identity/app/views/emailVerified.scala.html
@@ -23,6 +23,6 @@
                 <a class="submit-input" href="@idUrlBuilder.buildUrl("/verify-email", idRequest)" data-link-name="Sign in and resend verification email">Sign in to resend your verification email</a>
             }
         }
-        @registrationFooter(page, idRequest, idUrlBuilder)
+        @registrationFooter(idRequest, idUrlBuilder)
     </div>
 }

--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -6,6 +6,8 @@
 @import model.{Countries, PhoneNumbers, Titles}
 @import org.joda.time.DateTime.now
 @import helper._
+@import views.html.fragments.registrationFooter
+
 <form class="form js-account-details-form" novalidate action="@idUrlBuilder.buildUrl("/account/edit", idRequest)" role="main" method="post">
     <button type="submit" class="is-hidden"></button>
     @views.html.helper.CSRF.formField
@@ -199,3 +201,5 @@
 
 
 </form>
+
+@registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/fragments/profile/digitalPackDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/digitalPackDetailsForm.scala.html
@@ -1,3 +1,7 @@
+@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest)(implicit request: RequestHeader)
+
+@import views.html.fragments.registrationFooter
+
 <div class="manage-account-tab">
     <div class="manage-account-loader js-dig-loader">
         <span class="is-updating show-updating"></span>
@@ -7,3 +11,5 @@
     @fragments.profile.digitalPackForm.details()
     @fragments.profile.digitalPackForm.upsell()
 </div>
+
+@registrationFooter(idRequest, idUrlBuilder, model.DigitalPackUserhelp)

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -1,3 +1,7 @@
+@(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest)(implicit request: RequestHeader)
+
+@import views.html.fragments.registrationFooter
+
 <div class="manage-account-tab js-mem-tab" data-sprite-url="@Static("stylesheets/membership-icons.css")">
     <div class="manage-account-loader js-mem-loader">
         <span class="is-updating show-updating"></span>
@@ -8,3 +12,5 @@
     @fragments.profile.membershipForm.details()
     @fragments.profile.membershipForm.upsell()
 </div>
+
+@registrationFooter(idRequest, idUrlBuilder, model.MembershipUserhelp)

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -6,6 +6,7 @@
 @import views.html.fragments.form.{checkboxField}
 @import form.IdFormHelpers._
 @import helper._
+@import views.html.fragments.registrationFooter
 
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
@@ -61,3 +62,5 @@
 
     </fieldset>
 </form>
+
+@registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/fragments/profile/publicProfileForm.scala.html
+++ b/identity/app/views/fragments/profile/publicProfileForm.scala.html
@@ -8,6 +8,7 @@
 @import form.Input
 @import helper._
 @import conf.switches.Switches
+@import views.html.fragments.registrationFooter
 
 <fieldset class="fieldset">
     <div class="fieldset__heading">
@@ -72,3 +73,5 @@
 
     </fieldset>
 </form>
+
+@registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/fragments/registrationFooter.scala.html
+++ b/identity/app/views/fragments/registrationFooter.scala.html
@@ -1,8 +1,14 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader)
+@import model.IdentityUserhelp
+
+@(
+    idRequest: services.IdentityRequest,
+    idUrlBuilder: services.IdentityUrlBuilder,
+    userhelp: model.Userhelp = IdentityUserhelp)(implicit request: RequestHeader)
+
+@import views.html.fragments.userhelpFooter
 
 <ul class="nav nav--registration identity-section" data-link-name="Registration footer">
-    <li class="nav__item"><a class="nav__link" href="http://www.theguardian.com/help/identity-faq" data-link-name="FAQ">FAQ</a></li>
-    <li class="nav__item"><a class="nav__link" href="mailto:userhelp@@theguardian.com?subject=Account%20help" data-link-name="Email Userhelp">Email Userhelp</a></li>
+    @userhelpFooter(userhelp)
     <li class="nav__item"><a class="nav__link" href="@idUrlBuilder.buildUrl("/reset", idRequest)" data-link-name="Reset password" data-test-id="reset-password">Reset password</a></li>
     <li class="nav__item"><a class="nav__link" href="@idUrlBuilder.buildUrl("/signout", idRequest)" data-link-name="Sign out" data-test-id="sign-out">Sign out</a></li>
 </ul>

--- a/identity/app/views/fragments/userhelpFooter.scala.html
+++ b/identity/app/views/fragments/userhelpFooter.scala.html
@@ -1,0 +1,6 @@
+@import model.IdentityUserhelp
+
+@(userhelp: model.Userhelp = IdentityUserhelp)(implicit request: RequestHeader)
+
+<li class="nav__item"><a class="nav__link" href="@userhelp.faq" data-link-name="FAQ">@userhelp.name FAQ</a></li>
+<li class="nav__item"><a class="nav__link" href="mailto:@userhelp.email" data-link-name="Email Userhelp">Email @userhelp.name Help</a></li>

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -49,6 +49,6 @@ passwordExists: Boolean
     </form>
     }
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/password/emailSent.scala.html
+++ b/identity/app/views/password/emailSent.scala.html
@@ -10,6 +10,6 @@
     <p>Follow the link in the email to reset your password.
     <br />Reset password links are valid for 30 minutes.</p>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -14,6 +14,6 @@
         <p><a class="u-underline" href="@LinkTo{/}" data-link-name="Home">Return to the homepage</a> or <a class="u-underline" href="@idUrlBuilder.buildUrl("/account/edit", idRequest)" data-link-name="Edit profile">edit your profile</a>.</p>
     }
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/password/requestPasswordReset.scala.html
+++ b/identity/app/views/password/requestPasswordReset.scala.html
@@ -41,6 +41,6 @@
         <p class="identity-section__text"><a href="mailto:userhelp@@theguardian.com?subject=Account%20help" data-link-name="Email Userhelp">Email Userhelp</a> who'll be able to help you.</p>
     </div>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -35,6 +35,6 @@
             </fieldset>
         </form>
 
-        @registrationFooter(page, idRequest, idUrlBuilder)
+        @registrationFooter(idRequest, idUrlBuilder)
     </div>
 }

--- a/identity/app/views/password/resetPasswordRequestNewToken.scala.html
+++ b/identity/app/views/password/resetPasswordRequestNewToken.scala.html
@@ -35,6 +35,6 @@
         <p class="identity-section__text"><a class="u-underline" href="mailto:userhelp@@theguardian.com?subject=Account%20help" data-link-name="Email Userhelp">Email Userhelp</a> who'll be able to help you.</p>
     </div>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -48,14 +48,12 @@
 
             @content(2, "/account/edit")(fragments.profile.accountDetailsForm(idUrlBuilder, idRequest, user, forms.accountForm))
 
-            @content(3, "/membership/edit")(fragments.profile.membershipDetailsForm())
+            @content(3, "/membership/edit")(fragments.profile.membershipDetailsForm(idUrlBuilder, idRequest))
 
-            @content(4, "/digitalpack/edit")(fragments.profile.digitalPackDetailsForm())
+            @content(4, "/digitalpack/edit")(fragments.profile.digitalPackDetailsForm(idUrlBuilder, idRequest))
 
             @content(5, "/privacy/edit")(fragments.profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm))
         </div>
     </div>
-
-    @registrationFooter(page, idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -63,6 +63,6 @@
         </div>
     </div>
     <div class="js-activity-stream activity-stream-content" data-user-id="@user.id" data-stream-type="@activityType"></div>
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -84,7 +84,7 @@
         </fieldset>
     </form>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 
 }

--- a/identity/app/views/registrationConfirmation.scala.html
+++ b/identity/app/views/registrationConfirmation.scala.html
@@ -10,6 +10,6 @@
 
     <a class="submit-input" href="@returnUrl" data-link-name="Continue">Complete registration</a>
 
-    @registrationFooter(page, idRequest, idUrlBuilder)
+    @registrationFooter(idRequest, idUrlBuilder)
 </div>
 }

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -8,6 +8,6 @@
         <h1 class="identity-title">A new validation email has been sent to your account.</h1>
         <p>Please check your email (@user.getPrimaryEmailAddress) and follow the enclosed link.</p>
         <p>Validation links are valid for 30 minutes before expiring.</p>
-        @registrationFooter(page, idRequest, idUrlBuilder)
+        @registrationFooter(idRequest, idUrlBuilder)
     </div>
 }


### PR DESCRIPTION
## What does this change?

This give correct userhelp email and faq addresses for Subscriptions and Membership within the 'Edit Profile' pages.
## What is the value of this and can you measure success?

Userhelp requests for Membership and Subscriptions are handled by 3rd party company (Teleperformance) and should not be going to our in-house userhelp desk. 
## Screenshots

![memsubs_userhelp_2](https://cloud.githubusercontent.com/assets/13835317/18916918/0f0c04e4-858e-11e6-9247-c1146b86df14.gif)
## Request for comment

@johnduffell @JuliaBellis @andrewfindlay
