### PR TITLE
Move non-blocking JS and analytics from under head.scala.html

### DIFF
--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -32,16 +32,16 @@ See below for quick descriptions.
 				- commercial.js
 				- enhanced/main.js
 			- Cloudwatch beacon
-		- [inlineJSNonBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSNonBlocking.scala.html)
-			- getUserData.js
-			- detectAdblock
-			- showUserName
-			- editionaliseMenu
-			- ophanConfig
-		- [Analytics](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/base.scala.html)
-			- Google
-			- Omniture
-			- Comscore
+    - [inlineJSNonBlocking.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/inlineJSNonBlocking.scala.html)
+        - getUserData.js
+        - detectAdblock
+        - showUserName
+        - editionaliseMenu
+        - ophanConfig
+    - [Analytics](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/base.scala.html)
+        - Google
+        - Omniture
+        - Comscore
 
 ### Inline blocking JS
 


### PR DESCRIPTION
## What does this change?

Change the nesting of the list in the client-side architecture docs
## What is the value of this and can you measure success?

I believe these fragments are loaded directly in `main.scala.html`, not in `head.scala.html`.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@gtrufitt 
