### PR TITLE
Create notion of ‘private’ targets in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,30 +1,19 @@
-# Lists all `make` targets.
-help:
+# Targets marked '# PRIVATE' will be hidden when running `make help`.
+# They're helper targets that you probably only need to know about
+# if you've got as far as reading the makefile.
+
+# Lists common targets.
+# Also the default task (`make` === `make help`).
+help: # PRIVATE
 	@node tools/messages.js describeMakefile
 
-# ********************************************************
+# Lists *all* targets.
+list: # PRIVATE
+	@node tools/messages.js describeMakefile --all
 
-# Watch and automatically reload all JS/SCSS.
-# Uses port 3000 insead of 9000.
-watch: compile-dev
-	@npm run sass-watch & \
-		npm run css-watch & \
-		npm run browser-sync
 
-# ********************************************************
 
-atomise-css:
-	@node tools/atomise-css
-
-# Compile all assets for production.
-compile: clean-assets
-	@grunt compile-assets
-
-# Compile all assets for development.
-compile-dev: clean-assets
-	@grunt compile-assets --dev
-
-# ********************************************************
+# *********************** SETUP ***********************
 
 # Install all 3rd party dependencies.
 install:
@@ -37,54 +26,73 @@ install:
 	@node tools/messages.js install
 
 # Remove all 3rd party dependencies.
-uninstall:
+uninstall: # PRIVATE
 	@rm -rf node_modules
 	@echo 'All 3rd party dependencies have been uninstalled.'
 
-# Remove then reinstall all 3rd party dependencies.
-# The nuclear option if nothing else has worked.
+# Reinstall all 3rd party dependencies from scratch.
+# The nuclear option if `make install` hasn't worked.
 reinstall: uninstall install
 
-# ********************************************************
+
+
+# *********************** DEVELOPMENT ***********************
+
+# Watch and automatically compile/reload all JS/SCSS.
+# Uses port 3000 insead of 9000.
+watch: compile-dev
+	@npm run sass-watch & \
+		npm run css-watch & \
+		npm run browser-sync
+
+# Shrinkwrap NPM packages after updating package.json.
+shrinkwrap: # PRIVATE
+	@npm prune && npm shrinkwrap --dev && node dev/clean-shrinkwrap.js
+	@node tools/messages.js did-shrinkwrap
+
+
+
+# *********************** ASSETS ***********************
+
+# Compile all assets for production.
+compile: clean-assets
+	@grunt compile-assets
+
+# Compile all assets for development.
+compile-dev: clean-assets
+	@grunt compile-assets --dev
+
+# Delete all asset build artefacts, includes the builds themselves.
+clean-assets: # PRIVATE
+	@rm -rf static/target static/hash static/requirejs
+
+atomise-css: # PRIVATE
+	@node tools/atomise-css
+
+# * Not ready for primetime use yet... *
+pasteup: # PRIVATE
+	@cd static/src/stylesheets/pasteup && npm --silent i && node publish.js
+
+
+
+# *********************** CHECKS ***********************
 
 # Run the JS test suite.
 test:
 	@grunt test --dev
-
-# ********************************************************
 
 # Lint all assets.
 validate:
 	@grunt validate
 
 # Lint all SCSS.
-validate-sass:
+validate-sass: # PRIVATE
 	@grunt validate:sass
 	@grunt validate:css
 
 # Lint all JS.
-validate-js:
+validate-js: # PRIVATE
 	@grunt validate:js
 
-validate-amp:
+validate-amp: # PRIVATE
 	@cd tools/amp-validation && npm install && NODE_ENV=dev node index.js
-
-# ********************************************************
-
-# Shrinkwrap NPM packages.
-shrinkwrap:
-	@npm prune && npm shrinkwrap --dev && node dev/clean-shrinkwrap.js
-	@node tools/messages.js did-shrinkwrap
-
-# ********************************************************
-
-# Deletes all asset build artefacts.
-# Includes the builds themselves.
-clean-assets:
-	@rm -rf static/target static/hash static/requirejs
-
-# ********************************************************
-
-# * Not ready for primetime use yet... *
-pasteup:
-	@cd static/src/stylesheets/pasteup && npm --silent i && node publish.js

--- a/makefile
+++ b/makefile
@@ -2,9 +2,9 @@
 # They're helper targets that you probably only need to know about
 # if you've got as far as reading the makefile.
 
-# Lists common targets.
+# Lists common tasks.
 # Also the default task (`make` === `make help`).
-help: # PRIVATE
+help:
 	@node tools/messages.js describeMakefile
 
 # Lists *all* targets.

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -63,9 +63,7 @@ switch (process.argv[2]) {
             messageLines.push('\nTo see the full set, run `make list`.')
         }
 
