### PR TITLE
Avoid confusion with membership in comment activity

### DIFF
--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -17,7 +17,7 @@
                 @user.dates.accountCreatedDate.map { accountCreatedDate =>
                     <p class="user-profile__last-seen">
                         @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
-                        Member since @accountCreatedDate.toString("d MMM yyyy")
+                        Registered on @accountCreatedDate.toString("d MMM yyyy")
                     </p>
                 }
             </div>

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -58,7 +58,7 @@ class PublicProfileControllerTest extends path.FreeSpec with ShouldMatchers with
         content should include(user.publicFields.displayName.get)
       }
       "then rendered profile should include account creation date" in {
-        content should include("Member since " + user.dates.accountCreatedDate.get.toString("d MMM yyyy"))
+        content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
       }
     }
 
@@ -87,7 +87,7 @@ class PublicProfileControllerTest extends path.FreeSpec with ShouldMatchers with
         content should include(user.publicFields.displayName.get)
       }
       "then rendered profile should include account creation date" in {
-        content should include("Member since " + user.dates.accountCreatedDate.get.toString("d MMM yyyy"))
+        content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
       }
     }
 


### PR DESCRIPTION
## What does this change?

Userhelp is getting requests from confused users who think they are members just because 'Comment Activity' profile says "Member since.."
## Screenshots

![comment_activity_before_after](https://cloud.githubusercontent.com/assets/13835317/19237890/f4f72a9e-8ef6-11e6-809f-dfed154dd931.gif)
## Request for comment

@johnduffell  @andrewfindlay
