### PR TITLE
Fix: Multiple testsuites (extending OneServerPerSuite) use same test port

### DIFF
--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -12,6 +12,6 @@ class AdminTestSuite extends Suites (
   new controllers.admin.DeploysRadiatorControllerTest,
   new controllers.admin.DeploysNotifyControllerTest
 ) with SingleServerSuite {
-    override lazy val port: Int = 19001
+    override lazy val port: Int = 19015
 }
 

--- a/admin/test/pagepresser/HtmlCleanerTest.scala
+++ b/admin/test/pagepresser/HtmlCleanerTest.scala
@@ -2,7 +2,7 @@ package pagepresser
 
 import org.jsoup.Jsoup
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
-import test.{SingleServerSuite, ConfiguredTestSuite}
+import test.ConfiguredTestSuite
 import scala.io.Source
 
 @DoNotDiscover class HtmlCleanerTest extends FlatSpec with Matchers with ConfiguredTestSuite {

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -1,0 +1,11 @@
+package test
+
+import conf.CachedHealthCheckTest
+import org.scalatest.Suites
+
+class CommonTestSuite extends Suites (
+  new CachedHealthCheckTest
+) with SingleServerSuite {
+  override lazy val port: Int = 19016
+}
+

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -2,21 +2,21 @@ package conf
 
 import common.ExecutionContexts
 import org.joda.time.DateTime
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.{SingleServerSuite, WithTestWsClient}
+import test.{ConfiguredTestSuite, WithTestWsClient}
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-class CachedHealthCheckTest
+@DoNotDiscover class CachedHealthCheckTest
   extends WordSpec
   with Matchers
-  with SingleServerSuite
+  with ConfiguredTestSuite
   with ScalaFutures
   with ExecutionContexts
   with BeforeAndAfterAll

--- a/common/test/layout/WidthsByBreakpointTest.scala
+++ b/common/test/layout/WidthsByBreakpointTest.scala
@@ -2,8 +2,6 @@ package layout
 
 import layout.ContentWidths._
 import org.scalatest._
-import org.scalatest.concurrent.Eventually
-import test.SingleServerSuite
 
 class WidthsByBreakpointTest extends FreeSpec with ShouldMatchers {
   "ContentWidths" - {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

AdminTestSuite was set to specifically use port 19001 which is the `OneServerPerSuite` default testport
CachedHealthCheckTest was not overriding the test port and therefore was also using the port 19001
=> Possible conflict if the 2 test suites were run concurrently
This patch:
- changes the test port override for AdminTestSuite to another port (19015)
- Create a new test suite for common tests and override the test port to 19016. This new test suite is not absolutely necessary but would become handy if we are adding more tests which are shared and need to run with a server.
## What is the value of this and can you measure success?

No more `org.jboss.netty.channel.ChannelException: Failed to bind to: /0.0.0.0:19001` errors when running tests

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@rich-nguyen @guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
