### PR TITLE
Hosted Onward Journey fix

### DIFF
--- a/commercial/app/views/hosted/hostedArticleOnward.scala.html
+++ b/commercial/app/views/hosted/hostedArticleOnward.scala.html
@@ -13,7 +13,7 @@
         @for(trail <- trails) {
             <a href="@{trail.pageUrl}" class="hosted__next-page--tile" data-link-name="Next Hosted Page: @{trail.title}">
                 <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
-                <p class="hosted__next-page-title">@{trail.title}</p>
+                <p class="hosted__next-page-title hosted-article__next-page-title">@{trail.title}</p>
             </a>
         }
     </div>

--- a/commercial/app/views/hosted/hostedVideoOnward.scala.html
+++ b/commercial/app/views/hosted/hostedVideoOnward.scala.html
@@ -3,17 +3,17 @@
 
 @maybeTrail.map { trail =>
 
-    <div class="hosted__next-page hosted-video__next-page">
-        <div class="hosted__next-page--header">
-            <h2 class="hosted__text hosted__next-page--more-from">More from</h2>
-            <h2 class="hosted__next-page--client-name hosted-tone">@{trail.campaign.owner}</h2>
-        </div>
-        <a href="@{trail.pageUrl}" class="hosted__next-page--tile" data-colour="@{trail.campaign.fontColour.brandColour}" data-link-name="Next Hosted Video: @{trail.title}">
-            <div class="hosted-next-page-bg hosted-tone-bg"></div>
-            <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Video: @{trail.title}">
-            <p class="hosted__next-video-title">@{trail.title}</p>
-        </a>
+<div class="hosted__next-page hosted-video__next-page">
+    <div class="hosted__next-page--header">
+        <h2 class="hosted__text hosted__next-page--more-from">More from</h2>
+        <h2 class="hosted__next-page--client-name hosted-tone">@{trail.campaign.owner}</h2>
     </div>
+    <a href="@{trail.pageUrl}" class="hosted__next-page--tile" data-colour="@{trail.campaign.fontColour.brandColour}" data-link-name="Next Hosted Video: @{trail.title}">
+        <div class="hosted-next-page-bg hosted-tone-bg"></div>
+        <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Video: @{trail.title}">
+        <p class="hosted__next-page-title hosted-video__next-page-title">@{trail.title}</p>
+    </a>
+</div>
 
 
 }.getOrElse{

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -209,12 +209,10 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
         height: 10px;
         margin-bottom: 4px;
     }
-    .hosted__next-page-title {
+    .hosted-article__next-page-title {
         font-size: 16px;
         line-height: 18px;
         padding: 6px;
-        margin: 0;
-
         @include mq($until: phablet) {
             font-size: 14px;
             line-height: 16px;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -939,7 +939,10 @@ $hosted-video-height: 540px;
 }
 
 $nextPageThumbHeight: 72px;
+$nextPageThumbWidth: #{$nextPageThumbHeight * 5 / 3};
+
 $nextPageThumbHeightMobile: 54px;
+$nextPageThumbWidthMobile: #{$nextPageThumbHeightMobile * 5 / 3};
 
 .hosted__next-page .hosted__next-page--tile {
     display: block;
@@ -959,25 +962,29 @@ $nextPageThumbHeightMobile: 54px;
 
 .hosted__next-page-thumb {
     height: $nextPageThumbHeight;
-    width: #{$nextPageThumbHeight * 5 / 3};
+    width: $nextPageThumbWidth;
     object-fit: cover;
-    z-index: 1;
-    float: left;
+    position: absolute;
     margin-right: 6px;
 
     @include mq($until: phablet) {
         height: $nextPageThumbHeightMobile;
-        width: #{$nextPageThumbHeightMobile * 5 / 3};
+        width: $nextPageThumbWidthMobile;
     }
 }
 
-.hosted__next-video-title {
+.hosted__next-page-title {
+    z-index: 1;
+    margin: 0 0 0 $nextPageThumbWidth;
+    @include mq($until: phablet) {
+        margin-left: $nextPageThumbWidthMobile;
+    }
+}
+
+.hosted-video__next-page-title {
+    padding: 10px;
     font-size: 20px;
     line-height: 23px;
-    padding: 10px;
-    margin: 0;
-    z-index: 1;
-
     @include mq($until: phablet) {
         font-size: 18px;
         line-height: 20px;


### PR DESCRIPTION
## What does this change?

The text in the onward journey shouldn't flow under the image.
## Screenshots

Before
![image](https://cloud.githubusercontent.com/assets/6290008/19117569/5eec2402-8b11-11e6-9c7c-ef0114d99ef4.png)
After
![image](https://cloud.githubusercontent.com/assets/6290008/19117638/91ec1d08-8b11-11e6-843a-c28e1d72ebfa.png)
## Request for comment

@guardian/labs-beta 
