### PR TITLE
Supporting element from tablet onwards

### DIFF
--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -38,7 +38,7 @@
 }
 
 figure.element.element--supporting {
-    @include mq(desktop) {
+    @include mq(tablet) {
         position: relative;
         float: left;
         width: gs-span(4);

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -331,7 +331,7 @@
 
         &.element--supporting {
             figcaption {
-                @include mq(desktop) {
+                @include mq(tablet) {
                     max-width: gs-span(3) - 10;
                 }
                 @include mq(wide) {


### PR DESCRIPTION
# From leftCol a supporting element looks like this:

![screen shot 2016-10-03 at 16 16 18](https://cloud.githubusercontent.com/assets/14570016/19042837/9084dd02-8985-11e6-9258-5ba1988f14e0.png)
# And on a tablet it looks like this:

![screen shot 2016-10-03 at 16 16 41](https://cloud.githubusercontent.com/assets/14570016/19042690/dee67f7e-8984-11e6-9ed2-9cd8c3f92c53.png)
## It makes no sense for a supporting element to take up 100% of the content area when it is hierarchically considered subordinate to the content. It also means interactive elements often sit uncomfortably _not-quite-full-width_ whilst not allowing text to flow around them*
# So let's make it look like this:

![screen shot 2016-10-03 at 16 16 52](https://cloud.githubusercontent.com/assets/14570016/19042929/e8685134-8985-11e6-9103-e135588653c8.png)

*This causes unneccasary suffering for people like @duarte 
