### PR TITLE
Upgrade config version (training-preview: removing ophan.api key)

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 8
+    val s3ConfigVersion = 9
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/docs/03-dev-howtos/13-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/13-Update-configuration-in-s3.md
@@ -17,27 +17,27 @@ https://s3-eu-west-1.amazonaws.com/aws-frontend-store/config/eu-west-1-frontend.
 aws s3 ls --profile=frontend s3://aws-frontend-store/config/
 ```
 
-look for the most recent version ( the `v4` part ):
+look for the most recent version ( the `v9` part ):
 
 ```
-2016-08-30 21:52:58      31386 eu-west-1-frontend.v4.conf
+2016-08-30 21:52:58      31386 eu-west-1-frontend.v9.conf
 ```
 
-- Create a new copy of the s3 and bump the version number (change `v4` to `v5` ).
+- Create a new copy of the s3 and bump the version number (change `v9` to `v10` ).
 
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v4.conf s3://aws-frontend-store/config/eu-west-1-frontend.v5.conf
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v9.conf s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf
 ```
 
 -  Download the new file locally:
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v5.conf .
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf .
 ```
 
 - Make your changes ....
 -- Test them locally by uploading these to s3
 ```
-aws s3 cp --profile=frontend eu-west-1-frontend.v5.conf s3://aws-frontend-store/config/eu-west-1-frontend.v5.conf
+aws s3 cp --profile=frontend eu-west-1-frontend.v10.conf s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf
 ```
 and bump the version number `var s3ConfigVersion` in [/common/app/common/configuration.scala](https://github.com/guardian/frontend/blob/master/common/app/common/configuration.scala) to match the version of the config file you created.
 
@@ -45,7 +45,7 @@ and bump the version number `var s3ConfigVersion` in [/common/app/common/configu
 
 - Delete the local copy once you have finished
 ```
-rm eu-west-1-frontend.v4.conf
+rm eu-west-1-frontend.v10.conf
 ```
 
 - Once your pull request is merged, everything is done!


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Upgrading config version
## What is the value of this and can you measure success?

Removing Ophan.api keys in config for training preview, rather than empty string, so training-preview doesn't throw error when trying to fetch ophan url without a scheme and host

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
