### PR TITLE
Refactor port logic in healthcheck and tests Suite

### DIFF
--- a/admin-jobs/app/AppLoader.scala
+++ b/admin-jobs/app/AppLoader.scala
@@ -14,7 +14,6 @@ import play.api.http.HttpRequestHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
-import play.api.libs.ws.WSClient
 import services.ConfigAgentLifecycle
 import jobs.CommercialClientSideLoggingLifecycle
 import router.Routes
@@ -29,13 +28,10 @@ trait AdminJobsServices {
   lazy val breakingNewsApi = wire[BreakingNewsApi]
 }
 
-trait Controllers extends AdminJobsControllers {
-  def wsClient: WSClient
-  lazy val healthCheck = wire[HealthCheck]
-}
 
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
+trait AppComponents extends FrontendComponents with AdminJobsControllers with AdminJobsServices {
+
+  lazy val healthCheck = wire[HealthCheck]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -45,9 +41,6 @@ trait AppLifecycleComponents {
     wire[CachedHealthCheckLifeCycle],
     wire[CommercialClientSideLoggingLifecycle]
   )
-}
-
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with AdminJobsServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/admin-jobs/app/controllers/HealthCheck.scala
+++ b/admin-jobs/app/controllers/HealthCheck.scala
@@ -3,8 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9015,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/news-alert/alerts")
-)
+)(wsClient)

--- a/admin-jobs/test/AdminJobsTestSuite.scala
+++ b/admin-jobs/test/AdminJobsTestSuite.scala
@@ -1,14 +1,12 @@
-import controllers.BreakingNews.{BreakingNewsUpdaterTest, BreakingNewsApiTest}
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
-import test.{SingleServerSuite, WithTestWsClient}
+package test
+
+import controllers.BreakingNews.{BreakingNewsApiTest, BreakingNewsUpdaterTest}
+import org.scalatest.Suites
 
 class AdminJobsTestSuite extends Suites (
   new BreakingNewsApiTest,
   new BreakingNewsUpdaterTest,
   new controllers.NewsAlertControllerTest
-) with SingleServerSuite
-with BeforeAndAfterAll
-with WithTestWsClient {
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19002
 }

--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -3,7 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9001,
-  NeverExpiresSingleHealthCheck("/login"))
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/login")
+)(wsClient)

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -1,7 +1,6 @@
 package test
 
-import org.scalatest.{BeforeAndAfterAll, Suites}
-import pagepresser.InteractiveHtmlCleanerTest
+import org.scalatest.Suites
 
 class AdminTestSuite extends Suites (
   new football.PlayerControllerTest,
@@ -12,10 +11,7 @@ class AdminTestSuite extends Suites (
   new pagepresser.InteractiveHtmlCleanerTest,
   new controllers.admin.DeploysRadiatorControllerTest,
   new controllers.admin.DeploysNotifyControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+    override lazy val port: Int = 19001
 }
 

--- a/applications/app/controllers/HealthCheck.scala
+++ b/applications/app/controllers/HealthCheck.scala
@@ -4,18 +4,15 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import contentapi.SectionsLookUp
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent}
-
 import scala.concurrent.Future
 
-class HealthCheck(override val wsClient: WSClient, sectionsLookUp: SectionsLookUp) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9002,
+class HealthCheck(wsClient: WSClient, sectionsLookUp: SectionsLookUp) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/books"),
   NeverExpiresSingleHealthCheck("/books/harrypotter"),
   NeverExpiresSingleHealthCheck("/news/gallery/2012/oct/02/24-hours-in-pictures"),
   NeverExpiresSingleHealthCheck("/news/gallery/2012/oct/02/24-hours-in-pictures?index=2"),
   NeverExpiresSingleHealthCheck("/world/video/2012/dec/31/52-weeks-photos-2012-video")
