### PR TITLE
Make the discussion report ajax form POST in case JS fails

### DIFF
--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,4 +1,4 @@
-<form hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-report-comment-form">
+<form method="post" hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-report-comment-form">
     <div hidden class="d-discussion__error js-discussion__report-comment-error">
         <i class="i i-alert"></i>
         <span class="d-discussion__error-text">Sorry there was an error. Please try again later. If the problem persists, please contact <a data-link-name="report comment error : mailto : userhelp" href="mailto:userhelp@@theguardian.com">Userhelp</a></span>


### PR DESCRIPTION
Avoids the case of refreshing the page with the form fields in get params which then would appear in logs, referrer etc.
