### PR TITLE
Update sonobi script location to geo sensitive api.nexgen location

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -229,7 +229,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object sonobi {
-    lazy val jsLocation = configuration.getStringProperty("sonobi.js.location").getOrElse("//mtrx.go.sonobi.com/morpheus.theguardian.2919.js")
+    lazy val jsLocation = configuration.getStringProperty("sonobi.js.location").getOrElse("//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js")
   }
 
   object frontend {


### PR DESCRIPTION
This updates globally the Sonobi script location via our proxy. This proxy rewrites the location of the script depending on the geolocation of the request.

This is done by region: UK/ROW, AU and US.

This is not to be merged until Sonobi have tested the script on a test page.

See referred to PRs.

@rich-nguyen