### PR TITLE
Static deploy: don't prefix with stack

### DIFF
--- a/static/deploy.json
+++ b/static/deploy.json
@@ -5,7 +5,8 @@
             "type":"aws-s3",
             "data":{
                 "bucket":"aws-frontend-static",
-                "cacheControl":"public, max-age=315360000"
+                "cacheControl":"public, max-age=315360000",
+                "prefixStack": false
             }
         }
     },


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Static deploy: don't prefix with stack
## What is the value of this and can you measure success?

Static deployment works :/

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@guardian/dotcom-platform

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

Riff-Raff uses the default stack to prefix the file key.
Since we don't want this prefix we need to set prefixStack to false
