### PR TITLE
Remove high merch targeting check

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
@@ -9,7 +9,7 @@
 
     @fragments.onwardPlaceholder(isAdvertisementFeature = false)
 
-    @if(!crosswordPage.content.content.shouldHideAdverts && crosswordPage.content.commercial.needsHighMerchandisingSlot(Edition(request))) {
+    @if(!crosswordPage.content.content.shouldHideAdverts) {
         <div class="fc-container fc-container--commercial">
             @fragments.commercial.commercialComponentHigh(false)
         </div>

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -9,7 +9,6 @@ trait HighMerchandiseComponentAgent {
   protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem]
 
   def isTargetedByHighMerch(adUnitSuffix:String, tags: Seq[Tag],edition:Edition, pagePath:String) = {
-    highMerchandisingComponentSwitch.isSwitchedOff ||
     targetedHighMerchandisingLineItems.exists(_.matchesPageTargeting(adUnitSuffix, tags, edition,pagePath))
   }
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -236,16 +236,6 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val highMerchandisingComponentSwitch = Switch(
-    SwitchGroup.Commercial,
-    "optimise-high-merchandising",
-    "If on, server will check tags for high-merchandising target before rendering high-merch slot.",
-    owners = Seq(Owner.withGithub("Calum Campbell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016,10,12),
-    exposeClientSide = false
-  )
-
   val SponsoredSwitch = Switch(
     group = CommercialLabs,
     "sponsored",

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -57,12 +57,7 @@ final case class Commercial(
   metadata: MetaData,
   isInappropriateForSponsorship: Boolean,
   hasInlineMerchandise: Boolean
-) {
-
-  def needsHighMerchandisingSlot(edition: Edition): Boolean = {
-    DfpAgent.isTargetedByHighMerch(metadata.adUnitSuffix, tags.tags, edition, metadata.url)
-  }
-}
+) 
 
 /**
  * MetaData represents a page on the site, whether facia or content

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -17,11 +17,7 @@
     } {
         @fragments.mostPopularPlaceholder(content.metadata.sectionId)
     } {
-        @if(content.commercial.needsHighMerchandisingSlot(Edition(request))) {
-            <div class="fc-container fc-container--commercial">
-                @fragments.commercial.commercialComponentHigh(isPaidContent)
-            </div>
-        }
+        <div class="fc-container fc-container--commercial">@fragments.commercial.commercialComponentHigh(isPaidContent)</div>
     } {
         <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>
     } {


### PR DESCRIPTION
## What does this change?
- Remove code and switch for server side check of high merchandising slot.
- Ultimately it seems too difficult to identify wether or not the page will require a high merchandising slot or not server side.
- There are too many possible tag combinations for high merchandising slots to reliably decide wether or not to render a high-merchandising slot.  
- For example there may be a high merch line item that targets US edition and a certain URL, you would need to add this case to the checking rules which would not be possible for all possible cases. Or, you could set wide check and render a slot on nearly all pages and hope to not miss any cases and cause a high relevance merchandising slot not to render. This would not reduce the problem much and risk not rendering high merch slots when they should be. 
- Related to v.old PR https://github.com/guardian/frontend/pull/12795
## What is the value of this and can you measure success?
- Remove redundant code!
## Request for comment

@rich-nguyen @guardian/commercial-dev 
