### PR TITLE
--color is not universal, shoudl only be on things that support it...

### DIFF
--- a/tools/__tasks__/lint/javascript.js
+++ b/tools/__tasks__/lint/javascript.js
@@ -2,10 +2,10 @@ module.exports = {
     description: 'Lint JS',
     task: [{
         description: 'Lint tests',
-        task: 'eslint static/test/javascripts/**/*.js --fix --ignore-path static/test/javascripts/.eslintignore --rulesdir dev/eslint-rules --quiet'
+        task: 'eslint static/test/javascripts/**/*.js --fix --ignore-path static/test/javascripts/.eslintignore --rulesdir dev/eslint-rules --quiet --color'
     },{
         description: 'Lint app JS',
-        task: 'eslint static/src/**/*.js --fix --ignore-path static/src/.eslintignore --rulesdir dev/eslint-rules --quiet'
+        task: 'eslint static/src/**/*.js --fix --ignore-path static/src/.eslintignore --rulesdir dev/eslint-rules --quiet --color'
     }],
     concurrent: true
 };

--- a/tools/run-task
+++ b/tools/run-task
@@ -108,7 +108,7 @@ const cmd = task => {
             stdio: [process.stdin, process.stdout, 'pipe']
         });
     }
-    return execa(binary, options.concat([]));
+    return execa(binary, options);
 };
 
 // turn a list of our tasks into objects listr can use


### PR DESCRIPTION
## What does this change?

made a booboo in #14821 🙄 

## What is the value of this and can you measure success?

eslint errors are coloured, but r.js doesn't break

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

before:

<img width="511" alt="screen shot 2016-10-31 at 10 33 11" src="https://cloud.githubusercontent.com/assets/867233/19851372/856dd654-9f55-11e6-963d-be8640d0b9ce.png">

after:

<img width="414" alt="screen shot 2016-10-31 at 10 33 25" src="https://cloud.githubusercontent.com/assets/867233/19851378/8b6197a8-9f55-11e6-95c8-f21616781a63.png">
<img width="455" alt="screen shot 2016-10-31 at 10 33 34" src="https://cloud.githubusercontent.com/assets/867233/19851379/8de63402-9f55-11e6-9240-0726dcbb7546.png">


## Request for comment

@NataliaLKB @SiAdcock 