### PR TITLE
Optimise email images

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -126,9 +126,12 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
   override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
 }
 
-object EmailImage extends Profile(width = Some(580), autoFormat = false)
+object EmailImage extends Profile(width = Some(580), autoFormat = false) {
+  override val qualityparam = "q=30"
+}
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
   override val fitParam = "fit=crop"
+  override val qualityparam = "q=30"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=center"
   val blendImageParam = s"blend64=${Base64.getUrlEncoder.encodeToString(EmailHelpers.Images.play.getBytes)}"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -126,8 +126,8 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
   override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
 }
 
-object EmailImage extends Profile(width = Some(640), autoFormat = false)
-object EmailVideoImage extends Profile(width = Some(640), autoFormat = false) {
+object EmailImage extends Profile(width = Some(580), autoFormat = false)
+object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
   override val fitParam = "fit=crop"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=center"


### PR DESCRIPTION
Implements some of @paperboyo's excellent suggestions in #14423 for reducing image size for email endpoints.
## What is the value of this and can you measure success?

For the [latest Weekend Reading email](https://www.theguardian.com/membership/live/2016/oct/08/weekend-reading-mays-britain-scary-clowns-and-cheese-scones/email), which is particularly image-heavy:

```
                    before  after   reduction
                    54.9KB  24.2KB  55.92%
                    33.9KB  16.4KB  51.62%
                    50.1KB  24.7KB  50.70%
                    60.7KB  27.5KB  54.70%
                    42.KB   20.2KB  51.90%
                    29.7KB  14.8KB  50.17%

all images          430.KB  217.KB  49.53%
total pageweight    467.KB  254.KB  45.61%
```
## Screenshots
### Before

![picture 312](https://cloud.githubusercontent.com/assets/5122968/19320488/70cc4830-90a9-11e6-9d85-63e7b7d9e44c.png)
### After

![picture 311](https://cloud.githubusercontent.com/assets/5122968/19320496/77107b3a-90a9-11e6-9c1b-99e51b6921e8.png)
## Request for comment

@desbo 
cc @davidfurey 
