### PR TITLE
Fix routes for interactive service workers

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -90,7 +90,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                   
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>                        controllers.MediaController.render(path)
 
 # Interactive service worker
-GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/$file<interactive(-service)?-worker.js>           controllers.InteractiveController.proxyInteractiveWebWorker(path, file)
+GET        /$path<[\w\d-]*(/[\w\d-]*)+>/$file<interactive(-service)?-worker.js>           controllers.InteractiveController.proxyInteractiveWebWorker(path, file)
 
 # Interactive paths
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    controllers.InteractiveController.renderInteractiveJson(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -362,6 +362,7 @@ GET            /series/*path.json                                               
 GET            /sitemaps/news.xml                                                                                                controllers.SiteMapController.renderNewsSiteMap()
 GET            /sitemaps/video.xml                                                                                               controllers.SiteMapController.renderVideoSiteMap()
 GET            /service-worker.js                                                                                                controllers.WebAppController.serviceWorker()
+GET            /$path<[\w\d-]*(/[\w\d-]*)+>/$file<interactive(-service)?-worker.js>                                              controllers.InteractiveController.proxyInteractiveWebWorker(path, file)
 
 #Notifications Store
 POST           /notification/store                                                                                               controllers.NotificationsController.saveSubscription()


### PR DESCRIPTION
## What does this change?
This allows service worker routes to match any length of url.
It was previously only matching 3 levels deep :roll_eyes: 
Also adds support for `dev-build`
## Request for comment
@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

