### PR TITLE
Pages with signup contentType avoid the sticky banner once again

### DIFF
--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -19,7 +19,7 @@ object StaticPages {
       section = Option(SectionSummary(id="email-signup-page", activeBrandings=None)),
       webTitle = webTitle,
       analyticsName = "email-signup-page",
-      contentType = "signup",
+      contentType = "Signup",
       iosType = None,
       shouldGoogleIndex = false))
 }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -14,6 +14,7 @@ object Commercial {
   def shouldShowAds(page: Page): Boolean = page match {
     case c: model.ContentPage if c.item.content.shouldHideAdverts => false
     case p: model.Page if p.metadata.sectionId == "identity" => false
+    case s: model.SimplePage if s.metadata.contentType == "Signup" => false
     case p: model.CommercialExpiryPage => false
     case _ => true
   }


### PR DESCRIPTION
## What does this change?

Adds a new rule to stop ads appearing on the `signup` pages. These do not come from the content API, they are custom standalone pages.
## What is the value of this and can you measure success?

Signup pages used to be built with a custom `main` template, which avoided loading the top banner. These page(s) are now being built using the `main` template to ensure Google Analytics runs (#14601). 

This has had the side effect of the sticky ad banner now appearing; this PR resolves this.

Signup is a new contentType that is (currently) only used by the weekend reading [email signup page](https://www.theguardian.com/signup/weekendreading). The newsletters page (#14507) will also have the same type and this fix will extend to it.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

⚡️💌
## Request for comment

@regiskuckaertz @joelochlann
