### PR TITLE
Fix membership link bug

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic.js
@@ -129,7 +129,7 @@ define([
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
                         linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-main'),
-                        linkUrl2: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership-alt'),
+                        linkUrl2: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership_alt'),
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
                         p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
                         cta1: 'Make a contribution',
@@ -149,7 +149,7 @@ define([
                 id: 'member-contribute',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership-main'),
+                        linkUrl1: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership_main'),
                         linkUrl2: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-alt'),
                         p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure. Get closer to our journalism, be part of our story and join the Guardian.',
                         p3: 'Alternatively, you can ',


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Apparently, hypens are ok for contributions but not for membership. the codes were being cut off at the hypen. This bug fixes the campaign codes for the membership links

## What is the value of this and can you measure success?

We can measure the success of our test

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

