### PR TITLE
Logging form submission user errors as log.info

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -192,7 +192,7 @@ class EmailSignupController(wsClient: WSClient) extends Controller with Executio
 
     emailForm.bindFromRequest.fold(
       formWithErrors => {
-        log.error(s"FormErrors: ${formWithErrors.errors}")
+        log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
         EmailFormError.increment()
         Future.successful(respond(InvalidEmail))},
 

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -73,7 +73,6 @@ class ReauthenticationController(returnUrlVerifier: ReturnUrlVerifier,
 
         signInService.getCookies(authResponse, persistent) map {
           case Left(errors) =>
-            logger.error(errors.toString())
             logger.info(s"Reauthentication failed for user, ${errors.toString()}")
             val formWithErrors = errors.foldLeft(boundForm) { (formFold, error) =>
               val errorMessage =


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Logging form submission user errors as log.info

There are user errors, not errors on our side.
## What is the value of this and can you measure success?

Logging them as log.info so they doen't pollute our server-side error
logs

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@gtrufitt @janua 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
