### PR TITLE
Add missing defaultStacks and remove unused 'apps'

### DIFF
--- a/static/deploy.json
+++ b/static/deploy.json
@@ -1,8 +1,8 @@
 {
+    "defaultStacks": ["frontend"],
     "packages":{
         "frontend-static":{
             "type":"aws-s3",
-            "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-static",
                 "cacheControl":"public, max-age=315360000"
@@ -10,7 +10,6 @@
         },
         "frontend-abtests":{
             "type":"aws-s3",
-            "apps":[ "aws-s3" ],
             "data":{
                 "bucket":"aws-frontend-abtests",
                 "cacheControl":"public, max-age=300"

--- a/static/deploy.json
+++ b/static/deploy.json
@@ -7,24 +7,14 @@
                 "bucket":"aws-frontend-static",
                 "cacheControl":"public, max-age=315360000"
             }
-        },
-        "frontend-abtests":{
-            "type":"aws-s3",
-            "data":{
-                "bucket":"aws-frontend-abtests",
-                "cacheControl":"public, max-age=300"
-            }
         }
     },
     "recipes":{
         "default":{
-            "depends" : ["abTestsFileUpload", "staticFilesUpload"]
+            "depends" : ["staticFilesUpload"]
         },
         "staticFilesUpload":{
             "actionsBeforeApp": ["frontend-static.uploadStaticFiles"]
-        },
-        "abTestsFileUpload":{
-            "actionsBeforeApp": ["frontend-abtests.uploadStaticFiles"]
         }
     }
 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Add missing defaultStacks
Remove unused 'apps' field
Remove unused `frontend-abtests`
## What is the value of this and can you measure success?

No more deprecation warning in riff-raff

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Request for comment

@jfsoul @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
