### PR TITLE
Optimise Membership Engagement Banner Logic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -142,11 +142,13 @@ define([
         var message = messages[edition];
         if (message) {
             var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
-            return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
-                if (canShow && userHasMadeEnoughVisits) {
-                    show(edition, message);
-                }
-            });
+            if(userHasMadeEnoughVisits) {
+                return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
+                    if (canShow) {
+                        show(edition, message);
+                    }
+                });
+            }
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

A small optimisation that stops an unnecessary asynchronous call to commercial features that doesn't need to be called if the user has less than 10 visits
## What is the value of this and can you measure success?

Stops unnecessary code being ran => saves energy => saves some trees. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots
## Request for comment

@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
