### PR TITLE
Add slim header to immersive articles without main media

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -8,6 +8,7 @@
 @defining(model.article) { article =>
   @defining(isPaidContent(article, model)) { isPaidContent =>
     <div class="l-side-margins">
+
         <article id="article" data-test-id="article-root"
             class="content content--article content--immersive content--immersive-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
             @if(isPaidContent){content--advertisement-feature}

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -8,7 +8,6 @@
 @defining(model.article) { article =>
   @defining(isPaidContent(article, model)) { isPaidContent =>
     <div class="l-side-margins">
-
         <article id="article" data-test-id="article-root"
             class="content content--article content--immersive content--immersive-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
             @if(isPaidContent){content--advertisement-feature}

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -467,8 +467,8 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       twitterPropertiesOverrides = twitterProperties,
-      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainPicture)) && content.tags.isArticle,
-      isImmersiveArticle = content.isImmersive && content.tags.isArticle
+      shouldHideHeaderAndTopAds = content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainMedia) && content.tags.isArticle,
+      contentWithSlimHeader = content.isImmersive && content.tags.isArticle
     )
   }
 
@@ -696,7 +696,8 @@ object Gallery {
       openGraphImages = lightbox.openGraphImages,
       javascriptConfigOverrides = javascriptConfig,
       twitterPropertiesOverrides = twitterProperties,
-      opengraphPropertiesOverrides = openGraph
+      opengraphPropertiesOverrides = openGraph,
+      contentWithSlimHeader = true
     )
 
     val contentOverrides = content.copy(
@@ -857,7 +858,8 @@ object Interactive {
       contentType = contentType,
       analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}",
       adUnitSuffix = section + "/" + contentType.toLowerCase,
-      twitterPropertiesOverrides = twitterProperties
+      twitterPropertiesOverrides = twitterProperties,
+      contentWithSlimHeader = true
     )
     val contentOverrides = content.copy(
       metadata = metadata

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -467,7 +467,8 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       twitterPropertiesOverrides = twitterProperties,
-      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || content.isImmersive) && content.tags.isArticle
+      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainPicture)) && content.tags.isArticle,
+      isImmersiveArticle = content.isImmersive && content.tags.isArticle
     )
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -467,7 +467,7 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       twitterPropertiesOverrides = twitterProperties,
-      shouldHideHeaderAndTopAds = content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainMedia) && content.tags.isArticle,
+      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainMedia)) && content.tags.isArticle,
       contentWithSlimHeader = content.isImmersive && content.tags.isArticle
     )
   }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -57,7 +57,7 @@ final case class Commercial(
   metadata: MetaData,
   isInappropriateForSponsorship: Boolean,
   hasInlineMerchandise: Boolean
-) 
+)
 
 /**
  * MetaData represents a page on the site, whether facia or content
@@ -210,7 +210,8 @@ final case class MetaData (
   javascriptConfigOverrides: Map[String, JsValue] = Map(),
   opengraphPropertiesOverrides: Map[String, String] = Map(),
   isHosted: Boolean = false,
-  twitterPropertiesOverrides: Map[String, String] = Map()
+  twitterPropertiesOverrides: Map[String, String] = Map(),
+  isImmersiveArticle: Boolean = false
 ){
   val sectionId = section map (_.id) getOrElse ""
 
@@ -238,7 +239,8 @@ final case class MetaData (
       sectionId == "identity" ||
       contentType.toLowerCase == "gallery" ||
       contentType.toLowerCase == "survey" ||
-      contentType.toLowerCase == "signup"
+      contentType.toLowerCase == "signup" ||
+      isImmersiveArticle
 
   // Special means "Next Gen platform only".
   private val special = id.contains("-sp-")

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -211,7 +211,7 @@ final case class MetaData (
   opengraphPropertiesOverrides: Map[String, String] = Map(),
   isHosted: Boolean = false,
   twitterPropertiesOverrides: Map[String, String] = Map(),
-  isImmersiveArticle: Boolean = false
+  contentWithSlimHeader: Boolean = false
 ){
   val sectionId = section map (_.id) getOrElse ""
 
@@ -235,12 +235,10 @@ final case class MetaData (
   }
 
   val hasSlimHeader: Boolean =
-    contentType == "Interactive" ||
+    contentWithSlimHeader ||
       sectionId == "identity" ||
-      contentType.toLowerCase == "gallery" ||
       contentType.toLowerCase == "survey" ||
-      contentType.toLowerCase == "signup" ||
-      isImmersiveArticle
+      contentType.toLowerCase == "signup"
 
   // Special means "Next Gen platform only".
   private val special = id.contains("-sp-")
@@ -484,6 +482,8 @@ final case class Elements(elements: Seq[Element]) {
 
   def mainEmbed: Option[EmbedElement] = embeds.find(_.properties.isMain)
   lazy val hasMainEmbed: Boolean = mainEmbed.flatMap(_.embeds.embedAssets.headOption).isDefined
+
+  lazy val hasMainMedia: Boolean = hasMainPicture || hasMainVideo || hasMainEmbed || hasMainAudio
 
   lazy val bodyImages: Seq[ImageElement] = images.filter(_.properties.isBody)
   lazy val bodyVideos: Seq[VideoElement] = videos.filter(_.properties.isBody)

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -22,10 +22,12 @@
         "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
         <div class="gs-container immersive-main-media__logo">
-            <a href="@LinkTo{/}">
-                <span class="u-h">The Guardian</span>
-                @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
-            </a>
+            @if(page.item.elements.hasMainPicture) {
+                <a href="@LinkTo {/}">
+                    <span class="u-h">The Guardian</span>
+                    @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
+                </a>
+            }
 
             @if(ArticleBadgesSwitch.isSwitchedOn && isTheMinuteArticle) {
                 @badgeFor(page.item).map { badge =>

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -22,7 +22,7 @@
         "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
         <div class="gs-container immersive-main-media__logo">
-            @if(page.item.elements.hasMainPicture) {
+            @if(page.item.elements.hasMainMedia) {
                 <a href="@LinkTo {/}">
                     <span class="u-h">The Guardian</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -17,7 +17,6 @@
                 @fragments.commercial.topBanner(page.metadata, edition, maybeTags)
             }
         }
-
         @fragments.header(page)
 
         <div id="maincontent" tabindex="0"></div>
@@ -71,7 +70,6 @@
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
                     @headerAndTopAds(showAdverts, edition)
-
                     @fragments.immersiveMainMedia(page)
                 </div>
             }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -112,6 +112,7 @@
     @include fs-headline(7, true);
     line-height: 1;
     font-weight: 200;
+    color: #ffffff;
 
     @include mq(desktop) {
         font-size: 4rem;


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

This adds the slim header to the immersive article page when there is no main media set. Currently it looks bad (with the floaty logo and grey text):
<img width="1344" alt="screen shot 2016-10-19 at 14 52 18" src="https://cloud.githubusercontent.com/assets/2236852/19521468/b3f479cc-960b-11e6-8424-7fc8654be560.png">

After:
<img width="1332" alt="screen shot 2016-10-19 at 14 50 18" src="https://cloud.githubusercontent.com/assets/2236852/19521476/bbd445c8-960b-11e6-9bd2-90fc3afb6b6f.png">

This makes it more useable, though more style changes may come once we've used it like this.

Tested it with these immersive articles and all are fine:

Immersive w/ main picture
http://theguardian.com/lifeandstyle/2016/oct/19/luxury-watch-industry-survive-digital-age

Immersive w/ main embed
https://www.theguardian.com/us-news/2015/dec/01/the-county-kern-county-deadliest-police-killings

Immersive w/ no main media  + a boot script
https://www.theguardian.com/technology/2016/apr/12/the-dark-side-of-guardian-comments
## What is the value of this and can you measure success?

We can use the immersive article template in more circumstances.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
