### PR TITLE
Add one page test for new sonobi module

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -82,6 +82,17 @@ object CommercialHeaderBiddingControl extends TestDefinition(
   }
 }
 
+object CommercialSonobiRubiconAdapter extends TestDefinition(
+  name = "commercial-sonobi-rubicon",
+  description = "A test url for the new sonobi integration",
+  owners = Seq(Owner.withGithub("rich-nguyen"), Owner.withGithub("janua")),
+  sellByDate = new LocalDate(2016, 11, 1)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.path.endsWith("politics/2016/oct/24/nicola-sturgeon-says-brexit-meeting-was-deeply-frustrating")
+  }
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -100,7 +111,8 @@ object ActiveTests extends ServerSideABTests {
     ABNewHeaderControl,
     CommercialClientLoggingVariant,
     CommercialHeaderBiddingSonobiVariant,
-    CommercialHeaderBiddingControl
+    CommercialHeaderBiddingControl,
+    CommercialSonobiRubiconAdapter
   )
 }
 

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -1,6 +1,7 @@
 @()(implicit request: RequestHeader)
 @import conf.Static
 @import conf.Configuration
+@import mvt.CommercialSonobiRubiconAdapter
 
 window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',
@@ -63,7 +64,13 @@ window.curlConfig = {
             reqwest:                        'components/reqwest/reqwest',
             'foresee.js':                   'vendor/foresee/20150703/foresee-trigger.js',
             'googletag.js':                 '@{Configuration.javascript.config("googletagJsUrl")}',
-            'sonobi.js':                    '@{Configuration.javascript.config("sonobiHeaderBiddingJsUrl")}',
+            'sonobi.js': '@{
+               if (CommercialSonobiRubiconAdapter.isParticipating) {
+                   "//mtrx.go.sonobi.com/morpheus.theguardian.10744.js"
+               } else {
+                   Configuration.javascript.config("sonobiHeaderBiddingJsUrl")
+               }
+             }',
             'ophan/ng':                     '@{Configuration.javascript.config("ophanJsUrl")}',
             'prebid.js':                    'vendor/prebid/0.8.1/prebid.js',
             'discussion-frontend-react':    '@DiscussionAsset("discussion-frontend.react.amd")',


### PR DESCRIPTION
This change adds a new module path for our sonobi integration, for a single page. This new module contains a rubicon adapter, used during the server-side auction.
