### PR TITLE
Track all new header interactions in Ophan

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -94,7 +94,7 @@
                             @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { tertiaryLink =>
 
                                 <li class="tertiary-navigation__item">
-                                    <a class="tertiary-navigation__link" href="@LinkTo(tertiaryLink.url)" data-link-name="@tertiaryLink.name">
+                                    <a class="tertiary-navigation__link" href="@LinkTo(tertiaryLink.url)" data-link-name="nav2 : tertiary : @tertiaryLink.name">
                                         @Html(tertiaryLink.name)
                                         <i class="tertiary-navigation__icon rounded-icon"></i>
                                     </a>

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -2,14 +2,19 @@
 
 @import common.{Edition, LinkTo}
 
-<div class="edition-picker js-edition-picker-container">
+<div class="edition-picker js-edition-picker-container" data-component="edition-picker">
 
     <input class="edition-picker__button js-enhance-checkbox"
         type="checkbox"
         id="edition-picker"
         aria-controls="edition-picker__dropdown">
 
-    <label class="edition-picker__current-edition js-on-enter-click" for="edition-picker" tabindex="0">
+    <label
+        class="edition-picker__current-edition js-on-enter-click"
+        for="edition-picker"
+        tabindex="0"
+        data-link-name="edition-picker : show"
+    >
         @fragments.inlineSvg("world", "icon")
         <span class="u-h"> Change editions from the </span>
         @Edition(request).displayName

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -5,32 +5,29 @@
 <div class="edition-picker js-edition-picker-container" data-component="edition-picker">
 
     <input class="edition-picker__button js-enhance-checkbox"
-        type="checkbox"
-        id="edition-picker"
+        type="checkbox" id="edition-picker"
         aria-controls="edition-picker__dropdown">
 
-    <label
-        class="edition-picker__current-edition js-on-enter-click"
-        for="edition-picker"
-        tabindex="0"
-        data-link-name="edition-picker : show"
-    >
-        @fragments.inlineSvg("world", "icon")
-        <span class="u-h"> Change editions from the </span>
-        @Edition(request).displayName
+    <label class="edition-picker__current-edition js-on-enter-click"
+        for="edition-picker" tabindex="0"
+        data-link-name="nav2 : edition-picker">
+
+            @fragments.inlineSvg("world", "icon")
+            <span class="u-h"> Change editions from the </span>
+            @Edition(request).displayName
     </label>
 
     <ul class="edition-picker__dropdown js-edition-picker-dropdown" id="edition-picker__dropdown" aria-hidden="true">
         @Edition.others(request).map { edition =>
             <li class="edition-picker__dropdown__item">
                 <a class="edition-picker__dropdown-item-link"
-                data-edition="@edition.id"
-                data-link-name="new header switch to @edition.id edition"
-                title="Switch to the @edition.id edition"
-                tabindex="0"
-                href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")">
-                    <span class="u-h"> switch to the </span>
-                    <span> @edition.displayName </span>
+                    data-edition="@edition.id"
+                    data-link-name="nav2 : edition-picker : @edition.id"
+                    title="Switch to the @edition.id edition"
+                    tabindex="0"
+                    href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")">
+                        <span class="u-h"> switch to the </span>
+                        <span> @edition.displayName </span>
                 </a>
             </li>
         }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -53,9 +53,13 @@
         @if(SearchSwitch.isSwitchedOn) {
             <ul class="navigation-group">
                 <li class="navigation-group__item navigation-group__item--search">
-                    <form class="navigation-group__search-container" action="https://www.google.co.uk/search">
+                    <form class="navigation-group__search-container"
+                        action="https://www.google.co.uk/search"
+                        data-link-name="main-navigation : search">
+
                         <input type="text" name="q" class="navigation-group__search-box" placeholder="search for...">
                         <input type="hidden" name="as_sitesearch" value="www.theguardian.com">
+
                         @* label surrounding the input and icon so that if you click the search icon it will trigger the submit *@
                         <label for="submit-google-search">
                             <input class="u-h" type="submit" id="submit-google-search">
@@ -69,6 +73,7 @@
 
         <ul class="navigation-group navigation-group--grey secondary-navigation">
 
+
             @Edition.all.map { edition =>
 
                 @NewNavigation.MembershipLinks.getEditionalisedNavLinks(edition).map { item =>
@@ -76,7 +81,7 @@
                         data-edition=@{edition.id.toLowerCase}
                         @if(edition.id.toLowerCase != "uk") { hidden }>
 
-                            <a href="@item.url">
+                            <a href="@item.url" data-link-name="main-navigation : @item.name">
                                 @fragments.inlineSvg(item.iconName, "icon", List("main-menu__icon"))
                                 @item.name
                             </a>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -55,15 +55,17 @@
             <ul class="navigation-group">
                 <li class="navigation-group__item navigation-group__item--search">
                     <form class="navigation-group__search-container"
-                        action="https://www.google.co.uk/search"
-                        data-link-name="nav2 : search">
+                        action="https://www.google.co.uk/search">
 
-                        <input type="text" name="q" class="navigation-group__search-box" placeholder="search for...">
+                        <input type="text" name="q"
+                            class="navigation-group__search-box"
+                            placeholder="search for..."
+                            data-link-name="nav2 : search">
                         <input type="hidden" name="as_sitesearch" value="www.theguardian.com">
 
                         @* label surrounding the input and icon so that if you click the search icon it will trigger the submit *@
                         <label for="submit-google-search">
-                            <input class="u-h" type="submit" id="submit-google-search">
+                            <input class="u-h" type="submit" id="submit-google-search" data-link-name="nav2 : search : submit">
                             @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
                         </label>
                         <label for="q" class="u-h">What term do you want to search?</label>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -7,7 +7,7 @@
     <li class="main-navigation__item navigation-border js-navigation-item">
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name" open>
             <summary class="main-navigation__item__button js-navigation-button"
-                data-link-name="nav2 : secondary : summary-@topLevelSection.name">
+                data-link-name="nav2 : secondary : @topLevelSection.name">
 
                 <i class="main-menu__icon main-menu__icon--chevron"></i>
                 @topLevelSection.name

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -7,7 +7,7 @@
     <li class="main-navigation__item navigation-border js-navigation-item">
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name" open>
             <summary class="main-navigation__item__button js-navigation-button"
-                data-link-name="main-navigation-section : @topLevelSection.name">
+                data-link-name="nav2 : secondary : summary-@topLevelSection.name">
 
                 <i class="main-menu__icon main-menu__icon--chevron"></i>
                 @topLevelSection.name
@@ -23,7 +23,10 @@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                         <li class="navigation-group__item">
-                            <a href="@LinkTo { @sectionItem.url }" data-link-name="main-navigation-item : @sectionItem.name">@sectionItem.name</a>
+                            <a href="@LinkTo { @sectionItem.url }"
+                                data-link-name="nav2 : secondary : @sectionItem.name">
+                                    @sectionItem.name
+                            </a>
                         </li>
                     }
                 </ul>
@@ -32,12 +35,10 @@
     </li>
 }
 
-<label
-    for="main-menu-toggle"
+<label for="main-menu-toggle"
     class="main-menu-container__overlay"
     aria-hidden="true"
-    data-link-name="main-navigation : overlay"
-></label>
+    data-link-name="nav2 : overlay"></label>
 
 <div class="main-menu-container">
 
@@ -55,7 +56,7 @@
                 <li class="navigation-group__item navigation-group__item--search">
                     <form class="navigation-group__search-container"
                         action="https://www.google.co.uk/search"
-                        data-link-name="main-navigation : search">
+                        data-link-name="nav2 : search">
 
                         <input type="text" name="q" class="navigation-group__search-box" placeholder="search for...">
                         <input type="hidden" name="as_sitesearch" value="www.theguardian.com">
@@ -73,7 +74,6 @@
 
         <ul class="navigation-group navigation-group--grey secondary-navigation">
 
-
             @Edition.all.map { edition =>
 
                 @NewNavigation.MembershipLinks.getEditionalisedNavLinks(edition).map { item =>
@@ -81,7 +81,7 @@
                         data-edition=@{edition.id.toLowerCase}
                         @if(edition.id.toLowerCase != "uk") { hidden }>
 
-                            <a href="@item.url" data-link-name="main-navigation : @item.name">
+                            <a href="@item.url" data-link-name="nav2 : @item.name">
                                 @fragments.inlineSvg(item.iconName, "icon", List("main-menu__icon"))
                                 @item.name
                             </a>
@@ -102,7 +102,7 @@
 
                 @NewNavigation.NavFooterLinks.getEditionalisedNavLinks(edition).map { item =>
                     <li class="navigation-group__item">
-                        <a href="@LinkTo { @item.url }" data-link-name="main-navigation-item : @item.name">
+                        <a href="@LinkTo { @item.url }" data-link-name="nav2 : @item.name">
                             @item.name
                         </a>
                     </li>
@@ -114,7 +114,7 @@
 
             <li class="navigation-group__item">
                 <a href="https://www.facebook.com/theguardian"
-                    data-link-name="main-navigation-item : facebook">
+                    data-link-name="nav2 : facebook">
 
                     @fragments.inlineSvg("share-facebook", "icon", List("main-menu__icon", "main-menu__icon--social"))
                     Facebook
@@ -122,7 +122,7 @@
             </li>
             <li class="navigation-group__item">
                 <a href="https://twitter.com/guardian"
-                data-link-name="main-navigation-item : twitter">
+                data-link-name="nav2 : twitter">
 
                     @fragments.inlineSvg("share-twitter", "icon", List("main-menu__icon", "main-menu__icon--social"))
                     Twitter

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -1,13 +1,14 @@
 @()(implicit request: RequestHeader)
 
 @import common.{ NewNavigation, LinkTo, Edition }
-@import conf.Configuration
 @import conf.switches.Switches.SearchSwitch
 
 @sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection) = {
     <li class="main-navigation__item navigation-border js-navigation-item">
         <details class="js-close-nav-list main-navigation__primary-list" id="primary-list-@topLevelSection.name" open>
-            <summary class="main-navigation__item__button js-navigation-button">
+            <summary class="main-navigation__item__button js-navigation-button"
+                data-link-name="main-navigation-section : @topLevelSection.name">
+
                 <i class="main-menu__icon main-menu__icon--chevron"></i>
                 @topLevelSection.name
             </summary>
@@ -22,7 +23,7 @@
 
                     @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                         <li class="navigation-group__item">
-                            <a href="@LinkTo { @sectionItem.url }" data-link-name="@sectionItem.name">@sectionItem.name</a>
+                            <a href="@LinkTo { @sectionItem.url }" data-link-name="main-navigation-item : @sectionItem.name">@sectionItem.name</a>
                         </li>
                     }
                 </ul>
@@ -31,7 +32,12 @@
     </li>
 }
 
-<label for="main-menu-toggle" class="main-menu-container__overlay" aria-hidden="true"></label>
+<label
+    for="main-menu-toggle"
+    class="main-menu-container__overlay"
+    aria-hidden="true"
+    data-link-name="main-navigation : toggle"
+></label>
 
 <div class="main-menu-container">
 

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -36,7 +36,7 @@
     for="main-menu-toggle"
     class="main-menu-container__overlay"
     aria-hidden="true"
-    data-link-name="main-navigation : toggle"
+    data-link-name="main-navigation : overlay"
 ></label>
 
 <div class="main-menu-container">

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -96,20 +96,33 @@
                 @if(edition.id.toLowerCase != "uk") { hidden }>
 
                 @NewNavigation.NavFooterLinks.getEditionalisedNavLinks(edition).map { item =>
-                    <li class="navigation-group__item"><a href="@LinkTo { @item.url }"> @item.name </a></li>
+                    <li class="navigation-group__item">
+                        <a href="@LinkTo { @item.url }" data-link-name="main-navigation-item : @item.name">
+                            @item.name
+                        </a>
+                    </li>
                 }
             </ul>
         }
 
         <ul class="navigation-group navigation-border secondary-navigation">
-            <li class="navigation-group__item"><a href="https://www.facebook.com/theguardian">
-                @fragments.inlineSvg("share-facebook", "icon", List("main-menu__icon", "main-menu__icon--social"))
-                Facebook
-            </a></li>
-            <li class="navigation-group__item"><a href="https://twitter.com/guardian">
-                @fragments.inlineSvg("share-twitter", "icon", List("main-menu__icon", "main-menu__icon--social"))
-                Twitter
-            </a></li>
+
+            <li class="navigation-group__item">
+                <a href="https://www.facebook.com/theguardian"
+                    data-link-name="main-navigation-item : facebook">
+
+                    @fragments.inlineSvg("share-facebook", "icon", List("main-menu__icon", "main-menu__icon--social"))
+                    Facebook
+                </a>
+            </li>
+            <li class="navigation-group__item">
+                <a href="https://twitter.com/guardian"
+                data-link-name="main-navigation-item : twitter">
+
+                    @fragments.inlineSvg("share-twitter", "icon", List("main-menu__icon", "main-menu__icon--social"))
+                    Twitter
+                </a>
+            </li>
         </ul>
     </div>
 </div>

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -7,7 +7,7 @@
 
     <li class="navigation-group__item navigation-group__item--user-account js-show-user-account-links">
         <div class="user-account__login">
-            <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN" data-link-name="Sign in">
+            <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN" data-link-name="nav2 : sign in">
                 @fragments.inlineSvg("profile", "icon", List("main-menu__icon", "main-menu__icon--profile"))
                 Sign in
             </a>
@@ -15,7 +15,9 @@
 
         <div class="user-account__signed-in">
             <details>
-                <summary class="main-navigation__item__button user-account__signed-in__label">
+                <summary class="main-navigation__item__button user-account__signed-in__label"
+                    data-link-name="nav2 : my account">
+
                     <i class="main-menu__icon main-menu__icon--chevron"></i>
                     my account
                 </summary>
@@ -24,37 +26,33 @@
                     @if(SaveForLaterSwitch.isSwitchedOn) {
                         <li class="user-account__signed-in__link">
                             <a href="@Configuration.id.url/saved-for-later"
-                            data-link-name="Saved for Later">
-                                Saved for later
+                                data-link-name="nav2 : saved for later">
+                                    Saved for later
                             </a>
                         </li>
                     }
                     <li class="user-account__signed-in__link js-add-comment-activity-link" hidden>
-                        <a data-link-name="Comment activity">
+                        <a data-link-name="nav2 : comment activity">
                             Comment activity
                         </a>
                     </li>
                     <li class="user-account__signed-in__link">
-                        <a href="@Configuration.id.url/public/edit"
-                        data-link-name="Edit profile">
-                            Edit profile
+                        <a href="@Configuration.id.url/public/edit" data-link-name="nav2 : edit profile">
+                                Edit profile
                         </a>
                     </li>
                     <li class="user-account__signed-in__link">
-                        <a href="@Configuration.id.url/email-prefs"
-                        data-link-name="Email preferences">
+                        <a href="@Configuration.id.url/email-prefs" data-link-name="nav2 : email preferences">
                             Email preferences
                         </a>
                     </li>
                     <li class="user-account__signed-in__link">
-                        <a href="@Configuration.id.url/password/change"
-                        data-link-name="Change password">
+                        <a href="@Configuration.id.url/password/change" data-link-name="nav2 : change password">
                             Change password
                         </a>
                     </li>
                     <li class="user-account__signed-in__link">
-                        <a href="@Configuration.id.url/signout"
-                        data-link-name="Sign out">
+                        <a href="@Configuration.id.url/signout" data-link-name="nav2 : sign out">
                             Sign out
                         </a>
                     </li>

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -7,7 +7,7 @@
 
     <li class="navigation-group__item navigation-group__item--user-account js-show-user-account-links">
         <div class="user-account__login">
-            <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN">
+            <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN" data-link-name="Sign in">
                 @fragments.inlineSvg("profile", "icon", List("main-menu__icon", "main-menu__icon--profile"))
                 Sign in
             </a>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -26,7 +26,12 @@
             @NewNavigation.topLevelSections.map { section =>
                 @primaryLinks(section.name)
             }
-            <label for="main-menu-toggle" class="new-header__nav__menu-button js-change-link" tabindex="0">
+            <label
+                for="main-menu-toggle"
+                class="new-header__nav__menu-button js-change-link"
+                tabindex="0"
+                data-link-name="main-navigation : veggie-burger : show"
+            >
                 <span class="new-header__veggie-burger-icon"></span>
                 <span class="u-h">Menu</span>
             </label>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -15,7 +15,7 @@
 
 <header class="@Atomise("New-header")" role="banner">
     <div class="new-header__inner gs-container">
-        <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0">
+        <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="new-header-logo">
             <h1 class="u-h">The Guardian</h1>
             @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
         </a>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -7,7 +7,7 @@
     <label for="main-menu-toggle" class="new-header__nav__link js-open-section-in-menu"
         tabindex="0"
         aria-controls="primary-list-@sectionName"
-        data-link-name="@sectionName"
+        data-link-name="main-navigation-link : @sectionName"
     >
             @sectionName
     </label>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,36 +4,33 @@
 @import common.{LinkTo, NewNavigation}
 
 @primaryLinks(sectionName: String) = {
-    <label for="main-menu-toggle" class="new-header__nav__link js-open-section-in-menu"
-        tabindex="0"
+    <label for="main-menu-toggle" tabindex="0"
+        class="new-header__nav__link js-open-section-in-menu"
         aria-controls="primary-list-@sectionName"
-        data-link-name="main-navigation-link : @sectionName"
-    >
+        data-link-name="nav2 : primary : @sectionName">
             @sectionName
     </label>
 }
 
 <header class="@Atomise("New-header")" role="banner">
     <div class="new-header__inner gs-container">
-        <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="new-header-logo">
+        <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="nav2 : logo">
             <h1 class="u-h">The Guardian</h1>
             @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
         </a>
 
         @fragments.nav.editionPicker()
 
-        <nav class="new-header__nav" data-component="main-navigation">
+        <nav class="new-header__nav" data-component="nav2">
             @NewNavigation.topLevelSections.map { section =>
                 @primaryLinks(section.name)
             }
-            <label
-                for="main-menu-toggle"
+            <label for="main-menu-toggle"
                 class="new-header__nav__menu-button js-change-link"
                 tabindex="0"
-                data-link-name="main-navigation : veggie-burger : show"
-            >
-                <span class="new-header__veggie-burger-icon"></span>
-                <span class="u-h">Menu</span>
+                data-link-name="nav2 : veggie-burger">
+                    <span class="new-header__veggie-burger-icon"></span>
+                    <span class="u-h">Menu</span>
             </label>
             <input type="checkbox" id="main-menu-toggle" class="new-header__nav__button js-enhance-checkbox" aria-controls="main-menu">
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -28,7 +28,7 @@
             <label for="main-menu-toggle"
                 class="new-header__nav__menu-button js-change-link"
                 tabindex="0"
-                data-link-name="nav2 : veggie-burger">
+                data-link-name="nav2 : veggie-burger : show">
                     <span class="new-header__veggie-burger-icon"></span>
                     <span class="u-h">Menu</span>
             </label>

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -1,14 +1,14 @@
 define([
     'qwery',
     'fastdom',
+    'ophan/ng',
     'common/modules/navigation/edition-picker',
     'common/modules/navigation/user-account'
-], function (
-    qwery,
-    fastdom,
-    editionPicker,
-    userAccount
-) {
+], function (qwery,
+             fastdom,
+             ophan,
+             editionPicker,
+             userAccount) {
     var html = qwery('html')[0];
     var menuItems = qwery('.js-close-nav-list');
     var buttonClickHandlers = {
@@ -80,6 +80,14 @@ define([
                     applyEnhancementsTo(checkbox);
                     checkbox.removeEventListener('click', closeMenuHandler);
                 });
+                if (checkboxId === 'main-menu-toggle') {
+                    // record in Ophan that the menu was opened in a fully expanded state
+                    // i.e. standard JS had not been loaded when menu was first opened
+                    ophan.record({
+                        component: 'main-navigation',
+                        value: 'is fully expanded'
+                    });
+                }
             }
         });
     }

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -101,6 +101,7 @@ define([
                 button.setAttribute('aria-expanded', 'false');
                 mainMenu.setAttribute('aria-hidden', 'true');
                 veggieBurgerLink.classList.remove('new-header__nav__menu-button--open');
+                veggieBurgerLink.setAttribute('data-link-name', 'main-navigation : veggie-burger : show');
                 removeOrderingFromLists();
 
                 // Users should be able to scroll again
@@ -113,6 +114,7 @@ define([
                 button.setAttribute('aria-expanded', 'true');
                 mainMenu.setAttribute('aria-hidden', 'false');
                 veggieBurgerLink.classList.add('new-header__nav__menu-button--open');
+                veggieBurgerLink.setAttribute('data-link-name', 'main-navigation : veggie-burger : hide');
 
                 if (firstButton) {
                     firstButton.focus();

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -4,11 +4,13 @@ define([
     'ophan/ng',
     'common/modules/navigation/edition-picker',
     'common/modules/navigation/user-account'
-], function (qwery,
-             fastdom,
-             ophan,
-             editionPicker,
-             userAccount) {
+], function (
+    qwery,
+    fastdom,
+    ophan,
+    editionPicker,
+    userAccount
+) {
     var html = qwery('html')[0];
     var menuItems = qwery('.js-close-nav-list');
     var buttonClickHandlers = {
@@ -109,7 +111,7 @@ define([
                 button.setAttribute('aria-expanded', 'false');
                 mainMenu.setAttribute('aria-hidden', 'true');
                 veggieBurgerLink.classList.remove('new-header__nav__menu-button--open');
-                veggieBurgerLink.setAttribute('data-link-name', 'main-navigation : veggie-burger : show');
+                veggieBurgerLink.setAttribute('data-link-name', 'nav2 : veggie-burger : show');
                 removeOrderingFromLists();
 
                 // Users should be able to scroll again
@@ -122,7 +124,7 @@ define([
                 button.setAttribute('aria-expanded', 'true');
                 mainMenu.setAttribute('aria-hidden', 'false');
                 veggieBurgerLink.classList.add('new-header__nav__menu-button--open');
-                veggieBurgerLink.setAttribute('data-link-name', 'main-navigation : veggie-burger : hide');
+                veggieBurgerLink.setAttribute('data-link-name', 'nav2 : veggie-burger : hide');
 
                 if (firstButton) {
                     firstButton.focus();


### PR DESCRIPTION
## What does this change?

Allows us to track the following types of interaction:
- Opening the edition picker
- Selecting an edition from the edition picker
- Opening the menu by clicking a primary link
- Opening the menu by clicking the veggie burger icon
- Expanding / collapsing a menu group
- Clicking a link from within the menu
- Searching from within the menu
- Closing the menu by clicking the veggie burger icon
- Closing the menu by clicking outside the menu (clicking the overlay)

This change will also try to track whether the user opened the menu before JavaScript was loaded, and thus saw the menu in its less-than-ideal fully expanded state.
## What is the value of this and can you measure success?

this change will provide us with some of the data we need to help us understand how successful the new header menu is 🚀 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@NataliaLKB @stephanfowler @obrienm @dominickendrick @desbo 
