### PR TITLE
A 24 hour AB test of immediate display of engagement banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,13 +26,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  for (edition <- Edition.all) Switch(
+  Switch(
     ABTests,
-    "ab-membership-engagement-banner-extended-"+edition.id.toLowerCase,
-    "Test effectiveness of banner for driving membership.",
-    owners = Seq(Owner.withGithub("rtyley")),
+    "ab-membership-engagement-immediate",
+    "Test effectiveness of not waiting for 10 page reads before showing membership engagement banner to UK users.",
+    owners = Seq(Owner.withGithub("justinpinner")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 10, 10),
+    sellByDate = new LocalDate(2016, 10, 18),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -84,7 +84,11 @@ define([
 
     function isInTest(testId, variant) {
         var participations = storage.local.get('gu.ab.participations');
-        return variant === undefined ? participations[testId] : participations[testId].variant === variant;
+        if (participations) {
+            return variant === undefined ? participations[testId] : participations[testId].variant === variant;
+        } else {
+            return false;
+        }
     }
 
     function init() {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -82,16 +82,24 @@ define([
         return messageShown;
     }
 
+    function isInTest(testId, variant) {
+        var participations = storage.local.get('gu.ab.participations');
+        return variant === undefined ? participations[testId] : participations[testId].variant === variant;
+    }
+
     function init() {
+        // block default behaviour for participants of the MembershipEngagementImmediate AB test
         var edition = config.page.edition;
-        var message = messages[edition];
-        if (message) {
-            var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
-            return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
-                if (canShow && userHasMadeEnoughVisits) {
-                    show(edition, message);
-                }
-            });
+        if (!(isInTest('MembershipEngagementImmediate') && edition.toLowerCase() === 'uk')) {
+            var message = messages[edition];
+            if (message) {
+                var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
+                return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
+                    if (canShow && userHasMadeEnoughVisits) {
+                        show(edition, message);
+                    }
+                });
+            }
         }
         return Promise.resolve();
     }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -9,7 +9,8 @@ define([
     'lodash/utilities/noop',
     'common/modules/experiments/tests/discussion-promote-bottom-banner',
     'common/modules/experiments/tests/weekend-reading-email',
-    'common/modules/experiments/tests/weekend-reading-promo'
+    'common/modules/experiments/tests/weekend-reading-promo',
+    'common/modules/experiments/tests/membership-engagement-immediate'
 ], function (
     reportError,
     config,
@@ -21,13 +22,15 @@ define([
     noop,
     DiscussionPromoteBottomBanner,
     WeekendReadingEmail,
-    WeekendReadingPromo
+    WeekendReadingPromo,
+    MembershipEngagementImmediate
 ) {
 
     var TESTS = [
         new DiscussionPromoteBottomBanner(),
         new WeekendReadingEmail(),
-        new WeekendReadingPromo()
+        new WeekendReadingPromo(),
+        new MembershipEngagementImmediate()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
@@ -1,0 +1,111 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/config',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/modules/ui/message',
+    'text!common/views/membership-message.html',
+    'common/modules/commercial/commercial-features',
+    'common/utils/mediator'
+], function (
+    bean,
+    qwery,
+    config,
+    storage,
+    template,
+    Message,
+    messageTemplate,
+    commercialFeatures,
+    mediator
+) {
+    return function () {
+
+        this.id = 'MembershipEngagementImmediate';
+        this.start = '2016-10-13';
+        this.expiry = '2016-10-15';
+        this.author = 'Justin Pinner';
+        this.description = 'Test if showing engagement banner to users with less than 10 page views drives additional contributions.';
+        this.audience = 0.2;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Conversion for membership';
+        this.showForSensitive = false;
+        this.audienceCriteria = 'Twenty percent of uk edition readers (desktop and mobile web)';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.hypothesis = 'Although the conversion rate will likely drop slightly, we may see an uplift in the absolute value of contributions due to reaching a larger, and perhaps new audience segment.';
+
+        this.canRun = function () {
+            var matchesEdition = config.page.edition.toLowerCase() === 'uk';
+            return commercialFeatures.canReasonablyAskForMoney && matchesEdition;
+        };
+
+        var makeMessage = function(id) {
+            var linkHref = 'https://membership.theguardian.com/uk/supporter?INTCMP=' + id;
+            var colours = ['default','vibrant-blue','yellow','light-blue','deep-purple','teal'];
+            // Rotate through different colours on successive page views
+            var colourIndex = storage.local.get('gu.alreadyVisited') % colours.length;
+            var cssModifierClass = 'membership-message-' + colours[colourIndex];
+            //var messageText = 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.';
+            var messageText = 'You\'re seeing the variant message.' ;
+            var renderedBanner = template(messageTemplate, {messageText: messageText, linkHref: linkHref});
+            return new Message(
+                // change this to redisplay banners to everyone who has previously closed them
+                // 2016-10-12 matches the current PROD message id
+                id,
+                {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'membership message',
+                    siteMessageCloseBtn: 'hide',
+                    siteMessageComponentName: id,
+                    trackDisplay: true,
+                    cssModifierClass: cssModifierClass
+                }).show(renderedBanner);
+
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
+                    if (userHasMadeEnoughVisits) {
+                        commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
+                            var messageShown = makeMessage('mem_uk_banner_immediate_80pc');
+                            if (messageShown) {
+                                mediator.emit('membership-message:display');
+                            }
+                            mediator.emit('banner-message:complete');
+                        });
+                    }
+                },
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('membership-message:display', function () {
+                            bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+                        });
+                    }
+                }.bind(this)
+            },
+            {
+                id: 'immediate-display',
+                test: function () {
+                    commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
+                        var messageShown = makeMessage('mem_uk_banner_immediate_20pc');
+                        if (messageShown) {
+                            mediator.emit('membership-message:display');
+                        }
+                        mediator.emit('banner-message:complete');
+                    });
+                },
+                success: function (complete) {
+                    if (this.canRun()) {
+                        mediator.on('membership-message:display', function () {
+                            bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+                        });
+                    }
+                }.bind(this)
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
@@ -51,7 +51,7 @@ define([
             return new Message(
                 // change this to redisplay banners to everyone who has previously closed them
                 // 2016-10-12 matches the current PROD message id
-                id,
+                'engagement-banner-2016-10-12',
                 {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
@@ -46,8 +46,7 @@ define([
             // Rotate through different colours on successive page views
             var colourIndex = storage.local.get('gu.alreadyVisited') % colours.length;
             var cssModifierClass = 'membership-message-' + colours[colourIndex];
-            //var messageText = 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.';
-            var messageText = 'You\'re seeing the variant message.' ;
+            var messageText = 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.';
             var renderedBanner = template(messageTemplate, {messageText: messageText, linkHref: linkHref});
             return new Message(
                 // change this to redisplay banners to everyone who has previously closed them

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-immediate.js
@@ -70,11 +70,13 @@ define([
                     var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
                     if (userHasMadeEnoughVisits) {
                         commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
-                            var messageShown = makeMessage('mem_uk_banner_immediate_80pc');
-                            if (messageShown) {
-                                mediator.emit('membership-message:display');
+                            if (canShow) {
+                                var messageShown = makeMessage('mem_uk_banner_immediate_80pc');
+                                if (messageShown) {
+                                    mediator.emit('membership-message:display');
+                                }
+                                mediator.emit('banner-message:complete');
                             }
-                            mediator.emit('banner-message:complete');
                         });
                     }
                 },
@@ -90,11 +92,13 @@ define([
                 id: 'immediate-display',
                 test: function () {
                     commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
-                        var messageShown = makeMessage('mem_uk_banner_immediate_20pc');
-                        if (messageShown) {
-                            mediator.emit('membership-message:display');
+                        if (canShow) {
+                            var messageShown = makeMessage('mem_uk_banner_immediate_20pc');
+                            if (messageShown) {
+                                mediator.emit('membership-message:display');
+                            }
+                            mediator.emit('banner-message:complete');
                         }
-                        mediator.emit('banner-message:complete');
                     });
                 },
                 success: function (complete) {

--- a/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
@@ -93,7 +93,7 @@ define([
             afterEach(function () {
                 commercialFeatures.async.canDisplayMembershipEngagementBanner = showMembershipMessages;
                 storage.local.set('gu.alreadyVisited', alreadyVisited);
-                storage.local.set('gu.ab.participations', participations)
+                storage.local.set('gu.ab.participations', participations);
             });
 
             it('should not show any messages even to engaged readers', expectMessageNotToBeShown);

--- a/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
@@ -7,7 +7,8 @@ define([
     'helpers/fixtures',
     'helpers/injector',
     'Promise',
-    'common/modules/ui/message'
+    'common/modules/ui/message',
+    'common/modules/experiments/ab'
 ], function (
     bonzo,
     fastdom,
@@ -17,10 +18,11 @@ define([
     fixtures,
     Injector,
     Promise,
-    Message
+    Message,
+    ab
 ) {
     var commercialFeatures, membershipMessages,
-        showMembershipMessages, alreadyVisited, storage, config;
+        showMembershipMessages, alreadyVisited, storage, config, participations;
 
     var injector = new Injector();
 
@@ -85,12 +87,15 @@ define([
                 commercialFeatures.async.canDisplayMembershipEngagementBanner = Promise.resolve(false);
                 alreadyVisited = storage.local.get('gu.alreadyVisited');
                 storage.local.set('gu.alreadyVisited', 10);
+                participations = storage.local.get('gu.ab.participations');
+                storage.local.remove('gu.ab.participations');
                 done();
             });
 
             afterEach(function () {
                 commercialFeatures.async.canDisplayMembershipEngagementBanner = showMembershipMessages;
                 storage.local.set('gu.alreadyVisited', alreadyVisited);
+                storage.local.set('gu.ab.participations', participations)
             });
 
             it('should not show any messages even to engaged readers', expectMessageNotToBeShown);

--- a/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
@@ -7,8 +7,7 @@ define([
     'helpers/fixtures',
     'helpers/injector',
     'Promise',
-    'common/modules/ui/message',
-    'common/modules/experiments/ab'
+    'common/modules/ui/message'
 ], function (
     bonzo,
     fastdom,
@@ -18,8 +17,7 @@ define([
     fixtures,
     Injector,
     Promise,
-    Message,
-    ab
+    Message
 ) {
     var commercialFeatures, membershipMessages,
         showMembershipMessages, alreadyVisited, storage, config, participations;


### PR DESCRIPTION
## What does this change?

Introduces a 24 hour AB test to probe the hypothesis that showing the engagement banner to more users sooner, rather than waiting until 10 pages had been read, can result in additional contributions being made.

This is aimed specifically at UK edition readers, with a 20/80 split (20% see the messaging immediately, 80% follow the normal 10 article rule). We've tagged each variant so we can meaningfully track the effects over this relatively short timeframe.

**We're aiming to activate this today**, so it can be switched off again before the weekend.
## What is the value of this and can you measure success?

To prove the hypothesis that even with a reduction in percentage of conversions we would still see an uplift in raw contributions made.
## Does this affect other platforms - Amp, Apps, etc?

No. Web only.
## Screenshots

N/A - uses standard messaging UI
## Request for comment

@rtyley @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
