### PR TITLE
remove confusing step from config doc

### DIFF
--- a/docs/03-dev-howtos/13-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/13-Update-configuration-in-s3.md
@@ -4,13 +4,6 @@ We store all our configuration in a single file in `s3`
 This contains all the configuration for each application and for each stage.
 
 To add or update a configuration item you need to:
-- Download the configuration file
-- This is located at
-```
-https://s3-eu-west-1.amazonaws.com/aws-frontend-store/config/eu-west-1-frontend.conf
-```
-
-- This can be done by hand via the console or using the [aws cli tools](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) - You need valid [Janus](https://janus.gutools.co.uk) credentials for `frontend` to do this
 
 - Find the current version of the config file
 ```

--- a/docs/03-dev-howtos/13-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/13-Update-configuration-in-s3.md
@@ -5,6 +5,8 @@ This contains all the configuration for each application and for each stage.
 
 To add or update a configuration item you need to:
 
+- Get valid [Janus](https://janus.gutools.co.uk) credentials for frontend
+
 - Find the current version of the config file
 ```
 aws s3 ls --profile=frontend s3://aws-frontend-store/config/


### PR DESCRIPTION
This step makes no sense as it just instructs you to download an old version of the config. Maybe that file should be deleted as it confusingly has no version number?

CC @TBonnin @dominickendrick 