### PR TITLE
Extend expiry of Weekend Reading switches and JS

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -62,7 +62,7 @@ trait ABTestSwitches {
     "Try out two formats for the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 3),
+    sellByDate = new LocalDate(2016, 10, 31),
     exposeClientSide = true
   )
 
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Show visitors a snap banner to promote the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 3),
+    sellByDate = new LocalDate(2016, 10, 31),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-email.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-email.js
@@ -16,7 +16,7 @@ define([
     return function () {
         this.id = 'WeekendReadingEmail';
         this.start = '2016-08-23';
-        this.expiry = '2016-09-23';
+        this.expiry = '2016-10-31';
         this.author = 'Kate Whalen';
         this.description = '';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/weekend-reading-promo.js
@@ -28,7 +28,7 @@ define([
     return function () {
         this.id = 'WeekendReadingPromo';
         this.start = '2016-09-01';
-        this.expiry = '2016-10-03';
+        this.expiry = '2016-10-31';
         this.author = 'Kate Whalen';
         this.description = 'For just one pageview, show users a banner promoting the Weekend Reading email';
         this.audience = 1;


### PR DESCRIPTION
## What does this change?

Extends the Weekend Reading promo and AB test until the end of the month.
## What is the value of this and can you measure success?
- Keeps the tests running 
- Build doesn't break tomorrow.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@joelochlann 
