### PR TITLE
Contributions Epic with membership ask test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,4 +95,14 @@ trait ABTestSwitches {
     sellByDate =  new LocalDate(2016, 11, 4),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-contributions-membership-epic",
+    "Find the optimal way of offering Contributions along side Membership in the Epic component",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = On,
+    sellByDate =  new LocalDate(2016, 11, 7),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -18,8 +18,13 @@ define([
             variants: ['control', 'global', 'democracy']
         };
 
+        var contributionsMembershipEpic = {
+            name: 'ContributionsMembershipEpic',
+            variants: ['control', 'contribute-member', 'member-contribute']
+        };
 
-        var clashingTests = [contributionsCountriesUk, contributionsCountriesAmerica];
+
+        var clashingTests = [contributionsCountriesUk, contributionsCountriesAmerica, contributionsMembershipEpic];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,7 +14,9 @@ define([
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
     'common/modules/experiments/tests/contributions-countries-uk',
-    'common/modules/experiments/tests/contributions-countries-america'
+    'common/modules/experiments/tests/contributions-countries-america',
+    'common/modules/experiments/tests/contributions-membership-epic'
+    
 ], function (
     reportError,
     config,
@@ -31,7 +33,8 @@ define([
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
     ContributionsCountriesUk,
-    ContributionsCountriesAmerica
+    ContributionsCountriesAmerica,
+    ContributionsMembershipEpic
 ) {
 
     var TESTS = [
@@ -42,7 +45,8 @@ define([
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
         new ContributionsCountriesUk(),
-        new ContributionsCountriesAmerica()
+        new ContributionsCountriesAmerica(),
+        new ContributionsMembershipEpic()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-america.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-countries-america.js
@@ -43,7 +43,7 @@ define([
         this.showForSensitive = false;
         this.audience = 0.15;
         this.audienceOffset = 0.5;
-        this.successMeasure = 'Impressions to number of contributions';
+        this.successMeasure = 'Impressions to number of contributions/supporter sign ups';
         this.audienceCriteria = 'All users in US';
         this.dataLinkNames = '';
         this.idealOutcome = 'The messages performs less than 20% differently in different countries';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
@@ -36,22 +36,25 @@ define([
     return function () {
 
         this.id = 'ContributionsMembershipEpic';
-        this.start = '2016-11-01';
-        this.expiry = '2016-11-04';
-        this.author = 'Phil Wills';
+        this.start = '2016-11-03';
+        this.expiry = '2016-11-07';
+        this.author = 'Jonathan Rankin';
         this.description = 'Find the optimal way of offering Contributions along side Membership in the Epic component';
-        this.showForSensitive = false;
+        this.showForSensitive = true;
         this.audience = 0.15;
-        this.audienceOffset = 0.5;
+        this.audienceOffset = 0.71;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
-        this.audienceCriteria = 'All users in US';
+        this.audienceCriteria = 'All users in US and UK';
         this.dataLinkNames = '';
-        this.idealOutcome = 'The messages performs less than 20% differently in different countries';
+        this.idealOutcome = 'One of the 3 variants proves to be a clear winner';
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
         };
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
 
         var componentWriter = function (component) {
             ajax({
@@ -60,7 +63,7 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if(resp.country === 'GB') {
+                if(resp.country === 'GB' || resp.country === 'US') {
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         component.insertBefore(submetaElement);
@@ -71,13 +74,30 @@ define([
             });
         };
 
-        var makeUrl = function(intcmp) {
-            return 'https://contribute.theguardian.com/us?INTCMP=co_us_donatom_footer_' + intcmp + '&amount=50';
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
         };
 
         var completer = function (complete) {
             mediator.on('contributions-embed:insert', function () {
-                bean.on(qwery('.js-submit-input-contribute')[0], 'click', complete);
+                bean.on(qwery('.js-submit-input-contribute')[0], 'click', function(){
+                    complete();
+                    require(['ophan/ng'], function (ophan) {
+                        ophan.record({
+                            component: 'contribute-button'
+                        });
+                    });
+
+                });
+
+                bean.on(qwery('.js-submit-input-membership')[0], 'click', function(){
+                    complete();
+                    require(['ophan/ng'], function (ophan) {
+                        ophan.record({
+                            component: 'membership-button'
+                        });
+                    });
+                });
             });
         };
 
@@ -87,7 +107,57 @@ define([
                 id: 'control',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl: makeUrl('control')
+                        linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_control'),
+                        linkUrl2: '',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
+                        p3: '',
+                        cta1: 'Make a contribution',
+                        cta2: '',
+                        cta1Class: 'js-submit-input-contribute',
+                        cta2Class: '',
+                        hidden: 'hidden'
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'contribute-member',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-main'),
+                        linkUrl2: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership-alt'),
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
+                        p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
+                        cta1: 'Make a contribution',
+                        cta2: 'becoming a Supporter.',
+                        cta1Class: 'js-submit-input-contribute',
+                        cta2Class: 'js-submit-input-membership',
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'member-contribute',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership-main'),
+                        linkUrl2: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-alt'),
+                        p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure. Get closer to our journalism, be part of our story and join the Guardian.',
+                        p3: 'Alternatively, you can ',
+                        cta1: 'Become a Supporter',
+                        cta2: 'make a one-off contribution.',
+                        cta1Class: 'js-submit-input-membership',
+                        cta2Class: 'js-submit-input-contribute',
+                        hidden: ''
                     }));
                     componentWriter(component);
                 },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
@@ -1,0 +1,101 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpic,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsMembershipEpic';
+        this.start = '2016-11-01';
+        this.expiry = '2016-11-04';
+        this.author = 'Phil Wills';
+        this.description = 'Find the optimal way of offering Contributions along side Membership in the Epic component';
+        this.showForSensitive = false;
+        this.audience = 0.15;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'Impressions to number of contributions/supporter signups';
+        this.audienceCriteria = 'All users in US';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'The messages performs less than 20% differently in different countries';
+        this.canRun = function () {
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if(resp.country === 'GB') {
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        component.insertBefore(submetaElement);
+                        embed.init();
+                        mediator.emit('contributions-embed:insert', component);
+                    });
+                }
+            });
+        };
+
+        var makeUrl = function(intcmp) {
+            return 'https://contribute.theguardian.com/us?INTCMP=co_us_donatom_footer_' + intcmp + '&amount=50';
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', function () {
+                bean.on(qwery('.js-submit-input-contribute')[0], 'click', complete);
+            });
+        };
+
+        this.variants = [
+
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl: makeUrl('control')
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/views/contributions-epic.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic.html
@@ -5,16 +5,15 @@
         <p class="contributions__paragraph contributions__paragraph--epic">... we have a small favour to ask. More people are reading the Guardian than ever. But far fewer are paying for it. And advertising revenues are falling
             fast. So you can see why we need to ask for your help. The Guardian's independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we
             believe our perspective matters - because it might well be your perspective, too. </p>
-        <p class="contributions__paragraph contributions__paragraph--epic">If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure. You can
-            give money to the Guardian in less than a minute.</p>
+        <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
     </div>
     <div class="contributions__amount-field">
         <div >
-            <a class="js-submit-input contributions__option-button contributions__contribute contributions__contribute--epic" href="<%=linkUrl%>" target="_blank">
-                Contribute
+            <a class="<%=cta1Class%> contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member" href="<%=linkUrl1%>" target="_blank">
+                <%=cta1%>
             </a>
         </div>
     </div>
-    <p class="contributions__paragraph contributions__paragraph--epic">Alterna </p>
-
+    <p class="contributions__paragraph contributions__paragraph--extra-copy contributions__<%=hidden%>">
+        <%=p3%> <a class="<%=cta2Class%> contributions__epic-link" href="<%=linkUrl2%>" target="_blank"><%=cta2%></a></p>
 </div>

--- a/static/src/javascripts/projects/common/views/contributions-epic.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic.html
@@ -5,28 +5,16 @@
         <p class="contributions__paragraph contributions__paragraph--epic">... we have a small favour to ask. More people are reading the Guardian than ever. But far fewer are paying for it. And advertising revenues are falling
             fast. So you can see why we need to ask for your help. The Guardian's independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we
             believe our perspective matters - because it might well be your perspective, too. </p>
-
         <p class="contributions__paragraph contributions__paragraph--epic">If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure. You can
             give money to the Guardian in less than a minute.</p>
     </div>
-    <div class="contributions__amount-field contributions__amount-field--<%=position%>">
-        <div class="contributions__button-group--epic contributions__button-group--epic-<%=variant%>">
-            <div class="js-button-group contributions__button-group u-cf">
-                <button type="button" class="js-button contributions__option-button contributions__option-button--epic contributions__option-button--<%=position%>" data-amount="25">
-                    <span class="currency js-currency">£</span>25
-                </button><button type="button" class="js-button contributions__option-button contributions__option-button--epic contributions__option-button--<%=position%> active" data-amount="50">
-                <span class="currency js-currency">£</span>50
-            </button><button type="button" class="js-button contributions__option-button contributions__option-button--epic contributions__option-button--<%=position%>" data-amount="100">
-                <span class="currency js-currency">£</span>100
-            </button><button type="button" class="js-button contributions__option-button contributions__option-button--epic contributions__option-button--<%=position%>" data-amount="250">
-                <span class="currency js-currency">£</span>250</button>
-            </div>
-        </div>
+    <div class="contributions__amount-field">
         <div >
-            <a class="js-submit-input contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--<%=position%> contributions__contribute--<%=variant%>--<%=id%>" href="<%=linkUrl%>" target="_blank">
-                <%=linkName%>
+            <a class="js-submit-input contributions__option-button contributions__contribute contributions__contribute--epic" href="<%=linkUrl%>" target="_blank">
+                Contribute
             </a>
         </div>
     </div>
+    <p class="contributions__paragraph contributions__paragraph--epic">Alterna </p>
 
 </div>

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -128,6 +128,12 @@
     }
 }
 
+.contributions__contribute--epic-member {
+    width: 150px;
+}
+
+
+
 
 .contributions__option-button--epic {
     &:hover {
@@ -147,19 +153,6 @@
 
 .contributions__button-group--epic {
     margin-bottom: $gs-baseline;
-}
-
-.contributions__contribute--no-buttons--today {
-    width: 150px;
-}
-
-.contributions__contribute--no-buttons--make {
-    width: 170px;
-}
-
-.contributions__contribute--no-buttons--control,
-.contributions__contribute--no-buttons--give {
-    width: 130px;
 }
 
 @include mq($from: phablet) {

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -19,7 +19,7 @@
 }
 
 .contributions__title--epic {
-    margin-bottom: $gs-baseline;
+    margin-bottom: 0;
 }
 
 .contributions__paragraph  {
@@ -30,8 +30,20 @@
     margin-top: $gs-baseline;
 }
 
+.contributions__paragraph--extra-copy {
+    margin-bottom: 0;
+}
+
+.contributions__hidden {
+    display: none;
+}
+
 .contributions__paragraph--epic {
     @include fs-bodyCopy(2);
+}
+
+.contributions__epic-link {
+    text-decoration: underline;
 }
 
 .contributions__option-button {
@@ -129,7 +141,7 @@
 }
 
 .contributions__contribute--epic-member {
-    width: 150px;
+    width: 160px;
 }
 
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

This PR tests out different versions of the epic component in the US and in the UK. One version just has a contributions ask, one has a contributions ask with a less prominent membership ask and the other has a membership ask with a less prominent contributions ask. 
 
## What is the value of this and can you measure success?

We can test what effect adding membership asks to the epic has on the overall conversion rate. The most successful combination will become the default epic.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

![screenshot at nov 03 13-18-51](https://cloud.githubusercontent.com/assets/2844554/19967462/43bb67a6-a1c8-11e6-9929-4524b730c892.png)

![screenshot at nov 03 13-19-20](https://cloud.githubusercontent.com/assets/2844554/19967463/43bd2ec4-a1c8-11e6-8772-bb58faa7af68.png)

![screenshot at nov 03 13-19-43](https://cloud.githubusercontent.com/assets/2844554/19967461/43b9cda6-a1c8-11e6-9c04-5f3b024fd214.png)


## Request for comment

@jfsoul @gtrufitt @desbo 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
