### PR TITLE
Remove !important from inlined styles

### DIFF
--- a/common/app/views/fragments/email/stylesheets/footer.scala.html
+++ b/common/app/views/fragments/email/stylesheets/footer.scala.html
@@ -46,7 +46,10 @@
         top: 2px;
     }
 
-    .email__link {
+    .email__link,
+    .email__link:visited,
+    .email__link:hover,
+    .email__link:active {
         text-decoration: none;
         color: white !important;
     }


### PR DESCRIPTION
It turns out that Windows desktop versions of Outlook ignore inlined styles which have `!important` against them. This messes up a few aspects of the styling, most obviously the padding around the main content. So I've changed the CSS inliner so that it strips out `!important` from the inline styles.

To ensure that the important inlined styles still take precedence over non-important inlined styles, I sort the styles so that important styles appear to the right. Since [the logic in `mergeStyles`](https://github.com/guardian/frontend/blob/3ee4c1c79885ee715aa459697b36839a47a50f34/common/app/common/InlineStyles.scala#L128-L129) already takes account of `!important` when the properties have the same name, this case only actually matters when trying to override shorthand properties with related specific properties, e.g.:

``` css
#higher-specificity {
  padding: 5px;
}

.lower-specificity {
  /*
   * Once we strip !important, this must appear to the right of padding: 5px
   * otherwise it will be overridden by the #higher-specificity style
   */
  padding-top: 20px !important;
}
```

This change also has an impact on the subtle edge cases related to pseudo-selectors, whose styles can't be inlined. For instance, before this change, the `:hover` style in the example below would never take effect, since the bottom style would be inlined with `!important` which will always trump anything that is not inlined.

``` css
a:hover {
  /* This doesn't get inlined */
  color: blue !important;
}

a {
 /* This does get inlined so always trumps the :hover style */
  color: white !important;
}
```

Since we now strip `!important`, the `:hover` style works as it would without inlining. Unfortunately in the footer we were relying on the buggy behaviour to override `:hover`, `:active` and `:visited` styles in the links so I had to add in explicit overrides for these.

The TL;DR of using pseudo-selectors in email stylesheet is:
- pseudo-selectors **must** have **`!important`** if you want them to work
- the only way to override a pseudo-selector is with another pseudo-selector
### Before

![outlook-broken](https://cloud.githubusercontent.com/assets/5122968/18924197/1e67b33e-85a7-11e6-8120-c67291e3ed50.png)
### After

![outlook-fixed](https://cloud.githubusercontent.com/assets/5122968/18924200/22e2601c-85a7-11e6-9bc5-7779261745db.png)

@desbo 
