### PR TITLE
remove unused DOM changes from youtube JS

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -25,14 +25,8 @@ define([
 
     function prepareWrapper(el) {
         var wrapper = document.createElement('div');
-        var attrs = el.attributes;
+        wrapper.className += el.getAttribute('class');
 
-        forEach(attrs, function (attribute) {
-            //parent div should have the same class names
-            if (attribute.name === 'class') {
-                wrapper.className += attribute.value;
-            }
-        });
 
         fastdom.write(function () {
             el.parentNode.insertBefore(wrapper, el);

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -23,7 +23,7 @@ define([
 
     function prepareWrapper(el) {
         var wrapper = document.createElement('div');
-        wrapper.className += el.getAttribute('class');
+        wrapper.className += el.className;
 
 
         fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -31,13 +31,6 @@ define([
             //parent div should have the same class names
             if (attribute.name === 'class') {
                 wrapper.className += attribute.value;
-            } else if (attribute.name === 'id') {
-                //parent div should have almost the same id (without the `_iframe` part)
-                wrapper.id = attribute.value;
-                el.id += '_iframe';
-            } else if (attribute.name.substring(0, 5) === 'data-') {
-                //copy all of the data- attributes
-                wrapper.setAttribute(attribute.name, attribute.value);
             }
         });
 

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -59,7 +59,7 @@ define([
     }
 
     function init(el, handlers) {
-        //wrap <iframe/> in a div with almost the same class, id and data- attributes
+        //wrap <iframe/> in a div with dynamically updating class attributes
 
         loadYoutubeJs();
 

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -2,14 +2,12 @@ define([
     'fastdom',
     'Promise',
     'common/utils/$',
-    'common/utils/load-script',
-    'lodash/collections/forEach'
+    'common/utils/load-script'
 ], function (
     fastdom,
     Promise,
     $,
-    loadScript,
-    forEach
+    loadScript
 ) {
     var scriptId = 'youtube-player';
     var scriptSrc = 'https://www.youtube.com/player_api';


### PR DESCRIPTION
## What does this change?

Remove unused DOM mutations from youtube JS.

Note this JS is currently only used by commercial video pages e.g. https://www.theguardian.com/advertiser-content/explore-canada-food-busker-in-canada/savouring-ottawa
## What is the value of this and can you measure success?

Remove unused code

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

N/A
## Request for comment

CC @lps88 @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
