### PR TITLE
Add more apps to deploys-radiator

### DIFF
--- a/static/src/deploys-radiator/app/main.js
+++ b/static/src/deploys-radiator/app/main.js
@@ -27,8 +27,11 @@ const run = () => {
         'diagnostics',
         'discussion',
         'facia',
+        'facia-press',
         'identity',
         'onward',
+        'preview',
+        'rss',
         'sport'
     ]);
     const filterWhitelisted = (deploys) => deploys


### PR DESCRIPTION
## What does this change?
Adds preview, rss, facia-press to deploys radiator.  I would argue anything deployed via goo should be included in the radiator (these are the remaining ones AFAIK), but I'm willing to listen to counter-arguments 😄 

## What is the value of this and can you measure success?
Allows users of the radiator to see if preview, rss, facia-press fail deployment.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Request for comment
@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

