### PR TITLE
Expose window.guardian.triggerLoadApp for US election atom

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -487,4 +487,13 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val ElectionAppDelay = Switch(
+    SwitchGroup.Feature,
+    "election-app-delay",
+    "Delay loading app.js until interactive is ready - SHORT TERM HACK FOR US ELECTIONS",
+    owners = Seq(Owner.withGithub("wpf500")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 14),
+    exposeClientSide = false
+  )
 }

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -85,7 +85,9 @@
         window.guardian.triggerLoadApp = function () {
             @loadApp
         };
-        if (!window.guardian.config.page.atoms || window.guardian.config.page.atoms[0] !== "2016/general-election") {
+        var page = window.guardian.config.page;
+        if (page.contentType !== 'Interactive' ||
+              !page.atoms || page.atoms[0] !== '2016/general-election') {
             window.guardian.triggerLoadApp();
         }
     } else {

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -1,5 +1,5 @@
 @import common.InlineJs
-@import conf.switches.Switches.{AsyncCss, FontSwitch}
+@import conf.switches.Switches.{AsyncCss, FontSwitch, ElectionAppDelay}
 @import templates.inlineJS.blocking.js.{applyRenderConditions, cloudwatchBeacons, config, curlConfig, enableStylesheets, loadFonts, shouldEnhance}
 @import templates.inlineJS.blocking.polyfills.js.{classlist, details, matches, raf, setTimeout}
 
@@ -66,18 +66,30 @@
 
     // ************* LOAD THE MAIN APP ASYNC *************
 
+    @loadApp = {
+        @if(conf.Configuration.assets.useHashedBundles) {
+            // Polyfill for async script
+            (function (document) {
+                var script = document.createElement('script');
+                script.src = '@Static("javascripts/app.js")';
+                var ref = document.getElementsByTagName('script')[0];
+                ref.parentNode.insertBefore(script, ref);
+            })(document);
+        } else {
+            @Html(common.Assets.js.curl);
+            require(['boot']);
+        }
+    }
 
-    @if(conf.Configuration.assets.useHashedBundles) {
-        // Polyfill for async script
-        (function (document) {
-            var script = document.createElement('script');
-            script.src = '@Static("javascripts/app.js")';
-            var ref = document.getElementsByTagName('script')[0];
-            ref.parentNode.insertBefore(script, ref);
-        })(document);
+    @if(ElectionAppDelay.isSwitchedOn) {
+        window.guardian.triggerLoadApp = function () {
+            @loadApp
+        };
+        if (!window.guardian.config.page.atoms || window.guardian.config.page.atoms[0] !== "2016/general-election") {
+            window.guardian.triggerLoadApp();
+        }
     } else {
-        @Html(common.Assets.js.curl);
-        require(['boot']);
+        @loadApp
     }
 
 

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -1,5 +1,6 @@
 @import common.InlineJs
 @import conf.switches.Switches.{AsyncCss, FontSwitch, ElectionAppDelay}
+@import model.Page.getContent
 @import templates.inlineJS.blocking.js.{applyRenderConditions, cloudwatchBeacons, config, curlConfig, enableStylesheets, loadFonts, shouldEnhance}
 @import templates.inlineJS.blocking.polyfills.js.{classlist, details, matches, raf, setTimeout}
 
@@ -81,17 +82,17 @@
         }
     }
 
-    @if(ElectionAppDelay.isSwitchedOn) {
-        window.guardian.triggerLoadApp = function () {
+    @defining(
+        getContent(page).flatMap(_.content.atoms).flatMap(_.interactives.find(_.id == "2016/general-election")).isDefined
+    ) { hasElectionAtom =>
+
+        @if(ElectionAppDelay.isSwitchedOn && hasElectionAtom) {
+            window.guardian.triggerLoadApp = function () {
+                @loadApp
+            };
+        } else {
             @loadApp
-        };
-        var page = window.guardian.config.page;
-        if (page.contentType !== 'Interactive' ||
-              !page.atoms || page.atoms[0] !== '2016/general-election') {
-            window.guardian.triggerLoadApp();
         }
-    } else {
-        @loadApp
     }
 
 


### PR DESCRIPTION
Short term hack as discussed with @stephanfowler, @SiAdcock and others to allow the US election interactive to delay the loading of `app.js` to reduce initial page janking.

This hack is specifically targeted at a page which contains an atom whose ID is `2016/general-election`