### PR TITLE
Extend test for 4 weeks

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -20,9 +20,9 @@ trait ABTestSwitches {
     ABTests,
     "ab-discussion-promote-comments",
     "Promote the comments with a sticky bottom banner",
-    owners = Seq(Owner.withGithub("piuccio")),
+    owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 10, 12),
+    sellByDate = new LocalDate(2016, 11, 9),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Extends sell-by date for the `ab-discussion-promote-comments` A/B test.

For more info see original PR: https://github.com/guardian/frontend/pull/14410.
