### PR TITLE
clean atoms in main media

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -2,9 +2,9 @@
 @(article: model.Article, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import model.EndSlateComponents
-@import model.{AudioPlayer, VideoPlayer}
+@import model.{VideoPlayer}
 @import views.support.Video640
-@import views.{BodyCleaner, MainCleaner}
+@import views.{MainCleaner}
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
     <div class="media-primary">

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -28,7 +28,8 @@ object MainCleaner {
       withJsoup(BulletCleaner(html))(
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
-        MainFigCaptionCleaner
+        MainFigCaptionCleaner,
+        AtomsCleaner(article.content.atoms, shouldFence = true, amp)
       )
   }
 }


### PR DESCRIPTION
## What does this change?
Apply atom cleaner to main media block.

## What is the value of this and can you measure success?
Allow media atoms to display in a cleaned format within main media

## Does this affect other platforms - Amp, Apps, etc?
Also applies cleaner on AMP

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
<img width="774" alt="screen shot 2016-11-04 at 16 56 08" src="https://cloud.githubusercontent.com/assets/1764158/20015278/c13f4888-a2b2-11e6-9aa9-aa0a7171c427.png">


## Request for comment
CC @markjamesbutler @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

