### PR TITLE
Explicit 100% width for email banners since auto breaks in some clients

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -8,7 +8,7 @@
 @defining(page.article) { article =>
     @fullRow {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
-            <img width="580" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
+            <img width="580" class="full-width" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
         </a>
     }
 
@@ -83,7 +83,7 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { url =>
                             @fullRow {
-                                <img width="580" class="media--main" src="@url" @data.get("alt").map { alt => alt="@alt" }>
+                                <img width="580" class="full-width" src="@url" @data.get("alt").map { alt => alt="@alt" }>
                             }
 
                             @paddedRow {

--- a/article/app/views/fragments/emailMainMedia.scala.html
+++ b/article/app/views/fragments/emailMainMedia.scala.html
@@ -7,7 +7,7 @@
     @article.elements.mainPicture.map { picture =>
         @EmailImage.bestFor(picture.images).map { url =>
             @fullRow {
-                <img width="580" class="media--main" src="@url" alt="@ImgSrc.getFallbackAsset(picture.images).flatMap(_.altText).getOrElse("")" />
+                <img width="580" class="full-width" src="@url" alt="@ImgSrc.getFallbackAsset(picture.images).flatMap(_.altText).getOrElse("")" />
             }
 
             @picture.images.largestImage.map { img =>

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -5,7 +5,7 @@
         background: #e5e5e5;
     }
 
-    .media--main {
+    .full-width {
         width: 100%;
     }
 

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -92,7 +92,7 @@
         padding-top: 24px;
     }
 
-    .media--main {
+    .full-width {
         width: 100%;
     }
 

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -26,7 +26,7 @@
         @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
             <a @Html(href) class="facia-card facia-card--large @toneClass(pressedContent)">
                 @imageUrlFromPressedContent(pressedContent).map { url =>
-                    <img width="580" class="media--main" src="@url" />
+                    <img width="580" class="full-width" src="@url" />
                 }
                 @headline(pressedContent)
                 @pressedContent.card.trailText.map { trailText =>
@@ -48,7 +48,7 @@
                         </td>
                         <td class="five sub-columns last">
                             @imageUrlFromPressedContent(pressedContent).map { url =>
-                                <img width="580" class="media--main" src="@url" />
+                                <img width="580" class="full-width" src="@url" />
                             }
                         </td>
                     </tr>
@@ -59,7 +59,7 @@
 }
 
 @fullRow {
-    <img width="580" src="@Static("images/email/banners/generic.png")">
+    <img width="580" class="full-width" src="@Static("images/email/banners/generic.png")">
 }
 
 @page.frontProperties.onPageDescription.map { description =>


### PR DESCRIPTION
Fixes an image rendering issue in some email clients (notably Outlook Web, Yahoo mail, AOL mail). Certain images with `width: auto` would not respect their `max-width: 100%` and expand way beyond their container. Putting an explicit `width: 100%` fixed this.
### Before

![yahoo-broken](https://cloud.githubusercontent.com/assets/5122968/18953533/dc21df0e-8646-11e6-9bec-52627ce970ec.png)
### After

![yahoo-fixed](https://cloud.githubusercontent.com/assets/5122968/18953536/def1b5c4-8646-11e6-9c01-3456ca0468a1.png)

@desbo 
