### PR TITLE
Do not load sonobi on page skins

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
@@ -17,6 +17,9 @@ define([
         /* prebidEnabled: boolean. Set to true if header bidding is enabled, and the user is not participating in the sonobi test */
         prebidEnabled: config.page.edition == 'US' && !('tests' in config && config.tests.commercialHbSonobi),
 
+        /* sonobiEnabled: boolean. Set to true if sonobi real-time-bidding is enabled*/
+        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && !config.page.hasPageSkin,
+
         /* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
         lazyLoadEnabled: false,
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/init.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/init.js
@@ -28,7 +28,7 @@ define([
 
     function init() {
         if (commercialFeatures.dfpAdvertising) {
-            var initialTag = 'tests' in config && config.tests.commercialHbSonobi ? setupSonobi() : Promise.resolve();
+            var initialTag = dfpEnv.sonobiEnabled ? setupSonobi() : Promise.resolve();
             return initialTag.then(setupAdvertising);
         }
 
@@ -45,7 +45,7 @@ define([
 
         return new Promise(function(resolve) {
 
-            if ('tests' in config && config.tests.commercialHbSonobi && dfpEnv.shouldLazyLoad()) {
+            if (dfpEnv.sonobiEnabled) {
                 // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
                 require(['js!googletag.js']);
                 ophanTracking.addTag('sonobi');

--- a/static/src/javascripts/projects/commercial/modules/dfp/init.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/init.js
@@ -45,7 +45,7 @@ define([
 
         return new Promise(function(resolve) {
 
-            if ('tests' in config && config.tests.commercialHbSonobi) {
+            if ('tests' in config && config.tests.commercialHbSonobi && dfpEnv.shouldLazyLoad()) {
                 // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
                 require(['js!googletag.js']);
                 ophanTracking.addTag('sonobi');


### PR DESCRIPTION
The sonobi library doesn't support `enableSingleRequest`, so we should not run sonobi on pageskin pages.