### PR TITLE
Only add a badge to the first facia container that ISN'T a thrasher.

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -28,8 +28,14 @@
                 }
 
                 @defining(IndexPage.makeFront(index, Edition(request)).containers) { containers =>
-                    @containers.map { containerDefinition =>
-                        @container(containerDefinition, frontProperties = FrontProperties.fromBranding(branding))
+                    @defining(( containers filterNot (_.isThrasher) map (_.index) ).min ) { containerIndexForBadge =>
+                        @containers.map { containerDefinition =>
+
+                            @container( containerDefinition,
+                                        frontProperties = FrontProperties.fromBranding(branding),
+                                        showFrontBranding =  containerDefinition.index == containerIndexForBadge)
+                        }
+
                     }
                 }
 

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -7,6 +7,7 @@
 @import views.html.fragments.containers.facia_cards.{container, containerScaffold}
 @import views.html.fragments.pagination
 @import views.support.RenderClasses
+@import views.support.Commercial.container.isFirstNonThrasherContainer
 
 @if(index.page.metadata.id == "help/accessibility-help") {
     @containerScaffold("Preferences", "accesibility preferences") {
@@ -28,15 +29,11 @@
                 }
 
                 @defining(IndexPage.makeFront(index, Edition(request)).containers) { containers =>
-                    @defining(( containers filterNot (_.isThrasher) map (_.index) ).min ) { containerIndexForBadge =>
                         @containers.map { containerDefinition =>
-
-                            @container( containerDefinition,
-                                        frontProperties = FrontProperties.fromBranding(branding),
-                                        showFrontBranding =  containerDefinition.index == containerIndexForBadge)
+                            @container(containerDefinition,
+                                frontProperties = FrontProperties.fromBranding(branding),
+                                showFrontBranding = isFirstNonThrasherContainer(containerDefinition.index, containers))
                         }
-
-                    }
                 }
 
                 @index.page.metadata.pagination.map { paginationInstance =>

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -167,7 +167,8 @@ object FaciaContainer {
     None,
     useShowMore = true,
     hasShowMoreEnabled = !config.config.hideShowMore,
-    showBranding = config.config.showBranding
+    showBranding = config.config.showBranding,
+    isThrasher = config.config.collectionType == "fixed/thrasher"
   )
 
   def forStoryPackage(dataId: String, items: Seq[PressedContent], title: String, href: Option[String] = None) = {
@@ -200,7 +201,8 @@ case class FaciaContainer(
   dateLinkPath: Option[String],
   useShowMore: Boolean,
   hasShowMoreEnabled: Boolean,
-  showBranding: Boolean
+  showBranding: Boolean,
+  isThrasher: Boolean
 ) {
   def transformCards(f: ContentCard => ContentCard) = copy(
     containerLayout = containerLayout.map(_.transformCards(f))

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -12,7 +12,9 @@
   frontId: Option[String] = None,
   isPaidFront: Boolean = false,
   maybeContainerModel: Option[ContainerModel] = None,
-  pageId: String = "")(implicit request: RequestHeader)
+  pageId: String = "",
+  showFrontBranding: Boolean = false
+  )(implicit request: RequestHeader)
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -53,7 +55,7 @@
 
                     case _: Dynamic | _: Fixed => {
                         <div class="fc-container__inner">
-                            @standardContainer(containerDefinition, frontProperties, maybeContainerModel)
+                            @standardContainer(containerDefinition, frontProperties, maybeContainerModel, showFrontBranding)
                         </div>
                     }
 

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -3,13 +3,15 @@
 @import views.html.fragments.commercial.containerLogo
 @import views.html.fragments.containers.facia_cards.{containerHeader, showMore, showMoreButton, slice}
 @import views.support.RenderClasses
+
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties,
-  maybeContainerModel: Option[ContainerModel])(implicit request: RequestHeader)
+  maybeContainerModel: Option[ContainerModel],
+  showFrontBranding: Boolean)(implicit request: RequestHeader)
 
 @containerHeader(containerDefinition, frontProperties)
 
-@if(containerDefinition.index == 0) {
+@if(showFrontBranding) {
     @for(frontBranding <- frontProperties.branding(Edition(request))) {
         @containerLogo(frontBranding, isOnTheLeft = true)
     }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -115,6 +115,9 @@ object Commercial {
         }
       }.length
     }.getOrElse(0)
+
+    def isFirstNonThrasherContainer(containerIndex: Int, containers: Seq[FaciaContainer]): Boolean =
+      (containers filterNot (_.isThrasher) map (_.index)).min == containerIndex
   }
 
   object CssClassBuilder {

--- a/facia/app/views/fragments/brandedFrontBody.scala.html
+++ b/facia/app/views/fragments/brandedFrontBody.scala.html
@@ -2,6 +2,7 @@
 @import common.Edition
 @import common.commercial.{ContainerModel, PaidContent, Sponsored}
 @import views.support.RenderClasses
+@import views.support.Commercial.container.isFirstNonThrasherContainer
 
 @faciaPage.branding(Edition(request)) match {
 
@@ -28,7 +29,8 @@
                                     _.id == containerDefinition.dataId
                                 }.map {
                                     ContainerModel.fromPressedCollection(Edition(request))
-                                }
+                                },
+                                showFrontBranding = isFirstNonThrasherContainer(containerDefinition.index, collections)
                             )
                         }
 

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -113,7 +113,8 @@ class FixturesAndResults(competitions: Competitions) extends Football {
           dateLinkPath = None,
           useShowMore = false,
           hasShowMoreEnabled = true,
-          showBranding = false
+          showBranding = false,
+          isThrasher = false
         )
       }
     }).flatten


### PR DESCRIPTION
#### Background / Problem

If a front is sponsored/branded, then we add a badge to the first container on that page. However, in the cases where there is a thrasher, we want to add the badge to the one below it i.e. we want to add the badge to the first _non-thrasher_ container on a sponsored front.
#### Solution

We can have multiple thrashers on a given front and so only the front fragment being rendered can determine which container should hold the badge, and it must do this by inspecting the container objects it is about to render. This requires each `FaciaContainer` knowing whether or not it is a thrasher.
#### Disclaimer

I'm not proud of this - it seems a bit gross inspecting the layout name to determine whether a `FaciaContainer` is a thrasher or not but, short of creating a new field in FAPI that explicitly specifies which container should have a branded badge on, I think this is the best/easiest solution.

@kelvin-chappell 
