### PR TITLE
Fix gallery advert right align

### DIFF
--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -192,13 +192,16 @@ $mobile-max-container-width: gs-span(8);
     }
 
     // Gallery & Liveblog sections styles
-    &.ad-slot--gallery-inline,
     &.ad-slot--liveblog-inline {
         width: 100%;
         margin-left: auto;
         margin-right: auto;
         padding-top: 0;
         padding-bottom: 0;
+    }
+
+    &.ad-slot--gallery-inline {
+        margin-left: 0;
     }
 }
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -170,7 +170,7 @@
     @include mq($until: desktop) {
         text-align: center;
 
-        img {
+        .gallery__img {
             display: inline-block;
         }
     }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

This fixes right aligning adverts on galleries.

This also fixes `img` tags in adverts getting targeted by CSS made for the gallery `img` tags.
## Request for comment

@regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
