### PR TITLE
Add indication of native/non-native status to creative templates on commercial admin page.

### DIFF
--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -136,7 +136,8 @@ object DataMapper {
         (params map toParameter).toSeq
       }.getOrElse(Nil),
       snippet = dfpCreativeTemplate.getSnippet,
-      creatives = Nil
+      creatives = Nil,
+      isNative = dfpCreativeTemplate.getIsNativeEligible
     )
   }
 

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -17,14 +17,14 @@
             <div class="facia-container__inner">
                 <h1>Creative Templates</h1>
                 <p>This dashboard is to help debug DFP creative templates.<br />
-                    All unarchived custom creative templates are shown.</p>
+                    All unarchived custom creative templates are shown; native templates are indicated with a <b>*</b></p>
             </div>
 
             <div class="facia-container__inner">
                 <h2>Creative Templates: Contents</h2>
                 <ul>
                     @for(template <- templates) {
-                    <li><a href="#@template.name">@template.name</a></li>
+                    <li><a href="#@template.name">@template.name@if(template.isNative){<b>*</b>}</a></li>
                     }
                 </ul>
             </div>
@@ -34,7 +34,7 @@
                     <li class="container__border" >
                         <div class="facia-container__inner">
                             <h2 id="@template.name">
-                                @template.name (<a href="@DfpLink.creativeTemplate(template.id)">@template.id</a>)
+                                @template.name (<a href="@DfpLink.creativeTemplate(template.id)">@template.id</a>)@if(template.isNative){<b>*</b>}
                             </h2>
                             <p>@{template.description}</p>
                             @if(template.creatives.isEmpty){

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -36,21 +36,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
 
 object CustomTarget {
 
-  implicit val customTargetWrites = new Writes[CustomTarget] {
-    def writes(target: CustomTarget): JsValue = {
-      Json.obj(
-        "name" -> target.name,
-        "op" -> target.op,
-        "values" -> target.values
-      )
-    }
-  }
-
-  implicit val customTargetReads: Reads[CustomTarget] = (
-    (JsPath \ "name").read[String] and
-      (JsPath \ "op").read[String] and
-      (JsPath \ "values").read[Seq[String]]
-    )(CustomTarget.apply _)
+  implicit val customTargetFormats: Format[CustomTarget] = Json.format[CustomTarget]
 
 }
 
@@ -73,19 +59,7 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
 
 object CustomTargetSet {
 
-  implicit val customTargetSetWrites = new Writes[CustomTargetSet] {
-    def writes(targetSet: CustomTargetSet): JsValue = {
-      Json.obj(
-        "op" -> targetSet.op,
-        "targets" -> targetSet.targets
-      )
-    }
-  }
-
-  implicit val customTargetSetReads: Reads[CustomTargetSet] = (
-    (JsPath \ "op").read[String] and
-      (JsPath \ "targets").read[Seq[CustomTarget]]
-    )(CustomTargetSet.apply _)
+  implicit val customTargetSetFormats: Format[CustomTargetSet] = Json.format[CustomTargetSet]
 
 }
 
@@ -103,23 +77,7 @@ case class GeoTarget(id: Long, parentId: Option[Int], locationType: String, name
 
 object GeoTarget {
 
-  implicit val geoTargetWrites = new Writes[GeoTarget] {
-    def writes(geoTarget: GeoTarget): JsValue = {
-      Json.obj(
-        "id" -> geoTarget.id,
-        "parentId" -> geoTarget.parentId,
-        "locationType" -> geoTarget.locationType,
-        "name" -> geoTarget.name
-      )
-    }
-  }
-
-  implicit val geoTargetReads: Reads[GeoTarget] = (
-    (JsPath \ "id").read[Long] and
-      (JsPath \ "parentId").readNullable[Int] and
-      (JsPath \ "locationType").read[String] and
-      (JsPath \ "name").read[String]
-    )(GeoTarget.apply _)
+  implicit val geoTargetFormats: Format[GeoTarget] = Json.format[GeoTarget]
 
 }
 
@@ -134,7 +92,8 @@ case class GuAdUnit(id: String, path: Seq[String], status: String) {
 }
 
 object GuAdUnit {
-  implicit val adUnitFormat = Json.format[GuAdUnit]
+
+  implicit val adUnitFormats = Json.format[GuAdUnit]
 
   val ACTIVE = "ACTIVE"
   val INACTIVE = "INACTIVE"
@@ -178,7 +137,7 @@ case class GuTargeting(adUnitsIncluded: Seq[GuAdUnit],
 }
 
 object GuTargeting {
-  implicit val targetingFormat = Json.format[GuTargeting]
+  implicit val guTargetingFormats: Format[GuTargeting] = Json.format[GuTargeting]
 }
 
 case class GuLineItem(id: Long,
@@ -288,19 +247,7 @@ case class GuCreativePlaceholder(size: AdSize, targeting: Option[GuTargeting]) {
 
 object GuCreativePlaceholder {
 
-  implicit val writes: Writes[GuCreativePlaceholder] = new Writes[GuCreativePlaceholder] {
-    def writes(placeholder: GuCreativePlaceholder): JsValue = {
-      Json.obj(
-        "size" -> placeholder.size,
-        "targeting" -> placeholder.targeting
-      )
-    }
-  }
-
-  implicit val reads: Reads[GuCreativePlaceholder] = (
-    (JsPath \ "size").read[AdSize] and
-      (JsPath \ "targeting").readNullable[GuTargeting]
-    )(GuCreativePlaceholder.apply _)
+  implicit val guCreativePlaceholderFormats: Format[GuCreativePlaceholder] = Json.format[GuCreativePlaceholder]
 }
 
 
@@ -311,7 +258,7 @@ case class GuCreativeTemplateParameter(parameterType: String,
 
 object GuCreativeTemplateParameter {
 
-  implicit val writes = new Writes[GuCreativeTemplateParameter] {
+  implicit val GuCreativeTemplateParameterWrites = new Writes[GuCreativeTemplateParameter] {
     def writes(param: GuCreativeTemplateParameter): JsValue = {
       Json.obj(
         "type" -> param.parameterType,
@@ -322,7 +269,7 @@ object GuCreativeTemplateParameter {
     }
   }
 
-  implicit val reads: Reads[GuCreativeTemplateParameter] = (
+  implicit val GuCreativeTemplateParameterReads: Reads[GuCreativeTemplateParameter] = (
     (JsPath \ "type").read[String] and
       (JsPath \ "label").read[String] and
       (JsPath \ "isRequired").read[Boolean] and
@@ -352,29 +299,7 @@ object GuCreative {
     (mapById(old) ++ mapById(recent)).values.toSeq
   }
 
-  implicit val writes = new Writes[GuCreative] {
-    def writes(creative: GuCreative): JsValue = {
-      Json.obj(
-        "id" -> creative.id,
-        "name" -> creative.name,
-        "lastModified" -> creative.lastModified,
-        "args" -> creative.args,
-        "templateId" -> creative.templateId,
-        "snippet" -> creative.snippet,
-        "previewUrl" -> creative.previewUrl
-      )
-    }
-  }
-
-  implicit val reads: Reads[GuCreative] = (
-    (JsPath \ "id").read[Long] and
-      (JsPath \ "name").read[String] and
-      (JsPath \ "lastModified").read[DateTime] and
-      (JsPath \ "args").read[Map[String, String]] and
-      (JsPath \ "templateId").readNullable[Long] and
-      (JsPath \ "snippet").readNullable[String] and
-      (JsPath \ "previewUrl").readNullable[String]
-    ) (GuCreative.apply _)
+  implicit val guCreativeFormats: Format[GuCreative] = Json.format[GuCreative]
 }
 
 case class GuCreativeTemplate(id: Long,
@@ -391,27 +316,7 @@ case class GuCreativeTemplate(id: Long,
 
 object GuCreativeTemplate extends implicits.Collections {
 
-  implicit val writes = new Writes[GuCreativeTemplate] {
-    def writes(template: GuCreativeTemplate): JsValue = {
-      Json.obj(
-        "id" -> template.id,
-        "name" -> template.name,
-        "description" -> template.description,
-        "parameters" -> template.parameters,
-        "snippet" -> template.snippet,
-        "creatives" -> template.creatives
-      )
-    }
-  }
-
-  implicit val reads: Reads[GuCreativeTemplate] = (
-    (JsPath \ "id").read[Long] and
-      (JsPath \ "name").read[String] and
-      (JsPath \ "description").read[String] and
-      (JsPath \ "parameters").read[Seq[GuCreativeTemplateParameter]] and
-      (JsPath \ "snippet").read[String] and
-      (JsPath \ "creatives").read[Seq[GuCreative]]
-    )(GuCreativeTemplate.apply _)
+  implicit val guCreativeTemplateFormats: Format[GuCreativeTemplate] = Json.format[GuCreativeTemplate]
 }
 
 case class LineItemReport(timestamp: String, lineItems: Seq[GuLineItem]) {
@@ -423,18 +328,6 @@ case class LineItemReport(timestamp: String, lineItems: Seq[GuLineItem]) {
 
 object LineItemReport {
 
-  implicit val reportWrites = new Writes[LineItemReport] {
-    def writes(report: LineItemReport): JsValue = {
-      Json.obj(
-        "timestamp" -> report.timestamp,
-        "lineItems" -> report.lineItems
-      )
-    }
-  }
-
-  implicit val reportReads: Reads[LineItemReport] = (
-    (JsPath \ "timestamp").read[String] and
-      (JsPath \ "lineItems").read[Seq[GuLineItem]]
-    )(LineItemReport.apply _)
+  implicit val lineItemReportFormats: Format[LineItemReport] = Json.format[LineItemReport]
 
 }

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -307,6 +307,7 @@ case class GuCreativeTemplate(id: Long,
                               description: String,
                               parameters: Seq[GuCreativeTemplateParameter],
                               snippet: String,
+                              isNative: Boolean,
                               creatives: Seq[GuCreative]) {
 
   lazy val examplePreviewUrl: Option[String] = creatives flatMap {_.previewUrl} headOption


### PR DESCRIPTION
### What

Now when you go [here](https://frontend.gutools.co.uk/commercial/templates) you can easily see which templates are native and which aren't by the presence of an asterisk next to the template name.
### Why

Not groundbreaking but makes it easier to scan the list for natives, which is useful since we are currently working on a load of them.
### P.S

Also refactored a bunch of the JSON models to use macros - not all of them can be, usually because:
a) the field names of the case class do not match those in the JSON data or
b) some special transformation needs to be done to a specific field, which is a pain to do otherwise.

@guardian/commercial-dev  
