### PR TITLE
Move AB tests into enhanced js

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -8,6 +8,8 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/utils/user-timing',
+    'common/utils/robust',
+    'common/modules/experiments/ab',
     './common',
     './sport',
     'enhanced-common'
@@ -21,6 +23,8 @@ define([
     detect,
     mediator,
     userTiming,
+    robust,
+    ab,
     common,
     sport
 ) {
@@ -36,6 +40,20 @@ define([
 
         userTiming.mark('App Begin');
         bootstrapContext('common', common);
+
+        //
+        // A/B tests
+        //
+
+        robust.catchErrorsAndLog('ab-tests', function () {
+            ab.segmentUser();
+
+            robust.catchErrorsAndLog('ab-tests-run', ab.run);
+            robust.catchErrorsAndLog('ab-tests-registerImpressionEvents', ab.registerImpressionEvents);
+            robust.catchErrorsAndLog('ab-tests-registerCompleteEvents', ab.registerCompleteEvents);
+
+            ab.trackEvent();
+        });
 
         // Front
         if (config.page.isFront) {

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -16,7 +16,6 @@ define([
     'qwery',
     'fastdom',
     'common/modules/user-prefs',
-    'common/modules/experiments/ab',
     'common/modules/ui/images',
     'common/utils/storage',
     'common/utils/ajax',
@@ -33,7 +32,6 @@ define([
     qwery,
     fastdom,
     userPrefs,
-    ab,
     images,
     storage,
     ajax,
@@ -149,22 +147,6 @@ define([
                 });
             });
         }
-
-        //
-        // A/B tests
-        //
-
-        robust.catchErrorsAndLog('ab-tests', function () {
-            if (guardian.isEnhanced) {
-                ab.segmentUser();
-
-                robust.catchErrorsAndLog('ab-tests-run', ab.run);
-                robust.catchErrorsAndLog('ab-tests-registerImpressionEvents', ab.registerImpressionEvents);
-                robust.catchErrorsAndLog('ab-tests-registerCompleteEvents', ab.registerCompleteEvents);
-
-                ab.trackEvent();
-            }
-        });
 
         //
         // Set adtest query if url param declares it.


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

AB tests were bundled into the standard JS but it's rare there is a requirement that an AB test runs before the enhanced JS.

Some implications of this:
- As we don't run enhanced js on ipads, we won't see AB tests there
- AB tests will run later in the day
## What is the value of this and can you measure success?

The standard bundle will be much smaller as the dependency tree of ab tests can be pretty large. It also makes converting our standard JS for testing in a new architecture much easier.

In fact, with the current batch of A/B tests the app.js (bundled standard) is _308kb_, whereas removing the AB tests, the bundle is _89kb_. Obviously these kbs are moved elsewhere but that feels far more reasonable for **critical** JS..

@guardian/dotcom-platform 
