### PR TITLE
Implementing tertiary nav for the new header test

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -59,7 +59,7 @@
 
                 @defining(IndexPage.makeFront(index, Edition(request)).containers) { containers =>
                     @containers.map { containerDefinition =>
-                        @container(containerDefinition, empty)
+                        @container(containerDefinition, empty, pageId = index.page.metadata.url.drop(1))
                     }
                 }
 

--- a/applications/app/views/newspaperPage.scala.html
+++ b/applications/app/views/newspaperPage.scala.html
@@ -4,7 +4,7 @@
 
     @for(bookSection <- paper.bookSections) {
 
-        @fragments.containers.facia_cards.container(bookSection)
+        @fragments.containers.facia_cards.container(bookSection, pageId = paper.page.metadata.sectionId)
 
     }
 }

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -3,6 +3,7 @@ package common
 import conf.Configuration
 
 case class NavLink(name: String, url: String, iconName: String = "")
+case class TertiaryLink(frontId: String, name: String, url: String)
 
 object NewNavigation {
   val topLevelSections = List(News, Opinion, Sport, Arts, Life)
@@ -333,7 +334,6 @@ object NewNavigation {
     val name = ""
 
     val uk = List(
-//       TODO: use config for urls instead
       NavLink("become a supporter", s"${Configuration.id.membershipUrl}/uk/supporter?INTCMP=mem_uk_web_newheader", "marque-36"),
       NavLink("subscribe", s"${Configuration.id.digitalPackUrl}/uk?INTCMP=NGW_NEWHEADER_UK_GU_SUBSCRIBE", "device")
     )
@@ -352,5 +352,140 @@ object NewNavigation {
       NavLink("become a supporter", s"${Configuration.id.membershipUrl}/int/supporter?INTCMP=mem_int_web_newheader", "marque-36"),
       NavLink("subscribe", s"${Configuration.id.digitalPackUrl}/int?INTCMP=NGW_NEWHEADER_INT_GU_SUBSCRIBE", "device")
     )
+  }
+
+  object TertiaryNav {
+
+    val tertiaryLinks = List(
+      /**
+       * NEWS
+       */
+
+      // uk news
+      TertiaryLink("uk-news", "education", "/education"),
+      TertiaryLink("uk-news", "media", "/media"),
+      TertiaryLink("uk-news", "society", "/society"),
+      TertiaryLink("uk-news", "law", "/law"),
+      TertiaryLink("uk-news", "scotland", "/uk/scotland"),
+      TertiaryLink("uk-news", "wales", "/uk/wales"),
+      TertiaryLink("uk-news", "northern ireland", "/uk/northernireland"),
+
+      // world news
+      TertiaryLink("world", "europe", "/world/europe-news"),
+      TertiaryLink("world", "US", "/us-news"),
+      TertiaryLink("world", "americas", "/world/americas"),
+      TertiaryLink("world", "asia", "/world/asia"),
+      TertiaryLink("world", "australia", "/world/australia-news"),
+      TertiaryLink("world", "africa", "/world/africa"),
+      TertiaryLink("world", "middle east", "/world/middleeast"),
+      TertiaryLink("world", "cities", "/world/cities"),
+      TertiaryLink("world", "development", "/global-development"),
+
+      // business
+      TertiaryLink("uk/business", "economics", "/business/economics"),
+      TertiaryLink("uk/business", "banking", "/business/banking"),
+      TertiaryLink("uk/business", "retail", "/business/retail"),
+      TertiaryLink("uk/business", "markets", "/business/stock-markets"),
+      TertiaryLink("uk/business", "eurozone", "/business/eurozone"),
+
+      TertiaryLink("us/business", "economics", "/business/economics"),
+      TertiaryLink("us/business", "sustainable business", "/us/sustainable-business"),
+      TertiaryLink("us/business", "diversity & equality in business", "/business/diversity-and-equality"),
+      TertiaryLink("us/business", "small business", "business/us-small-business"),
+
+      TertiaryLink("au/business", "markets", "/business/stock-markets"),
+      TertiaryLink("au/business", "money", "/au/money"),
+
+      // environment
+      TertiaryLink("uk/environment", "climate change", "/environment/climate-change"),
+      TertiaryLink("uk/environment", "wildlife", "/environment/wildlife"),
+      TertiaryLink("uk/environment", "energy", "/environment/energy"),
+      TertiaryLink("uk/environment", "pollution", "/environment/pollution"),
+
+      TertiaryLink("us/environment", "climate change", "/environment/climate-change"),
+      TertiaryLink("us/environment", "wildlife", "/environment/wildlife"),
+      TertiaryLink("us/environment", "energy", "/environment/energy"),
+      TertiaryLink("us/environment", "pollution", "/environment/pollution"),
+
+      TertiaryLink("au/environment", "cities", "/cities"),
+      TertiaryLink("au/environment", "development", "/global-development"),
+      TertiaryLink("au/environment", "sustainable business", "/au/sustainable-business"),
+
+      // money
+      TertiaryLink("uk/money", "property", "/money/property"),
+      TertiaryLink("uk/money", "pensions", "/money/pensions"),
+      TertiaryLink("uk/money", "savings", "/money/savings"),
+      TertiaryLink("uk/money", "borrowing", "/money/debt"),
+      TertiaryLink("uk/money", "careers", "/money/work-and-careers"),
+
+      /**
+        * SPORT
+        */
+
+      // football
+      TertiaryLink("football", "live scores", "/football/live"),
+      TertiaryLink("football", "tables", "/football/tables"),
+      TertiaryLink("football", "competitions", "/football/competitions"),
+      TertiaryLink("football", "results", "/football/results"),
+      TertiaryLink("football", "fixtures", "/football/fixtures"),
+      TertiaryLink("football", "clubs", "/football/teams"),
+
+      /**
+        * LIFE
+        */
+
+      // travel
+      TertiaryLink("uk/travel", "UK", "/travel/uk"),
+      TertiaryLink("uk/travel", "europe", "/travel/europe"),
+      TertiaryLink("uk/travel", "US", "/travel/usa"),
+      TertiaryLink("uk/travel", "skiing", "/travel/skiing"),
+
+      TertiaryLink("us/travel", "USA", "/travel/usa"),
+      TertiaryLink("us/travel", "europe", "/travel/europe"),
+      TertiaryLink("us/travel", "UK", "/travel/uk"),
+      TertiaryLink("us/travel", "skiing", "/travel/skiing"),
+
+      TertiaryLink("au/travel", "australasia", "/travel/usa"),
+      TertiaryLink("au/travel", "asia", "/travel/europe"),
+      TertiaryLink("au/travel", "UK", "/travel/uk"),
+      TertiaryLink("au/travel", "europe", "/travel/europe"),
+      TertiaryLink("au/travel", "US", "/travel/usa"),
+      TertiaryLink("au/travel", "skiing", "/travel/skiing"),
+
+      /**
+        * OTHER
+        */
+
+      // today's paper
+      TertiaryLink("todayspaper", "editorials & letters", "/theguardian/mainsection/editorialsandreply"),
+      TertiaryLink("todayspaper", "obituaries", "/tone/obituaries"),
+      TertiaryLink("todayspaper", "g2", "/theguardian/g2"),
+      TertiaryLink("todayspaper", "weekend", "/theguardian/weekend"),
+      TertiaryLink("todayspaper", "the guide", "/theguardian/theguide"),
+      TertiaryLink("todayspaper", "saturday review", "/theguardian/guardianreview"),
+
+      // sunday's paper
+      TertiaryLink("theobserver", "comment", "/theobserver/news/comment"),
+      TertiaryLink("theobserver", "the new review", "/theobserver/new-review"),
+      TertiaryLink("theobserver", "observer magazine", "/theobserver/magazine"),
+
+      // crosswords
+      TertiaryLink("crosswords", "blog", "/crosswords/crossword-blog"),
+      TertiaryLink("crosswords", "editor", "/crosswords/series/crossword-editor-update"),
+      TertiaryLink("crosswords", "quick", "/crosswords/series/quick"),
+      TertiaryLink("crosswords", "cryptic", "/crosswords/series/cryptic"),
+      TertiaryLink("crosswords", "prize", "/crosswords/series/prize"),
+      TertiaryLink("crosswords", "quiptic", "/crosswords/series/quiptic"),
+      TertiaryLink("crosswords", "genius", "/crosswords/series/genius"),
+      TertiaryLink("crosswords", "speedy", "/crosswords/series/speedy"),
+      TertiaryLink("crosswords", "everyman", "/crosswords/series/everyman"),
+      TertiaryLink("crosswords", "azed", "/crosswords/series/azed")
+    )
+
+    def getTertiaryNavLinks(frontId: String): List[TertiaryLink] = {
+      tertiaryLinks.filter{ item =>
+        item.frontId == frontId
+      }
+    }
   }
 }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -91,11 +91,11 @@
 
                         <ul class="tertiary-navigation mobile-only">
 
