### PR TITLE
load youtube js only when you need it

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -17,9 +17,11 @@ define([
         window.onYouTubeIframeAPIReady = resolve;
     });
 
-    fastdom.write(function () {
-        loadScript({ id: scriptId, src: scriptSrc });
-    }, this);
+    function loadYoutubeJs() {
+        fastdom.write(function () {
+            loadScript({ id: scriptId, src: scriptSrc });
+        }, this);
+    }
 
     function prepareWrapper(el) {
         var wrapper = document.createElement('div');
@@ -71,6 +73,9 @@ define([
 
     function init(el, handlers) {
         //wrap <iframe/> in a div with almost the same class, id and data- attributes
+
+        loadYoutubeJs();
+
         var wrapper = prepareWrapper(el);
 
         return promise.then(function () {


### PR DESCRIPTION
## What does this change?

to avoid a clash when double loading youtube api (e.g. documentary pages)
## What is the value of this and can you measure success?

Lighter pages as only loading lib when needed, working documentary interactives.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@lps88 @gidsg 
