### PR TITLE
Display image with video icon correctly in emails

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -1,6 +1,6 @@
 @(page: PageWithStoryPackage)(implicit request: RequestHeader)
 
-@import views.support.EmailImage
+@import views.support.{EmailImage, EmailVideoImage}
 @import views.support.EmailHelpers._
 @import model.liveblog._
 @import model.EmailAddons.EmailContentType
@@ -105,9 +105,15 @@
                     }
 
                     case GuVideoBlockElement(video, media, data) => {
-                        @data.get("url").map { url =>
-                            @fullRowWithBackground(media) {
-                                <a class="play--button" href="@url"><img class="float-left play--icon" src="@Images.play"></a>
+                        @EmailVideoImage.bestFor(media).map { imageUrl =>
+                            @fullRow {
+                                @data.get("url").fold {
+                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                }{ linkUrl =>
+                                    <a href="@linkUrl">
+                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    </a>
+                                }
                             }
                         }
                     }

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -96,10 +96,6 @@
         width: 100%;
     }
 
-    .row.background--image {
-        background-size: cover;
-    }
-
     .container,
     .panel {
         background: white;
@@ -131,20 +127,6 @@
 
     .icon-camera {
         margin-right: 4px;
-    }
-
-    .play--button {
-        display: table-cell;
-        vertical-align: middle;
-        text-align: center;
-        width: 580px;
-    }
-
-    .play--icon {
-        float: none;
-        clear: none;
-        margin: 0 auto;
-        padding: 20% 0;
     }
 
     .text--brand {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -49,16 +49,6 @@ object EmailHelpers {
     case p: PressedPage => p.frontProperties.onPageDescription
   }
 
-  def fullRowWithBackground(media: ImageMedia)(inner: Html): Html = {
-    EmailImage.bestFor(media).map { url =>
-      Html {
-        s"""<table style="background-image: url($url)" class="row background--image">
-          <tr>${columns(12)(inner)}</tr>
-        </table>"""
-      }
-    } getOrElse (fullRow(inner))
-  }
-
   def icon(name: String) = Html {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="float-left icon icon-$name">"""
   }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import java.net.{URI, URISyntaxException}
+import java.util.Base64
 import common.Logging
 import conf.switches.Switches.{ImageServerSwitch, FacebookShareImageLogoOverlay, TwitterShareImageLogoOverlay}
 import conf.Configuration
@@ -126,6 +127,17 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
 }
 
 object EmailImage extends Profile(width = Some(640), autoFormat = false)
+object EmailVideoImage extends Profile(width = Some(640), autoFormat = false) {
+  override val fitParam = "fit=crop"
+  val blendModeParam = "bm=normal"
+  val blendOffsetParam = "ba=center"
+  val blendImageParam = s"blend64=${Base64.getUrlEncoder.encodeToString(EmailHelpers.Images.play.getBytes)}"
+
+  override def resizeString = {
+    val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
+    s"?$params"
+  }
+}
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))


### PR DESCRIPTION
Currently these clients don't support background images:
- all windows desktop versions of outlook
- gmail app (android)
- outlook.com

Unfortunately we use a background image to overlay a video "play" icon on top of an image as an enticement to click the link and see the video on theguardian.com. This doesn't look great in the above clients. So I've opted to use imgix magic to overlay the play icon on top of the main image and just serve up one image. This has other advantages, namely being able to center the play icon, and deleting some now unused markup & styles.
### Before

![picture 304](https://cloud.githubusercontent.com/assets/5122968/19000843/93c5a2a8-873c-11e6-905a-26e97d8cde98.png)
### After

![picture 306](https://cloud.githubusercontent.com/assets/5122968/19000845/96fe4880-873c-11e6-8a86-9172e7afb9ff.png)

@desbo 
