### PR TITLE
Hosted native cards - fix the font contrast

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/gu-style-comcontent.js
@@ -31,6 +31,19 @@ define([
         this.params  = params;
     };
 
+    var isDark = function(hex) {
+        var colour = (hex.charAt(0) == '#') ? hex.substring(1, 7) : hex;
+        var R = parseInt(colour.substring(0, 2), 16);
+        var G = parseInt(colour.substring(2, 4), 16);
+        var B = parseInt(colour.substring(4, 6), 16);
+
+        var min = Math.min(Math.min(R, G), B);
+        var max = Math.max(Math.max(R, G), B);
+        var lightness = (min + max) / 510;
+        return lightness < 0.5;
+
+    };
+
     GustyleComcontent.prototype.create = function () {
         var externalLinkIcon = svgs('externalLink', ['gu-external-icon']),
             templateOptions = {
@@ -40,6 +53,7 @@ define([
                 articleTextFontSize: 'gu-display__content-size--' + this.params.articleTextFontSize,
                 brandLogoPosition: 'gu-display__logo-pos--' + this.params.brandLogoPosition,
                 externalLinkIcon: externalLinkIcon,
+                contrastFontColour: isDark(this.params.brandColor) ? "gu-display__hosted-bright" : "",
                 isHostedBottom: this.params.adType === 'gu-style-hosted-bottom'
             };
         var templateToLoad = this.params.adType === 'gu-style' ? gustyleComcontentTpl : gustyleHostedTpl;

--- a/static/src/javascripts/projects/commercial/views/creatives/gu-style-hosted.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/gu-style-hosted.html
@@ -1,5 +1,5 @@
 <% if (data.isHostedBottom) { %>
-    <div class="gu-display gu-display--hostedbottom">
+    <div class="gu-display gu-display--hostedbottom <%=data.contrastFontColour%>">
         <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" data-link-name="<%=data.linkTracking%>">
             <div class="gu-display__image-layer inlined-image">
                 <img class="gu-display__image" src="<%=data.articleImage%>">

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -11,6 +11,10 @@
     }
 }
 
+.gu-display__hosted-bright .hostedbadge__info {
+    color: #ffffff;
+}
+
 .gu-display__image-layer {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Makes the font colour white if the brand colour is dark on Hosted By native cards.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Screenshots

![image](https://cloud.githubusercontent.com/assets/6290008/19808241/cc514aa6-9d1b-11e6-9e25-44fb523061ae.png)
## Request for comment

@Calanthe 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
