### PR TITLE
Page skin error reporter

### DIFF
--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -9,21 +9,26 @@ import org.joda.time.DateTime
 
 object DfpApi extends Logging {
 
-  private def readLineItems(stmtBuilder: StatementBuilder): Seq[GuLineItem] = {
+  case class DfpLineItems(apiRaw: Map[Boolean, Seq[GuLineItem]]) {
+    val validItems: Seq[GuLineItem] = apiRaw.getOrElse(true, Nil)
+    val invalidLineItems: Seq[GuLineItem] = apiRaw.getOrElse(false, Nil)
+  }
 
-    withDfpSession( session => {
+  private def readLineItems(stmtBuilder: StatementBuilder): DfpLineItems = {
+
+    val lineItems = withDfpSession( session => {
       session.lineItems(stmtBuilder)
         .map( dfpLineItem => {
           toGuLineItem(session)(dfpLineItem) -> dfpLineItem
         })
-        .filter(Function.tupled(DataValidation.isGuLineItemValid))
-        .map({
-          case (guLineItem, _) => guLineItem
-        })
     })
+
+    DfpLineItems(lineItems
+      .groupBy(Function.tupled(DataValidation.isGuLineItemValid))
+      .mapValues(_.map(_._1)))
   }
 
-  def readCurrentLineItems(): Seq[GuLineItem] = {
+  def readCurrentLineItems: DfpLineItems = {
 
     val stmtBuilder = new StatementBuilder()
                       .where("status = :readyStatus OR status = :deliveringStatus")
@@ -34,7 +39,7 @@ object DfpApi extends Logging {
     readLineItems(stmtBuilder)
   }
 
-  def readLineItemsModifiedSince(threshold: DateTime): Seq[GuLineItem] = {
+  def readLineItemsModifiedSince(threshold: DateTime): DfpLineItems = {
 
     val stmtBuilder = new StatementBuilder()
                       .where("lastModifiedDateTime > :threshold")

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -9,10 +9,7 @@ import org.joda.time.DateTime
 
 object DfpApi extends Logging {
 
-  case class DfpLineItems(apiRaw: Map[Boolean, Seq[GuLineItem]]) {
-    val validItems: Seq[GuLineItem] = apiRaw.getOrElse(true, Nil)
-    val invalidLineItems: Seq[GuLineItem] = apiRaw.getOrElse(false, Nil)
-  }
+  case class DfpLineItems(validItems: Seq[GuLineItem], invalidItems: Seq[GuLineItem])
 
   private def readLineItems(stmtBuilder: StatementBuilder): DfpLineItems = {
 
@@ -23,9 +20,13 @@ object DfpApi extends Logging {
         })
     })
 
-    DfpLineItems(lineItems
+    val validatedLineItems = lineItems
       .groupBy(Function.tupled(DataValidation.isGuLineItemValid))
-      .mapValues(_.map(_._1)))
+      .mapValues(_.map(_._1))
+
+    DfpLineItems(
+      validItems = validatedLineItems.getOrElse(true, Nil),
+      invalidItems = validatedLineItems.getOrElse(false, Nil))
   }
 
   def readCurrentLineItems: DfpLineItems = {

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -5,7 +5,6 @@ import common.{ExecutionContexts, Logging}
 import conf.switches.Switches.DfpCachingSwitch
 import dfp.DfpApi.DfpLineItems
 import org.joda.time.DateTime
-import play.api.libs.json.Json
 import play.api.libs.json.Json.{toJson, _}
 import tools.Store
 import scala.concurrent.Future
@@ -51,14 +50,11 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
   private def loadLineItems(): DfpDataExtractor = {
 
     def fetchCachedLineItems(): DfpLineItems = {
-      val maybeLineItems = for {
-        json <- Store.getDfpLineItemsReport()
-        lineItemReport <- Json.parse(json).asOpt[LineItemReport]
-      } yield DfpLineItems(Map(
+      val lineItemReport = Store.getDfpLineItemsReport()
+
+      DfpLineItems(Map(
         true -> lineItemReport.lineItems,
         false -> lineItemReport.invalidLineItems ))
-
-      maybeLineItems getOrElse DfpLineItems(Map.empty)
     }
 
     val start = System.currentTimeMillis

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -138,7 +138,7 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
         prevCount = cachedLineItems.validItems.size,
         loadThreshold = Some(threshold),
         validLineItems = updateCachedContent(cachedLineItems.validItems, recentlyModified.validItems),
-        invalidLineItems = updateCachedContent(cachedLineItems.problemItems, recentlyModified.problemItems),
+        invalidLineItems = updateCachedContent(cachedLineItems.invalidLineItems, recentlyModified.invalidLineItems),
         recentlyAddedIds = Nil,
         recentlyModifiedIds = Nil,
         recentlyRemovedIds = Nil

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -52,9 +52,9 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
     def fetchCachedLineItems(): DfpLineItems = {
       val lineItemReport = Store.getDfpLineItemsReport()
 
-      DfpLineItems(Map(
-        true -> lineItemReport.lineItems,
-        false -> lineItemReport.invalidLineItems ))
+      DfpLineItems(
+        validItems = lineItemReport.lineItems,
+        invalidItems = lineItemReport.invalidLineItems)
     }
 
     val start = System.currentTimeMillis
@@ -95,7 +95,7 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
         prevCount = 0,
         loadThreshold = None,
         validLineItems = allActiveLineItems.validItems,
-        invalidLineItems = allActiveLineItems.invalidLineItems,
+        invalidLineItems = allActiveLineItems.invalidItems,
         recentlyAddedIds = allActiveLineItems.validItems.map(_.id),
         recentlyModifiedIds = Nil,
         recentlyRemovedIds = Nil
@@ -134,7 +134,7 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
         prevCount = cachedLineItems.validItems.size,
         loadThreshold = Some(threshold),
         validLineItems = updateCachedContent(cachedLineItems.validItems, recentlyModified.validItems),
-        invalidLineItems = updateCachedContent(cachedLineItems.invalidLineItems, recentlyModified.invalidLineItems),
+        invalidLineItems = updateCachedContent(cachedLineItems.invalidItems, recentlyModified.invalidItems),
         recentlyAddedIds = Nil,
         recentlyModifiedIds = Nil,
         recentlyRemovedIds = Nil

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -3,9 +3,11 @@ package dfp
 import common.Edition
 import common.dfp._
 
-case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
+case class DfpDataExtractor(
+  lineItems: Seq[GuLineItem],
+  invalidLineItems: Seq[GuLineItem]) {
 
-  val isValid = lineItems.nonEmpty
+  val hasValidLineItems = lineItems.nonEmpty
 
   val inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = {
     lineItems.foldLeft(InlineMerchandisingTagSet()) { (soFar, lineItem) =>

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -63,7 +63,14 @@ trait Store extends Logging with Dates {
     S3.get(dfpHighMerchandisingTagsDataKey) flatMap (HighMerchandisingTargetedTagsReportParser(_))
   } getOrElse HighMerchandisingTargetedTagsReport(now, HighMerchandisingLineItems(items = List.empty))
 
-  def getDfpLineItemsReport(): Option[String] = S3.get(dfpLineItemsKey)
+  def getDfpLineItemsReport(): LineItemReport = {
+    val maybeLineItems = for {
+      json <- S3.get(dfpLineItemsKey)
+      lineItemReport <- Json.parse(json).asOpt[LineItemReport]
+    } yield lineItemReport
+
+    maybeLineItems getOrElse LineItemReport("Empty Report", Nil, Nil)
+  }
 
   def getSlotTakeoversReport(slotName: String): Option[String] = slotName match {
     case "top-above-nav" => S3.get(topAboveNavSlotTakeoversKey)

--- a/admin/app/views/commercial/adTests.scala.html
+++ b/admin/app/views/commercial/adTests.scala.html
@@ -1,7 +1,7 @@
 @import common.dfp.GuLineItem
 @import tools.DfpLink
 
-@(env: String, timestamp: Option[String], groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader)
+@(env: String, timestamp: String, groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader)
 
 @admin_main("Ad Tests", env, isAuthed = true) {
 

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -38,6 +38,7 @@
                         <li><a href="@controllers.admin.routes.CommercialController.renderAdTests()">Ad Tests</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderKeyValues()">Key Values</a></li>
                         <li><a href="@controllers.admin.commercial.routes.DfpDataController.renderCacheFlushPage()">Refresh all cached DFP data</a></li>
+                        <li><a href="@controllers.admin.routes.CommercialController.renderInvalidItems()">Invalid Line Items</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/commercial/invalidLineItems.scala.html
+++ b/admin/app/views/commercial/invalidLineItems.scala.html
@@ -1,0 +1,116 @@
+@import tools.DfpLink
+@import common.dfp.PageSkinSponsorship
+@import common.dfp.{HighMerchandisingLineItem, GuLineItem}
+
+@(env: String,
+  invalidPageskins: Seq[PageSkinSponsorship],
+  invalidTopAbove: Seq[GuLineItem],
+  invalidHighMerchandising: Seq[HighMerchandisingLineItem],
+  unknownInvalidLineItems: Seq[GuLineItem])(implicit request: RequestHeader)
+
+@admin_main("Line Item Problems", env, isAuthed = true, hasCharts = false) {
+
+    <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at(" css/commercial.css")">
+
+    <h1>Invalid Line Items</h1>
+
+    <p>
+    This page shows line items which appear to target Frontend, but have not passed validation.
+    A line item is only considered valid if it targets ad units at or below <em>theguardian.com</em>.
+    Invalid line items are not processed by the Frontend system, and may cause unexpected results.
+    </p>
+
+    <p>
+    Use this page to diagnose issues with page skins, or high-merchandising items, or top slot takeovers.
+    </p>
+
+    <h2>Invalid Page Skin Sponsorships</h2>
+
+    @if(invalidPageskins.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-4">Sponsorship Name</th>
+                    <th class="col-md-4">DFP link</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(sponsorship <- invalidPageskins) {
+                    <tr>
+                        <td>@{sponsorship.lineItemName}</td>
+                        <td><a target="_blank" href="@DfpLink.lineItem(sponsorship.lineItemId)">@{sponsorship.lineItemId}</a></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    <h2>Invalid High-Merchandising Line Items</h2>
+
+    @if(invalidHighMerchandising.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-4">Line Item Name</th>
+                    <th class="col-md-4">DFP link</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(invalidHighMerch <- invalidHighMerchandising) {
+                    <tr>
+                        <td>@{invalidHighMerch.name}</td>
+                        <td><a target="_blank" href="@DfpLink.lineItem(invalidHighMerch.id)">@{invalidHighMerch.id}</a></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    <h2>Invalid Top-Above-Nav Line Items</h2>
+
+    @if(invalidTopAbove.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-4">Line Item Name</th>
+                    <th class="col-md-4">DFP link</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(invalidTopAbove <- invalidTopAbove) {
+                    <tr>
+                        <td>@{invalidTopAbove.name}</td>
+                        <td><a target="_blank" href="@DfpLink.lineItem(invalidTopAbove.id)">@{invalidTopAbove.id}</a></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    <h2>Unidentified Line Items</h2>
+
+    <p>
+    The remaining invalid line items do not target <em>theguardian.com</em> ad units exclusively, and don't clearly target Frontend.
+    They are likely to be line items targeting other platforms, but it is possible for unidentified anomalies to appear here too.
+    </p>
+
+    @if(unknownInvalidLineItems.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-4">Line Item Name</th>
+                    <th class="col-md-4">DFP link</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(lineItem <- unknownInvalidLineItems) {
+                    <tr>
+                        <td>@{lineItem.name}</td>
+                        <td><a target="_blank" href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -94,6 +94,7 @@ GET         /commercial/adops/takeovers-empty-mpus                              
 GET         /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.viewForm()
 POST        /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.create()
 POST        /commercial/adops/takeovers-empty-mpus/remove                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(takeoverStr)
+GET         /commercial/invalid-lineitems                                                           controllers.admin.CommercialController.renderInvalidItems()
 
 # Metrics
 GET         /metrics/loadbalancers                                                                  controllers.admin.MetricsController.renderLoadBalancers()

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -1,6 +1,7 @@
 package dfp
 
 import common.dfp.{GuLineItem, GuTargeting}
+import dfp.DfpApi.DfpLineItems
 import org.joda.time.DateTime
 import org.scalatest._
 
@@ -30,15 +31,20 @@ class DfpDataCacheJobTest
     )
   }
 
-  private val cachedLineItems = Seq(lineItem(1, "a"), lineItem(2, "b"), lineItem(3, "c"))
-  private val allReadyOrDeliveringLineItems = Nil
+  private val cachedLineItems = DfpLineItems(
+    validItems = Seq(lineItem(1, "a-cache"), lineItem(2, "b-cache"), lineItem(3, "c-cache")),
+    invalidItems = Seq.empty)
+
+  private val allReadyOrDeliveringLineItems = DfpLineItems(Seq.empty, Seq.empty)
 
   "loadLineItems" should "dedupe line items that have changed in an unknown way" in {
-    def lineItemsModifiedSince(threshold: DateTime) = Seq(
-      lineItem(1, "a"),
-      lineItem(2, "b"),
-      lineItem(3, "c")
-    )
+    def lineItemsModifiedSince(threshold: DateTime) = DfpLineItems(
+      validItems = Seq(
+        lineItem(1, "a-fresh"),
+        lineItem(2, "b-fresh"),
+        lineItem(3, "c-fresh")
+      ),
+      invalidItems = Seq.empty)
 
     val lineItems = DfpDataCacheJob.loadLineItems(
       cachedLineItems,
@@ -50,16 +56,19 @@ class DfpDataCacheJobTest
     lineItems.recentlyAddedIds shouldBe empty
     lineItems.recentlyModifiedIds shouldBe Set(1, 2, 3)
     lineItems.recentlyRemovedIds shouldBe empty
-    lineItems.current.size shouldBe 3
-    lineItems.current shouldBe Seq(lineItem(1, "a"), lineItem(2, "b"), lineItem(3, "c"))
+    lineItems.validLineItems.size shouldBe 3
+    lineItems.validLineItems shouldBe Seq(lineItem(1, "a-fresh"), lineItem(2, "b-fresh"), lineItem(3, "c-fresh"))
+    lineItems.invalidLineItems shouldBe empty
   }
 
   it should "dedupe line items that have changed in a known way" in {
-    def lineItemsModifiedSince(threshold: DateTime) = Seq(
-      lineItem(1, "d"),
-      lineItem(2, "e"),
-      lineItem(4, "f")
-    )
+    def lineItemsModifiedSince(threshold: DateTime) = DfpLineItems(
+      validItems = Seq(
+        lineItem(1, "d"),
+        lineItem(2, "e"),
+        lineItem(4, "f")
+      ),
+      invalidItems = Seq.empty)
 
     val lineItems = DfpDataCacheJob.loadLineItems(
       cachedLineItems,
@@ -71,8 +80,8 @@ class DfpDataCacheJobTest
     lineItems.recentlyAddedIds shouldBe Set(4)
     lineItems.recentlyModifiedIds shouldBe Set(1, 2)
     lineItems.recentlyRemovedIds shouldBe empty
-    lineItems.current.size shouldBe 4
-    lineItems.current shouldBe Seq(
+    lineItems.validLineItems.size shouldBe 4
+    lineItems.validLineItems shouldBe Seq(
       lineItem(1, "d"),
       lineItem(2, "e"),
       lineItem(3, "c"),
@@ -81,11 +90,13 @@ class DfpDataCacheJobTest
   }
 
   it should "omit line items whose state has changed to no longer be ready or delivering" in {
-    def lineItemsModifiedSince(threshold: DateTime) = Seq(
-      lineItem(1, "a", completed = true),
-      lineItem(2, "e"),
-      lineItem(4, "f")
-    )
+    def lineItemsModifiedSince(threshold: DateTime) = DfpLineItems(
+      validItems = Seq(
+        lineItem(1, "a", completed = true),
+        lineItem(2, "e"),
+        lineItem(4, "f")
+      ),
+      invalidItems = Seq.empty)
 
     val lineItems = DfpDataCacheJob.loadLineItems(
       cachedLineItems,
@@ -97,7 +108,7 @@ class DfpDataCacheJobTest
     lineItems.recentlyAddedIds shouldBe Set(4)
     lineItems.recentlyModifiedIds shouldBe Set(2)
     lineItems.recentlyRemovedIds shouldBe Set(1)
-    lineItems.current.size shouldBe 3
-    lineItems.current shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
+    lineItems.validLineItems.size shouldBe 3
+    lineItems.validLineItems shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
   }
 }

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -52,7 +52,6 @@ class DfpDataCacheJobTest
       allReadyOrDeliveringLineItems
     )
 
-    lineItems.prevCount shouldBe 3
     lineItems.validLineItems.size shouldBe 3
     lineItems.validLineItems shouldBe Seq(lineItem(1, "a-fresh"), lineItem(2, "b-fresh"), lineItem(3, "c-fresh"))
     lineItems.invalidLineItems shouldBe empty
@@ -73,7 +72,6 @@ class DfpDataCacheJobTest
       allReadyOrDeliveringLineItems
     )
 
-    lineItems.prevCount shouldBe 3
     lineItems.validLineItems.size shouldBe 4
     lineItems.validLineItems shouldBe Seq(
       lineItem(1, "d"),
@@ -98,7 +96,6 @@ class DfpDataCacheJobTest
       allReadyOrDeliveringLineItems
     )
 
-    lineItems.prevCount shouldBe 3
     lineItems.validLineItems.size shouldBe 3
     lineItems.validLineItems shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
   }

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -76,7 +76,7 @@ class DfpDataCacheJobTest
     lineItems.validLineItems shouldBe Seq(
       lineItem(1, "d"),
       lineItem(2, "e"),
-      lineItem(3, "c"),
+      lineItem(3, "c-cache"),
       lineItem(4, "f")
     )
   }
@@ -97,6 +97,9 @@ class DfpDataCacheJobTest
     )
 
     lineItems.validLineItems.size shouldBe 3
-    lineItems.validLineItems shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
+    lineItems.validLineItems shouldBe Seq(
+      lineItem(2, "e"),
+      lineItem(3, "c-cache"),
+      lineItem(4, "f"))
   }
 }

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -53,9 +53,6 @@ class DfpDataCacheJobTest
     )
 
     lineItems.prevCount shouldBe 3
-    lineItems.recentlyAddedIds shouldBe empty
-    lineItems.recentlyModifiedIds shouldBe Set(1, 2, 3)
-    lineItems.recentlyRemovedIds shouldBe empty
     lineItems.validLineItems.size shouldBe 3
     lineItems.validLineItems shouldBe Seq(lineItem(1, "a-fresh"), lineItem(2, "b-fresh"), lineItem(3, "c-fresh"))
     lineItems.invalidLineItems shouldBe empty
@@ -77,9 +74,6 @@ class DfpDataCacheJobTest
     )
 
     lineItems.prevCount shouldBe 3
-    lineItems.recentlyAddedIds shouldBe Set(4)
-    lineItems.recentlyModifiedIds shouldBe Set(1, 2)
-    lineItems.recentlyRemovedIds shouldBe empty
     lineItems.validLineItems.size shouldBe 4
     lineItems.validLineItems shouldBe Seq(
       lineItem(1, "d"),
@@ -105,9 +99,6 @@ class DfpDataCacheJobTest
     )
 
     lineItems.prevCount shouldBe 3
-    lineItems.recentlyAddedIds shouldBe Set(4)
-    lineItems.recentlyModifiedIds shouldBe Set(2)
-    lineItems.recentlyRemovedIds shouldBe Set(1)
     lineItems.validLineItems.size shouldBe 3
     lineItems.validLineItems shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -399,13 +399,13 @@ class GuardianConfiguration extends Logging {
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v6.json"
-    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v4.json"
+    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v5.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
     lazy val dfpMobileAppsAdUnitListKey = s"$dfpRoot/mobile-active-ad-units.csv"
     lazy val dfpFacebookIaAdUnitListKey = s"$dfpRoot/facebookia-active-ad-units.csv"
     lazy val dfpTemplateCreativesKey = s"$dfpRoot/template-creatives.json"
     lazy val dfpCustomTargetingKey = s"$dfpRoot/custom-targeting-key-values.json"
-    lazy val topAboveNavSlotTakeoversKey = s"$dfpRoot/top-above-nav-slot-takeovers-v1.json"
+    lazy val topAboveNavSlotTakeoversKey = s"$dfpRoot/top-above-nav-slot-takeovers-v2.json"
 
     lazy val takeoversWithEmptyMPUsKey = s"$commercialRoot/takeovers-with-empty-mpus.json"
 

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -235,8 +235,9 @@ object GuLineItem {
       (JsPath \ "targeting").read[GuTargeting] and
       (JsPath \ "lastModified").read[String].map(timeFormatter.parseDateTime)
     )(GuLineItem.apply _)
-}
 
+  def asMap(lineItems: Seq[GuLineItem]) = lineItems.map(item => item.id -> item).toMap
+}
 
 case class GuCreativePlaceholder(size: AdSize, targeting: Option[GuTargeting]) {
 
@@ -320,7 +321,10 @@ object GuCreativeTemplate extends implicits.Collections {
   implicit val guCreativeTemplateFormats: Format[GuCreativeTemplate] = Json.format[GuCreativeTemplate]
 }
 
-case class LineItemReport(timestamp: String, lineItems: Seq[GuLineItem]) {
+case class LineItemReport(
+  timestamp: String,
+  lineItems: Seq[GuLineItem],
+  invalidLineItems: Seq[GuLineItem]) {
 
   lazy val (adTestLineItems, nonAdTestLineItems) = lineItems partition {
     _.targeting.hasAdTestTargetting


### PR DESCRIPTION
Adding an admin page that uses the invalid line items we normally reject, and reports them on a best-guess basis. This should help the ops team when the next pageskin goes wrong.

<img width="744" alt="screen shot 2016-10-27 at 15 46 26" src="https://cloud.githubusercontent.com/assets/4549425/19771962/96128fe6-9c5c-11e6-8bbe-f1a6b124c231.png">
