### PR TITLE
remove omniture calls from external video embed js

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -9,7 +9,6 @@ define([
     'common/utils/config',
     'common/utils/defer-to-analytics',
     'common/utils/template',
-    'common/modules/analytics/omniture',
     'common/modules/component',
     'common/modules/video/events',
     'common/modules/media/videojs-plugins/fullscreener',
@@ -28,7 +27,6 @@ define([
     config,
     deferToAnalytics,
     template,
-    omniture,
     Component,
     events,
     fullscreener,
@@ -56,14 +54,6 @@ define([
             icon: svgs('marque36icon')
         };
         $('.vjs-control-bar').after(template(titlebarTmpl, data));
-        bean.on($('.vjs-title-bar')[0], 'click', function (e) {
-            omniture.logTag({
-                tag: 'Embed | title bar',
-                sameHost: false,
-                samePage: false,
-                target: e.target
-            });
-        });
     }
 
     function initEndSlate(player) {
@@ -74,14 +64,6 @@ define([
 
         endSlate.fetch(player.el(), 'html').then(function () {
             $('.end-slate-container .fc-item__action').each(function (e) { e.href += '?CMP=embed_endslate'; });
-            bean.on($('.end-slate-container')[0], 'click', function (e) {
-                omniture.logTag({
-                    tag: 'Embed | endslate',
-                    sameHost: false,
-                    samePage: false,
-                    target: e.target
-                });
-            });
         });
 
         player.on('ended', function () {
@@ -141,13 +123,11 @@ define([
                 if (config.switches.thirdPartyEmbedTracking) {
                     deferToAnalytics(function () {
                         events.initOphanTracking(player, mediaId);
-                        events.initOmnitureTracking(player);
                         events.bindContentEvents(player);
                     });
 
                 }
 
-                events.initOmnitureTracking(player, mediaId);
                 events.bindContentEvents(player);
             });
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Removes calls to omniture on the external embed video pages.

https://github.com/guardian/frontend/pull/14652 but scoped just to `embed.theguardian.com` pages.
## What is the value of this and can you measure success?

No more omniture.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

n/a
## Request for comment

@mkopka @guardian/guardian-frontend 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
