### PR TITLE
Data lake upload commercial logs

### DIFF
--- a/admin-jobs/app/jobs/CommercialClientSideLogging.scala
+++ b/admin-jobs/app/jobs/CommercialClientSideLogging.scala
@@ -112,5 +112,6 @@ class CommercialClientSideLoggingLifecycle(
 }
 
 object S3CommercialReports extends S3 {
+  // A bucket owned by the Ophan team, it's not in Frontend. We have been given cross-account access.
   override lazy val bucket = "ophan-raw-client-side-ad-metrics"
 }

--- a/admin-jobs/app/jobs/CommercialClientSideLogging.scala
+++ b/admin-jobs/app/jobs/CommercialClientSideLogging.scala
@@ -6,6 +6,7 @@ import common.commercial.ClientSideLogging
 import org.joda.time.{Duration, DateTime}
 import org.slf4j.LoggerFactory
 import play.api.inject.ApplicationLifecycle
+import services.S3
 import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration._
 
@@ -44,18 +45,19 @@ class CommercialClientSideLoggingLifecycle(
   }}
 
   // 5 minutes between each log write.
-  private val loggingJobFrequency = 5.minutes
-  // 15 minutes between each log upload.
-  private val uploadJobFrequency = 15.minutes
+  private val loggingJobFrequency = new Duration(5.minutes)
+
 
   override def start(): Unit = {
     jobs.deschedule("CommercialClientSideLoggingJob")
     jobs.deschedule("CommercialClientSideUploadJob")
 
+    // 5 minutes between each log write.
     jobs.scheduleEveryNMinutes("CommercialClientSideLoggingJob", 5) {
       writeReportsFromRedis(akkaAsync)
     }
 
+    // 15 minutes between each log upload.
     jobs.scheduleEveryNMinutes("CommercialClientSideLoggingJob", 15) {
       uploadReports(akkaAsync)
     }
@@ -65,16 +67,27 @@ class CommercialClientSideLoggingLifecycle(
     akkaAsync.after1s {
       if (mvt.CommercialClientLoggingVariant.switch.isSwitchedOn) {
         // Start searching logs from two periods behind the current time. This allows fresh data to settle.
-        val timeStart = DateTime.now.minusSeconds(loggingJobFrequency.toSeconds.toInt * 2)
+        val timeStart = DateTime.now.minus(loggingJobFrequency.multipliedBy(2L))
         log.logger.info(s"Fetching commercial performance logs from Redis for time period ${timeStart.toString("yyyy-MM-dd HH:mm")}")
-        val numReports = CommercialClientSideLogging.writeReportsToLog(timeStart, new Duration(loggingJobFrequency.toMillis))
+        val numReports = CommercialClientSideLogging.writeReportsToLog(timeStart, loggingJobFrequency)
         log.logger.info(s"Fetched $numReports logs from Redis.")
       } else {
-        log.logger.info(s"Job skipped, logging switch is turned off.")
+        log.logger.info(s"Logging Job skipped, logging switch is turned off.")
       }
     }
   }
 
   private def uploadReports(akkaAgent: AkkaAsync): Future[Unit] = Future {
+    akkaAsync.after1s {
+      if (mvt.CommercialClientLoggingVariant.switch.isSwitchedOn) {
+
+      } else {
+        log.logger.info(s"Log Upload Job skipped, logging switch is turned off.")
+      }
+    }
   }
+}
+
+object S3CommercialReports extends S3 {
+  override lazy val bucket = "ophan-raw-client-side-ad-metrics"
 }

--- a/admin-jobs/app/jobs/CommercialClientSideLogging.scala
+++ b/admin-jobs/app/jobs/CommercialClientSideLogging.scala
@@ -29,7 +29,7 @@ object CommercialClientSideLogging extends Logging {
         report
       }
     })
-    timestamps.map(ClientSideLogging.cleanUpReports)
+    timestamps.foreach(ClientSideLogging.cleanUpReports)
     reports.length
   }
 }

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -85,6 +85,11 @@ trait S3 extends Logging {
     put(key: String, value: String, contentType: String, PublicRead)
   }
 
+  def putPublic(key: String, file: File, contentType: String): Unit = {
+    val request = new PutObjectRequest(bucket, key, file).withCannedAcl(PublicRead)
+    client.foreach(_.putObject(request))
+  }
+
   def putPrivate(key: String, value: String, contentType: String) {
     put(key: String, value: String, contentType: String, Private)
   }


### PR DESCRIPTION
This is the final part of the work to upload the commercial performance logs to the data lake S3 bucket. The uploading is batched on a 15 minute schedule.
