### PR TITLE
Tidy up commercial Redis logs

### DIFF
--- a/admin-jobs/app/jobs/CommercialClientSideLogging.scala
+++ b/admin-jobs/app/jobs/CommercialClientSideLogging.scala
@@ -29,6 +29,7 @@ object CommercialClientSideLogging extends Logging {
         report
       }
     })
+    timestamps.map(ClientSideLogging.cleanUpReports)
     reports.length
   }
 }

--- a/admin-jobs/conf/application-logger.xml
+++ b/admin-jobs/conf/application-logger.xml
@@ -19,7 +19,7 @@
         <file>logs/frontend-commercial-client-side.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-commercial-client-side/date=%d{yyyy-MM-dd, aux}/%d{yyyy-MM-dd--HH-mm}.log</fileNamePattern>
+            <fileNamePattern>logs/frontend-commercial-client-side-archive/%d{yyyy-MM-dd--HH-mm}.log</fileNamePattern>
             <maxHistory>20</maxHistory>
         </rollingPolicy>
 

--- a/common/app/common/commercial/ClientSideLogging.scala
+++ b/common/app/common/commercial/ClientSideLogging.scala
@@ -27,6 +27,17 @@ object ClientSideLogging extends Logging {
     reports.toList
   }
 
+  def cleanUpReports(dateTime: DateTime): Unit = {
+    redisClient.map( client => {
+      val timeKey = ClientSideLogging.reportsKeyFromDate(dateTime)
+      val pageViewIds = client.smembers[String](timeKey).map(_.flatten).getOrElse(List())
+      val dataKeys = pageViewIds.map(ClientSideLogging.dataKeyFromId)
+      client.del(dataKeys ++ timeKey)
+    })
+
+
+  }
+
   // Make a client for each usage, otherwise there may be protocol errors.
   def redisClient: Option[RedisClient] = {
     try {

--- a/common/app/common/commercial/ClientSideLogging.scala
+++ b/common/app/common/commercial/ClientSideLogging.scala
@@ -34,8 +34,6 @@ object ClientSideLogging extends Logging {
       val dataKeys = pageViewIds.map(ClientSideLogging.dataKeyFromId)
       client.del(dataKeys ++ timeKey)
     })
-
-
   }
 
   // Make a client for each usage, otherwise there may be protocol errors.


### PR DESCRIPTION
Once commercial reports are read and logged, they should be removed from Redis.
