### PR TITLE
Fixing scrolling bug new header

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -181,7 +181,7 @@ define([
                         moveTargetListToTop(id);
                         menuButton.focus();
                         // Prevents scrolling on the body
-                        html.style.overflow = 'hidden';
+                        html.classList.add('nav-is-open');
                     });
                 });
             });


### PR DESCRIPTION
## What does this change?

At the moment if you are opted in to the new header and click on one of the primary links (life, art, news, etc) the menu opens and you can't scroll on the body. But, if you close the menu then you still can't scroll. 

This fixes it.
## What is the value of this and can you measure success?

People can still scroll 😓 
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@SiAdcock @zeftilldeath @stephanfowler 
