### PR TITLE
Membership/Contributions Epic brexit test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -88,8 +88,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-membership-epic",
-    "Find the optimal way of offering Contributions along side Membership in the Epic component",
+    "ab-contributions-membership-epic-brexit",
+    "Find the optimal way of offering Contributions along side Membership in the Epic component on articles about Brexit",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = On,
     sellByDate =  new LocalDate(2016, 11, 7),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -19,8 +19,8 @@ define([
         };
 
         var contributionsMembershipEpic = {
-            name: 'ContributionsMembershipEpic',
-            variants: ['control', 'contribute-member', 'member-contribute']
+            name: 'ContributionsMembershipEpicBrexit',
+            variants: ['control', 'member-contribute']
         };
 
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,7 +14,7 @@ define([
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
     'common/modules/experiments/tests/contributions-countries-uk',
     'common/modules/experiments/tests/contributions-countries-america',
-    'common/modules/experiments/tests/contributions-membership-epic'
+    'common/modules/experiments/tests/contributions-membership-epic-brexit'
     
 ], function (
     reportError,
@@ -32,7 +32,7 @@ define([
     MembershipEngagementUSMessageCopyExperiment,
     ContributionsCountriesUk,
     ContributionsCountriesAmerica,
-    ContributionsMembershipEpic
+    ContributionsMembershipEpicBrexit
 ) {
 
     var TESTS = [
@@ -43,7 +43,7 @@ define([
         new MembershipEngagementUSMessageCopyExperiment(),
         new ContributionsCountriesUk(),
         new ContributionsCountriesAmerica(),
-        new ContributionsMembershipEpic()
+        new ContributionsMembershipEpicBrexit()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
@@ -35,22 +35,25 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsMembershipEpic';
-        this.start = '2016-11-03';
+        this.id = 'ContributionsMembershipEpicBrexit';
+        this.start = '2016-11-04';
         this.expiry = '2016-11-07';
         this.author = 'Jonathan Rankin';
-        this.description = 'Find the optimal way of offering Contributions along side Membership in the Epic component';
+        this.description = 'Find the optimal way of offering Contributions along side Membership in the Epic component on stories about Brexit';
         this.showForSensitive = true;
-        this.audience = 0.15;
-        this.audienceOffset = 0.71;
+        this.audience = 1;
+        this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
         this.audienceCriteria = 'All users in US and UK';
         this.dataLinkNames = '';
-        this.idealOutcome = 'One of the 3 variants proves to be a clear winner';
+        this.idealOutcome = 'One of the 2 variants proves to be a clear winner';
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
-            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            var keywords = config.page.keywordIds.split(',');
+            var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
+            var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
+            return isAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
         };
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
@@ -63,7 +66,7 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if(resp.country === 'GB' || resp.country === 'US') {
+                if(resp.country === 'GB') {
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         component.insertBefore(submetaElement);
@@ -102,34 +105,12 @@ define([
         };
 
         this.variants = [
-
             {
                 id: 'control',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_control'),
-                        linkUrl2: '',
-                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
-                        p3: '',
-                        cta1: 'Make a contribution',
-                        cta2: '',
-                        cta1Class: 'js-submit-input-contribute',
-                        cta2Class: '',
-                        hidden: 'hidden'
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'contribute-member',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-main'),
-                        linkUrl2: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership_alt'),
+                        linkUrl1: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-main_brexit'),
+                        linkUrl2: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership_alt_brexit'),
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
                         p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
                         cta1: 'Make a contribution',
@@ -149,8 +130,8 @@ define([
                 id: 'member-contribute',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership_main'),
-                        linkUrl2: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-alt'),
+                        linkUrl1: makeUrl(membershipUrl, 'gdnwb_copts_mem_epic_membership-main_brexit'),
+                        linkUrl2: makeUrl(contributeUrl, 'co_ukus_epic_footer_contribute-alt_brexit'),
                         p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure. Get closer to our journalism, be part of our story and join the Guardian.',
                         p3: 'Alternatively, you can ',
                         cta1: 'Become a Supporter',


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

In one fell swoop replaces the Contributions Membership Epic test we were running in the US and UK and replaces it with the same test with one fewer variant, but just running in the UK on Brexit articles and for 100% of the audience. 

## What is the value of this and can you measure success?

Can can gauge how strongly we can react to smaller news stories, as well as see if [main membership ask with a small contributions ask]  or [main contributions ask with small membership ask] resonates more with readers of Brexit related issues.  


<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

