### PR TITLE
Membership engagement copy A/B test in the US

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -75,4 +75,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 11, 8),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-membership-engagement-us-message-copy-experiment",
+    "Test alternate short messages on US membership engagement banner",
+    owners = Seq(Owner.withGithub("justinpinner")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -99,6 +99,13 @@ define([
                     engagementText[0].textContent = opts.setEngagementText;
                 }
             }
+
+            if (opts.testName === 'messaging-test-us-1') {
+                var engagementText = $('.site-message__message.site-message__message--membership');
+                if (engagementText && opts.setEngagementText) {
+                    engagementText[0].textContent = opts.setEngagementText;
+                }
+            }
         }
     };
 
@@ -111,6 +118,7 @@ define([
             customOpts = {},
             prominentTestVariant = ab.testCanBeRun('MembershipEngagementWarpFactorOne') ? ab.getTestVariantId('MembershipEngagementWarpFactorOne') : undefined,
             messagingTestVariant = ab.testCanBeRun('MembershipEngagementMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementMessageCopyExperiment') : undefined,
+            usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
             linkHref = formatEndpointUrl(edition, message);
 
         if (prominentTestVariant) {
@@ -148,6 +156,23 @@ define([
                 customOpts = {
                     testName: messagingTestName,
                     setEngagementText: messagingTestVariant === 'control' ? undefined : variantMessages[messagingTestVariant]
+                };
+                customJs = getCustomJs;
+            }
+        }
+
+        if (usMessagingTestVariant) {
+            if (usMessagingTestVariant !== 'notintest') {
+                var usVariantMessages = {
+                    coffee: 'For less than the price of a coffee a week you could help secure the Guardian\'s future. Become a Guardian US member for just $49 a year.',
+                    defies: 'When politicians defy belief you need journalism that defies politicians. Become a Guardian US member for just $49 a year.',
+                    value: 'If you value our independent, international journalism, you can support it. Become a Guardian US member for just $49 a year.'
+                };
+                campaignCode = 'gdnwb_copts_mem_banner_messaging1us' + '__' + usMessagingTestVariant;
+                linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
+                customOpts = {
+                    testName: 'messaging-test-us-1',
+                    setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
                 };
                 customJs = getCustomJs;
             }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,8 @@ define([
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/weekend-reading-promo',
     'common/modules/experiments/tests/membership-engagement-warp-factor-one',
-    'common/modules/experiments/tests/membership-engagement-message-copy-experiment'
+    'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
+    'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment'
 ], function (
     reportError,
     config,
@@ -27,7 +28,8 @@ define([
     WeekendReadingEmail,
     WeekendReadingPromo,
     MembershipEngagementWarpFactorOne,
-    MembershipEngagementMessageCopyExperiment
+    MembershipEngagementMessageCopyExperiment,
+    MembershipEngagementUSMessageCopyExperiment
 ) {
 
     var TESTS = [
@@ -36,7 +38,8 @@ define([
         new WeekendReadingEmail(),
         new WeekendReadingPromo(),
         new MembershipEngagementWarpFactorOne(),
-        new MembershipEngagementMessageCopyExperiment()
+        new MembershipEngagementMessageCopyExperiment(),
+        new MembershipEngagementUSMessageCopyExperiment()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -1,0 +1,71 @@
+define([
+    'bean',
+    'reqwest',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/modules/commercial/commercial-features',
+    'common/utils/mediator'
+], function (
+    bean,
+    reqwest,
+    fastdom,
+    qwery,
+    $,
+    config,
+    commercialFeatures,
+    mediator
+) {
+    return function () {
+        this.id = 'MembershipEngagementUsMessageCopyExperiment';
+        this.start = '2016-10-27';
+        this.expiry = '2016-11-15';
+        this.author = 'Justin Pinner';
+        this.description = 'Test alternate short messages on engagement banner';
+        this.audience = 0.25;    // TODO: confirm 25% allocation
+        this.audienceOffset = 0.3;  // TODO: confirm offset to avoid US header experiment users
+        this.successMeasure = 'More US membership sign-ups';
+        this.audienceCriteria = '25 percent of (non-member) US edition readers';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'More US readers engage with the banner and then complete membership sign-up';
+        this.hypothesis = 'More persuasive copy will improve US membership conversions from impressions';
+
+        this.canRun = function () {
+            return config.page.edition.toLowerCase() === 'us' &&
+                commercialFeatures.canReasonablyAskForMoney &&
+                config.page.contentType !== 'signup';
+        };
+
+        var success = function (complete) {
+            if (this.canRun()) {
+                mediator.on('membership-message:display', function () {
+                    bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+                });
+            }
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'coffee',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'defies',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'value',
+                test: function () {},
+                success: success.bind(this)
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -24,7 +24,7 @@ define([
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
         this.audience = 0.5;
-        this.audienceOffset = 0; //TODO: Check for conflicts with other US tests
+        this.audienceOffset = 0;
         this.successMeasure = 'More US membership sign-ups';
         this.audienceCriteria = '50 percent of (non-member) US edition readers';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -23,10 +23,10 @@ define([
         this.expiry = '2016-11-15';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
-        this.audience = 0.25;    // TODO: confirm 25% allocation
-        this.audienceOffset = 0.3;  // TODO: confirm offset to avoid US header experiment users
+        this.audience = 0.5;
+        this.audienceOffset = 0; //TODO: Check for conflicts with other US tests
         this.successMeasure = 'More US membership sign-ups';
-        this.audienceCriteria = '25 percent of (non-member) US edition readers';
+        this.audienceCriteria = '50 percent of (non-member) US edition readers';
         this.dataLinkNames = '';
         this.idealOutcome = 'More US readers engage with the banner and then complete membership sign-up';
         this.hypothesis = 'More persuasive copy will improve US membership conversions from impressions';


### PR DESCRIPTION
## What does this change?

Adds a multivariate test to explore the effects of different messaging to a portion of our US audience.

Explores the hypothesis that "more persuasive copy will improve US membership conversions from impressions"

We've been cleared to engage with 50% of the US audience.

**By default it will be switched off**, so deployment won't alter production behaviour until it is manually switched on.

Also, this is a **change to text only** in the **US only**, no styling will be altered as a result of enabling the test.
## What is the value of this and can you measure success?

Careful use of copy in the message will help to engage more US readers and promote increased membership sign-ups.
## Does this affect other platforms - Amp, Apps, etc?

No. Web only.
## Screenshots

**(variants)**
## ![screen shot 2016-10-27 at 16 58 03](https://cloud.githubusercontent.com/assets/690395/19775038/f801f4bc-9c66-11e6-9490-de2c3cf121d9.png)
## ![screen shot 2016-10-27 at 16 58 51](https://cloud.githubusercontent.com/assets/690395/19775055/095534e0-9c67-11e6-93b6-f34f798c0a30.png)
## ![screen shot 2016-10-27 at 16 59 33](https://cloud.githubusercontent.com/assets/690395/19775065/13d3b450-9c67-11e6-8331-077d3827dd53.png)

**(control / notintest)**
![screen shot 2016-10-27 at 17 00 15](https://cloud.githubusercontent.com/assets/690395/19775096/2b407704-9c67-11e6-890e-9ee2752ba156.png)
## Request for comment

@jranks123 @rtyley @svillafe @Ap0c
cc @NataliaLKB for info 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
