### PR TITLE
Boot: remove preferences test

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -73,7 +73,7 @@ define([
                 .then(function (boot) {
                     boot();
                 });
-        } else Promise.resolve();
+        }
     };
 
     domReadyPromise

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -41,6 +41,10 @@ define([
     };
 
     var bootCommercial = function () {
+        if (!config.switches.commercial) {
+            return;
+        }
+
         if (config.page.isDev) {
             guardian.adBlockers.onDetect.push(function (isInUse) {
                 var needsMessage = isInUse && window.console && window.console.warn;
@@ -53,15 +57,13 @@ define([
 
         return promiseRequire(['raven'])
             .then(function (raven) {
-                if (config.switches.commercial) {
-                    return promiseRequire(['bootstraps/commercial'])
-                        .then(raven.wrap(
-                            { tags: { feature: 'commercial' } },
-                            function (commercial) {
-                                commercial.init();
-                            }
-                        ));
-                }
+                return promiseRequire(['bootstraps/commercial'])
+                    .then(raven.wrap(
+                        { tags: { feature: 'commercial' } },
+                        function (commercial) {
+                            commercial.init();
+                        }
+                    ));
             });
     };
 

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -53,10 +53,7 @@ define([
 
         return promiseRequire(['raven'])
             .then(function (raven) {
-                // Preference pages are served via HTTPS for service worker support.
-                // These pages must not have mixed (HTTP/HTTPS) content, so
-                // we disable ads (until the day comes when all ads are HTTPS).
-                if (config.switches.commercial && !config.page.isPreferencesPage) {
+                if (config.switches.commercial) {
                     return promiseRequire(['bootstraps/commercial'])
                         .then(raven.wrap(
                             { tags: { feature: 'commercial' } },


### PR DESCRIPTION
All ads are https-compliant now, so there is no need for that test anymore. Also, minor refactoring.

cc @gtrufitt 
