### PR TITLE
Add github docs to admin app view

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -135,7 +135,6 @@
                 <div class="panel-body">
                     <ul>
                         <li><a href="https://github.com/guardian/frontend/tree/master/docs">Frontend Docs</a></li>
-                        <li><a href="https://github.com/guardian/frontend/blob/master/docs/02-architecture/02-fronts-architecture.md">Facia Docs</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -127,5 +127,19 @@
                 </div>
             </div>
         </div>
+
+        <div class="col-md-4">
+            <h3>Documentation</h3>
+            <div class="panel panel-default well--front">
+                <div class="panel-heading">Dotcom Docs</div>
+                <div class="panel-body">
+                    <ul>
+                        <li><a href="https://github.com/guardian/frontend/tree/master/docs">Frontend Docs</a></li>
+                        <li><a href="https://github.com/guardian/frontend/blob/master/docs/02-architecture/02-fronts-architecture.md">Facia Docs</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
     </div>
 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Quick PR to add links to the docs to the admin app so they show up on the frontend gutools 
## What is the value of this and can you measure success?

We said back in the tech time planning that this might be helpful so the gutools area can act as a portal to the frontend stuff.
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

N/A
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
