### PR TITLE
Hosted Article fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -73,19 +73,7 @@
 
                         </div>
                         <div class="hide-on-desktop">
-                            <div class="hosted__next-video">
-                                <div class="hosted__next-video--header">
-                                    <div class="hosted__next-page-header--border hosted-tone-bg"></div>
-                                    <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
-                                    <h2 class="hosted__next-video--client-name hosted-tone">@{page.campaign.owner}</h2>
-                                </div>
-                                @for(nextPage <- page.nextPages) {
-                                    <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Page: @{nextPage.title}">
-                                        <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Page: @{nextPage.title}">
-                                        <p class="hosted__next-page-title">@{nextPage.title}</p>
-                                    </a>
-                                }
-                            </div>
+                            @guardianHostedArticleOj(page.campaign.owner, page.nextPages)
                         </div>
                         <div class="hosted__standfirst">
                             <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
@@ -96,21 +84,7 @@
                         </div>
                     </div>
                     <div class="content__secondary-column js-secondary-column">
-                        @for(nextPage <- page.nextPages.headOption) {
-                            <div class="hosted__next-video">
-                                <div class="hosted__next-video--header">
-                                    <div class="hosted__next-page-header--border hosted-tone-bg"></div>
-                                    <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
-                                    <h2 class="hosted__next-video--client-name hosted-tone">@{page.campaign.owner}</h2>
-                                </div>
-                                @for(nextPage <- page.nextPages) {
-                                    <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Page: @{nextPage.title}">
-                                        <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Page: @{nextPage.title}">
-                                        <p class="hosted__next-page-title">@{nextPage.title}</p>
-                                    </a>
-                                }
-                            </div>
-                        }
+                        @guardianHostedArticleOj(page.campaign.owner, page.nextPages)
                     </div>
                 </div>
             </div>

--- a/commercial/app/views/hosted/guardianHostedArticleOj.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticleOj.scala.html
@@ -1,0 +1,18 @@
+@import common.commercial.hosted.NextHostedPage
+@(campaignOwner: String, nextPages: List[NextHostedPage])
+@for(nextPage <- nextPages.headOption) {
+    <div class="hosted__next-video">
+        <div class="hosted__next-video--header">
+            <div class="hosted__next-page-header--border hosted-tone-bg"></div>
+            <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
+            <h2 class="hosted__next-video--client-name hosted-tone">@{campaignOwner}</h2>
+        </div>
+        @for(nextPage <- nextPages) {
+            <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Page: @{nextPage.title}">
+                <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Page: @{nextPage.title}">
+                <p class="hosted__next-page-title">@{nextPage.title}</p>
+            </a>
+        }
+    </div>
+}
+


### PR DESCRIPTION
## What does this change?

extract article onward journey to separate class, as we use it twice
## What is the value of this and can you measure success?

a fix I put in yesterday (https://github.com/guardian/frontend/pull/14497) was accidentally only applied in one of the onward journey positions

@guardian/labs-beta 
