### PR TITLE
Do not stringify circular structures in SpaceFinder

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -226,7 +226,7 @@ define([
 
     function SpaceError(rules) {
         this.name = 'SpaceError';
-        this.message = 'There is no space left matching rules ' + JSON.stringify(rules);
+        this.message = 'There is no space left matching rules from ' + rules.bodySelector;
         this.stack = (new Error()).stack;
     }
 


### PR DESCRIPTION
There are a high number of errors coming from space finder in Sentry. Removing the `stringify`, don't think it's super useful to have the full object.