### PR TITLE
HTMLCleaner now understands schema-less url

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -1,8 +1,8 @@
 package views.support
 
 import java.text.Normalizer
+import java.net.URI
 import java.util.regex.{Matcher, Pattern}
-
 import common.{Edition, LinkTo}
 import conf.switches.Switches._
 import layout.ContentWidths
@@ -153,7 +153,7 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
 
   def findContainerFromId(id: String, src: String): Option[ImageElement] = {
     // It is possible that a single data media id can appear multiple times in the elements array.
-    val srcImagePath = new java.net.URL(src).getPath()
+    val srcImagePath = new URI(src).getPath()
     val imageContainers = article.elements.bodyImages.filter(_.properties.id == id)
 
     // Try to match the container based on both URL and media ID.


### PR DESCRIPTION
## What does this change?

java.net.URL must have a protocol

```
java.net.MalformedURLException: no protocol: //upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Baby_diving.jpg/512px-Baby_diving.jpg
    at java.net.URL.<init>(URL.java:593)
    at java.net.URL.<init>(URL.java:490)
    at java.net.URL.<init>(URL.java:439)
    at views.support.PictureCleaner.findContainerFromId(HtmlCleaner.scala:156)
    at views.support.PictureCleaner$$anonfun$clean$4$$anonfun$apply$4.apply(HtmlCleaner.scala:103)
```

Since we are only interested in the path, this patch is replacing URL by URI which is more lenient on this matter.
## What is the value of this and can you measure success?

Articles that embed images specified without protocol can be served.
Ex: https://www.theguardian.com/science/occams-corner/2013/may/07/aquatic-apes-creationism-evolution
https://content.guardianapis.com/science/occams-corner/2013/may/07/aquatic-apes-creationism-evolution?format=json&api-key=teleporter-view&show-elements=all&show-rights=all&show-fields=all&show-tags=all&show-blocks=all&show-references=all
## Request for comment

@jfsoul @guardian/dotcom-platform

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
