### PR TITLE
Update canResonablyAskForMoney to reflect the new line from central production

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -124,7 +124,7 @@ define([
             switches.commercial;
 
         this.canReasonablyAskForMoney = // eg become a supporter, give a contribution
-            !(userFeatures.isPayingMember() || config.page.isSensitive || config.page.isAdvertisementFeature);
+            !(userFeatures.isPayingMember() || config.page.shouldHideAdverts || config.page.isAdvertisementFeature);
 
         this.async = {
             canDisplayMembershipEngagementBanner : detect.adblockInUse.then(function (adblockUsed) {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Currently, if an article is marked as isSensititve, we do not show any components that ask our readers for money in any way. However, on many of these articles, the shouldHideAdverts tag is marked as false. This is because the isSensitive tag is used very freely, especially on articles about foreign countries. The shouldHideAdverts tag is applied much more carefully, only on highly sensitive articles where it would be inappropriate to show adverts. 

We think the shouldHideAdverts tag is more suitable for our ads, and we asked Central Prod and they agree. So this change reflects the new line from Central Production on when it is ok to ask our readers for money. 

## What is the value of this and can you measure success?
We can show ads on more articles, whilst still not showing ads on clearly inappropriate articles. 


<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

… on when we can ask for money