### PR TITLE
Hosted youtube video - controls in the new template

### DIFF
--- a/commercial/app/views/hosted/guardianHostedControlButtons.scala.html
+++ b/commercial/app/views/hosted/guardianHostedControlButtons.scala.html
@@ -1,0 +1,21 @@
+@import common.commercial.hosted.HostedVideoPage
+
+@(page: HostedVideoPage)(implicit request: RequestHeader)
+<div class="vjs-control-bar youtube-player">
+    <div class="vjs-current-time vjs-time-control vjs-control" aria-hidden="true">
+        <div class="vjs-current-time-display" aria-live="off">
+            <span class="vjs-control-text">Current Time </span><span class="js-youtube-current-time">0:00</span>
+        </div>
+    </div>
+    <div class="vjs-time-control vjs-time-divider" aria-hidden="true">
+        <div>
+            <span>/</span>
+        </div>
+    </div>
+    <div class="vjs-duration vjs-time-control vjs-control" aria-hidden="true">
+        <div class="vjs-duration-display" aria-live="off">
+            <span class="vjs-control-text">Duration Time</span>@{"%2d:%02d".format(page.video.duration/60, page.video.duration % 60)}
+        </div>
+    </div>
+</div>
+

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -1,7 +1,7 @@
 @import common.commercial.hosted.HostedVideoPage
 @import common.commercial.hosted.hardcoded.Support.makeshiftPage
 @import conf.Configuration.site.host
-@import views.html.hosted.{guardianHostedCta, guardianHostedHeader, guardianHostedShareButtons, hostedVideoOnward}
+@import views.html.hosted.{guardianHostedCta, guardianHostedHeader, guardianHostedShareButtons, hostedVideoOnward, guardianHostedControlButtons}
 @(page: HostedVideoPage)(implicit request: RequestHeader)
 
 @main(page, Some("commercial")) { } {
@@ -52,23 +52,7 @@
                         src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(host != "") s"&origin=$host" else ""}"
                         frameborder="0"
                         allowfullscreen=""></iframe>
-                        <div class="vjs-control-bar youtube-player">
-                            <div class="vjs-current-time vjs-time-control vjs-control" aria-hidden="true">
-                                <div class="vjs-current-time-display" aria-live="off">
-                                    <span class="vjs-control-text">Current Time </span><span class="js-youtube-current-time">0:00</span>
-                                </div>
-                            </div>
-                            <div class="vjs-time-control vjs-time-divider" aria-hidden="true">
-                                <div>
-                                    <span>/</span>
-                                </div>
-                            </div>
-                            <div class="vjs-duration vjs-time-control vjs-control" aria-hidden="true">
-                                <div class="vjs-duration-display" aria-live="off">
-                                    <span class="vjs-control-text">Duration Time</span>@{"%2d:%02d".format(page.video.duration/60, page.video.duration % 60)}
-                                </div>
-                            </div>
-                        </div>
+                        @guardianHostedControlButtons(page)
                     }.getOrElse {
                         <video
                         data-duration="@{page.video.duration}"


### PR DESCRIPTION
## What does this change?

Just a small change when controls are moved to the separate template, so the main one stays simple.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

@lps88 @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
