### PR TITLE
New header: Fixing bug where on https, section link starts with `//`

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -35,7 +35,7 @@
                         <div class="content__section-label @if(item.content.tags.isGallery) { content__section-label--gallery }">
                             <a class="content__section-label__link"
                                 data-link-name="article section"
-                                href="@LinkTo {/@sectionLink.href}">
+                                href="@LinkTo(sectionLink.href)">
                                     @sectionLink.title
                             </a>
                         </div>


### PR DESCRIPTION
## What does this change?

There is currently a bug in the new header test where if you click on a section link instead of taking you to `www.theguardian.com/...` it takes you to `//...`, which of course doesn't exist.

Interestingly, I didn't catch this locally because locally all urls are relative and works fine. 

This change fixes this problem.
## What is the value of this and can you measure success?

People can make the onward journeys that they expect
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@dominickendrick @guardian/dotcom-platform 
