### PR TITLE
Fix subscribing to web notifications when there is an exception

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -112,6 +112,7 @@ define([
                     if (Notification.permission === 'denied') {
                         omniture.trackLinkImmediate('browser-notifications-denied');
                     }
+                    modules.configureSubscribeButton();
                 });
         },
 


### PR DESCRIPTION
This fixes a bug in web notifications signup; when there is an exception in the JS upon signup, the handler to sign up does not get added back onto the element of the DOM.
This then requires the user to refresh the page.

This change ensures the handles gets added back onto the DOM element.

@stephanfowler @gtrufitt 
