### PR TITLE
Add another variant to the new header test

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -40,6 +40,42 @@ object NewNavigation {
     }
   }
 
+  case object PrimaryLinks extends EditionalisedNavigationSection {
+    val name = ""
+
+    val uk = List(
+      NavLink("news", "/uk-news"),
+      NavLink("opinion", "/uk/commentisfree"),
+      NavLink("sport", "/uk/sport"),
+      NavLink("arts", "/uk/culture"),
+      NavLink("life", "/uk/lifeandstyle")
+    )
+
+    val au = List(
+      NavLink("news", "/australia-news"),
+      NavLink("opinion", "/au/commentisfree"),
+      NavLink("sport", "/au/sport"),
+      NavLink("arts", "/au/culture"),
+      NavLink("life", "/au/lifeandstyle")
+    )
+
+    val us = List(
+      NavLink("news", "/us-news"),
+      NavLink("opinion", "/us/commentisfree"),
+      NavLink("sport", "/us/sport"),
+      NavLink("arts", "/us/culture"),
+      NavLink("life", "/us/lifeandstyle")
+    )
+
+    val int = List(
+      NavLink("news", "/world"),
+      NavLink("opinion", "/uk/commentisfree"),
+      NavLink("sport", "/uk/sport"),
+      NavLink("arts", "/uk/culture"),
+      NavLink("life", "/uk/lifeandstyle")
+    )
+  }
+
   case object News extends EditionalisedNavigationSection {
     val name = "news"
 

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -44,7 +44,7 @@ object NewNavigation {
     val name = ""
 
     val uk = List(
-      NavLink("news", "/uk-news"),
+      NavLink("news", "/uk"),
       NavLink("opinion", "/uk/commentisfree"),
       NavLink("sport", "/uk/sport"),
       NavLink("arts", "/uk/culture"),
@@ -52,7 +52,7 @@ object NewNavigation {
     )
 
     val au = List(
-      NavLink("news", "/australia-news"),
+      NavLink("news", "/au"),
       NavLink("opinion", "/au/commentisfree"),
       NavLink("sport", "/au/sport"),
       NavLink("arts", "/au/culture"),
@@ -60,7 +60,7 @@ object NewNavigation {
     )
 
     val us = List(
-      NavLink("news", "/us-news"),
+      NavLink("news", "/us"),
       NavLink("opinion", "/us/commentisfree"),
       NavLink("sport", "/us/sport"),
       NavLink("arts", "/us/culture"),
@@ -68,7 +68,7 @@ object NewNavigation {
     )
 
     val int = List(
-      NavLink("news", "/world"),
+      NavLink("news", "/international"),
       NavLink("opinion", "/uk/commentisfree"),
       NavLink("sport", "/uk/sport"),
       NavLink("arts", "/uk/culture"),

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -27,6 +27,17 @@ object ABNewHeaderVariant extends TestDefinition(
   }
 }
 
+object ABNewHeaderVariantTwo extends TestDefinition(
+  name = "ab-new-header-variant",
+  description = "users in this test will see the new header",
+  owners = Seq(Owner.withGithub("natalialkb")),
+  sellByDate = new LocalDate(2016, 12, 8) // Thursday
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-header").contains("varianttwo")
+  }
+}
+
 object ABNewHeaderControl extends TestDefinition(
   name = "ab-new-header-control",
   description = "control for the new header test",

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -18,7 +18,7 @@ import conf.switches.Switches.ServerSideTests
 
 object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
-  description = "users in this test will see the new header",
+  description = "users in this test will see the new header first variant",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
 ) {
@@ -28,8 +28,8 @@ object ABNewHeaderVariant extends TestDefinition(
 }
 
 object ABNewHeaderVariantTwo extends TestDefinition(
-  name = "ab-new-header-variant",
-  description = "users in this test will see the new header",
+  name = "ab-new-header-variant-two",
+  description = "users in this test will see the new header second variant",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
 ) {

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.ContainerModel
-@import common.{NewNavigation, LinkTo}
+@import common.{NewNavigation, LinkTo, Edition, NavLink}
 @import layout.MetaDataHeader
 @import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, Video}
 @import views.html.commercial.containers.paidContainer
@@ -91,14 +91,39 @@
 
                         <ul class="tertiary-navigation mobile-only">
 
-                            @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { tertiaryLink =>
+                            @* TODO: we should make sure that sport, culture, and life have tertiary links *@
+                            @* TODO: should this only happen on the second variant?*@
+                            @defining(Edition(request)) { edition: Edition =>
+                                @println(edition.networkFrontId)
 
-                                <li class="tertiary-navigation__item">
-                                    <a class="tertiary-navigation__link" href="@LinkTo(tertiaryLink.url)" data-link-name="nav2 : tertiary : @tertiaryLink.name">
-                                        <span class="tertiary-navigation__text">@Html(tertiaryLink.name)</span>
-                                        <i class="tertiary-navigation__icon rounded-icon"></i>
-                                    </a>
-                                </li>
+                                @id match {
+                                    case news if id == edition.networkFrontId => {
+                                        @NewNavigation.News.getEditionalisedNavLinks(edition).drop(1).map(link => tertiaryLink(link))
+                                    }
+                                    case opinion if id.contains("commentisfree") => {
+                                        @NewNavigation.Opinion.getEditionalisedNavLinks(edition).drop(1).map(link => tertiaryLink(link))
+                                    }
+                                    case sport if id.contains("sport") => {
+                                        @NewNavigation.Sport.getEditionalisedNavLinks(edition).drop(1).map(link => tertiaryLink(link))
+                                    }
+                                    case arts if id.contains("culture") => {
+                                        @NewNavigation.Arts.getEditionalisedNavLinks(edition).drop(1).map(link => tertiaryLink(link))
+                                    }
+                                    case life if id.contains("lifestyle") => {
+                                        @NewNavigation.Life.getEditionalisedNavLinks(edition).drop(1).map(link => tertiaryLink(link))
+                                    }
+                                    case _ => {
+                                        @NewNavigation.TertiaryNav.getTertiaryNavLinks(id).map { tertiaryLink =>
+
+                                            <li class="tertiary-navigation__item">
+                                                <a class="tertiary-navigation__link" href="@LinkTo(tertiaryLink.url)" data-link-name="nav2 : tertiary : @tertiaryLink.name">
+                                                    <span class="tertiary-navigation__text">@Html(tertiaryLink.name)</span>
+                                                    <i class="tertiary-navigation__icon rounded-icon"></i>
+                                                </a>
+                                            </li>
+                                        }
+                                    }
+                                }
                             }
                         </ul>
 
@@ -107,4 +132,13 @@
             </section>
         }
     }
+}
+
+@tertiaryLink(link: NavLink) = {
+    <li class="tertiary-navigation__item">
+        <a class="tertiary-navigation__link" href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @link.name">
+            <span class="tertiary-navigation__text">@Html(link.name)</span>
+            <i class="tertiary-navigation__icon rounded-icon"></i>
+        </a>
+    </li>
 }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -94,7 +94,6 @@
                             @* TODO: we should make sure that sport, culture, and life have tertiary links *@
                             @* TODO: should this only happen on the second variant?*@
                             @defining(Edition(request)) { edition: Edition =>
-                                @println(edition.networkFrontId)
 
                                 @id match {
                                     case news if id == edition.networkFrontId => {

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -87,7 +87,7 @@
                     frontId.getOrElse(pageId)
                     )) { case (isFirstContainer, id) =>
 
-                    @if(mvt.ABNewHeaderVariant.isParticipating && isFirstContainer) {
+                    @if((mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) && isFirstContainer) {
 
                         <ul class="tertiary-navigation mobile-only">
 

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}">
+                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,11 +4,11 @@
 @import conf.Configuration
 @import conf.switches.Switches._
 
-@if(mvt.ABNewHeaderVariant.isParticipating) {
+@if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {
     @fragments.newHeader()
 }
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -25,7 +25,7 @@
     }
 
     @* TODO: if this feature is proven successful, this should be refactored to remove the logic from the template as much as possible *@
-    @if(mvt.ABNewHeaderVariant.isParticipating) {
+    @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {
         <div class="mobile-only">
             @defining(Edition(request).navigation) { navigation =>
 
@@ -62,7 +62,7 @@
         </div>
     }
 
-    <div class="@if(mvt.ABNewHeaderVariant.isParticipating) {hide-on-mobile}">
+    <div class="@if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}">
 
         @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
             <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,9 +1,10 @@
+@import common.NavLink
 @()(implicit request: RequestHeader)
 
 @import conf.Atomise
-@import common.{LinkTo, NewNavigation}
+@import common.{LinkTo, NewNavigation, Edition}
 
-@primaryLinks(sectionName: String) = {
+@primaryLinksv1(sectionName: String) = {
     <label for="main-menu-toggle" tabindex="0"
         class="new-header__nav__link js-open-section-in-menu"
         aria-controls="primary-list-@sectionName"
@@ -11,6 +12,15 @@
             @sectionName
     </label>
 }
+
+@primaryLinksv2(link: NavLink) = {
+    <a class="new-header__nav__link js-open-section-in-menu"
+        href="@LinkTo(link.url)"
+        data-link-name="nav2 : primary : @link.name">
+            @link.name
+    </a>
+}
+
 
 <header class="@Atomise("New-header")" role="banner">
     <div class="new-header__inner gs-container">
@@ -22,8 +32,14 @@
         @fragments.nav.editionPicker()
 
         <nav class="new-header__nav" data-component="nav2">
-            @NewNavigation.topLevelSections.map { section =>
-                @primaryLinks(section.name)
+            @if(mvt.ABNewHeaderVariant.isParticipating) {
+                @NewNavigation.topLevelSections.map { section =>
+                    @primaryLinksv1(section.name)
+                }
+            } else {
+                @NewNavigation.PrimaryLinks.getEditionalisedNavLinks(Edition(request)).map { link =>
+                    @primaryLinksv2(link)
+                }
             }
             <label for="main-menu-toggle"
                 class="new-header__nav__menu-button js-change-link"

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -40,7 +40,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
-            ("has-new-header", mvt.ABNewHeaderVariant.isParticipating),
+            ("has-new-header", mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating),
             ("is-immersive", getContent(page).exists(_.content.isImmersive)),
             ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -717,7 +717,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
     flex-direction: row;
     flex-flow: row wrap;
     justify-content: space-between;
-    margin-top: -$gs-baseline;
     margin-bottom: -$gs-baseline/2;
     margin-left: $gs-gutter / 2;
     margin-right: $gs-gutter / 2;


### PR DESCRIPTION
## What does this change?

Based on some of the preliminary data analysis we have done we have decided to add another variant to the test.

This variant will have the 5 primary links go straight to a front.
![image](https://cloud.githubusercontent.com/assets/8774970/19352322/5a7c482e-9157-11e6-8e35-9f8dc63fa756.png)

And on each front of the main fronts for both variants we should see the corresponding menu as tertiary links. For example, on the main network front you would now see:

![image](https://cloud.githubusercontent.com/assets/8774970/19352387/94d42fd2-9157-11e6-9357-084d8ed784c5.png)

Feel free to chat to myself or @stephanfowler if you want to see some of the data!

Please note that no users will see this variant until a fastly change is made.
## What is the value of this and can you measure success?

We can gather even more data to help us make a decision about the new header
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@stephanfowler @zeftilldeath @SiAdcock
