### PR TITLE
Fix display of loading dots for MMA card update

### DIFF
--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -29,51 +29,56 @@ define([
         var $button = $('.js-manage-account-change-card', $parent);
         var $updating = $('.js-updating', $parent);
 
-        /*  show/hide */
+        /*  show/hide
+        *   once we've sent the token, we don't want to change the state of the dots until we redisplay
+        * */
         var loading = function () {
             var HIDDEN = 'is-hidden';
             var $elems = [$button, $number, $type, $last4];
-            var stack = 1; //We're waiting for the card to be displayed.
-            return function (isLoading) {
-                fastdom.write(function () {
-                    if (isLoading) {
-                        stack++;
-                    } else {
-                        stack--;
-                    }
-                    if (stack > 0) {
-                        $elems.forEach(function ($e) {
-                            $e.addClass(HIDDEN);
-                        });
-                        $updating.removeClass(HIDDEN);
-
-                    } else {
-                        $elems.forEach(function ($e) {
-                            $e.removeClass(HIDDEN);
-                        });
-                        $updating.addClass(HIDDEN);
-                    }
-                });
+            var sent = false;
+            var showDots = function(isLoading){
+                if(sent){
+                    return;
+                }
+                if(isLoading){
+                    $elems.forEach(function ($e) {
+                        $e.addClass(HIDDEN);
+                    });
+                    $updating.removeClass(HIDDEN);
+                } else {
+                    $elems.forEach(function ($e) {
+                        $e.removeClass(HIDDEN);
+                    });
+                    $updating.addClass(HIDDEN);
+                }
+            };
+            var send = function(){
+                sent = true;
+            };
+            return {
+                send:send,
+                showDots:showDots
             };
         }();
 
+        //Decode and display card
         var oldCardType = $type.data('type');
         var newCardType = 'i-' + card.type.toLowerCase().replace(' ', '-');
 
-        if (oldCardType) {
-            $type.removeClass(oldCardType);
-        }
+        bean.off($button[0], 'click');
+
+        bean.on($button[0], 'click', handler());
 
         fastdom.write(function () {
+            if (oldCardType) {
+                $type.removeClass(oldCardType);
+            }
             $last4.text(card.last4);
-            loading(false);
             $type.addClass(newCardType);
             $type.data('type', newCardType);
             $parent.removeClass('is-hidden');
+            loading.showDots(false);
         });
-
-        bean.off($button[0], 'click');
-        bean.on($button[0], 'click', handler());
 
 
         /*
@@ -86,7 +91,9 @@ define([
             var email = $button.data('email');
             return function (e) {
                 e.preventDefault();
-                loading(true);
+                fastdom.write(function () {
+                   loading.showDots(true);
+                });
 
                 checkoutHandler.open({
                     email: email,
@@ -94,7 +101,9 @@ define([
                     panelLabel: 'Update',
                     token: update(endpoint),
                     closed: function () {
-                        loading(false);
+                        fastdom.write(function(){
+                            loading.showDots(false);
+                        })
                     }
 
                 });
@@ -120,6 +129,7 @@ define([
          */
         function update(endpoint) {
             return function (token) {
+                loading.send();
                 ajax({
                     url: endpoint,
                     crossOrigin: true,

--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -30,34 +30,37 @@ define([
         var $updating = $('.js-updating', $parent);
 
         /*  show/hide
-        *   once we've sent the token, we don't want to change the state of the dots until we redisplay
-        * */
+         *   once we've sent the token, we don't want to change the state of the dots until we redisplay
+         * */
         var loading = function () {
             var HIDDEN = 'is-hidden';
             var $elems = [$button, $number, $type, $last4];
             var sent = false;
-            var showDots = function(isLoading){
-                if(sent){
+            var showDots = function () {
+                if (sent) {
                     return;
                 }
-                if(isLoading){
-                    $elems.forEach(function ($e) {
-                        $e.addClass(HIDDEN);
-                    });
-                    $updating.removeClass(HIDDEN);
-                } else {
-                    $elems.forEach(function ($e) {
-                        $e.removeClass(HIDDEN);
-                    });
-                    $updating.addClass(HIDDEN);
-                }
+                $elems.forEach(function ($e) {
+                    $e.addClass(HIDDEN);
+                });
+                $updating.removeClass(HIDDEN);
             };
-            var send = function(){
+            var hideDots = function () {
+                if (sent) {
+                    return;
+                }
+                $elems.forEach(function ($e) {
+                    $e.removeClass(HIDDEN);
+                });
+                $updating.addClass(HIDDEN);
+            };
+            var send = function () {
                 sent = true;
             };
             return {
-                send:send,
-                showDots:showDots
+                send: send,
+                showDots: showDots,
+                hideDots: hideDots
             };
         }();
 
@@ -77,7 +80,7 @@ define([
             $type.addClass(newCardType);
             $type.data('type', newCardType);
             $parent.removeClass('is-hidden');
-            loading.showDots(false);
+            loading.hideDots();
         });
 
 
@@ -91,9 +94,7 @@ define([
             var email = $button.data('email');
             return function (e) {
                 e.preventDefault();
-                fastdom.write(function () {
-                   loading.showDots(true);
-                });
+                fastdom.write(loading.showDots);
 
                 checkoutHandler.open({
                     email: email,
@@ -101,11 +102,8 @@ define([
                     panelLabel: 'Update',
                     token: update(endpoint),
                     closed: function () {
-                        fastdom.write(function(){
-                            loading.showDots(false);
-                        })
+                        fastdom.write(loading.hideDots)
                     }
-
                 });
                 /*
                  Nonstandard javascript alert:
@@ -143,7 +141,6 @@ define([
                     }
                 }).then(function success(card) {
                     display($parent, card);
-
                 }, function fail() {
                     $parent.text('We have not been able to update your card details at this time.');
                 });


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?


Fixes small bug in the new stripe checkout flow where the old card number would be shown whilst members data api thinks about things. 

## What is the value of this and can you measure success?

bugfix :( 
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
na
## Request for comment
@SiAdcock 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

