### PR TITLE
Add fine print text to Hosted CTA banner

### DIFF
--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -17,6 +17,11 @@
                     <div class="hosted__cta-wrapper hosted__cta-btn-wrapper">
                         <span class="hosted__cta-label">@{cta.label}</span>
                         <span class="hosted__cta-btn-text hosted-tone-btn">@{cta.btnText} @fragments.inlineSvg("external-link", "icon")</span>
+                        @if(page.campaign.id == "lloyds-bank-wealth"){
+                            <span class="hosted__cta-fine-print">
+                                Advertisement creative produced by Guardian Labs on behalf of Lloyds Bank.
+                            </span>
+                        }
                     </div>
                 }
             </a>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -102,6 +102,15 @@ $hosted-video-height: 540px;
     }
 }
 
+.hosted__cta-fine-print {
+    @include f-headlineSans;
+    color: #ffffff;
+    display: block;
+    font-size: 12px;
+    margin: 8px 0;
+    line-height: 14px;
+}
+
 .host__header {
     display: flex;
     flex-direction: column;
@@ -605,7 +614,7 @@ $hosted-video-height: 540px;
     }
 
     @include mq(mobile) {
-        height: 200px;
+        min-height: 200px;
         background-position: left;
     }
 


### PR DESCRIPTION
## What does this change?

Add some fine print to the hosted CTA banner for pages in the Lloyds Bank Wealth campaign, on client's request.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/6290008/19393231/c9b2ea5c-922b-11e6-9ad0-acb2afc2f5ea.png)
## Request for comment

@guardian/labs-beta 
