### PR TITLE
Make images links in minute email

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -81,9 +81,15 @@
                     }
 
                     case ImageBlockElement(media, data, showCredit) => {
-                        @EmailImage.bestFor(media).map { url =>
+                        @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                <img width="580" class="full-width" src="@url" @data.get("alt").map { alt => alt="@alt" }>
+                                @block.url.fold {
+                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                } { linkUrl =>
+                                    <a href="@linkUrl">
+                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    </a>
+                                }
                             }
 
                             @paddedRow {

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -83,12 +83,12 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @block.url.filter(_ => article.isLiveBlog).fold {
-                                    @img(src = imageUrl, alt = data.get("alt"))
-                                } { linkUrl =>
-                                    <a href="@linkUrl">
+                                @if(article.isLiveBlog && block.url.isDefined) {
+                                    <a href="@block.url.getOrElse("#")">
                                         @img(src = imageUrl, alt = data.get("alt"))
                                     </a>
+                                } else {
+                                    @img(src = imageUrl, alt = data.get("alt"))
                                 }
                             }
 

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -8,7 +8,7 @@
 @defining(page.article) { article =>
     @fullRow {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
-            <img width="580" class="full-width" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
+            @img(src = page.banner, alt = page.email.map(_.name))
         </a>
     }
 
@@ -84,10 +84,10 @@
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
                                 @block.url.filter(_ => article.isLiveBlog).fold {
-                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    @img(src = imageUrl, alt = data.get("alt"))
                                 } { linkUrl =>
                                     <a href="@linkUrl">
-                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                        @img(src = imageUrl, alt = data.get("alt"))
                                     </a>
                                 }
                             }
@@ -114,10 +114,10 @@
                         @EmailVideoImage.bestFor(media).map { imageUrl =>
                             @fullRow {
                                 @data.get("url").fold {
-                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    @img(src = imageUrl, alt = data.get("alt"))
                                 }{ linkUrl =>
                                     <a href="@linkUrl">
-                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                        @img(src = imageUrl, alt = data.get("alt"))
                                     </a>
                                 }
                             }

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -83,7 +83,7 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @block.url.fold {
+                                @block.url.filter(_ => article.isLiveBlog).fold {
                                     <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
                                 } { linkUrl =>
                                     <a href="@linkUrl">

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -7,9 +7,14 @@
 
 @defining(page.article) { article =>
     @fullRow {
-        <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
-            <img width="580" class="full-width" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
-        </a>
+        @defining(page.email.map(_.name)) { emailName =>
+            @imageMaybeWithLink(
+                imageUrl = page.banner,
+                alt = emailName,
+                linkUrl = Some(article.metadata.webUrl),
+                linkTitle = emailName
+            )
+        }
     }
 
     @page.fallbackSeriesText.map { seriesName =>
@@ -83,13 +88,11 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @block.url.filter(_ => article.isLiveBlog).fold {
-                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
-                                } { linkUrl =>
-                                    <a href="@linkUrl">
-                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
-                                    </a>
-                                }
+                                @imageMaybeWithLink(
+                                    imageUrl = imageUrl,
+                                    alt = data.get("alt"),
+                                    linkUrl = block.url.filter(_ => article.isLiveBlog)
+                                )
                             }
 
                             @paddedRow {
@@ -113,13 +116,11 @@
                     case GuVideoBlockElement(video, media, data) => {
                         @EmailVideoImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @data.get("url").fold {
-                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
-                                }{ linkUrl =>
-                                    <a href="@linkUrl">
-                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
-                                    </a>
-                                }
+                                @imageMaybeWithLink(
+                                    imageUrl = imageUrl,
+                                    alt = data.get("alt"),
+                                    linkUrl = data.get("url")
+                                )
                             }
                         }
                     }

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -7,14 +7,9 @@
 
 @defining(page.article) { article =>
     @fullRow {
-        @defining(page.email.map(_.name)) { emailName =>
-            @imageMaybeWithLink(
-                imageUrl = page.banner,
-                alt = emailName,
-                linkUrl = Some(article.metadata.webUrl),
-                linkTitle = emailName
-            )
-        }
+        <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
+            <img width="580" class="full-width" src="@page.banner" @page.email.map { email => alt="View @email.name online"}>
+        </a>
     }
 
     @page.fallbackSeriesText.map { seriesName =>
@@ -88,11 +83,13 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @imageMaybeWithLink(
-                                    imageUrl = imageUrl,
-                                    alt = data.get("alt"),
-                                    linkUrl = block.url.filter(_ => article.isLiveBlog)
-                                )
+                                @block.url.filter(_ => article.isLiveBlog).fold {
+                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                } { linkUrl =>
+                                    <a href="@linkUrl">
+                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    </a>
+                                }
                             }
 
                             @paddedRow {
@@ -116,11 +113,13 @@
                     case GuVideoBlockElement(video, media, data) => {
                         @EmailVideoImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @imageMaybeWithLink(
-                                    imageUrl = imageUrl,
-                                    alt = data.get("alt"),
-                                    linkUrl = data.get("url")
-                                )
+                                @data.get("url").fold {
+                                    <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                }{ linkUrl =>
+                                    <a href="@linkUrl">
+                                        <img width="580" class="full-width" src="@imageUrl" @data.get("alt").map { alt => alt="@alt" }>
+                                    </a>
+                                }
                             }
                         }
                     }

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -86,7 +86,7 @@ case class BodyBlock(
   }
 
   lazy val url: Option[String] = elements.collectFirst {
-    case TextBlockElement(Some(html)) => {
+    case TextBlockElement(Some(html)) if Jsoup.parse(html).getElementsByTag("a").size() == 1 => {
       Jsoup.parse(html).getElementsByTag("a").get(0).attr("href")
     }
   }

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -2,11 +2,12 @@ package model.liveblog
 
 import java.util.Locale
 
-import com.gu.contentapi.client.model.v1.{BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks, Block}
+import com.gu.contentapi.client.model.v1.{Block, BlockAttributes => ApiBlockAttributes, Blocks => ApiBlocks}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import model.liveblog.BodyBlock._
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone}
+import org.jsoup.Jsoup
 
 object Blocks {
 
@@ -82,6 +83,12 @@ case class BodyBlock(
     case SummaryEvent => " is-summary"
     case KeyEvent => " is-key-event"
     case UnclassifiedEvent => ""
+  }
+
+  lazy val url: Option[String] = elements.collectFirst {
+    case TextBlockElement(Some(html)) => {
+      Jsoup.parse(html).getElementsByTag("a").get(0).attr("href")
+    }
   }
 
   def republishedDate(timezone: DateTimeZone): Option[LiveBlogDate] = {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,6 +53,10 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="float-left icon icon-$name">"""
   }
 
+  def img(src: String, alt: Option[String] = None) = Html {
+    s"""<img width="580" class="full-width" src="${src}" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
+  }
+
   object Images {
     val footerG = Static("images/email/grey-g.png")
     val quote = Static("images/email/quote.png")

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,6 +53,16 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="float-left icon icon-$name">"""
   }
 
+  def imageMaybeWithLink(imageUrl: String, alt: Option[String], linkUrl: Option[String], linkTitle: Option[String] = None) = Html {
+    linkUrl.fold {
+      s"""<img width="580" class="full-width" src="${imageUrl}" ${alt.map(a => s"""alt="${a}"""").getOrElse("")}>"""
+    } { linkUrl =>
+      s"""<a href="${linkUrl}" ${linkTitle.map(t => s"""title="${t}""").getOrElse("")}>
+        <img width="580" class="full-width" src="${imageUrl}" ${alt.map(a => s"""alt="${a}"""").getOrElse("")}>
+      </a>"""
+    }
+  }
+
   object Images {
     val footerG = Static("images/email/grey-g.png")
     val quote = Static("images/email/quote.png")

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,16 +53,6 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="float-left icon icon-$name">"""
   }
 
-  def imageMaybeWithLink(imageUrl: String, alt: Option[String], linkUrl: Option[String], linkTitle: Option[String] = None) = Html {
-    linkUrl.fold {
-      s"""<img width="580" class="full-width" src="${imageUrl}" ${alt.map(a => s"""alt="${a}"""").getOrElse("")}>"""
-    } { linkUrl =>
-      s"""<a href="${linkUrl}" ${linkTitle.map(t => s"""title="${t}""").getOrElse("")}>
-        <img width="580" class="full-width" src="${imageUrl}" ${alt.map(a => s"""alt="${a}"""").getOrElse("")}>
-      </a>"""
-    }
-  }
-
   object Images {
     val footerG = Static("images/email/grey-g.png")
     val quote = Static("images/email/quote.png")


### PR DESCRIPTION
We're currently testing a Weekend Reading email in two formats:
- [minute-like](https://www.theguardian.com/membership/live/2016/oct/29/weekend-reading-heathrow-aggro-tabloids-revenge-and-good-scares/email) (generated from a live blog)
- [article-like](https://www.theguardian.com/membership/2016/oct/29/weekend-reading-heathrow-aggro-tabloids-revenge-and-good-scares/email) (generated from an article)

The difference is a bit subtle and there's not a lot to choose between them right now. I'm curious about whether making the images into links in the minute format will have an impact on the clickthrough rate relative to the article format, based on my anecdotal instinct to click on the images whenever I open the email. ([Click-To-Open-Rate](http://www.mailermailer.com/resources/metrics/2013/click-to-open-rates.rwp) is one of our email-related key results)

Making some minute-y assumptions that there's one link inside each block, I can try and generate a url for each block in the liveblog-generated email, and make the image link to that url.

@davidfurey @desbo 