### PR TITLE
headline fix on mobile

### DIFF
--- a/static/src/stylesheets/inline/article-explore.scss
+++ b/static/src/stylesheets/inline/article-explore.scss
@@ -137,13 +137,14 @@ $explore-series-header-element-opacity: .85;
 
 .explore-series-headline__content {
     color: #ffffff;
-    margin: $gs-baseline 0;
+    margin: $gs-baseline;
     width: 94%;
     padding-left: 0;
 
     @include mq($from: desktop) {
         width: gs-span(8);
         padding-left: $gs-gutter;
+        margin: $gs-baseline 0;
     }
 }
 


### PR DESCRIPTION
Just adds some margin to the headline on mobile. 

**Before**
![picture 169](https://cloud.githubusercontent.com/assets/11950919/19863588/a72bfa00-9f8c-11e6-8ac4-da4217af2762.png)
**After**
![picture 170](https://cloud.githubusercontent.com/assets/11950919/19863590/a918d874-9f8c-11e6-90f5-4f36d0587a9d.png)
