### PR TITLE
make section related calls iff section exists

### DIFF
--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -16,6 +16,7 @@ case class VideoPlayer(
   title: String,
   autoPlay: Boolean,
   showControlsAtStart: Boolean,
+  // TODO make Option[String] as relies on section being set
   endSlatePath: String,
   // TODO make `String` once `path` is available on main media on fronts
   path: Option[String],

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -150,7 +150,6 @@ define([
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs'),
             mediaId = $el.attr('data-media-id'),
-            showEndSlate = $el.attr('data-show-end-slate') === 'true',
             endSlateUri = $el.attr('data-end-slate'),
             embedPath = $el.attr('data-embed-path'),
             // we need to look up the embedPath for main media videos
@@ -162,6 +161,11 @@ define([
             playerSetupComplete,
             withPreroll,
             blockVideoAds;
+
+        //end-slate url follows the patten /video/end-slate/section/<section>.json?shortUrl=
+        //only show end-slate if page has a section i.e. not on the `/global` path
+        //e.g https://www.theguardian.com/global/video/2016/nov/01/what-happened-at-the-battle-of-orgreave-video-explainer
+        var showEndSlate = $el.attr('data-show-end-slate') === 'true' && !!config.page.section;
 
         player = createVideoPlayer(el, videojsOptions({
             plugins: {
@@ -399,7 +403,11 @@ define([
         mediator.on('page:media:moreinloaded', initPlayButtons);
 
         initFacia();
-        initMoreInSection();
+
+        if (config.page.section) {
+            initMoreInSection();
+        }
+
         initOnwardContainer();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -336,7 +336,7 @@ define([
     }
 
     function initMoreInSection() {
-        if (!config.isMedia || !config.page.showRelatedContent) {
+        if (!config.isMedia || !config.page.showRelatedContent || !config.page.section) {
             return;
         }
 
@@ -404,10 +404,8 @@ define([
 
         initFacia();
 
-        if (config.page.section) {
-            initMoreInSection();
-        }
-
+        initMoreInSection();
+        
         initOnwardContainer();
     }
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
More in series and end-slate relies on page section. If the section doesn't exist then the requests 404. See console on https://www.theguardian.com/global/video/2016/nov/01/what-happened-at-the-battle-of-orgreave-video-explainer for example.

This change checks page section exists before making api calls.

## What is the value of this and can you measure success?
Fewer 404s

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No. Will very likely need to replicate on off platform embed player in a later PR.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
n/a

## Request for comment
@gidsg @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

