### PR TITLE
Add discussion external assets lifecycle to applications AppLoader

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,4 +1,5 @@
 import app.{FrontendApplicationLoader, FrontendComponents}
+import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
 import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
@@ -57,7 +58,8 @@ trait AppLifecycleComponents {
     wire[SectionsLookUpLifecycle],
     wire[SwitchboardLifecycle],
     wire[SiteMapLifecycle],
-    wire[CachedHealthCheckLifeCycle]
+    wire[CachedHealthCheckLifeCycle],
+    wire[DiscussionExternalAssetsLifecycle]
   )
 }
 


### PR DESCRIPTION
## What does this change?

The lifecycle component that populated the `DiscussionAssetsMap` agent was not added to the `applications` app.  This meant that content served from `applications` (e.g. cartoons) did not have the asset map populated and therefore would not load the comment count.  This adds the lifecycle component to `applications` (I don't think it needs to be added to any other apps).
## What is the value of this and can you measure success?

Comment count works for content served from `applications`
## Screenshots

No screenshots as the comment section is still being hidden (but comment count not loading will no longer be the cause!)
## Request for comment

@gtrufitt @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
