### PR TITLE
Amp youtube atom cleaner

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -50,7 +50,7 @@ object BodyCleaner {
       TableEmbedComplimentaryToP,
       R2VideoCleaner,
       PictureCleaner(article, amp),
-      AtomsCleaner(article.content.atoms, shouldFence = true, isAmp = amp),
+      AtomsCleaner(article.content.atoms, shouldFence = true, amp = amp),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -50,7 +50,7 @@ object BodyCleaner {
       TableEmbedComplimentaryToP,
       R2VideoCleaner,
       PictureCleaner(article, amp),
-      AtomsCleaner(article.content.atoms, shouldFence = true),
+      AtomsCleaner(article.content.atoms, shouldFence = true, isAmp = amp),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,0 +1,11 @@
+@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+
+
+    <amp-youtube
+    data-videoid="@media.assets.head.id"
+    layout="responsive"
+    width="5" height="3" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
+    </amp-youtube>
+
+
+

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,4 +1,4 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean)(implicit request: RequestHeader)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, isAmp: Boolean)(implicit request: RequestHeader)
 @import _root_.model.content.Quiz
 @import _root_.model.content.MediaAtom
 @import _root_.model.content.InteractiveAtom
@@ -7,7 +7,7 @@
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil)
         case media: MediaAtom => media match {
-            case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media)
+            case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media, isAmp)
             case _ => views.html.fragments.atoms.media(media)
         }
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -7,7 +7,8 @@
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil)
         case media: MediaAtom => media match {
-            case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media, isAmp)
+            case youtube if media.assets.head.platform == "Youtube" =>
+                if(isAmp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media)
             case _ => views.html.fragments.atoms.media(media)
         }
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,18 +1,8 @@
 @import conf.Configuration.site.host
 @import views.support.RenderClasses
 
-@(media: model.content.MediaAtom, isAmp: Boolean)(implicit request: RequestHeader)
-@if(isAmp){
+@(media: model.content.MediaAtom)(implicit request: RequestHeader)
 
-    <amp-youtube
-    data-videoid="@media.assets.head.id"
-    layout="responsive"
-    width="5" height="3" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
-    </amp-youtube>
-
-
-
-} else {
     <div class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
         "u-responsive-ratio--hd" -> true
@@ -25,6 +15,5 @@
             </iframe>
 
     </div>
-    }
 }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,8 +1,18 @@
 @import conf.Configuration.site.host
 @import views.support.RenderClasses
 
-@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, isAmp: Boolean)(implicit request: RequestHeader)
+@if(isAmp){
 
+    <amp-youtube
+    data-videoid="@media.assets.head.id"
+    layout="responsive"
+    width="5" height="3" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
+    </amp-youtube>
+
+
+
+} else {
     <div class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
         "u-responsive-ratio--hd" -> true
@@ -15,5 +25,6 @@
             </iframe>
 
     </div>
+    }
 }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -3,6 +3,7 @@ package views.support
 import java.text.Normalizer
 import java.net.URI
 import java.util.regex.{Matcher, Pattern}
+
 import common.{Edition, LinkTo}
 import conf.switches.Switches._
 import layout.ContentWidths
@@ -12,6 +13,8 @@ import model.content.{Atom, Atoms}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
+import views.html.fragments.atoms.atom
+
 import scala.collection.JavaConversions._
 
 trait HtmlCleaner {
@@ -618,7 +621,7 @@ object ChaptersLinksCleaner extends HtmlCleaner {
   }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, isAmp: Boolean = false)(implicit val request: RequestHeader) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -631,7 +634,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean)(implicit val
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence).toString()
+        val html = views.html.fragments.atoms.atom(atomData, shouldFence, isAmp).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -621,7 +621,7 @@ object ChaptersLinksCleaner extends HtmlCleaner {
   }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, isAmp: Boolean = false)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, amp: Boolean = false)(implicit val request: RequestHeader) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -634,7 +634,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, isAmp: Boole
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, isAmp).toString()
+        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Add AMP template for youtube atoms.

(This mirrors the logic currently provided for video elements  in [AmpEmbedCleaner](https://github.com/guardian/frontend/blob/master/common/app/views/support/cleaner/AmpEmbedCleaner.scala) for YouTube atoms)
## What is the value of this and can you measure success?

Fix validation error and allow rendering of youtube atoms on AMP pages

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

AMP 

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

CC @markjamesbutler @TBonnin @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
