### PR TITLE
Use a specific search criteria to choose log files to upload 

### DIFF
--- a/admin-jobs/conf/application-logger.xml
+++ b/admin-jobs/conf/application-logger.xml
@@ -20,7 +20,7 @@
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend-commercial-client-side-archive/%d{yyyy-MM-dd--HH-mm}.log</fileNamePattern>
-            <maxHistory>20</maxHistory>
+            <maxHistory>40</maxHistory>
         </rollingPolicy>
 
         <encoder>


### PR DESCRIPTION
The commercial logs that are written to data lake suffered a problem where a log race condition was interfering with the upload. This was a clash between logback's max history setting and the upload step.
