### PR TITLE
Allow Outlook to use correct fallback font

### DIFF
--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -28,7 +28,6 @@
     }
 
     h2 {
-        font-weight: bold;
         font-size: 24px;
         line-height: 28px;
         margin-bottom: 5px;

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -12,6 +12,20 @@
         <link rel="canonical" href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))" />
         <title>@views.support.Title(page)</title>
 
+        @*
+         * Outlook doesn't support web fonts and also doesn't handle
+         * fallback fonts correctly, so all "Guardian Egyptian Text" will
+         * come out as Times New Roman despite the fallback font of Georgia.
+         * So for Outlook we explicitly set Georgia as the preferred font.
+         *@
+        <!--[if mso]>
+        <style>
+            h1, h2, h3, h4, h5, h6, p, blockquote {
+                font-family: Georgia, serif !important;
+            }
+        </style>
+        <![endif]-->
+
         @fragments.email.stylesheets.ink()
         @fragments.email.stylesheets.fonts()
         @fragments.email.stylesheets.main()


### PR DESCRIPTION
Outlook doesn't support web fonts and also doesn't handle fallback fonts correctly, so all "Guardian Egyptian Text" currently comes out as Times New Roman despite the fallback font of Georgia.

Now we explicitly set Georgia as the preferred font in Outlook. Since bold Georgia in the subheadings looks a bit weird, I also un-bolded the `<h2></h2>` elements.
## Outlook before:

![outlook 2016 before](https://cloud.githubusercontent.com/assets/5122968/19766089/dc5edd92-9c43-11e6-8499-f34f0a6c94f3.png)
## Outlook after:

![outlook 2016 after](https://cloud.githubusercontent.com/assets/5122968/19766085/da6a90da-9c43-11e6-9d77-2b746a29e60f.png)
## Gmail before:

![gmail before](https://cloud.githubusercontent.com/assets/5122968/19766094/e03bbbe2-9c43-11e6-8a23-fcd3cd0a9a70.png)
## Gmail after:

![gmail after](https://cloud.githubusercontent.com/assets/5122968/19766090/dea687da-9c43-11e6-8903-b2cc73e3b298.png)

@desbo 
