### PR TITLE
Removing deprecated opt in/out routes

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -29,14 +29,12 @@ class OptInController extends Controller {
 
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
-      case "hsts" => hsts.opt(choice)
       case "header" => header.opt(choice)
       case "headertwo" => headerTwo.opt(choice)
       case _ => NotFound
     }))
   }
 
-  val hsts = OptInFeature("hsts_opt_in")
   val header = OptInFeature("new_header_opt_in")
   val headerTwo = OptInFeature("new_header_two_opt_in")
 }

--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -29,16 +29,12 @@ class OptInController extends Controller {
 
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
-      case "https" => https.opt(choice)
       case "hsts" => hsts.opt(choice)
       case "header" => header.opt(choice)
-      case "gallery" => gallery.opt(choice)
       case _ => NotFound
     }))
   }
 
-  val https = HttpsOptFeature("https_opt_in")
   val hsts = OptInFeature("hsts_opt_in")
   val header = OptInFeature("new_header_opt_in")
-  val gallery = OptInFeature("gallery_redesign_opt_in")
 }

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -49,13 +49,7 @@ GET        /embed/video/*path                                                   
 # Preferences
 GET        /preferences                                                         controllers.PreferencesController.indexPrefs()
 
-# opt-in/out routes: this format is deprecated in favour of /opt/<in|out>/<feature>
-# don't add any new ones!
-GET        /https/optin                                                         controllers.OptInController.handle(feature = "https", choice = "in")
-GET        /https/optout                                                        controllers.OptInController.handle(feature = "https", choice = "out")
-GET        /new-header/optin                                                    controllers.OptInController.handle(feature = "header", choice = "in")
-GET        /new-header/optout                                                   controllers.OptInController.handle(feature = "header", choice = "out")
-
+# opt-in/out routes
 GET        /opt/$choice<in|out|delete>/:feature                                 controllers.OptInController.handle(feature, choice)
 
 # Web App paths


### PR DESCRIPTION
## What does this change?

While making some changes I noticed that there were some opt in/out routes that I don't think are needed anymore. This just cleans them up.
## What is the value of this and can you measure success?

Cleaning is always good ✨ 
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@desbo @guardian/dotcom-platform 
