### PR TITLE
Increase troubleshooter fetch timeout to 5s

### DIFF
--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -122,7 +122,7 @@ class TroubleshooterController(wsClient: WSClient) extends Controller with Loggi
   }
 
   private def httpGet(testName: String, url: String) =  {
-    wsClient.url(url).withVirtualHost("www.theguardian.com").withRequestTimeout(2000).get().map {
+    wsClient.url(url).withVirtualHost("www.theguardian.com").withRequestTimeout(5000).get().map {
       response =>
         if (response.status == 200) {
           TestPassed(testName)


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Increase troubleshooter fetch timeout to 5s
## What is the value of this and can you measure success?

Direct fetch to the router sometimes times out with the current value. I hope increasing timeout to 5s will fix the issue 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@jfsoul

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
