### PR TITLE
Explore template tweaks

### DIFF
--- a/static/src/stylesheets/inline/article-explore.scss
+++ b/static/src/stylesheets/inline/article-explore.scss
@@ -367,11 +367,6 @@ $explore-series-header-element-opacity: .85;
         border-top: 1px dotted $neutral-4;
     }
 
-    //only show first three social links
-    .social__item:nth-child(n+4) {
-        display: none;
-    }
-
     @include mq($from: desktop) {
         position: absolute;
         margin-left: 0;

--- a/static/src/stylesheets/inline/article-explore.scss
+++ b/static/src/stylesheets/inline/article-explore.scss
@@ -177,8 +177,9 @@ $explore-series-header-element-opacity: .85;
         font-weight: 900;
 
         @include mq($from: tablet) {
-            @include fs-headline(6);
+            @include fs-headline(7);
             font-weight: 900;
+            line-height: 38px;
         }
 
         @include mq($until: leftCol) {


### PR DESCRIPTION
## What does this change?

With the launch of the "View from Middletown" Explore series, I have made some small design tweaks to the Explore template:
1. Increased headline font size and line height
2. Reinstated hidden social share links
## What is the value of this and can you measure success?
1. Gives the headline more breathing space on desktop
2. Provides users with more sharing options
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![picture 104](https://cloud.githubusercontent.com/assets/5931528/19193816/8500a1f2-8ca3-11e6-9331-b9437ab23dc5.png)
## Request for comment

@duarte

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
