### PR TITLE
Dev-build also needs to have access to play.api.i18n.Messages value

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -29,10 +29,11 @@ class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait AdminServices {
+trait AdminServices extends I18nComponents  {
   def wsClient: WSClient
   def akkaAsync: AkkaAsync
   def actorSystem: ActorSystem
+  lazy val messages: Messages = Messages(Lang.defaultLang, messagesApi)
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   lazy val contentApiClient = wire[ContentApiClient]
   lazy val ophanApi = wire[OphanApi]
@@ -46,9 +47,7 @@ trait AdminServices {
   lazy val rebuildIndexJob = wire[RebuildIndexJob]
 }
 
-trait AppComponents extends FrontendComponents with AdminControllers with AdminServices with I18nComponents {
-
-  lazy val messages: Messages = Messages(Lang.defaultLang, messagesApi)
+trait AppComponents extends FrontendComponents with AdminControllers with AdminServices {
 
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Dev-build also needs to have access to a play.api.i18n.Messages value.
Moving its definition to AdminServices which is extended by dev-build
AppComponents
## What is the value of this and can you measure success?

dev-build compiles :/

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
