### PR TITLE
Disable sticky banner when the top slot is disabled

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -28,9 +28,9 @@ define([
 
     function init(_window) {
         win = _window || window;
-        if (detect.isBreakpoint({ min: 'desktop' })) {
+        topSlot = document.getElementById(topSlotId);
+        if (topSlot && detect.isBreakpoint({ min: 'desktop' })) {
             header = document.getElementById('header');
-            topSlot = document.getElementById(topSlotId);
             stickyBanner = topSlot.parentNode;
 
             // First, let's assign some default values so that everything


### PR DESCRIPTION
Some pages don't have a top slot, like the profile pages for instance. The sticky top banner is trying to access the parent of a node that does not exist then:

```
topSlot = document.getElementById(topSlotId); // does not exist
stickyBanner = topSlot.parentNode; // ಥ_ಥ
```

To prevent this from happening, we just make sure the top slot exists.

cc @rich-nguyen 
