### PR TITLE
Removing event tracking from various places

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -11,14 +11,14 @@ define([
     'common/utils/robust',
     'common/views/svgs',
     'common/modules/user-prefs',
+    'common/modules/analytics/google',
     'text!common/views/ui/notifications-follow-link.html',
     'text!common/views/ui/notifications-explainer.html',
     'text!common/views/ui/notifications-permission-denied-message.html',
     'lodash/collections/some',
     'lodash/arrays/uniq',
     'lodash/arrays/without',
-    'lodash/objects/isEmpty',
-    'common/modules/analytics/omniture'
+    'lodash/objects/isEmpty'
 ], function (
     bonzo,
     qwery,
@@ -32,14 +32,14 @@ define([
     robust,
     svgs,
     userPrefs,
+    googleAnalytics,
     followLink,
     explainer,
     permissionsTemplate,
     some,
     uniq,
     without,
-    isEmpty,
-    omniture
+    isEmpty
 ) {
     var modules = {
 
@@ -106,11 +106,11 @@ define([
                 .then(function() {
                     var isNowGranted = Notification.permission === 'granted';
                     if (wasNotGranted && isNowGranted) {
-                        omniture.trackLinkImmediate('browser-notifications-granted');
+                        googleAnalytics.trackNonClickInteraction('browser-notifications-granted');
                     }
                 }) .catch( function () {
                     if (Notification.permission === 'denied') {
-                        omniture.trackLinkImmediate('browser-notifications-denied');
+                        googleAnalytics.trackNonClickInteraction('browser-notifications-denied');
                     }
                     modules.configureSubscribeButton();
                 });

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -14,7 +14,6 @@ define([
     'lodash/functions/throttle',
     'lodash/collections/forEach',
     'common/modules/analytics/interaction-tracking',
-    'common/modules/analytics/omniture',
     'common/utils/chain',
     'common/utils/load-css-promise'
 ], function (bean,
@@ -32,7 +31,6 @@ define([
              throttle,
              forEach,
              interactionTracking,
-             omniture,
              chain,
              loadCssPromise) {
 
@@ -369,7 +367,6 @@ define([
 
     HostedGallery.prototype.trackNavBetweenImages = function (data) {
         if (data && data.nav) {
-            omniture.trackLinkImmediate(config.page.trackingPrefix + data.nav + ' - image ' + this.index);
             interactionTracking.trackNonClickInteraction(config.page.trackingPrefix + data.nav + ' - image ' + this.index);
         }
     };

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
@@ -1,13 +1,13 @@
 define([
     'bean',
     'fastdom',
-    'common/modules/analytics/omniture',
-    'common/utils/$'
+    'common/utils/$',
+    'common/modules/analytics/google'
 ], function (
     bean,
     fastdom,
-    omniture,
-    $
+    $,
+    googleAnalytics
 ) {
     var nextVideoInterval;
     var $hostedNext = $('.js-hosted-next-autoplay');
@@ -39,7 +39,7 @@ define([
                 });
             }
             if (timeLeft <= 0){
-                omniture.trackLinkImmediate('Immediately play the next video');
+                googleAnalytics.trackNonClickInteraction('Immediately play the next video');
                 window.location = nextVideoPage;
             }
         }, 1000);

--- a/static/src/javascripts/projects/common/modules/atoms/quiz.js
+++ b/static/src/javascripts/projects/common/modules/atoms/quiz.js
@@ -2,14 +2,12 @@ define([
     'bean',
     'common/utils/$',
     'common/utils/fastdom-promise',
-    'lodash/collections/toArray',
-    'common/modules/analytics/omniture'
+    'lodash/collections/toArray'
 ], function (
     bean,
     $,
     fastdom,
-    toArray,
-    omniture
+    toArray
 ) {
     return {
         // find a bucket message to show once you finish a quiz
@@ -26,7 +24,6 @@ define([
                         var quiz = e.currentTarget,
                             total =  $(':checked + .atom-quiz__answer__item', quiz).length;
 
-                        omniture.trackLinkImmediate('quiz-question-answered-'+total);
                         if (quiz.checkValidity()) { // the form (quiz) is complete
                             var $bucket__message = null;
                             do {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -8,11 +8,11 @@ define([
     'text!common/views/email/iframe.html',
     'common/utils/template',
     'common/modules/article/space-filler',
-    'common/modules/analytics/omniture',
     'common/utils/robust',
     'common/modules/email/run-checks',
     'common/utils/page',
     'common/utils/storage',
+    'common/modules/analytics/google',
     'lodash/collections/find'
 ], function (
     $,
@@ -24,11 +24,11 @@ define([
     iframeTemplate,
     template,
     spaceFiller,
-    omniture,
     robust,
     emailRunChecks,
     page,
     storage,
+    googleAnalytics,
     find
 ) {
     var insertBottomOfArticle = function ($iframeEl) {
@@ -156,14 +156,14 @@ define([
                     fastdom.write(function () {
                         listConfig.insertMethod($iframeEl);
 
-                        omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
+                        googleAnalytics.trackNonClickInteraction('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailRunChecks.setEmailInserted();
                         emailRunChecks.setEmailShown(listConfig.listName);
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
                         $iframeEl.insertBefore(paras[0]);
-                        omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
+                        googleAnalytics.trackNonClickInteraction('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailRunChecks.setEmailInserted();
                         emailRunChecks.setEmailShown(listConfig.listName);
                     });

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -12,6 +12,7 @@ define([
     'common/utils/mediator',
     'common/utils/template',
     'common/utils/robust',
+    'common/modules/analytics/google',
     'lodash/functions/debounce',
     'lodash/collections/contains',
     'common/views/svgs',
@@ -34,6 +35,7 @@ define([
     mediator,
     template,
     robust,
+    googleAnalytics,
     debounce,
     contains,
     svgs,
@@ -43,27 +45,6 @@ define([
     userPrefs,
     uniq
 ) {
-    var omniture;
-
-    /**
-     * The omniture module depends on common/modules/experiments/ab, so trying to
-     * require omniture directly inside an AB test gives you a circular dependency.
-     *
-     * This is a workaround to load omniture without making it a dependency of
-     * this module, which is required by an AB test.
-     */
-    function getOmniture() {
-        return new Promise(function (resolve) {
-            if (omniture) {
-                return resolve(omniture);
-            }
-
-            require('common/modules/analytics/omniture', function (omnitureM) {
-                omniture = omnitureM;
-                resolve(omniture);
-            });
-        });
-    }
 
     var state = {
         submitting: false
@@ -115,10 +96,6 @@ define([
             userPrefs.set('email-sign-up-' + analytics.formType, uniq(currentListPrefs));
 
             $(iframe).remove();
-
-            getOmniture().then(function (omniture) {
-                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | form hidden');
-            });
 
         },
         ui = {
@@ -263,9 +240,8 @@ define([
 
                         state.submitting = true;
 
-                        return getOmniture().then(function (omniture) {
-                            omniture.trackLinkImmediate(analyticsInfo.replace('%action%', 'subscribe clicked'));
-
+                        return new Promise(function () {
+                            googleAnalytics.trackNonClickInteraction(analyticsInfo.replace('%action%', 'subscribe clicked'));
                             return fetch(config.page.ajaxUrl + url, {
                                 method: 'post',
                                 body: data,
@@ -279,12 +255,12 @@ define([
                                 }
                             })
                             .then(function () {
-                                omniture.trackLinkImmediate(analyticsInfo.replace('%action%', 'subscribe successful'));
+                                googleAnalytics.trackNonClickInteraction(analyticsInfo.replace('%action%', 'subscribe successful'));
                             })
                             .then(handleSubmit(true, $form))
                             .catch(function (error) {
                                 robust.log('c-email', error);
-                                omniture.trackLinkImmediate(analyticsInfo.replace('%action%', 'error'));
+                                googleAnalytics.trackNonClickInteraction(analyticsInfo.replace('%action%', 'error'));
                                 handleSubmit(false, $form)();
                             });
                         });

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -97,6 +97,8 @@ define([
 
             $(iframe).remove();
 
+            googleAnalytics.trackNonClickInteraction('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | form hidden');
+
         },
         ui = {
             updateForm: function (thisRootEl, el, analytics, opts) {

--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -1,10 +1,8 @@
-/*global s*/
 define([
     'bonzo',
     'common/utils/ajax',
     'common/utils/config',
     'common/utils/time',
-    'common/modules/analytics/omniture',
     'common/modules/identity/api',
     'common/modules/identity/facebook-authorizer',
     'common/modules/navigation/profile',
@@ -16,7 +14,6 @@ function (
     ajax,
     config,
     time,
-    omniture,
     id,
     FacebookAuthorizer,
     Profile,
@@ -74,11 +71,6 @@ function (
                         });
                         profile.init();
                         new Toggles().init();
-
-                        omniture.populateEventProperties('Social signin auto');
-                        s.eVar13 = 'facebook auto';
-                        s.linkTrackVars += ',eVar13';
-                        s.tl(this, 'o', 'Social signin auto');
                     }
                 }
             });

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -11,7 +11,6 @@ define([
     'common/utils/storage',
     'common/utils/template',
     'common/modules/ui/relativedates',
-    'common/modules/analytics/omniture',
     'common/views/svgs',
     'text!common/views/breaking-news.html',
     'lodash/objects/isArray',
@@ -31,7 +30,6 @@ define([
     storage,
     template,
     relativeDates,
-    omniture,
     svgs,
     alertHtml,
     isArray,
@@ -157,7 +155,6 @@ define([
         if (alert) {
             var $body = bonzo(document.body);
             var $breakingNews = bonzo(qwery('.js-breaking-news-placeholder'));
-            var trackingMessage = 'breaking news alert shown' + (has(knownAlertIDs, alert.id) ? '' : ' 2 or more times');
 
             // if its the first time we've seen this alert, we wait 3 secs to show it
             // otherwise we show it immediately
@@ -181,7 +178,6 @@ define([
                     $breakingNews.removeClass('breaking-news--hidden');
                     markAlertAsSeen(alert.id);
                 });
-                omniture.trackLink(this, trackingMessage);
             }, alertDelay);
         }
         return alert;

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -4,7 +4,6 @@ define([
     'common/utils/fetch-json',
     'common/utils/mediator',
     'common/utils/report-error',
-    'common/modules/analytics/omniture',
     'lodash/collections/forEach',
     'lodash/arrays/initial',
     'common/utils/chain'
@@ -14,7 +13,6 @@ define([
     fetchJson,
     mediator,
     reportError,
-    omniture,
     forEach,
     initial,
     chain
@@ -124,7 +122,6 @@ define([
                 // Send data to whoever is listening
                 mediator.emit('autocomplete:fetch', data);
                 this.setInputValue();
-                omniture.trackLinkImmediate('weather location set by user');
                 inputTmp = data.city;
                 $input.blur();
 

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -22,7 +22,6 @@ define([
     'common/utils/fetch-json',
     'common/utils/mediator',
     'common/utils/template',
-    'common/modules/analytics/omniture',
     'common/modules/user-prefs',
     'facia/modules/onwards/search-tool',
     'lodash/collections/contains'
@@ -36,7 +35,6 @@ define([
     fetchJson,
     mediator,
     template,
-    omniture,
     userPrefs,
     SearchTool,
     contains


### PR DESCRIPTION
## What does this change?
This removes omniture event tracking from 🚯  :
- weather
- quiz
- autosignin
- breaking news alerts

And migrated the following to Google Analytics ▶️ 🔮  :
- email
- hosted video 
- notifications

## What is the value of this and can you measure success?
Turn of Omniture 🏯 💰 
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
Omniture, Google Analytics

## Request for comment
@guardian/dotcom-platform @mkopka 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

