### PR TITLE
Extend UK message copy experiment switch beyond POTUS election

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -61,8 +61,8 @@ trait ABTestSwitches {
     "ab-membership-engagement-message-copy-experiment",
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 11, 8),
+    safeState = On, // so we don't inadvertently turn off during deployment
+    sellByDate = new LocalDate(2016, 11, 10), // Thursday night
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
The UK membership engagement copy test finishes on Monday night, and its master switch is due to expire on Tuesday night. 

We don't want to deploy anything from Monday aftenoon through to Wednesday morning due to the US election. This PR extends the switch expiry date to Thursday (night). 

The switch `safeState` now defaults to `On` so that we don't switch the test off as the change is deployed.

The test will still end as planned on Monday night, but builds won't break due to an expired switch.

## What is the value of this and can you measure success?
Builds won't break. Or at least not because of this switch.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
N/A

## Request for comment
@Ap0c @svillafe @rtyley @rupertbates 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

