### PR TITLE
remove omniture script from embed template

### DIFF
--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -20,7 +20,8 @@ import conf.Configuration
 
     // Scenarios
 
-    scenario("Ensure all clicked links are recorded by Analytics") {
+
+    scenario("Ensure all links have data-link-name for tracking") {
       Given("I am on an article entitled 'Olympic opening ceremony will recreate countryside with real animals'")
       goTo("/sport/2012/jun/12/london-2012-olympic-opening-ceremony") { browser =>
         Then("all links on the page should be decorated with the Omniture meta-data attribute")


### PR DESCRIPTION
## What does this change?
remove omniture script from embed template

## What is the value of this and can you measure success?
Save on Omniture calls

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
Nothing to see here

## Request for comment
CC @mkopka @TBonnin 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

