### PR TITLE
Use cors mode to call hosted onward container

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -16,7 +16,7 @@ define([
             return fetchJson(config.page.ajaxUrl + '/'
                 + config.page.pageId + '/'
                 + config.page.contentType.toLowerCase() + '/'
-                + 'onward.json')
+                + 'onward.json', {mode: 'cors'})
                 .then(function (json) {
                     return fastdom.write(function () {
                         var i;


### PR DESCRIPTION
This should avoid the preflight options call that results in a 404.