-) {
+)(wsClient) {
   override def healthCheck(): Action[AnyContent] = Action.async { request =>
     if (!sectionsLookUp.isLoaded()) {
       Future.successful(InternalServerError("Sections have not loaded from Content API"))

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -2,9 +2,7 @@ package test
 
 import java.util.{List => JList}
 
-import contentapi.SectionsLookUp
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 import services.NewspaperControllerTest
 
 import collection.JavaConversions._
@@ -40,11 +38,6 @@ class ApplicationsTestSuite extends Suites (
   new ShareLinksTest,
   new CrosswordDataTest,
   new NewspaperControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient
-  with WithTestContentApiClient {
-
-  lazy val sectionsLookUp = new SectionsLookUp(testContentApiClient)
-  override lazy val port: Int = new HealthCheck(wsClient, sectionsLookUp).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19003
 }

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -21,20 +21,12 @@ class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait ArchiveServices {
-  def wsClient: WSClient
-  lazy val dynamoDB = wire[DynamoDB]
-}
+trait AppComponents extends FrontendComponents {
 
-trait Controllers {
-  def wsClient: WSClient
-  def dynamoDB: DynamoDB
+  lazy val dynamoDB = wire[DynamoDB]
+
   lazy val healthCheck = wire[HealthCheck]
   lazy val archiveController = wire[ArchiveController]
-}
-
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -43,9 +35,6 @@ trait AppLifecycleComponents {
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle]
   )
-}
-
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with ArchiveServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/archive/app/controllers/HealthCheck.scala
+++ b/archive/app/controllers/HealthCheck.scala
@@ -3,7 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9003,
-  NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html")
+)(wsClient)

--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -1,8 +1,7 @@
 package test
 
 import java.util.{ List => JList }
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 
 import collection.JavaConversions._
 
@@ -15,9 +14,6 @@ object `package` {
 
 class ArchiveTestSuite extends Suites (
   new ArchiveControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19004
 }

--- a/article/app/controllers/HealthCheck.scala
+++ b/article/app/controllers/HealthCheck.scala
@@ -3,8 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9004,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/football/2015/jul/23/barcelona-fined-uefa-pro-catalan-banners-champions-league")
-)
+)(wsClient)

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -3,6 +3,7 @@ package test
 import controllers.HealthCheck
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
+import play.api.test.Helpers
 import org.scalatest.concurrent.ScalaFutures
 
 @DoNotDiscover class CdnHealthCheckTest
@@ -14,7 +15,9 @@ import org.scalatest.concurrent.ScalaFutures
   with WithTestWsClient {
 
   "CDN health check" should "mimic the instance health check" in {
-    val controller = new HealthCheck(wsClient)
+    val testPort: Int = port
+    val controller = new HealthCheck(wsClient) { override val port = testPort }
+
     // Cache internal healthCheck results before to test endpoints
     whenReady(controller.runChecks) { _ =>
       status(controller.healthCheck()(TestRequest("/_healthcheck"))) should be (200)

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,7 +1,7 @@
 package test
 
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites, Tag}
+import org.scalatest.{Suites, Tag}
+import play.api.test.Helpers
 
 object ArticleComponents extends Tag("article components")
 
@@ -16,9 +16,6 @@ class ArticleTestSuite extends Suites (
   new SectionsNavigationFeatureTest,
   new MembershipAccessTest,
   new PublicationControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19005
 }

--- a/commercial/app/controllers/HealthCheck.scala
+++ b/commercial/app/controllers/HealthCheck.scala
@@ -3,12 +3,10 @@ package commercial.controllers
 import conf.{AnyGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AnyGoodCachedHealthCheck(
-  wsClient,
-  9005,
+class HealthCheck(wsClient: WSClient) extends AnyGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/commercial/soulmates/mixed.json"),
   NeverExpiresSingleHealthCheck("/commercial/masterclasses.json"),
   NeverExpiresSingleHealthCheck("/commercial/travel/offers.json"),
   NeverExpiresSingleHealthCheck("/commercial/jobs.json"),
   NeverExpiresSingleHealthCheck("/commercial/books/books.json")
-)
+)(wsClient)

--- a/commercial/test/test/CommercialTestSuite.scala
+++ b/commercial/test/test/CommercialTestSuite.scala
@@ -1,10 +1,9 @@
 package commercial.test
 
-import commercial.controllers.HealthCheck
-import commercial.model.merchandise.{books, events, jobs, soulmates}
 import commercial.model.capi.LookupTest
-import org.scalatest.{BeforeAndAfterAll, Suites}
-import test.{SingleServerSuite, WithTestWsClient}
+import commercial.model.merchandise.{books, events, jobs, soulmates}
+import org.scalatest.Suites
+import test.SingleServerSuite
 
 class CommercialTestSuite extends Suites (
   new commercial.controllers.TravelOffersControllerTest,
@@ -17,9 +16,6 @@ class CommercialTestSuite extends Suites (
   new LookupTest,
   new books.BookFinderTest,
   new books.BookTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19006
 }

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -37,7 +37,7 @@ class CachedHealthCheckTest
     // Create a CachedHealthCheck controller with mock results
     val mockHealthChecks: Seq[SingleHealthCheck] = mockResults.map(result => ExpiringSingleHealthCheck(result.url))
     val mockTestPort: Int = 9100
-    val controller = new CachedHealthCheck(policy, wsClient, mockTestPort, mockHealthChecks:_*) {
+    val controller = new CachedHealthCheck(policy, mockHealthChecks:_*)(wsClient) {
       override val cache = new HealthCheckCache(wsClient) {
         override def fetchResults(testPort: Int, paths: SingleHealthCheck*): Future[Seq[HealthCheckResult]] = {
           Future.successful(mockResults)

--- a/diagnostics/app/controllers/HealthCheck.scala
+++ b/diagnostics/app/controllers/HealthCheck.scala
@@ -3,7 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9006,
-  NeverExpiresSingleHealthCheck("/robots.txt"))
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/robots.txt")
+)(wsClient)

--- a/diagnostics/test/package.scala
+++ b/diagnostics/test/package.scala
@@ -1,13 +1,8 @@
 package test
 
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 
 class DiagnosticsTestSuite extends Suites (
-  // Add you test classes here
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19007
 }

--- a/discussion/app/controllers/HealthCheck.scala
+++ b/discussion/app/controllers/HealthCheck.scala
@@ -3,7 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9007,
-  NeverExpiresSingleHealthCheck("/discussion/p/37v3a"))
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/discussion/p/37v3a")
+)(wsClient)

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -1,8 +1,7 @@
 package test
 
 import conf.Configuration
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 import recorder.DefaultHttpRecorder
 import play.api.libs.ws.WSClient
 import java.io.File
@@ -39,8 +38,6 @@ class DiscussionTestSuite extends Suites (
   new discussion.DiscussionApiTest,
   new CommentCountControllerTest,
   new ProfileTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19008
 }

--- a/facia/app/controllers/HealthCheck.scala
+++ b/facia/app/controllers/HealthCheck.scala
@@ -4,13 +4,11 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent}
 import services.ConfigAgent
-
 import scala.concurrent.Future
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9008,
-  NeverExpiresSingleHealthCheck("/uk/business")) {
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/uk/business")
+)(wsClient) {
 
   override def healthCheck(): Action[AnyContent] = Action.async { request =>
     if (!ConfigAgent.isLoaded()) {

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -2,10 +2,9 @@ package test
 
 import java.io.File
 
-import controllers.HealthCheck
 import controllers.front.FrontJsonFapiLive
 import org.fluentlenium.core.domain.FluentWebElement
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 import play.api.libs.ws.WSClient
 import recorder.HttpRecorder
 
@@ -55,8 +54,6 @@ class FaciaTestSuite extends Suites (
   new views.fragments.nav.NavigationTest,
   new FaciaControllerTest,
   new metadata.FaciaMetaDataTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19009
 }

--- a/identity/app/controllers/HealthCheck.scala
+++ b/identity/app/controllers/HealthCheck.scala
@@ -3,7 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9010,
-  NeverExpiresSingleHealthCheck("/signin"))
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  NeverExpiresSingleHealthCheck("/signin")
+)(wsClient)

--- a/identity/test/controllers/IdentityTestSuite.scala
+++ b/identity/test/controllers/IdentityTestSuite.scala
@@ -1,14 +1,12 @@
 package controllers
 
-import org.scalatest.{BeforeAndAfterAll, Suites}
-import test.{SingleServerSuite, WithTestWsClient}
+import org.scalatest.Suites
+import test.SingleServerSuite
 
 class IdentityTestSuite extends Suites(
   new EditProfileControllerTest,
   new EmailControllerTest,
   new SignoutControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19010
 }

--- a/onward/app/controllers/HealthCheck.scala
+++ b/onward/app/controllers/HealthCheck.scala
@@ -3,9 +3,7 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9011,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/top-stories.json"),
   NeverExpiresSingleHealthCheck("/most-read/society.json")
-)
+)(wsClient)

--- a/onward/test/package.scala
+++ b/onward/test/package.scala
@@ -1,7 +1,6 @@
 package test
 
-import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 
 class OnwardTestSuite extends Suites (
   new controllers.ChangeEditionControllerTest,
@@ -15,9 +14,6 @@ class OnwardTestSuite extends Suites (
   new TopStoriesControllerTest,
   new VideoInSectionTest,
   new RichLinkControllerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19011
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -7,7 +7,6 @@ import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.HttpErrorHandler
-import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
@@ -17,16 +16,9 @@ class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait Controllers {
-  def wsClient: WSClient
-  lazy val healthCheck = wire[HealthCheck]
-  lazy val responsiveViewerController = wire[ResponsiveViewerController]
-}
-
 trait AppComponents
   extends FrontendComponents
   with StandaloneControllerComponents
-  with Controllers
   with StandaloneLifecycleComponents
   with AdminJobsServices
   with OnwardServices
@@ -35,6 +27,9 @@ trait AppComponents
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
   override lazy val ophanApi = wire[OphanApi]
+
+  lazy val healthCheck = wire[HealthCheck]
+  lazy val responsiveViewerController = wire[ResponsiveViewerController]
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/preview/app/controllers/HealthCheck.scala
+++ b/preview/app/controllers/HealthCheck.scala
@@ -3,8 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9017,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
-)
+)(wsClient)

--- a/preview/test/PreviewServerTest.scala
+++ b/preview/test/PreviewServerTest.scala
@@ -4,11 +4,8 @@ import org.scalatest._
 
 class PreviewTestSuite extends Suites (
   new PreviewServerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19012
 }
 
 @DoNotDiscover class PreviewServerTest extends FlatSpec with Matchers with ConfiguredTestSuite {

--- a/rss/app/controllers/HealthCheck.scala
+++ b/rss/app/controllers/HealthCheck.scala
@@ -3,8 +3,6 @@ package controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9014,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/books/harrypotter/rss")
-)
+)(wsClient)

