### PR TITLE
Better detection of native ads

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
@@ -14,6 +14,7 @@ define([
             id: adSlotNode.id,
             node: adSlotNode,
             sizes: null,
+            size: null,
             slot: null,
             isEmpty: null,
             isLoading: false,

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -2,7 +2,6 @@ define([
     'commercial/modules/dfp/get-advert-by-id',
     'commercial/modules/messenger/post-message'
 ], function (getAdvertById, postMessage) {
-    var nativeAdName = /^\d+-\d+-\d+;\d+;<!DOCTYPE/;
     var host = location.protocol + '//' + location.host;
     return onLoad;
 
@@ -17,12 +16,7 @@ define([
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
         var iframe = advert.node.querySelector('iframe');
-        /* We don't have (yet) a means to identify a native creative, so we
-           resort to that heuristic for now, which tests whether the iframe[name]
-           starts with a special string such as 1-0-4;33540;<!DOCTYPE
-
-           Note: this test detects SafeFrames, not native ads in particular */
-        if (nativeAdName.test(iframe.name)) {
+        if (advert.size === 'fluid') {
             postMessage({ id: iframe.id, host: host }, iframe.contentWindow);
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -15,8 +15,8 @@ define([
     */
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
-        var iframe = advert.node.querySelector('iframe');
         if (advert.size === 'fluid') {
+            var iframe = advert.node.querySelector('iframe');
             postMessage({ id: iframe.id, host: host }, iframe.contentWindow);
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -16,7 +16,7 @@ define([
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
         if (advert.size === 'fluid') {
-            var iframe = advert.node.querySelector('iframe');
+            var iframe = advert.node.getElementsByTagName('iframe')[0];
             postMessage({ id: iframe.id, host: host }, iframe.contentWindow);
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -125,12 +125,12 @@ define([
                 });
 
             function callSizeCallback() {
-                var size = slotRenderEvent.size.join(',');
-                if (size === '0,0') {
-                    size = 'fluid';
+                advert.size = slotRenderEvent.size.join(',');
+                if (advert.size === '0,0') {
+                    advert.size = 'fluid';
                 }
-                return Promise.resolve(sizeCallbacks[size] ?
-                    sizeCallbacks[size](slotRenderEvent, advert) :
+                return Promise.resolve(sizeCallbacks[advert.size] ?
+                    sizeCallbacks[advert.size](slotRenderEvent, advert) :
                     null
                 );
             }


### PR DESCRIPTION
Google recently changed a pivotal attribute in the detection of native ads, the `name` of the iframe. The consequence is that no message could be exchanged between native ads and the parent frame since then.

This led me to find a better way to perform the detection, using the size of the returned creative. Alas, this size is not available in the `onSlotLoad` event, only in the `onSlotRender` one, so I had to add a new property to the `Advert` structure.
