### PR TITLE
Inline require calls for interactives

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -66,13 +66,8 @@
     <script>
         @HtmlFormat.raw(common.Assets.js.curl)
 
-        [].slice.apply(document.querySelectorAll('figure.interactive')).forEach(function (el) {
-            var mainJS = el.getAttribute('data-interactive');
-            if (!mainJS) {
-                return;
-            }
-
-            require([mainJS], function (interactive) {
+        [].slice.apply(document.querySelectorAll('figure.interactive[data-interactive]')).forEach(function (el) {
+            require([el.getAttribute('data-interactive')], function (interactive) {
                 interactive.boot(el, document, window.guardian.config);
             }, function (err) {
                 console.log('Interactive failed', mainJS);

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -62,4 +62,22 @@
         </div>
         @fragments.contentFooter(interactive, page.related, isPaidContent = isPaidContent)
     }
+
+    <script>
+        @HtmlFormat.raw(common.Assets.js.curl)
+
+        [].slice.apply(document.querySelectorAll('figure.interactive')).forEach(function (el) {
+            var mainJS = el.getAttribute('data-interactive');
+            if (!mainJS) {
+                return;
+            }
+
+            require([mainJS], function (interactive) {
+                interactive.boot(el, document, window.guardian.config);
+            }, function (err) {
+                console.log('Interactive failed', mainJS);
+                console.log('Error:', err);
+            });
+        });
+    </script>
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -63,16 +63,18 @@
         @fragments.contentFooter(interactive, page.related, isPaidContent = isPaidContent)
     }
 
-    <script>
-        @HtmlFormat.raw(common.Assets.js.curl)
+    @if(conf.switches.Switches.InlineInteractiveRequire.isSwitchedOn) {
+        <script>
+            @HtmlFormat.raw(common.Assets.js.curl)
 
-        [].slice.apply(document.querySelectorAll('figure.interactive[data-interactive]')).forEach(function (el) {
-            require([el.getAttribute('data-interactive')], function (interactive) {
-                interactive.boot(el, document, window.guardian.config);
-            }, function (err) {
-                console.log('Interactive failed', mainJS);
-                console.log('Error:', err);
+            [].slice.apply(document.querySelectorAll('figure.interactive[data-interactive]')).forEach(function (el) {
+                require([el.getAttribute('data-interactive')], function (interactive) {
+                    interactive.boot(el, document, window.guardian.config);
+                }, function (err) {
+                    console.log('Interactive failed', mainJS);
+                    console.log('Error:', err);
+                });
             });
-        });
-    </script>
+        </script>
+    }
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -207,4 +207,14 @@ trait PerformanceSwitches {
     sellByDate = new LocalDate(2016, 12, 1),
     exposeClientSide = false
   )
+
+  val InlineInteractiveRequire = Switch(
+    SwitchGroup.Performance,
+    "inline-interactive-require",
+    "If this switch is on, require is inlined on interactives",
+    owners = Seq(Owner.withGithub("wpf500")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 11),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -127,7 +127,7 @@ define([
          *  Interactives are content, we want them booting as soon (and as stable) as possible.
          */
 
-        if (/Article|Interactive|LiveBlog/.test(config.page.contentType)) {
+        if (/Article|LiveBlog/.test(config.page.contentType)) {
             qwery('figure.interactive').forEach(function (el) {
                 var mainJS = el.getAttribute('data-interactive');
                 if (!mainJS) {

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -127,7 +127,8 @@ define([
          *  Interactives are content, we want them booting as soon (and as stable) as possible.
          */
 
-        if (/Article|LiveBlog/.test(config.page.contentType)) {
+        var interactiveTest = config.switches.inlineInteractiveRequire ? /Article|LiveBlog/ : /Article|Interactive|LiveBlog/;
+        if (interactiveTest.test(config.page.contentType)) {
             qwery('figure.interactive').forEach(function (el) {
                 var mainJS = el.getAttribute('data-interactive');
                 if (!mainJS) {

--- a/static/src/javascripts/components/curl/curl-domReady.js
+++ b/static/src/javascripts/components/curl/curl-domReady.js
@@ -1,4 +1,4 @@
-(function(){/*
+window.require || (function(){/*
  MIT License (c) copyright 2010-2013 B Cavalier & J Hann */
 (function(l){function p(){}function v(a,b){return 0==T.call(a).indexOf("[object "+b)}function x(a){return a&&"/"==a.charAt(a.length-1)?a.substr(0,a.length-1):a}function D(a,b){var d,c,f,g;d=1;c=a;"."==c.charAt(0)&&(f=!0,c=c.replace(U,function(a,b,c,f){c&&d++;return f||""}));if(f){f=b.split("/");g=f.length-d;if(0>g)return a;f.splice(g,d);return f.concat(c||[]).join("/")}return c}function C(a){var b=a.indexOf("!");return{g:a.substr(b+1),d:0<=b&&a.substr(0,b)}}function A(){}function y(a,b){A.prototype=
 a||N;var d=new A;A.prototype=N;for(var c in b)d[c]=b[c];return d}function E(){function a(a,b,d){c.push([a,b,d])}function b(a,b){for(var d,f=0;d=c[f++];)(d=d[a])&&d(b)}var d,c,f;d=this;c=[];f=function(d,n){a=d?function(a){a&&a(n)}:function(a,b){b&&b(n)};f=p;b(d?0:1,n);b=p;c=s};this.then=function(b,c,f){a(b,c,f);return d};this.h=function(a){d.B=a;f(!0,a)};this.f=function(a){d.pa=a;f(!1,a)};this.v=function(a){b(2,a)}}function z(a){return a instanceof E||a instanceof h}function t(a,b,d,c){z(a)?a.then(b,


### PR DESCRIPTION
~~This is a proof of concept, the code is very hacky, but it would be great to get people's thoughts about the concept.~~

All of this only applies to the interactive content type, not interactive embeds on articles etc.

Interactive's are currently loaded in `app.js`. This means that interactives load very late (~2-3 secs on good machine/internet) and experience performance problems as they load (competing for resources with commercial components etc.). An interactive's JS is an important part of the content, so maybe we should defer loading `app.js` to later?
## What does this change?

The purpose of this PR is two-fold:
- Load interactive JS as soon as possible
- ~~Defer loading `app.js` to after interactive's have finished booting~~

## Does this affect other platforms - Amp, Apps, etc?

I don't think interactives are ever available off platform

This would affect old interactives as we would be inlining their boot loader.
