### PR TITLE
Make Diagnostics httpFilters consistant with the other apps

### DIFF
--- a/diagnostics/app/AppLoader.scala
+++ b/diagnostics/app/AppLoader.scala
@@ -3,7 +3,7 @@ import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CachedHealthCheckLifeCycle, CommonGzipFilter}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.{Assets, DiagnosticsControllers, HealthCheck}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
@@ -39,5 +39,5 @@ trait AppLifecycleComponents {
 trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
   lazy val router: Router = wire[Routes]
   lazy val appIdentity = ApplicationIdentity("frontend-diagnostics")
-  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonGzipFilter].filters
+  override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Change Diagnostics httpFilters to CommonFilters rather than just GZip filter

@rich-nguyen any idea why it was like that? Thx

## What is the value of this and can you measure success?
Make Diagnostics httpFilters consistent with the other apps.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Request for comment
@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

