### PR TITLE
Remove snap type specific styling for soulmates

### DIFF
--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -256,22 +256,6 @@
             }
         }
 
-        @supports(scroll-snap-type: mandatory) {
-            @include mq($until: tablet) {
-                display: flex;
-                scroll-snap-type: mandatory;
-
-                > * {
-                    width: min-content;
-                    scroll-snap-align: start;
-                }
-
-                > * + * {
-                    margin-top: 0;
-                    margin-left: $gs-gutter;
-                }
-            }
-        }
     }
 
     .adverts__row--wrap {


### PR DESCRIPTION
Removing snap specific styling for soulmates container in high merch slot.

This may affect the original pr https://github.com/guardian/frontend/pull/12805, but I think it's safer to be simple.
### before

![screen shot 2016-10-24 at 18 14 13](https://cloud.githubusercontent.com/assets/4549425/19656019/07787f7c-9a16-11e6-9293-1a67cc9417c8.png)
### after

![screen shot 2016-10-24 at 18 14 23](https://cloud.githubusercontent.com/assets/4549425/19656035/20cd650a-9a16-11e6-812d-65f1c88f77f4.png)
