### PR TITLE
Show light logo on dark backgrounds, if one is available

### DIFF
--- a/common/app/common/commercial/Branding.scala
+++ b/common/app/common/commercial/Branding.scala
@@ -1,6 +1,7 @@
 package common.commercial
 
-import com.gu.contentapi.client.model.v1.{Sponsorship => ApiSponsorship, SponsorshipTargeting => ApiSponsorshipTargeting, SponsorshipType => ApiSponsorshipType}
+import com.gu.contentapi.client.model.v1.{SponsorshipLogoDimensions, Sponsorship => ApiSponsorship,
+SponsorshipTargeting => ApiSponsorshipTargeting, SponsorshipType => ApiSponsorshipType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import common.Edition
 import org.joda.time.DateTime
@@ -77,6 +78,7 @@ case class Branding(
   sponsorshipType: SponsorshipType,
   sponsorName: String,
   sponsorLogo: Logo,
+  highContrastSponsorLogo: Option[Logo],
   sponsorLink: String,
   aboutThisLink: String,
   targeting: Option[SponsorshipTargeting],
@@ -116,6 +118,10 @@ object Branding {
   implicit val brandingFormat = Json.format[Branding]
 
   def make(sectionOrTagName: String)(sponsorship: ApiSponsorship): Branding = {
+
+    def mkLogo(url: String, dimensions: Option[SponsorshipLogoDimensions]) =
+      Logo(url, dimensions map (d => Dimensions(d.width, d.height)))
+
     Branding(
       sponsorshipType = sponsorship.sponsorshipType match {
         case ApiSponsorshipType.PaidContent => PaidContent
@@ -123,8 +129,10 @@ object Branding {
         case _ => Sponsored
       },
       sponsorName = sponsorship.sponsorName,
-      sponsorLogo =
-        Logo(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions map (d => Dimensions(d.width, d.height))),
+      sponsorLogo = mkLogo(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions),
+      highContrastSponsorLogo = sponsorship.highContrastSponsorLogo map { url =>
+        mkLogo(url, sponsorship.highContrastSponsorLogoDimensions)
+      },
       sponsorLink = sponsorship.sponsorLink,
       aboutThisLink = sponsorship.aboutLink getOrElse "/sponsored-content",
       targeting = sponsorship.targeting map SponsorshipTargeting.make,

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -2,6 +2,9 @@
 @import common.Edition
 @import views.html.fragments.commercial.pageLogo
 
-    @for(branding <- page.branding(Edition(request))) {
-        @pageLogo(branding, content.tags.isInteractive)
-    }
+@for(branding <- page.branding(Edition(request))) {
+    @pageLogo(branding,
+              content.tags.isInteractive,
+              onDarkBackground = content.tags.isAudio || content.tags.isVideo || content.tags.isGallery
+    )
+}

--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -1,20 +1,40 @@
-@(branding: common.commercial.Branding)(implicit request: RequestHeader)
-@import common.commercial.PaidContent
+@(branding: common.commercial.Branding, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
+@import common.commercial.{Logo, PaidContent}
+
+@standardLogo(logo: Logo) = {
+    <img src="@logo.url" alt="@branding.sponsorName" class="badge__logo">
+}
+
+@ampLogo(logo: Logo) = {
+    @logo.dimensions.map { dim =>
+        <amp-img src="@logo.url"
+                 width="@dim.width"
+                 height="@dim.height"
+                 alt="@branding.sponsorName"
+                 class="badge__logo"></amp-img>
+    }.getOrElse {
+        <p>@branding.sponsorName</p>
+    }
+}
 
 @branding.label
 <a class="badge__link" href="@branding.sponsorLink" data-link-name="logo link">
     @if(request.isAmp) {
-        @branding.sponsorLogo.dimensions.map { dim =>
-            <amp-img src="@branding.sponsorLogo.url"
-                     width="@dim.width"
-                     height="@dim.height"
-                     alt="@branding.sponsorName"
-                     class="badge__logo"></amp-img>
-    }.getOrElse {
-        <p>@branding.sponsorName</p>
-    }
-} else {
-    <img src="@branding.sponsorLogo.url" alt="@branding.sponsorName" class="badge__logo">
+        @if(onDarkBackground && branding.highContrastSponsorLogo.nonEmpty) {
+            @for(highContrastLogo <- branding.highContrastSponsorLogo) {
+                @ampLogo(highContrastLogo)
+            }
+        } else {
+            @ampLogo(branding.sponsorLogo)
+        }
+    } else {
+        @if(onDarkBackground && branding.highContrastSponsorLogo.nonEmpty) {
+            @for(highContrastLogo <- branding.highContrastSponsorLogo) {
+                @standardLogo(highContrastLogo)
+            }
+        } else {
+            @standardLogo(branding.sponsorLogo)
+        }
     }
 </a>
 @if(branding.sponsorshipType != PaidContent) {

--- a/common/app/views/fragments/commercial/pageLogo.scala.html
+++ b/common/app/views/fragments/commercial/pageLogo.scala.html
@@ -1,5 +1,8 @@
-@(branding: common.commercial.Branding, isInteractive: Boolean)(implicit request: RequestHeader)
+@(branding: common.commercial.Branding,
+  isInteractive: Boolean,
+  onDarkBackground: Boolean = false
+)(implicit request: RequestHeader)
 
 <div class="badge badge--alt @if(isInteractive){badge--interactive}">
-    @logo(branding)
+    @logo(branding, onDarkBackground)
 </div>

--- a/common/test/common/commercial/BrandingTest.scala
+++ b/common/test/common/commercial/BrandingTest.scala
@@ -13,6 +13,7 @@ class BrandingTest extends FlatSpec with Matchers {
         "https://static.theguardian.com/commercial/sponsor/world/series/united-nations-70-years/logo.png",
         None
       ),
+      highContrastSponsorLogo = None,
       sponsorLink = "http://www.theguardian.com/global-development",
       aboutThisLink = "/sponsored-content",
       targeting = None,

--- a/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
@@ -10,6 +10,7 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfter
     sponsorshipType = Sponsored,
     sponsorName,
     sponsorLogo = Logo("", None),
+    highContrastSponsorLogo = None,
     sponsorLink = "",
     aboutThisLink = "",
     targeting = None,


### PR DESCRIPTION
The tag manager now supports an optional extra logo for use on dark backgrounds.

For example:

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/19238604/3b8d408a-8efa-11e6-851c-3e57e356aece.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/19238578/14e10412-8efa-11e6-932d-1f6ebf412f77.png)

/cc @guardian/labs-beta 

@DiegoVazquezNanini @GHaberis Not sure if apps will need to do something similar?
