### PR TITLE
Add admin-jobs to deploys-radiator

### DIFF
--- a/static/src/deploys-radiator/app/main.js
+++ b/static/src/deploys-radiator/app/main.js
@@ -19,6 +19,7 @@ const run = () => {
     // with goo
     const serverWhitelist = List([
         'admin',
+        'admin-jobs',
         'applications',
         'archive',
         'article',


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Add admin-jobs to deploys-radiator
## What is the value of this and can you measure success?

Admin-jobs is currently missing 😢  in the deploys-radiator

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
