### PR TITLE
Inline interactive atom JS

### DIFF
--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -21,11 +21,8 @@
             @HtmlFormat.raw(interactive.html)
 
             @for(js <- interactive.mainJS) {
-                <script src="https://interactive.guim.co.uk/libs/require.js/2.3.2/require.min.js"></script>
                 <script>
-                    require(['@js'], function (interactive) {
-                        interactive.boot(document.body);
-                    });
+                    @HtmlFormat.raw(js)
                 </script>
             }
             <script>
@@ -38,10 +35,15 @@
 @if(shouldFence) {
     <iframe class="interactive-atom-fence" srcdoc="@iframeBody.toString"></iframe>
 } else {
-    <figure class="interactive interactive-atom" @for(js <- interactive.mainJS) { data-interactive="@js" }>
+    <figure class="interactive interactive-atom">
         <style>
             @HtmlFormat.raw(interactive.css)
         </style>
         @HtmlFormat.raw(interactive.html)
+        @for(js <- interactive.mainJS) {
+            <script>
+                @HtmlFormat.raw(js)
+            </script>
+        }
     </figure>
 }


### PR DESCRIPTION
Interactive atoms now inline their JS, as per [this conversation](https://groups.google.com/a/guardian.co.uk/forum/#!topic/interactives.wg/LiUOIGUu-sM)

Basic rationale is:
- Even faster loading
- Removing an interactive's dependency on frontend (and other platforms) having an AMD loader

@SiAdcock 
