### PR TITLE
Extend the membership banner A/B test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -29,7 +29,7 @@ trait ABTestSwitches {
   for (edition <- Edition.all) Switch(
     ABTests,
     "ab-membership-engagement-banner-"+edition.id.toLowerCase,
-    "Test effectiveness of header for driving contributions vs membership.",
+    "Test effectiveness of banner for driving membership.",
     owners = Seq(Owner.withGithub("rtyley")),
     safeState = On,
     sellByDate = new LocalDate(2017, 9, 8),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,11 +28,11 @@ trait ABTestSwitches {
 
   for (edition <- Edition.all) Switch(
     ABTests,
-    "ab-membership-engagement-banner-"+edition.id.toLowerCase,
+    "ab-membership-engagement-banner-extended-"+edition.id.toLowerCase,
     "Test effectiveness of banner for driving membership.",
     owners = Seq(Owner.withGithub("rtyley")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 9, 8),
+    sellByDate = new LocalDate(2017, 10, 10),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner.js
@@ -24,15 +24,15 @@ define([
     var EditionTest = function (edition) {
 
         this.edition = edition;
-        this.id = 'MembershipEngagementBanner'+edition[0].toUpperCase() + edition.substr(1);
-        this.start = '2016-09-08';
-        this.expiry = '2016-10-08';
+        this.id = 'MembershipEngagementBannerExtended'+edition[0].toUpperCase() + edition.substr(1);
+        this.start = '2016-10-10';
+        this.expiry = '2017-10-10';
         this.author = 'Roberto Tyley';
-        this.description = 'Show contributions as well as membership messages for the ' + edition + ' edition.';
+        this.description = 'Show membership messages for the ' + edition + ' edition.';
         this.showForSensitive = false;
         this.audience = 1.0;
         this.audienceOffset = 0;
-        this.successMeasure = 'Conversion for contributions';
+        this.successMeasure = 'Conversion for membership';
         this.audienceCriteria = 'All users in the ' + edition + ' edition.';
         this.dataLinkNames = '';
         this.idealOutcome = '';
@@ -111,7 +111,6 @@ define([
     return [
         new EditionTest('uk')
             .addMembershipVariant('coffee', 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.')
-            .addMembershipVariant('voice', 'The Guardian’s voice is needed now more than ever. Support our journalism for just £49 per year.')
         ,new EditionTest('us')
             .addMembershipVariant('fearless', 'We need your help to support our fearless, independent journalism. Become a Guardian US Member for just $49 a year.')
             .addMembershipVariant('accountable', 'We’re accountable to readers, not shareholders. Support The Guardian for $49 a year.')


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

The membership banner A/B test expired on Friday, we need to extend it for a short while while we think of new variants.

I also removed the not-so-well performing UK variant at Jesse's request.

I did not enable the re-display to people who have closed it, as that will happen when the new variants go live.
## What is the value of this and can you measure success?

Increased  conversions / resumption of the existing conversion rate.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No, only web.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

cc @johnduffell @JustinPinner @rtyley 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
