### PR TITLE
Enable liveblog paging in preview by adding article route to standalone

### DIFF
--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -192,6 +192,7 @@ GET        /news-alert/alerts                                                   
 # Articles
 GET        /*path.json                                                                         controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET        /*path/email                                                                        controllers.ArticleController.renderArticle(path)
+GET        /$path<[^/]+/([^/]+/)?live/.*>                                                      controllers.ArticleController.renderLiveBlog(path, page: Option[String], format: Option[String])
 
 # Don't forward requests for favicon.ico to the Content API
 GET        /favicon.ico                                                                        controllers.FaviconController.favicon


### PR DESCRIPTION
## What does this change?

Adds a liveblog route to `standalone` (which is imported by preview) so that paging on liveblogs in preview works.

Still looking into why liveblog updates in preview are in reverse, but removing this annoyance might help.
## What is the value of this and can you measure success?

Liveblog previews are pageable.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@guardian/dotcom-platform @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
