### PR TITLE
Membership promintent engagement messaging adjustments

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -110,7 +110,7 @@ define([
                 cssModifierClass = 'membership-message' + ' ' + testName + ' ' + thisColour;
                 customOpts = {
                     addButtonClass: testName + '_' + testVariant,
-                    setButtonText: 'Become a supporter',
+                    setButtonText: 'Become a Supporter',
                     parentColour: thisColour
                 };
                 customJs = getCustomJs;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -71,8 +71,7 @@ define([
 
     var getCustomJs = function(options) {
         var opts = options || {},
-            textLink = $('#membership__engagement-message-link'),
-            buttonLink = $('#membership__engagement-message-button-link'),
+            buttonCaption = $('#membership__engagement-message-button-caption'),
             buttonEl = $('#membership__engagement-message-button');
 
         buttonEl.removeClass('is-hidden');
@@ -80,20 +79,10 @@ define([
             buttonEl.addClass(opts.addButtonClass);
         }
         if (opts.setButtonText) {
-            buttonLink.text(opts.setButtonText);
+            buttonCaption.text(opts.setButtonText);
         }
         if (opts.parentColour) {
             buttonEl.addClass(opts.parentColour);
-        }
-        if (opts.appendLinkClickIdentifier) {
-            if (!textLink.attr('href').endsWith(opts.appendLinkClickIdentifier)) {
-                textLink.attr('href', textLink.attr('href') + opts.appendLinkClickIdentifier);
-            }
-        }
-        if (opts.appendButtonClickIdentifier) {
-            if (!buttonLink.attr('href').endsWith(opts.appendButtonClickIdentifier)) {
-                buttonLink.attr('href', buttonLink.attr('href') + opts.appendButtonClickIdentifier);
-            }
         }
     };
 
@@ -111,24 +100,18 @@ define([
             var testName = 'prominent-level-1';
 
             if (testVariant !== 'notintest') {
-                campaignCode = campaignCode + '_' + testName + '_' + testVariant;
+                campaignCode = 'gdnwb_copts_mem_banner_prominent1uk' + '__' + testVariant;
                 linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
             }
 
-            if (testVariant === 'become' || testVariant === 'join') {
-                var variantMessages = {
-                    become: 'Become a member',
-                    join: 'Join today'
-                };
+            if (testVariant === 'become') {
                 colours = ['yellow','purple','bright-blue','dark-blue'];
                 thisColour = thisInstanceColour(colours);
                 cssModifierClass = 'membership-message' + ' ' + testName + ' ' + thisColour;
                 customOpts = {
                     addButtonClass: testName + '_' + testVariant,
-                    setButtonText: variantMessages[testVariant],
-                    parentColour: thisColour,
-                    appendLinkClickIdentifier: '_link',
-                    appendButtonClickIdentifier: '_button'
+                    setButtonText: 'Become a supporter',
+                    parentColour: thisColour
                 };
                 customJs = getCustomJs;
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-warp-factor-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-warp-factor-one.js
@@ -19,7 +19,7 @@ define([
 ) {
     return function () {
         this.id = 'MembershipEngagementWarpFactorOne';
-        this.start = '2016-10-20';
+        this.start = '2016-10-24';
         this.expiry = '2016-11-3';
         this.author = 'Justin Pinner';
         this.description = 'The first level of prominent engagement messaging';
@@ -53,11 +53,6 @@ define([
             },
             {
                 id: 'become',
-                test: function () {},
-                success: success.bind(this)
-            },
-            {
-                id: 'join',
                 test: function () {},
                 success: success.bind(this)
             }

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,10 +1,10 @@
 <div id="site-message__message">
     <div class="site-message__message site-message__message--membership">
         <%=messageText%>
+        <span id="membership__engagement-message-button" class="message-button-rounded__cta is-hidden">
+            <span id="membership__engagement-message-button-caption"></span><span id="membership__engagement-message-button-arrow"><%=arrowWhiteRight%></span>
+        </span>
     </div>
     <a id="membership__engagement-message-link" class="u-faux-block-link__overlay" target="_blank" href="<%=linkHref%>" data-link-name="Read more link">
     </a>
-    <span id="membership__engagement-message-button" class="message-button-rounded__cta is-hidden">
-        <a id="membership__engagement-message-button-link" href="<%=linkHref%>" target="_blank" data-link-name="Read more button"></a><%=arrowWhiteRight%>
-    </span>
 </div>

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -573,7 +573,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             line-height: 28px;
             height: 28px;
             svg {
-                top: 0px;
+                top: -2px;
                 height: 28px;
                 width: 28px;
             }
@@ -604,9 +604,6 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             stroke: #ffffff;
             fill: #ffffff;
         }
-        a {
-            color: #ffffff;
-        }
         color: #ffffff;
         background-color: #dc2a7d;
     }
@@ -615,10 +612,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             stroke: #000333;
             fill: #000333;
         }
-        a {
-            color: #000333;
-        }
-        color: #ffffff;
+        color: #000333;
         background-color: #4bc6df;
     }
     .message-button-rounded__cta.bright-blue {
@@ -626,13 +620,9 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             stroke: #ffffff;
             fill: #ffffff;
         }
-        a {
-            color: #ffffff;
-        }
-        color: #000000;
+        color: #ffffff;
         background-color: #005689;
     }
-
     .inline-arrow-white-right {
         display: block;
         float: right;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -528,10 +528,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         }
     }
     .site-message__inner {
-        padding-top: 10px;
+        padding-top: 5px;
         padding-left: 5px;
         padding-right: 5px;
-        padding-bottom: 5px;
+        padding-bottom: 10px;
     }
     .site-message__message--membership {
         margin-right: 5px;
@@ -542,6 +542,11 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             margin-right: 10px;
         }
         @include mq($from: tablet) {
+            font-size: 24px;
+            line-height: 28px;
+            margin-right: 20px;
+        }
+        @include mq($from: desktop) {
             font-size: 28px;
             line-height: 32px;
             margin-right: 20px;
@@ -555,37 +560,45 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         display: inline-block;
         width: auto;
         @include mq($from: mobile) {
-            margin-left: 5px;
             font-size: 12px;
-            line-height: 24px;
-            height: 24px;
+            line-height: 20px;
+            height: 20px;
+            margin-top: 3px;
             svg {
                 position: relative;
                 top: -4px;
-                height: 24px;
-                width: 24px;
+                height: 20px;
+                width: 20px;
             }
-            margin-bottom: $gs-row-height / 4;
         }
         @include mq($from: tablet) {
-            margin-left: 10px;
+            font-size: 14px;
+            line-height: 24px;
+            height: 24px;
+            margin-top: 5px;
+            top: -5px;
+            svg {
+                top: -3px;
+                height: 24px;
+                width: 28px;
+            }
+        }
+        @include mq($from: desktop) {
             font-size: 14px;
             line-height: 28px;
             height: 28px;
+            margin-top: 10px;
+            top: -5px;
             svg {
                 top: -2px;
                 height: 28px;
                 width: 28px;
             }
-            margin-bottom: $gs-row-height / 2;
         }
         padding: 1px 24px;
         position: relative;
         cursor: pointer;
-        margin-top: 10px;
         background-color: transparent;
-        top: 25%;
-        height: 50%;
         font-weight: bold;
         a {
             text-decoration: none;


### PR DESCRIPTION
## What does this change?

Some modifications to the prominent messaging AB test;
_Functional:_
We don't want to track button clicks separately from link clicks anymore.
We only want to test one button caption, so we only need two AB groups: "control" and "become"
Use GA tracking codes

_Visual:_
Flows the button inline with the link text
Use smaller font on tablet breakpoint
Adjustments to padding and button heights to accommodate in-lining of button and changes to font
## What is the value of this and can you measure success?

See https://github.com/guardian/frontend/pull/14746
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

_In the test ("become" group)_
## ![screen shot 2016-10-24 at 17 31 26 become](https://cloud.githubusercontent.com/assets/690395/19655461/e7306aec-9a13-11e6-98ad-c022171c4c04.png)
## ![screen shot 2016-10-24 at 17 32 04 become](https://cloud.githubusercontent.com/assets/690395/19655474/f5e26734-9a13-11e6-92a4-6ecbecfdd09c.png)
## ![screen shot 2016-10-24 at 17 32 34 become](https://cloud.githubusercontent.com/assets/690395/19655481/005f91fa-9a14-11e6-9777-db0f51b5dcfc.png)
## ![screen shot 2016-10-24 at 17 33 15 become](https://cloud.githubusercontent.com/assets/690395/19655494/0a5d8d6a-9a14-11e6-8296-884a7a939703.png)

![screen shot 2016-10-24 at 17 33 47 become](https://cloud.githubusercontent.com/assets/690395/19655502/14d2baf4-9a14-11e6-96fd-50ae5ee6476f.png)

_In the test ("control" group)_
## ![screen shot 2016-10-24 at 17 36 31 control](https://cloud.githubusercontent.com/assets/690395/19655521/2efb0e36-9a14-11e6-8b3c-98a4c94c8338.png)
## ![screen shot 2016-10-24 at 17 37 26 control](https://cloud.githubusercontent.com/assets/690395/19655526/3642166c-9a14-11e6-915e-8eab04c1bd4b.png)
## ![screen shot 2016-10-24 at 17 37 57 control](https://cloud.githubusercontent.com/assets/690395/19655532/3e553a3c-9a14-11e6-816c-c02b6814c88a.png)
## ![screen shot 2016-10-24 at 17 38 28 control](https://cloud.githubusercontent.com/assets/690395/19655537/45762218-9a14-11e6-9b5c-dff6dbf3957b.png)

![screen shot 2016-10-24 at 17 38 58 control](https://cloud.githubusercontent.com/assets/690395/19655545/4c286e36-9a14-11e6-8781-40794120d880.png)
## Request for comment

@benwuersching @rtyley 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
