### PR TITLE
Fix US Countries test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -88,7 +88,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-countries-us",
+    "ab-contributions-countries-america",
     "Test whether different messages perform better/worse in different countries",
     owners = Seq(Owner.withGithub("philwills")),
     safeState = On,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -13,13 +13,13 @@ define([
             variants: ['control', 'global', 'democracy']
         };
 
-        var contributionsCountriesUSA = {
-            name: 'ContributionsCountriesUsa',
+        var contributionsCountriesAmerica = {
+            name: 'ContributionsCountriesAmerica',
             variants: ['control', 'global', 'democracy']
         };
 
 
-        var clashingTests = [contributionsCountriesUk, contributionsCountriesUSA];
+        var clashingTests = [contributionsCountriesUk, contributionsCountriesAmerica];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,7 +14,7 @@ define([
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
     'common/modules/experiments/tests/contributions-countries-uk',
-    'common/modules/experiments/tests/contributions-countries-usa'
+    'common/modules/experiments/tests/contributions-countries-america'
 ], function (
     reportError,
     config,
@@ -30,8 +30,8 @@ define([
     MembershipEngagementWarpFactorOne,
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
-    ContributionsCountriesUK,
-    ContributionsCountriesUSA
+    ContributionsCountriesUk,
+    ContributionsCountriesAmerica
 ) {
 
     var TESTS = [
@@ -41,8 +41,8 @@ define([
         new MembershipEngagementWarpFactorOne(),
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
-        new ContributionsCountriesUK(),
-        new ContributionsCountriesUSA()
+        new ContributionsCountriesUk(),
+        new ContributionsCountriesAmerica()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-america.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-america.js
@@ -35,8 +35,8 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsCountriesUsa';
-        this.start = '2016-10-28';
+        this.id = 'ContributionsCountriesAmerica';
+        this.start = '2016-11-01';
         this.expiry = '2016-11-04';
         this.author = 'Phil Wills';
         this.description = 'Test whether different messages perform better/worse in different countries (USA)';


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
On the previously named ContributionsCountriesUsa test, the component wasn't rendering as the name of the test in ABTestSwitches didn't match the name of the js file. We have renamed it, double tested it and now it definitely works. (Note: the reason it wasn't tested before was because we tested the identical UK (aside from the different geo-targeting) test which did work and assumed that the reason the US test didn't render was because we weren't in the US. We should have hard-coded the location to do a quick test before we released. Learnings from this: presume nothing, test everything!)

## What is the value of this and can you measure success?
We can start seeing the results from our test. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment

@jfsoul 
<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

