### PR TITLE
Changing redirect table location for Admin tool

### DIFF
--- a/admin/app/services/Redirects.scala
+++ b/admin/app/services/Redirects.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 
 object Redirects {
 
-  private lazy val table = if (Configuration.environment.isProd) "redirects" else "redirects-DEV"
+  private lazy val table = if (Configuration.environment.isProd) "redirects" else "redirects-CODE"
 
   private lazy val client = {
     val client = new AmazonDynamoDBClient(Configuration.aws.mandatoryCredentials)


### PR DESCRIPTION
## What does this change?

Currently we read redirects in `CODE` and `DEV` from `redirects-CODE` DynamoDB table in [DynamoDb.scala](https://github.com/guardian/frontend/blob/master/common/app/services/DynamoDB.scala#L22), but the admin tool is writing to `redirects-DEV` which stops us being able to test redirects in `CODE`
This PR fixes that!

@guardian/dotcom-platform 
