### PR TITLE
Add verification code for https://www.theguardian.com

### DIFF
--- a/applications/app/controllers/SiteVerificationController.scala
+++ b/applications/app/controllers/SiteVerificationController.scala
@@ -9,6 +9,7 @@ class SiteVerificationController extends Controller {
   // A list of accepted accounts.
   private val acceptedGoogleAccounts = List(
     "f2ddac7ca1547968", // Main Guardian channel - https://www.youtube.com/user/TheGuardian
+    "b49f4f3dd93492fb", // HTTPS protocol on www.theguardian.com
     "bbb4e09fa25b64ba"  // Used by:
       // Football channel - https://www.youtube.com/user/GuardianFootball
       // Owen Jones channel - https://www.youtube.com/channel/UCSYCo8uRGF39qDCxF870K5Q


### PR DESCRIPTION
Allows us to verify the HTTPS with Google search console
