### PR TITLE
Fix Explore series link

### DIFF
--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -64,7 +64,7 @@
                     <div class="series-identity__background">
                         @fragments.inlineSvg("explore-series-identity-bg", "membership")
                     </div>
-                    <a class="series-identity__links" href="/membership/ng-interactive/2016/jun/23/explore-series">
+                    <a class="series-identity__links" href="/membership/ng-interactive/2016/jun/23/labour-liverpool">
                         <div class="series-identity__title">Labour &amp; Liverpool</div>
                         <div class="series-identity__byline">with Ewen MacAskill</div>
                     </a>


### PR DESCRIPTION
## What does this change?

Currently, the Labour Liverpool series identity link points to a non-existent "explore series" page. It looks like a case of find-replace gone awry. I have restored it to point to the Labour Liverpool series page.
## What is the value of this and can you measure success?

Readers can navigate from Labour Liverpool articles to the Labour Liverpool series page.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@guardian/dotcom-platform 
