### PR TITLE
Update CommercialSonobiRubicon test location for Sonobi Geo

### DIFF
--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -31,7 +31,7 @@ window.curlConfig = {
             'googletag.js':                      '@{Configuration.javascript.config("googletagJsUrl")}',
             'sonobi.js': '@{
                 if (CommercialSonobiRubiconAdapter.isParticipating) {
-                    "//mtrx.go.sonobi.com/morpheus.theguardian.10744.js"
+                    "//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js"
                 } else {
                     Configuration.javascript.config("sonobiHeaderBiddingJsUrl")
                 }
@@ -72,7 +72,7 @@ window.curlConfig = {
             'googletag.js':                 '@{Configuration.javascript.config("googletagJsUrl")}',
             'sonobi.js': '@{
                if (CommercialSonobiRubiconAdapter.isParticipating) {
-                   "//mtrx.go.sonobi.com/morpheus.theguardian.10744.js"
+                   "//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js"
                } else {
                    Configuration.javascript.config("sonobiHeaderBiddingJsUrl")
                }


### PR DESCRIPTION
This updates the `CommercialSonobiRubiconAdapter` test to point to the new geo sensitive location of the Sonobi script.

See https://github.com/guardian/frontend/pull/14883 and https://github.com/guardian/frontend/pull/14768

The test location is at `/politics/2016/oct/24/nicola-sturgeon-says-brexit-meeting-was-deeply-frustrating`

@rich-nguyen 