### PR TITLE
Fix double nav on explore template

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -467,7 +467,7 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       twitterPropertiesOverrides = twitterProperties,
-      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && content.elements.hasMainMedia)) && content.tags.isArticle,
+      shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && (content.elements.hasMainMedia || content.fields.main.nonEmpty))) && content.tags.isArticle,
       contentWithSlimHeader = content.isImmersive && content.tags.isArticle
     )
   }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

This adds an extra check to make sure that we still hide the top ad banner on the explore template, even when they supply an embed code as the main media. In this circumstance isMainEmbed returns false as CAPI doesn't return an element with the relation field set to main, unlike when you supply a bootjs as the main media, so the most reliable check is whether the main field is empty.

Before:
![screen shot 2016-10-24 at 16 26 42](https://cloud.githubusercontent.com/assets/2236852/19651907/b00aa0e4-9a06-11e6-9039-92d66bbaf24f.png)

After:
![screen shot 2016-10-24 at 16 27 17](https://cloud.githubusercontent.com/assets/2236852/19651922/c0e50ac6-9a06-11e6-8046-e06a1004c073.png)
## What is the value of this and can you measure success?

No double logo.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@blongden73 @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
