### PR TITLE
Tweak email image quality

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -127,11 +127,11 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
 }
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {
-  override val qualityparam = "q=30"
+  override val qualityparam = "q=40"
 }
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
   override val fitParam = "fit=crop"
-  override val qualityparam = "q=30"
+  override val qualityparam = "q=40"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=center"
   val blendImageParam = s"blend64=${Base64.getUrlEncoder.encodeToString(EmailHelpers.Images.play.getBytes)}"


### PR DESCRIPTION
I might have been a bit too aggressive with reducing image quality in #14669. I've bumped the `q` imgix param back up a little bit. It's a subtle but noticeable difference, in my opinion, and only adds 49K overall to [a typical email](https://www.theguardian.com/membership/live/2016/oct/29/weekend-reading-heathrow-aggro-tabloids-revenge-and-good-scares/email)

#### before
<img width="581" alt="picture 322" src="https://cloud.githubusercontent.com/assets/5122968/19865647/0e1208a6-9f95-11e6-80ac-411d873a88e4.png">

#### after
<img width="577" alt="picture 323" src="https://cloud.githubusercontent.com/assets/5122968/19865652/13c85cf0-9f95-11e6-963d-fd4710c43e14.png">

