### PR TITLE
extract some video logic into modules

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -10,14 +10,13 @@ define([
     'common/utils/defer-to-analytics',
     'common/utils/detect',
     'common/utils/mediator',
-    'common/utils/url',
-    'common/utils/ajax',
     'common/modules/analytics/beacon',
-    'commercial/modules/build-page-targeting',
+    'common/modules/commercial/video-ad-url',
     'common/modules/commercial/commercial-features',
     'common/modules/component',
     'common/modules/experiments/ab',
     'common/modules/video/events',
+    'common/modules/video/metadata',
     'common/modules/media/videojs-plugins/fullscreener',
     'common/modules/media/videojs-plugins/skip-ad',
     'common/modules/video/video-container',
@@ -40,14 +39,13 @@ define([
     deferToAnalytics,
     detect,
     mediator,
-    urlUtils,
-    ajax,
     beacon,
-    buildPageTargeting,
+    videoAdUrl,
     commercialFeatures,
     Component,
     ab,
     events,
+    videoMetadata,
     fullscreener,
     skipAd,
     videoContainer,
@@ -57,24 +55,6 @@ define([
     videojs,
     loadingTmpl
 ) {
-    function getAdUrl() {
-        var queryParams = {
-            ad_rule:                 1,
-            correlator:              new Date().getTime(),
-            cust_params:             encodeURIComponent(urlUtils.constructQuery(buildPageTargeting())),
-            env:                     'vp',
-            gdfp_req:                1,
-            impl:                    's',
-            iu:                      config.page.adUnit,
-            output:                  'xml_vast2',
-            scp:                     encodeURIComponent('slot=video'),
-            sz:                      '400x300',
-            unviewed_position_start: 1
-        };
-
-        return 'https://' + config.page.dfpHost + '/gampad/ads?' + urlUtils.constructQuery(queryParams);
-    }
-
     function initLoadingSpinner(player) {
         player.loadingSpinner.contentEl().innerHTML = loadingTmpl;
     }
@@ -97,7 +77,7 @@ define([
 
     function createVideoPlayer(el, options) {
         var player = videojs(el, options);
-        // Commenting out line below but reluctant to delete it
+
         var duration = parseInt(el.getAttribute('data-duration'), 10);
 
         player.ready(function () {
@@ -166,31 +146,6 @@ define([
         }
     }
 
-    function isGeoBlocked(el) {
-        var source = el.currentSrc;
-
-        // we currently only block to the uk
-        // these files are placed in a special location
-        if (source.indexOf('/ukonly/') !== -1) {
-            return new Promise(function(resolve) {
-                ajax({
-                    url: source,
-                    crossOrigin: true,
-                    method: 'head'
-                }).then(function() {
-                    resolve(false);
-                }, function (response) {
-                    // videos are blocked at the CDN level
-                    resolve(response.status === 403);
-                });
-            });
-        } else {
-            return new Promise(function (resolve) {
-                resolve(false);
-            });
-        }
-    }
-
     function enhanceVideo(el, autoplay, shouldPreroll) {
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs'),
@@ -202,38 +157,11 @@ define([
             canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? embedPath : null),
             // the fallback to window.location.pathname should only happen for main media on fronts
             gaEventLabel = canonicalUrl || window.location.pathname,
-            shouldHideAdverts = $el.attr('data-block-video-ads') !== 'false',
             player,
             mouseMoveIdle,
             playerSetupComplete,
             withPreroll,
             blockVideoAds;
-
-        var videoInfo = new Promise(function(resolve) {
-            // We only have the canonical URL in videos embedded in articles / main media.
-            // These are set to the safest defaults that will always play video.
-            var defaultVideoInfo = {
-                expired: false,
-                shouldHideAdverts: shouldHideAdverts
-            };
-
-            if (!canonicalUrl) {
-                resolve(defaultVideoInfo);
-            } else {
-                var ajaxInfoUrl = config.page.ajaxUrl + '/' + canonicalUrl;
-
-                ajax({
-                    url: ajaxInfoUrl + '/info.json',
-                    type: 'json',
-                    crossOrigin: true
-                }).then(function(videoInfo) {
-                    resolve(videoInfo);
-                }, function() {
-                    // if this fails, don't stop, keep going.
-                    resolve(defaultVideoInfo);
-                });
-            }
-        });
 
         player = createVideoPlayer(el, videojsOptions({
             plugins: {
@@ -247,7 +175,7 @@ define([
         events.addPrerollEvents(player, mediaId, mediaType);
         events.bindGoogleAnalyticsEvents(player, gaEventLabel);
 
-        videoInfo.then(function(videoInfo) {
+        videoMetadata.getVideoInfo(el).then(function(videoInfo) {
             if (videoInfo.expired) {
                 player.ready(function() {
                     player.error({
@@ -261,7 +189,7 @@ define([
                     player.controlBar.dispose();
                 });
             } else {
-                isGeoBlocked($el[0]).then(function (isVideoGeoBlocked) {
+                videoMetadata.isGeoBlocked(el).then(function (isVideoGeoBlocked) {
                     if (isVideoGeoBlocked) {
                         player.ready(function() {
                             player.error({
@@ -319,28 +247,25 @@ define([
                                     }
 
                                     if (withPreroll) {
-                                        raven.wrap(
-                                            { tags: { feature: 'media' } },
-                                            function () {
-                                                player.ima({
-                                                    id: mediaId,
-                                                    adTagUrl: getAdUrl(),
-                                                    prerollTimeout: 1000,
-                                                    // We set this sightly higher so contrib-ads never timeouts before ima.
-                                                    contribAdsSettings: {
-                                                        timeout: 2000
-                                                    }
-                                                });
-                                                player.on('adstart', function() {
-                                                    player.skipAd(mediaType, 15);
-                                                });
-                                                player.ima.requestAds();
+                                        raven.wrap({ tags: { feature: 'media' } }, function () {
+                                            player.ima({
+                                                id: mediaId,
+                                                adTagUrl: videoAdUrl.get(),
+                                                prerollTimeout: 1000,
+                                                // We set this sightly higher so contrib-ads never timeouts before ima.
+                                                contribAdsSettings: {
+                                                    timeout: 2000
+                                                }
+                                            });
+                                            player.on('adstart', function() {
+                                                player.skipAd(mediaType, 15);
+                                            });
+                                            player.ima.requestAds();
 
-                                                // Video analytics event.
-                                                player.trigger(events.constructEventName('preroll:request', player));
-                                                resolve();
-                                            }
-                                        )();
+                                            // Video analytics event.
+                                            player.trigger(events.constructEventName('preroll:request', player));
+                                            resolve();
+                                        })();
                                     } else {
                                         resolve();
                                     }

--- a/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
+++ b/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
@@ -1,0 +1,31 @@
+define([
+    'common/utils/config',
+    'common/utils/url',
+    'commercial/modules/build-page-targeting'
+], function (
+    config,
+    urlUtils,
+    buildPageTargeting
+) {
+    function getAdUrl () {
+        var queryParams = {
+            ad_rule: 1,
+            correlator: new Date().getTime(),
+            cust_params: encodeURIComponent(urlUtils.constructQuery(buildPageTargeting())),
+            env: 'vp',
+            gdfp_req: 1,
+            impl:'s',
+            iu: config.page.adUnit,
+            output: 'xml_vast2',
+            scp: encodeURIComponent('slot=video'),
+            sz: '400x300',
+            unviewed_position_start: 1
+        };
+
+        return 'https://' + config.page.dfpHost + '/gampad/ads?' + urlUtils.constructQuery(queryParams);
+    }
+
+    return {
+        get: getAdUrl
+    };
+});

--- a/static/src/javascripts/projects/common/modules/video/metadata.js
+++ b/static/src/javascripts/projects/common/modules/video/metadata.js
@@ -1,0 +1,71 @@
+define([
+    'common/utils/ajax',
+    'common/utils/config'
+], function (
+    ajax,
+    config
+) {
+    function isGeoBlocked(el) {
+        var source = el.currentSrc;
+
+        // we currently only block to the uk
+        // these files are placed in a special location
+        if (source.indexOf('/ukonly/') !== -1) {
+            return new Promise(function(resolve) {
+                ajax({
+                    url: source,
+                    crossOrigin: true,
+                    method: 'head'
+                }).then(function() {
+                    resolve(false);
+                }, function (response) {
+                    // videos are blocked at the CDN level
+                    resolve(response.status === 403);
+                });
+            });
+        } else {
+            return new Promise(function (resolve) {
+                resolve(false);
+            });
+        }
+    }
+
+    function getVideoInfo(el) {
+        var shouldHideAdverts = el.dataset.blockVideoAds !== 'false';
+        var embedPath = el.dataset.embedPath;
+
+        // we need to look up the embedPath for main media videos
+        var canonicalUrl = el.dataset.canonicalUrl || (embedPath ? embedPath : null);
+
+        return new Promise(function(resolve) {
+            // We only have the canonical URL in videos embedded in articles / main media.
+            // These are set to the safest defaults that will always play video.
+            var defaultVideoInfo = {
+                expired: false,
+                shouldHideAdverts: shouldHideAdverts
+            };
+
+            if (!canonicalUrl) {
+                resolve(defaultVideoInfo);
+            } else {
+                var ajaxInfoUrl = config.page.ajaxUrl + '/' + canonicalUrl;
+
+                ajax({
+                    url: ajaxInfoUrl + '/info.json',
+                    type: 'json',
+                    crossOrigin: true
+                }).then(function(videoInfo) {
+                    resolve(videoInfo);
+                }, function() {
+                    // if this fails, don't stop, keep going.
+                    resolve(defaultVideoInfo);
+                });
+            }
+        });
+    }
+
+    return {
+        isGeoBlocked: isGeoBlocked,
+        getVideoInfo: getVideoInfo
+    };
+});


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
no functional change, just makes `media/main.js` slightly easier to reason about

## What is the value of this and can you measure success?
fewer 🤕 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
n/a

## Request for comment
@gidsg @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->