### PR TITLE
Remove Akka.system (depracated in Play 2.5)

### DIFF
--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -6,7 +6,6 @@ import play.api.BuiltInComponents
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
 trait ArticleControllers {
-  self: BuiltInComponents =>
   def contentApiClient: ContentApiClient
   lazy val bookAgent: NewspaperBookTagAgent = wire[NewspaperBookTagAgent]
   lazy val bookSectionAgent: NewspaperBookSectionTagAgent = wire[NewspaperBookSectionTagAgent]

--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{Future, blocking}
 import scala.language.postfixOps
 
 class NewspaperBooksAndSectionsAutoRefresh(newspaperBookSectionTagAgent: NewspaperBookSectionTagAgent,
-                                           newspaperBookTagAgent: NewspaperBookTagAgent)
+                                           newspaperBookTagAgent: NewspaperBookTagAgent)(implicit actorSystem: ActorSystem)
   extends LifecycleComponent {
   override def start(): Unit = {
     newspaperBookTagAgent.start()
@@ -30,7 +30,7 @@ trait NewspaperTags {
   }
 }
 
-class NewspaperBookTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes, actorSystem) with NewspaperTags {
+class NewspaperBookTagAgent extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes) with NewspaperTags {
   override val source = "newspaper_books"
   override protected def refresh(): Future[TagIndexListings] = Future {
     blocking {
@@ -39,7 +39,7 @@ class NewspaperBookTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[Tag
   }
 }
 
-class NewspaperBookSectionTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes, actorSystem) with NewspaperTags {
+class NewspaperBookSectionTagAgent extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes) with NewspaperTags {
   override val source = "newspaper_book_sections"
   override protected def refresh(): Future[TagIndexListings] = Future {
     blocking {

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -1,11 +1,12 @@
 package app
 
+import akka.actor.ActorSystem
 import common._
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.HttpFilters
-import play.api.inject.{NewInstanceInjector, SimpleInjector, Injector}
+import play.api.inject.{Injector, NewInstanceInjector, SimpleInjector}
 import play.api.libs.ws.ning.NingWSComponents
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
@@ -44,6 +45,8 @@ trait FrontendComponents
   self: BuiltInComponents =>
 
   lazy val prefix = "/"
+
+  implicit lazy val as = actorSystem
 
   lazy val jobScheduler = new JobScheduler(environment)
   lazy val akkaAsync = new AkkaAsync(environment, actorSystem)

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /** Simple class for repeatedly updating a value on a schedule */
-abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDuration, actorSystem: => ActorSystem = Akka.system()) extends Logging {
+abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDuration)  extends Logging {
   private lazy val agent = Agent[Option[A]](None)
 
   @volatile private var subscription: Option[Cancellable] = None
@@ -23,7 +23,7 @@ abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDura
     a <- get
   } yield Future.successful(a)).getOrElse(refresh())
 
-  final def start() = {
+  final def start()(implicit actorSystem: ActorSystem) = {
     log.info(s"Starting refresh cycle after $initialDelay repeatedly over $interval delay")
 
     subscription = Some(actorSystem.scheduler.schedule(initialDelay, interval) {

--- a/common/app/services/indexAutoRefreshes.scala
+++ b/common/app/services/indexAutoRefreshes.scala
@@ -1,5 +1,6 @@
 package services
 
+import akka.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import model.TagIndexListings
@@ -9,7 +10,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, blocking}
 import scala.language.postfixOps
 
-class IndexListingsLifecycle extends LifecycleComponent {
+class IndexListingsLifecycle(implicit actorSystem: ActorSystem) extends LifecycleComponent {
   override def start(): Unit = {
     KeywordSectionIndexAutoRefresh.start()
     KeywordAlphaIndexAutoRefresh.start()

--- a/diagnostics/app/common/DiagnosticsLifecycle.scala
+++ b/diagnostics/app/common/DiagnosticsLifecycle.scala
@@ -6,7 +6,7 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DiagnosticsLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, system: ActorSystem)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+class DiagnosticsLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler)(implicit ec: ExecutionContext, actorSystem: ActorSystem) extends LifecycleComponent with Logging {
 
   appLifecycle.addStopHook { () => Future {
     descheduleJobs()

--- a/onward/app/business/StocksDataLifecycle.scala
+++ b/onward/app/business/StocksDataLifecycle.scala
@@ -1,11 +1,12 @@
 package business
 
+import akka.actor.ActorSystem
 import app.LifecycleComponent
 import play.api.inject.ApplicationLifecycle
 
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.{ExecutionContext, Future}
 
-class StocksDataLifecycle(appLifecycle: ApplicationLifecycle, stocksData: StocksData)(implicit ec: ExecutionContext) extends LifecycleComponent {
+class StocksDataLifecycle(appLifecycle: ApplicationLifecycle, stocksData: StocksData)(implicit ec: ExecutionContext, actorSystem: ActorSystem) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () => Future {
     stocksData.stop()

--- a/onward/app/feed/MostPopularSocialAutoRefresh.scala
+++ b/onward/app/feed/MostPopularSocialAutoRefresh.scala
@@ -1,5 +1,6 @@
 package feed
 
+import akka.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import play.api.inject.ApplicationLifecycle
@@ -24,7 +25,7 @@ class MostPopularSocialAutoRefresh(ophanApi: OphanApi) extends AutoRefresh[MostR
 
 class MostPopularFacebookAutoRefreshLifecycle(appLifeCycle: ApplicationLifecycle,
                                               mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh)
-                                             (implicit ec: ExecutionContext) extends LifecycleComponent {
+                                             (implicit ec: ExecutionContext, actorSystem: ActorSystem) extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () => Future {
     mostPopularSocialAutoRefresh.stop()


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Remove last reference of Akka.system (depracated in Play 2.5) 🎉 
## What is the value of this and can you measure success?

=> Play 2.5

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@alexduf @jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
