### PR TITLE
Bump config for switch to gu-web beacon urls

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 7
+    val s3ConfigVersion = 8
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
This changes the config so that the beacon endpoint moves to `gu-web.net`. This means:

`beacon.www.code.dev-theguardian.com` becomes `beacon-code.gu-web.net` and
`beacon.guim.co.uk` becomes `beacon.gu-web.net`

The reason I'm doing this is so that I can move diagnostics into the VPC.
