### PR TITLE
Media atom embed

### DIFF
--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -18,6 +18,7 @@ trait ApplicationsControllers {
   lazy val notificationsController = wire[NotificationsController]
   lazy val tagIndexController = wire[TagIndexController]
   lazy val embedController = wire[EmbedController]
+  lazy val mediaAtomEmbedController = wire[MediaAtomEmbedController]
   lazy val preferencesController = wire[PreferencesController]
   lazy val optInController = wire[OptInController]
   lazy val webAppController = wire[WebAppController]

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -1,0 +1,65 @@
+package controllers
+
+import com.gu.contentapi.client.model.v1.ItemResponse
+import com.gu.contentatom.thrift.{AtomData, Atom => AtomApi}
+import common._
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import model._
+import play.api.mvc._
+
+import scala.concurrent.Future
+import contentapi.ContentApiClient
+import model.content.{Atom, MediaAtom}
+
+class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
+
+  def render(id: String) = Action.async { implicit request =>
+    lookup(s"atom/media/$id") map {
+      case Left(model) => renderMediaAtom(model)
+      case Right(other) => renderOther(other)
+    }
+  }
+
+  def make(apiAtom: Option[AtomApi]): Option[MediaAtom] = {
+    apiAtom map (a => {
+      val id = a.id
+      val defaultHtml = a.defaultHtml
+      val mediaAtom = a.data.asInstanceOf[AtomData.Media].media
+      MediaAtom.mediaAtomMake(id, defaultHtml, mediaAtom)
+    })
+  }
+
+
+
+  private def lookup(path: String)(implicit request: RequestHeader) = {
+    val edition = Edition(request)
+
+    println(s"Fetching media atom: $path for edition $edition")
+
+    val response: Future[ItemResponse] = contentApiClient.getResponse(contentApiClient.item(path, edition)
+
+    )
+
+    val result = response map { response =>
+
+      val modelOption = make(response.media)
+
+      modelOption match {
+        case Some(x) => Left(x)
+        case _ => Right(NotFound)
+      }
+    }
+
+    result recover convertApiExceptions
+  }
+
+  private def renderOther(result: Result)(implicit request: RequestHeader) = result.header.status match {
+    case 404 => NoCache(NotFound)
+    case 410 => Cached(60)(WithoutRevalidationResult(Gone(views.html.videoEmbedMissing())))
+    case _ => result
+  }
+
+  private def renderMediaAtom(model: Atom)(implicit request: RequestHeader): Result = {
+    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.atom(model, shouldFence = false)))
+  }
+}

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -61,19 +61,10 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
   }
 
   private def renderMediaAtom(model: MediaAtom)(implicit request: RequestHeader): Result = {
-    val body: Html = model match {
-      case youtube if model.assets.head.platform == "Youtube" => Html(views.html.fragments.atoms.youtube(model).toString)
-      case _ => Html(views.html.fragments.atoms.media(model).toString)
-  }
-    val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model, body)
 
-    Cached(600)(RevalidatableResult.Ok(model match {
-      case youtube if model.assets.head.platform == "Youtube" => {
-        views.html.fragments.atoms.mediaEmbed(page)
-      }
-      case _ => views.html.fragments.atoms.mediaEmbed(page)
-        }
-      )
+    val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model)
+
+    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.mediaEmbed(page))
     )
   }
 }

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -9,7 +9,8 @@ import play.api.mvc._
 
 import scala.concurrent.Future
 import contentapi.ContentApiClient
-import model.content.{MediaAtom}
+import model.content.MediaAtom
+import play.twirl.api.Html
 
 class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
 
