### PR TITLE
Check node version

### DIFF
--- a/dev/check-node-version.js
+++ b/dev/check-node-version.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+
+var currentVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
+var minVersion = Number(fs.readFileSync(path.join(__dirname, '../', '.nvmrc'), 'utf8'));
+if (currentVersion < minVersion) {
+    console.log("You are using Node v" + currentVersion + ".\n" +
+        "Frontend requires Node v" + minVersion + " or later.\n" +
+        "If you're using NVM, you can 'nvm use'...");
+    process.exit(1);
+}

--- a/dev/check-node-version.js
+++ b/dev/check-node-version.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
+// given this could be any version of node that runs this, it uses no bells or whistles...
+
 var fs = require('fs');
 var path = require('path');
 
 var currentVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
 var minVersion = Number(fs.readFileSync(path.join(__dirname, '../', '.nvmrc'), 'utf8'));
+
 if (currentVersion < minVersion) {
     console.log("You are using Node v" + currentVersion + ".\n" +
         "Frontend requires Node v" + minVersion + " or later.\n" +

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ list: # PRIVATE
 # *********************** SETUP ***********************
 
 # Install all 3rd party dependencies.
-install:
+install: check-node
 	@echo 'Installing 3rd party dependencies…'
 	@npm install
 	@echo '…done.'
@@ -34,7 +34,8 @@ uninstall: # PRIVATE
 # The nuclear option if `make install` hasn't worked.
 reinstall: uninstall install
 
-
+check-node:
+	@./dev/check-node-version.js
 
 # *********************** DEVELOPMENT ***********************
 
@@ -55,36 +56,36 @@ shrinkwrap: # PRIVATE
 # *********************** ASSETS ***********************
 
 # Compile all assets for production.
-compile:
+compile: check-node
 	@./tools/assets/compile.js
 
 # Compile all assets for development.
-compile-dev:
+compile-dev: check-node
 	@./tools/assets/compile.js --dev
 
-compile-javascript: # PRIVATE
+compile-javascript: check-node # PRIVATE
 	@./tools/assets/compile.js javascript
 
-compile-javascript-dev: # PRIVATE
+compile-javascript-dev: check-node # PRIVATE
 	@./tools/assets/compile.js javascript --dev
 
-compile-css: # PRIVATE
+compile-css: check-node # PRIVATE
 	@./tools/assets/compile.js css
 
-compile-images: # PRIVATE
+compile-images: check-node # PRIVATE
 	@./tools/assets/compile.js images
 
-compile-svgs: # PRIVATE
+compile-svgs: check-node # PRIVATE
 	@./tools/assets/compile.js inline-svgs
 
-compile-fonts: # PRIVATE
+compile-fonts: check-node # PRIVATE
 	@./tools/assets/compile.js fonts
 
-atomise-css: # PRIVATE
+atomise-css: check-node # PRIVATE
 	@node tools/atomise-css
 
 # * Not ready for primetime use yet... *
-pasteup: # PRIVATE
+pasteup: check-node # PRIVATE
 	@cd static/src/stylesheets/pasteup && npm --silent i && node publish.js
 
 
@@ -92,21 +93,21 @@ pasteup: # PRIVATE
 # *********************** CHECKS ***********************
 
 # Run the JS test suite.
-test:
+test: check-node
 	@grunt test --dev
 
 # Lint all assets.
-validate:
+validate: check-node
 	@grunt validate
 
 # Lint all SCSS.
-validate-sass: # PRIVATE
+validate-sass: check-node # PRIVATE
 	@grunt validate:sass
 	@grunt validate:css
 
 # Lint all JS.
-validate-javascript: # PRIVATE
+validate-javascript: check-node # PRIVATE
 	@grunt validate:js
 
-validate-amp: # PRIVATE
+validate-amp: check-node # PRIVATE
 	@cd tools/amp-validation && npm install && NODE_ENV=dev node index.js


### PR DESCRIPTION
## What does this change?

checks current node version matches `.nvmrc` when running `make` tasks.
## What is the value of this and can you measure success?

stops issues where things don't seem to work because you're using the wrong version of node.
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

<img width="493" alt="screen shot 2016-10-14 at 12 05 58" src="https://cloud.githubusercontent.com/assets/867233/19385482/9c36396e-9206-11e6-9262-05d7ed52ae72.png">
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
