### PR TITLE
Render youtube media atoms as amp-iframe

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -307,6 +307,7 @@ class GuardianConfiguration extends Logging {
     lazy val path =
       if (environment.secure) configuration.getMandatoryStringProperty("static.securePath")
       else configuration.getMandatoryStringProperty("static.path")
+    lazy val externalEmbedHost = configuration.getMandatoryStringProperty("guardian.page.externalEmbedHost")
   }
 
   object images {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -307,7 +307,6 @@ class GuardianConfiguration extends Logging {
     lazy val path =
       if (environment.secure) configuration.getMandatoryStringProperty("static.securePath")
       else configuration.getMandatoryStringProperty("static.path")
-    lazy val externalEmbedHost = configuration.getMandatoryStringProperty("guardian.page.externalEmbedHost")
   }
 
   object images {
@@ -619,6 +618,7 @@ class GuardianConfiguration extends Logging {
     val ttlInSeconds = configuration.getIntegerProperty("png_resizer.image_ttl").getOrElse(86400)
   }
 
+
   object emailSignup {
     val url = configuration.getMandatoryStringProperty("email.signup.url")
   }
@@ -650,9 +650,15 @@ class GuardianConfiguration extends Logging {
   object Survey {
     lazy val formStackAccountName: String = "guardiannewsampampmedia"
   }
+
+  object Media {
+    lazy val externalEmbedHost = configuration.getMandatoryStringProperty("guardian.page.externalEmbedHost")
+  }
+
 }
 
 object ManifestData {
   lazy val build = ManifestFile.asKeyValuePairs.getOrElse("Build", "DEV").dequote.trim
   lazy val revision = ManifestFile.asKeyValuePairs.getOrElse("Revision", "DEV").dequote.trim
 }
+

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 9
+    val s3ConfigVersion = 10
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -4,7 +4,7 @@
     <amp-iframe
     sandbox="allow-scripts allow-same-origin allow-popups"
     layout="responsive"
-    width="16" height="9" src="@Configuration.static.externalEmbedHost/embed/atom/media/@media.id">
+    width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
         @if(media.posterUrl.isDefined){
         <amp-img layout="fill" src="@media.posterUrl.get" placeholder></amp-img>
     }

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,14 +1,14 @@
 @(media: model.content.MediaAtom)(implicit request: RequestHeader)
 @import conf.Configuration
 
-    <amp-iframe
-    sandbox="allow-scripts allow-same-origin allow-popups"
-    layout="responsive"
-    width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
-        @if(media.posterUrl.isDefined){
-        <amp-img layout="fill" src="@media.posterUrl.get" placeholder></amp-img>
-    }
-    </amp-iframe>
+<amp-iframe
+sandbox="allow-scripts allow-same-origin allow-popups"
+layout="responsive"
+width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
+@if(media.posterUrl.isDefined) {
+    <amp-img layout="fill" src="@media.posterUrl.get" placeholder></amp-img>
+}
+</amp-iframe>
 
 
 

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -4,7 +4,7 @@
     <amp-iframe
     sandbox="allow-scripts allow-same-origin allow-popups"
     layout="responsive"
-    width="16" height="9" src="https://embed.theguardian.com/embed/atom/media/@media.id.toString">
+    width="16" height="9" src="https://embed.theguardian.com/embed/atom/media/@media.id">
         @if(media.posterUrl.isDefined){
         <amp-img layout="fill" src="@media.posterUrl.get" placeholder="@media.posterUrl.get"></amp-img>
     }

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,12 +1,12 @@
 @(media: model.content.MediaAtom)(implicit request: RequestHeader)
-
+@import conf.Configuration
 
     <amp-iframe
     sandbox="allow-scripts allow-same-origin allow-popups"
     layout="responsive"
-    width="16" height="9" src="https://embed.theguardian.com/embed/atom/media/@media.id">
+    width="16" height="9" src="@Configuration.static.externalEmbedHost/embed/atom/media/@media.id">
         @if(media.posterUrl.isDefined){
-        <amp-img layout="fill" src="@media.posterUrl.get" placeholder="@media.posterUrl.get"></amp-img>
+        <amp-img layout="fill" src="@media.posterUrl.get" placeholder></amp-img>
     }
     </amp-iframe>
 

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,11 +1,16 @@
 @(media: model.content.MediaAtom)(implicit request: RequestHeader)
 
 
-    <amp-youtube
-    data-videoid="@media.assets.head.id"
+    <amp-iframe
+    sandbox="allow-scripts allow-same-origin allow-popups"
     layout="responsive"
-    width="5" height="3" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
-    </amp-youtube>
+    width="16" height="9" src="https://embed.theguardian.com/embed/atom/media/@media.id.toString">
+        @if(media.posterUrl.isDefined){
+        <amp-img layout="fill" src="@media.posterUrl.get" placeholder="@media.posterUrl.get"></amp-img>
+    }
+    </amp-iframe>
+
+
 
 
 

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -69,6 +69,7 @@ guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
 guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
 guardian.page.discussionApiUrl=https://discussion.code.dev-theguardian.com/discussion-api
+guardian.page.externalEmbedHost=https://embed.theguardian.com
 
 aws.region=eu-west-1
 

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -44,10 +44,10 @@ class AtomCleanerTest extends FlatSpec with Matchers with FakeRequests {
     result.select("iframe").attr("src") should include("enablejsapi=1")
   }
 
-  "AtomsCleaner" should "use amp-youtube markup if amp is true" in {
+  "AtomsCleaner" should "use amp-iframe markup if amp is true" in {
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc, youTubeAtom, amp = true)
-    result.select("amp-youtube").attr("data-videoid") shouldBe("nQuN9CUsdVg")
+    result.select("amp-iframe").attr("src") should include("887fb7b4-b31d-4a38-9d1f-26df5878cf9c")
   }
 
 

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -60,7 +60,7 @@ define([
         var endSlate = new Component(),
             endState = 'vjs-has-ended';
 
-        endSlate.endpoint = config.page.externalEmbedHost + $('.js-gu-media--enhance').first().attr('data-end-slate');
+        endSlate.endpoint = $('.js-gu-media--enhance').first().attr('data-end-slate');
 
         endSlate.fetch(player.el(), 'html').then(function () {
             $('.end-slate-container .fc-item__action').each(function (e) { e.href += '?CMP=embed_endslate'; });


### PR DESCRIPTION
## What does this change?
Renders youtube media atoms as `amp-iframe` pointing to the embed host, rather than using `amp-youtube`

## What is the value of this and can you measure success?
Pros
* Allows us to serve pre-roll ads on AMP as this functionality is whitelisted to referrer **.theguardian.com*
* Allows us in future to serve our own branded play button and poster image.

Cons
* I am acutely aware there is a **performance** and **responsibility** hit by serving this as an `amp-iframe` i.e. there is an additional external call to https://embed.theguardian.com, however I believe that the benefit of being able to monetise these views outweighs that. It would be worth revisiting this were google to provide a way to target ads at an `amp-youtube` player.


<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
AMP


<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
<img width="778" alt="screen shot 2016-10-31 at 14 32 56" src="https://cloud.githubusercontent.com/assets/1764158/19888625/bd91c3ba-a027-11e6-9f8a-6e97b833875a.png">

## Request for comment
CC @markjamesbutler @NataliaLKB @TBonnin 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
