### PR TITLE
Animate height updates on fluid merch-high slots (for expandables)

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -638,6 +638,14 @@
         width: auto;
     }
 
+    &.ad-slot--commercial-component-high {
+
+        &,
+        & > .ad-slot__content > iframe {
+            transition: height 1s;
+        }
+    }
+
     &.ad-slot--liveblog-inline {
         @include mq(mobile, $until: mobileLandscape) {
             margin-left: $gs-gutter / -2;


### PR DESCRIPTION
Fabric Expandables change height upon user interaction. These changes need to be animated.

For now this feature is restricted to the high-relevance merchandising slot only.

nb: we could use easing curves to make the animation look more natural, but this is difficult. Two animations will run in parallel: one for the ad slot and one for the creative. Since they are both in separate views, there will be small discrepancies between the results of easing functions, which are more perceptible with non-linear curves.
