### PR TITLE
Hosted video pages - analytics tracking

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -73,9 +73,13 @@ define([
                     }
 
                     $videoEl.each(function(el){
+                        var mediaId = $videoEl.attr('data-media-id');
                         player = videojs(el, videojsOptions());
                         player.guMediaType = 'video';
                         videojs.plugin('fullscreener', fullscreener);
+
+                        events.addContentEvents(player, mediaId, player.guMediaType);
+                        events.bindGoogleAnalyticsEvents(player, window.location.pathname);
 
                         player.ready(function () {
                             var vol;
@@ -92,7 +96,6 @@ define([
 
                             player.fullscreener();
 
-                            var mediaId = $videoEl.attr('data-media-id');
                             deferToAnalytics(function () {
                                 events.initOphanTracking(player, mediaId);
                                 events.bindGlobalEvents(player);

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -152,6 +152,7 @@ define([
             return 'media:' + eventName;
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
+                console.log(canonicalUrl, mediaEvent);
                 ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
             });
         });

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -152,7 +152,6 @@ define([
             return 'media:' + eventName;
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
-                console.log(canonicalUrl, mediaEvent);
                 ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
             });
         });


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

This PR fixes analytics tracking on the hosted video pages.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![screen shot 2016-10-28 at 12 01 07](https://cloud.githubusercontent.com/assets/489567/19804437/446ddd9e-9d06-11e6-928e-5de618ed0706.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
