### PR TITLE
Update diagnostics loadbalancer name

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -29,7 +29,7 @@ object LoadBalancer extends Logging {
       LoadBalancer("frontend-SportLoa-GLJK02HUD48W", "Sport", "frontend-sport"),
       LoadBalancer("frontend-Commerci-12ZQ79RIOLIYE", "Commercial", "frontend-commercial"),
       LoadBalancer("frontend-OnwardLo-14YIUHL6HIW63", "Onward", "frontend-onward"),
-      LoadBalancer("frontend-Diagnost-1SCNCG3BR1RFE", "Diagnostics", "frontend-diagnostics" ),
+      LoadBalancer("frontend-Diagnost-11YL3E40NW4C2", "Diagnostics", "frontend-diagnostics" ),
       LoadBalancer("frontend-ArchiveL-C2GJNZE0TS7", "Archive", "frontend-archive" )
     )
 


### PR DESCRIPTION
## What does this change?

Updates the diagnostics load balancer name which was recently moved into VPC.
## What is the value of this and can you measure success?

Admin (diagnostics) metrics work again
## Request for comment

@guardian/dotcom-platform 

FYI: @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
