### PR TITLE
Improve hosted page button styles

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -14,11 +14,15 @@
         background-color: @{page.campaign.fontColour.brandColour};
     }
 
-    .hosted-tone-btn,
+    .hosted-tone-btn {
+        color: @{page.campaign.fontColour.brandColour};
+        border: 1px solid @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted__banner .hosted-tone-btn,
     .hosted-tone-btn:focus,
     .hosted-tone-btn:hover {
         background-color: @{page.campaign.fontColour.brandColour};
-        border-color: @{page.campaign.fontColour.brandColour};
     }
 
     .hosted-page .hosted__link {

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -15,11 +15,15 @@
         background-color: @{page.campaign.fontColour.brandColour};
     }
 
-    .hosted-tone-btn,
+    .hosted-tone-btn {
+        color: @{page.campaign.fontColour.brandColour};
+        border: 1px solid @{page.campaign.fontColour.brandColour};
+    }
+
+    .hosted__banner .hosted-tone-btn,
     .hosted-tone-btn:focus,
     .hosted-tone-btn:hover {
         background-color: @{page.campaign.fontColour.brandColour};
-        border-color: @{page.campaign.fontColour.brandColour};
     }
 
     .hosted-page .hosted-next-autoplay__video,

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -129,14 +129,12 @@ $hosted-video-height: 540px;
 }
 
 .hosted-page--bright {
-    .hosted-tone-btn {
-        &,
-        &:focus,
-        &:hover {
-            color: #ffffff;
-            svg {
-                fill: #ffffff;
-            }
+    .hosted__banner .hosted-tone-btn,
+    .hosted-tone-btn:focus,
+    .hosted-tone-btn:hover {
+        color: #ffffff;
+        svg {
+            fill: #ffffff;
         }
     }
 
@@ -726,6 +724,7 @@ $hosted-video-height: 540px;
     .hosted-page:not(.hosted-page--bright) & {
         background-color: #ffffff;
         border-color: #ffffff;
+        color: #333333;
     }
 }
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
New button style for the onward journey popup. On hover it has the old style (white text on red).

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/19862708/60dfd6aa-9f89-11e6-854a-4a5ff66ea26e.png)

## Request for comment
@guardian/labs-beta 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
