### PR TITLE
Call impression as well as complete events when forcing into an A/B test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -352,14 +352,18 @@ define([
             });
         },
 
-        forceRegisterCompleteEvent: function(testId, variantId) {
+        forceVariantCompleteFunctions: function(testId, variantId) {
             var test = getTest(testId);
-            var variant = test && test.variants.filter(function (v) {
-                    return v.id.toLowerCase() === variantId.toLowerCase();
-                })[0];
-            var onTestComplete = variant && variant.success || noop;
 
-            onTestComplete(recordTestComplete(test, variantId, true));
+            var variant = test && test.variants.filter(function (v) {
+                return v.id.toLowerCase() === variantId.toLowerCase();
+            })[0];
+
+            var impression = variant && variant.impression || noop;
+            var complete = variant && variant.success || noop;
+
+            impression(recordTestComplete(test, variantId, false));
+            complete(recordTestComplete(test, variantId, true));
         },
 
         segmentUser: function () {
@@ -373,7 +377,7 @@ define([
                     test = abParam[0];
                     variant = abParam[1];
                     ab.forceSegment(test, variant);
-                    ab.forceRegisterCompleteEvent(test, variant);
+                    ab.forceVariantCompleteFunctions(test, variant);
                 });
             } else {
                 ab.segment();


### PR DESCRIPTION
## What does this change?

When you force yourself into a test with the anchor link, it'll call the new `impression` function for your variant as well as `success`.
## What is the value of this and can you measure success?

Easier (well, actually possible) to test the `impression` function during development!

@jranks123 
