### PR TITLE
fail gracefully if `isHosted` property doesn't exist

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -74,7 +74,7 @@
         ga('@{trackerName}.set', 'dimension21', getQueryParam('INTCMP')); @* internal campaign code *@
         ga('@{trackerName}.set', 'dimension22', getQueryParam('CMP_BUNIT')); @* campaign business unit*@
         ga('@{trackerName}.set', 'dimension23', getQueryParam('CMP_TU')); @* campaign team*@
-        ga('@{trackerName}.set', 'dimension26', guardian.config.page.isHosted.toString());
+        ga('@{trackerName}.set', 'dimension26', (!!guardian.config.page.isHosted).toString());
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Relates to https://github.com/guardian/frontend/pull/14632

`isHosted` doesn't seem to be set on interactive pages, this fixes the `TypeError: Cannot read property 'toString' of undefined` being thrown when `isHosted` is not on the page config e.g. here - https://www.theguardian.com/environment/ng-interactive/2015/nov/26/the-mekong-river-stories-from-the-heart-of-the-climate-crisis-interactive.
## What is the value of this and can you measure success?

Fewer JS errors.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

n/a
## Request for comment

@gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