-                            @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { footballNavItem =>
+                            @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { tertiaryLink =>
 
                                 <li class="tertiary-navigation__item">
-                                    <a class="tertiary-navigation__link" href="@LinkTo(footballNavItem.url)" data-link-name="@footballNavItem.name">
-                                        @Html(footballNavItem.name)
+                                    <a class="tertiary-navigation__link" href="@LinkTo(tertiaryLink.url)" data-link-name="@tertiaryLink.name">
+                                        @Html(tertiaryLink.name)
                                         <i class="tertiary-navigation__icon rounded-icon"></i>
                                     </a>
                                 </li>

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,4 +1,5 @@
 @import common.commercial.ContainerModel
+@import common.{NewNavigation, LinkTo}
 @import layout.MetaDataHeader
 @import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, Video}
 @import views.html.commercial.containers.paidContainer
@@ -10,7 +11,8 @@
   frontProperties: model.FrontProperties = model.FrontProperties.empty,
   frontId: Option[String] = None,
   isPaidFront: Boolean = false,
-  maybeContainerModel: Option[ContainerModel] = None)(implicit request: RequestHeader)
+  maybeContainerModel: Option[ContainerModel] = None,
+  pageId: String = "")(implicit request: RequestHeader)
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -77,6 +79,29 @@
                         <div class="fc-container__inner">
                             @mostPopularContainer(containerDefinition, frontProperties)
                         </div>
