### PR TITLE
Remove some unecessary happy path info logging

### DIFF
--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -10,7 +10,6 @@ import play.api.mvc.{RequestHeader, Action, Controller}
 class ShortUrlsController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
-    log.info(s"Redirecting short url $shortUrl")
     redirectUrl(shortUrl, request.queryString)
   }
 
@@ -23,7 +22,6 @@ class ShortUrlsController(contentApiClient: ContentApiClient) extends Controller
   }
 
   def fetchCampaignAndRedirectShortCode(shortUrl: String, campaignCode: String) = Action.async { implicit request =>
-    log.info(s"Fetching campaign for $campaignCode and redirect short url")
     val queryString = request.queryString ++ ShortCampaignCodes.makeQueryParameter(campaignCode)
     redirectUrl(shortUrl, queryString)
   }

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -147,7 +147,7 @@ class ArchiveController(dynamoDB: DynamoDB) extends Controller with Logging with
         log.warn(s"404,${RequestLog(request)}")
         GoogleBotMetric.Googlebot404Count.increment()
       case _ =>
-        log.info(s"404,${RequestLog(request)}")
+        log.warn(s"404,${RequestLog(request)}")
     }
 
   private def lookupPath(path: String) = destinationFor(path).map{ _.flatMap(processLookupDestination(path).lift)}

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -193,7 +193,6 @@ class ArticleController(contentApiClient: ContentApiClient) extends Controller w
   private def lookup(path: String, range: Option[BlockRange])(implicit request: RequestHeader): Future[ItemResponse] = {
     val edition = Edition(request)
 
-    log.info(s"Fetching article: $path for edition ${edition.id}: ${RequestLog(request)}")
     val capiItem = contentApiClient.item(path, edition)
       .showTags("all")
       .showFields("all")

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -226,7 +226,6 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
   /* Google news hits this endpoint */
   def renderCollectionRss(id: String) = Action.async { implicit request =>
-    log.info(s"Serving collection ID: $id")
     getPressedCollection(id).flatMap {
       case Some(collection) =>
         successful{

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -31,7 +31,6 @@ trait FrontJsonFapi extends Logging with ExecutionContexts {
   def getRaw(path: String): Future[Option[String]] = {
     val response = secureS3Request.urlGet(getAddressForPath(path)).get()
     response.map { r =>
-      log.info(s"S3 got ${r.header("Content-Length").getOrElse("unknown")} bytes (ungzipped to ${r.bodyAsBytes.length} bytes) for front $path")
       r.status match {
         case 200 => Some(r.body)
         case 403 =>
@@ -59,7 +58,6 @@ trait FrontJsonFapi extends Logging with ExecutionContexts {
     val response = secureS3Request.urlGet(getAddressForPath(path)).get()
 
     response.flatMap { r =>
-      log.info(s"S3 got ${r.header("Content-Length").getOrElse("unknown")} bytes (ungzipped to ${r.bodyAsBytes.length} bytes) json for front $path")
       r.status match {
         case 200 => Future.successful(Json.parse(r.body))
         case _   => Future.failed(new RuntimeException(s"Could not get new format for $path"))


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Looking at the logs, there is a few `info` logs which are not very useful. They log happy-path, often duplicating logging made later (like in the `RequestFilterLogging` class)

Tell me what you think
## What is the value of this and can you measure success?

Less noise in the logs

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
