### PR TITLE
Fix explainer in multiple paid-for MPUs

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -26,7 +26,7 @@ define([
 
             controls.forEach(function (control) {
                 if (!bonzo(control).hasClass(readyClass)) {
-                    var target = self.getTarget(control);
+                    var target = self.getTarget(parent, control);
 
                     if (target && !(!isSignedIn && control.getAttribute('data-toggle-signed-in') === 'true')) {
                         control.toggleTarget = target;
@@ -63,10 +63,10 @@ define([
         });
     };
 
-    Toggles.prototype.getTarget = function (control) {
+    Toggles.prototype.getTarget = function (parent, control) {
         var targetClass = bonzo(control).data('toggle');
         if (targetClass) {
-            return document.body.querySelector('.' + targetClass);
+            return parent.querySelector('.' + targetClass);
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -26,7 +26,7 @@ define([
 
             controls.forEach(function (control) {
                 if (!bonzo(control).hasClass(readyClass)) {
-                    var target = self.getTarget(parent, control);
+                    var target = self.getTarget(component, control);
 
                     if (target && !(!isSignedIn && control.getAttribute('data-toggle-signed-in') === 'true')) {
                         control.toggleTarget = target;


### PR DESCRIPTION
When there is more than one `paidFor` MPU on the page, the about button breaks.

This fixes `getTarget` used to get the toggle target so that is searches from the parent only instead of the whole document.

@regiskuckaertz 
