### PR TITLE
Refresh the comment count

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -1,7 +1,11 @@
 define([
+    'fastdom',
+    'common/utils/formatters',
     'common/utils/mediator',
     'common/utils/report-error'
 ], function(
+    fastdom,
+    formatters,
     mediator,
     reportError
 ) {
@@ -19,10 +23,16 @@ define([
                     // in the page refresh their value.
                     var otherValues = document.getElementsByClassName('js_commentcount_actualvalue');
                     for (var i = 0, len = otherValues.length; i < len; i += 1) {
-                        otherValues[i].textContent = value;
+                        updateCommentCount(otherValues[i], value);
                     }
                 }
                 mediator.emit('comments-count-loaded');
+            });
+        }
+
+        function updateCommentCount (element, value) {
+            fastdom.write(function () {
+                element.textContent = formatters.integerCommas(value);
             });
         }
 

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -13,6 +13,14 @@ define([
             emitter.once('comment-count', function (value) {
                 if (value === 0) {
                     loader.setState('empty');
+                } else {
+                    // By the time discussion frontent loads, the number of comments
+                    // might have changed. If there are other comment counts element
+                    // in the page refresh their value.
+                    var otherValues = document.getElementsByClassName('js_commentcount_actualvalue');
+                    for (var i = 0, len = otherValues.length; i < len; i += 1) {
+                        otherValues[i].textContent = value;
+                    }
                 }
                 mediator.emit('comments-count-loaded');
             });

--- a/static/src/javascripts/projects/common/views/discussion/comment-count--content.html
+++ b/static/src/javascripts/projects/common/views/discussion/comment-count--content.html
@@ -1,4 +1,4 @@
 <a href="<%=url%>" data-link-name="Comment count" class="commentcount2 tone-colour">
     <h3 class="commentcount2__heading"><%=icon%> Comments</h3>
-    <span class="commentcount2__value tone-colour"><%=count%></span>
+    <span class="commentcount2__value tone-colour js_commentcount_actualvalue"><%=count%></span>
 </a>


### PR DESCRIPTION
## What does this change?

When discussions are enabled on an article, there are two requests for the comment count. One for the icon at the top, one for the discussion block at the bottom.

Now that we're using preact asynchronously, the time difference between the two requests might be higher. In articles with a fast changing comment count this means that the two values are not in sync.

This PR makes sure that the two values are the same after the comments load.
## What is the value of this and can you measure success?

People won't be confused
## Does this affect other platforms - Amp, Apps, etc?

No
