### PR TITLE
Remove AMP live blog switches

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -2,23 +2,19 @@
 @import model.Article
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
-@import conf.switches.Switches.{LiveUpdateAmpSwitch,AmpLiveBlogNewsArticleSwitch}
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.LinkTo
 
-@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isAmpAndStructuredAsNewsArticle() = @{
-    amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
-}
-
 @blocks.map { block =>
     <div
         id="block-@block.id"
-        @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" }
+        data-sort-time="@block.publishedCreatedTimestamp()"
         class="block block--content@block.eventClass"
-        @if(!isAmpAndStructuredAsNewsArticle()){ itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting" }
+        itemprop="liveBlogUpdate"
+        itemscope=""
+        itemtype="http://schema.org/BlogPosting"
     >
         <p class="block-time published-time">
             @if(amp){

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -1,6 +1,5 @@
 @import _root_.liveblog.KeyEventData
 @import model.Badges.badgeFor
-@import model.ArticleSchemas
 @import _root_.liveblog.Canonical
 
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
@@ -13,21 +12,13 @@
 @import views.support.TrailCssClasses.toneClass
 @import _root_.liveblog.SinceBlockId
 
-@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isAmpAndStructuredAsNewsArticle() = @{
-    amp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
-}
-@schemaType(page: LiveBlogPage) = @{
-    if(isAmpAndStructuredAsNewsArticle()) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
-}
-
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
 <div class="js-notifications-blocked"></div>
 <div class="l-side-margins">
 
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        itemscope itemtype="@schemaType(model)" role="main">
+        itemscope itemtype="@model.article.metadata.schemaType" role="main">
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
         <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -3,7 +3,6 @@
 @(model: LiveBlogPage)(implicit request: RequestHeader)
 
 @import common.Edition
-@import conf.switches.Switches.LiveUpdateAmpSwitch
 @import views.support.{AmpAd, AmpAdDataSlot}
 @import org.joda.time.DateTimeZone
 
@@ -13,7 +12,7 @@
 
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
         @if(blockGroup.length == 5 && index < 8) {
-            <div @if(LiveUpdateAmpSwitch.isSwitchedOn) { id="amp-ad-@index" data-sort-time="1" } class="block amp-ad-container amp-ad-container--live-blog">
+            <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
                     json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
                     data-slot=@AmpAdDataSlot(article).toString()>
@@ -28,7 +27,6 @@
         @if(model.currentPage.currentPage.isArchivePage) {
             @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, amp = true)
         }
-        @if(LiveUpdateAmpSwitch.isSwitchedOn) {
             <amp-live-list
                 id="live-list"
                 data-poll-interval="15000"
@@ -50,14 +48,7 @@
                     @liveBlogBlocksAMP(article, timezone)
                 </div>
             </amp-live-list>
-        } else {
-            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
-                _root_.liveblog.LatestBlock(article.blocks)
-            }" data-test-id="live-blog-blocks"
-            itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
-                @liveBlogBlocksAMP(article, timezone)
-            </div>
-        }
+
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, amp = true)
     </div>
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -357,37 +357,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val LiveBlogAmpSwitch = Switch(
-    SwitchGroup.Feature,
-    "live-blog-amp",
-    "If this switch is on, link to amp pages will be in the metadata for live blogs",
-    owners = Seq(Owner.withGithub("SiAdcock")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 26),
-    exposeClientSide = false
-  )
-
-  // see https://github.com/guardian/frontend/pull/13916
-  val AmpLiveBlogNewsArticleSwitch = Switch(
-    SwitchGroup.Feature,
-    "live-blog-amp-news-article",
-    "If this switch is on, amp live blog articles have an itemtype of NewsArticle, and thus appear in Google's AMP carousel",
-    owners = Seq(Owner.withGithub("SiAdcock")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 26),
-    exposeClientSide = false
-  )
-
-  val LiveUpdateAmpSwitch = Switch(
-    SwitchGroup.Feature,
-    "live-update-amp",
-    "If this switch is on, amp-live-list will be included in live blogs",
-    owners = Seq(Owner.withGithub("SiAdcock")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 10, 26),
-    exposeClientSide = false
-  )
-
   val R2PagePressServiceSwitch = Switch(
     SwitchGroup.Feature,
     "r2-page-press-service",

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,14 +1,8 @@
 @import common.RichRequestHeader
-@import conf.switches.Switches.AmpLiveBlogNewsArticleSwitch
 @import org.joda.time.DateTime
 @import views.support.{AuFriendlyFormat, Format}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
-
-@* Aug 2016: Google only supports NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/LiveBlogPosting *@
-@isAmpAndStructuredAsNewsArticle() = @{
-    request.isAmp && AmpLiveBlogNewsArticleSwitch.isSwitchedOn
-}
 
 <p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}" aria-hidden="true">
     <time itemprop="datePublished" datetime='@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
@@ -19,18 +13,14 @@
             @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
         }
     </time>
-    @* Aug 2016: disable coverage start time for AMP Live Blogs, which currently have an article type of NewsArticle *@
-    @if(isLiveBlog && !isAmpAndStructuredAsNewsArticle()) {
-        <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
-    }
+    <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     @if(hasBeenModified && !isMinute) {
         <time itemprop="dateModified" datetime='@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@lastModified.getMillis" class="content__dateline-lm js-lm u-h">
             Last modified on @Format(lastModified, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(lastModified)</span>
         </time>
     }
-    @* Aug 2016: disable coverage end time for AMP Live Blogs, which currently have an article type of NewsArticle *@
-    @if(isLiveBlog && !isLive && !isAmpAndStructuredAsNewsArticle()) {
+    @if(isLiveBlog && !isLive) {
         <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, LiveBlogAmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -43,18 +43,13 @@
 
     <link rel="manifest" href="/2015-06-24-manifest.json" crossorigin="use-credentials">
 
+
     @Page.getContentPage(page).map { page =>
         @if(
-            (
-                page.item.tags.isArticle &&
-                !page.item.tags.isLiveBlog &&
-                !page.item.content.isImmersive &&
-                !page.item.tags.isQuiz &&
-                AmpSwitch.isSwitchedOn
-            ) || (
-                page.item.tags.isLiveBlog &&
-                LiveBlogAmpSwitch.isSwitchedOn
-            )
+            page.item.tags.isArticle &&
+            !page.item.content.isImmersive &&
+            !page.item.tags.isQuiz &&
+            AmpSwitch.isSwitchedOn
         ) {
             <link rel="amphtml" href="@AmpLinkTo{/@page.metadata.id}">
         }

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -2,7 +2,6 @@
 
 @import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
-@import conf.switches.Switches.LiveUpdateAmpSwitch
 @import views.support.OmnitureAnalyticsData
 @import views.support.FBPixel
 
@@ -24,9 +23,7 @@
         <script custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js" async></script>
         @if(content.tags.isLiveBlog) {
             <script custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js" async></script>
-            @if(LiveUpdateAmpSwitch.isSwitchedOn) {
-                <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
-            }
+            <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
         }
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         @* Required for outbrain served in an amp-iframe *@


### PR DESCRIPTION
## What does this change?

Live Blogs that use the LiveBlogPosting structured data format and live updates are now supported in AMP. We no longer need the switches that control these features. Disabling AMP will allow us to disable AMP Live Blogs, if absolutely necessary. 
## What is the value of this and can you measure success?

Tidy up switches that are no longer needed
## Does this affect other platforms - Amp, Apps, etc?

It only affects AMP 😄 
## Request for comment

@NataliaLKB @stephanfowler 
