### PR TITLE
fixed video page bug with explore and immersive

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -57,7 +57,7 @@
                     @fragments.immersiveGalleryMainMedia(page)
                 </div>
             }
-            case page: model.ContentPage if (page.item.content.isExplore && !page.item.content.tags.isInteractive) => {
+            case page: model.ContentPage if (page.item.content.isExplore && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@RenderClasses(Map(
                     ("immersive-header-container", page.item.fields.main.nonEmpty),
                     ("immersive-header-container--explore-series", page.item.content.tags.isExploreSeries),
@@ -68,7 +68,7 @@
                     @fragments.exploreSeries(page)
                 </div>
             }
-            case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive) => {
+            case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
                     @headerAndTopAds(showAdverts, edition)
 


### PR DESCRIPTION
Fixing this problem. ->

![picture 127](https://cloud.githubusercontent.com/assets/11950919/19265396/e9b5900c-8f9c-11e6-8f52-a3e5b1f28f41.png)

Immersive also needs to otherwise it trys to use the immersive template second. 

@SiAdcock how does this look?
