### PR TITLE
Include server side tests whose name starts with commercial

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -95,7 +95,8 @@ define([
             });
 
             forIn(keys(config.tests), function (n) {
-                if (n.toLowerCase().match(/^cm/)) {
+                if (n.toLowerCase().match(/^cm/) ||
+                    n.toLowerCase().match(/^commercial/)) {
                     abParams.push(n);
                 }
             });


### PR DESCRIPTION
Adding another clause to include tests that affect commercial. This will allow us to read these test participations from our viewability report 
