### PR TITLE
Fix preview liveblog ordering

### DIFF
--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -13,7 +13,8 @@ object Blocks {
   def make(blocks: ApiBlocks): Blocks = {
 
     def orderBlocks(blocks: Seq[BodyBlock]) =
-      blocks.sortBy(_.firstPublishedDate.map(_.getMillis).getOrElse(0L)).reverse
+      blocks.sortBy(-_.publishedCreatedTimestamp().getOrElse(0L)) // Negate rather than reverse result: leaves
+                                                                  // order unchanged when there are no timestamps
 
     val bodyBlocks = orderBlocks(blocks.body.toSeq.flatMap(BodyBlock.make))
     val reqBlocks: Map[String, Seq[BodyBlock]] = blocks.requestedBodyBlocks.map { map =>


### PR DESCRIPTION
## What does this change?

Fixes the order of liveblogs in preview by changing the sorting logic for blocks.  If there is no published date (as in the case of preview) then we default to using the created date for ordering.
## What is the value of this and can you measure success?

Liveblogs are once again ordered correctly in preview.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8754692/19120536/f753db6e-8b1a-11e6-9420-acc3803bb972.png)

After:
![image](https://cloud.githubusercontent.com/assets/8754692/19120541/feff32dc-8b1a-11e6-9f18-8a9f09a123c5.png)
## Request for comment

@guardian/dotcom-platform 

@johnduffell thanks for the tip! 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
