### PR TITLE
Paid content audio pages - caption fix

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -871,6 +871,12 @@
             }
         }
 
+        .content__main-column--audio {
+            .caption--img {
+                color: $neutral-4;
+            }
+        }
+
         .gu-media-wrapper--audio,
         .vjs-control-bar,
         .vjs-embed-button:hover .vjs-control-text,


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
This PR fixes small styling bug with a caption under an image in paid audio page.

## What is the value of this and can you measure success?
The caption is more visible now.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
Before:
![screen shot 2016-11-02 at 16 46 52](https://cloud.githubusercontent.com/assets/489567/19938204/02a78882-a11c-11e6-870a-4299a26cac9b.png)

After:
![screen shot 2016-11-02 at 16 47 01](https://cloud.githubusercontent.com/assets/489567/19938216/08caa834-a11c-11e6-8706-b965eb6ebffe.png)


## Request for comment
@guardian/commercial-dev 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

