### PR TITLE
Move some fluid styles to fabric

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -104,11 +104,6 @@ define([
     sizeCallbacks[adSizes.fluid250] = addFluid250(['ad-slot--top-banner-ad']);
 
     /**
-     * Mobile adverts with fabric sizes get 'fluid' full-width design
-     */
-    sizeCallbacks[adSizes.fabric] = addFluid(['ad-slot--top-banner-ad']);
-
-    /**
      * Commercial components with merch sizing get fluid-250 styling
      */
     sizeCallbacks[adSizes.merchandising] = addFluid250(['ad-slot--commercial-component']);

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -129,7 +129,7 @@
         height: 250px;
     }
 
-    &.ad-slot--fluid {
+    &.ad-slot--fabric {
         > .ad-slot__label {
             box-sizing: content-box;
             // Copying stuff from _mixins.scss because I don't want to
@@ -655,6 +655,10 @@
 .ad-slot--fabric {
     overflow: hidden;
     width: auto;
+    min-height: 250px;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
 }
 
 .ad-slot--fabric-v1,


### PR DESCRIPTION
Last change before the end of the quarter 😆 

There were some overlap between the treatment of Fabrics and Fluid ads around the label. Fluid ads won't have label, so we can safely move that over to Fabrics only. Also, we seal the styling on Fabrics in its own modifier (`ad-slot--fabric`) to prevent future mixups.

Before (no label):

![picture 2](https://cloud.githubusercontent.com/assets/629976/18998198/7ed2fcfe-872f-11e6-9786-e77934645800.jpg)

After:

![picture 1](https://cloud.githubusercontent.com/assets/629976/18998210/889a8d06-872f-11e6-87f9-4a13024249c9.jpg)
