### PR TITLE
Add New Zealand to the countries that MostPopularAgent saves in memory

### DIFF
--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -44,7 +44,7 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
   def mostPopular(country: String): Seq[RelatedContentItem] =
     ophanPopularAgent().getOrElse(country, ophanPopularAgent().getOrElse(defaultCountry, Nil))
 
-  def refresh() {
+  def refresh(): Unit = {
     log.info("Refreshing most popular for countries.")
     countries foreach update
   }

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -38,7 +38,11 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
   // This allows us to choose carefully the codes that give us the most impact. The trade-off is caching.
   private val countries = Seq("GB", "US", "AU", "CA", "IN", "NG", "NZ", "row")
 
-  def mostPopular(country: String): Seq[RelatedContentItem] = ophanPopularAgent().get(country).getOrElse(Nil)
+  // Default country if the country does is not currently populated
+  private val defaultCountry: String = "row"
+
+  def mostPopular(country: String): Seq[RelatedContentItem] =
+    ophanPopularAgent().getOrElse(country, ophanPopularAgent().getOrElse(defaultCountry, Nil))
 
   def refresh() {
     log.info("Refreshing most popular for countries.")

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -36,7 +36,7 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
 
   // These are the only country codes (row must be lower-case) passed to us from the fastly service.
   // This allows us to choose carefully the codes that give us the most impact. The trade-off is caching.
-  private val countries = Seq("GB", "US", "AU", "CA", "IN", "NG", "row")
+  private val countries = Seq("GB", "US", "AU", "CA", "IN", "NG", "NZ", "row")
 
   def mostPopular(country: String): Seq[RelatedContentItem] = ophanPopularAgent().get(country).getOrElse(Nil)
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

This updates the `GeoMostPopularAgent` to save New Zealand in memory. We have made changes in fastly that means the `NZ` region will start getting passed along.
This will mean in the `NZ` region we will see nothing as we would return `Nil`.

#### Alternative
Instead of diluting the cache in fastly with another region that doesn't have massive number, the alternative would be to change this PR to translate `NZ` to Rest of World; `row`.

The path in `ophan` for this new request is at `/api/mostread?country=nz`.

## What is the value of this and can you measure success?

This means for `NZ` we will return most popular for the region instead of nothing.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Request for comment

@rich-nguyen 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

