### PR TITLE
youtube player refactor

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -1,13 +1,11 @@
 define([
     'fastdom',
-    'bonzo',
     'Promise',
     'common/utils/$',
     'common/utils/load-script',
     'lodash/collections/forEach'
 ], function (
     fastdom,
-    bonzo,
     Promise,
     $,
     loadScript,
@@ -49,31 +47,39 @@ define([
         return wrapper;
     }
 
+    function _onPlayerStateChange(event, handlers, wrapper) {
+        //change class according to the current state
+        fastdom.write(function () {
+            ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
+                wrapper.classList.toggle('youtube__video-' + status.toLocaleLowerCase(), event.data === window.YT.PlayerState[status]);
+            });
+            wrapper.classList.add('youtube__video-started');
+        });
+        if (handlers && typeof handlers.onPlayerStateChange === 'function') {
+            handlers.onPlayerStateChange(event);
+        }
+    }
+
+    function _onPlayerReady(event, handlers, wrapper) {
+        fastdom.write(function () {
+            wrapper.classList.add('youtube__video-ready');
+        });
+        if (handlers && typeof handlers.onPlayerReady === 'function') {
+            handlers.onPlayerReady(event);
+        }
+    }
+
     function init(el, handlers) {
         //wrap <iframe/> in a div with almost the same class, id and data- attributes
         var wrapper = prepareWrapper(el);
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
-                //change class according to the current state
-                fastdom.write(function () {
-                    ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
-                        bonzo(wrapper).toggleClass('youtube__video-' + status.toLocaleLowerCase(), event.data === window.YT.PlayerState[status]);
-                    });
-                    bonzo(wrapper).addClass('youtube__video-started');
-                });
-                if (handlers && typeof handlers.onPlayerStateChange === 'function') {
-                    handlers.onPlayerStateChange(event);
-                }
+                _onPlayerStateChange(event, handlers, wrapper);
             }
 
             function onPlayerReady(event) {
-                fastdom.write(function () {
-                    bonzo(wrapper).addClass('youtube__video-ready');
-                });
-                if (handlers && typeof handlers.onPlayerReady === 'function') {
-                    handlers.onPlayerReady(event);
-                }
+                _onPlayerReady(event, handlers, wrapper);
             }
 
             return new window.YT.Player(el.id, {

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -1,17 +1,17 @@
 define([
     'fastdom',
-    'common/utils/$',
     'bonzo',
-    'bean',
     'Promise',
-    'common/utils/load-script'
+    'common/utils/$',
+    'common/utils/load-script',
+    'lodash/collections/forEach'
 ], function (
     fastdom,
-    $,
     bonzo,
-    bean,
     Promise,
-    loadScript
+    $,
+    loadScript,
+    forEach
 ) {
     var scriptId = 'youtube-player';
     var scriptSrc = 'https://www.youtube.com/player_api';
@@ -23,54 +23,69 @@ define([
         loadScript({ id: scriptId, src: scriptSrc });
     }, this);
 
-    return {
-        init: function(el, handlers) {
-            var wrapper = document.createElement('div');
-            var attrs = el.attributes;
-            Object.getOwnPropertyNames(attrs).forEach(function (attr) {
-                var attribute = attrs[attr];
-                if (attribute.name === 'class') {
-                    bonzo(wrapper).addClass(attribute.value);
-                    el.classname = 'youtube-player';
-                } else if (attribute.name === 'id') {
-                    var id = attribute.value;
-                    el.id += '_iframe';
-                    wrapper.id = id;
-                } else if(attribute.name !== 'src') {
-                    wrapper.setAttribute(attribute.name, attribute.value);
-                }
-            });
+    function prepareWrapper(el) {
+        var wrapper = document.createElement('div');
+        var attrs = el.attributes;
+
+        forEach(attrs, function (attribute) {
+            //parent div should have the same class names
+            if (attribute.name === 'class') {
+                wrapper.className += attribute.value;
+            } else if (attribute.name === 'id') {
+                //parent div should have almost the same id (without the `_iframe` part)
+                wrapper.id = attribute.value;
+                el.id += '_iframe';
+            } else if (attribute.name.substring(0, 5) === 'data-') {
+                //copy all of the data- attributes
+                wrapper.setAttribute(attribute.name, attribute.value);
+            }
+        });
+
+        fastdom.write(function () {
             el.parentNode.insertBefore(wrapper, el);
             wrapper.appendChild(el);
+        });
 
-            return promise.then(function () {
-                function onPlayerStateChange(event) {
-                    //change class according to the current state
-                    fastdom.write(function () {
-                        ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
-                            bonzo(wrapper).toggleClass('youtube__video-' + status.toLocaleLowerCase(), event.data === window.YT.PlayerState[status]);
-                        });
-                        bonzo(wrapper).addClass('youtube__video-started');
+        return wrapper;
+    }
+
+    function init(el, handlers) {
+        //wrap <iframe/> in a div with almost the same class, id and data- attributes
+        var wrapper = prepareWrapper(el);
+
+        return promise.then(function () {
+            function onPlayerStateChange(event) {
+                //change class according to the current state
+                fastdom.write(function () {
+                    ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
+                        bonzo(wrapper).toggleClass('youtube__video-' + status.toLocaleLowerCase(), event.data === window.YT.PlayerState[status]);
                     });
-                    if(handlers && typeof handlers.onPlayerStateChange == 'function') {
-                        handlers.onPlayerStateChange(event);
-                    }
-                }
-                function onPlayerReady(event) {
-                    fastdom.write(function () {
-                        bonzo(wrapper).addClass('youtube__video-ready');
-                    });
-                    if(handlers && typeof handlers.onPlayerReady == 'function') {
-                        handlers.onPlayerReady(event);
-                    }
-                }
-                return new window.YT.Player(el.id, {
-                    events: {
-                        'onReady': onPlayerReady,
-                        'onStateChange': onPlayerStateChange
-                    }
+                    bonzo(wrapper).addClass('youtube__video-started');
                 });
+                if (handlers && typeof handlers.onPlayerStateChange === 'function') {
+                    handlers.onPlayerStateChange(event);
+                }
+            }
+
+            function onPlayerReady(event) {
+                fastdom.write(function () {
+                    bonzo(wrapper).addClass('youtube__video-ready');
+                });
+                if (handlers && typeof handlers.onPlayerReady === 'function') {
+                    handlers.onPlayerReady(event);
+                }
+            }
+
+            return new window.YT.Player(el.id, {
+                events: {
+                    'onReady': onPlayerReady,
+                    'onStateChange': onPlayerStateChange
+                }
             });
-        }
+        });
+    }
+
+    return {
+        init: init
     };
 });


### PR DESCRIPTION
## What does this change?

Refactor of the youtube player module.
## What is the value of this and can you measure success?

The youtube player module is more understandable now.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

@lps88 @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
