### PR TITLE
Support Vimeo elements in AMP

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -17,6 +17,7 @@
         <script custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js" async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
+        <script custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js" async></script>
         <script custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -45,7 +45,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
 
   object AmpExternalVideo {
     def getAmpExternalVideoByUrl(videoUrl: String) : Option[AmpExternalVideo] = {
-      val youtubePattern = """^https?:\/\/www\.youtube\.com\/watch\?v=([^#\^&\^?]+).*""".r
+      val youtubePattern = """^https?:\/\/www\.youtube\.com\/watch\?v=([^#&?]+).*""".r
       val vimeoPattern = """^https?:\/\/vimeo\.com\/(\d+).*""".r
       videoUrl match {
         case youtubePattern(videoId) => Some(YoutubeExternalVideo(videoId))

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -39,15 +39,17 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
     })
   }
 
-  class AmpExternalVideo(val videoId: String, val elementType: String) {}
+  sealed abstract class AmpExternalVideo(val videoId: String, val elementType: String)
+  case class YoutubeExternalVideo(override val videoId: String) extends AmpExternalVideo(videoId, "amp-youtube")
+  case class VimeoExternalVideo(override val videoId: String) extends AmpExternalVideo(videoId, "amp-vimeo")
 
   object AmpExternalVideo {
     def getAmpExternalVideoByUrl(videoUrl: String) : Option[AmpExternalVideo] = {
-      val youtubePattern = ".*https?://www.youtube.com/watch\\?v=(.+).*".r
-      val vimeoPattern = ".*https?://vimeo.com/(\\d+).*".r
+      val youtubePattern = "^https?:\\/\\/www\\.youtube\\.com\\/watch\\?v=(.+).*".r
+      val vimeoPattern = "^https?:\\/\\/vimeo\\.com\\/(\\d+).*".r
       videoUrl match {
-        case youtubePattern(videoId) => Some(new AmpExternalVideo(videoId, "amp-youtube"))
-        case vimeoPattern(videoId) => Some(new AmpExternalVideo(videoId, "amp-vimeo"))
+        case youtubePattern(videoId) => Some(YoutubeExternalVideo(videoId))
+        case vimeoPattern(videoId) => Some(VimeoExternalVideo(videoId))
         case _ => None
       }
     }

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -45,8 +45,8 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
 
   object AmpExternalVideo {
     def getAmpExternalVideoByUrl(videoUrl: String) : Option[AmpExternalVideo] = {
-      val youtubePattern = "^https?:\\/\\/www\\.youtube\\.com\\/watch\\?v=(.+).*".r
-      val vimeoPattern = "^https?:\\/\\/vimeo\\.com\\/(\\d+).*".r
+      val youtubePattern = """^https?:\/\/www\.youtube\.com\/watch\?v=([^#\^&\^?]+).*""".r
+      val vimeoPattern = """^https?:\/\/vimeo\.com\/(\d+).*""".r
       videoUrl match {
         case youtubePattern(videoId) => Some(YoutubeExternalVideo(videoId))
         case vimeoPattern(videoId) => Some(VimeoExternalVideo(videoId))

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -49,7 +49,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
     }
 
     def getVideoIdFromUrl(videoUrl: String): Option[String] = {
-      val youtubePattern = ".*youtube.com/watch\\?v=([\\w|\\d]+).*".r
+      val youtubePattern = ".*youtube.com/watch\\?v=(.+).*".r
       videoUrl match {
         case youtubePattern(videoId) => Some(videoId)
         case _ => None
@@ -60,7 +60,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
       for {
         videoElement <- document.getElementsByClass("element-video")
         iframeElement <- videoElement.getElementsByTag("iframe")
-        videoId <- getVideoIdFromUrl(iframeElement.attr("data-canonical-url"))
+        videoId <- getVideoIdFromUrl(videoElement.attr("data-canonical-url"))
       } yield {
         val ampVideoElement = createElement(document, videoId)
         videoElement.appendChild(ampVideoElement)

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -16,6 +16,65 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     document
   }
 
+  /////////////////////////////
+  // Youtube cleaner
+  /////////////////////////////
+
+  "AmpEmbedCleaner" should "replace an iframe in a YouTube video-element with an amp-youtube element" in {
+    val youtubeUrl = "https://www.youtube.com/watch?v=foo123"
+    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(1)
+  }
+
+  "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
+    val youtubeUrl = s"http://www.youtube.com/"
+    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(0)
+  }
+
+  /////////////////////////////
+  // Vimeo cleaner
+  /////////////////////////////
+
+  "AmpEmbedCleaner" should "replace an iframe in a Vimeo video-element with an amp-vimeo element" in {
+    val vimeoUrl = "https://vimeo.com/1234"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-vimeo").size should be(1)
+  }
+
+  "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
+    val vimeoUrl = s"http://vimeo.com/"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-vimeo").size should be(0)
+  }
+
+  "AmpEmbedCleaner" should "be able to create an amp-youtube element and an amp-vimeo in the same document" in {
+    val youtubeUrl = "https://www.youtube.com/watch?v=foo123"
+    val vimeoUrl = "https://vimeo.com/1234"
+    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(1)
+    result.getElementsByTag("amp-vimeo").size should be(1)
+  }
+
+  /////////////////////////////
+  // Soundcloud cleaner
+  /////////////////////////////
+
  "AmpEmbedCleaner" should "replace an iframe in an audio-element with an amp-soundcloud element" in {
    val soundcloudUrl = "http://www.soundcloud.com%2Ftracks%2F1234"
    val doc = s"""<html><body><figure class="element-audio"><iframe src="$soundcloudUrl"></iframe></figure></body></html>"""
@@ -50,6 +109,10 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
     result.getElementsByTag("amp-soundcloud").size should be(0)
   }
+
+  /////////////////////////////
+  // Maps cleaner
+  /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in an map element with an amp-iframe element" in {
     val doc = s"""<html><body><figure class="element-map"><iframe src="$googleMapsUrl"></iframe></figure></body></html>"""

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -18,7 +18,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
   private def documentWithVideos(videoUrls: String*): Document = {
     val doc = "<html><body>" +
-      videoUrls.map{ (url: String) => s"""<figure class="element-video" data-canonical-url="$url"><iframe></iframe></figure>""" }.mkString +
+      videoUrls.map{ url: String => s"""<figure class="element-video" data-canonical-url="$url"><iframe></iframe></figure>""" }.mkString +
       "</body></html>"
     val document: Document = Jsoup.parse(doc)
     clean(document)

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -20,7 +20,16 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   // External video cleaner
   /////////////////////////////
 
-  "AmpEmbedCleaner" should "replace an iframe in a YouTube video-element with an amp-youtube element" in {
+  "AmpEmbedCleaner" should "replace an iframe in a http YouTube video-element with an amp-youtube element" in {
+    val youtubeUrl = "http://www.youtube.com/watch?v=foo_12-34"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(1)
+  }
+
+  "AmpEmbedCleaner" should "replace an iframe in a https YouTube video-element with an amp-youtube element" in {
     val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
@@ -30,7 +39,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
-    val youtubeUrl = s"http://www.youtube.com/"
+    val youtubeUrl = s"https://www.youtube.com/"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
@@ -38,7 +47,16 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
-  "AmpEmbedCleaner" should "replace an iframe in a Vimeo video-element with an amp-vimeo element" in {
+  "AmpEmbedCleaner" should "replace an iframe in a http Vimeo video-element with an amp-vimeo element" in {
+    val vimeoUrl = "http://vimeo.com/1234"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-vimeo").size should be(1)
+  }
+
+  "AmpEmbedCleaner" should "replace an iframe in a https Vimeo video-element with an amp-vimeo element" in {
     val vimeoUrl = "https://vimeo.com/1234"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
@@ -48,7 +66,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
-    val vimeoUrl = s"http://vimeo.com/"
+    val vimeoUrl = s"https://vimeo.com/"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -38,6 +38,22 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
+  "AmpEmbedCleaner" should "not replace an iframe in a fake YouTube video-element with an amp-vimeo element" in {
+    val fakeYoutubeUrl1 = "http://www.youtube.com.de/watch?v=foo_12-34"
+    val fakeYoutubeUrl2 = "http://myyoutube.com/watch?v=foo_12-34"
+    val fakeYoutubeUrl3 = "https://www.youtuber.com/watch?v=foo_12-34"
+    val doc =
+      s"""<html><body>
+         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl1"><iframe></iframe></figure>
+         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl2"><iframe></iframe></figure>
+         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl3"><iframe></iframe></figure>
+         |</body></html>""".stripMargin
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(0)
+  }
+
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
     val youtubeUrl = s"https://www.youtube.com/"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
@@ -65,6 +81,22 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
+  "AmpEmbedCleaner" should "not replace an iframe in a fake Vimeo video-element with an amp-vimeo element" in {
+    val fakeVimeoUrl1 = "https://vimeo.com.zz/1234"
+    val fakeVimeoUrl2 = "https://myvimeo.com/1234"
+    val fakeVimeoUrl3 = "https://vimeofake.com/1234"
+    val doc =
+      s"""<html><body>
+         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl1"><iframe></iframe></figure>
+         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl2"><iframe></iframe></figure>
+         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl3"><iframe></iframe></figure>
+         |</body></html>""".stripMargin
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-vimeo").size should be(0)
+  }
+  
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
     val vimeoUrl = s"https://vimeo.com/"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
@@ -77,7 +109,11 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   "AmpEmbedCleaner" should "be able to create an amp-youtube element and an amp-vimeo in the same document" in {
     val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
     val vimeoUrl = "https://vimeo.com/1234"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val doc =
+      s"""<html><body>
+         |<figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure>
+         |<figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure>
+         |</body></html>""".stripMargin
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -16,9 +16,9 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     document
   }
 
-  private def documentWithVideos(videoUrls: Seq[String]): Document = {
+  private def documentWithVideos(videoUrls: String*): Document = {
     val doc = "<html><body>" +
-      videoUrls.foldLeft(""){ (res: String, next: String) => res + s"""<figure class="element-video" data-canonical-url="$next"><iframe></iframe></figure>""" } +
+      videoUrls.map{ (url: String) => s"""<figure class="element-video" data-canonical-url="$url"><iframe></iframe></figure>""" }.mkString +
       "</body></html>"
     val document: Document = Jsoup.parse(doc)
     clean(document)
@@ -29,58 +29,58 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in a http YouTube video-element with an amp-youtube element" in {
-    val result = documentWithVideos(Seq("http://www.youtube.com/watch?v=foo_12-34"))
+    val result = documentWithVideos("http://www.youtube.com/watch?v=foo_12-34")
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https YouTube video-element with an amp-youtube element" in {
-    val result = documentWithVideos(Seq("https://www.youtube.com/watch?v=foo_12-34"))
+    val result = documentWithVideos("https://www.youtube.com/watch?v=foo_12-34")
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake YouTube video-element with an amp-vimeo element" in {
-    val result = documentWithVideos(Seq(
+    val result = documentWithVideos(
       "http://www.youtube.com.de/watch?v=foo_12-34",
       "http://myyoutube.com/watch?v=foo_12-34",
       "https://www.youtuber.com/watch?v=foo_12-34"
-    ))
+    )
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
-    val result = documentWithVideos(Seq("https://www.youtube.com/"))
+    val result = documentWithVideos("https://www.youtube.com/")
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a http Vimeo video-element with an amp-vimeo element" in {
-    val result = documentWithVideos(Seq("http://vimeo.com/1234"))
+    val result = documentWithVideos("http://vimeo.com/1234")
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https Vimeo video-element with an amp-vimeo element" in {
-    val result = documentWithVideos(Seq("https://vimeo.com/1234"))
+    val result = documentWithVideos("https://vimeo.com/1234")
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake Vimeo video-element with an amp-vimeo element" in {
-    val result = documentWithVideos(Seq(
+    val result = documentWithVideos(
       "https://vimeo.com.zz/1234",
       "https://vimeofake.com/1234",
       "https://myvimeo.com/1234"
-    ))
+    )
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
 
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
-    val result = documentWithVideos(Seq("https://vimeo.com/"))
+    val result = documentWithVideos("https://vimeo.com/")
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
 
   "AmpEmbedCleaner" should "be able to create an amp-youtube element and an amp-vimeo in the same document" in {
-    val result = documentWithVideos(Seq(
+    val result = documentWithVideos(
       "https://www.youtube.com/watch?v=foo_12-34",
       "https://vimeo.com/1234"
-    ))
+    )
     result.getElementsByTag("amp-youtube").size should be(1)
     result.getElementsByTag("amp-vimeo").size should be(1)
   }

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -17,7 +17,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   /////////////////////////////
-  // Youtube cleaner
+  // External video cleaner
   /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in a YouTube video-element with an amp-youtube element" in {
@@ -37,10 +37,6 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
     result.getElementsByTag("amp-youtube").size should be(0)
   }
-
-  /////////////////////////////
-  // Vimeo cleaner
-  /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in a Vimeo video-element with an amp-vimeo element" in {
     val vimeoUrl = "https://vimeo.com/1234"

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -16,125 +16,71 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     document
   }
 
+  private def documentWithVideos(videoUrls: Seq[String]): Document = {
+    val doc = "<html><body>" +
+      videoUrls.foldLeft(""){ (res: String, next: String) => res + s"""<figure class="element-video" data-canonical-url="$next"><iframe></iframe></figure>""" } +
+      "</body></html>"
+    val document: Document = Jsoup.parse(doc)
+    clean(document)
+  }
+
   /////////////////////////////
   // External video cleaner
   /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in a http YouTube video-element with an amp-youtube element" in {
-    val youtubeUrl = "http://www.youtube.com/watch?v=foo_12-34"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("http://www.youtube.com/watch?v=foo_12-34"))
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https YouTube video-element with an amp-youtube element" in {
-    val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("https://www.youtube.com/watch?v=foo_12-34"))
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake YouTube video-element with an amp-vimeo element" in {
-    val fakeYoutubeUrl1 = "http://www.youtube.com.de/watch?v=foo_12-34"
-    val fakeYoutubeUrl2 = "http://myyoutube.com/watch?v=foo_12-34"
-    val fakeYoutubeUrl3 = "https://www.youtuber.com/watch?v=foo_12-34"
-    val doc =
-      s"""<html><body>
-         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl1"><iframe></iframe></figure>
-         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl2"><iframe></iframe></figure>
-         |<figure class="element-video" data-canonical-url="$fakeYoutubeUrl3"><iframe></iframe></figure>
-         |</body></html>""".stripMargin
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq(
+      "http://www.youtube.com.de/watch?v=foo_12-34",
+      "http://myyoutube.com/watch?v=foo_12-34",
+      "https://www.youtuber.com/watch?v=foo_12-34"
+    ))
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
-    val youtubeUrl = s"https://www.youtube.com/"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
-    result.getElementsByTag("amp-youtube").size should be(0)
-  }
-
-  "AmpEmbedCleaner" should "not create an amp-youtube element if the iframe is missing" in {
-    val youtubeUrl = "http://www.youtube.com.de/watch?v=foo_12-34"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("https://www.youtube.com/"))
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a http Vimeo video-element with an amp-vimeo element" in {
-    val vimeoUrl = "http://vimeo.com/1234"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("http://vimeo.com/1234"))
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https Vimeo video-element with an amp-vimeo element" in {
-    val vimeoUrl = "https://vimeo.com/1234"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("https://vimeo.com/1234"))
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake Vimeo video-element with an amp-vimeo element" in {
-    val fakeVimeoUrl1 = "https://vimeo.com.zz/1234"
-    val fakeVimeoUrl2 = "https://myvimeo.com/1234"
-    val fakeVimeoUrl3 = "https://vimeofake.com/1234"
-    val doc =
-      s"""<html><body>
-         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl1"><iframe></iframe></figure>
-         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl2"><iframe></iframe></figure>
-         |<figure class="element-video" data-canonical-url="$fakeVimeoUrl3"><iframe></iframe></figure>
-         |</body></html>""".stripMargin
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq(
+      "https://vimeo.com.zz/1234",
+      "https://vimeofake.com/1234",
+      "https://myvimeo.com/1234"
+    ))
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
 
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
-    val vimeoUrl = s"https://vimeo.com/"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
-    result.getElementsByTag("amp-vimeo").size should be(0)
-  }
-
-  "AmpEmbedCleaner" should "not create an amp-vimeo element if the iframe is missing" in {
-    val vimeoUrl = "https://vimeo.com/1234"
-    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"></figure></body></html>"""
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq("https://vimeo.com/"))
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
 
   "AmpEmbedCleaner" should "be able to create an amp-youtube element and an amp-vimeo in the same document" in {
-    val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
-    val vimeoUrl = "https://vimeo.com/1234"
-    val doc =
-      s"""<html><body>
-         |<figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure>
-         |<figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure>
-         |</body></html>""".stripMargin
-    val document: Document = Jsoup.parse(doc)
-    val result: Document = clean(document)
-
+    val result = documentWithVideos(Seq(
+      "https://www.youtube.com/watch?v=foo_12-34",
+      "https://vimeo.com/1234"
+    ))
     result.getElementsByTag("amp-youtube").size should be(1)
     result.getElementsByTag("amp-vimeo").size should be(1)
   }

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -21,8 +21,8 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   /////////////////////////////
 
   "AmpEmbedCleaner" should "replace an iframe in a YouTube video-element with an amp-youtube element" in {
-    val youtubeUrl = "https://www.youtube.com/watch?v=foo123"
-    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure></body></html>"""
+    val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 
@@ -31,7 +31,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
     val youtubeUrl = s"http://www.youtube.com/"
-    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure></body></html>"""
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 
@@ -61,9 +61,9 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "be able to create an amp-youtube element and an amp-vimeo in the same document" in {
-    val youtubeUrl = "https://www.youtube.com/watch?v=foo123"
+    val youtubeUrl = "https://www.youtube.com/watch?v=foo_12-34"
     val vimeoUrl = "https://vimeo.com/1234"
-    val doc = s"""<html><body><figure class="element-video"><iframe data-canonical-url="$youtubeUrl"></iframe></figure><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"><iframe></iframe></figure><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -63,6 +63,15 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
+  "AmpEmbedCleaner" should "not create an amp-youtube element if the iframe is missing" in {
+    val youtubeUrl = "http://www.youtube.com.de/watch?v=foo_12-34"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$youtubeUrl"></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-youtube").size should be(0)
+  }
+
   "AmpEmbedCleaner" should "replace an iframe in a http Vimeo video-element with an amp-vimeo element" in {
     val vimeoUrl = "http://vimeo.com/1234"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
@@ -96,10 +105,19 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
-  
+
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
     val vimeoUrl = s"https://vimeo.com/"
     val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"><iframe></iframe></figure></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = clean(document)
+
+    result.getElementsByTag("amp-vimeo").size should be(0)
+  }
+
+  "AmpEmbedCleaner" should "not create an amp-vimeo element if the iframe is missing" in {
+    val vimeoUrl = "https://vimeo.com/1234"
+    val doc = s"""<html><body><figure class="element-video" data-canonical-url="$vimeoUrl"></figure></body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = clean(document)
 

--- a/tools/amp-validation/endpoints.js
+++ b/tools/amp-validation/endpoints.js
@@ -27,7 +27,7 @@ module.exports = (() => {
         '/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper', // Instagram + Twitter
         '/sport/live/2016/aug/25/county-cricket-surrey-lancashire-live-blog', // Twitter
         //'/sport/blog/2016/aug/25/baseball-olympic-games-2020-tokyo-mlb-team-selection', // Vine
-        //'/stage/2016/aug/24/they-drink-it-in-the-congo-review-adam-brace', // Vimeo
+        '/stage/2016/aug/24/they-drink-it-in-the-congo-review-adam-brace', // Vimeo
         '/commentisfree/2016/aug/25/burkini-french-muslim-isis', // Videop
         //'/music/musicblog/2010/sep/02/wiley-ustream', // uStream
         //'/world/2015/mar/16/london-teenagers-stopped-syria-parents-islamic-state', // audioboom


### PR DESCRIPTION
## What does this change?

Adds support for Vimeo embeds in AMP 🎥 ⚡️ 

Vimeo and YouTube embeds are constructed in a very similar way so I have built one consolidated cleaner for both embed types. 

## What is the value of this and can you measure success?

Articles with Vimeo embeds will now be indexable by AMP search platforms. Users will be able to view articles containing Vimeo embeds through AMP, providing a faster mobile experience for these articles.

## Does this affect other platforms - Amp, Apps, etc?

Yep 😄 

## Screenshots

![picture 122](https://cloud.githubusercontent.com/assets/5931528/19896383/079e777c-a04c-11e6-98b0-6968b4557b05.png)

## Request for comment

@guardian/dotcom-platform 

