### PR TITLE
Collapse ad on click-throughs even with the video CTA

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
@@ -53,7 +53,7 @@ define([
                 fastdom.write(function () { open(isClosed); });
             });
 
-            bean.on($adSlot[0], 'click', '.creative__cta', function () {
+            bean.on($adSlot[0], 'click', '.video-container__cta, .creative__cta', function () {
                 fastdom.write(function () { open(false); });
             });
 


### PR DESCRIPTION
When the user clicks through a Fabric video expanding, the ad should collapse. This is the case when a click happens on the main button (`.creative__cta`), but there's another which should also trigger the behaviour: `.video-container__cta`
