### PR TITLE
Update CAPI models and client

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val commonsLang = "commons-lang" % "commons-lang" % "2.4"
   val commonsIo = "commons-io" % "commons-io" % "2.4"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.18"
-  val contentApiClient = "com.gu" %% "content-api-client" % "9.5"
+  val contentApiClient = "com.gu" %% "content-api-client" % "10.2"
   val capiScalaModels = "com.gu" % "content-api-models-scala" % capiModelsVersion
   val capiJsonModels = "com.gu" % "content-api-models-json" % capiModelsVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "2.8.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
   val faciaVersion = "2.0.2"
-  val capiModelsVersion = "9.24"
+  val capiModelsVersion = "10.1"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"


### PR DESCRIPTION
CAPI models have undergone a major version upgrade, which I think changes a lot of internals, but nothing externally (@tomrf1 might know more, see https://github.com/guardian/content-api-models/pull/60)

I need a more recent version of CAPI models (`10.2`) for the interactive atom work, this PR is a stepping stone to get frontend synced to `10.x`. I'm not aware of any testing, but have spoken to @jfsoul who says he will check it!
