### PR TITLE
Add functionality for A/B tests to defer their Ophan impression event

### DIFF
--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -76,6 +76,10 @@ define(['bonzo'], function (bonzo) {
                 test: function (context, config) {
                 },
 
+                impression: function(track) {
+                    // call track() when the impression should be registered (e.g. your element is in view)
+                },
+
                 success: function(complete) {
                     // do something that determines whether the user has completed
                     // the test (e.g. set up an event listener) and call 'complete' afterwards
@@ -86,6 +90,10 @@ define(['bonzo'], function (bonzo) {
                 id: 'hide',
                 test: function (context, config) {
                     bonzo(context.querySelector('.js-related')).hide();
+                },
+
+                impression: function(track) {
+                    // call track() when the impression should be registered (e.g. your element is in view)
                 },
 
                 success: function(complete) {
@@ -122,7 +130,8 @@ The AMD module must return an object with the following properties,
     - the variant objects can contain three properties:
         - variant.id: the name of the variant
         - variant.test: the main test function that applies the treatment for the test
-        - variant.success: a function that's called alongside test that determines if the user has finished the test. it receives a callback as a parameter that you must call when the test is completed.
+        - variant.impression (optional): a function that's called to register the impression of the test. it receives a callback that you should call when you want to fire the impression. if not provided, the impression will fire on pageload (as long as canRun is true)
+        - variant.success (optional): a function that's called alongside test that determines if the user has finished the test. it receives a callback as a parameter that you must call when the test is completed.
 
 
 When choosing your audience offset, it is good to avoid overlapping tests. You can check [here](https://frontend.gutools.co.uk/analytics/abtests) to see what tests are currently running, and what their offset is.

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -155,6 +155,7 @@ define([
                 ab.segmentUser();
 
                 robust.catchErrorsAndLog('ab-tests-run', ab.run);
+                robust.catchErrorsAndLog('ab-tests-registerImpressionEvents', ab.registerImpressionEvents);
                 robust.catchErrorsAndLog('ab-tests-registerCompleteEvents', ab.registerCompleteEvents);
 
                 ab.trackEvent();

--- a/static/test/javascripts/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab.spec.js
@@ -293,6 +293,23 @@ define([
 
                 expect(spy).toHaveBeenCalled();
             });
+
+            it('should defer firing the impression when the function is provided', function () {
+                var spy = sinon.spy();
+
+                ab.addTest(test.one);
+
+                /**
+                 * impression events are only registered if every variant has an `impression` function
+                 */
+                test.one.variants.forEach(function(t) {
+                    t.impression = spy;
+                });
+
+                ab.registerImpressionEvents();
+
+                expect(spy).toHaveBeenCalled();
+            });
         });
 
     });


### PR DESCRIPTION
## What does this change?

If all of the variants in a test provide an `impression` function, they won't be registered Ophan as part of the [`trackEvent` call in `standard/main`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/standard/main.js#L160). Instead, the `impression` function in the variant will need to call the function it receives as a parameter to register itself with Ophan. It works in the same way as the `success` function that you can already add to your variants.

This impacts the `completions` A/B metric, which compares the number of `complete = false` events against the number of `complete = true` for a test. `complete = false` is fired either at pageload (when `canRun` is true) or now by the `impression` function, if a test provides it.
## What is the value of this and can you measure success?

Instead of counting impressions as soon as the page loads, this gives you extra control over when an impression is counted. It'll probably remove some noise from test results.

For example, if you're testing the behaviour of a component that's positioned low down on a page, you might only want to count impressions from when the element is actually in view, to rule out anyone who hasn't seen it. Here's how you'd do that:

``` javascript
this.variants = [
    {
        id: 'variantA',

        test: function () {
            // add some element to the page
        },

       impression: function (track) {
           // when the element is in view, call track()
        },

        success: function (complete) {
           // when the user clicks the element, call complete()
        }
    }
// more variants
```
## Does this affect other platforms - Amp, Apps, etc?

No 
## Request for comment

@jranks123 @gtrufitt 
