### PR TITLE
Add clear to dateline for floated badges

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -387,6 +387,7 @@
     box-sizing: border-box;
     padding-top: $gs-baseline / 6;
     margin-bottom: $gs-baseline / 2;
+    clear: left; // a dateline may be preceded by a floated badge.
 
     time {
         display: inline-block;


### PR DESCRIPTION
The new badges system floats the badge left, which needs clearing through dateline. The vertical alignment is a separate issue.

**Before**

![before](https://cloud.githubusercontent.com/assets/4549425/19481150/ed744ef6-9544-11e6-8294-f2aa9fde56a0.jpg)

**After**

![after](https://cloud.githubusercontent.com/assets/4549425/19481159/f331998e-9544-11e6-95de-8c2b5c6fa8fb.jpg)
