### PR TITLE
Do not downgrade link to http anymore

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -54,30 +54,9 @@ trait LinkTo extends Logging {
 
     val url = s"$host/$editionalisedPath"
     url match {
-      case ProdURL() =>
-        if (isHttpOnly(editionalisedPath)) {
-          url.replace("https://", "http://")
-        } else {
-          url.replace("http://", "https://")
-        }
-
+      case ProdURL() => url.replace("http://", "https://")
       case _ => url
     }
-  }
-
-  private def isHttpOnly(path: String) = {
-    // check if the url has _any_ edition prefix (/au/, /us/ ... )
-    // as users can have au edition cookie but be on a us edition url
-
-    val hasEditionPrefix = Edition.all.exists{ edition =>
-      path.startsWith(edition.id.toLowerCase + "/")
-    }
-
-    def sectionPath = path.replaceFirst(s"^(${editionRegex})/", "")
-
-    val pathWithoutEdition = if (hasEditionPrefix) sectionPath else path
-
-    httpSections.exists(pathWithoutEdition.startsWith) || InteractiveUrl.findFirstIn(path).nonEmpty
   }
 
   private def clean(path: String) = path match {

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -22,10 +22,6 @@ trait LinkTo extends Logging {
   private val GuardianUrl = "^(http[s]?://www.theguardian.com)?(/.*)?$".r
   private val RssPath = "^(/.+)?(/rss)".r
   private val TagPattern = """^([\w\d-]+)/([\w\d-]+)$""".r
-  private val InteractiveUrl = """(/(ng-)?interactive/.*)$""".r
-
-  val httpSections: Seq[String] =
-    Seq("politics")
 
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -64,7 +64,7 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
     TestLinkTo("/rss", edition) should be ("http://www.foo.com/uk/rss")
     // not editionalised
     TestLinkTo("/football/rss", edition) should be ("http://www.foo.com/football/rss")
-  }s
+  }
 
   it should "always write interactives as https links" in {
     val interactives = Seq(

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -64,31 +64,17 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
     TestLinkTo("/rss", edition) should be ("http://www.foo.com/uk/rss")
     // not editionalised
     TestLinkTo("/football/rss", edition) should be ("http://www.foo.com/football/rss")
-  }
+  }s
 
-  it should "always write http-only section links as http whether editionalised or not" in {
-    for (ed <- editions) {
-      for (httpSection <- LinkTo.httpSections) {
-        val expectedPath = if(ed.editionalisedSections.contains(httpSection)) s"${ed.id.toLowerCase}/$httpSection" else httpSection
-        withClue(s"http://www.theguardian.com/$httpSection -> http://www.theguardian.com/$expectedPath") {
-          TheGuardianLinkTo(s"http://www.theguardian.com/$httpSection", ed) should be (s"http://www.theguardian.com/$expectedPath")
-        }
-        withClue(s"/$httpSection/foo -> http://www.theguardian.com/$httpSection/foo") {
-          TheGuardianLinkTo(s"/$httpSection/foo", ed) should be (s"http://www.theguardian.com/$httpSection/foo")
-        }
-      }
-    }
-  }
-
-  it should "always write interactives as http links" in {
+  it should "always write interactives as https links" in {
     val interactives = Seq(
       "www.theguardian.com/women-in-leadership/ng-interactive/2014/feb/28/star-women-leading-ladies-behind-scenes-film-interactive",
       "www.theguardian.com/observer-food-monthly-awards/ng-interactive/2016/may/15/observer-food-monthly-awards-your-chance-to-vote",
       "www.theguardian.com/lifeandstyle/ng-interactive/2016/jun/22/will-brexit-take-the-nhs-to-breaking-point-cartoon"
     )
     for (interactive <- interactives) {
-      TheGuardianLinkTo("https://" + interactive) should be ("http://" + interactive)
-      TheGuardianLinkTo("http://" + interactive) should be ("http://" + interactive)
+      TheGuardianLinkTo("https://" + interactive) should be ("https://" + interactive)
+      TheGuardianLinkTo("http://" + interactive) should be ("https://" + interactive)
     }
   }
 


### PR DESCRIPTION
## What does this change?

We currently still downgrade links to http. Because we have now the `HSTS` header this has a limited impact, but this a dust we need to clean.
## What is the value of this and can you measure success?

N/A
## Does this affect other platforms - Amp, Apps, etc?

No
