### PR TITLE
Fix to fix for breaking news

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -284,7 +284,7 @@ define([
 
             loadBreakingNews: function () {
                 if (config.switches.breakingNews && config.page.section !== 'identity' && !config.page.isHosted) {
-                    breakingNews().check(function() {
+                    breakingNews().catch(function() {
                         // breaking news may not load if local storage is unavailable - this is fine
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -221,7 +221,7 @@ define([
                     reportError(ex, { feature: 'breaking-news' });
                 });
         } else {
-            return Promise.reject('cannot dismiss');
+            return Promise.reject(new Error('cannot dismiss'));
         }
     }
 

--- a/static/test/javascripts/spec/common/onward/breaking-news.spec.js
+++ b/static/test/javascripts/spec/common/onward/breaking-news.spec.js
@@ -93,7 +93,7 @@ define([
                     done.fail('user cannot use local storage, but we seem to think things are okish');
                 }, function (res) {
                     expect(fetchJson).not.toHaveBeenCalled();
-                    expect(res).toEqual('cannot dismiss');
+                    expect(res.message).toEqual('cannot dismiss');
                     expect($('.js-breaking-news-placeholder:not(:empty)').length).toBe(0);
                 }).then(done).catch(done.fail);
             });


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

typo, weirdly only manifested on code checking

## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

