### PR TITLE
Extend British Council Beacon by 2 weeks

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -232,7 +232,7 @@ trait CommercialSwitches {
     "British Council's beacon",
     owners = Seq(Owner.withGithub("kenlim")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 30),
+    sellByDate = new LocalDate(2016, 10, 17),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

This extends the running of the British Council Partner Zone beacon by 2 weeks, as requested by G-Labs
