### PR TITLE
Use specified AWS format for date string

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.s3.model._
 import com.amazonaws.util.StringInputStream
 import common.Logging
 import conf.Configuration
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import play.Play
 import play.api.libs.ws.{WSClient, WSRequest}
 import sun.misc.BASE64Encoder
@@ -195,7 +195,7 @@ class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {
         case _ => Nil
       }
 
-      val date = DateTime.now.toHttpDateTimeString
+      val date = DateTime.now(DateTimeZone.UTC).toString("yyyyMMdd'T'HHmmss'Z'")
       val signedString = signAndBase64Encode(generateStringToSign(httpVerb, id, date, sessionTokenHeaders), credentials.getAWSSecretKey)
 
       Seq(


### PR DESCRIPTION
## What does this change?

How the value for the header on S3 requests is computed
## What is the value of this and can you measure success?

Frontend can now run on (a) computers not set to English
(b) computers not set to UTC

This particularly resolves issues with fetching the pressed JSON for facia
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

cc/ @guardian/dotcom-platform 