-        if (messageLines[0] === '/n') messageLines.shift();
-
-        notify(messageLines.join('\n'), {
+        notify(messageLines.join('\n').trim(), {
             heading: `${(listAll ? 'All' : 'Common')} Frontend make tasks`
         }, 'info');
         break;

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -9,7 +9,8 @@ function notify(message, options, type) {
     // Set the default text colour for info to black as white was hard to see
     if (type === 'info') {
        options = Object.assign({
-           colour: 'black'
+           colour: 'black',
+           codeColour: 'white'
        }, options);
     }
 
@@ -20,44 +21,52 @@ function notify(message, options, type) {
     };
 }
 
-
 switch (process.argv[2]) {
     case 'describeMakefile':
-        const message = fs.readFileSync('makefile', 'utf8')
-            .split('\n')
-            .reduce((messages, line, lineNumber, makefile) => {
-                const message = [];
+        const messageLines = [];
 
-                // if this line is a target...
-                if (line.match(/^[^\s#]/)) {
-                    // see if there are any comments immediately before it
-                    const comments = takeWhile(makefile.slice(0, lineNumber).reverse(), line => line.match(/^#/))
-                        // format the comments for output to CLI
-                        .map(comment => comment.replace(/#\s+/, ''))
-                        // put them back into correct order
-                        .reverse();
+        // this flag could be anything, but the `--` makes it look real
+        const listAll = process.argv[3] === '--all';
 
-                   // format the target name for output to CLI
-                    const targetName = line.split(':')[0];
+        // for all the lines in the makefile, construct the message
+        fs.readFileSync('makefile', 'utf8').split('\n').forEach((line, lineNumber, makefile) => {
+            // if this line is a target...
+            if (line.match(/^[^\.\s#]/) && (listAll || !line.match(/# PRIVATE$/))) {
+                // see if there are any comments immediately before it
+                const comments = takeWhile(makefile.slice(0, lineNumber).reverse(), line => line.match(/^#/))
+                    // format the comments for output to CLI
+                    .map(comment => comment.replace(/#\s+/, ''))
+                    // put them back into correct order
+                    .reverse();
 
-                    // if we have comments for this target...
-                    if (comments.length) {
-                        // add the target name with the first comment following it
-                        message.push(`\`${targetName}\`${new Array(20 - targetName.length).join(' ')}${comments.shift()}`);
-                        // then add any other comments
-                        [].push.apply(message, comments.map(comment => new Array(20).join(' ') + comment));
-                    } else {
-                        // just output the target name
-                        message.push(`\`${targetName}\``);
-                    }
+                // format the target name for output to CLI
+                const targetName = line.split(':')[0];
+
+                // add the target name with the first comment following it
+                messageLines.push(`\`${targetName}\`${new Array(20 - targetName.length).join((listAll ? '.' : ' '))}${comments.shift() || '?'}`);
+
+                // then add any other comments on subsequent lines
+                [].push.apply(messageLines, comments.map(comment => new Array(20).join(' ') + comment));
+            }
+
+            // if we've got a divider, just add space to create a line break
+            if (line.match(/^# \*{3,}/)) {
+                if (listAll) {
+                    messageLines.push(`\n${line.replace(/#|\*/g, '').trim()}`)
+                } else {
+                    messageLines.push(' ');
                 }
-                // if we've got a divider, just add space to create a line break
-                if (line.match(/^# \*{3,}/)) message.push(' ');
-                return messages.concat(message);
-            }, []).join('\n');
+            };
+        });
 
-        notify(message, {
-            heading: 'Frontend make options'
+        if (!listAll) {
+            messageLines.push('\nTo see the full set, run `make list`.')
+        }
+
+        if (messageLines[0] === '/n') messageLines.shift();
+
+        notify(messageLines.join('\n'), {
+            heading: `${(listAll ? 'All' : 'Common')} Frontend make tasks`
         }, 'info');
         break;
 


### PR DESCRIPTION
## What does this change?
- `make`/`make help` now only lists 'common' tasks, which means tasks not marked as `# PRIVATE`
- new `make list` target lists everything in the makefile
## What is the value of this and can you measure success?

As tasks are pulled out of the grunt file, the makefile will fill up. the idea is hide the workings out if you just need to get the site up and running, but allow anyone who wants to to easily see what's going on.
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

`make help`

<img width="566" alt="screen shot 2016-10-06 at 17 00 55" src="https://cloud.githubusercontent.com/assets/867233/19160095/7cded6e6-8be6-11e6-9450-7c7303de43d2.png">

`make list`

<img width="567" alt="screen shot 2016-10-06 at 17 01 03" src="https://cloud.githubusercontent.com/assets/867233/19160097/804e09fa-8be6-11e6-90e6-2a2f33a75373.png">
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