--- a/sport/app/football/controllers/HealthCheck.scala
+++ b/sport/app/football/controllers/HealthCheck.scala
@@ -3,9 +3,7 @@ package football.controllers
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9013,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/football/live"),
   NeverExpiresSingleHealthCheck("/football/premierleague/results")
-)
+)(wsClient)

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -5,9 +5,8 @@ import java.io.File
 import common.ExecutionContexts
 import conf.{FootballClient, SportConfiguration}
 import football.collections.RichListTest
-import football.controllers.HealthCheck
 import football.model._
-import org.scalatest.{BeforeAndAfterAll, Suites}
+import org.scalatest.Suites
 import pa.{Http, Response => PaResponse}
 import play.api.libs.ws.WSClient
 import recorder.{DefaultHttpRecorder, HttpRecorder}
@@ -34,8 +33,8 @@ class SportTestSuite extends Suites (
   new MatchFeatureTest,
   new ResultsFeatureTest,
   new rugby.model.MatchParserTest
-) with SingleServerSuite with BeforeAndAfterAll with WithTestWsClient {
-  override lazy val port: Int = new HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19013
 }
 
 trait WithTestFootballClient {

--- a/training-preview/app/AppLoader.scala
+++ b/training-preview/app/AppLoader.scala
@@ -16,15 +16,9 @@ class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait Controllers {
-  def wsClient: WSClient
-  lazy val healthCheck = wire[HealthCheck]
-}
-
 trait AppComponents
   extends FrontendComponents
   with StandaloneControllerComponents
-  with Controllers
   with StandaloneLifecycleComponents
   with AdminJobsServices
   with ApplicationsServices {
@@ -32,6 +26,8 @@ trait AppComponents
   override lazy val capiHttpClient: HttpClient = wire[TrainingHttp]
   override lazy val contentApiClient = wire[ContentApiClient]
   override lazy val ophanApi = wire[OphanApi]
+
+  lazy val healthCheck = wire[HealthCheck]
 
   lazy val standaloneRoutes: standalone.Routes = wire[standalone.Routes]
 

--- a/training-preview/app/controllers/HealthCheck.scala
+++ b/training-preview/app/controllers/HealthCheck.scala
@@ -3,10 +3,10 @@ package controllers
 import common.ExecutionContexts
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import dispatch.{FunctionHandler, Http}
-
 import scala.concurrent.Future
-import contentapi.{ContentApiClient, HttpClient, Response}
+import contentapi.{HttpClient, Response}
 import conf.Configuration.contentApi.previewAuth
+import play.api.Environment
 import play.api.libs.ws.WSClient
 
 class TrainingHttp extends HttpClient with ExecutionContexts {
@@ -40,8 +40,6 @@ class TrainingHttp extends HttpClient with ExecutionContexts {
   }
 }
 
-class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  wsClient,
-  9016,
+class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
   NeverExpiresSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
-)
+)(wsClient)

