### PR TITLE
Add rest of world epic cta and messages test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -85,4 +85,15 @@ trait ABTestSwitches {
     sellByDate =  new LocalDate(2016, 11, 11),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-contributions-membership-epic-cta-rest-of-world",
+    "1) Find optimal way to present contributions and membershuip asks in Epic component. 2) Test 3 different messages for the Epic not in the United States ",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 11, 11),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -18,8 +18,13 @@ define([
             variants: ['control', 'contributions2', 'contributions3', 'membership1', 'membership2', 'membership3', 'equal1', 'equal2', 'equal3']
         };
 
+        var contributionsMembershipEpicCtaRestOfWorld = {
+            name: 'ContributionsMembershipEpicCtaRestOfWorld',
+            variants: ['control', 'contributions2', 'contributions3', 'membership1', 'membership2', 'membership3', 'equal1', 'equal2', 'equal3']
+        };
 
-        var clashingTests = [contributionsMembershipEpic, contributionsMembershipEpicCtaUnitedStates];
+
+        var clashingTests = [contributionsMembershipEpic, contributionsMembershipEpicCtaUnitedStates, contributionsMembershipEpicCtaRestOfWorld];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,7 +13,8 @@ define([
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
     'common/modules/experiments/tests/contributions-membership-epic-brexit',
-    'common/modules/experiments/tests/contributions-membership-epic-cta-united-states'
+    'common/modules/experiments/tests/contributions-membership-epic-cta-united-states',
+    'common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world'
 
 
 ], function (
@@ -31,7 +32,8 @@ define([
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
     ContributionsMembershipEpicBrexit,
-    ContributionsMembershipEpicCtaUnitedStates
+    ContributionsMembershipEpicCtaUnitedStates,
+    ContributionsMembershipEpicCtaRestOfWorld
 
 ) {
 
@@ -42,7 +44,8 @@ define([
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
         new ContributionsMembershipEpicBrexit(),
-        new ContributionsMembershipEpicCtaUnitedStates()
+        new ContributionsMembershipEpicCtaUnitedStates(),
+        new ContributionsMembershipEpicCtaRestOfWorld()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
@@ -1,0 +1,327 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'text!common/views/contributions-epic.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             contributionsEpic,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures
+) {
+
+
+    return function () {
+
+        this.id = 'ContributionsMembershipEpicCtaRestOfWorld';
+        this.start = '2016-11-07';
+        this.expiry = '2016-11-11';
+        this.author = 'Jonathan Rankin';
+        this.description = '1) Find optimal way to present contributions and membership asks in Epic component. 2) Test 3 different messages for the Epic';
+        this.showForSensitive = true;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Impressions to number of contributions/supporter signups';
+        this.audienceCriteria = 'All readers who are not the US, who are reading about US politics OR the US election, as well as not reading a Brexit articles ';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component, and we lean what the most effective of the 3 messages is';
+        this.canRun = function () {
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            if('keywordIds' in config.page && 'nonKeywordTagIds' in config.page) {
+                var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
+                var keywords = config.page.keywordIds.split(',');
+                var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
+                var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
+                var isMinuteArticle = ('isMinuteArticle' in config.page && config.page.isMinuteArticle);
+                var isAboutUsElectionOrUsPolitics = (keywords.indexOf('us-news/us-elections-2016') !== -1) || (nonKeywordTagIds.indexOf('us-news/us-politics') !== -1);
+                return !isMinuteArticle && !isAboutBrexit && isAboutUsElectionOrUsPolitics && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            } else {
+                return false;
+            }
+
+        };
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+
+        var messages = {
+            m1  : '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues are falling fast. ' +
+            'So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do ' +
+            'it because we believe our perspective matters – because it might well be your perspective, too.',
+
+            m2: '... we’ve got a favour to ask. The US election has revealed the deep divides that run through American society, and the dangers of a politics based on untruths' +
+            ' and innuendo. When politicians lie and basic facts are disputed, independent journalism is more important than ever. The Guardian will hold the new President to account,' +
+            ' just as we have held the candidates to account with fearless, honest, in-depth reporting and a diverse range of commentary. When rumours swirl, we deal in facts; when other ' +
+            'outlets deliver soundbites, we give voters a voice. But these are tough times for independent news organisations and producing quality, global journalism is difficult and expensive.',
+
+
+            m3: '... we’ve got a favour to ask. The Guardian believes that good journalism gives people a voice, so we’ve travelled far and wide to bring you our coverage of the US election.' +
+            ' We’ve asked not just who people are voting for, but why – and which issues they care about most. And we’ve shown how the effects of this election are being felt in other countries, ' +
+            'too. Political reporting with a global perspective helps all of us understand the bigger picture. But producing this kind of quality journalism is expensive and these are tough times for ' +
+            'independent news organisations.'
+
+
+        };
+
+        var cta = {
+            contributionsMain : {
+                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
+                p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
+                cta1: 'Make a contribution',
+                cta2: 'becoming a Supporter.'
+            },
+
+            membershipMain : {
+                p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure. Get closer to our journalism, be part of our story and join the Guardian.',
+                p3: 'Alternatively, you can ',
+                cta1: 'Become a supporter',
+                cta2: 'make a one-off contribution.'
+            },
+
+            equal: {
+                p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure. Give to the Guardian by becoming a Supporter or by making a one-off contribution.',
+                p3: '',
+                cta1: 'Become a supporter',
+                cta2: 'Make a contribution'
+            }
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if(resp.country !== 'US') {
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        if(submetaElement.length > 0) {
+                            component.insertBefore(submetaElement);
+                            embed.init();
+                            mediator.emit('contributions-embed:insert', component);
+                        }
+                    });
+                }
+            });
+        };
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', complete);
+        };
+
+        var contributeUrlPrefix = 'co_row_epic_footer_';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_';
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_row'),
+                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_contributions_main_row'),
+                        p1: messages.m1,
+                        p2: cta.contributionsMain.p2,
+                        p3: cta.contributionsMain.p3,
+                        cta1: cta.contributionsMain.cta1,
+                        cta2: cta.contributionsMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'contributions2',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_contributions_main_row'),
+                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix +'m2_contributions_main_row'),
+                        p1: messages.m2,
+                        p2: cta.contributionsMain.p2,
+                        p3: cta.contributionsMain.p3,
+                        cta1: cta.contributionsMain.cta1,
+                        cta2: cta.contributionsMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'contributions3',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_contributions_main_row'),
+                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_contributions_main_row'),
+                        p1: messages.m3,
+                        p2: cta.contributionsMain.p2,
+                        p3: cta.contributionsMain.p3,
+                        cta1: cta.contributionsMain.cta1,
+                        cta2: cta.contributionsMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'membership1',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix  + 'm1_membership_main_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_membership_main_row'),
+                        p1: messages.m1,
+                        p2: cta.membershipMain.p2,
+                        p3: cta.membershipMain.p3,
+                        cta1: cta.membershipMain.cta1,
+                        cta2: cta.membershipMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'membership2',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_membership_main_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_membership_main_row'),
+                        p1: messages.m2,
+                        p2: cta.membershipMain.p2,
+                        p3: cta.membershipMain.p3,
+                        cta1: cta.membershipMain.cta1,
+                        cta2: cta.membershipMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'membership3',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_membership_main_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_membership_main_row'),
+                        p1: messages.m3,
+                        p2: cta.membershipMain.p2,
+                        p3: cta.membershipMain.p3,
+                        cta1: cta.membershipMain.cta1,
+                        cta2: cta.membershipMain.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'equal1',
+                test: function () {
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_equal_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_equal_row'),
+                        p1: messages.m1,
+                        p2: cta.equal.p2,
+                        cta1: cta.equal.cta1,
+                        cta2: cta.equal.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'equal2',
+                test: function () {
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_equal_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_equal_row'),
+                        p1: messages.m2,
+                        p2: cta.equal.p2,
+                        cta1: cta.equal.cta1,
+                        cta2: cta.equal.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            },
+            {
+                id: 'equal13',
+                test: function () {
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_equal_row'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_equal_row'),
+                        p1: messages.m3,
+                        p2: cta.equal.p2,
+                        cta1: cta.equal.cta1,
+                        cta2: cta.equal.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            }
+
+
+        ];
+    };
+});


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
We have 3 possible messages and 3 possible ways of displaying membership and contributions alongside eachother on the epic.

This test has 9 variants, and tests every combination of message and CTA.


(Same as PR #14906, except for everywhere else in the world apart from the US)

## What is the value of this and can you measure success?
We will know what our strongest message and cta combination is.



<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

![var1 ong](https://cloud.githubusercontent.com/assets/2844554/20064149/a127d21c-a501-11e6-9f2c-b8acf7170f19.png)
![var5](https://cloud.githubusercontent.com/assets/2844554/20064150/a12a2f1c-a501-11e6-9415-51f1ed42ed34.png)
![var9](https://cloud.githubusercontent.com/assets/2844554/20064151/a12a7b52-a501-11e6-9407-0ccb5ab7cbfd.png)


## Request for comment

@gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

