### PR TITLE
Extend Brexit test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Find the optimal way of offering Contributions along side Membership in the Epic component on articles about Brexit",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = On,
-    sellByDate =  new LocalDate(2016, 11, 7),
+    sellByDate =  new LocalDate(2016, 11, 11),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-brexit.js
@@ -37,7 +37,7 @@ define([
 
         this.id = 'ContributionsMembershipEpicBrexit';
         this.start = '2016-11-04';
-        this.expiry = '2016-11-07';
+        this.expiry = '2016-11-11';
         this.author = 'Jonathan Rankin';
         this.description = 'Find the optimal way of offering Contributions along side Membership in the Epic component on stories about Brexit';
         this.showForSensitive = true;


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Extend the Epic component running on Brexit articles test till Friday. 

## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

