### PR TITLE
missed this in the labyrinth

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
     /**
      * Validate tasks
      */
-    grunt.registerTask('validate:css', ['compile:images', 'sass:compile']);
+    grunt.registerTask('validate:css', ['shell:validateCCS']);
     grunt.registerTask('validate:sass', ['sasslint']);
     grunt.registerTask('validate:js', function (app) {
         var target = (app) ? ':' + app : '';

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -38,6 +38,10 @@ module.exports = function () {
 
         atomiseCSS: {
             command: 'make atomise-css'
+        },
+
+        validateCCS: {
+            command: 'make compile-css'
         }
     };
 };


### PR DESCRIPTION
## What does this change?

fixes an oversight in #14658
## What is the value of this and can you measure success?

temporary work around for `grunt validate:css`
## Does this affect other platforms - Amp, Apps, etc?

no
## Request for comment

@NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

temporay workaround
