### PR TITLE
No commercial.js on immersive interactives with ads disabled

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -32,6 +32,7 @@ define([
 
     var guardian = window.guardian;
     var config = guardian.config;
+    var page = config.page;
 
     var domReadyPromise = new Promise(function (resolve) { domReady(resolve); });
 
@@ -40,12 +41,14 @@ define([
             .then(function (boot) { boot(); });
     };
 
+    var suppressCommercial = !config.switches.commercial || (page.contentType === 'Interactive' && page.isImmersive && page.shouldHideAdverts);
+
     var bootCommercial = function () {
-        if (!config.switches.commercial) {
+        if (suppressCommercial) {
             return;
         }
 
-        if (config.page.isDev) {
+        if (page.isDev) {
             guardian.adBlockers.onDetect.push(function (isInUse) {
                 var needsMessage = isInUse && window.console && window.console.warn;
                 var message = 'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
@@ -68,7 +71,7 @@ define([
     };
 
     var bootEnhanced = function () {
-        if (guardian.isEnhanced) {
+        if (!suppressCommercial && guardian.isEnhanced) {
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
                     boot();

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -27,7 +27,6 @@ define([
     'common/modules/discussion/comment-count',
     'common/modules/identity/autosignin',
     'common/modules/identity/cookierefresh',
-    'common/modules/navigation/navigation',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
     'common/modules/navigation/membership',
@@ -80,7 +79,6 @@ define([
     CommentCount,
     AutoSignin,
     CookieRefresh,
-    navigation,
     Profile,
     Search,
     membership,
@@ -123,10 +121,6 @@ define([
                 }
 
                 search.init(header);
-            },
-
-            initialiseNavigation: function () {
-                navigation.init();
             },
 
             showTabs: function () {
@@ -361,7 +355,6 @@ define([
                 ['c-iframe', modules.checkIframe],
                 ['c-tabs', modules.showTabs],
                 ['c-top-nav', modules.initialiseTopNavItems],
-                ['c-init-nav', modules.initialiseNavigation],
                 ['c-toggles', modules.showToggles],
                 ['c-dates', modules.showRelativeDates],
                 ['c-clickstream', modules.initClickstream],

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -25,6 +25,7 @@ define([
     'common/utils/cookies',
     'common/utils/robust',
     'common/utils/user-timing',
+    'common/modules/navigation/navigation',
     'common/modules/navigation/newHeaderNavigation',
     'common/utils/detect'
 ], function (
@@ -41,6 +42,7 @@ define([
     cookies,
     robust,
     userTiming,
+    navigation,
     newHeaderNavigation,
     detect
 ) {
@@ -299,6 +301,7 @@ define([
             // do nothing
         }
 
+        navigation.init();
         /**
          *  New Header Navigation
          */


### PR DESCRIPTION
On immersive interactives with ads disabled, `commercial.js` doesn't add anything, so lets just not load it. `enhanced.js` doesn't add anything either and seems to have some dependencies on `commercial.js`, so disable that too!

The only thing that does might be useful is the navigation, so I've moved the navigation initialisation from enhanced to standard. From what I can tell the `navigation` module doesn't require anything that standard doesn't already have, and the `newHeaderNavigation` is already in standard, so why not put both in there?
