### PR TITLE
Capi Traffic Driver Endpoint

### DIFF
--- a/commercial/app/controllers/commercial/CommercialControllers.scala
+++ b/commercial/app/controllers/commercial/CommercialControllers.scala
@@ -30,4 +30,5 @@ trait CommercialControllers {
   lazy val travelOffersController = wire[TravelOffersController]
   lazy val subscriberNumberPageController = wire[SubscriberNumberPageController]
   lazy val contributorEmailPageController = wire[ContributorEmailPageController]
+  lazy val trafficDriverController = wire[TrafficDriverController]
 }

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -1,13 +1,14 @@
 package controllers.commercial
 
-import common.{ExecutionContexts, Logging}
+import common.{Edition, ExecutionContexts, JsonComponent, Logging}
 import contentapi.ContentApiClient
-import model.commercial.{CapiAgent, Lookup}
-import model.ContentType
-import play.api.mvc.{AnyContent, Controller, Request}
+import model.commercial.{CapiAgent, CapiSingle, Lookup}
+import model.{Cached, ContentType}
+import play.api.mvc.{Action, AnyContent, Controller, Request}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
+import scala.concurrent.duration.DurationInt
 
 class TrafficDriverController(
     contentApiClient: ContentApiClient,
@@ -32,6 +33,17 @@ class TrafficDriverController(
         }
 
         content
+
+    }
+
+    private def renderJson() = Action.async { implicit request =>
+
+        retrieveContent().map {
+            case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
+            case content :: _ => Cached(60.seconds) {
+                JsonComponent(CapiSingle.fromContent(content, Edition(request)))
+            }
+        }
 
     }
 

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -18,8 +18,6 @@ class TrafficDriverController(
   with implicits.Requests
   with Logging {
 
-    private val lookup = new Lookup(contentApiClient)
-
     private def retrieveContent()(implicit request: Request[AnyContent]):
         Future[Seq[ContentType]] = {
 
@@ -36,11 +34,11 @@ class TrafficDriverController(
 
     }
 
-    private def renderJson() = Action.async { implicit request =>
+    def renderJson() = Action.async { implicit request =>
 
         retrieveContent().map {
             case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
-            case content :: _ => Cached(60.seconds) {
+            case content +: _ => Cached(60.seconds) {
                 JsonComponent(CapiSingle.fromContent(content, Edition(request)))
             }
         }

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -1,0 +1,38 @@
+package controllers.commercial
+
+import common.{ExecutionContexts, Logging}
+import contentapi.ContentApiClient
+import model.commercial.{CapiAgent, Lookup}
+import model.ContentType
+import play.api.mvc.{AnyContent, Controller, Request}
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+class TrafficDriverController(
+    contentApiClient: ContentApiClient,
+    capiAgent: CapiAgent)
+  extends Controller
+  with ExecutionContexts
+  with implicits.Requests
+  with Logging {
+
+    private val lookup = new Lookup(contentApiClient)
+
+    private def retrieveContent()(implicit request: Request[AnyContent]):
+        Future[Seq[ContentType]] = {
+
+        val content: Future[Seq[model.ContentType]] =
+            capiAgent.contentByShortUrls(specificIds)
+
+        content onFailure {
+            case NonFatal(e) => log.error(
+                s"Looking up content by short URL failed: ${e.getMessage}"
+            )
+        }
+
+        content
+
+    }
+
+}

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -2,7 +2,7 @@ package controllers.commercial
 
 import common.{Edition, ExecutionContexts, JsonComponent, Logging}
 import contentapi.ContentApiClient
-import model.commercial.{CapiAgent, CapiSingle, Lookup}
+import model.commercial.{CapiAgent, TrafficDriver, Lookup}
 import model.{Cached, ContentType}
 import play.api.mvc.{Action, AnyContent, Controller, Request}
 
@@ -39,7 +39,7 @@ class TrafficDriverController(
         retrieveContent().map {
             case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
             case content :: _ => Cached(60.seconds) {
-                JsonComponent(CapiSingle.fromContent(content, Edition(request)))
+                JsonComponent(TrafficDriver.fromContent(content, Edition(request)))
             }
         }
 

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -18,11 +18,12 @@ class TrafficDriverController(
   with implicits.Requests
   with Logging {
 
+    // Request information about the article from cAPI.
     private def retrieveContent()(implicit request: Request[AnyContent]):
-        Future[List[ContentType]] = {
+        Future[Option[ContentType]] = {
 
-        val content: Future[List[model.ContentType]] =
-            capiAgent.contentByShortUrls(specificIds).map(_.toList)
+        val content: Future[Option[model.ContentType]] =
+            capiAgent.contentByShortUrls(specificIds).map(_.headOption)
 
         content onFailure {
             case NonFatal(e) => log.error(
@@ -34,12 +35,16 @@ class TrafficDriverController(
 
     }
 
+    // Build model from cAPI data and return as JSON, or empty if nothing found.
     def renderJson() = Action.async { implicit request =>
 
         retrieveContent().map {
-            case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
-            case content :: _ => Cached(60.seconds) {
-                JsonComponent(TrafficDriver.fromContent(content, Edition(request)))
+            case None => Cached(componentNilMaxAge){ jsonFormat.nilResult }
+            case Some(content) => Cached(60.seconds) {
+
+                val edition = Edition(request)
+                JsonComponent(TrafficDriver.fromContent(content, edition))
+
             }
         }
 

--- a/commercial/app/controllers/commercial/TrafficDriverController.scala
+++ b/commercial/app/controllers/commercial/TrafficDriverController.scala
@@ -19,10 +19,10 @@ class TrafficDriverController(
   with Logging {
 
     private def retrieveContent()(implicit request: Request[AnyContent]):
-        Future[Seq[ContentType]] = {
+        Future[List[ContentType]] = {
 
-        val content: Future[Seq[model.ContentType]] =
-            capiAgent.contentByShortUrls(specificIds)
+        val content: Future[List[model.ContentType]] =
+            capiAgent.contentByShortUrls(specificIds).map(_.toList)
 
         content onFailure {
             case NonFatal(e) => log.error(
@@ -38,7 +38,7 @@ class TrafficDriverController(
 
         retrieveContent().map {
             case Nil => Cached(componentNilMaxAge){ jsonFormat.nilResult }
-            case content +: _ => Cached(60.seconds) {
+            case content :: _ => Cached(60.seconds) {
                 JsonComponent(CapiSingle.fromContent(content, Edition(request)))
             }
         }

--- a/commercial/app/model/commercial/TrafficDriver.scala
+++ b/commercial/app/model/commercial/TrafficDriver.scala
@@ -6,23 +6,23 @@ import play.api.libs.json.{Json, Writes}
 import CapiImages.ImageInfo
 
 case class TrafficDriver(articleHeadline: String, articleUrl: String,
-    articleText: Option[String], articleImage: ImageInfo, edition: String)
+  articleText: Option[String], articleImage: ImageInfo, edition: String)
 
 object TrafficDriver {
 
-    def fromContent(
-        contentType: ContentType,
-        edition: Edition): TrafficDriver = {
+  def fromContent(
+    contentType: ContentType,
+    edition: Edition): TrafficDriver = {
 
-        val content = contentType.content
-        val imageInfo = CapiImages.buildImageData(content.trail.trailPicture)
+    val content = contentType.content
+    val imageInfo = CapiImages.buildImageData(content.trail.trailPicture)
 
-        TrafficDriver(content.trail.headline, content.metadata.webUrl,
-            content.trail.fields.trailText, imageInfo, edition.id)
+    TrafficDriver(content.trail.headline, content.metadata.webUrl,
+      content.trail.fields.trailText, imageInfo, edition.id)
 
-    }
+  }
 
-    implicit val writesTrafficDriver: Writes[TrafficDriver] =
-        Json.writes[TrafficDriver]
+  implicit val writesTrafficDriver: Writes[TrafficDriver] =
+    Json.writes[TrafficDriver]
 
 }

--- a/commercial/app/model/commercial/TrafficDriver.scala
+++ b/commercial/app/model/commercial/TrafficDriver.scala
@@ -1,0 +1,28 @@
+package model.commercial
+
+import common.Edition
+import model.ContentType
+import play.api.libs.json.{Json, Writes}
+import CapiImages.ImageInfo
+
+case class TrafficDriver(articleHeadline: String, articleUrl: String,
+    articleText: Option[String], articleImage: ImageInfo, edition: String)
+
+object TrafficDriver {
+
+    def fromContent(
+        contentType: ContentType,
+        edition: Edition): TrafficDriver = {
+
+        val content = contentType.content
+        val imageInfo = CapiImages.buildImageData(content.trail.trailPicture)
+
+        TrafficDriver(content.trail.headline, content.metadata.webUrl,
+            content.trail.fields.trailText, imageInfo, edition.id)
+
+    }
+
+    implicit val writesTrafficDriver: Writes[TrafficDriver] =
+        Json.writes[TrafficDriver]
+
+}

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -42,6 +42,7 @@ GET         /commercial/api/capi-multiple.json                            contro
 GET         /commercial/capi-single                                       controllers.commercial.ContentApiOffersController.itemHtml
 GET         /commercial/capi-single-merch.json                            controllers.commercial.ContentApiOffersController.itemJson
 GET         /commercial/capi-single-merch                                 controllers.commercial.ContentApiOffersController.itemHtml
+GET         /commercial/api/traffic-driver.json                           controllers.commercial.TrafficDriverController.renderJson
 GET         /commercial/paid.json                                         controllers.commercial.PaidContentCardController.cardJson
 GET         /commercial/paid                                              controllers.commercial.PaidContentCardController.cardHtml
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -302,6 +302,7 @@ GET            /commercial/api/capi-single.json                                 
 GET            /commercial/api/capi-multiple.json                                                                                controllers.commercial.ContentApiOffersController.nativeJsonMulti
 GET            /commercial/capi-single-merch.json                                                                                controllers.commercial.ContentApiOffersController.itemJson
 GET            /commercial/capi-single-merch                                                                                     controllers.commercial.ContentApiOffersController.itemHtml
+GET            /commercial/api/traffic-driver.json                                                                               controllers.commercial.TrafficDriverController.renderJson
 GET            /commercial/paid.json                                                                                             controllers.commercial.PaidContentCardController.cardJson
 GET            /commercial/paid                                                                                                  controllers.commercial.PaidContentCardController.cardHtml
 GET            /commercial/multi.json                                                                                            controllers.commercial.Multi.renderMulti


### PR DESCRIPTION
## What does this change?

Adds an endpoint to frontend for retrieving cAPI data about an article by short URL. Used for the gLabs Traffic Driver native template.
- Adds new controller to commercial and wires it up.
- Adds new model to commercial for Traffic Driver data.
- Adds new route to commercial and dev-build for endpoint.
## What is the value of this and can you measure success?

Needed to provide cAPI data for the gLabs Traffic Driver native template, making use of pre-existing code in frontend.
## Request for comment

Not built a component within Play like this before, so would appreciate any comments if e.g. I've done it all horribly wrong @guardian/commercial-dev @janua 
