### PR TITLE
Revert "Revert "Add functionality for A/B tests to defer their Ophan impression event""

### DIFF
--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -76,6 +76,10 @@ define(['bonzo'], function (bonzo) {
                 test: function (context, config) {
                 },
 
+                impression: function(track) {
+                    // call track() when the impression should be registered (e.g. your element is in view)
+                },
+
                 success: function(complete) {
                     // do something that determines whether the user has completed
                     // the test (e.g. set up an event listener) and call 'complete' afterwards
@@ -86,6 +90,10 @@ define(['bonzo'], function (bonzo) {
                 id: 'hide',
                 test: function (context, config) {
                     bonzo(context.querySelector('.js-related')).hide();
+                },
+
+                impression: function(track) {
+                    // call track() when the impression should be registered (e.g. your element is in view)
                 },
 
                 success: function(complete) {
@@ -122,7 +130,8 @@ The AMD module must return an object with the following properties,
     - the variant objects can contain three properties:
         - variant.id: the name of the variant
         - variant.test: the main test function that applies the treatment for the test
-        - variant.success: a function that's called alongside test that determines if the user has finished the test. it receives a callback as a parameter that you must call when the test is completed.
+        - variant.impression (optional): a function that's called to register the impression of the test. it receives a callback that you should call when you want to fire the impression. if not provided, the impression will fire on pageload (as long as canRun is true)
+        - variant.success (optional): a function that's called alongside test that determines if the user has finished the test. it receives a callback as a parameter that you must call when the test is completed.
 
 
 When choosing your audience offset, it is good to avoid overlapping tests. You can check [here](https://frontend.gutools.co.uk/analytics/abtests) to see what tests are currently running, and what their offset is.

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -155,6 +155,7 @@ define([
                 ab.segmentUser();
 
                 robust.catchErrorsAndLog('ab-tests-run', ab.run);
+                robust.catchErrorsAndLog('ab-tests-registerImpressionEvents', ab.registerImpressionEvents);
                 robust.catchErrorsAndLog('ab-tests-registerCompleteEvents', ab.registerCompleteEvents);
 
                 ab.trackEvent();

--- a/static/test/javascripts/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab.spec.js
@@ -293,6 +293,23 @@ define([
 
                 expect(spy).toHaveBeenCalled();
             });
+
+            it('should defer firing the impression when the function is provided', function () {
+                var spy = sinon.spy();
+
+                ab.addTest(test.one);
+
+                /**
+                 * impression events are only registered if every variant has an `impression` function
+                 */
+                test.one.variants.forEach(function(t) {
+                    t.impression = spy;
+                });
+
+                ab.registerImpressionEvents();
+
+                expect(spy).toHaveBeenCalled();
+            });
         });
 
     });


### PR DESCRIPTION
false alarm

Reverts guardian/frontend#14574
