### PR TITLE
adding a space

### DIFF
--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -24,7 +24,7 @@
                     if (standfirst.contains(item.trail.byline.get)) {
                         ContributorLinks(standfirst, item.tags.contributors).toString()
                     } else {
-                        standfirst + "<p>by" + ContributorLinks(item.trail.byline.get, item.tags.contributors) + "</p>"
+                        standfirst + "<p>by " + ContributorLinks(item.trail.byline.get, item.tags.contributors) + "</p>"
                     }
                 } else {
                     standfirst


### PR DESCRIPTION
## What does this change?

Adds a space in immersive articles byline to prevent there from being no visual space if there is no contributor profile.

Bug outlined here: https://trello.com/c/eFibsu9b/114-immersive-template-byline-spacing-issue
## What is the value of this and can you measure success?

It looks better
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/19161375/70180ffe-8beb-11e6-8c53-23f27c97df56.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/19161403/8bc459ba-8beb-11e6-9ab4-e05eea60be20.png)
## Request for comment

@jfsoul 
