### PR TITLE
To avoid an error, encode url first

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import java.text.Normalizer
-import java.net.URI
+import java.net.{URI, URLEncoder}
 import java.util.regex.{Matcher, Pattern}
 import common.{Edition, LinkTo}
 import conf.switches.Switches._
@@ -153,7 +153,8 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
 
   def findContainerFromId(id: String, src: String): Option[ImageElement] = {
     // It is possible that a single data media id can appear multiple times in the elements array.
-    val srcImagePath = new URI(src).getPath()
+    val encodedSrc = URLEncoder.encode(src, "UTF-8")
+    val srcImagePath = new URI(encodedSrc).getPath()
     val imageContainers = article.elements.bodyImages.filter(_.properties.id == id)
 
     // Try to match the container based on both URL and media ID.

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -109,6 +109,12 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
     Item700.bestFor(gifImage) should be (Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif"))
   }
 
+  it should "not convert the URL of the image if it is an SVG" in {
+    ImageServerSwitch.switchOn()
+    val svgImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("https://static.guim.co.uk/ni/1399891635186/Conle-Buildings_1205.svg")),0)))
+    Item700.bestFor(svgImage) should be (Some("https://static.guim.co.uk/ni/1399891635186/Conle-Buildings_1205.svg"))
+  }
+
   it should "not convert the URL of the image if it is not one of ours" in {
     ImageServerSwitch.switchOn()
     val someoneElsesImage = ImageMedia(Seq(ImageAsset.make(asset.copy(file = Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)))


### PR DESCRIPTION
## What does this change?

We had an image in an old article cause an internal server error not too long ago. It was brought up because the article had to be edited by legal. Even though embedding svgs isn't a normal procedure in composer, our code should handle this better.

Even though I can't replicate this error, some googling around seems to suggest that special characters causes this error:

```
java.net.URISyntaxException: Illegal character in path at index 67: https://static.guim.co.uk/ni/1399891635186/Conle-Buildings_1205.svg
at java.net.URI$Parser.fail(URI.java:2848)
at java.net.URI$Parser.checkChars(URI.java:3021)
at java.net.URI$Parser.parseHierarchical(URI.java:3105)
at java.net.URI$Parser.parse(URI.java:3053)
at java.net.URI.<init>(URI.java:588)
```

The advice is to encode the url first. Mind you, since we deal with images better now the chance of this error again is low. 

The bug is described more here: https://trello.com/c/L1d7z4rN/119-embedded-svg-causes-internal-server-error
## What is the value of this and can you measure success?

This only protects against very old articles that are not embedding images correctly
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@guardian/dotcom-platform 
