### PR TITLE
add geo locaiton end point

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -101,6 +101,8 @@ GET            /most-read/*path.json                                            
 GET            /most-read-geo.json                                                                                               controllers.MostPopularController.renderPopularGeo()
 GET            /most-read-day.json                                                                                               controllers.MostPopularController.renderPopularDay(countryCode)
 
+GET            /user-geo-location.json                                                                                           controllers.GeoLocationController.getGeoLocation()
+
 GET            /top-stories.json                                                                                                 controllers.TopStoriesController.renderTopStories()
 GET            /top-stories/trails.json                                                                                          controllers.TopStoriesController.renderTrails()
 GET            /related/*path.json                                                                                               controllers.RelatedController.render(path)

--- a/onward/app/controllers/GeoLocationController.scala
+++ b/onward/app/controllers/GeoLocationController.scala
@@ -1,0 +1,20 @@
+package controllers
+
+import common.JsonComponent
+import model.{Cached}
+import play.api.mvc.{Action, Controller}
+import scala.concurrent.duration._
+
+class GeoLocationController extends Controller {
+
+
+  def getGeoLocation() = Action { implicit request =>
+    val headers = request.headers.toSimpleMap
+    val countryCode = headers.getOrElse("X-GU-GeoLocation","country:row").replace("country:","")
+    Cached(4*7.days) {
+      JsonComponent(
+        "country" -> countryCode
+      )
+    }
+  }
+}

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -44,4 +44,5 @@ trait OnwardControllers {
   lazy val seriesController = wire[SeriesController]
   lazy val stocksController = wire[StocksController]
   lazy val techFeedbackController = wire[TechFeedbackController]
+  lazy val geoLocationController = wire[GeoLocationController]
 }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -29,6 +29,8 @@ GET        /most-read/*path.json                      controllers.MostPopularCon
 GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeo()
 GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDay(countryCode)
 
+GET         /user-geo-location.json                   controllers.GeoLocationController.getGeoLocation()
+
 GET        /top-stories.json                          controllers.TopStoriesController.renderTopStories()
 GET        /top-stories/trails.json                   controllers.TopStoriesController.renderTrails()
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

This PR adds an endpoint to the onward project which returns the geo location of whoever calls it. It is needed for filtering contributions ads to specific countries, as it has been decided that filtering based on edition is not good enough for requirements. 
## What is the value of this and can you measure success?

It means that when, for example, we show a targeted ad to the US, we can be sure that everyone seeing that ad is from the US. A not tiny amount of people reading the US edition are not from the US, and also a not tiny amount of people from the US do not read the US edition, so by targeting on geo-location we can reach more of the right people with our ads. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![geo](https://cloud.githubusercontent.com/assets/2844554/19266478/923bca30-8fa1-11e6-8bae-e83a203f5217.png)
## Request for comment

@dominickendrick @stephanfowler @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
