### PR TITLE
use config value rather than hard-coded string

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -112,7 +112,7 @@ define([
                 plugins: {
                     embed: {
                         embeddable: guardian.config.switches.externalVideoEmbeds && guardian.config.page.embeddable,
-                        location: 'https://embed.theguardian.com/embed/video/' + guardian.config.page.pageId
+                        location: guardian.config.page.externalEmbedHost + '/embed/video/' + guardian.config.page.pageId
                     }
                 }
             }));


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

nothing really, just makes sense
## What is the value of this and can you measure success?

removes a magic string

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

n/a
## Request for comment

@guardian/guardian-frontend 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
