### PR TITLE
Fix for cannot dismiss bug

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -284,7 +284,9 @@ define([
 
             loadBreakingNews: function () {
                 if (config.switches.breakingNews && config.page.section !== 'identity' && !config.page.isHosted) {
-                    breakingNews();
+                    breakingNews().check(function() {
+                        // breaking news may not load if local storage is unavailable - this is fine
+                    });
                 }
             },
 

--- a/static/src/javascripts/projects/common/utils/fetch-json.js
+++ b/static/src/javascripts/projects/common/utils/fetch-json.js
@@ -24,11 +24,11 @@ define([
                         try {
                             return JSON.parse(responseText);
                         } catch (ex) {
-                            throw new Error('Fetch error: Invalid JSON response');
+                            throw new Error('Fetch error while requesting ' + input + ': Invalid JSON response');
                         }
                     });
                 } else {
-                    throw new Error('Fetch error: ' + resp.statusText);
+                    throw new Error('Fetch error while requesting ' + input + ': ' + resp.statusText);
                 }
             }
         });


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Fix for cannot dismiss bug
    
1. The cannot dismiss message from breaking news is caused
    by an unhandled promise rejection bubbling up to the top
    level when local storage is not available - we now ignore
    this error.
    
2. Improvement to the fetch error messages.

## What is the value of this and can you measure success?

Fixes another sentry crash

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

Nope

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

N/A

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

1. The cannot dismiss message from breaking news is caused
   by an unhandled promise rejection bubbling up to the top
   level when local storage is not available - we now ignore
   this error.

2. Improvement to the fetch error messages.