### PR TITLE
Remove omniture clickstream tracking

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
+++ b/static/src/javascripts/projects/common/modules/analytics/interaction-tracking.js
@@ -2,13 +2,11 @@ define([
     'common/utils/mediator',
     'common/utils/storage',
     'common/modules/analytics/google',
-    'common/modules/analytics/omniture',
     'common/utils/robust'
 ], function (
     mediator,
     storage,
     google,
-    omniture,
     robust
 ) {
     var NG_STORAGE_KEY = 'gu.analytics.referrerVars';
@@ -43,14 +41,12 @@ define([
     // used where we don't have an element to pass as a tag, eg. keyboard interaction
     function trackNonClickInteraction(actionName) {
         google.trackNonClickInteraction(actionName);
-        omniture.trackLinkImmediate(actionName);
     }
 
     function trackSamePageLinkClick(spec) {
         // Do not perform a same-page track link when there isn't a tag.
         if (spec.tag) {
             google.trackSamePageLinkClick(spec.target, spec.tag);
-            omniture.trackSamePageLinkClick(spec.target, spec.tag, {customEventProperties: spec.customEventProperties});
         }
     }
 
@@ -72,7 +68,6 @@ define([
         // and rely on Omniture to provide a 500 ms delay so they both get a chance to complete.
         // TODO when Omniture goes away, implement the delay ourselves.
         google.trackExternalLinkClick(spec.target, spec.tag);
-        omniture.trackExternalLinkClick(spec.target, spec.tag, {customEventProperties: spec.customEventProperties});
     }
 
     function init(options) {
@@ -80,7 +75,6 @@ define([
         if (options.location) {
             loc = options.location; // allow a fake location to be passed in for testing
         }
-        omniture.go();
         addHandlers();
         mediator.emit('analytics:ready');
     }

--- a/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
+++ b/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
@@ -14,21 +14,14 @@ define([
                     trackSamePageLinkClick: sinon.spy(),
                     trackExternalLinkClick: sinon.spy()
                 })
-                .mock('common/modules/analytics/omniture', {
-                    go: sinon.spy(),
-                    trackSamePageLinkClick: sinon.spy(),
-                    trackExternalLinkClick: sinon.spy()
-                })
                 .require([
                     'common/utils/mediator',
                     'common/modules/analytics/google',
-                    'common/modules/analytics/omniture',
                     'common/modules/analytics/interaction-tracking'
                 ], function () {
                     mediator = arguments[0];
                     google = arguments[1];
-                    omniture = arguments[2];
-                    interactionTracking = arguments[3];
+                    interactionTracking = arguments[2];
 
                     done();
                 });
@@ -54,7 +47,6 @@ define([
             mediator.emit('module:clickstream:click', clickSpec);
 
             expect(google.trackSamePageLinkClick).toHaveBeenCalledOnce();
-            expect(omniture.trackSamePageLinkClick).toHaveBeenCalledOnce();
         });
 
         it('should not log clickstream events with an invalidTarget', function () {
@@ -71,7 +63,6 @@ define([
             mediator.emit('module:clickstream:click', clickSpec);
 
             expect(google.trackSamePageLinkClick.callCount).toBe(0);
-            expect(omniture.trackSamePageLinkClick.callCount).toBe(0);
         });
 
         it('should use local storage for same-host links', function () {
@@ -107,7 +98,6 @@ define([
             mediator.emit('module:clickstream:click', clickSpec);
 
             expect(google.trackExternalLinkClick).toHaveBeenCalledOnce();
-            expect(omniture.trackExternalLinkClick).toHaveBeenCalledOnce();
         });
     });
 });

--- a/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
+++ b/static/test/javascripts/spec/common/analytics/interaction-tracking.spec.js
@@ -5,7 +5,7 @@ define([
 ) {
     describe('interaction-tracking', function () {
 
-        var google, omniture, mediator, interactionTracking, injector;
+        var google, mediator, interactionTracking, injector;
 
         beforeEach(function (done) {
             injector = new Injector();


### PR DESCRIPTION
## What does this change?

This removes general Omniture click tracking from dotcom
## What is the value of this and can you measure success?

Help us migrate away from Omniture
## Does this affect other platforms - Amp, Apps, etc?

Omniture

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## QA

Check that internal and external and in page link interactions do not fire. Note that Pageview events still fire
## Request for comment

@guardian/dotcom-platform @mkopka 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
