### PR TITLE
Renaming new header to new nav

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -16,8 +16,8 @@ import conf.switches.Switches.ServerSideTests
 //    val tests = List(ExampleTest)
 // }
 
-object ABNewHeaderVariant extends TestDefinition(
-  name = "ab-new-header-variant",
+object ABNewNavVariant extends TestDefinition(
+  name = "ab-new-nav-variant",
   description = "users in this test will see the new header first variant",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
@@ -27,8 +27,8 @@ object ABNewHeaderVariant extends TestDefinition(
   }
 }
 
-object ABNewHeaderVariantTwo extends TestDefinition(
-  name = "ab-new-header-variant-two",
+object ABNewNavVariantTwo extends TestDefinition(
+  name = "ab-new-nav-variant-two",
   description = "users in this test will see the new header second variant",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
@@ -38,8 +38,8 @@ object ABNewHeaderVariantTwo extends TestDefinition(
   }
 }
 
-object ABNewHeaderControl extends TestDefinition(
-  name = "ab-new-header-control",
+object ABNewNavControl extends TestDefinition(
+  name = "ab-new-nav-control",
   description = "control for the new header test",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2016, 12, 8) // Thursday
@@ -95,9 +95,9 @@ trait ServerSideABTests {
 
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
-    ABNewHeaderVariant,
-    ABNewHeaderVariantTwo,
-    ABNewHeaderControl,
+    ABNewNavVariant,
+    ABNewNavVariantTwo,
+    ABNewNavControl,
     CommercialClientLoggingVariant,
     CommercialHeaderBiddingSonobiVariant,
     CommercialHeaderBiddingControl

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -90,7 +90,7 @@
                     frontId.getOrElse(pageId)
                     )) { case (isFirstContainer, id) =>
 
-                    @if((mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) && isFirstContainer) {
+                    @if((mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) && isFirstContainer) {
 
                         <ul class="tertiary-navigation mobile-only">
 

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}">
+                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) {hide-on-mobile}">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,11 +4,11 @@
 @import conf.Configuration
 @import conf.switches.Switches._
 
-@if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {
+@if(mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) {
     @fragments.newHeader()
 }
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -20,7 +20,7 @@
     @InlineJs(showUserName().body, "showUserName.js")
 }
 
-@if(mvt.ABNewHeaderVariant.canRun) {
+@if(mvt.ABNewNavVariant.canRun) {
     // editionalise new header navigation
     @InlineJs(editionaliseMenu().body, "editionaliseMenu.js")
 }

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -25,7 +25,7 @@
     }
 
     @* TODO: if this feature is proven successful, this should be refactored to remove the logic from the template as much as possible *@
-    @if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {
+    @if(mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) {
         <div class="mobile-only">
             @defining(Edition(request).navigation) { navigation =>
 
@@ -62,7 +62,7 @@
         </div>
     }
 
-    <div class="@if(mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating) {hide-on-mobile}">
+    <div class="@if(mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating) {hide-on-mobile}">
 
         @if(!(item.content.isImmersive && item.content.tags.isArticle)) {
             <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -30,7 +30,7 @@
         @fragments.nav.editionPicker()
 
         <nav class="new-header__nav" data-component="nav2">
-            @if(mvt.ABNewHeaderVariant.isParticipating) {
+            @if(mvt.ABNewNavVariant.isParticipating) {
                 @NewNavigation.topLevelSections.map { section =>
                     @primaryLinksv1(section.name)
                 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -39,7 +39,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
-            ("has-new-header", mvt.ABNewHeaderVariant.isParticipating || mvt.ABNewHeaderVariantTwo.isParticipating),
+            ("has-new-header", mvt.ABNewNavVariant.isParticipating || mvt.ABNewNavVariantTwo.isParticipating),
             ("is-immersive", getContent(page).exists(_.content.isImmersive)),
             ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">


### PR DESCRIPTION
## What does this change?

This renames the new header tests to "reset" them. Unfortunately when I moved the tests [here](https://github.com/guardian/fastly-edge-cache/pull/692) I didn't change the name. This means there are people who are potentially not seeing the new header who are reporting seeing the new header.

This should give everything a nice clean start (unless I have forgotten something else 😞 )
## What is the value of this and can you measure success?

Clean data!
## Does this affect other platforms - Amp, Apps, etc?

No!
## Request for comment

@stephanfowler @guardian/dotcom-platform 
