### PR TITLE
Embeds now display in the explore template

### DIFF
--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -45,7 +45,7 @@
                 @if(page.item.elements.hasMainVideo) {
                   @fragments.immersiveVideo(page)
                 }
-                @if(hasMainMedia && !page.item.elements.hasMainVideo) {
+                @if(hasMainMedia && !hasVideo) {
                     <div class="immersive-main-media__media__loading">
                         <div class="immersive-main-media__loading-animation is-updating"></div>
                         <span class="u-h">Loading header</span>
@@ -54,7 +54,7 @@
                 }
             }
         </div>
-        @if(!page.item.elements.hasMainVideo && !page.item.elements.hasMainEmbed){
+        @if(!page.item.elements.hasMainVideo){
           <div class="immersive-main-media__image-overlay"></div>
         }
         <div class="series-identity-explore">

--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -45,7 +45,7 @@
                 @if(page.item.elements.hasMainVideo) {
                   @fragments.immersiveVideo(page)
                 }
-                @if(page.item.elements.hasMainEmbed) {
+                @if(hasMainMedia && !page.item.elements.hasMainVideo) {
                     <div class="immersive-main-media__media__loading">
                         <div class="immersive-main-media__loading-animation is-updating"></div>
                         <span class="u-h">Loading header</span>
@@ -54,7 +54,7 @@
                 }
             }
         </div>
-        @if(!page.item.elements.hasMainVideo){
+        @if(!page.item.elements.hasMainVideo && !page.item.elements.hasMainEmbed){
           <div class="immersive-main-media__image-overlay"></div>
         }
         <div class="series-identity-explore">


### PR DESCRIPTION
**Before**
![picture 133](https://cloud.githubusercontent.com/assets/11950919/19314291/8d3d53dc-9091-11e6-878f-6d2119e99de1.png)

**After**
![picture 132](https://cloud.githubusercontent.com/assets/11950919/19314297/9174ff9a-9091-11e6-8bca-f74edb1f48bb.png)
