### PR TITLE
Membership engagement messaging AB test (US) lint fix

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -75,4 +75,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 11, 8),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-membership-engagement-us-message-copy-experiment",
+    "Test alternate short messages on US membership engagement banner",
+    owners = Seq(Owner.withGithub("justinpinner")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -99,6 +99,13 @@ define([
                     engagementText[0].textContent = opts.setEngagementText;
                 }
             }
+
+            if (opts.testName === 'messaging-test-us-1') {
+                var engagementText = $('.site-message__message.site-message__message--membership');
+                if (engagementText && opts.setEngagementText) {
+                    engagementText[0].textContent = opts.setEngagementText;
+                }
+            }
         }
     };
 
@@ -111,6 +118,7 @@ define([
             customOpts = {},
             prominentTestVariant = ab.testCanBeRun('MembershipEngagementWarpFactorOne') ? ab.getTestVariantId('MembershipEngagementWarpFactorOne') : undefined,
             messagingTestVariant = ab.testCanBeRun('MembershipEngagementMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementMessageCopyExperiment') : undefined,
+            usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
             linkHref = formatEndpointUrl(edition, message);
 
         if (prominentTestVariant) {
@@ -148,6 +156,23 @@ define([
                 customOpts = {
                     testName: messagingTestName,
                     setEngagementText: messagingTestVariant === 'control' ? undefined : variantMessages[messagingTestVariant]
+                };
+                customJs = getCustomJs;
+            }
+        }
+
+        if (usMessagingTestVariant) {
+            if (usMessagingTestVariant !== 'notintest') {
+                var usVariantMessages = {
+                    coffee: 'For less than the price of a coffee a week you could help secure the Guardian\'s future. Become a Guardian US member for just $49 a year.',
+                    defies: 'When politicians defy belief you need journalism that defies politicians. Become a Guardian US member for just $49 a year.',
+                    value: 'If you value our independent, international journalism, you can support it. Become a Guardian US member for just $49 a year.'
+                };
+                campaignCode = 'gdnwb_copts_mem_banner_messaging1us' + '__' + usMessagingTestVariant;
+                linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
+                customOpts = {
+                    testName: 'messaging-test-us-1',
+                    setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
                 };
                 customJs = getCustomJs;
             }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -101,9 +101,9 @@ define([
             }
 
             if (opts.testName === 'messaging-test-us-1') {
-                var engagementText = $('.site-message__message.site-message__message--membership');
-                if (engagementText && opts.setEngagementText) {
-                    engagementText[0].textContent = opts.setEngagementText;
+                var usEngagementText = $('.site-message__message.site-message__message--membership');
+                if (usEngagementText && opts.setEngagementText) {
+                    usEngagementText[0].textContent = opts.setEngagementText;
                 }
             }
         }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,8 @@ define([
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/weekend-reading-promo',
     'common/modules/experiments/tests/membership-engagement-warp-factor-one',
-    'common/modules/experiments/tests/membership-engagement-message-copy-experiment'
+    'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
+    'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment'
 ], function (
     reportError,
     config,
@@ -27,7 +28,8 @@ define([
     WeekendReadingEmail,
     WeekendReadingPromo,
     MembershipEngagementWarpFactorOne,
-    MembershipEngagementMessageCopyExperiment
+    MembershipEngagementMessageCopyExperiment,
+    MembershipEngagementUSMessageCopyExperiment
 ) {
 
     var TESTS = [
@@ -36,7 +38,8 @@ define([
         new WeekendReadingEmail(),
         new WeekendReadingPromo(),
         new MembershipEngagementWarpFactorOne(),
-        new MembershipEngagementMessageCopyExperiment()
+        new MembershipEngagementMessageCopyExperiment(),
+        new MembershipEngagementUSMessageCopyExperiment()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -1,0 +1,71 @@
+define([
+    'bean',
+    'reqwest',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/modules/commercial/commercial-features',
+    'common/utils/mediator'
+], function (
+    bean,
+    reqwest,
+    fastdom,
+    qwery,
+    $,
+    config,
+    commercialFeatures,
+    mediator
+) {
+    return function () {
+        this.id = 'MembershipEngagementUsMessageCopyExperiment';
+        this.start = '2016-10-27';
+        this.expiry = '2016-11-15';
+        this.author = 'Justin Pinner';
+        this.description = 'Test alternate short messages on engagement banner';
+        this.audience = 0.5;
+        this.audienceOffset = 0;
+        this.successMeasure = 'More US membership sign-ups';
+        this.audienceCriteria = '50 percent of (non-member) US edition readers';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'More US readers engage with the banner and then complete membership sign-up';
+        this.hypothesis = 'More persuasive copy will improve US membership conversions from impressions';
+
+        this.canRun = function () {
+            return config.page.edition.toLowerCase() === 'us' &&
+                commercialFeatures.canReasonablyAskForMoney &&
+                config.page.contentType !== 'signup';
+        };
+
+        var success = function (complete) {
+            if (this.canRun()) {
+                mediator.on('membership-message:display', function () {
+                    bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+                });
+            }
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'coffee',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'defies',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'value',
+                test: function () {},
+                success: success.bind(this)
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

Reverts https://github.com/guardian/frontend/pull/14814 and fixes the lint error
## What is the value of this and can you measure success?

Activates the US messaging AB test as described on https://github.com/guardian/frontend/pull/14807
## Does this affect other platforms - Amp, Apps, etc?

See https://github.com/guardian/frontend/pull/14807
## Screenshots

See https://github.com/guardian/frontend/pull/14807
## Request for comment

@sndrs for the lint error fix (no-redeclare) in `static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js` on line 104

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
