### PR TITLE
Bye bye WS

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -19,7 +19,7 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
-import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
+import services.{ConfigAgentLifecycle, IndexListingsLifecycle, OphanApi}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -32,21 +32,18 @@ trait ApplicationsServices {
   lazy val contentApiClient = wire[ContentApiClient]
   lazy val siteMapJob = wire[SiteMapJob]
   lazy val sectionsLookUp = wire[SectionsLookUp]
+  lazy val ophanApi = wire[OphanApi]
 }
 
-trait Controllers extends ApplicationsControllers {
-  self: FrontendComponents with ApplicationsServices =>
-  def wsClient: WSClient
+
+trait AppComponents extends FrontendComponents with ApplicationsControllers with ApplicationsServices {
+
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
   lazy val assets = wire[Assets]
   lazy val emailSignupController = wire[EmailSignupController]
   lazy val surveyPageController = wire[SurveyPageController]
   lazy val signupPageController = wire[SignupPageController]
-}
-
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers with ApplicationsServices =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -61,9 +58,6 @@ trait AppLifecycleComponents {
     wire[CachedHealthCheckLifeCycle],
     wire[DiscussionExternalAssetsLifecycle]
   )
-}
-
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with ApplicationsServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/applications/test/TestAppLoader.scala
+++ b/applications/test/TestAppLoader.scala
@@ -4,7 +4,7 @@ import play.api.BuiltInComponentsFromContext
 import test.WithTestContentApiClient
 
 trait TestComponents extends WithTestContentApiClient {
-  self: ApplicationsServices =>
+  self: AppComponents =>
   override lazy val contentApiClient = testContentApiClient
 }
 

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -18,29 +18,21 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
-import play.api.libs.ws.WSClient
-import services.NewspaperBooksAndSectionsAutoRefresh
+import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait ArticleServices {
-  def wsClient: WSClient
+trait AppComponents extends FrontendComponents with ArticleControllers {
+
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   lazy val contentApiClient = wire[ContentApiClient]
-}
+  lazy val ophanApi = wire[OphanApi]
 
-trait Controllers extends ArticleControllers {
-  self: BuiltInComponents =>
-  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
-}
-
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -53,9 +45,6 @@ trait AppLifecycleComponents {
     wire[TargetingLifecycle],
     wire[DiscussionExternalAssetsLifecycle]
   )
-}
-
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with ArticleServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/article/test/TestAppLoader.scala
+++ b/article/test/TestAppLoader.scala
@@ -4,7 +4,7 @@ import play.api.BuiltInComponentsFromContext
 import test.WithTestContentApiClient
 
 trait TestComponents extends WithTestContentApiClient {
-  self: ArticleServices =>
+  self: AppComponents =>
   override lazy val contentApiClient = testContentApiClient
 }
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -13,8 +13,6 @@ import conf.switches.Switches.CircuitBreakerSwitch
 import model.{Content, Trail}
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
-import play.api.libs.ws.WS
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future}
@@ -161,17 +159,6 @@ final case class CircuitBreakingContentApiClient(
     } else {
       super.fetch(url)
     }
-  }
-}
-
-//TODO: Do not use. For legacy reason only.
-//To delete once all references to ContentApiClient are via the class
-object ContentApiClient extends ContentApiClient(WSCapiHttpClient)
-object WSCapiHttpClient extends HttpClient {
-  import play.api.Play.current
-  lazy val httpClient = new CapiHttpClient(WS.client)
-  def GET(url: String, headers: Iterable[(String, String)]): Future[Response] = {
-    httpClient.GET(url, headers)
   }
 }
 

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -4,9 +4,8 @@ import java.net.URLEncoder
 
 import common.{BadConfigurationException, ExecutionContexts, Logging}
 import conf.Configuration._
-import play.api.Play.current
 import play.api.libs.json._
-import play.api.libs.ws.{WS, WSClient}
+import play.api.libs.ws.WSClient
 
 import scala.concurrent.Future
 

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -106,5 +106,3 @@ class OphanApi(wsClient: WSClient) extends ExecutionContexts with Logging with i
     getBody("video/mostviewed")(Map("hours" -> hours.toString, "count" -> count.toString))
 }
 
-object OphanApi extends OphanApi(WS.client) //Do not use. TODO: To delete once we find an elegant way to inject OphanApi into SurgingContentAgent
-

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -31,8 +31,6 @@ trait TestSettings {
       }
     }
   }
