### PR TITLE
Extend prominent membership engagement test by one day

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,8 +51,8 @@ trait ABTestSwitches {
     "ab-membership-engagement-warp-factor-one",
     "The first level of prominent membership engagement messaging",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 11, 3),
+    safeState = On, // so we don't inadvertently turn off during deployment
+    sellByDate = new LocalDate(2016, 11, 4),  // Friday 4th 23:59:59
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-warp-factor-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-warp-factor-one.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'MembershipEngagementWarpFactorOne';
         this.start = '2016-10-24';
-        this.expiry = '2016-11-3';
+        this.expiry = '2016-11-4';  // Friday 4th 00:00:00
         this.author = 'Justin Pinner';
         this.description = 'The first level of prominent engagement messaging';
         this.audience = 0.3;


### PR DESCRIPTION
## What does this change?
Adds one day to the expiry of the **prominent membership engagement AB test** (and switch). Based on the observed impressions rate so far, we estimate that we'll achieve statistical significance by the end of Thursday 3rd.

## What is the value of this and can you measure success?
Don't end the test too soon!

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
N/A (for this PR)

## Request for comment
@svillafe @Ap0c @rtyley @rupertbates

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
