### PR TITLE
Extend expiring switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Show visitors new video play button",
     owners = Seq(Owner.withGithub("mr-mr")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 30),
+    sellByDate = new LocalDate(2016, 10, 4),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
To avoid breaking build.
