### PR TITLE
Use parameters to query soulmates API rather than path capturing.

### DIFF
--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -7,6 +7,7 @@ import model.commercial.soulmates._
 import model.commercial.Member
 import model.Cached
 import play.api.mvc._
+import controllers.commercial
 
 import scala.concurrent.duration._
 
@@ -40,8 +41,10 @@ class SoulmatesController extends Controller with implicits.Requests {
     }
   }
 
-  def getSoulmates(groupName: String) = Action { implicit request =>
-
-    Cached(60.seconds){ JsonComponent(soulmatesSample(groupName)) }
+  def getSoulmates() = Action { implicit request =>
+    specificId match {
+      case Some(feed) => Cached(60.seconds) { JsonComponent(soulmatesSample(feed)) }
+      case None => Cached(componentNilMaxAge){ jsonFormat.nilResult }
+    }
   }
 }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -20,7 +20,7 @@ GET         /commercial/masterclasses.json                                  cont
 
 # Soulmates merchandising components
 GET        /commercial/soulmates/$subgroup<\w+>.json                        controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
-GET        /commercial/soulmates/api/$subgroup<\w+>.json                    controllers.commercial.SoulmatesController.getSoulmates(subgroup)
+GET        /commercial/api/soulmates.json                                   controllers.commercial.SoulmatesController.getSoulmates
 
 # Book merchandising components
 GET         /commercial/books/book.json                                     controllers.commercial.BookOffersController.renderBook

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -289,7 +289,7 @@ GET            /commercial/jobs.json                                            
 GET            /commercial/jobs/api/jobs.json                                                                                    controllers.commercial.JobsController.getJobs
 GET            /commercial/masterclasses.json                                                                                    controllers.commercial.MasterclassesController.renderMasterclasses
 GET            /commercial/soulmates/$subgroup<\w+>.json                                                                         controllers.commercial.SoulmatesController.renderSoulmates(subgroup)
-GET            /commercial/soulmates/api/$subgroup<\w+>.json                                                                     controllers.commercial.SoulmatesController.getSoulmates(subgroup)
+GET            /commercial/api/soulmates.json                                                                          controllers.commercial.SoulmatesController.getSoulmates
 GET            /commercial/books/book.json                                                                                       controllers.commercial.BookOffersController.renderBook
 GET            /commercial/books/books.json                                                                                      controllers.commercial.BookOffersController.renderBooks
 GET            /commercial/books/api/books.json                                                                                  controllers.commercial.BookOffersController.getBooks


### PR DESCRIPTION
Yet more small Native Template changes.

The native template will now fetch soulmates via URL params, as opposed to the path. This will allow us to more easily expand the customised nature of the API call in future e.g. number of soulmates etc.