@@ -60,11 +61,11 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
   }
 
   private def renderMediaAtom(model: MediaAtom)(implicit request: RequestHeader): Result = {
-    val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model)
-
-
-
-
+    val body: Html = model match {
+      case youtube if model.assets.head.platform == "Youtube" => Html(views.html.fragments.atoms.youtube(model).toString)
+      case _ => Html(views.html.fragments.atoms.media(model).toString)
+  }
+    val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model, body)
 
     Cached(600)(RevalidatableResult.Ok(model match {
       case youtube if model.assets.head.platform == "Youtube" => {

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import com.gu.contentatom.thrift.{AtomData, Atom => AtomApi}
+import com.gu.contentatom.thrift.{Atom => AtomApi}
 import common._
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
@@ -10,7 +10,6 @@ import play.api.mvc._
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 import model.content.MediaAtom
-import play.twirl.api.Html
 
 class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Controller with Logging with ExecutionContexts {
 
@@ -22,12 +21,9 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
   }
 
   def make(apiAtom: Option[AtomApi]): Option[MediaAtom] = {
-    apiAtom map (a => {
-      val id = a.id
-      val defaultHtml = a.defaultHtml
-      val mediaAtom = a.data.asInstanceOf[AtomData.Media].media
-      MediaAtom.mediaAtomMake(id, defaultHtml, mediaAtom)
-    })
+    apiAtom map {
+      MediaAtom.make
+    }
   }
 
 

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -60,9 +60,17 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
   }
 
   private def renderMediaAtom(model: MediaAtom)(implicit request: RequestHeader): Result = {
+    val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model)
+
+
+
+
+
     Cached(600)(RevalidatableResult.Ok(model match {
-      case youtube if model.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(model)
-      case _ => views.html.fragments.atoms.media(model)
+      case youtube if model.assets.head.platform == "Youtube" => {
+        views.html.fragments.atoms.mediaEmbed(page)
+      }
+      case _ => views.html.fragments.atoms.mediaEmbed(page)
         }
       )
     )

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -44,6 +44,7 @@ GET        /index/contributors                                                  
 GET        /index/contributors/*contributor                                     controllers.TagIndexController.contributor(contributor)
 
 GET        /embed/video/*path                                                   controllers.EmbedController.render(path)
+GET        /embed/atom/media/:id                                                controllers.MediaAtomEmbedController.render(id)
 
 
 # Preferences

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -78,10 +78,7 @@ object Atoms extends common.Logging {
       })
 
       val media = extract(atoms.media, atom => {
-        val id = atom.id
-        val defaultHtml = atom.defaultHtml
-        val mediaAtom = atom.data.asInstanceOf[AtomData.Media].media
-        MediaAtom.mediaAtomMake(id, defaultHtml, mediaAtom)
+        MediaAtom.make(atom)
       })
 
       val interactives = extract(atoms.interactives, atom => {
@@ -96,6 +93,13 @@ object Atoms extends common.Logging {
 
 
 object MediaAtom extends common.Logging {
+
+  def make(atom: AtomApiAtom): MediaAtom = {
+    val id = atom.id
+    val defaultHtml = atom.defaultHtml
+    val mediaAtom = atom.data.asInstanceOf[AtomData.Media].media
+    MediaAtom.mediaAtomMake(id, defaultHtml, mediaAtom)
+  }
 
   def mediaAtomMake(id: String, defaultHtml: String, mediaAtom: AtomApiMediaAtom): MediaAtom =
     MediaAtom(

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -400,7 +400,7 @@ case class GalleryPage(
 
 case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) extends ContentPage
 
-case class MediaAtomEmbedPage(atom: MediaAtom, body: Html) extends Page {
+case class MediaAtomEmbedPage(atom: MediaAtom) extends Page {
   override val metadata = MetaData.make(id = atom.id,
     webTitle = atom.title,
     analyticsName = atom.id,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -8,6 +8,7 @@ import common.dfp._
 import common.{Edition, ManifestData, NavItem, Pagination}
 import conf.Configuration
 import cricketPa.CricketTeams
+import model.content.MediaAtom
 import model.liveblog.Blocks
 import model.meta.{Guardian, LinkedData, PotentialAction, WebPage}
 import ophan.SurgingContentAgent
@@ -397,6 +398,13 @@ case class GalleryPage(
 }
 
 case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) extends ContentPage
+
+case class MediaAtomEmbedPage(atom: MediaAtom) extends Page {
+  override val metadata = MetaData.make(id = atom.id,
+    webTitle = atom.title,
+    analyticsName = atom.id,
+    section = None)
+}
 
 case class TagCombiner(
   id: String,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -17,6 +17,7 @@ import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
 import play.api.mvc.RequestHeader
+import play.twirl.api.Html
 
 object Commercial {
 
@@ -399,7 +400,7 @@ case class GalleryPage(
 
 case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) extends ContentPage
 
-case class MediaAtomEmbedPage(atom: MediaAtom) extends Page {
+case class MediaAtomEmbedPage(atom: MediaAtom, body: Html) extends Page {
   override val metadata = MetaData.make(id = atom.id,
     webTitle = atom.title,
     analyticsName = atom.id,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -403,7 +403,6 @@ case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) ext
 case class MediaAtomEmbedPage(atom: MediaAtom) extends Page {
   override val metadata = MetaData.make(id = atom.id,
     webTitle = atom.title,
-    //TODO figure out what the analytics name should be
     analyticsName = atom.id,
     section = None)
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -403,6 +403,7 @@ case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) ext
 case class MediaAtomEmbedPage(atom: MediaAtom) extends Page {
   override val metadata = MetaData.make(id = atom.id,
     webTitle = atom.title,
+    //TODO figure out what the analytics name should be
     analyticsName = atom.id,
     section = None)
 }

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -12,7 +12,6 @@ object `package` {
     lazy val isGallery: Boolean = content.tags exists { _.id == "type/gallery" }
     lazy val isVideo: Boolean = content.tags exists { _.id == "type/video" }
     lazy val isAudio: Boolean = content.tags exists { _.id == "type/audio" }
-    lazy val isMediaAtom: Boolean = content.atoms.exists { _.media.isDefined} && content.fields.isEmpty
     lazy val isMedia: Boolean = isGallery || isVideo || isAudio
     lazy val isPoll: Boolean = content.tags exists { _.id == "type/poll" }
     lazy val isImageContent: Boolean = content.tags exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -12,6 +12,7 @@ object `package` {
     lazy val isGallery: Boolean = content.tags exists { _.id == "type/gallery" }
     lazy val isVideo: Boolean = content.tags exists { _.id == "type/video" }
     lazy val isAudio: Boolean = content.tags exists { _.id == "type/audio" }
+    lazy val isMediaAtom: Boolean = content.atoms.exists { _.media.isDefined} && content.fields.isEmpty
     lazy val isMedia: Boolean = isGallery || isVideo || isAudio
     lazy val isPoll: Boolean = content.tags exists { _.id == "type/poll" }
     lazy val isImageContent: Boolean = content.tags exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -6,11 +6,7 @@
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil)
-        case media: MediaAtom => media match {
-            case youtube if media.assets.head.platform == "Youtube" =>
-                if(isAmp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media)
-            case _ => views.html.fragments.atoms.media(media)
-        }
+        case media: MediaAtom => views.html.fragments.atoms.media(media)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,4 +1,4 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean, isAmp: Boolean)(implicit request: RequestHeader)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean)(implicit request: RequestHeader)
 @import _root_.model.content.Quiz
 @import _root_.model.content.MediaAtom
 @import _root_.model.content.InteractiveAtom
@@ -6,7 +6,7 @@
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, Nil)
-        case media: MediaAtom => views.html.fragments.atoms.media(media)
+        case media: MediaAtom => views.html.fragments.atoms.media(media, amp)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/genericMedia.scala.html
+++ b/common/app/views/fragments/atoms/genericMedia.scala.html
@@ -1,0 +1,14 @@
+@import views.support.RenderClasses
+
+@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+
+<div class="@RenderClasses(Map(
+    "u-responsive-ratio" -> true,
+    "u-responsive-ratio--hd" -> true
+))">
+
+@Html(media.defaultHtml)
+
+</div>
+
+

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,8 +1,8 @@
-@(media: _root_.model.content.MediaAtom)(implicit request: RequestHeader)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false)(implicit request: RequestHeader)
 
 @{
     media match {
-            case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media)
+            case youtube if media.assets.head.platform == "Youtube" => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,14 +1,9 @@
-@import views.support.RenderClasses
+@(media: _root_.model.content.MediaAtom)(implicit request: RequestHeader)
 
-@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+@{
+    media match {
+            case youtube if media.assets.head.platform == "Youtube" => views.html.fragments.atoms.youtube(media)
+            case _ => views.html.fragments.atoms.genericMedia(media)
+        }
 
-<div class="@RenderClasses(Map(
-    "u-responsive-ratio" -> true,
-    "u-responsive-ratio--hd" -> true
-))">
-
-@Html(media.defaultHtml)
-
-</div>
-
-
+}

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -1,9 +1,6 @@
-@import conf.{Configuration, Static}
-@import model.{EmbedPage, VideoPlayer}
-@import templates.inlineJS.blocking.js.curlConfig
-@import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
-
+@import conf.Static
 @import model.MediaAtomEmbedPage
+
 @(page: MediaAtomEmbedPage)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
@@ -18,7 +15,7 @@
         <base target="_parent"/>
     </head>
     <body>
-        @page.body
+        @views.html.fragments.atoms.media(page.atom)
 
         @fragments.analytics.base(page)
     </body>

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -1,0 +1,25 @@
+@import conf.{Configuration, Static}
+@import model.{EmbedPage, VideoPlayer}
+@import templates.inlineJS.blocking.js.curlConfig
+@import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
+
+@import model.MediaAtomEmbedPage
+@(page: MediaAtomEmbedPage)(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html lang="en-GB" class="gu-video-embed-html">
+    <head>
+        <title>@page.atom.title</title>
+        <base target="_parent"/>
+    </head>
+    <body>
+
+    @defining( page.atom ) { atom =>
+
+Hello World
+
+        @fragments.analytics.base(page)
+
+    }
+    </body>
+</html>

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -10,16 +10,16 @@
 <html lang="en-GB" class="gu-video-embed-html">
     <head>
         <title>@page.atom.title</title>
+        <style>
+        * { margin: 0; padding: 0; }
+        figure { margin: 0 !important; }
+        </style>
+        <link rel="stylesheet" href="@Static("stylesheets/media-player.css")"/>
         <base target="_parent"/>
     </head>
     <body>
-
-    @defining( page.atom ) { atom =>
-
-Hello World
+        @page.body
 
         @fragments.analytics.base(page)
-
-    }
     </body>
 </html>

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -22,25 +22,34 @@ class AtomCleanerTest extends FlatSpec with Matchers with FakeRequests {
     interactives = Nil
   )
 )
- private def clean(document: Document, atom:Option[Atoms]): Document = {
-    val cleaner = AtomsCleaner(youTubeAtom, shouldFence = false)(TestRequest())
-    cleaner.clean(document)
-    document
-  }
-
-  "AtomsCleaner" should "create YouTube template" in {
-    Switches.UseAtomsSwitch.switchOn()
-    val doc = Jsoup.parse( s"""<figure class="element element-atom">
+  def doc = Jsoup.parse( s"""<figure class="element element-atom">
                                 <gu-atom data-atom-id="887fb7b4-b31d-4a38-9d1f-26df5878cf9c" data-atom-type="media">
                                 <div>
                                  <iframe src="https://www.youtube.com/embed/nQuN9CUsdVg" allowfullscreen="" width="420" height="315" frameborder="0"> </iframe>
                                  </div>
                                 </gu-atom>
                                </figure>""")
-    val result: Document = clean(doc, youTubeAtom)
+
+
+ private def clean(document: Document, atom:Option[Atoms], amp: Boolean): Document = {
+    val cleaner = AtomsCleaner(youTubeAtom, shouldFence = false, amp = amp)(TestRequest())
+    cleaner.clean(document)
+    document
+  }
+
+  "AtomsCleaner" should "create YouTube template" in {
+    Switches.UseAtomsSwitch.switchOn()
+    val result: Document = clean(doc, youTubeAtom, amp = false)
     result.select("iframe").attr("id") shouldBe("youtube-nQuN9CUsdVg")
     result.select("iframe").attr("src") should include("enablejsapi=1")
-
   }
+
+  "AtomsCleaner" should "use amp-youtube markup if amp is true" in {
+    Switches.UseAtomsSwitch.switchOn()
+    val result: Document = clean(doc, youTubeAtom, amp = true)
+    result.select("amp-youtube").attr("data-videoid") shouldBe("nQuN9CUsdVg")
+  }
+
+
 
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -370,6 +370,7 @@ POST           /notification/delete                                             
 GET            /2015-06-24-manifest.json                                                                                         controllers.WebAppController.manifest()
 GET            /preferences                                                                                                      controllers.PreferencesController.indexPrefs()
 GET            /embed/video/*path                                                                                                controllers.EmbedController.render(path)
+GET            /embed/atom/media/:id                                                                                             controllers.MediaAtomEmbedController.render(id)
 GET            /index/subjects                                                                                                   controllers.TagIndexController.keywords()
 GET            /index/subjects/*index                                                                                            controllers.TagIndexController.keyword(index)
 GET            /index/contributors                                                                                               controllers.TagIndexController.contributors()


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Creates a embeddable version of a media atom available at: `/embed/atom/media/:id`
## What is the value of this and can you measure success?

This is required by some internal clients such as the Daily Edition app, which require a version of media atoms renderable as a standalone `iframe`.

(This is equivalent to the embed functionality we currently provide for video pages e.g. https://embed.theguardian.com/embed/video/politics/video/2016/jul/14/boris-johnson-humbled-to-be-appointed-foreign-secretary-video but intended for use by internal clients only)
## Does this affect other platforms - Amp, Apps, etc?

Daily Edition app.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

<img width="960" alt="screen shot 2016-10-27 at 11 35 10" src="https://cloud.githubusercontent.com/assets/1764158/19764170/8fbaf200-9c39-11e6-9dce-092478a5ea0c.png">
## Request for comment

@markjamesbutler @akash1810 @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