-
-  ContentApiClient.thriftClient._httpClient = toRecorderHttp(ContentApiClient.thriftClient._httpClient)
 }
 
 trait ConfiguredTestSuite extends ConfiguredServer with ConfiguredBrowser with ExecutionContexts {

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -1,4 +1,4 @@
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
@@ -16,7 +16,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
-import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
+import services.{ConfigAgentLifecycle, IndexListingsLifecycle, OphanApi}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -29,16 +29,12 @@ trait FapiServices {
   lazy val frontJsonFapiDraft = wire[FrontJsonFapiDraft]
 }
 
-trait Controllers extends FaciaControllers {
-  self: BuiltInComponents =>
-  def wsClient: WSClient
+trait AppComponents extends FrontendComponents with FaciaControllers with FapiServices {
+
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val assets = wire[Assets]
-}
-
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
+  lazy val ophanApi = wire[OphanApi]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -50,9 +46,6 @@ trait AppLifecycleComponents {
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle]
   )
-}
-
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with FapiServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -11,6 +11,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
+import services.OphanApi
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -33,6 +34,7 @@ trait AppComponents
 
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
+  override lazy val ophanApi = wire[OphanApi]
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -15,7 +15,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
-import services.ConfigAgentLifecycle
+import services.{ConfigAgentLifecycle, OphanApi}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -28,6 +28,7 @@ trait AppComponents extends FrontendComponents {
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   lazy val contentApiClient = wire[ContentApiClient]
   lazy val sectionsLookUp = wire[SectionsLookUp]
+  lazy val ophanApi = wire[OphanApi]
 
   // Controllers
   lazy val healthCheck = wire[HealthCheck]

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -27,6 +27,7 @@ import router.Routes
 import rugby.controllers.RugbyControllers
 import rugby.feed.{CapiFeed, OptaFeed}
 import rugby.jobs.RugbyStatsJob
+import services.OphanApi
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -45,6 +46,7 @@ trait SportServices {
   lazy val rugbyFeed = wire[OptaFeed]
   lazy val rugbyStatsJob = wire[RugbyStatsJob]
   lazy val capiFeed = wire[CapiFeed]
+  lazy val ophanApi = wire[OphanApi]
 }
 
 trait AppComponents extends FrontendComponents

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -2,9 +2,8 @@ package model
 
 import common._
 import contentapi.ContentApiClient
-import feed.Competitions
+import _root_.feed.Competitions
 import pa._
-import ContentApiClient.getResponse
 
 case class Team(team: FootballTeam, tag: Option[Tag], shortName: Option[String]) extends FootballTeam {
   lazy val url = tag.map(_.metadata.url)
@@ -106,9 +105,9 @@ object TeamMap extends ExecutionContexts with Logging {
 
   def findUrlNameFor(teamId: String): Option[String] = teamAgent().get(teamId).map(_.metadata.url.replace("/football/", ""))
 
-  def refresh(page: Int = 1) { //pages are 1 based
+  def refresh(page: Int = 1)(implicit contentApiClient: ContentApiClient) { //pages are 1 based
     log.info(s"Refreshing team tag mappings - page $page")
-    getResponse(ContentApiClient.tags
+    contentApiClient.getResponse(contentApiClient.tags
       .page(page)
       .pageSize(50)
       .referenceType("pa-football-team")

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -9,7 +9,7 @@ import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
 import cricket.conf.CricketLifecycle
 import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
-import services.ConfigAgentLifecycle
+import services.{ConfigAgentLifecycle, OphanApi}
 
 trait StandaloneLifecycleComponents extends SportServices with CommercialServices with FapiServices with OnwardServices {
   self: FrontendComponents =>
@@ -17,6 +17,7 @@ trait StandaloneLifecycleComponents extends SportServices with CommercialService
   //Override conflicting members
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
+  override lazy val ophanApi = wire[OphanApi]
 
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],

--- a/training-preview/app/AppLoader.scala
+++ b/training-preview/app/AppLoader.scala
@@ -10,6 +10,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
+import services.OphanApi
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -30,6 +31,7 @@ trait AppComponents
 
   override lazy val capiHttpClient: HttpClient = wire[TrainingHttp]
   override lazy val contentApiClient = wire[ContentApiClient]
+  override lazy val ophanApi = wire[OphanApi]
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Removing the 2 last usages of global `WS`
## What is the value of this and can you measure success?

=> Play 2.5

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@alexduf @jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
