### PR TITLE
fetch end-slate on video play rather than page load

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -312,18 +312,20 @@ define([
 
     function initEndSlate(player, endSlatePath) {
         var endSlate = new Component(),
-            endState = 'vjs-has-ended';
+            endStateClass = 'vjs-has-ended';
 
         endSlate.endpoint = endSlatePath;
-        endSlate.fetch(player.el(), 'html');
 
         player.one(events.constructEventName('content:play', player), function () {
+            endSlate.fetch(player.el(), 'html');
+
             player.on('ended', function () {
-                bonzo(player.el()).addClass(endState);
+                bonzo(player.el()).addClass(endStateClass);
             });
         });
+
         player.on('playing', function () {
-            bonzo(player.el()).removeClass(endState);
+            bonzo(player.el()).removeClass(endStateClass);
         });
     }
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Reduces the number of calls made on page load. The end-slate url looks like http://localhost:9000/video/end-slate/section/film.json?shortUrl=https://gu.com/p/5amt6. The shortUrl is expanded, which is slow. Removing this call on page load should mean playback starts that bit sooner.

## What is the value of this and can you measure success?
Faster intial video playback.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
GIF of a video I've played before, to emphasise the fact the request is done on play rather than page load.

Before
![end-slate-before](https://cloud.githubusercontent.com/assets/836140/20015360/172e2dea-a2b3-11e6-9d67-e16f7d2fdb94.gif)

After
![end-slate](https://cloud.githubusercontent.com/assets/836140/20015275/be6af710-a2b2-11e6-98de-a4a1669c1346.gif)


## Request for comment
@gidsg @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

