### PR TITLE
Add guard in canRun for contributions tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
@@ -50,10 +50,14 @@ define([
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
-            var keywords = config.page.keywordIds.split(',');
-            var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
-            var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
-            return isAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            if('keywordIds' in config.page &&  'nonKeywordTagIds' in config.page) {
+                var keywords = config.page.keywordIds.split(',');
+                var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
+                var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
+                return isAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            } else {
+                return false;
+            }
         };
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-side-by-side.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-side-by-side.js
@@ -50,10 +50,15 @@ define([
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
-            var keywords = config.page.keywordIds.split(',');
-            var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
-            var isNotAboutBrexit = (keywords.indexOf('politics/eu-referendum') === -1) || (nonKeywordTagIds.indexOf('tone/news') === -1);
-            return isNotAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            if('keywordIds' in config.page &&  'nonKeywordTagIds' in config.page) {
+                var keywords = config.page.keywordIds.split(',');
+                var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
+                var isNotAboutBrexit = (keywords.indexOf('politics/eu-referendum') === -1) || (nonKeywordTagIds.indexOf('tone/news') === -1);
+                return isNotAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            } else {
+                return false;
+            }
+                
         };
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Fixes a bug where config.page.keywordIds and config.page.nonKeywordTagIds did not exist. 

## What is the value of this and can you measure success?
We can run the test that we planned for the weekend.
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

