### PR TITLE
Fix text for share button being wrong

### DIFF
--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -10,29 +10,27 @@
     <div class="sharing-buttons" data-link-name="comment social">
     @defining(s"${comment.webUrl}") { permalink =>
         @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body.replaceAll("<blockquote>.*</blockquote>", ""), Whitelist.none()))) { commentBody =>
-            <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"""${comment.profile.displayName} commented: "$commentBody"""")).href"
-            target="_blank"
-            class="social__action social-icon-wrapper"
-            data-link-name="social-comment : facebook">
-                <span class="inline-icon__fallback button">
-                    Share on Facebook</span>
-                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon", "social-icon", "social-icon--facebook", "comment-facebook-icon"))
-                <span class="u-h">Facebook</span>
-            </a>
+            @shareLink(permalink, Facebook, "", Some(s"""${comment.profile.displayName} commented: "$commentBody""""))
 
             @* Twitter allows 140 characters. We need 2 for the quotes and 24 for the URL. *@
             @defining(if(commentBody.length <= 114) s""""$commentBody"""" else s""""${commentBody.take(111)}..."""") { commentText =>
-                <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = permalink, text = commentText).href"
-                target="_blank"
-                class="social__action social-icon-wrapper"
-                data-link-name="social-comment : twitter">
-                    <span class="inline-icon__fallback button">
-                        Share on Facebook</span>
-                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon", "social-icon", "social-icon--twitter", "comment-twitter-icon"))
-                    <span class="u-h">Twitter</span>
-                </a>
+                @shareLink(permalink, Twitter, commentText, None)
             }
         }
     }
+
+    @shareLink(permalink: String, platform: SharePlatform, text: String, quote: Option[String]) = {
+
+        <a href="@ShareLinks.createShareLinkForComment(platform = platform, href = permalink, text = text, quote = quote).href"
+        target="_blank"
+        class="social__action social-icon-wrapper"
+        data-link-name=s"social-comment : ${platform.css}">
+            <span class="inline-icon__fallback button">
+                @platform.userMessage</span>
+            @fragments.inlineSvg(s"share-${platform.css}", "icon", List("rounded-icon", "social-icon", s"social-icon--${platform.css}", s"comment-${platform.css}-icon"))
+            <span class="u-h">@platform.text</span>
+        </a>
+    }
+
     </div>
 </div>


### PR DESCRIPTION
## What does this change?

Fallback text for share icons in comments
## What is the value of this and can you measure success?

Previously the twitter button had the wrong text ("Share on Facebook") and lots of hardcoded properties that could be read off the available data. Now that happens, so we have reduced the number of sources of truth
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@guardian/dotcom-platform 
