### PR TITLE
Add user agent and full url to GA

### DIFF
--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -7,7 +7,7 @@
     <script type="application/json">
             {
               "requests": {
-                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}"
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}"
               },
               "vars": {
                 "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,4 +1,4 @@
-@(content: model.Content)
+@(content: model.Content)(implicit request: RequestHeader)
 
 @import views.support.GoogleAnalyticsAccount
 
@@ -7,7 +7,7 @@
     <script type="application/json">
             {
               "requests": {
-                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}"
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}"
               },
               "vars": {
                 "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
@@ -27,7 +27,8 @@
                     "keywordIds": "@{content.tags.keywords.map(_.id).mkString(",")}",
                     "toneIds": "@{content.tags.tones.map(_.id).mkString(",")}",
                     "seriesId": "@{content.tags.series.map(_.id).headOption.getOrElse("")}",
-                    "isHostedFlag": "@{content.metadata.isHosted.toString}"
+                    "isHostedFlag": "@{content.metadata.isHosted.toString}",
+                    "fullRequestUrl": "@{request.domain}@{request.uri}"
                   }
                 }
               }

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -75,6 +75,7 @@
         ga('@{trackerName}.set', 'dimension22', getQueryParam('CMP_BUNIT')); @* campaign business unit*@
         ga('@{trackerName}.set', 'dimension23', getQueryParam('CMP_TU')); @* campaign team*@
         ga('@{trackerName}.set', 'dimension26', (!!guardian.config.page.isHosted).toString());
+        ga('@{trackerName}.set', 'dimension27', navigator.userAgent);
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -76,6 +76,7 @@
         ga('@{trackerName}.set', 'dimension23', getQueryParam('CMP_TU')); @* campaign team*@
         ga('@{trackerName}.set', 'dimension26', (!!guardian.config.page.isHosted).toString());
         ga('@{trackerName}.set', 'dimension27', navigator.userAgent);
+        ga('@{trackerName}.set', 'dimension29', window.location + window.location.search);
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?

Adds the user agent string and URL to the GA page hit.

## What is the value of this and can you measure success?

- user-agent: Full string is required by ABC auditing and is not not available from the standard page view hits in GA
- URL: Full string is required as GA "automatically strips out all 'utm' parameters before it populates the page report (but leaves in any native non google query params like own own CMP parameters)." via @mkopka 

## Does this affect other platforms - Amp, Apps, etc?

Yes, I have added the url but I can't add the user-agent as there's some weirdness happening with the `amp-analytics` side of things that I've queried with them so will add that later.

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
