### PR TITLE
Refactor hosted video sources

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -64,10 +64,9 @@
                         data-block-video-ads="true"
                         poster="@{page.video.posterUrl}"
                         class="vjs-hosted__video hosted__video gu-media--video vjs vjs-paused vjs-controls-enabled vjs_video_1-dimensions vjs-user-active">
-                            <source type="video/mp4" src="@{page.video.srcUrlMp4}">
-                            <source type="video/webm" src="@{page.video.srcUrlWebm}">
-                            <source type="video/ogg" src="@{page.video.srcUrlOgg}">
-                            <source type="video/m3u8" src="@{page.video.srcM3u8}">
+                            @for(source <- page.video.sources) {
+                                <source type="@source.mimeType" src="@source.url">
+                            }
                         </video>
                     }
                     @if(page.video.youtubeId.isDefined && !Option(page.video.posterUrl).getOrElse("").isEmpty){

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -75,10 +75,7 @@ object HostedVideoPage extends Logging {
           duration = video.duration.map(_.toInt) getOrElse 0,
           posterUrl = video.posterUrl getOrElse "",
           youtubeId = youtubeId,
-          srcUrlMp4 = videoUrl("video/mp4"),
-          srcUrlWebm = videoUrl("video/webm"),
-          srcUrlOgg = videoUrl("video/ogg"),
-          srcM3u8 = videoUrl("video/m3u8")
+          sources = videoVariants.flatMap(asset => asset.mimeType map (mimeType => VideoSource(mimeType, asset.id)))
         ),
         cta = HostedCallToAction.fromAtom(ctaAtom),
         socialShareText = content.fields.flatMap(_.socialShareText),
@@ -101,8 +98,7 @@ case class HostedVideo(
   duration: Int,
   posterUrl: String,
   youtubeId: Option[String] = None,
-  srcUrlMp4: String,
-  srcUrlWebm: String,
-  srcUrlOgg: String,
-  srcM3u8: String
+  sources: Seq[VideoSource]
 )
+
+case class VideoSource(mimeType: String, url: String)

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -28,6 +28,8 @@ object LeffeHostedPages {
     btnText = Some("Visit Leffe on Facebook")
   )
 
+  private val videoSrcRoot = "https://cdn.theguardian.tv/interactive"
+
   private val willardWiganPageWithoutNextPage: HostedVideoPage = {
     val pageUrl = s"$host/advertiser-content/${campaign.id}/$willardWiganPageName"
     val pageName = willardWiganPageName
@@ -39,10 +41,24 @@ object LeffeHostedPages {
       title = videoTitle,
       duration = 127,
       posterUrl = Static("images/commercial/willard-wigan_poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629WillardWigan_V3_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629WillardWigan_V3_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629WillardWigan_V3.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/29/160629WillardWigan_V3_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/29/160629WillardWigan_V3_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/29/160629WillardWigan_V3_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/29/HLS/160629WillardWigan_V3.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -69,14 +85,24 @@ object LeffeHostedPages {
       title = videoTitle,
       duration = 116,
       posterUrl = Static("images/commercial/adrienne-treeby_poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian" +
-                  ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian" +
-                   ".tv/interactive/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian" +
-                  ".tv/interactive/mp4/1080/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian" +
-                ".tv/interactive/2016/06/29/HLS/160629AdrienneTreeby_KP-28311272_h264_mezzanine.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/29/160629AdrienneTreeby_KP-28311272_h264_mezzanine_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/29/HLS/160629AdrienneTreeby_KP-28311272_h264_mezzanine.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -103,11 +129,24 @@ object LeffeHostedPages {
       title = videoTitle,
       duration = 138,
       posterUrl = Static("images/commercial/pete-lawrence_poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629PeteLawrence_h264_mezzanine_mid" +
-                  ".ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629PeteLawrence_h264_mezzanine.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/29/160629PeteLawrence_h264_mezzanine_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/29/160629PeteLawrence_h264_mezzanine_mid.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/29/HLS/160629PeteLawrence_h264_mezzanine.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -117,7 +156,9 @@ object LeffeHostedPages {
       video,
       cta,
       socialShareText = None,
-      shortSocialShareText = Some("Leffe presents Slow Time: Capturing Time, featuring @Avertedvision. Watch full film: "),
+      shortSocialShareText = Some(
+        "Leffe presents Slow Time: Capturing Time, featuring @Avertedvision. Watch full film: "
+      ),
       nextPage = None,
       metadata = Metadata.forHardcodedHostedVideoPage(campaign, video, pageUrl, pageName, standfirst)
     )
@@ -134,11 +175,24 @@ object LeffeHostedPages {
       title = videoTitle,
       duration = 146,
       posterUrl = Static("images/commercial/susan-derges_poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629SusanDerges_h264_mezzanine_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629SusanDerges_h264_mezzanine-1_lo" +
-                  ".ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629SusanDerges_h264_mezzanine.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/29/160629SusanDerges_h264_mezzanine_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/29/160629SusanDerges_h264_mezzanine_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/29/160629SusanDerges_h264_mezzanine-1_lo.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/29/HLS/160629SusanDerges_h264_mezzanine.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -165,10 +219,24 @@ object LeffeHostedPages {
       title = videoTitle,
       duration = 134,
       posterUrl = Static("images/commercial/quay-brothers_poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/29/160629QuayBrothers_V3_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/29/160629QuayBrothers_V3-3_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/29/HLS/160629QuayBrothers_V3.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/29/160629QuayBrothers_V3_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/29/160629QuayBrothers_V3_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/29/160629QuayBrothers_V3-3_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/29/HLS/160629QuayBrothers_V3.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -26,6 +26,8 @@ object RenaultHostedPages {
     btnText = None
   )
 
+  private val videoSrcRoot = "https://cdn.theguardian.tv/interactive"
+
   private val teaserWithoutNextPage: HostedVideoPage = {
     val pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser"
     val pageName = teaserPageName
@@ -39,10 +41,24 @@ object RenaultHostedPages {
       title = videoTitle,
       duration = 86,
       posterUrl = Static("images/commercial/renault-video-poster.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/17/HLS/160516GlabsTestSD.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/05/17/160516GlabsTestSD_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/05/17/160516GlabsTestSD_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/05/17/HLS/160516GlabsTestSD.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -70,10 +86,24 @@ object RenaultHostedPages {
       title = videoTitle,
       duration = 160,
       posterUrl = Static("images/commercial/renault-video-poster-ep1.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/23/HLS/160523GlabsRenaultTestHD.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/05/23/HLS/160523GlabsRenaultTestHD.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,
@@ -101,10 +131,24 @@ object RenaultHostedPages {
       title = videoTitle,
       duration = 158,
       posterUrl = Static("images/commercial/renault-video-poster-ep2.jpg"),
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/03/HLS/160603GlabsRenaultTest3.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/2016/06/03/HLS/160603GlabsRenaultTest3.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -30,18 +30,30 @@ object ZootropolisHostedPages {
                      "Don’t let the sloths slow you down – download instantly through Sky Store, " +
                      "the fastest way to bring your favourite characters home!"
     val videoTitle = "Disney’s Zootropolis: Download and keep today!"
+    val videoSrcRoot = "https://cdn.theguardian.tv/interactive"
     val video = HostedVideo(
       mediaId = videoPageName,
       title = videoTitle,
       duration = 32,
       posterUrl = "https://static.theguardian.com/commercial/hosted/disney-zootropolis/ZOO_1132_130_0_009_00_0091.jpg",
-      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_H264" +
-                  ".mp4",
-      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_vp8" +
-                   ".webm",
-      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/07/18/160718GLZootropolisSpot_h264_mezzanine" +
-                  "-1_lo.ogv",
-      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/07/18/HLS/160718GLZootropolisSpot_h264_mezzanine.m3u8"
+      sources = Seq(
+        VideoSource(
+          "video/mp4",
+          s"$videoSrcRoot/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_H264.mp4"
+        ),
+        VideoSource(
+          "video/webm",
+          s"$videoSrcRoot/interactive/2016/07/18/160718GLZootropolisSpot_h264_mezzanine_2M_vp8.webm"
+        ),
+        VideoSource(
+          "video/ogg",
+          s"$videoSrcRoot/interactive/mp4/1080/2016/07/18/160718GLZootropolisSpot_h264_mezzanine-1_lo.ogv"
+        ),
+        VideoSource(
+          "video/m3u8",
+          s"$videoSrcRoot/interactive/2016/07/18/HLS/160718GLZootropolisSpot_h264_mezzanine.m3u8"
+        )
+      )
     )
     HostedVideoPage(
       campaign,


### PR DESCRIPTION
This change avoids having to specify specific video mime types in frontend.
We just render whatever is passed in through capi.

/cc @guardian/labs-beta 
