### PR TITLE
Provide commercial support for native LiveEvent merchandise component

### DIFF
--- a/commercial/app/controllers/LiveEventsController.scala
+++ b/commercial/app/controllers/LiveEventsController.scala
@@ -33,4 +33,8 @@ class LiveEventsController(liveEventAgent: LiveEventAgent)
       Future.successful(NoCache(jsonFormat.nilResult.result))
     }
   }
+
+  def getLiveEvent = Action { implicit request =>
+    ???
+  }
 }

--- a/commercial/app/controllers/LiveEventsController.scala
+++ b/commercial/app/controllers/LiveEventsController.scala
@@ -2,37 +2,30 @@ package commercial.controllers
 
 import common.{ExecutionContexts, JsonComponent}
 import commercial.controllers.util.{specificId, jsonFormat}
-import model.{Cached, NoCache}
+import model.Cached
 import model.commercial.events.LiveEventAgent
 import play.api.mvc._
 import util.{componentMaxAge, componentNilMaxAge}
-
-import scala.concurrent.Future
 
 class LiveEventsController(liveEventAgent: LiveEventAgent)
   extends Controller
   with ExecutionContexts
   with implicits.Requests {
 
-  def renderEvent = Action.async { implicit request =>
-    specificId map { eventId =>
-        Future {
+  def renderEvent = Action { implicit request =>
+    {
+      for {
+        id <- specificId
+        event <- liveEventAgent.specificLiveEvent(id)
+      } yield {
+        Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")
           val omnitureId = request.getParameter("omnitureId")
-          val selectedLiveEvents = liveEventAgent.specificLiveEvent(eventId)
 
-          selectedLiveEvents match {
-            case Some(event) =>
-              Cached(60)(jsonFormat.result(views.html.liveevents.liveEvent(
-                event,
-                omnitureId,
-                clickMacro)))
-            case None => NoCache(jsonFormat.nilResult.result)
-          }
+          jsonFormat.result(views.html.liveevents.liveEvent(event, omnitureId, clickMacro))
+        }
       }
-    } getOrElse {
-      Future.successful(NoCache(jsonFormat.nilResult.result))
-    }
+    } getOrElse Cached(componentNilMaxAge){ jsonFormat.nilResult }
   }
 
   def getLiveEvent = Action { implicit request =>

--- a/commercial/app/controllers/LiveEventsController.scala
+++ b/commercial/app/controllers/LiveEventsController.scala
@@ -1,10 +1,11 @@
 package commercial.controllers
 
-import common.{ExecutionContexts}
+import common.{ExecutionContexts, JsonComponent}
 import commercial.controllers.util.{specificId, jsonFormat}
 import model.{Cached, NoCache}
 import model.commercial.events.LiveEventAgent
 import play.api.mvc._
+import util.{componentMaxAge, componentNilMaxAge}
 
 import scala.concurrent.Future
 
@@ -35,6 +36,11 @@ class LiveEventsController(liveEventAgent: LiveEventAgent)
   }
 
   def getLiveEvent = Action { implicit request =>
-    ???
+    {
+      for {
+        id <- specificId
+        event <- liveEventAgent.specificLiveEvent(id)
+      } yield Cached(componentMaxAge) { JsonComponent(event) }
+    } getOrElse Cached(componentNilMaxAge) { jsonFormat.nilResult }
   }
 }

--- a/commercial/app/model/capi/CapiImages.scala
+++ b/commercial/app/model/capi/CapiImages.scala
@@ -1,15 +1,23 @@
 package model.commercial
 
 import views.support.ImgSrc
-import cards.{Standard, Half, Third}
+import cards.{Half, Standard, Third}
+import com.gu.contentapi.client.model.v1.{Asset, AssetType}
 import layout.{FaciaWidths, ItemClasses}
-import model.ImageMedia
+import model.{ImageAsset, ImageMedia}
 import play.api.libs.json.{Json, Writes}
 
 object CapiImages {
 
+  def buildImageDataFromUrl(imageUrl: String, noImages: Int = 1): ImageInfo = {
+    val asset: Asset = Asset(AssetType.Image, Some("image/jpeg"), Some(imageUrl))
+    val imageAsset: ImageAsset = ImageAsset.make(asset, 0)
+    val image: ImageMedia = ImageMedia(List(imageAsset))
+    buildImageData(Some(image))
+  }
+
   // Puts together image source info using data from cAPI.
-  def buildImageData(imageData: Option[ImageMedia], noImages: Int = 1) = {
+  def buildImageData(imageData: Option[ImageMedia], noImages: Int = 1): ImageInfo = {
 
     val fallbackImageUrl = imageData flatMap ImgSrc.getFallbackUrl
     val imageType = noImages match {
@@ -48,8 +56,7 @@ object CapiImages {
   )
 
   object ImageSource {
-    implicit val writesImageSource: Writes[ImageSource] =
-      Json.writes[ImageSource]
+    implicit val writesImageSource: Writes[ImageSource] = Json.writes[ImageSource]
   }
 
   // Holds all source element data, and the backup image src for older browsers.

--- a/commercial/app/model/merchandise/Merchandise.scala
+++ b/commercial/app/model/merchandise/Merchandise.scala
@@ -1,18 +1,19 @@
 package model.commercial
 
 import model.ImageElement
+import model.commercial.CapiImages.ImageInfo
 import model.commercial.events.LiveEventMembershipInfo
 import model.commercial.events.Eventbrite._
 import model.commercial.jobs.Industries
 import views.support.Item300
-
-import org.apache.commons.lang.{StringUtils, StringEscapeUtils}
+import org.apache.commons.lang.{StringEscapeUtils, StringUtils}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
+
 import scala.util.Try
 import scala.util.control.NonFatal
 import scala.xml.Node
@@ -55,7 +56,7 @@ case class LiveEvent(eventId: String,
                      status: String,
                      venue: Venue,
                      tickets: Seq[Ticket],
-                     imageUrl: String) extends Merchandise with TicketHandler with EventHandler
+                     image: ImageInfo) extends Merchandise with TicketHandler with EventHandler
 
 case class TravelOffer(id: String,
                        title: String,
@@ -352,7 +353,7 @@ object LiveEvent {
       status = event.status,
       venue = event.venue,
       tickets = event.tickets,
-      imageUrl = eventMembershipInformation.mainImageUrl
+      image = CapiImages.buildImageDataFromUrl(eventMembershipInformation.mainImageUrl)
     )
 
   implicit val liveEventWrites: Writes[LiveEvent] = Json.writes[LiveEvent]

--- a/commercial/app/model/merchandise/events/Eventbrite.scala
+++ b/commercial/app/model/merchandise/events/Eventbrite.scala
@@ -47,11 +47,8 @@ object Eventbrite extends ExecutionContexts with Logging {
   }
 
 
-  implicit val jodaDateTimeFormats: Format[DateTime] = {
-
-    val dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-    Format(Reads.jodaDateReads(dateFormat), Writes.jodaDateWrites(dateFormat))
-  }
+  implicit val jodaDateTimeFormats: Format[DateTime] =
+    Format(Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ssZ"), Writes.jodaDateWrites("dd MMM yyyy"))
 
   implicit val ticketReads: Reads[Ticket] = (
     (JsPath \ "hidden").read[Boolean] and

--- a/commercial/app/views/liveevents/liveEvent.scala.html
+++ b/commercial/app/views/liveevents/liveEvent.scala.html
@@ -13,9 +13,11 @@
         <div class="adverts__body">
             <a class="advert advert--inline advert--brand" href="@clickMacro@event.eventUrl" data-link-name="merchandising-liveEvents-superHigh-@{event.eventId}-@{event.name}">
                 <h2 class="advert__title">@event.name</h2>
-                <div class="advert__image-container">
-                    <img class="advert__image" src="@ImgSrc(event.imageUrl, Item300)" alt="">
-                </div>
+               @event.image.backupSrc.map { imageUrl =>
+                    <div class="advert__image-container">
+                        <img class="advert__image" src="@ImgSrc(imageUrl, Item300)" alt="">
+                    </div>
+               }
                 <div class="advert__meta">
                     @event.date.toString("dd MMM yyyy"), @event.venue.description
                 </div>

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -29,6 +29,7 @@ GET         /commercial/books/api/books.json                                comm
 
 # Live events merchandising components
 GET         /commercial/liveevents/event.json                               commercial.controllers.LiveEventsController.renderEvent
+GET         /commercial/api/liveevent.json                                  controllers.commercial.LiveEventsController.getLiveEvent
 
 # Multiple offer merchandising components
 GET         /commercial/multi.json                                          commercial.controllers.Multi.renderMulti

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -29,7 +29,7 @@ GET         /commercial/books/api/books.json                                comm
 
 # Live events merchandising components
 GET         /commercial/liveevents/event.json                               commercial.controllers.LiveEventsController.renderEvent
-GET         /commercial/api/liveevent.json                                  controllers.commercial.LiveEventsController.getLiveEvent
+GET         /commercial/api/liveevent.json                                  commercial.controllers.LiveEventsController.getLiveEvent
 
 # Multiple offer merchandising components
 GET         /commercial/multi.json                                          commercial.controllers.Multi.renderMulti

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -294,6 +294,7 @@ GET            /commercial/books/book.json                                      
 GET            /commercial/books/books.json                                                                                      commercial.controllers.BookOffersController.renderBooks
 GET            /commercial/books/api/books.json                                                                                  commercial.controllers.BookOffersController.getBooks
 GET            /commercial/liveevents/event.json                                                                                 commercial.controllers.LiveEventsController.renderEvent
+GET            /commercial/api/liveevent.json                                                                                    controllers.commercial.LiveEventsController.getLiveEvent
 GET            /commercial/capi.json                                                                                             commercial.controllers.ContentApiOffersController.itemsJson
 GET            /commercial/capi                                                                                                  commercial.controllers.ContentApiOffersController.itemsHtml
 GET            /commercial/capi-single.json                                                                                      commercial.controllers.ContentApiOffersController.itemJson

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -294,7 +294,7 @@ GET            /commercial/books/book.json                                      
 GET            /commercial/books/books.json                                                                                      commercial.controllers.BookOffersController.renderBooks
 GET            /commercial/books/api/books.json                                                                                  commercial.controllers.BookOffersController.getBooks
 GET            /commercial/liveevents/event.json                                                                                 commercial.controllers.LiveEventsController.renderEvent
-GET            /commercial/api/liveevent.json                                                                                    controllers.commercial.LiveEventsController.getLiveEvent
+GET            /commercial/api/liveevent.json                                                                                    commercial.controllers.LiveEventsController.getLiveEvent
 GET            /commercial/capi.json                                                                                             commercial.controllers.ContentApiOffersController.itemsJson
 GET            /commercial/capi                                                                                                  commercial.controllers.ContentApiOffersController.itemsHtml
 GET            /commercial/capi-single.json                                                                                      commercial.controllers.ContentApiOffersController.itemJson


### PR DESCRIPTION
## What does this change?
### Background

We have a number of templates in frontend used to render specific merchandise components on the site. There is ongoing work to remove these templates and ultimately have all of these fragments stored directly in DFP. When being served from frontend, the fragments can call on the merchandise agents, grab a specific LiveEvent/Book/Job/Soulmate and use it/them to render a template in one fell swoop.

The new native merchandise component (that will sit in DFP) also needs to be able to render itself using specific Live Event information. Given that it will not have access to the frontend agents, it will have to fetch it client side; hence the new JSON route in this PR.

Eventually the `renderLiveEvent` method will be removed when we are happy with the native components as no rendering of components will be done within frontend.
### Changes

This tidies up the LiveEvent controller in general and provides a new method for getting specific live events back as raw JSON rather than renderable HTML.

This also updates the `LiveEvent` model to keep an `ImageInfo` rather than a simple Image URL. This allows the recipient of the LiveEvent JSON to use `srcsets` and be responsi(ve/ble).
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@guardian/commercial-dev 
