### PR TITLE
Include surging values in Prebid

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/PrebidService.js
@@ -76,24 +76,30 @@ define([
     };
 
     function PrebidAdUnit(advert) {
+        var prebidParams = {
+            accountId : 11702,
+            siteId : 37668,
+            zoneId : 157046,
+            visitor : {geo : 'us'},
+            // Lets us target advert inventory
+            inventory : {
+                section : config.page.section
+            },
+            // Lets us report on targeting
+            keyword : config.page.section,
+            // Let us send the page view ID
+            userId : config.ophan.pageViewId
+        };
+        if (config.page.isSurging) {
+            prebidParams.inventory = {
+                surging: config.page.isSurging
+            };
+        }
         this.code = advert.id;
         this.sizes = getMatchingSizes(advert);
         this.bids = [{
             bidder : 'rubicon',
-            params : {
-                accountId : 11702,
-                siteId : 37668,
-                zoneId : 157046,
-                visitor : {geo : 'us'},
-                // Lets us target advert inventory
-                inventory : {
-                    section : config.page.section
-                },
-                // Lets us report on targeting
-                keyword : config.page.section,
-                // Let us send the page view ID
-                userId : config.ophan.pageViewId
-            }
+            params : prebidParams
         }];
     }
 


### PR DESCRIPTION
The Rubicon SSP we use is passed information about surging content, as measured by Ophan. In the US, we use Prebid to perform an "auction" with Rubicon. I'm adding surging parameters to the Prebid system. The value is to help out the US commercial team.
