### PR TITLE
New Header Test: Creating "kicker" like section link for articles

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -47,7 +47,7 @@
             <div class="content__header tonal__header u-cf">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--liveblog">
-                        @fragments.meta.metaInline(article, amp)
+                        @fragments.meta.metaInline(article, amp, page = model)
                         <h1 itemprop="headline" class="content__headline js-score">@Html(article.trail.headline)</h1>
                     </div>
                 </div>

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -1,6 +1,8 @@
 package common
 
 import conf.Configuration
+import model.Page
+import play.api.mvc.RequestHeader
 
 case class NavLink(name: String, url: String, iconName: String = "")
 case class TertiaryLink(frontId: String, name: String, url: String)
@@ -22,6 +24,19 @@ object NewNavigation {
       case editions.Au => au
       case editions.Us => us
       case editions.International => int
+    }
+  }
+
+  def getSubSectionOrSectionLink(navigation: Seq[NavItem], page: Page)(implicit request: RequestHeader): Option[SectionLink] = {
+
+    val topLevelLink = Navigation.topLevelItem(navigation, page)
+
+    if (topLevelLink.isDefined) {
+      val subLink = topLevelLink.get.searchForCurrentSublink(page)
+
+      Some(subLink.getOrElse(topLevelLink.get.name))
+    } else {
+      None
     }
   }
 

--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -61,7 +61,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                   <div class="series-identity-explore__container">
-                      @fragments.meta.metaInline(page.item)
+                      @fragments.meta.metaInline(page.item, page = page)
                       <div class="series-identity__byline">
                       <span class="byline-meta">with</span>  @fragments.meta.byline(page.item.trail.byline, page.item.tags)
                       </div>

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -4,7 +4,7 @@
     <div class="gs-container">
         <div class="content__main-column">
 
-            @fragments.meta.metaInline(item)
+            @fragments.meta.metaInline(item, page = page)
 
             <h1 class="content__headline js-score" itemprop="headline">@Html(item.trail.headline)</h1>
 

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -17,7 +17,7 @@
             <div class="content__main-column u-cf">
 
                 @if(showMeta) {
-                    @fragments.meta.metaInline(item, amp)
+                    @fragments.meta.metaInline(item, amp, page = page)
                 }
 
                 <h1 class="content__headline js-score" itemprop="headline">

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -19,7 +19,7 @@
 
     <div class="immersive-main-media__headline-container--dark immersive-main-media__headline-container">
         <div class="gs-container">
-            @fragments.meta.metaInline(page.item)
+            @fragments.meta.metaInline(page.item, page = page)
 
             <h1 class="content__headline content__headline--immersive content__headline--gallery content__headline--immersive--with-main-media">
                 @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -75,7 +75,7 @@
             <div class="gs-container">
                 @if(!isTheMinuteArticle) {
                     <div class="content__main-column">
-                    @fragments.meta.metaInline(page.item)
+                    @fragments.meta.metaInline(page.item, page = page)
                 }
 
                 <h1 class="@RenderClasses(Map(

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -1,6 +1,6 @@
-@(item: model.ContentType, isAmp: Boolean = false)(implicit request: RequestHeader)
+@(item: model.ContentType, isAmp: Boolean = false, page: model.Page)(implicit request: RequestHeader)
 
-@import common.{LinkTo, Localisation}
+@import common.{LinkTo, Localisation, NewNavigation, Edition}
 @import conf.switches.Switches.ArticleBadgesSwitch
 @import model.Badges.badgeFor
 @import views.support.RenderClasses
@@ -24,21 +24,83 @@
         }
     }
 
-    @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
-        <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">
-            <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@item.content.sectionLabelLink}">@Html(Localisation(item.content.sectionLabelName))</a>
+    @if(mvt.ABNewHeaderVariant.isParticipating) {
+        <div class="mobile-only">
+            @defining(Edition(request).navigation) { navigation =>
+
+                @NewNavigation.getSubSectionOrSectionLink(navigation, page).map { sectionLink =>
+                    @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
+
+                        <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">
+                            <a class="content__section-label__link"
+                                data-link-name="article section"
+                                href="@LinkTo {/@sectionLink.href}">
+                                    @sectionLink.title
+                            </a>
+                        </div>
+                    }
+
+                    @if(item.content.blogOrSeriesTag.isDefined) {
+                        @if(item.content.blogOrSeriesTag.get.name.toLowerCase() == sectionLink.title.toLowerCase()) {
+                            @ObserverOrSectionLabel()
+                        }
+
+                        @if(!(item.content.blogOrSeriesTag.get.name.toLowerCase() == sectionLink.title.toLowerCase())) {
+                            @item.content.blogOrSeriesTag.map { series =>
+                                <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
+                                    <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
+                                </div>
+                            }.getOrElse {
+                                @ObserverOrSectionLabel()
+                            }
+                        }
+                    } else {
+                        @ObserverOrSectionLabel()
+                    }
+                }
+            }
         </div>
     }
 
