### PR TITLE
Fix Admin troubleshooter tool

### DIFF
--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -30,18 +30,14 @@ class TroubleshooterController(wsClient: WSClient) extends Controller with Loggi
 
     val loadBalancers = LoadBalancer.all.filter(_.testPath.isDefined)
 
-    val thisLoadBalancer = loadBalancers.find(_.project == id).head
+    val thisLoadBalancer = loadBalancers.find(_.project == id).headOption
 
+    val directToLoadBalancer = thisLoadBalancer.map(testOnLoadBalancer(_, testPath, id))
+      .getOrElse(Future.successful(TestFailed("Can find the appropriate loadbalancer")))
     val viaWebsite = testOnGuardianSite(testPath, id)
-
     val directToContentApi = testOnContentApi(testPath, id)
-
-    val directToLoadBalancer = testOnLoadBalancer(thisLoadBalancer, testPath, id)
-
     val directToRouter = testOnRouter(testPath, id)
-
     val directToPreviewContentApi = testOnPreviewContentApi(testPath, id)
-
     val viaPreviewWebsite = testOnPreviewSite(testPath, id)
 
     // NOTE - the order of these is important, they are ordered so that the first failure is furthest 'back'
@@ -60,19 +56,30 @@ class TroubleshooterController(wsClient: WSClient) extends Controller with Loggi
 
 
   private def testOnRouter(testPath: String, id: String): Future[EndpointStatus] = {
-    val router = LoadBalancer.all.find(_.project == "frontend-router").flatMap(_.url).head
-    val result = httpGet("Can fetch directly from Router load balancer", s"http://$router$testPath")
-    result.map{ result =>
-      if (result.isOk)
-        result
-      else
-        TestFailed(result.name, result.messages.toSeq :+
-          "NOTE: if hitting the Router you MUST set Host header to 'www.theguardian.com' or else you will get '403 Forbidden'":_*)
+
+    def fetchWithRouterUrl(url: String) = {
+      val result = httpGet("Can fetch directly from Router load balancer", s"http://$url$testPath")
+      result.map{ result =>
+        if (result.isOk)
+          result
+        else
+          TestFailed(result.name, result.messages.toSeq :+
+            "NOTE: if hitting the Router you MUST set Host header to 'www.theguardian.com' or else you will get '403 Forbidden'":_*)
+      }
     }
+
+    LoadBalancer.all
+      .find(_.project == "frontend-router")
+      .flatMap(_.url)
+      .map(fetchWithRouterUrl(_))
+      .getOrElse(Future.successful(TestFailed("Can get Frontend router url")))
+
   }
 
   private def testOnLoadBalancer(thisLoadBalancer: LoadBalancer, testPath: String, id: String): Future[EndpointStatus] = {
-    httpGet(s"Can fetch directly from ${thisLoadBalancer.name} load balancer", s"http://${thisLoadBalancer.url.head}$testPath")
+    thisLoadBalancer.url.map { url =>
+      httpGet(s"Can fetch directly from ${thisLoadBalancer.name} load balancer", s"http://${url}$testPath")
+    }.getOrElse(Future(TestFailed(s"Can get ${thisLoadBalancer.name}'s loadbalancer url")))
   }
 
   private def testOnContentApi(testPath: String, id: String): Future[EndpointStatus] = {

--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -113,11 +113,11 @@ class TroubleshooterController(wsClient: WSClient) extends Controller with Loggi
   }
 
   private def testOnGuardianSite(testPath: String, id: String): Future[EndpointStatus] = {
-    httpGet("Can fetch from www.theguardian.com", s"http://www.theguardian.com$testPath")
+    httpGet("Can fetch from www.theguardian.com", s"https://www.theguardian.com$testPath")
   }
 
   private def testOnPreviewSite(testPath: String, id: String): Future[EndpointStatus] = {
-    httpGet("Can fetch from preview.gutools.co.uk", s"http://preview.gutools.co.uk$testPath")
+    httpGet("Can fetch from preview.gutools.co.uk", s"https://preview.gutools.co.uk$testPath")
   }
 
   private def httpGet(testName: String, url: String) =  {

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -140,6 +140,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
       rebuildIndexJob.run()
       videoEncodingsJob.run(akkaAsync)
       AssetMetricsCache.run()
+      LoadBalancer.refresh()
     }
   }
 }

--- a/admin/app/views/troubleshooterResults.scala.html
+++ b/admin/app/views/troubleshooterResults.scala.html
@@ -1,9 +1,9 @@
-@(loadbalancer: tools.LoadBalancer, results: Seq[controllers.admin.EndpointStatus])(implicit request: RequestHeader)
+@(loadbalancer: Option[tools.LoadBalancer], results: Seq[controllers.admin.EndpointStatus])(implicit request: RequestHeader)
 
 @admin_main("Troubleshooting results", "PROD", isAuthed = true) {
 
     <div class="row-fluid">
-        <h4>@loadbalancer.name (@loadbalancer.project)</h4>
+        <h4>@loadbalancer.fold("Unknown loadbalancer")(lb => s"${lb.name} (${lb.project})")</h4>
         <p>Failures are in order - the cause of the error will most likely be at the level of the first failure</p>
     </div>
     <table class="table table-striped table-bordered">

--- a/admin/app/views/troubleshooterResults.scala.html
+++ b/admin/app/views/troubleshooterResults.scala.html
@@ -3,7 +3,7 @@
 @admin_main("Troubleshooting results", "PROD", isAuthed = true) {
 
     <div class="row-fluid">
-        <h4>@loadbalancer.fold("Unknown loadbalancer")(lb => s"${lb.name} (${lb.project})")</h4>
+        <h4>@loadbalancer.map(lb => s"${lb.name} (${lb.project})").getOrElse("Unknown loadbalancer")</h4>
         <p>Failures are in order - the cause of the error will most likely be at the level of the first failure</p>
     </div>
     <table class="table table-striped table-bordered">


### PR DESCRIPTION
## What does this change?

Fetch loadbalancers info (url, ...) right after app startup.
Handle missing elb properly.
Check via https
## What is the value of this and can you measure success?

Ensure the Troubleshoot tool (https://frontend.gutools.co.uk/troubleshoot/pages) works all the time
## Request for comment

@jfsoul @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
