### PR TITLE
package.json should have indent size of 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ insert_final_newline = true
 [*.scala]
 indent_size = 2
 
+[package.json]
+indent_size = 2
+
 [makefile]
 indent_style = tab


### PR DESCRIPTION
## What does this change?

All code files (except Scala files `¯\_(ツ)_/¯`) have a default indent size of `4`, which works very well for us. However,  `package.json` is automatically regenerated when you run `npm install --save library-xyz`, and is always generated with an indent size of `2`. 

To reduce some annoyance when editing this file manually, I have created an exception to the indent size rule.
## What is the value of this and can you measure success?

Less frustration 😤  when manually editing `package.json` and using auto-format tools ☺️ 
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
