### PR TITLE
Improve make install/git hooks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,6 @@ module.exports = function (grunt) {
     /**
      * Miscellaneous tasks
      */
-    grunt.registerTask('hookmeup', ['clean:hooks', 'shell:copyHooks']);
     grunt.registerTask('emitAbTestInfo', 'shell:abTestInfo');
 
 };

--- a/grunt-configs/copy.js
+++ b/grunt-configs/copy.js
@@ -72,18 +72,6 @@ module.exports = function (grunt, options) {
                 src: ['**/*.svg'],
                 dest: 'common/conf/assets/inline-svgs'
             }]
-        },
-        /**
-         * NOTE: not using this as doesn't preserve file permissions (using shell:copyHooks instead)
-         * Waiting for Grunt 0.4.3 - https://github.com/gruntjs/grunt/issues/615
-         */
-        hooks: {
-            files: [{
-                expand: true,
-                cwd: 'git-hooks',
-                src: ['*'],
-                dest: '.git/hooks/'
-            }]
         }
     };
 };

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -1,15 +1,5 @@
 module.exports = function () {
     return {
-        /**
-         * Using this task to copy hooks, as Grunt's own copy task doesn't preserve permissions
-         */
-        copyHooks: {
-            command: 'ln -s ../git-hooks .git/hooks',
-            options: {
-                failOnError: false
-            }
-        },
-
         abTestInfo: {
             command: 'node tools/ab-test-info/ab-test-info.js ' +
                      'static/src/javascripts/projects/common/modules/experiments/tests ' +

--- a/makefile
+++ b/makefile
@@ -17,10 +17,7 @@ list: # PRIVATE
 
 # Install all 3rd party dependencies.
 install: check-node check-yarn
-	@echo 'Installing 3rd party dependencies…'
 	@yarn install
-	@echo '…done.'
-	@node tools/messages.js install
 
 # Remove all 3rd party dependencies.
 uninstall: # PRIVATE

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "fsevents": "*"
   },
   "scripts": {
-    "postinstall": "grunt hookmeup",
+    "postinstall": "./tools/run-task githooks",
     "sass-watch": "node-sass -w ./static/src/stylesheets -o ./static/target/stylesheets --source-map=true",
     "css-watch": "gulp --cwd ./dev watch:css",
     "browser-sync": "browser-sync start --config ./dev/bs-config.js",

--- a/static/test/javascripts/conf/settings.js
+++ b/static/test/javascripts/conf/settings.js
@@ -1,4 +1,4 @@
-var isTeamcityReporterEnabled = process.env.KARMA_TEAMCITY_REPORTER === 'true',
+var isTeamcityReporterEnabled = process.env.TEAMCITY === 'true',
     karmaReporters = [ isTeamcityReporterEnabled ? 'teamcity' : 'spec' ];
 
 module.exports = function (config) {

--- a/tools/__tasks__/githooks/index.js
+++ b/tools/__tasks__/githooks/index.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const fs = require('fs');
+const {root} = require('../config').paths;
+
+const src = path.resolve(root, 'git-hooks');
+const target = path.resolve(root, '.git', 'hooks');
+
+module.exports = {
+    description: 'Update githooks',
+    task: () => {
+        // always try and remove any old ones
+        try {
+            fs.unlinkSync(target);
+        } catch (e) { /* do nothing */ }
+
+        // TC doesn't want them, but everyone else does
+        if (process.env.TEAMCITY !== 'true') fs.symlinkSync(src, target);
+        return;
+    }
+};

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -71,13 +71,6 @@ switch (process.argv[2]) {
         }, 'info');
         break;
 
-    case 'install':
-        notify(
-            'All 3rd party dependencies have been installed.', {
-            heading: 'make install'
-        }, 'info');
-        break;
-
     case 'should-yarn':
         notify('Run `make install` and include any changes to `/yarn.locl` in your commit.', {
             heading: 'Dependencies have changed'


### PR DESCRIPTION
## What does this change?

- updates the way we manage git hooks:
 - only install them if we're not on TC
 - install them with the task runner
- removes the megalog success message when installing

## What is the value of this and can you measure success?

simpler procedure for githooks and less visual cruft when installing

## Does this affect other platforms - Amp, Apps, etc?

maybe TC, yeah (hopefully not though)

## Screenshots

<img width="621" alt="screen shot 2016-11-07 at 15 26 09" src="https://cloud.githubusercontent.com/assets/867233/20063330/a233777c-a4fe-11e6-9bb2-ee53549261cc.png">

## Request for comment

@guardian/dotcom-platform 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->