### PR TITLE
Render default HTML for quizzes on AMP

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -9,7 +9,7 @@ object InteractiveBodyCleaner {
   def apply(interactive: Interactive)(implicit request: RequestHeader): Html = {
     val html = interactive.fields.body
     val cleaners = List(
-      AtomsCleaner(interactive.content.atoms, shouldFence = false)
+      AtomsCleaner(interactive.content.atoms, amp = false, shouldFence = false)
     ) ++ (if (interactive.content.isImmersive) List(InteractiveSrcdocCleaner) else Nil)
 
     withJsoup(html)(cleaners: _*)

--- a/applications/app/views/quizAnswerPage.scala.html
+++ b/applications/app/views/quizAnswerPage.scala.html
@@ -8,7 +8,7 @@
             <div class="content__main">
                 <div class="gs-container">
                     <div class="content__main-column">
-                        @{views.html.fragments.atoms.quiz(page.quiz, maybeResults = Some(page.results), showResults = true, page.shares)}
+                        @{views.html.fragments.atoms.quiz(page.quiz, maybeResults = Some(page.results), showResults = true, page.shares, amp = false)}
                     </div>
                 </div>
             </div>

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -50,7 +50,7 @@ object BodyCleaner {
       TableEmbedComplimentaryToP,
       R2VideoCleaner,
       PictureCleaner(article, amp),
-      AtomsCleaner(article.content.atoms, shouldFence = true),
+      AtomsCleaner(article.content.atoms, amp, shouldFence = true),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -41,6 +41,7 @@ final case class MediaAsset(
 
 final case class Quiz(
   override val id: String,
+  defaultHtml: String,
   title: String,
   path: String,
   quizType: String,
@@ -74,7 +75,7 @@ object Atoms extends common.Logging {
     content.atoms.map { atoms =>
       val quizzes = extract(atoms.quizzes, atom => {
         val quizAtom = atom.data.asInstanceOf[AtomData.Quiz].quiz
-        Quiz.make(content.id, quizAtom)
+        Quiz.make(content.id, atom.defaultHtml, quizAtom)
       })
 
       val media = extract(atoms.media, atom => {
@@ -151,7 +152,7 @@ object Quiz extends common.Logging {
 
 
 
-  def make(path: String, quiz: atomapi.quiz.QuizAtom): Quiz = {
+  def make(path: String, defaultHtml: String, quiz: atomapi.quiz.QuizAtom): Quiz = {
     val questions = quiz.content.questions.map { question =>
       val answers = question.answers.map { answer =>
         Answer(
@@ -196,6 +197,7 @@ object Quiz extends common.Logging {
 
     Quiz(
       id = quiz.id,
+      defaultHtml = defaultHtml,
       path = path,
       title = quiz.title,
       quizType = quiz.quizType,

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,11 +1,11 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean)(implicit request: RequestHeader)
+@(model: _root_.model.content.Atom, amp: Boolean, shouldFence: Boolean)(implicit request: RequestHeader)
 @import _root_.model.content.Quiz
 @import _root_.model.content.MediaAtom
 @import _root_.model.content.InteractiveAtom
 
 @{
     model match {
-        case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil)
+        case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil, amp)
         case media: MediaAtom => media match {
             case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media)
             case _ => views.html.fragments.atoms.media(media)

--- a/common/app/views/fragments/atoms/quiz.scala.html
+++ b/common/app/views/fragments/atoms/quiz.scala.html
@@ -4,29 +4,34 @@
 @import layout.ContentWidths.BodyMedia
 @import views.support.RenderClasses
 
-@(quiz: model.content.Quiz, maybeResults: Option[QuizResults], showResults: Boolean, sharelinks: Seq[model.ShareLink])(implicit request: RequestHeader)
+@(quiz: model.content.Quiz, maybeResults: Option[QuizResults], showResults: Boolean, sharelinks: Seq[model.ShareLink], amp: Boolean)(implicit request: RequestHeader)
 
-<form action="@postUrl(quiz)" method="POST" class="@RenderClasses(Map(
-    ("atom-quiz", true),
-    ("atom-quiz--personality", quiz.quizType == "personality"),
-    ("atom-quiz--knowledge", quiz.quizType == "knowledge"),
-    ("atom-quiz--is-not-results", !showResults),
-    ("atom-quiz--is-results", showResults),
-    ("atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge"),
-    ("js-atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge")
-))">
-    @renderHeader(maybeResults)
-    @quiz.content.questions.zipWithIndex.map { case (question, index) =>
-        @renderQuestion(question,
-            playForm(s"answers[$index]"),
-            maybeResults.flatMap(_.getAnswerFor(question))
-        )
-    }
-    @renderFooter(maybeResults)
-    @if(maybeResults.isEmpty) {
-        <button class="button button--xlarge button--primary" type="submit">Submit answers</button>
-    }
-</form>
+@if(amp) {
+    @HtmlFormat.raw(quiz.defaultHtml)
+} else {
+
+    <form action="@postUrl(quiz)" method="POST" class="@RenderClasses(Map(
+        ("atom-quiz", true),
+        ("atom-quiz--personality", quiz.quizType == "personality"),
+        ("atom-quiz--knowledge", quiz.quizType == "knowledge"),
+        ("atom-quiz--is-not-results", !showResults),
+        ("atom-quiz--is-results", showResults),
+        ("atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge"),
+        ("js-atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge")
+    ))">
+        @renderHeader(maybeResults)
+        @quiz.content.questions.zipWithIndex.map { case (question, index) =>
+            @renderQuestion(question,
+                playForm(s"answers[$index]"),
+                maybeResults.flatMap(_.getAnswerFor(question))
+            )
+        }
+        @renderFooter(maybeResults)
+        @if(maybeResults.isEmpty) {
+            <button class="button button--xlarge button--primary" type="submit">Submit answers</button>
+        }
+    </form>
+}
 
 @renderQuestion(question: Question, field: play.api.data.Field, maybeUserAnswer: Option[Answer]) = {
     <fieldset class="atom-quiz__question">

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -618,7 +618,7 @@ object ChaptersLinksCleaner extends HtmlCleaner {
   }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], amp:Boolean, shouldFence: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -631,7 +631,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean)(implicit val
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence).toString()
+        val html = views.html.fragments.atoms.atom(atomData, amp, shouldFence).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }


### PR DESCRIPTION
## What does this change?

Make quizzes work on AMP

The frontend render of quizzes uses forms etc., which don't validate in AMP. This just renders the standard atom's default HTML which at least makes the article validate successfully
## Does this affect other platforms - Amp, Apps, etc?

AMP
