### PR TITLE
Update Heroic switch name and extend expiry date

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -5,13 +5,13 @@ import org.joda.time.LocalDate
 
 trait FeatureSwitches {
   // see https://github.com/guardian/frontend/pull/13446
-  val HeroicTemplateSwitch = Switch(
+  val ExploreTemplateSwitch = Switch(
     SwitchGroup.Feature,
-    "heroic-main-media",
-    "If this switch is on, Heroic template will be applied to heroic articles. This template is part of a Membership Explore test",
+    "explore-main-media",
+    "If this switch is on, Explore template will be applied to explore articles. This template is part of a Membership Explore test",
     owners = Seq(Owner.withGithub("siadcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 29),
+    sellByDate = new LocalDate(2016, 11, 15),
     exposeClientSide = false
   )
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -88,7 +88,7 @@ final case class Content(
         }
     )
   }
-  lazy val isExplore = HeroicTemplateSwitch.isSwitchedOn && tags.isExploreSeries
+  lazy val isExplore = ExploreTemplateSwitch.isSwitchedOn && tags.isExploreSeries
   lazy val isImmersive = fields.displayHint.contains("immersive") || isImmersiveGallery || tags.isTheMinuteArticle || isExplore
   lazy val isAdvertisementFeature: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
 


### PR DESCRIPTION
## What does this change?

Push the switch expiry to the week after the US elections, as it will continue to be used for Explore articles covering the election.

I've also renamed the switch to better suit its purpose.
## Request for comment

@gtrufitt @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
