### PR TITLE
Show main images on audio page

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -37,7 +37,6 @@ class MediaController(contentApiClient: ContentApiClient) extends Controller wit
     val response: Future[ItemResponse] = contentApiClient.getResponse(
       contentApiClient.item(path, edition)
         .showFields("all")
-        .showBlocks("main")
     )
 
     val result = response map { response =>

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -37,6 +37,7 @@ class MediaController(contentApiClient: ContentApiClient) extends Controller wit
     val response: Future[ItemResponse] = contentApiClient.getResponse(
       contentApiClient.item(path, edition)
         .showFields("all")
+        .showBlocks("main")
     )
 
     val result = response map { response =>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -29,18 +29,18 @@
                         <div class="content__main-column content__main-column--media content__main-column--@mediaType">
                             <div class="media-body">
 
-                                @media match {
-                                    case audio: Audio if audio.elements.mainAudio.exists(_.images.imageCrops.nonEmpty) => {
-                                        @media.elements.mainAudio.map { audio =>
-                                            @fragments.imageFigure(audio.images)
-                                        }
-                                    }
-                                    case _ => {}
-                                }
-
                                 <div class="media-primary player">
                                 @media match {
                                     case audio: Audio => {
+
+                                        @audio.elements.images.map { img =>
+
+                                            @fragments.imageFigure(
+                                                img.images,
+                                                doCaption=false
+                                            )
+                                        }
+
                                         <figure data-component="main audio">
                                         @audio.elements.mainAudio.map { audioElement =>
                                             @fragments.media.audio(

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -34,7 +34,6 @@
                                     case audio: Audio => {
 
                                         @audio.elements.images.map { img =>
-
                                             @fragments.imageFigure(
                                                 img.images,
                                                 doCaption=false

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -2,7 +2,6 @@ package model
 
 import java.net.URL
 
-import com.gu.contentapi.client.model.v1.{AssetType, Blocks, ElementType}
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.facia.api.{utils => fapiutils}
 import com.gu.facia.client.models.TrailMetaData
@@ -68,8 +67,7 @@ final case class Content(
   showByline: Boolean,
   hasStoryPackage: Boolean,
   rawOpenGraphImage: String,
-  showFooterContainers: Boolean = false,
-  blocks: Option[Blocks] = None
+  showFooterContainers: Boolean = false
 ) {
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
@@ -392,8 +390,7 @@ object Content {
           .orElse(elements.mainPicture.flatMap(_.images.largestImageUrl))
           .orElse(trail.trailPicture.flatMap(_.largestImageUrl))
           .getOrElse(Configuration.images.fallbackLogo)
-      },
-      blocks = apiContent.blocks
+      }
     )
   }
 }
@@ -580,14 +577,6 @@ final case class Audio (override val content: Content) extends ContentType {
   private lazy val podcastTag: Option[Tag] = tags.tags.find(_.properties.podcast.nonEmpty)
   lazy val iTunesSubscriptionUrl: Option[String] = podcastTag.flatMap(_.properties.podcast.flatMap(_.subscriptionUrl))
   lazy val seriesFeedUrl: Option[String] = podcastTag.map(tag => s"/${tag.id}/podcast.xml")
-
-  val mainSectionImages = for {
-    blocks <- content.blocks
-    mainBlock <- blocks.main
-    firstElement <- mainBlock.elements.headOption
-    assets = firstElement.assets.filter(_.`type` == AssetType.Image)
-    nativeImages = assets.zipWithIndex.map{ case (e, i) => ImageAsset.make(e, i)}
-  } yield ImageMedia(nativeImages)
 
 }
 

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -10,7 +10,8 @@
     widthsByBreakpoint: layout.WidthsByBreakpoint = MainMedia.inline,
     image_figureClasses: Option[(model.ImageAsset, String)] = None,
     shareInfo: Option[(Seq[model.ShareLink], String)] = None,
-    amp: Boolean = false
+    amp: Boolean = false,
+    doCaption: Boolean = true
 )(implicit request: RequestHeader)
 
 
@@ -61,8 +62,10 @@
                 }
             }
         }
-        @showcaseFeature{
-            @caption(picture, imageOption, isMain)
+        @if(doCaption) {
+            @showcaseFeature{
+                @caption(picture, imageOption, isMain)
+            }
         }
     </figure>
 


### PR DESCRIPTION
## What does this change?

I have _massive_ misgivings about the content of this PR, but I thought it'd create it anyway as a way to get feedback.

This change is to begin showing main pictures on Audio pages. 

CAPI Now supply that image (conditionally) on audio content, so in theory this is just a template change to get it to show up.

Here is an audio item that has the main image enabled on the CAPI output: https://www.theguardian.com/science/audio/2016/sep/13/the-nature-of-intelligence-science-weekly-podcast

Now, some background.

The scala-capi-client library that we use is what talks to CAPI, consumes it's output, and spits us out an ItemResponse. Upon this ItemResponse is a Content object, and that Content object has various properties such as tags, fields, blocks and elements.

I am almost sure that the way it's SUPPOSED to work is that the scala capi client should give us the images on the ItemResponse.Content.elements property (this is, for example, how Video media elements work).

However, the scala client does not give us this, it only appears on the _blocks_ property of the Content class, not elements, which we actually something we've never had to use before. I talked to the CAPI people and they were adamant that I need to pick the images off of the Blocks property.

So if you look at my code you'll see I had to start passing through the Blocks element down to the Audio class, and introduce a weird one-off getMainSectionImages val. This feels pretty wonky but technically it works so I'll be interested in the feedback on this.

As another aside, had to put in a toggle for captions on the ImageFigure since they don't want it being shown, despite the image data actually having a caption. I could have fudged the ImageAsset classes to do this, but I decided since it was a presentation concern that the logic should be at the presentation level.
## What is the value of this and can you measure success?

Shows images on media pages
## Does this affect other platforms - Amp, Apps, etc?

May affect AMP - need to confirm.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