-    @item.content.blogOrSeriesTag.map { series =>
+    @* TODO: This should actually show, but just not on mobile. Above should only show on mobile*@
+    <div class="@if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}">
+
+        @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
+            <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">
+                <a class="content__section-label__link"
+                    data-link-name="article section"
+                    href="@LinkTo {/@item.content.sectionLabelLink}">
+                        @Html(Localisation(item.content.sectionLabelName))
+                </a>
+            </div>
+        }
+
+        @item.content.blogOrSeriesTag.map { series =>
         <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
             <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
         </div>
-    }.getOrElse {
-        @if(item.content.isFromTheObserver) {
-            <div class="content__series-label">
-                <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
-            </div>
+        }.getOrElse {
+            @if(item.content.isFromTheObserver) {
+                <div class="content__series-label">
+                    <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+                </div>
+            }
         }
-    }
+    </div>
 </div>
+
+@ObserverOrSectionLabel() = {
+    @if(item.content.isFromTheObserver) {
+        <div class="content__series-label">
+            <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+        </div>
+    }
+
+    @if(!item.content.isFromTheObserver) {
+        <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
+            <a class="content__series-label__link" href="@LinkTo {/@item.content.sectionLabelLink}">
+                @Html(Localisation(item.content.sectionLabelName))
+            </a>
+        </div>
+    }
+}

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -24,6 +24,7 @@
         }
     }
 
+    @* TODO: if this feature is proven successful, this should be refactored to remove the logic from the template as much as possible *@
     @if(mvt.ABNewHeaderVariant.isParticipating) {
         <div class="mobile-only">
             @defining(Edition(request).navigation) { navigation =>
@@ -41,11 +42,10 @@
                     }
 
                     @if(item.content.blogOrSeriesTag.isDefined) {
+
                         @if(item.content.blogOrSeriesTag.get.name.toLowerCase() == sectionLink.title.toLowerCase()) {
                             @ObserverOrSectionLabel()
-                        }
-
-                        @if(!(item.content.blogOrSeriesTag.get.name.toLowerCase() == sectionLink.title.toLowerCase())) {
+                        } else {
                             @item.content.blogOrSeriesTag.map { series =>
                                 <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
                                     <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
@@ -62,7 +62,6 @@
         </div>
     }
 
-    @* TODO: This should actually show, but just not on mobile. Above should only show on mobile*@
     <div class="@if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}">
 
         @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
@@ -94,9 +93,7 @@
         <div class="content__series-label">
             <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
         </div>
-    }
-
-    @if(!item.content.isFromTheObserver) {
+    } else {
         <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
             <a class="content__series-label__link" href="@LinkTo {/@item.content.sectionLabelLink}">
                 @Html(Localisation(item.content.sectionLabelName))


### PR DESCRIPTION
## What does this change?

We decided the last thing we were missing before turning on the new header test was a replacement for the breadcrumb/signposting on the old nav. This PR adds that replacement. 

The logic for this is rather complicated and I would really like to rewrite it. However, I feel like it would take too long to justify for a test. 

Once we know the result of the new header test I can take some of the logic outside this template. Until then...
## What is the value of this and can you measure success?

Users will be able to see what section an article belongs to.
## Does this affect other platforms - Amp, Apps, etc?

Nope :)
## Screenshots

Before:
## ![image](https://cloud.githubusercontent.com/assets/8774970/19122823/28c295ba-8b24-11e6-8047-12d268dd6da4.png)

![image](https://cloud.githubusercontent.com/assets/8774970/19122874/63535d90-8b24-11e6-92e5-ee8b7e7b871f.png)

After:
The first link is either the top level section or the subsection (if the subsection exists).
The second link is either the blog or series link, the observer link, or the section link from the metadata
## ![image](https://cloud.githubusercontent.com/assets/8774970/19122839/3b45aa24-8b24-11e6-8d76-2d140e7a2fdd.png)

![image](https://cloud.githubusercontent.com/assets/8774970/19122857/51181634-8b24-11e6-940f-2458ee29d0c2.png)
## Request for comment

@stephanfowler @zeftilldeath @SiAdcock 
