### PR TITLE
DAPI 404 should result in Frontend 404

### DIFF
--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -1,13 +1,13 @@
 import dev.DevAssetsController
 import http.CorsHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.{DiscussionControllers, HealthCheck}
-import discussion.DiscussionApi
+import discussion.api.DiscussionApi
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpErrorHandler

--- a/discussion/app/controllers/CommentCountController.scala
+++ b/discussion/app/controllers/CommentCountController.scala
@@ -2,7 +2,8 @@ package controllers
 
 import model.Cached
 import common.JsonComponent
-import discussion.DiscussionApiLike
+import discussion.api.DiscussionApiLike
+import discussion.api.DiscussionApiException._
 import play.api.libs.json.{JsArray, JsObject}
 import play.api.mvc.Action
 
@@ -20,7 +21,7 @@ class CommentCountController(val discussionApi: DiscussionApiLike) extends Discu
               JsObject(Seq("counts" -> JsArray(counts.map(_.toJson))))
             )
           }
-      }
+      } recover toResult
   }
 
 }

--- a/discussion/app/controllers/DiscussionController.scala
+++ b/discussion/app/controllers/DiscussionController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc.Controller
 import common.{ExecutionContexts, Logging}
-import discussion.DiscussionApiLike
+import discussion.api.DiscussionApiLike
 
 trait DiscussionController
   extends Controller

--- a/discussion/app/controllers/DiscussionControllers.scala
+++ b/discussion/app/controllers/DiscussionControllers.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.softwaremill.macwire._
-import discussion.DiscussionApi
+import discussion.api.DiscussionApi
 import play.api.libs.ws.WSClient
 import play.filters.csrf.CSRFComponents
 

--- a/discussion/app/controllers/ProfileActivityController.scala
+++ b/discussion/app/controllers/ProfileActivityController.scala
@@ -1,7 +1,8 @@
 package controllers
 
 import common.JsonComponent
-import discussion.DiscussionApiLike
+import discussion.api.DiscussionApiLike
+import discussion.api.DiscussionApiException._
 import discussion.model.Profile
 import model.{Cached, MetaData, SectionSummary, SimplePage}
 import play.api.mvc.Action
@@ -25,7 +26,7 @@ class ProfileActivityController(val discussionApi: DiscussionApiLike) extends Di
           profileDiscussions
         ))
       }
-    }
+    } recover toResult
   }
 
   def profileReplies(userId: String) = Action.async { implicit request =>
@@ -37,7 +38,7 @@ class ProfileActivityController(val discussionApi: DiscussionApiLike) extends Di
           replies
         ))
       }
-    }
+    } recover toResult
   }
 
   def profileSearch(userId: String, q: String) = Action.async { implicit request =>
@@ -49,7 +50,7 @@ class ProfileActivityController(val discussionApi: DiscussionApiLike) extends Di
           comments
         ))
       }
-    }
+    } recover toResult
   }
 
   def profilePicks(userId: String) = Action.async { implicit request =>
@@ -61,6 +62,6 @@ class ProfileActivityController(val discussionApi: DiscussionApiLike) extends Di
           picks
         ))
       }
-    }
+    } recover toResult
   }
 }

--- a/discussion/app/controllers/WitnessActivityController.scala
+++ b/discussion/app/controllers/WitnessActivityController.scala
@@ -5,6 +5,7 @@ import model.Cached
 import common.{ExecutionContexts, JsonComponent}
 import discussion.model._
 import discussion.api.WitnessApi
+import discussion.api.DiscussionApiException._
 import conf.Configuration
 import play.api.libs.ws.WSClient
 
@@ -13,7 +14,7 @@ trait WitnessActivityController extends WitnessApi with Controller with Executio
   def witnessActivity(userId: String): Action[AnyContent] = Action.async {
     implicit request => {
       def renderWitnessActivityJson = (contributions: List[WitnessActivity]) => Cached(60)(JsonComponent(views.html.profileActivity.witnessActivity(contributions)))
-      getWitnessActivity(userId) map renderWitnessActivityJson
+      getWitnessActivity(userId) map renderWitnessActivityJson recover toResult
     }
   }
 }

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -1,18 +1,17 @@
-package discussion
+package discussion.api
 
 import java.net.URLEncoder
 
+import com.netaporter.uri.dsl._
 import common.{ExecutionContexts, Logging}
+import conf.Configuration
+import discussion.model.{CommentCount, _}
+import discussion.util.Http
+import play.api.libs.json.{JsNull, JsNumber, JsObject}
+import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.mvc.{Cookie, Headers, RequestHeader}
 
 import scala.concurrent.Future
-import discussion.model._
-import play.api.mvc.{Cookie, Headers, RequestHeader}
-import discussion.util.Http
-import play.api.libs.ws.{WSClient, WSResponse}
-import play.api.libs.json.{JsNull, JsNumber, JsObject}
-import discussion.model.CommentCount
-import com.netaporter.uri.dsl._
-import conf.Configuration
 
 trait DiscussionApiLike extends Http with ExecutionContexts with Logging {
 

--- a/discussion/app/discussion/api/DiscussionApiException.scala
+++ b/discussion/app/discussion/api/DiscussionApiException.scala
@@ -1,0 +1,18 @@
+package discussion.api
+
+import model.{CacheTime, Cached}
+import model.Cached.WithoutRevalidationResult
+import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.{InternalServerError, NotFound}
+
+sealed abstract class DiscussionApiException(msg: String) extends RuntimeException(msg)
+case class NotFoundException(msg: String) extends DiscussionApiException(msg)
+case class OtherException(msg: String) extends DiscussionApiException(msg)
+
+object DiscussionApiException {
+
+  def toResult(implicit request: RequestHeader): PartialFunction[Throwable, Result] = {
+    case NotFoundException(msg) => Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound(msg)))
+    case OtherException(msg) => InternalServerError(msg)
+  }
+}

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import conf.Configuration
-import discussion.DiscussionApiLike
+import discussion.api.DiscussionApiLike
 import discussion.model.Comment
 import org.scalatest._
 import test.{ConfiguredTestSuite, WithTestWsClient}

--- a/discussion/test/discussion/DiscussionApiTest.scala
+++ b/discussion/test/discussion/DiscussionApiTest.scala
@@ -1,5 +1,6 @@
 package discussion
 
+import discussion.api.{DiscussionApiLike, DiscussionParams}
 import discussion.model.DiscussionKey
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec}
 import play.api.libs.ws.{WSClient, WSResponse}

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -6,7 +6,7 @@ import recorder.DefaultHttpRecorder
 import play.api.libs.ws.WSClient
 import java.io.File
 
-import discussion.DiscussionApiLike
+import discussion.api.DiscussionApiLike
 
 
 object DiscussionApiHttpRecorder extends DefaultHttpRecorder {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Discussion endpoints now return 404 when DAPI response is 404

This is not the most elegant solution but most likely the one which allow me not to refactor the whole discussion api code.
## What is the value of this and can you measure success?

Not returning 503 anymore when DAPI response was 404.
=> Not triggering 5xx discussion alarm when bots randomly crawl discussion endpoints

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Request for comment

@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
