### PR TITLE
Analytics tracking for hosted gallery

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -13,6 +13,7 @@ define([
     'lodash/collections/map',
     'lodash/functions/throttle',
     'lodash/collections/forEach',
+    'common/modules/analytics/interaction-tracking',
     'common/modules/analytics/omniture',
     'common/utils/chain',
     'common/utils/load-css-promise'
@@ -30,6 +31,7 @@ define([
              map,
              throttle,
              forEach,
+             interactionTracking,
              omniture,
              chain,
              loadCssPromise) {
@@ -368,6 +370,7 @@ define([
     HostedGallery.prototype.trackNavBetweenImages = function (data) {
         if (data && data.nav) {
             omniture.trackLinkImmediate(config.page.trackingPrefix + data.nav + ' - image ' + this.index);
+            interactionTracking.trackNonClickInteraction(config.page.trackingPrefix + data.nav + ' - image ' + this.index);
         }
     };
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
A proper analytics tracking event is triggered when someone will click on the next/prev hosted gallery image.

## What is the value of this and can you measure success?
We can track clicking events in google analytics.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
![screen shot 2016-10-31 at 16 22 35](https://cloud.githubusercontent.com/assets/489567/19862960/4a9b1368-9f8a-11e6-90ce-b9ffee04ab86.png)


## Request for comment
@lps88 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

