### PR TITLE
fix the theme of two emails

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -185,7 +185,7 @@ object EmailSubscriptions {
   def featureEmails(subscribedListIds: Iterable[String] = None) = List(
     EmailSubscription(
       name = "Weekend Reading",
-      theme = "feature",
+      theme = "news",
       about = "Feature",
       teaser = "The best stuff you didn't have time to read during the week - from features and news analysis to lifestyle and culture",
       description = "The best stuff you didn't have time to read during the week - from features and news analysis to lifestyle and culture.",
@@ -197,7 +197,7 @@ object EmailSubscriptions {
     ),
     EmailSubscription(
       name = "The Long Read",
-      theme = "feature",
+      theme = "news",
       about = "Feature",
       teaser = "Get your teeth into the Long Read with a weekly delivery of the latest features and podcasts",
       description = "Bringing you the latest Long Read features and podcasts, delivered to your inbox.",


### PR DESCRIPTION
## What does this change?

Changes the theme of Weekend Reading and the Long Read back to 'news' so that they get added to one of the dropdowns in the EmailPrefs page.
## What is the value of this and can you measure success?

Weekend Reading and Long Read are visible on email prefs page
Fixes a bug introduced in #14418 😓
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Request for comment

@joelochlann 
