### PR TITLE
Remove Play.isTest (deprecated in Play 2.5)

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -148,7 +148,7 @@ object S3 extends S3
 object S3FrontsApi extends S3 {
 
   override lazy val bucket = Configuration.aws.bucket
-  lazy val stage = if (Play.isTest) "TEST" else Configuration.facia.stage.toUpperCase
+  lazy val stage = Configuration.facia.stage.toUpperCase
   val namespace = "frontsapi"
   lazy val location = s"$stage/$namespace"
 

--- a/common/app/services/TagIndexesS3.scala
+++ b/common/app/services/TagIndexesS3.scala
@@ -3,7 +3,6 @@ package services
 import conf.Configuration
 import model.{TagIndexListings, TagIndexPage}
 import play.api.Play
-import play.api.Play.current
 import play.api.libs.json._
 
 sealed trait TagIndexError
@@ -14,7 +13,7 @@ case class TagIndexReadError(error: JsError) extends TagIndexError
 object TagIndexesS3 extends S3 {
   override lazy val bucket = Configuration.indexes.tagIndexesBucket
 
-  val stage = if (Play.isTest) "TEST" else Configuration.facia.stage.toUpperCase
+  val stage = Configuration.facia.stage.toUpperCase
 
   val ListingKey = "_listing"
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Remove Play.isTest (deprecated in Play 2.5). Unnecessary old code
## What is the value of this and can you measure success?

=> Play 2.5

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
