### PR TITLE
Add Edition to cAPI Endpoint for Native Templates

### DIFF
--- a/commercial/app/controllers/commercial/ContentApiOffersController.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffersController.scala
@@ -126,10 +126,10 @@ class ContentApiOffersController(contentApiClient: ContentApiClient, capiAgent: 
     retrieveContent().map {
       case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
       case content if isMulti => Cached(60.seconds) {
-        JsonComponent(CapiMultiple.fromContent(content))
+        JsonComponent(CapiMultiple.fromContent(content, Edition(request)))
       }
       case first :: _ => Cached(60.seconds) {
-        JsonComponent(CapiSingle.fromContent(first))
+        JsonComponent(CapiSingle.fromContent(first, Edition(request)))
       }
     }
 

--- a/commercial/app/model/commercial/CapiMultiple.scala
+++ b/commercial/app/model/commercial/CapiMultiple.scala
@@ -2,16 +2,17 @@ package model.commercial
 
 import model.ContentType
 import play.api.libs.json.{Json, Writes}
+import common.Edition
 
 // The information needed to render the native cAPI multiple ad.
 case class CapiMultiple(articles: Seq[CapiSingle])
 
 object CapiMultiple {
 
-  def fromContent(articles: Seq[ContentType]): CapiMultiple = {
+  def fromContent(articles: Seq[ContentType], edition: Edition) = {
 
     CapiMultiple(articles.map(article => {
-    	CapiSingle.fromContent(article, articles.length)
+    	CapiSingle.fromContent(article, edition, articles.length)
     }))
 
   }

--- a/commercial/app/model/commercial/CapiSingle.scala
+++ b/commercial/app/model/commercial/CapiSingle.scala
@@ -9,18 +9,23 @@ import CapiImages.ImageInfo
 case class CapiSingle(articleHeadline: String, articleUrl: String,
                       articleText: Option[String], articleImage: ImageInfo,
                       audioTag: Boolean, galleryTag: Boolean,
-                      videoTag: Boolean, branding: Option[Branding])
+                      videoTag: Boolean, branding: Option[Branding],
+                      edition: String)
 
 object CapiSingle {
   import ElementsFormat._
 
-  def fromContent(contentType: ContentType, noArticles: Int = 1): CapiSingle = {
+  def fromContent(
+    contentType: ContentType,
+    edition: Edition,
+    noArticles: Int = 1): CapiSingle = {
+
     val content = contentType.content
-    val branding = BrandHunter.findContentBranding(contentType, Edition.defaultEdition)
+    val branding = BrandHunter.findContentBranding(contentType, edition)
     val imageInfo = CapiImages.buildImageData(content.trail.trailPicture, noArticles)
 
     CapiSingle(content.trail.headline, content.metadata.webUrl, content.trail.fields.trailText, imageInfo, content.tags.isAudio,
-      content.tags.isGallery, content.tags.isVideo, branding)
+      content.tags.isGallery, content.tags.isVideo, branding, edition.id)
   }
   implicit val writesCapiSingle: Writes[CapiSingle] = Json.writes[CapiSingle]
 }


### PR DESCRIPTION
## What does this change?
- Replaces placeholder edition used to generate branding in the endpoint.
- Passes edition information back to the client for use in cAPI native templates.
## What is the value of this and can you measure success?

Needed to allow cAPI native templates to display edition and branding correctly.
## Request for comment

@annebyrne 
@regiskuckaertz decided against modifying `getIframeId` message passing; we were already using edition for branding in the endpoint (plus we only need it for these templates anyway) .
