### PR TITLE
http -> https in footer links

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -69,7 +69,7 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
                             membership</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
+                        <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
                             jobs</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
@@ -81,7 +81,7 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
                             Guardian labs</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
+                        <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="https://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
                             subscribe</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
@@ -110,13 +110,13 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/GuardianUs">
                             Twitter</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
+                        <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                             jobs</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
                             guardian labs</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
+                        <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="https://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
                             subscribe</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
@@ -154,10 +154,10 @@
                         <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs-australia}">
                             Guardian labs</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
+                        <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="https://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                             subscribe</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
+                        <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
                             UK jobs</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Jobs + subscribe links are now https 🔐 

Only jobs was asked for, but we don't do things by half around here...
## What is the value of this and can you measure success?

~~There are less cards on the trello board~~ We save a redirect from http for these footer links.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
