### PR TITLE
Creating the new header control for the test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -18,12 +18,23 @@ import conf.switches.Switches.ServerSideTests
 
 object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
-  description = "Feature switch (0% test) for the new header",
+  description = "users in this test will see the new header",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variant")
+  }
+}
+
+object ABNewHeaderControl extends TestDefinition(
+  name = "ab-new-header-control",
+  description = "control for the new header test",
+  owners = Seq(Owner.withGithub("natalialkb")),
+  sellByDate = new LocalDate(2016, 12, 8) // Thursday
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-header").contains("control")
   }
 }
 
@@ -63,6 +74,7 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     ABNewHeaderVariant,
+    ABNewHeaderControl,
     CommercialClientLoggingVariant,
     CommercialHeaderBiddingSonobiVariant
   )


### PR DESCRIPTION
## What does this change?

We need a control to test the variant against. 

Please note that this PR does not turn on the test! That needs to be done via fastly. A PR for that will follow shortly
## What is the value of this and can you measure success?

Better data!
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@guardian/dotcom-platform 
