### PR TITLE
Add config override how-to doc 📄 

### DIFF
--- a/docs/03-dev-howtos/15-override-default-configuration.md
+++ b/docs/03-dev-howtos/15-override-default-configuration.md
@@ -1,0 +1,27 @@
+# Overriding default configuration
+
+Tired of pointing your `facia.stage` at `CODE`?  Have you ever longed to change the `content.api.host` you use for development?  Need to change some switches in `DEV`? Look no further!
+
+## How-to
+
+1. Create a file at `~/.gu/frontend.conf`
+2. Add your configuration with the following syntax:
+
+        devOverrides {
+          key1.name=value1
+          key2.name=value2
+        }
+
+    E.g.
+
+        devOverrides {
+          switches.key=DEV/config/switches-yournamehere.properties
+          facia.stage=CODE
+        }
+
+3. Restart the app you're working on
+
+## Notes
+
+* You can see all configuration keys by looking at the [GuardianConfiguration class](https://github.com/guardian/frontend/blob/master/common/app/common/configuration.scala#L125)
+* Downloading the default configuration from s3 is not recommended as it contains secrets that you shouldn't keep locally

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 - [How to build a docker image for the dev environment](03-dev-howtos/12-Build-dev-docker-image.md)
 - [Update configuration in s3](03-dev-howtos/13-Update-configuration-in-s3.md)
 - [Implement Google Analytics](03-dev-howtos/14-implement-google-analytics.md)
+- [Overriding default configuration](03-dev-howtos/15-override-default-configuration.md)
 
 ##[Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)


### PR DESCRIPTION
## What does this change?

Adds documentation for how to override the default configuration for development.  I don't believe this exists yet.  There might be more to say on the subject, but this is the basics.
## What is the value of this and can you measure success?

At the very least, I will be helping myself in case I forget how to do this again.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
