### PR TITLE
Add Preview and Sport app to architecture document

### DIFF
--- a/docs/02-architecture/01-applications-architecture.md
+++ b/docs/02-architecture/01-applications-architecture.md
@@ -106,6 +106,12 @@ Parts of identity, including sign in and registration are now served by a separa
 
 [All supported routes](https://github.com/guardian/frontend/blob/master/identity/conf/routes)
 
+# Sport
+Sport app serves match results, league tables, upcoming matches, teams and competition for Football, Cricket and Rugby.
+
+[All supported routes](https://github.com/guardian/frontend/blob/master/sport/conf/routes)
+
+
 # Rss
 Rss app is rendering the RSS version for all Guardian content.
 
@@ -136,3 +142,14 @@ If yes the Archive app returns this old static content or redirect, otherwise a 
 Diagnostics app is used internally to gather data and analytics from the Guardian frontend client side.
 
 [All supported routes](https://github.com/guardian/frontend/blob/master/diagnostics/conf/routes)
+
+# Preview 
+Preview is a standalone version of the guardian website (ie: an aggregation of all the other apps) used in the editorial tool to preview draft article before they are live.
+It allows us to have a fully functional version of the website without the overhead of maintaining an entire new stack.
+
+[All supported routes](https://github.com/guardian/frontend/blob/master/preview/conf/routes)
+
+# Training-Preview 
+Training-preview is used by when running editorial tool training.
+
+[All supported routes](https://github.com/guardian/frontend/blob/master/training-preview/conf/routes)

--- a/docs/02-architecture/01-applications-architecture.md
+++ b/docs/02-architecture/01-applications-architecture.md
@@ -107,7 +107,7 @@ Parts of identity, including sign in and registration are now served by a separa
 [All supported routes](https://github.com/guardian/frontend/blob/master/identity/conf/routes)
 
 # Sport
-Sport app serves match results, league tables, upcoming matches, teams and competition for Football, Cricket and Rugby.
+Sport app serves match results, league tables, upcoming matches, teams and competitions for Football, Cricket and Rugby.
 
 [All supported routes](https://github.com/guardian/frontend/blob/master/sport/conf/routes)
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Add missing apps in architecture doc
## What is the value of this and can you measure success?

Better doc 📜 📜 📜 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
