### PR TITLE
adds ga tracking to off platform video player

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -83,7 +83,10 @@ define([
             var player,
                 mouseMoveIdle,
                 $el = bonzo(el).addClass('vjs'),
-                mediaId = $el.attr('data-media-id');
+                mediaId = $el.attr('data-media-id'),
+                canonicalUrl = $el.attr('data-canonical-url'),
+                gaEventLabel = canonicalUrl,
+                mediaType = el.tagName.toLowerCase();
 
             bonzo(el).addClass('vjs');
 
@@ -128,7 +131,9 @@ define([
 
                 }
 
+                events.addContentEvents(player, mediaId, mediaType);
                 events.bindContentEvents(player);
+                events.bindGoogleAnalyticsEvents(player, gaEventLabel);
             });
 
             mouseMoveIdle = debounce(function () { player.removeClass('vjs-mousemoved'); }, 500);


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Adds GA tracking to off platform video player. Not sure if we want to prefix `gaEventLabel` with something to help distinguish these events as coming from the off platform video player?

## What is the value of this and can you measure success?
GA replaces omniture.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
no

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
`cm6` is video end

<img width="640" alt="screen shot 2016-11-04 at 14 17 56" src="https://cloud.githubusercontent.com/assets/836140/20008898/3c769416-a29a-11e6-976a-061b4f1b1a22.png">


## Request for comment
@gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

