### PR TITLE
Refactor RequestLogger and add response status custom field

### DIFF
--- a/commercial/app/CommercialLifecycle.scala
+++ b/commercial/app/CommercialLifecycle.scala
@@ -2,6 +2,7 @@ package commercial
 
 import app.LifecycleComponent
 import commercial.feeds._
+import common.LoggingField._
 import common._
 import metrics.MetricUploader
 import model.commercial.jobs.Industries
@@ -9,7 +10,6 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
-
 
 object CommercialMetrics {
   val metrics = MetricUploader("Commercial")

--- a/common/app/common/Logging.scala
+++ b/common/app/common/Logging.scala
@@ -1,5 +1,6 @@
 package common
 
+import common.LoggingField._
 import play.api.Logger
 import org.apache.commons.lang.exception.ExceptionUtils
 import net.logstash.logback.marker.LogstashMarker
@@ -15,6 +16,18 @@ trait Logging {
     log.error(ExceptionUtils.getStackTrace(e))
   }
 
+  def logInfoWithCustomFields(message: String, customFields: List[LogField]): Unit = {
+    log.logger.info(customFieldMarkers(customFields), message)
+  }
+  def logWarningWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
+    log.logger.warn(customFieldMarkers(customFields), message, error)
+  }
+  def logErrorWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
+    log.logger.error(customFieldMarkers(customFields), message, error)
+  }
+}
+
+object LoggingField {
   /*
    * Passing custom fields into the logs
    * Fields are passed as a map (fieldName -> fieldValue)
@@ -34,7 +47,7 @@ trait Logging {
   implicit def tupleToLogFieldDouble(t: (String, Double)) = LogFieldDouble(t._1, t._2)
   implicit def tupleToLogFieldLong(t: (String, Long)) = LogFieldLong(t._1, t._2)
 
-  private def customFieldMarkers(fields: List[LogField]) : LogstashMarker = {
+  def customFieldMarkers(fields: List[LogField]) : LogstashMarker = {
     val fieldsMap = fields.map {
       case LogFieldInt(n, v) => (n, v)
       case LogFieldString(n, v) => (n, v)
@@ -45,15 +58,4 @@ trait Logging {
       .asJava
     appendEntries(fieldsMap)
   }
-
-  def logInfoWithCustomFields(message: String, customFields: List[LogField]): Unit = {
-    log.logger.info(customFieldMarkers(customFields), message)
-  }
-  def logWarningWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
-    log.logger.warn(customFieldMarkers(customFields), message, error)
-  }
-  def logErrorWithCustomFields(message: String, error: Throwable, customFields: List[LogField]): Unit = {
-    log.logger.error(customFieldMarkers(customFields), message, error)
-  }
 }
-

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -3,6 +3,8 @@ package common
 import play.api.mvc.{RequestHeader, Result}
 import common.LoggingField._
 
+import scala.util.Random
+
 case class RequestLoggerFields(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch]) {
 
   private lazy val requestHeadersFields: List[LogField] = {
@@ -36,7 +38,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       List[LogField](
         "req.method" -> r.method,
         "req.url" -> r.uri,
-        "req.id" -> r.id.toString
+        "req.id" -> Random.nextInt(Integer.MAX_VALUE).toString
       )
     }.getOrElse(Nil)
 

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -1,0 +1,47 @@
+package common
+
+import play.api.mvc.RequestHeader
+import common.LoggingField._
+
+case class RequestLogger(rh: RequestHeader)(implicit stopWatch: StopWatch) extends Logging {
+  private lazy val headersFields: List[LogField] = {
+    val whitelistedHeaderNames = Set(
+      "Host",
+      "From",
+      "Origin",
+      "Referer",
+      "User-Agent",
+      "Cache-Control",
+      "If-None-Match",
+      "ETag",
+      "Fastly-Client",
+      "Fastly-Client-IP",
+      "Fastly-FF",
+      "Fastly-SSL",
+      "Fastly-Digest"
+    )
+    val allHeadersFields = rh.headers.toMap.map {
+      case (headerName, headerValues) => (headerName, headerValues.mkString(","))
+    }
+    val whitelistedHeaders = allHeadersFields.filterKeys(whitelistedHeaderNames.contains(_))
+    val guardianSpecificHeaders = allHeadersFields.filterKeys(_.toUpperCase.startsWith("X-GU-"))
+    (whitelistedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
+  }
+  private lazy val customFields: List[LogField] = List(
+    "req.method" -> rh.method,
+    "req.url" -> rh.uri,
+    "req.id" -> rh.id.toString,
+    "req.latency_millis" -> stopWatch.elapsed
+  )
+  private[common] lazy val allFields: List[LogField] = customFields ++ headersFields
+
+  def info(message: String): Unit = {
+    logInfoWithCustomFields(message, allFields)
+  }
+  def warn(message: String, error: Throwable): Unit = {
+    logWarningWithCustomFields(message, error, allFields)
+  }
+  def error(message: String, error: Throwable): Unit = {
+    logErrorWithCustomFields(message, error, allFields)
+  }
+}

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -1,56 +1,12 @@
 package filters
 
-import common.{ExecutionContexts, Logging, StopWatch}
+import common.{ExecutionContexts, Logging, RequestLogger, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
+
 import scala.concurrent.Future
-import scala.util.{Failure, Random, Success}
-import play.api.Logger
+import scala.util.{Failure, Success}
 
 class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
-
-  case class RequestLogger(rh: RequestHeader)(implicit internalLogger: Logger, stopWatch: StopWatch) {
-    private lazy val pseudoId = Random.nextInt(Integer.MAX_VALUE)
-    private lazy val headersFields: List[LogField] = {
-      val whitelistedHeaderNames = Set(
-        "Host",
-        "From",
-        "Origin",
-        "Referer",
-        "User-Agent",
-        "Cache-Control",
-        "If-None-Match",
-        "ETag",
-        "Fastly-Client",
-        "Fastly-Client-IP",
-        "Fastly-FF",
-        "Fastly-SSL",
-        "Fastly-Digest"
-      )
-      val allHeadersFields = rh.headers.toMap.map {
-        case (headerName, headerValues) => (headerName, headerValues.mkString(","))
-      }
-      val whitelistedHeaders = allHeadersFields.filterKeys(whitelistedHeaderNames.contains(_))
-      val guardianSpecificHeaders = allHeadersFields.filterKeys(_.toUpperCase.startsWith("X-GU-"))
-      (whitelistedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
-    }
-    private lazy val customFields: List[LogField] = List(
-      "req.method" -> rh.method,
-      "req.url" -> rh.uri,
-      "req.id" -> pseudoId.toString,
-      "req.latency_millis" -> stopWatch.elapsed
-    )
-    private lazy val allFields = customFields ++ headersFields
-
-    def info(message: String): Unit = {
-      logInfoWithCustomFields(message, allFields)
-    }
-    def warn(message: String, error: Throwable): Unit = {
-      logWarningWithCustomFields(message, error, allFields)
-    }
-    def error(message: String, error: Throwable): Unit = {
-      logErrorWithCustomFields(message, error, allFields)
-    }
-  }
 
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
 

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -10,9 +10,9 @@ class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
 
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
 
-    implicit val stopWatch = new StopWatch
+    val stopWatch = new StopWatch
     val result = next(rh)
-    val requestLogger = RequestLogger(rh)
+    val requestLogger = RequestLogger().withRequestHeaders(rh).withStopWatch(stopWatch)
     result onComplete {
       case Success(response) =>
         response.header.headers.get("X-Accel-Redirect") match {

--- a/common/test/common/RequestLoggerTest.scala
+++ b/common/test/common/RequestLoggerTest.scala
@@ -1,0 +1,32 @@
+package common
+
+import common.LoggingField._
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.test.FakeRequest
+
+class RequestLoggerTest extends FlatSpec with Matchers {
+
+  "RequestLogger" should "log expected fields" in {
+    val headers = List(
+      ("X-GU-header1", "value1"),
+      ("X-GU-header2", "value2"),
+      ("Host", "someHost"),
+      ("Referer", "someReferer"),
+      ("NotSupported", "value")
+    )
+    val req = FakeRequest("GET", "/some/path").withHeaders(headers:_*)
+    implicit val stopWatch = new StopWatch
+    val logger = RequestLogger(req)
+    val expectedFields: List[LogField] = List(
+      "req.method" -> "GET",
+      "req.url" -> "/some/path",
+      "req.header.X-GU-header1" -> "value1",
+      "req.header.X-GU-header2" -> "value2",
+      "req.header.Host" -> "someHost",
+      "req.header.Referer" -> "someReferer"
+    )
+    val notExpectedFields: List[LogField] = List("NotSupported" -> "value")
+    expectedFields.forall(logger.allFields.contains) should be(true)
+    notExpectedFields.forall(logger.allFields.contains) should be(false)
+  }
+}

--- a/common/test/common/RequestLoggerTest.scala
+++ b/common/test/common/RequestLoggerTest.scala
@@ -15,8 +15,7 @@ class RequestLoggerTest extends FlatSpec with Matchers {
       ("NotSupported", "value")
     )
     val req = FakeRequest("GET", "/some/path").withHeaders(headers:_*)
-    implicit val stopWatch = new StopWatch
-    val logger = RequestLogger(req)
+    val logger = RequestLogger().withRequestHeaders(req)
     val expectedFields: List[LogField] = List(
       "req.method" -> "GET",
       "req.url" -> "/some/path",

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -1,6 +1,7 @@
 package discussion.util
 
-import play.api.libs.ws.{WS, WSClient, WSResponse}
+import common.LoggingField.LogField
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.libs.json.{JsValue, Json}
 import common.{ExecutionContexts, Logging, StopWatch}
 


### PR DESCRIPTION
## What does this change?

Refactoring RequestLogger and adding tests.
The goal was to be able to log response info rather than request info only
## What is the value of this and can you measure success?

Being able to log response status so we can graph in kibana per status. Right now the status code is only part of the message, which we cannot parse or tokenize.

I want to use this new status field to investigate redirects loops (301 to same url) that have been recently reported  

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Request for comment

@jfsoul @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
