### PR TITLE
Remove the min-height of advert__image when there is a pageskin

### DIFF
--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -173,6 +173,14 @@
         }
     }
 
+    .has-page-skin &:not(.advert--landscape) {
+        .advert__image {
+            @include mq(desktop) {
+                min-height: 0;
+            }
+        }
+    }
+
     .advert__image-container {
         height: auto;
     }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

This fixes paid content containers on fronts that appear stretched or squished when there is a pageskin.

This removes the `min-height` of `advert__image` when there is a pageskin.

## Screenshots

#### Broken

![broken](https://cloud.githubusercontent.com/assets/445472/19859440/2ca845cc-9f7d-11e6-9ead-f3f769417255.png)

#### Fixed

![fixed](https://cloud.githubusercontent.com/assets/445472/19859441/2caf5e02-9f7d-11e6-8f3e-f2c928e90338.png)





## Request for comment

@regiskuckaertz 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

