### PR TITLE
Add link to US Glabs page 

### DIFF
--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -60,16 +60,18 @@
 }
 
 @stamp = {
-
-    <a @if(Edition(request).id == "AU") {
-            href="@LinkTo("/guardian-labs-australia")"
-        } else {
-            href="@LinkTo("/guardian-labs")"
+    @defining(
+        Edition(request).id match {
+            case "AU" => "-australia"
+            case "US" => "-us"
+            case _ => ""
         }
-        >
-        @inlineSvg("glabs-logo", "logo")
-        <span class='u-h'>Guardian Labs</span>
-    </a>
+    ) { glabsUrlSuffix =>
+        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
+            @inlineSvg("glabs-logo", "logo")
+            <span class='u-h'>Guardian Labs</span>
+        </a>
+    }
 }
 
 @badge = {

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -1,11 +1,13 @@
 @import common.commercial.CardContent
-@import common.{Edition, LinkTo}
+@import common.LinkTo
 @import controllers.commercial.{PaidFor, SponsorType, Supported}
 @import fragments.commercial.paidForMeta
 @import views.html.commercial.cards.itemLargeCard
 @import views.html.commercial.containerWrapper
 @import views.html.fragments.inlineSvg
 @import views.support.commercial.TrackingCodeBuilder.mkCapiCardTrackingCode
+@import views.support.Commercial.glabsLink
+
 @(card: CardContent,
   optSection: Option[String],
   optLogo: Option[String],
@@ -60,18 +62,10 @@
 }
 
 @stamp = {
-    @defining(
-        Edition(request).id match {
-            case "AU" => "-australia"
-            case "US" => "-us"
-            case _ => ""
-        }
-    ) { glabsUrlSuffix =>
-        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
-            @inlineSvg("glabs-logo", "logo")
-            <span class='u-h'>Guardian Labs</span>
-        </a>
-    }
+    <a href="@LinkTo(glabsLink(request))">
+        @inlineSvg("glabs-logo", "logo")
+        <span class='u-h'>Guardian Labs</span>
+    </a>
 }
 
 @badge = {

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -69,18 +69,20 @@
 }
 
 @stamp = {
-
-    <a @if(Edition(request).id == "AU") {
-            href="@LinkTo("/guardian-labs-australia")"
-        } else {
-            href="@LinkTo("/guardian-labs")"
+    @defining(
+        Edition(request).id match {
+            case "AU" => "-australia"
+            case "US" => "-us"
+            case _ => ""
         }
-        >
-        @inlineSvg("glabs-logo", "logo")
-        <span class='u-h'>Guardian Labs</span>
-    </a>
-
+    ) { glabsUrlSuffix =>
+        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
+            @inlineSvg("glabs-logo", "logo")
+            <span class='u-h'>Guardian Labs</span>
+        </a>
+    }
 }
+
 
 @badge = {
 

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.CardContent
-@import common.{Edition, LinkTo}
+@import common.LinkTo
 @import controllers.commercial.{PaidFor, SponsorType, Supported}
 @import fragments.commercial.paidForMeta
 @import views.html.commercial.cards.itemCard
@@ -7,6 +7,8 @@
 @import views.html.fragments.inlineSvg
 @import views.support.commercial.TrackingCodeBuilder.mkCapiCardTrackingCode
 @import cards.{Half, Third, Standard}
+@import views.support.Commercial.glabsLink
+
 @(cards: Seq[CardContent],
   optSection: Option[String],
   optLogo: Option[String],
@@ -69,18 +71,10 @@
 }
 
 @stamp = {
-    @defining(
-        Edition(request).id match {
-            case "AU" => "-australia"
-            case "US" => "-us"
-            case _ => ""
-        }
-    ) { glabsUrlSuffix =>
-        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
-            @inlineSvg("glabs-logo", "logo")
-            <span class='u-h'>Guardian Labs</span>
-        </a>
-    }
+    <a href="@LinkTo(glabsLink(request))">
+        @inlineSvg("glabs-logo", "logo")
+        <span class='u-h'>Guardian Labs</span>
+    </a>
 }
 
 

--- a/commercial/app/views/paidContent/card.scala.html
+++ b/commercial/app/views/paidContent/card.scala.html
@@ -18,13 +18,22 @@
         <a href="@optClickMacro@articleUrl" data-link-name="@linkTracking | article image">
             @pictureUrl.map{ url => <img src="@url" alt="@linkLabel" class="lineitem__image" /> }
         </a>
-        <a @if(Edition(request).id == "AU") {
-                href="@LinkTo("/guardian-labs-australia")"
-            } else {
-                href="@LinkTo("/guardian-labs")"
-            } class="paidfor-content__glabs-logo" title="glabs" data-link-name="@linkTracking | labs logo">
-            @fragments.inlineSvg("glabs-logo-small", "logo")
-        </a>
+
+        @defining(
+            Edition(request).id match {
+                case "AU" => "-australia"
+                case "US" => "-us"
+                case _ => ""
+            }
+        ) { glabsUrlSuffix =>
+            <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")"
+                class="paidfor-content__glabs-logo"
+                title="glabs"
+                data-link-name="@linkTracking | labs logo"
+            >
+                @fragments.inlineSvg("glabs-logo-small", "logo")
+            </a>
+        }
     </div>
     @fragments.commercial.paidForMeta()
     <a href="@optClickMacro@articleUrl" class="paidfor-box paidfor-box--header" data-link-name="@linkTracking | article title">

--- a/commercial/app/views/paidContent/card.scala.html
+++ b/commercial/app/views/paidContent/card.scala.html
@@ -10,7 +10,9 @@
   trackingPixel: Option[String],
   cacheBuster: Option[String])(implicit request: RequestHeader)
 
+@import common.LinkTo
 @import views.html.fragments
+@import views.support.Commercial.glabsLink
 
 @for(trackingPx <- trackingPixel){ <img src="@trackingPx@cacheBuster" class="creative__tracking-pixel" height="1px" width="1px"/> }
 <div class="paidfor-content">
@@ -19,21 +21,14 @@
             @pictureUrl.map{ url => <img src="@url" alt="@linkLabel" class="lineitem__image" /> }
         </a>
 
-        @defining(
-            Edition(request).id match {
-                case "AU" => "-australia"
-                case "US" => "-us"
-                case _ => ""
-            }
-        ) { glabsUrlSuffix =>
-            <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")"
-                class="paidfor-content__glabs-logo"
-                title="glabs"
-                data-link-name="@linkTracking | labs logo"
-            >
-                @fragments.inlineSvg("glabs-logo-small", "logo")
-            </a>
-        }
+        <a href="@LinkTo(glabsLink(request))"
+            class="paidfor-content__glabs-logo"
+            title="glabs"
+            data-link-name="@linkTracking | labs logo"
+        >
+            @fragments.inlineSvg("glabs-logo-small", "logo")
+        </a>
+
     </div>
     @fragments.commercial.paidForMeta()
     <a href="@optClickMacro@articleUrl" class="paidfor-box paidfor-box--header" data-link-name="@linkTracking | article title">

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -2,12 +2,13 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-@import common.{Edition, LinkTo}
+@import common.LinkTo
 @import views.html.commercial.containerWrapper
 @import views.html.commercial.containers._
 @import views.html.fragments.commercial.containerLogo
 @import views.html.fragments.inlineSvg
 @import views.support.commercial.TrackingCodeBuilder.mkInteractionTrackingCode
+@import views.support.Commercial.glabsLink
 
 <div data-id="@containerModel.id" class="fc-container">
     @containerWrapper(
@@ -57,18 +58,10 @@
 </div>
 
 @stamp = {
-    @defining(
-        Edition(request).id match {
-            case "AU" => "-australia"
-            case "US" => "-us"
-            case _ => ""
-        }
-    ) { glabsUrlSuffix =>
-        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
-            @inlineSvg("glabs-logo", "logo")
-            <span class='u-h'>Guardian Labs</span>
-        </a>
-    }
+    <a href="@LinkTo(glabsLink(request))">
+        @inlineSvg("glabs-logo", "logo")
+        <span class='u-h'>Guardian Labs</span>
+    </a>
 }
 
 @logoSlot = {

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -57,17 +57,18 @@
 </div>
 
 @stamp = {
-
-    <a @if(Edition(request).id == "AU") {
-            href="@LinkTo("/guardian-labs-australia")"
-        } else {
-            href="@LinkTo("/guardian-labs")"
+    @defining(
+        Edition(request).id match {
+            case "AU" => "-australia"
+            case "US" => "-us"
+            case _ => ""
         }
-        >
-        @inlineSvg("glabs-logo", "logo")
-        <span class='u-h'>Guardian Labs</span>
-    </a>
-
+    ) { glabsUrlSuffix =>
+        <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
+            @inlineSvg("glabs-logo", "logo")
+            <span class='u-h'>Guardian Labs</span>
+        </a>
+    }
 }
 
 @logoSlot = {

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -113,7 +113,7 @@
                         <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                             jobs</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                        <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
                             guardian labs</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">

--- a/common/app/views/fragments/guBand.scala.html
+++ b/common/app/views/fragments/guBand.scala.html
@@ -4,14 +4,17 @@
 <div class="paidfor-band">
     <div class="gs-container paidfor-band__inner">
         @fragments.commercial.paidForMeta()
-        <a class="paidfor-branding"
-            @if(Edition(request).id == "AU") {
-                href="@LinkTo("/guardian-labs-australia")"
-            } else {
-                href="@LinkTo("/guardian-labs")"
-            }>
-            @fragments.inlineSvg("glabs-logo", "logo")
-            <span class='u-h'>Guardian Labs</span>
-        </a>
+        @defining(
+            Edition(request).id match {
+                case "AU" => "-australia"
+                case "US" => "-us"
+                case _ => ""
+            }
+        ) { glabsUrlSuffix =>
+            <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
+                @fragments.inlineSvg("glabs-logo", "logo")
+                <span class='u-h'>Guardian Labs</span>
+            </a>
+        }
     </div>
 </div>

--- a/common/app/views/fragments/guBand.scala.html
+++ b/common/app/views/fragments/guBand.scala.html
@@ -1,20 +1,13 @@
 @()(implicit request: RequestHeader)
-@import common.{Edition, LinkTo}
+@import views.support.Commercial.glabsLink
+@import common.LinkTo
 
 <div class="paidfor-band">
     <div class="gs-container paidfor-band__inner">
         @fragments.commercial.paidForMeta()
-        @defining(
-            Edition(request).id match {
-                case "AU" => "-australia"
-                case "US" => "-us"
-                case _ => ""
-            }
-        ) { glabsUrlSuffix =>
-            <a href="@LinkTo(s"""/guardian-labs$glabsUrlSuffix""")">
-                @fragments.inlineSvg("glabs-logo", "logo")
-                <span class='u-h'>Guardian Labs</span>
-            </a>
-        }
+        <a href="@LinkTo(glabsLink(request))">
+            @inlineSvg("glabs-logo", "logo")
+            <span class='u-h'>Guardian Labs</span>
+        </a>
     </div>
 </div>

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -8,6 +8,7 @@ import layout.{ColumnAndCards, ContentCard, FaciaContainer}
 import model.{ContentType, MetaData, Page, Tags}
 import play.api.mvc.RequestHeader
 
+
 object Commercial {
 
   def shouldShowAds(page: Page): Boolean = page match {
@@ -15,6 +16,16 @@ object Commercial {
     case p: model.Page if p.metadata.sectionId == "identity" => false
     case p: model.CommercialExpiryPage => false
     case _ => true
+  }
+
+  def glabsLink (request: RequestHeader): String = {
+    val glabsUrlSuffix = Edition(request).id match {
+      case "AU" => "-australia"
+      case "US" => "-us"
+      case _ => ""
+    }
+
+    s"/guardian-labs$glabsUrlSuffix"
   }
 
   private def isBrandedContent(page: Page, edition: Edition, sponsorshipType: SponsorshipType): Boolean =


### PR DESCRIPTION
## What does this change?

When in the US edition, the website will link through to the glabs page. Adds a helper method to return the editionalised glabs link.

https://trello.com/c/PRpIcqUP/70-guardian-labs-footer-nav-link-in-us-edition

@guardian/dotcom-platform @kelvin-chappell @Calanthe 
