### PR TITLE
Make the Twitter and Facebook overlays immortal

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -41,7 +41,7 @@ trait FeatureSwitches {
     "If this switch is turned on, we will overlay the guardian logo along the bottom of images shared on facebook",
     owners = Seq(Owner.withGithub("dominickendrick")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 11, 7),
+    sellByDate = never,
     exposeClientSide = false
   )
 
@@ -51,7 +51,7 @@ trait FeatureSwitches {
     "If this switch is turned on, we will overlay the guardian logo along the bottom of images shared on twitter",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 11, 7),
+    sellByDate = never,
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

- Makes the expiring Overlay feature switches live on

## What is the value of this and can you measure success?

- Switches do not expire next week
- Keeps the overlays on Twitter Cards and Open Graph image shares
- Keeps doing what we were doing

## Does this affect other platforms - Amp, Apps, etc?

- Twitter & Facebook - keeps the banner on our images for all shares
- Overlay will also still appear in Slack, WhatsApp, Telegram and any other apps that use the Open Graph protocol http://ogp.me/

## Screenshots

Twitter overlay images here: #13421
Facebook overlay images here: #13026

#### Bonus: Slack uses Open Graph 🎉 

<img width="639" alt="picture 348" src="https://cloud.githubusercontent.com/assets/8607683/19937571/b13e8fce-a119-11e6-8f8d-f605a15e7999.png">

## Request for comment

@dominickendrick 

