### PR TITLE
Bump config version for targeting client

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 5
+    val s3ConfigVersion = 6
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
## What does this change?

Increases the version of the config in order to support the upcoming targeting client deploy.

Added `targeting.campaignsUrl` to `PROD`, `CODE`, and `DEV`.

`PROD` is set to:

`targeting.campaignsUrl="https://targeting.gutools.co.uk/api/campaigns"`

`CODE` and `DEV` are both set as:

`targeting.campaignsUrl="https://targeting.code.dev-gutools.co.uk/api/campaigns"`

This allows developers working on campaign related content (such as rendering) to not have to run a local code of targeting.
