### PR TITLE
Remove implicit/global imports for all templates; explicitly state each

### DIFF
--- a/admin/app/views/commercial/adTests.scala.html
+++ b/admin/app/views/commercial/adTests.scala.html
@@ -1,28 +1,30 @@
-@(env: String, timestamp: Option[String], groupedLineItems: Seq[(String, Seq[dfp.GuLineItem])])(implicit request: RequestHeader)
-    @import tools.DfpLink
+@import common.dfp.GuLineItem
+@import tools.DfpLink
 
-    @admin_main("Ad Tests", env, isAuthed = true) {
+@(env: String, timestamp: Option[String], groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader)
 
-    <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")" />
+@admin_main("Ad Tests", env, isAuthed = true) {
 
-    <h1>Current Ad Tests</h1>
-    <p>Last updated: @timestamp</p>
-    <p>This page shows ready and delivering line items that are hidden behind a test cookie.</p >
+<link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")" />
 
-    <table>
-        <thead><tr><th>Cookie</th><th>Line items</th></tr></thead>
-        <tbody>
-        @for((testValue, lineItems) <- groupedLineItems) {
-            <tr id="cookie-@testValue" class="cookie-row">
-                <td align="right" valign="top"><button value="@testValue" class="cookie">@testValue</button></td>
-                <td>
-                @for(lineItem <- lineItems) {
-                    @{lineItem.name} (<a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a>
-                    )<br />
-                }
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
+<h1>Current Ad Tests</h1>
+<p>Last updated: @timestamp</p>
+<p>This page shows ready and delivering line items that are hidden behind a test cookie.</p >
+
+<table>
+    <thead><tr><th>Cookie</th><th>Line items</th></tr></thead>
+    <tbody>
+    @for((testValue, lineItems) <- groupedLineItems) {
+        <tr id="cookie-@testValue" class="cookie-row">
+            <td align="right" valign="top"><button value="@testValue" class="cookie">@testValue</button></td>
+            <td>
+            @for(lineItem <- lineItems) {
+                @{lineItem.name} (<a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a>
+                )<br />
+            }
+            </td>
+        </tr>
     }
+    </tbody>
+</table>
+}

--- a/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
@@ -1,6 +1,7 @@
-@(env: String, report: dfp.InlineMerchandisingTargetedTagsReport)(implicit request: RequestHeader)
-@import tools.SiteLink
-@import tools.CapiLink
+@import common.dfp.InlineMerchandisingTargetedTagsReport
+@import tools.{CapiLink, SiteLink}
+
+@(env: String, report: InlineMerchandisingTargetedTagsReport)(implicit request: RequestHeader)
 
 @admin_main("Commercial IM Slot", env, isAuthed = true, hasCharts = false) {
 

--- a/applications/app/views/all.scala.html
+++ b/applications/app/views/all.scala.html
@@ -1,8 +1,9 @@
-@(index: services.IndexPage, nav: PreviousAndNext)(implicit request: RequestHeader)
-
+@import layout.{ContainerDisplayConfig, ContainerLayout}
 @import model.pressed.CollectionConfig
+@import services.IndexPage
 @import views.support.PreviousAndNext
-@import layout.{ContainerLayout, ContainerDisplayConfig}
+
+@(index: IndexPage, nav: PreviousAndNext)(implicit request: RequestHeader)
 
 @main(index.page, projectName = Option("facia")){  }{
 <div class="l-side-margins">

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -1,10 +1,12 @@
-@(page: model.GalleryPage)(implicit request: RequestHeader)
-
 @import common.LinkTo
 @import layout.ContentWidths.GalleryMedia
+@import model.{GalleryPage, ImageAsset, ImageElement}
 @import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{RenderClasses, GalleryCaptionCleaner}
+@import views.support.`package`.Seq2zipWithRowInfo
+@import views.support.{GalleryCaptionCleaner, RenderClasses}
+
+@(page: GalleryPage)(implicit request: RequestHeader)
 
 <div class="l-side-margins l-side-margins--media l-side-margins--gallery">
 
@@ -47,7 +49,7 @@
     @fragments.contentFooter(page.item, page.related, "media", isPaidContent(page.item, page))
 </div>
 
-@galleryItem(adSlots: Seq[String], adInterval: Int, image: model.ImageAsset, rowNum: Int, imageElement: model.ImageElement) = {
+@galleryItem(adSlots: Seq[String], adInterval: Int, image: ImageAsset, rowNum: Int, imageElement: ImageElement) = {
 
     <li id="img-@rowNum" class="gallery__item js-gallery-item" data-link-name="Gallery item | @rowNum">
         <figure itemscope itemtype="http://schema.org/ImageObject">

--- a/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
+++ b/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
@@ -1,8 +1,11 @@
-@(page: model.GalleryPage)(implicit request: RequestHeader)
-@import common.{Edition, LinkTo}
+@import common.LinkTo
 @import layout.ContentWidths.GalleryMedia
+@import model.GalleryPage
 @import views.support.TrailCssClasses.toneClass
+@import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.{ImgSrc, RenderClasses}
+
+@(page: GalleryPage)(implicit request: RequestHeader)
 
 <div class="l-side-margins l-side-margins--media">
 

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -1,3 +1,5 @@
+@import controllers.InteractivePage
+
 @(model: InteractivePage)(implicit request: RequestHeader)
 
 @main(model){ }{

--- a/applications/app/views/signup/weekendReading.scala.html
+++ b/applications/app/views/signup/weekendReading.scala.html
@@ -1,6 +1,6 @@
-@(signupPage: Page)(implicit request: RequestHeader)
-
 @import model.Page
+
+@(signupPage: Page)(implicit request: RequestHeader)
 
 @main(signupPage, projectName = Some("signup")) { } {
     <div class="illustration-container">

--- a/applications/app/views/survey/formstackSurvey.scala.html
+++ b/applications/app/views/survey/formstackSurvey.scala.html
@@ -1,7 +1,7 @@
-@(formName: String, surveyPage: Page)(implicit request: RequestHeader)
-
 @import model.Page
 @import conf.Configuration.Survey.formStackAccountName
+
+@(formName: String, surveyPage: Page)(implicit request: RequestHeader)
 
     @surveyMain(surveyPage){
         <div class="l-side-margins">

--- a/applications/app/views/survey/quickSurvey.scala.html
+++ b/applications/app/views/survey/quickSurvey.scala.html
@@ -1,32 +1,32 @@
-@(surveyPage: Page)(implicit request: RequestHeader)
-
 @import model.Page
 
-    @surveyMain(surveyPage) {
-        <div class="illustration-container">
+@(surveyPage: Page)(implicit request: RequestHeader)
 
-        @fragments.inlineSvg("survey", "illustration", Seq("illustration-mobile"))
+@surveyMain(surveyPage) {
+    <div class="illustration-container">
 
-        </div>
+    @fragments.inlineSvg("survey", "illustration", Seq("illustration-mobile"))
 
-        <div class="content">
+    </div>
 
-            <div class="wrapper">
+    <div class="content">
 
-                <div class="wrapper-inner">
+        <div class="wrapper">
 
-                    @fragments.inlineSvg("survey_clipboard", "illustration")
+            <div class="wrapper-inner">
 
-                    <h2>Thank you</h2>
+                @fragments.inlineSvg("survey_clipboard", "illustration")
 
-                    <p>Got two minutes spare? We would like to hear your thoughts on this feature while we are still finalising it.</p>
+                <h2>Thank you</h2>
 
-                    <p><a href="/survey/emaildigest" class="button button--primary button--medium" data-link-name="take part in survey">
-                        Tell us your thoughts</a></p>
+                <p>Got two minutes spare? We would like to hear your thoughts on this feature while we are still finalising it.</p>
 
-                </div>
+                <p><a href="/survey/emaildigest" class="button button--primary button--medium" data-link-name="take part in survey">
+                    Tell us your thoughts</a></p>
 
             </div>
 
         </div>
-    }
+
+    </div>
+}

--- a/applications/app/views/survey/surveyMain.scala.html
+++ b/applications/app/views/survey/surveyMain.scala.html
@@ -1,8 +1,8 @@
-@(surveyPage: Page)(body: Html)(implicit request: RequestHeader)
-
 @import common.InlineJs
-@import templates.inlineJS.blocking.js._
 @import model.Page
+@import templates.inlineJS.blocking.js.enableStylesheets
+
+@(surveyPage: Page)(body: Html)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
 <html id="js-context" class="js-off is-not-modern id--signed-out" data-page-path="@request.path">

--- a/applications/app/views/survey/thankyou.scala.html
+++ b/applications/app/views/survey/thankyou.scala.html
@@ -1,21 +1,21 @@
-@(surveyPage: Page)(implicit request: RequestHeader)
-
 @import model.Page
 
-    @surveyMain(surveyPage){
-            <div class="l-side-margins">
+@(surveyPage: Page)(implicit request: RequestHeader)
 
-                <div class="wrapper">
+@surveyMain(surveyPage){
+        <div class="l-side-margins">
 
-                    <div class="wrapper-inner">
+            <div class="wrapper">
 
-                        <h1>Thank you</h1>
+                <div class="wrapper-inner">
 
-                        <p class="standfirst">Your feedback has been submitted.</p>
+                    <h1>Thank you</h1>
 
-                    </div>
+                    <p class="standfirst">Your feedback has been submitted.</p>
 
                 </div>
 
             </div>
-    }
+
+        </div>
+}

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -1,10 +1,9 @@
-@(page: model.EmbedPage)(implicit request: RequestHeader)
-
-@import model.{Video, VideoPlayer}
-@import views.support.Video640
-@import conf.Static
-@import conf.Configuration
+@import conf.{Configuration, Static}
+@import model.{EmbedPage, VideoPlayer}
 @import templates.inlineJS.blocking.js.curlConfig
+@import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
+
+@(page: EmbedPage)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-video-embed-html ">

--- a/article/app/views/fragments/articleBodyExplore.scala.html
+++ b/article/app/views/fragments/articleBodyExplore.scala.html
@@ -1,10 +1,10 @@
-@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader)
-
 @import common.LinkTo
+@import controllers.ArticlePage
 @import views.BodyCleaner
 @import views.support.Commercial.isPaidContent
-@import views.support.TrailCssClasses.toneClass
-@import views.support.{ImgSrc, Item140}
+@import views.support.RenderClasses
+
+@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @defining(model.article) { article =>
     <div class="l-side-margins @if(article.content.elements.hasMainVideo){explore--video}">

--- a/commercial/app/views/masterclasses/masterclassCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassCard.scala.html
@@ -1,4 +1,7 @@
-@(event: model.commercial.Masterclass,
+@import model.commercial.Masterclass
+@import views.support.Item300
+
+@(event: Masterclass,
   clickMacro: Option[String],
   optClassNames: Option[Seq[String]] = None)
 

--- a/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
@@ -1,4 +1,7 @@
-@(event: model.commercial.Masterclass,
+@import model.commercial.Masterclass
+@import views.support.Item300
+
+@(event: Masterclass,
   clickMacro: Option[String],
   optAdvertClassNames: Option[Seq[String]] = None)
 

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -1,6 +1,8 @@
-@(interactive: _root_.model.content.InteractiveAtom, shouldFence: Boolean)
+@import common.InlineJs
+@import _root_.model.content.InteractiveAtom
+@import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 
-@import templates.inlineJS.nonBlocking.js._
+@(interactive: InteractiveAtom, shouldFence: Boolean)
 
 @iframeBody = {
     <!DOCTYPE html>

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -1,5 +1,5 @@
 @import common.InlineJs
-@import _root_.model.content.InteractiveAtom
+@import model.content.InteractiveAtom
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 
 @(interactive: InteractiveAtom, shouldFence: Boolean)

--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -1,6 +1,7 @@
-@(branding: common.commercial.Branding, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
-@import common.commercial.{Logo, PaidContent}
+@import common.commercial.{Branding, Logo, PaidContent}
+@import implicits.Requests.RichRequestHeader
 
+@(branding: common.commercial.Branding, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
 @standardLogo(logo: Logo) = {
     <img src="@logo.url" alt="@branding.sponsorName" class="badge__logo">
 }

--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -1,6 +1,7 @@
-@(dataId: Option[String] = None)(implicit request: RequestHeader)
-
+@import common.LinkTo
 @import views.html.fragments.inlineSvg
+
+@(dataId: Option[String] = None)(implicit request: RequestHeader)
 
 <div class="paidfor-meta">
     <span class="paidfor-meta__label">Paid content</span>

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,6 +1,7 @@
-@(metaData: model.MetaData, edition: common.Edition, maybeTags: Option[Tags])
-@import views.support.Commercial.topAboveNavSlot
 @import model.Tags
+@import views.support.Commercial.topAboveNavSlot
+
+@(metaData: model.MetaData, edition: common.Edition, maybeTags: Option[Tags])
 
 <div class="@topAboveNavSlot.cssClasses(metaData, edition, maybeTags)">
     @fragments.commercial.standardAd(

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -1,9 +1,9 @@
-@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
-
-@import model.VideoPlayer
-@import views.support.Video700
+@import model.{InlineImage, VideoPlayer}
 @import views.html.fragments.media.video
 @import views.html.fragments.nav.treats
+@import views.support.{RenderClasses, Video640, Video700}
+
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 <div class="fc-container__inner">
     <h2 class="video-title fc-container__header__title">

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -1,9 +1,12 @@
-@(trails: Seq[model.pressed.PressedContent], containerLayout: layout.ContainerLayout, containerIndex: Int, actualDate: org.joda.time.DateTime, page: model.MetaData, nav: PreviousAndNext, tzOverride: Option[org.joda.time.DateTimeZone] = None)(implicit request: RequestHeader, config: model.pressed.CollectionConfig)
-
 @import common.LinkTo
+@import layout.ContainerLayout
+@import model.MetaData
+@import model.pressed.{CollectionConfig, PressedContent}
+@import org.joda.time.{DateTime, DateTimeZone}
 @import views.html.fragments.containers.facia_cards.{date, slice}
-@import views.support.Commercial.container
 @import views.support.{GetClasses, PreviousAndNext}
+
+@(trails: Seq[PressedContent], containerLayout: ContainerLayout, containerIndex: Int, actualDate: DateTime, page: MetaData, nav: PreviousAndNext, tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader, config: CollectionConfig)
 
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -1,5 +1,8 @@
-@(content: model.Content, isCommentable: Boolean, discussionClosed: Boolean, discussionId: String)(implicit request: RequestHeader)
+@import common.LinkTo
 @import conf.switches.Switches._
+@import model.Content
+
+@(content: Content, isCommentable: Boolean, discussionClosed: Boolean, discussionId: String)(implicit request: RequestHeader)
 
 @sectionHeading = {
 

--- a/common/app/views/fragments/email/signup/subscriptionResult.scala.html
+++ b/common/app/views/fragments/email/signup/subscriptionResult.scala.html
@@ -1,6 +1,7 @@
+@import model.{InvalidEmail, OtherError, Subscribed, SubscriptionResult}
+
 @(result: SubscriptionResult)
 
-@import model.{SubscriptionResult, Subscribed, InvalidEmail, OtherError}
 <div class="email-sub email-sub--article">
     <div class="email-sub__message">
         @result match {

--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -1,10 +1,9 @@
-@(page: ContentPage)(implicit request: RequestHeader)
-
 @import common.LinkTo
 @import layout.ContentWidths.MainMedia
 @import model.ContentPage
-@import views.support.TrailCssClasses.toneClass
 @import views.support.RenderClasses
+@import views.support.TrailCssClasses.toneClass
+@(page: ContentPage)(implicit request: RequestHeader)
 
 @defining((
     page.item.elements.hasMainEmbed,

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -1,5 +1,5 @@
 @import layout.ContentWidths.MainMedia
-@import views.support.ImgSrc
+@import views.support.{ImgSrc, RenderClasses}
 
 @(
     picture: model.ImageMedia,

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -1,6 +1,6 @@
-@import model.ImageAsset
 @import layout.ContentWidths.MainMedia
-@import views.support.ImgSrc
+@import model.ImageAsset
+@import views.support.{ImgSrc, Item700}
 
 @(
     picture: model.ImageMedia,

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -1,9 +1,9 @@
-@(page: ContentPage)(implicit request: RequestHeader)
-
 @import layout.ContentWidths.MainMedia
 @import model.ContentPage
-@import views.support.TrailCssClasses.toneClass
 @import views.support.ContributorLinks
+@import views.support.TrailCssClasses.toneClass
+
+@(page: ContentPage)(implicit request: RequestHeader)
 
 <div class="content content--immersive tonal tonal--@toneClass(page.item) immersive-main-media">
 

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -1,5 +1,5 @@
 @import common.{LinkTo, Localisation}
-@import conf.switches.Switches._
+@import conf.switches.Switches.ArticleBadgesSwitch
 @import layout.ContentWidths.MainMedia
 @import model.Badges.badgeFor
 @import model.ContentPage

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -1,12 +1,12 @@
-@(page: ContentPage)(implicit request: RequestHeader)
-
 @import common.{LinkTo, Localisation}
-@import layout.ContentWidths.MainMedia
-@import model.ContentPage
-@import views.support.TrailCssClasses.toneClass
-@import views.support.RenderClasses
 @import conf.switches.Switches._
+@import layout.ContentWidths.MainMedia
 @import model.Badges.badgeFor
+@import model.ContentPage
+@import views.support.RenderClasses
+@import views.support.TrailCssClasses.toneClass
+
+@(page: ContentPage)(implicit request: RequestHeader)
 
 @defining((
     page.item.tags.isTheMinuteArticle,

--- a/common/app/views/fragments/immersiveVideo.scala.html
+++ b/common/app/views/fragments/immersiveVideo.scala.html
@@ -1,3 +1,6 @@
+@import model.{ContentPage, EndSlateComponents, VideoPlayer}
+@import views.support.Video640
+
 @(page: ContentPage)(implicit request: RequestHeader)
 <div class="explore-video">
   <div class="gs-conatainer">

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -1,8 +1,9 @@
-@(page: model.Page)(implicit request: RequestHeader)
-@import conf.switches.Switches._
 @import common.InlineJs
-@import templates.inlineJS.blocking.js._
-@import templates.inlineJS.blocking.polyfills.js._
+@import conf.switches.Switches.{AsyncCss, FontSwitch}
+@import templates.inlineJS.blocking.js.{applyRenderConditions, cloudwatchBeacons, config, curlConfig, enableStylesheets, loadFonts, shouldEnhance}
+@import templates.inlineJS.blocking.polyfills.js.{classlist, details, matches, raf, setTimeout}
+
+@(page: model.Page)(implicit request: RequestHeader)
 
 <!--[if lt IE 8]>
     <script src="@Static("javascripts/components/JSON-js/json2.js")"></script>

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -1,13 +1,14 @@
+@import common.InlineJs
+@import conf.switches.Switches.IdentityProfileNavigationSwitch
+@import conf.Configuration
+@import templates.inlineJS.nonBlocking.js._
+
 @()(implicit request: RequestHeader)
 
 @**
  * Use this fragment to add JavaScript that can improve the perceived rendering speed
  * but that is too blocking / risky to be put in the `head` of the document
  *@
-
-@import conf.switches.Switches.IdentityProfileNavigationSwitch
-@import conf.Configuration
-@import templates.inlineJS.nonBlocking.js._
 
 <script>
 // non-blocking JS to improve the perceived rendering speed

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,5 +1,8 @@
 @import layout.WidthsByBreakpoint
-@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageMedia: Option[model.ImageMedia] = None, maybePath: Option[String] = None, maybeSrc: Option[String] = None)
+@import model.ImageMedia
+@import views.support.{ImgSrc, RenderClasses}
+
+@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageMedia: Option[ImageMedia] = None, maybePath: Option[String] = None, maybeSrc: Option[String] = None)
 
 <picture>
     @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -1,9 +1,8 @@
-@(faciaContent: model.pressed.PressedContent, info: RowInfo)(implicit request: RequestHeader)
-
-@import views.support.RowInfo
 @import common.LinkTo
-@import views.support.RemoveOuterParaHtml
 @import model.SupportedUrl
+@import views.support.{RemoveOuterParaHtml, RowInfo}
+
+@(faciaContent: model.pressed.PressedContent, info: RowInfo)(implicit request: RequestHeader)
 
 <a href="@LinkTo(SupportedUrl.fromFaciaContent(faciaContent))" data-link-name="@info.rowNum | text">
     @faciaContent.properties.linkText.map(RemoveOuterParaHtml.apply)

--- a/common/app/views/fragments/meta/byline.scala.html
+++ b/common/app/views/fragments/meta/byline.scala.html
@@ -1,3 +1,6 @@
+@import model.Tags
+@import views.support.ContributorLinks
+
 @(byline: Option[String], tags: Tags)(implicit request: RequestHeader)
 
 @byline.map { text =>

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -1,3 +1,7 @@
+@import common.RichRequestHeader
+@import model.Tag
+@import views.support.{ImgSrc, Item300}
+
 @(profileTag: Tag)(implicit request: RequestHeader)
 <div class="liveblog-block-byline">
     @profileTag.contributorImagePath.map { src =>

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,6 +1,9 @@
-@(webPublicationDate: org.joda.time.DateTime, lastModified: org.joda.time.DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
-@import views.support.AuFriendlyFormat
+@import common.RichRequestHeader
 @import conf.switches.Switches.AmpLiveBlogNewsArticleSwitch
+@import org.joda.time.DateTime
+@import views.support.{AuFriendlyFormat, Format}
+
+@(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
 @* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
 @isAmpAndStructuredAsNewsArticle() = @{

--- a/common/app/views/fragments/nav/topNavigation.scala.html
+++ b/common/app/views/fragments/nav/topNavigation.scala.html
@@ -1,6 +1,8 @@
-@(page: model.Page, navigation: Seq[common.NavItem])(implicit request: RequestHeader)
+@import model.Page
+@import common.{Edition, LinkTo, NavItem, Navigation}
+@import views.support.RenderClasses
 
-@import _root_.common._
+@(page: Page, navigation: Seq[NavItem])(implicit request: RequestHeader)
 
 <ul class="top-navigation js-top-navigation">
     <li class="top-navigation__item top-navigation__item--home">

--- a/common/app/views/fragments/nav/treats.scala.html
+++ b/common/app/views/fragments/nav/treats.scala.html
@@ -1,9 +1,9 @@
-@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
-
 @import crosswords.{CrosswordGrid, CrosswordPreview}
-@import views.support.{Treat, CrosswordTreat, SnappableTreat, ClimateTreat, NormalTreat}
-@import model.SupportedUrl
 @import implicits.Requests.RichRequestHeader
+@import model.SupportedUrl
+@import views.support.{ClimateTreat, CrosswordTreat, GlastoTreat, NormalTreat, SnappableTreat, Treat}
+
+@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 
 @if(containerDefinition.collectionEssentials.treats.nonEmpty) {
     <ul class="treats__container">

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -1,12 +1,12 @@
+@import common.{PagePaths, Pagination}
+@import views.support.Format
+
 @(title: String,
   pagination: Pagination,
   pagePaths: PagePaths,
   actionClass: Option[String] = None,
   showFull: Boolean = true,
   ariaContext: Option[String] = None)(implicit request: RequestHeader)
-
-@import common._
-@import views.support.Format
 
 @paginated(pageNum: Int) = {@common.LinkTo(pagePaths.pathFor(pageNum))}
 @paginationPointer(pageNo: Option[Int], dir: String) = {

--- a/common/app/views/fragments/relativeDate.scala.html
+++ b/common/app/views/fragments/relativeDate.scala.html
@@ -1,4 +1,7 @@
-@(webPublicationDate: org.joda.time.DateTime, isLive: Boolean = false, isFront: Boolean = false)(implicit request: RequestHeader)
+@import org.joda.time.DateTime
+@import views.support.Format
+
+@(webPublicationDate: DateTime, isLive: Boolean = false, isFront: Boolean = false)(implicit request: RequestHeader)
 
 <p class="relative-timestamp @if(isFront){ front-timestamp}">
     @if(isLive){

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,4 +1,8 @@
-@(item: model.ContentType)(implicit request: RequestHeader)
+@import common.Edition
+@import model.ContentType
+@import views.support.{BulletCleaner, ContributorLinks, InBodyLinkCleaner, RenderClasses, withJsoup}
+
+@(item: ContentType)(implicit request: RequestHeader)
 
 <div class="@RenderClasses(Map(
     "content__standfirst--gallery" -> item.content.isImmersiveGallery,

--- a/common/app/views/fragments/trails/headline.scala.html
+++ b/common/app/views/fragments/trails/headline.scala.html
@@ -1,6 +1,9 @@
-@(trail: model.pressed.PressedContent, rowNum: Int, related: Boolean = false, element: String = "li", headingLevel: Int = 2)(implicit request: RequestHeader)
-
+@import common.{Edition, LinkTo}
 @import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
+@import model.pressed.PressedContent
+@import views.support.cleanTrailText
+
+@(trail: PressedContent, rowNum: Int, related: Boolean = false, element: String = "li", headingLevel: Int = 2)(implicit request: RequestHeader)
 
 <@element class="trail trail--headline t@rowNum"
     @if(trail.discussion.isCommentable) {

--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -1,3 +1,6 @@
+@import common.LinkTo
+@import discussion.CommentPage
+
 @(page: CommentPage)(implicit request: RequestHeader)
 @main(page){
 } {

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -1,6 +1,12 @@
-@(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
+@import common.Edition
 @import conf.Configuration
 @import conf.switches.Switches.SharingComments
+@import discussion.model.Comment
+@import views.support.{Format, RenderClasses}
+@import views.support.`package`.withJsoup
+@import views.support.{BulletCleaner, InBodyLinkCleaner}
+
+@(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 
 @* Please don't use the isTopComment switch - we've kept it pretty clean without it, but just need a solution for IDs *@
 <li class="d-comment

--- a/discussion/app/views/fragments/commentSchema.scala.html
+++ b/discussion/app/views/fragments/commentSchema.scala.html
@@ -1,3 +1,6 @@
+@import views.support.withJsoup
+@import discussion.model.Comment
+
 @(comment: Comment, showMore: Boolean = false)(implicit request: RequestHeader)
 
 @import common.Edition

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,7 +1,10 @@
-@(comment: Comment)
+@import _root_.model.{Facebook, ShareLinks, SharePlatform, Twitter}
+@import discussion.model.Comment
+@import org.apache.commons.lang.StringEscapeUtils
 @import org.jsoup.Jsoup
 @import org.jsoup.safety.Whitelist
-@import org.apache.commons.lang.StringEscapeUtils
+
+@(comment: Comment)
 
 <div class="d-comment__action d-comment__action--share">
 

--- a/discussion/app/views/fragments/topComment.scala.html
+++ b/discussion/app/views/fragments/topComment.scala.html
@@ -1,5 +1,8 @@
-@(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 @import conf.Configuration
+@import discussion.model.Comment
+@import views.support.{BulletCleaner, Format, InBodyLinkCleaner, TruncateCleaner, withJsoup}
+
+@(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 
 @* Please don't use the isTopComment switch - we've kept it pretty clean without it, but just need a solution for IDs *@
 <li class="d-top-comment"

--- a/discussion/app/views/profileActivity/comment.scala.html
+++ b/discussion/app/views/profileActivity/comment.scala.html
@@ -1,3 +1,7 @@
+@import common.Edition
+@import discussion.model.Comment
+@import views.support.{BulletCleaner, InBodyLinkCleaner, withJsoup}
+
 @(comment: Comment, canRecommend: Boolean = false)(implicit request: RequestHeader)
 <div class="disc-comment u-cf">
     <div class="disc-comment__meta u-cf">

--- a/identity/app/views/fragments/profile/saveForLater/contentListPage.scala.html
+++ b/identity/app/views/fragments/profile/saveForLater/contentListPage.scala.html
@@ -1,6 +1,8 @@
+@import common.LinkTo
 @import model.SaveForLaterItem
 @import views.html.fragments.items.facia_cards.contentCard
-@import common.LinkTo
+@import views.support.RenderClasses
+@import views.support.`package`.Seq2zipWithRowInfo
 
 @(articles: Seq[SaveForLaterItem])(implicit request: RequestHeader)
 <div class="saved-contents js-saved-contents" data-link-name="saved">

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -1,6 +1,9 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader)
-
+@import common.LinkTo
+@import model.Page
+@import services.{IdentityRequest, IdentityUrlBuilder}
 @import views.html.fragments.registrationFooter
+
+@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader)
 
 @main(page, projectName = Option("identity")){
 }{

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -1,7 +1,10 @@
-@(page: model.Page, emailPrefsForm: Form[EmailPrefsData], formActionUrl: String, emailSubscriptions: EmailSubscriptions)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
-
-@import views.html.fragments.form.{checkboxField, radioField}
 @import form.IdFormHelpers._
+@import model.{EmailSubscription, EmailSubscriptions}
+@import views.html.fragments.form.radioField
+@import views.support.RenderClasses
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(page: model.Page, emailPrefsForm: Form[EmailPrefsData], formActionUrl: String, emailSubscriptions: EmailSubscriptions)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @emailListCategoryList(theme: String, subscriptions: List[EmailSubscription], isActive: Boolean) = {
     @fragments.dropdown(theme, isActive = isActive) {

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -1,9 +1,10 @@
-@(content: model.ContentType)(implicit request: RequestHeader)
-
-
+@import model.ContentType
 @import model.pressed.{Comment, DefaultCardstyle, Feature, Media, SpecialReport}
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{ImgSrc, RichLinkContributor, Item460, RenderClasses}
+@import views.support.{BulletCleaner, ImgSrc, Item460, RenderClasses, RichLinkContributor}
+
+@(content: ContentType)(implicit request: RequestHeader)
+
 
 @kicker = {
     @if(content.tags.isAnalysis) {

--- a/onward/app/views/mostViewedGalleries.scala.html
+++ b/onward/app/views/mostViewedGalleries.scala.html
@@ -1,3 +1,5 @@
+@import model.Page
+
 @(page: Page, container: Html)(implicit request: RequestHeader)
 
 @main(page, Some("facia")){

--- a/onward/app/views/topStories.scala.html
+++ b/onward/app/views/topStories.scala.html
@@ -1,3 +1,5 @@
+@import model.Page
+
 @(page: Page, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader)
 
 @main(page){

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -71,10 +71,6 @@ trait Prototypes {
   val frontendClientSideSettings = Seq(
 
     TwirlKeys.templateImports ++= Seq(
-      "common._",
-      "model._",
-      "views._",
-      "views.support._",
       "conf._",
       "play.api.Play",
       "play.api.Play.current"

--- a/sport/app/cricket/views/cricketMatch.scala.html
+++ b/sport/app/cricket/views/cricketMatch.scala.html
@@ -1,4 +1,6 @@
+@import common.LinkTo
 @import cricket.controllers.CricketMatchPage
+
 @(page: CricketMatchPage)(implicit request: RequestHeader)
 
 @main(page, "football"){ } {

--- a/sport/app/football/views/competitions.scala.html
+++ b/sport/app/football/views/competitions.scala.html
@@ -1,3 +1,6 @@
+@import football.controllers.CompetitionFilter
+@import model.Page
+
 @(competitions: Map[String, Seq[CompetitionFilter]], page: Page, competitionList: List[String])(implicit request: RequestHeader)
 
 @main(page, "football"){

--- a/sport/app/football/views/fragments/competitionsBody.scala.html
+++ b/sport/app/football/views/fragments/competitionsBody.scala.html
@@ -1,3 +1,6 @@
+@import football.controllers.CompetitionFilter
+@import common.LinkTo
+
 @(competitions: Map[String, Seq[CompetitionFilter]], page: model.Page, competitionList: List[String])(implicit request: RequestHeader)
 <div class="l-side-margins">
     <div class="monocolumn-wrapper">

--- a/sport/app/football/views/fragments/matchNav.scala.html
+++ b/sport/app/football/views/fragments/matchNav.scala.html
@@ -1,5 +1,9 @@
-@(component: football.controllers.MatchNav)(implicit request: RequestHeader)
+@import common.LinkTo
+@import football.controllers.MatchNav
 @import football.model.FootballMatchTrail
+
+@(component: MatchNav)(implicit request: RequestHeader)
+
 
 @report(trail: FootballMatchTrail, text: String) = {
     @if(component.currentPage.exists(_.url == trail.url)){

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -1,5 +1,11 @@
-@(theMatch: FootballMatch, competition: Option[model.Competition] = None, responsive: Boolean = false, link: Boolean = false)(implicit request: RequestHeader)
+@import common.LinkTo
 @import implicits.Football._
+@import model.Competition
+@import pa.FootballMatch
+@import views.support.RenderClasses
+
+@(theMatch: FootballMatch, competition: Option[Competition] = None, responsive: Boolean = false, link: Boolean = false)(implicit request: RequestHeader)
+
 
 @defining((theMatch.homeTeam, theMatch.awayTeam)){ case (homeTeam, awayTeam) =>
 <@if(link){a href="@LinkTo("/football/match-redirect/"+theMatch.id)"}else{div}

--- a/sport/app/football/views/fragments/status.scala.html
+++ b/sport/app/football/views/fragments/status.scala.html
@@ -1,3 +1,6 @@
+@import pa.{Fixture, FootballMatch, MatchDay}
+@import views.MatchStatus
+
 @(theMatch: FootballMatch)
 
 @theMatch match {

--- a/sport/app/football/views/fragments/teamlistBody.scala.html
+++ b/sport/app/football/views/fragments/teamlistBody.scala.html
@@ -1,3 +1,8 @@
+@import common.LinkTo
+@import football.controllers.TablesPage
+@import model.TeamUrl
+@import views.support.`package`.Seq2zipWithRowInfo
+
 @(pageModel: TablesPage, comps: Seq[model.Competition])(implicit request: RequestHeader)
 <div class="l-side-margins">
     <div class="monocolumn-wrapper">

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -1,6 +1,7 @@
-@(matchesList: football.model.MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader)
+@import football.model.MatchesList
+@import views.support.`package`.Seq2zipWithRowInfo
 
-@import football.model._
+@(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader)
 
 <div data-component="football-matches-embed" class="c-football-matches">
 

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -1,8 +1,9 @@
-@(page: MatchPage)(implicit request: RequestHeader)
+@import football.controllers.MatchPage
+@import model.TeamColours
+@import views.support.RenderClasses
+@import views.{NudgePercent, PercentMaker}
 
-@import views.support._
-@import views.FootballHelpers._
-@import feed._
+@(page: MatchPage)(implicit request: RequestHeader)
 
 @defining((page.hasPaStats, page.lineUp.homeTeam, page.lineUp.awayTeam, page.lineUp, TeamColours(page.lineUp.homeTeam, page.lineUp.awayTeam))){ case (hasStats, home, away, lineUp, teamColours) =>
 @if(hasStats) {

--- a/sport/app/football/views/matchStats/matchStatsPage.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsPage.scala.html
@@ -1,7 +1,10 @@
-@(page: MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader)
-
+@import common.LinkTo
+@import pa.LineUpPlayer
 @import implicits.Football._
 @import views.FootballHelpers._
+
+
+@(page: MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader)
 
 @team(players: Seq[LineUpPlayer]) = {
     <ul class="team-list u-unstyled">

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -1,4 +1,8 @@
-@(competition: model.Competition, group: Group,
+@import model.{Competition, Group, TeamUrl}
+@import views.support.RenderClasses
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(competition: Competition, group: Group,
     heading: Option[String] = None,
     headingLink: Option[String] = None,
     highlightTeamId: Option[String] = None, striped: Boolean = false,

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -1,4 +1,6 @@
-@(competition: model.Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader)
+@import model.{Competition, Group}
+
+@(competition: Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader)
 
 @if(!multiGroup) {
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -1,3 +1,6 @@
+@import football.controllers.TablesPage
+@import views.support.`package`.Seq2zipWithRowInfo
+
 @(page: TablesPage)(implicit request: RequestHeader)
 
 @main(page.page, "football"){

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -1,5 +1,7 @@
-@(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
 @import implicits.Football._
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
 
 <ul class="football-groups u-unstyled u-cf">
     @groupStage.groupTables.zipWithRowInfo.map{ case ((round, leagueTableEntries), row) =>

--- a/sport/app/football/views/wallchart/knockoutList.scala.html
+++ b/sport/app/football/views/wallchart/knockoutList.scala.html
@@ -1,4 +1,8 @@
-@(competition: model.Competition, knockoutStage: _root_.football.model.Knockout, hasSpider: Boolean = false)(implicit request: RequestHeader)
+@import _root_.football.model.Knockout
+@import model.Competition
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(competition: Competition, knockoutStage: Knockout, hasSpider: Boolean = false)(implicit request: RequestHeader)
 
 <div class="football-knockouts @if(hasSpider){football-knockouts--has-spider}">
     @knockoutStage.rounds.zipWithRowInfo.map{ case (round, row) =>

--- a/sport/app/football/views/wallchart/page.scala.html
+++ b/sport/app/football/views/wallchart/page.scala.html
@@ -1,4 +1,7 @@
-@(page: Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader)
+@import _root_.football.model.CompetitionStageLike
+@import model.{Competition, Page}
+
+@(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike])(implicit request: RequestHeader)
 
 @main(page, "football"){
 }{

--- a/sport/app/rugby/views/fragments/groupTable.scala.html
+++ b/sport/app/rugby/views/fragments/groupTable.scala.html
@@ -1,5 +1,5 @@
-@import rugby.model.Match
-@import rugby.model.GroupTable
+@import rugby.model.{GroupTable, Match}
+@import views.support.RenderClasses
 
 @(theMatch: Match, group: Option[GroupTable])
 

--- a/sport/app/rugby/views/fragments/matchNav.scala.html
+++ b/sport/app/rugby/views/fragments/matchNav.scala.html
@@ -1,6 +1,10 @@
-@(matchNav: rugby.feed.MatchNavigation, currentPage: Option[String])(implicit request: RequestHeader)
+@import common.LinkTo
+@import model.ContentType
+@import rugby.feed.MatchNavigation
 
-@tab(content: model.ContentType, text: String) = {
+@(matchNav: MatchNavigation, currentPage: Option[String])(implicit request: RequestHeader)
+
+@tab(content: ContentType, text: String) = {
     @if(currentPage.exists( _.endsWith(content.metadata.id))) {
         <li class="tabs__tab tab--@text.toLowerCase tabs__tab--selected tone-colour tone-accent-border">
             <span class="tab__link">@text</span>

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -1,5 +1,6 @@
-@import rugby.model.Match
-@import rugby.model.MatchStat
+@import rugby.model.{Match, MatchStat}
+@import views.{NudgePercent, PercentMaker}
+@import views.support.RenderClasses
 
 @(theMatch: Match, matchStat: Option[MatchStat])
 

--- a/sport/app/rugby/views/fragments/matchSummary.scala.html
+++ b/sport/app/rugby/views/fragments/matchSummary.scala.html
@@ -1,5 +1,9 @@
-@import rugby.model.Status._
-@(page: model.Page, theMatch: rugby.model.Match)
+@import model.Page
+@import rugby.model.Match
+@import rugby.model.Status.{FirstHalf, HalfTime, Result, SecondHalf}
+@import views.support.RenderClasses
+
+@(page: Page, theMatch: Match)
 
 @status() = {
     @theMatch.status match {

--- a/sport/app/rugby/views/matchSummary.scala.html
+++ b/sport/app/rugby/views/matchSummary.scala.html
@@ -1,5 +1,7 @@
-@import rugby.model.ScoreEvent
-@(page: model.Page, theMatch: rugby.model.Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader)
+@import model.Page
+@import rugby.model.{Match, ScoreEvent}
+
+@(page: Page, theMatch: Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader)
 
 @main(page, "football") { } {
     <div class="l-side-margins">


### PR DESCRIPTION
In `Prototypes.scala`, we specify the following packages as _always_ being imported:
-      "common._",  
-      "model._",  
-      "views._",  
-      "views.support._"

This is _really_ annoying, because it means that any subpackage in any of these packages can cause a namespace conflict with something else and starts to require specifying modules with `_root_.` etc.

Making this change means that each project is able to manage it's own namespace and each template can specifically import whichever models/controllers/views/helpers it needs, without worrying about clashing namespaces within common / model / views / views.support.

This won't really add much of a burden on anyone developing new templates or editing current ones - it is just quite a large initial effort to do (and maybe review (sorry)).

**I'd suggest reviewing this ignoring whitespace...**

**Added bonus**
Play allows the specification of imports before specifying the parameters to a template, so our parameter lists can now be things like `page: Page` rather than `page: model.Page`, which is a bit cleaner.
