### PR TITLE
Add branding to paid immersive interactives

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -18,6 +18,9 @@
 
 @body(interactive: model.Interactive, isImmersive: Boolean, isPaidContent: Boolean) = {
     @if(isImmersive) {
+
+        @if(isPaidContent){ @fragments.guBand() }
+
         @* Must not be wrapped in any elements to support full screen immersives *@
         @bodyRaw(interactive)
     } else {


### PR DESCRIPTION
This reinstates the branding band that was inadvertently removed recently.

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/20053866/5fc53e4c-a4d2-11e6-9a55-30139e740415.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/20053800/1f3be02e-a4d2-11e6-9896-72dbb5f3491c.png)


/cc @guardian/commercial-dev 