+                    }
+                }
+
+                @defining((
+                    containerDefinition.index == 0,
+                    frontId.getOrElse(pageId)
+                    )) { case (isFirstContainer, id) =>
+
+                    @if(mvt.ABNewHeaderVariant.isParticipating && isFirstContainer) {
+
+                        <ul class="tertiary-navigation mobile-only">
+
+                            @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { footballNavItem =>
+
+                                <li class="tertiary-navigation__item">
+                                    <a class="tertiary-navigation__link" href="@LinkTo(footballNavItem.url)" data-link-name="@footballNavItem.name">
+                                        @Html(footballNavItem.name)
+                                        <i class="tertiary-navigation__icon rounded-icon"></i>
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+
                     }
                 }
             </section>

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -668,3 +668,75 @@ svg.main-menu__icon--social__svg {
 .no-text-transform {
     text-transform: none;
 }
+
+// Breathing space between header and content
+@include mq($until: tablet) {
+    .has-new-header {
+        .weather {
+            padding-top: 1px;
+        }
+
+        .fc-container--first .fc-container__inner,
+        .index-page-header {
+            padding-top: $gs-baseline / 2 + $gs-baseline / 4;
+        }
+
+        .content__labels {
+            padding: ($gs-baseline / 2 + $gs-baseline / 4) 0;
+        }
+    }
+}
+
+/****************
+ * Tertiary Nav
+ ****************/
+
+.tertiary-navigation {
+    list-style: none;
+    display: flex;
+    flex-direction: row;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    margin-left: $gs-gutter / 2;
+    margin-right: $gs-gutter / 2;
+
+    @include mq(mobileLandscape) {
+        margin-left: $gs-gutter;
+        margin-right: $gs-gutter;
+    }
+}
+
+.tertiary-navigation__item {
+    width: calc(50% - #{$gs-gutter / 2});
+    border-top: 1px solid $neutral-5;
+    padding-bottom: $gs-baseline / 2;
+}
+
+.tertiary-navigation__link {
+    @include fs-textSans(5);
+    font-weight: 600;
+    color: $news-main-1;
+}
+
+.tertiary-navigation__icon {
+    background-color: $news-main-2;
+    height: $gs-gutter;
+    width: $gs-gutter;
+    margin-top: 2px;
+    float: right;
+
+    &:before {
+        content: '';
+        display: block;
+        // Visually, this is the best size for this icon
+        width: 7px;
+        height: 7px;
+        border: 2px solid #ffffff;
+        transform: rotate(-45deg);
+        border-top: 0;
+        border-left: 0;
+        // Optically aligns the icon in it's container
+        margin-top: 5px;
+        margin-left: 4px;
+    }
+}


### PR DESCRIPTION
## What does this change?

This implements tertiary nav to the new header test.
## What is the value of this and can you measure success?

This will allow super users (and some other users) to navigate to parts of the site that aren't in the nav. For example, match reports on football.
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

![image](https://cloud.githubusercontent.com/assets/8774970/19035368/08cd94c2-8961-11e6-9681-214a6c6bb568.png)
## Request for comment

@zeftilldeath @stephanfowler @SiAdcock 
