### PR TITLE
Remove wrapping div on immersives

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -18,9 +18,8 @@
 
 @body(interactive: model.Interactive, isImmersive: Boolean, isPaidContent: Boolean) = {
     @if(isImmersive) {
-        <div class="@RenderClasses(Map("paid-content--advertisement-feature" -> isPaidContent))">
-            @bodyRaw(interactive)
-        </div>
+        @* Must not be wrapped in any elements to support full screen immersives *@
+        @bodyRaw(interactive)
     } else {
         <div class="l-side-margins">
             <article id="article" class="@RenderClasses(


### PR DESCRIPTION
It's really hard to do fullscreen (i.e. height: 100%) immersive interactives. We have to apply `height: 100%` to `html`, `body` and `figure.interactive` elements, as well as any of our own elements.

Recently a `div` has crept in which makes it impossible (has no classes to select on in most cases), and as far as I can tell `paid-content--advertisement-feature` has no effect on immersive interactives.

@regiskuckaertz do you know if that class is ever used?

We really need our immersive interactives to be a direct descendent of the `body` tag. This really needs to be a requirement if we are going to not break old interactives when we change these templates.
