### PR TITLE
Hosted gallery Enlarged Captions mode [not to be merged yet]

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -33,7 +33,7 @@
     }
     </style>
         <!--<![endif]-->
-    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
+    <div class="hosted-page hosted-gallery-page--container hosted-gallery-page small-captions @if(page.campaign.fontColour.shouldHaveBrightFont) {hosted-page--bright}">
         @guardianHostedHeader("hosted-gallery-page", page)
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">
@@ -41,7 +41,7 @@
                 <div class="js-hosted-gallery-frame hosted-gallery__gallery-frame">
                     <div class="js-hosted-gallery-images hosted-gallery__images-container">
                         @guardianHostedGalleryImage(page.images.head, {
-                            <div class="hosted-gallery__meta js-hosted-gallery-meta">
+                            <div class="hosted-gallery__meta js-hosted-gallery-meta hosted-gallery__small-captions-only">
                                 <div class="content__main-column">
                                     <h1 class="hosted-gallery__heading">{page.title}</h1>
                                     <h3 class="hosted-gallery__sub-heading">{page.standfirst}</h3>
@@ -55,6 +55,13 @@
                     <div class="hosted-gallery__scroll-container js-hosted-gallery-scroll-container">
                         @for(i <- page.images.indices) {
                             <div class="hosted-gallery__image--placeholder"></div>
+                        }
+                    </div>
+                    <div class="hosted-gallery__large-captions-container hosted-gallery__large-captions-only">
+                        @for(i <- page.images.indices) {
+                            <div class="js-hosted-gallery-caption hosted-gallery__enlarged-caption">
+                                <div class="content__main-column">@{page.images(i).caption}</div>
+                            </div>
                         }
                     </div>
                     @guardianHostedGalleryCta(page.cta.label, page.cta.url, page.cta.btnText)
@@ -89,14 +96,14 @@
                                         @page.images(i).title
                                     </span>
                                 </div>
-                                <div class="hosted-gallery__caption-text">
+                                <div class="hosted-gallery__caption-text hosted-gallery__small-captions-only">
                                     @page.images(i).caption
                                     @if(page.images(i).caption.nonEmpty && page.images(i).credit.nonEmpty) {<br/>}
                                     @page.images(i).credit
                                 </div>
                             </div>
                         }
-                        <div class="hosted-gallery__info-button js-gallery-caption-button">
+                        <div class="hosted-gallery__info-button js-gallery-caption-button hosted-gallery__small-captions-only">
                             <span class="icon-i">i</span>
                             @fragments.inlineSvg("cross", "icon", List("inline-cross inline-icon "))
                         </div>

--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -38,6 +38,7 @@
         <div class="l-side-margins hosted__side">
             <section class="hosted-tone--dark hosted-gallery__gallery-section">
                 <div class="js-hosted-gallery-container hosted-gallery__gallery-container">
+                <div class="js-hosted-gallery-frame hosted-gallery__gallery-frame">
                     <div class="js-hosted-gallery-images hosted-gallery__images-container">
                         @guardianHostedGalleryImage(page.images.head, {
                             <div class="hosted-gallery__meta js-hosted-gallery-meta">
@@ -71,6 +72,7 @@
                         @fragments.inlineSvg("arrow-right", "icon", List("inline-arrow-down"))
                     </div>
                     @guardianHostedGalleryOj(page.cta.label, page.cta.url, page.cta.btnText, page.nextPages)
+                </div>
                 </div>
                 <div class="hosted__container hosted__container--content hosted-gallery__lower-bar js-gallery-caption-bar">
                     <header class="host__header hosted__social">

--- a/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
@@ -1,5 +1,5 @@
 @(ctaText: Option[String], ctaLink: String, buttonText: Option[String])
-    <div class="hosted-gallery__cta js-hosted-gallery-cta">
+    <div class="hosted-gallery__cta js-hosted-gallery-cta hosted-gallery__small-captions-only">
         <div class="hosted-gallery__cta-title">
             @{ctaText}
         </div>

--- a/commercial/app/views/hosted/guardianHostedGalleryOj.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryOj.scala.html
@@ -1,6 +1,6 @@
 @import common.commercial.hosted.hardcoded.NextHostedPage
 @(ctaText: Option[String], ctaLink: String, buttonText: Option[String], nextPages: List[NextHostedPage])
-    <div class="hosted-gallery__oj js-hosted-gallery-oj">
+    <div class="hosted-gallery__oj js-hosted-gallery-oj hosted-gallery__small-captions-only">
         <div class="hosted-gallery__oj-cta hosted-tone-border">
             <div class="hosted-gallery__cta-title">
                 @{ctaText}

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -49,7 +49,7 @@ define([
         this.$header = $('.js-hosted-headerwrap');
         this.$imagesContainer = $('.js-hosted-gallery-images', this.$galleryEl);
         this.$captionContainer = $('.js-gallery-caption-bar');
-        this.$captions = $('.js-hosted-gallery-caption', this.$captionContainer);
+        this.$captions = $('.js-hosted-gallery-caption');
         this.$scrollEl = $('.js-hosted-gallery-scroll-container', this.$galleryEl);
         this.$images = $('.js-hosted-gallery-image', this.$imagesContainer);
         this.$progress = $('.js-hosted-gallery-progress', this.$galleryEl);
@@ -311,7 +311,7 @@ define([
                 // load prev/current/next
                 this.loadSurroundingImages(this.index, this.$images.length);
                 this.$captions.each(function (caption, index) {
-                    bonzo(caption).toggleClass('current-caption', that.index === index + 1);
+                    bonzo(caption).toggleClass('current-caption', that.index - 1 === index  % that.$images.length);
                 });
                 bonzo(this.$counter).html(this.index + '/' + this.$images.length);
 
@@ -393,7 +393,8 @@ define([
             $galleryFrame = this.$galleryFrame,
             imgRatio = 5 / 3,
             imageWidth = width,
-            leftRight = 0;
+            leftRight = 0,
+            that = this;
         if (imgRatio < width / height) {
             imageWidth = height * imgRatio;
             leftRight = (width - imageWidth) / 2 + 'px';
@@ -404,6 +405,7 @@ define([
             $footer.css('width', 'auto');
             $galleryFrame.css('left', leftRight);
             $galleryFrame.css('right', leftRight);
+            that.loadSurroundingImages(0, that.$images.length);
         });
     };
 
@@ -426,6 +428,10 @@ define([
             return false;
         } else if (e.keyCode === 73) { // 'i'
             this.trigger('toggle-info');
+        } else if (e.keyCode === 67 && e.altKey && e.shiftKey) {
+            var $page = $('.hosted-page');
+            $page.toggleClass('small-captions');
+            $page.toggleClass('large-captions');
         }
     };
 

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -45,6 +45,7 @@ define([
 
         // ELEMENT BINDINGS
         this.$galleryEl = $('.js-hosted-gallery-container');
+        this.$galleryFrame = $('.js-hosted-gallery-frame');
         this.$header = $('.js-hosted-headerwrap');
         this.$imagesContainer = $('.js-hosted-gallery-images', this.$galleryEl);
         this.$captionContainer = $('.js-gallery-caption-bar');
@@ -188,14 +189,13 @@ define([
 
     HostedGallery.prototype.resizeImage = function (imgIndex) {
         var $imageDiv = this.$images[imgIndex],
-            $imagesContainer = this.$imagesContainer[0],
-            $gallery = this.$galleryEl[0],
+            $galleryFrame = this.$galleryFrame[0],
             $ctaFloat = this.$ctaFloat,
             $ojFloat = this.$ojFloat,
             $meta = this.$meta,
             $images = this.$images,
-            width = $gallery.clientWidth,
-            height = $imagesContainer.clientHeight,
+            width = $galleryFrame.clientWidth,
+            height = $galleryFrame.clientHeight,
             $sizer = $('.js-hosted-gallery-image-sizer', $imageDiv),
             imgRatio = this.imageRatios[imgIndex],
             ctaSize = getFrame(0),
@@ -390,9 +390,7 @@ define([
             height = $imagesContainer.clientHeight,
             $header = this.$header,
             $footer = this.$captionContainer,
-            $progress = this.$progress,
-            $ctaFloat = this.$ctaFloat,
-            $ojFloat = this.$ojFloat,
+            $galleryFrame = this.$galleryFrame,
             imgRatio = 5 / 3,
             imageWidth = width,
             leftRight = 0;
@@ -404,11 +402,8 @@ define([
             $header.css('width', imageWidth);
             $footer.css('margin', '0 ' + leftRight);
             $footer.css('width', 'auto');
-            $progress.css('right', leftRight);
-            bonzo($ctaFloat).css('left', leftRight);
-            bonzo($ojFloat).css('left', leftRight);
-            bonzo($ctaFloat).css('right', leftRight);
-            bonzo($ojFloat).css('right', leftRight);
+            $galleryFrame.css('left', leftRight);
+            $galleryFrame.css('right', leftRight);
         });
     };
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -302,6 +302,15 @@
     }
 }
 
+.hosted-gallery__gallery-frame {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+}
+
 .hosted-gallery-page--container {
     position: absolute;
     top: 0;
@@ -481,7 +490,7 @@ $progressColor: #ffffff;
     position: absolute;
     top: 50%;
     margin-top: $progressHeight / -2;
-    right: -10px;
+    right: 0;
     height: $progressHeight;
     width: $progressHeight;
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -1,3 +1,8 @@
+
+$headerHeight: 58px;
+$footerHeight: 46px;
+$approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
+
 .hosted-gallery__scroll-container {
     overflow-x: hidden;
     overflow-y: scroll;
@@ -302,6 +307,35 @@
     }
 }
 
+.small-captions .hosted-gallery__large-captions-only,
+.large-captions .hosted-gallery__small-captions-only {
+    display: none;
+}
+
+.hosted-gallery__enlarged-caption {
+    @include f-headlineSans;
+    position: absolute;
+    line-height: 26px;
+    font-size: 24px;
+    color: #ffffff;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    opacity: 0;
+    pointer-events: none;
+    padding: $gs-baseline $gs-gutter;
+    background: linear-gradient(to top, rgba(51, 51, 51, .9) 0%, rgba(51, 51, 51, .7) 50%, transparent 100%);
+    &.current-caption {
+        pointer-events: auto;
+        opacity: 1;
+    }
+    @include mq($until: tablet) {
+        padding-bottom: $footerHeight;
+        line-height: 20px;
+        font-size: 18px;
+    }
+}
+
 .hosted-gallery__gallery-frame {
     position: absolute;
     top: 0;
@@ -340,14 +374,9 @@
     height: calc(100% - 58px);
 }
 
-$headerHeight: 58px;
-$footerHeight: 46px;
-$approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
-
 .hosted-gallery-page {
     .hosted__headerwrap {
         width: $approxGalleryWidth;
-        max-width: 100%;
     }
     .hosted__social.host__header {
         padding: 0;
@@ -406,6 +435,9 @@ $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
     &.current-caption {
         opacity: 1;
         visibility: visible;
+    }
+    .large-captions & {
+        right: $gs-gutter;
     }
 }
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
New mode for the Hosted Gallery, where the captions are displayed over the top of the images. 

We will switch between the two modes based on a flag from CAPI eventually, but for now there's a keyboard shortcut (press alt-shift-C), so we can see how it looks for existing galleries.

## What is the value of this and can you measure success?
Makes the gallery more versatile (and a current prospective client happy, we hope)
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No 
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
Existing mode:
![image](https://cloud.githubusercontent.com/assets/6290008/20011256/dca2e93c-a2a2-11e6-9310-bf56cf915597.png)
New mode:
![image](https://cloud.githubusercontent.com/assets/6290008/20010758/3bf15c40-a2a1-11e6-8ac8-1795c6b0fce9.png)

## Request for comment
@guardian/labs-beta 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
