### PR TITLE
British Council beacon to cover October 2016

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -242,7 +242,7 @@ trait CommercialSwitches {
     "British Council's beacon",
     owners = Seq(Owner.withGithub("kenlim")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 17),
+    sellByDate = new LocalDate(2016, 11, 1),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
The G-labs account manager has confirmed that the sponsorship is now extended for the whole month of October. 

Will expire this on Tuesday, 1 November 2016 (nice of them to make it a working day). 
