### PR TITLE
Contributions uk vs us test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,4 +86,23 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-contributions-countries-uk",
+    "Test whether different messages perform better/worse in different countries",
+    owners = Seq(Owner.withGithub("philwills")),
+    safeState = On,
+    sellByDate =  new LocalDate(2016, 11, 4),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-countries-us",
+    "Test whether different messages perform better/worse in different countries",
+    owners = Seq(Owner.withGithub("philwills")),
+    safeState = On,
+    sellByDate =  new LocalDate(2016, 11, 4),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -7,8 +7,19 @@ define([
 ) {
 
     function userIsInAClashingAbTest() {
-        
-        var clashingTests = [];
+
+        var contributionsCountriesUk = {
+            name: 'ContributionsCountriesUK',
+            variants: ['control', 'global', 'democracy']
+        };
+
+        var contributionsCountriesUSA = {
+            name: 'ContributionsCountriesUSA',
+            variants: ['control', 'global', 'democracy']
+        };
+
+
+        var clashingTests = [contributionsCountriesUk, contributionsCountriesUSA];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -9,12 +9,12 @@ define([
     function userIsInAClashingAbTest() {
 
         var contributionsCountriesUk = {
-            name: 'ContributionsCountriesUK',
+            name: 'ContributionsCountriesUk',
             variants: ['control', 'global', 'democracy']
         };
 
         var contributionsCountriesUSA = {
-            name: 'ContributionsCountriesUSA',
+            name: 'ContributionsCountriesUsa',
             variants: ['control', 'global', 'democracy']
         };
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,7 +13,9 @@ define([
     'common/modules/experiments/tests/weekend-reading-promo',
     'common/modules/experiments/tests/membership-engagement-warp-factor-one',
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
-    'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment'
+    'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
+    'common/modules/experiments/tests/contributions-countries-uk',
+    'common/modules/experiments/tests/contributions-countries-usa'
 ], function (
     reportError,
     config,
@@ -29,7 +31,9 @@ define([
     WeekendReadingPromo,
     MembershipEngagementWarpFactorOne,
     MembershipEngagementMessageCopyExperiment,
-    MembershipEngagementUSMessageCopyExperiment
+    MembershipEngagementUSMessageCopyExperiment,
+    ContributionsCountriesUK,
+    ContributionsCountriesUSA
 ) {
 
     var TESTS = [
@@ -39,7 +43,9 @@ define([
         new WeekendReadingPromo(),
         new MembershipEngagementWarpFactorOne(),
         new MembershipEngagementMessageCopyExperiment(),
-        new MembershipEngagementUSMessageCopyExperiment()
+        new MembershipEngagementUSMessageCopyExperiment(),
+        new ContributionsCountriesUK(),
+        new ContributionsCountriesUSA()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
@@ -35,11 +35,11 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsCountriesUK';
+        this.id = 'ContributionsCountriesUk';
         this.start = '2016-10-28';
         this.expiry = '2016-11-04';
         this.author = 'Phil Wills';
-        this.description = 'Test whether different messages perform better/worse in different countries';
+        this.description = 'Test whether different messages perform better/worse in different countries (UK)';
         this.showForSensitive = false;
         this.audience = 0.15;
         this.audienceOffset = 0.56;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
@@ -1,0 +1,143 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-embed.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEmbed,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsCountriesUK';
+        this.start = '2016-10-28';
+        this.expiry = '2016-11-04';
+        this.author = 'Phil Wills';
+        this.description = 'Test whether different messages perform better/worse in different countries';
+        this.showForSensitive = false;
+        this.audience = 0.15;
+        this.audienceOffset = 0.56;
+        this.successMeasure = 'Impressions to number of contributions';
+        this.audienceCriteria = 'All users in UK';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'The messages performs less than 20% differently in different countries';
+        this.canRun = function () {
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: config.page.ajaxUrl + '/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if(resp.country === 'GB') {
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        component.insertBefore(submetaElement);
+                        embed.init();
+                        mediator.emit('contributions-embed:insert', component);
+                    });
+                }
+            });
+        };
+
+        var makeUrl = function(intcmp) {
+            return 'https://contribute.theguardian.com/uk?INTCMP=co_uk_donatom_footer_' + intcmp + '&amount=50';
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', function () {
+                bean.on(qwery('.js-submit-input-contribute')[0], 'click', complete);
+            });
+        };
+
+        this.variants = [
+
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'If you use it, if you like it, then why not pay for it? It’s only fair.',
+                        linkUrl: makeUrl('control2'),
+                        currency: '£'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'global',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'Reporting from a global perspective is vital. But it’s also expensive. Please give to the Guardian today. ',
+                        linkUrl: makeUrl('global'),
+                        currency: '£'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert',track);
+                },
+                success: completer
+            },
+
+            {
+                id: 'democracy',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'An independent press and a working democracy. You can\'t have one without the other. Please give to the Guardian today.',
+                        linkUrl: makeUrl('democracy'),
+                        currency: '£'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-uk.js
@@ -126,7 +126,7 @@ define([
                     var component = $.create(template(contributionsEmbed, {
                         position : 'inline',
                         variant: 'bottom',
-                        titleCopy: 'An independent press and a working democracy. You can\'t have one without the other. Please give to the Guardian today.',
+                        titleCopy: 'An independent press and a working democracy. You can’t have one without the other. Please give to the Guardian today.',
                         linkUrl: makeUrl('democracy'),
                         currency: '£'
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
@@ -1,0 +1,143 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-embed.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEmbed,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsCountriesUSA';
+        this.start = '2016-10-28';
+        this.expiry = '2016-11-04';
+        this.author = 'Phil Wills';
+        this.description = 'Test whether different messages perform better/worse in different countries';
+        this.showForSensitive = false;
+        this.audience = 0.15;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'Impressions to number of contributions';
+        this.audienceCriteria = 'All users in US';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'The messages performs less than 20% differently in different countries';
+        this.canRun = function () {
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: config.page.ajaxUrl + '/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if(resp.country === 'US') {
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        component.insertBefore(submetaElement);
+                        embed.init();
+                        mediator.emit('contributions-embed:insert', component);
+                    });
+                }
+            });
+        };
+
+        var makeUrl = function(intcmp) {
+            return 'https://contribute.theguardian.com/us?INTCMP=co_us_donatom_footer_' + intcmp + '&amount=50';
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', function () {
+                bean.on(qwery('.js-submit-input-contribute')[0], 'click', complete);
+            });
+        };
+
+        this.variants = [
+
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'If you use it, if you like it, then why not pay for it? It’s only fair.',
+                        linkUrl: makeUrl('control2'),
+                        currency: '$'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'global',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'Reporting from a global perspective is vital. But it’s also expensive. Please give to the Guardian today. ',
+                        linkUrl: makeUrl('global'),
+                        currency: '$'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert',track);
+                },
+                success: completer
+            },
+
+            {
+                id: 'democracy',
+                test: function () {
+                    var component = $.create(template(contributionsEmbed, {
+                        position : 'inline',
+                        variant: 'bottom',
+                        titleCopy: 'An independent press and a working democracy. You can\'t have one without the other. Please give to the Guardian today.',
+                        linkUrl: makeUrl('democracy'),
+                        currency: '$'
+
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
@@ -126,7 +126,7 @@ define([
                     var component = $.create(template(contributionsEmbed, {
                         position : 'inline',
                         variant: 'bottom',
-                        titleCopy: 'An independent press and a working democracy. You can\'t have one without the other. Please give to the Guardian today.',
+                        titleCopy: 'An independent press and a working democracy. You can’t have one without the other. Please give to the Guardian today.',
                         linkUrl: makeUrl('democracy'),
                         currency: '$'
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-usa.js
@@ -35,11 +35,11 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsCountriesUSA';
+        this.id = 'ContributionsCountriesUsa';
         this.start = '2016-10-28';
         this.expiry = '2016-11-04';
         this.author = 'Phil Wills';
-        this.description = 'Test whether different messages perform better/worse in different countries';
+        this.description = 'Test whether different messages perform better/worse in different countries (USA)';
         this.showForSensitive = false;
         this.audience = 0.15;
         this.audienceOffset = 0.5;


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->
## What does this change?

Adds tests to compare whether different messages are more effective in the US compared to the UK.
## What is the value of this and can you measure success?

We hope to be able to tell if we can use the same message in the US as for the UK to ask for contributions

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

![image](https://cloud.githubusercontent.com/assets/68329/19813132/4493a932-9d30-11e6-9849-519f7b046899.png)
## Request for comment

@jfsoul @jranks123 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

Two tests to run simultaneously, one in the UK, one in the US to test whether different messages are more effective in the two countries.