--- a/training-preview/test/PreviewServerTest.scala
+++ b/training-preview/test/PreviewServerTest.scala
@@ -4,11 +4,8 @@ import org.scalatest._
 
 class TrainingTestSuite extends Suites (
   new TrainingServerTest
-) with SingleServerSuite
-  with BeforeAndAfterAll
-  with WithTestWsClient {
-
-  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
+) with SingleServerSuite {
+  override lazy val port: Int = 19014
 }
 
 @DoNotDiscover class TrainingServerTest extends FlatSpec with Matchers with ConfiguredTestSuite {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

My original goal was to get rid of the `Play.current` reference into the `HealthCheck` code.
However I thought it would be a good time to refactor this weird logic where a port is specify to the Healthcheck, which is then used to override the OneServerPerSuite port so multiple suite don't overlap on the same port and the healthcheck is aware of this port on which it needs to run its internal check.

So now:
- test port logic has been removed from healthcheck 
- test port is explicitly set for each test `Suite`
- when testing healthcheck ([1 single place](https://github.com/guardian/frontend/pull/14736/files#diff-c68b31e0978004f8eac907de04add445R19)), the healthcheck port is overridden with the currently running test suite port
## What is the value of this and can you measure success?
- => Play 2.5
- Simpler code

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@alexduf @jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
