### PR TITLE
Set correct audience size for side by side test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-side-by-side.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-side-by-side.js
@@ -41,8 +41,8 @@ define([
         this.author = 'Jonathan Rankin';
         this.description = 'Find out if offering membership and contributions side by side with equal weighting is as effective as just offering membership by itself';
         this.showForSensitive = true;
-        this.audience = 0;
-        this.audienceOffset = 0.1;
+        this.audience = 0.1;
+        this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
         this.audienceCriteria = 'All users in US and UK who are not reading articles about Brexit';
         this.dataLinkNames = '';


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
The audience size for the ContributionsMembershipEpicSideBySide test was set to 0. This needs to be set to 0.1

## What is the value of this and can you measure success?
The test will run for the correct audience size


<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

