### PR TITLE
Hosted onward journey improvements

### DIFF
--- a/commercial/app/views/hosted/hostedOnwardJourney.scala.html
+++ b/commercial/app/views/hosted/hostedOnwardJourney.scala.html
@@ -16,9 +16,11 @@
         </div>
         <div class="hosted__ab-test-control">
             @for(trail <- trails.slice(0, defaultRows)) {
-                <a href="@{trail.url}" class="hosted__next-page--tile js-hosted-onward-journey-link" data-link-name="Next Hosted Page: @{trail.title}">
-                    <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
-                    <p class="hosted__next-page-title">@{trail.title}</p>
+                <a href="@{trail.url}" class="hosted__next-page--tile  js-hosted-onward-journey-link hosted-tone-bg" data-link-name="Next Hosted Page: @{trail.title}">
+                    <div class="hosted-next-page__wrapper">
+                        <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
+                        <p class="hosted__next-page-title">@{trail.title}</p>
+                    </div>
                 </a>
             }
         </div>
@@ -33,9 +35,11 @@
                 @for(i <- trails.indices if i % maxRows == 0) {
                     <div class="carousel-page" style="left: @{i*100/maxRows}%;">
                         @for(trail <- trails.slice(i, i + maxRows)) {
-                            <a href="@{trail.url}" class="hosted__next-page--tile js-hosted-onward-journey-link" data-link-name="Next Hosted Page: @{trail.title}">
-                                <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
-                                <p class="hosted__next-page-title">@{trail.title}</p>
+                            <a href="@{trail.url}" class="hosted__next-page--tile  js-hosted-onward-journey-link hosted-tone-bg" data-link-name="Next Hosted Page: @{trail.title}">
+                                <div class="hosted-next-page__wrapper">
+                                    <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
+                                    <p class="hosted__next-page-title">@{trail.title}</p>
+                                </div>
                             </a>
                         }
                     </div>
@@ -51,9 +55,11 @@
         </div>
         <div class="hosted__ab-test-variant-popup">
             @for(trail <- trails.slice(0, defaultRows)) {
-                <a href="@{trail.url}" class="hosted__next-page--tile js-hosted-onward-journey-link" data-link-name="Next Hosted Page: @{trail.title}">
-                    <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
-                    <p class="hosted__next-page-title">@{trail.title}</p>
+                <a href="@{trail.url}" class="hosted__next-page--tile  js-hosted-onward-journey-link hosted-tone-bg" data-link-name="Next Hosted Page: @{trail.title}">
+                    <div class="hosted-next-page__wrapper">
+                        <img class="hosted__next-page-thumb" src="@{trail.imageUrl}" alt="Next Page: @{trail.title}">
+                        <p class="hosted__next-page-title">@{trail.title}</p>
+                    </div>
                 </a>
             }
             @if(trails.length > defaultRows){
@@ -62,15 +68,16 @@
             <div class="u-h">
                 <div class="js-hosted-more-from-popup-content">
                     @for(trail <- trails) {
-                        <a href="@{trail.url}" class="hosted__next-page-tile--popup js-hosted-onward-journey-link" data-link-name="Next Hosted Page: @{trail.title}">
-                            <div class="hosted-next-page-bg hosted-tone-bg"></div>
-                            @fragments.image(
-                                ImageMedia.make(Seq(ImageAsset.make(Asset(AssetType.Image, Some("image/jpeg"), Some(trail.imageUrl), typeData = Some(AssetFields(width = Some(5), height = Some(3)))), 0))),
-                                Seq("hosted__next-page-thumb--popup"),
-                                GalleryMedia.inline,
-                                trail.title
-                            )
-                            <p class="hosted__next-page-title--popup">@{trail.title}</p>
+                        <a href="@{trail.url}" class="hosted__next-page-tile--popup js-hosted-onward-journey-link hosted-tone-bg" data-link-name="Next Hosted Page: @{trail.title}">
+                            <div class="hosted-next-page__wrapper">
+                                @fragments.image(
+                                    ImageMedia.make(Seq(ImageAsset.make(Asset(AssetType.Image, Some("image/jpeg"), Some(trail.imageUrl), typeData = Some(AssetFields(width = Some(5), height = Some(3)))), 0))),
+                                    Seq("hosted__next-page-thumb--popup"),
+                                    GalleryMedia.inline,
+                                    trail.title
+                                )
+                                <p class="hosted__next-page-title--popup">@{trail.title}</p>
+                            </div>
                         </a>
                     }
                 </div>

--- a/commercial/app/views/hosted/hostedOnwardJourney.scala.html
+++ b/commercial/app/views/hosted/hostedOnwardJourney.scala.html
@@ -48,7 +48,7 @@
             @if(trails.length > maxRows){
                 <div class="hosted__carousel-marker">
                     @for(i <- trails.indices if i % maxRows == 0) {
-                        <div class="hosted__carousel-dot hosted-tone-btn js-carousel-dot-@{i/maxRows} @{if(i == 0) "highlighted" else ""}"></div>
+                        <div class="hosted__carousel-dot hosted-tone-btn js-carousel-dot @{if(i == 0) "highlighted" else ""}"></div>
                     }
                 </div>
             }

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -14,9 +14,13 @@ define([
 
     }
 
-    HostedCarousel.prototype.moveCarousel = function(direction) {
+    HostedCarousel.prototype.moveCarouselBy = function(direction) {
+        this.moveCarouselTo(this.index + direction);
+    };
+
+    HostedCarousel.prototype.moveCarouselTo = function(index) {
         var that = this;
-        var pageNo = Math.min(Math.max(this.index + direction, 0), this.pageCount - 1);
+        var pageNo = Math.min(Math.max(index, 0), this.pageCount - 1);
         this.index = pageNo;
 
         fastdom.write(function () {
@@ -25,9 +29,9 @@ define([
                 '-webkit-transform': translate,
                 'transform': translate
             });
-            for(var i = 0; i < that.pageCount; i++){
-                $('.js-carousel-dot-' + i).toggleClass('highlighted', i === pageNo);
-            }
+            that.$dots.each(function(el, i){
+                $(el).toggleClass('highlighted', (i % that.pageCount) === pageNo);
+            });
             that.$prevItem.css({
                 opacity: pageNo === 0 ? 0.5 : 1
             });
@@ -41,16 +45,20 @@ define([
         this.$carousel = $('.js-carousel-wrapper');
         this.$nextItem = $('.next-oj-item');
         this.$prevItem = $('.prev-oj-item');
+        this.$dots = $('.js-carousel-dot');
         this.pageCount = $('.carousel-page', this.$carousel).length;
         this.index = 0;
 
         if (this.$carousel.length) {
             var that = this;
             this.$nextItem.each(function(el){
-                bean.on(el, 'click', that.moveCarousel.bind(that, 1));
+                bean.on(el, 'click', that.moveCarouselBy.bind(that, 1));
             });
             this.$prevItem.each(function(el){
-                bean.on(el, 'click', that.moveCarousel.bind(that, -1));
+                bean.on(el, 'click', that.moveCarouselBy.bind(that, -1));
+            });
+            this.$dots.each(function(el, i){
+                bean.on(el, 'click', that.moveCarouselTo.bind(that, i % that.pageCount));
             });
         }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -638,7 +638,7 @@ $dotSize: 8px;
     height: $dotSize;
     border-radius: $dotSize;
     display: inline-block;
-    pointer-events: none;
+    cursor: pointer;
     border: 1px solid;
     transition: background-color 750ms ease;
     &:not(.highlighted) {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -170,7 +170,7 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
 
     .hide-on-desktop {
         .hosted__next-page {
-            margin-top: 30px;
+            margin: 30px 0 20px;
             position: relative;
         }
         .hosted__next-page--header {
@@ -225,14 +225,15 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
     font-size: 16px;
     line-height: 18px;
     padding: 6px;
+    min-height: 60px;
     @include mq($until: phablet) {
         font-size: 14px;
         line-height: 16px;
+        min-height: 42px;
     }
 }
 
 .hosted__next-page .hosted__next-page--tile {
-    background: transparent;
     border-top: 2px solid #e0e0e0;
     margin-bottom: 10px;
 }
@@ -604,19 +605,25 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
     @include mq(leftCol) {
         max-width: gs-span(4);
     }
+
+    .hosted-next-page__wrapper {
+        background: rgba(255, 255, 255, .9);
+    }
+
+    &:hover .hosted-next-page__wrapper  {
+        background: rgba(255, 255, 255, .8);
+    }
 }
 
 .hosted__next-page-thumb--popup {
     width: 100%;
-    z-index: 1;
-    position: absolute;
 }
 
 .hosted__next-page-title--popup {
     @include f-headlineSans;
     color: $neutral-1;
-    padding: 8px;
-    z-index: 1;
+    padding: 8px 8px 16px;
+    margin: 0;
     min-height: 48px;
 }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -963,6 +963,14 @@ $nextPageThumbWidthMobile: #{$nextPageThumbHeightMobile * 5 / 3};
     &:active {
         color: #333333;
     }
+
+    .hosted-next-page__wrapper {
+        background: #ffffff;
+    }
+
+    &:hover .hosted-next-page__wrapper {
+        background: rgba(255, 255, 255, .9);
+    }
 }
 
 .hosted__next-page-thumb {
@@ -993,12 +1001,4 @@ $nextPageThumbWidthMobile: #{$nextPageThumbHeightMobile * 5 / 3};
         font-size: 18px;
         line-height: 20px;
     }
-}
-
-.hosted-next-page-bg {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    opacity: .1;
-    z-index: 0;
 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Small UI improvements to the new onward journey components.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

Hover state has slightly darker background colours, more visible IRL than in screenshots!
![image](https://cloud.githubusercontent.com/assets/6290008/19774144/f938d808-9c63-11e6-99bc-fc35cfbfc4d5.png)
![image](https://cloud.githubusercontent.com/assets/6290008/19774208/33e4487a-9c64-11e6-82bf-2aae5dd20aa0.png)
## Request for comment

@guardian/labs-beta 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
