### PR TITLE
Reapply targeting-client patch

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -4,6 +4,7 @@ import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
+import targeting.TargetingLifecycle
 import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters}
@@ -49,6 +50,7 @@ trait AppLifecycleComponents {
     wire[SurgingContentAgentLifecycle],
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle],
+    wire[TargetingLifecycle],
     wire[DiscussionExternalAssetsLifecycle]
   )
 }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 5
+    val s3ConfigVersion = 6
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")
@@ -472,6 +472,10 @@ class GuardianConfiguration extends Logging {
 
   object front {
     lazy val config = configuration.getMandatoryStringProperty("front.config")
+  }
+
+  object targeting {
+    lazy val campaignsUrl = configuration.getStringProperty("targeting.campaignsUrl")
   }
 
   object facia {

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -506,4 +506,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 9, 30),
     exposeClientSide = true
   )
+
+  // Owner: Sam Cutler / Editorial Tools
+  val Targeting = Switch(
+    SwitchGroup.Feature,
+    "targeting",
+    "When ON will the targeting system will poll for updates and merge targeted campaigns into content",
+    owners= Seq(Owner.withGithub("currysoup")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -5,6 +5,7 @@ import java.net.URL
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.facia.api.{utils => fapiutils}
 import com.gu.facia.client.models.TrailMetaData
+import com.gu.targeting.client.Campaign
 import common._
 import common.commercial.{BrandHunter, PaidContent}
 import common.dfp.DfpAgent
@@ -91,6 +92,7 @@ final case class Content(
   lazy val isExplore = HeroicTemplateSwitch.isSwitchedOn && tags.isExploreSeries
   lazy val isImmersive = fields.displayHint.contains("immersive") || isImmersiveGallery || tags.isTheMinuteArticle || isExplore
   lazy val isAdvertisementFeature: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
+  lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -227,7 +229,8 @@ final case class Content(
     ("showRelatedContent", JsBoolean(if (tags.isTheMinuteArticle) { false } else (showInRelated && !legallySensitive))),
     ("productionOffice", JsString(productionOffice.getOrElse(""))),
     ("isImmersive", JsBoolean(isImmersive)),
-    ("isExplore", JsBoolean(isExplore))
+    ("isExplore", JsBoolean(isExplore)),
+    ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
   )
 
   // Dynamic Meta Data may appear on the page for some content. This should be used for conditional metadata.

--- a/common/app/targeting/CampaignAgent.scala
+++ b/common/app/targeting/CampaignAgent.scala
@@ -1,0 +1,41 @@
+package targeting
+
+import common._
+import com.gu.targeting.client.CampaignCache
+import conf.Configuration
+import scala.concurrent.Future
+import conf.switches.Switches.Targeting
+
+object CampaignAgent extends Logging with ExecutionContexts {
+  private val agent = AkkaAgent[CampaignCache](CampaignCache(Nil, None))
+
+  def refresh(): Future[Unit] = {
+    // The maximum number of campaigns which will be fetched. If there are too many campaigns additional campaigns will be truncated.
+    // Which campaigns make it through is undefined
+    val campaignLimit = 100
+
+    // Total number of rules allowed per campaign, any campaigns with more than one rule will be filtered
+    val ruleLimit = 1
+
+    // The combined number of tags allowed in the required and lacking fields of a rule.
+    // Any campaigns with rules with too many tags will be filtered
+    val tagLimit = 20
+
+    if (Targeting.isSwitchedOn) {
+      Configuration.targeting.campaignsUrl.map(url => {
+        CampaignCache.fetch(url, campaignLimit, Some(ruleLimit), Some(tagLimit))
+          .flatMap(agent.alter).map(_ => ())
+      }).getOrElse(Future.failed(new BadConfigurationException("Campaigns URL not configured")))
+    } else {
+      Future.successful(())
+    }
+  }
+
+  def getCampaignsForTags(tags: Seq[String]) = {
+    if (Targeting.isSwitchedOn) {
+      agent().getCampaignsForTags(tags)
+    } else {
+      Nil
+    }
+  }
+}

--- a/common/app/targeting/TargetingLifecycle.scala
+++ b/common/app/targeting/TargetingLifecycle.scala
@@ -1,0 +1,31 @@
+package targeting
+
+import app.LifecycleComponent
+import common.{JobScheduler, AkkaAsync}
+import play.api.inject.ApplicationLifecycle
+import scala.concurrent.duration._
+import scala.concurrent.{Future, ExecutionContext}
+
+class TargetingLifecycle(
+                          appLifecycle: ApplicationLifecycle,
+                          jobs: JobScheduler,
+                          akkaAsync: AkkaAsync)(implicit executionContext: ExecutionContext) extends LifecycleComponent {
+
+
+  appLifecycle.addStopHook {
+    () => Future {
+      jobs.deschedule("TargetingCampaignRefreshJob")
+    }
+  }
+
+  override def start(): Unit = {
+    jobs.deschedule("TargetingCampaignRefreshJob")
+    jobs.scheduleEvery("TargetingCampaignRefreshJob", 1.minutes) {
+      CampaignAgent.refresh()
+    }
+
+    akkaAsync.after1s {
+      CampaignAgent.refresh()
+    }
+  }
+}

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -27,6 +27,7 @@ import router.Routes
 import rugby.conf.RugbyLifecycle
 import rugby.controllers.RugbyControllers
 import services._
+import targeting.TargetingLifecycle
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -92,6 +93,7 @@ trait AppComponents
     wire[FootballLifecycle],
     wire[CricketLifecycle],
     wire[RugbyLifecycle],
+    wire[TargetingLifecycle],
     wire[DiscussionExternalAssetsLifecycle]
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,6 +72,7 @@ object Dependencies {
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4"
   val logback = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
+  val targetingClient = "com.gu" %% "targeting-client-play24" % "0.8.0"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -50,7 +50,8 @@ object Frontend extends Build with Prototypes {
       cssParser,
       w3cSac,
       logback,
-      kinesisLogbackAppender
+      kinesisLogbackAppender,
+      targetingClient
     )
   ).settings(
       mappings in TestAssets ~= filterAssets

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -58,6 +58,7 @@ trait Prototypes {
       Resolver.sonatypeRepo("releases"),
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
+      "Guardian Editorial Tools Bintray" at "https://dl.bintray.com/guardian/editorial-tools",
       "Spy" at "https://files.couchbase.com/maven2/"
     ),
 


### PR DESCRIPTION
Reapplying the `targeting-client` patch (without the weird docs changes)
## What does this change?

Adds an Akka agent that pulls in currently active campaigns and adds them to articles. The JSON for the matching campaigns will end up at the top of the article beside the `nonKeywordTagIds` etc.
## What is the value of this and can you measure success?

This patch is unrelated to the rendering side of targeting, it simply delivers the latest data.

If campaigns with the correct tag rules end up in the JSON embedded in the HTML.
## Does this affect other platforms - Amp, Apps, etc?

Currently limited to `article` and `dev-build` so I think this is isolated, but would like some feedback. We'll be adding features like this to the mobile app soon. I'm unsure about Amp.
## Request for comment

@dominickendrick 
