### PR TITLE
Treat 404 from members data API as valid response

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -1,13 +1,13 @@
 define([
     'common/utils/cookies',
     'common/utils/config',
-    'common/utils/fetch-json',
+    'common/utils/fetch',
     'common/utils/storage',
     'common/modules/identity/api'
 ], function (
     cookies,
     config,
-    fetchJson,
+    fetch,
     storage,
     identity
 ) {
@@ -60,11 +60,31 @@ define([
     };
 
     function requestNewData() {
-        fetchJson(config.page.userAttributesApiUrl + '/me/features', {
+        // Cannot use `fetchJson` here as we consider 404 to be a valid response
+        var userAttributeUrl = config.page.userAttributesApiUrl + '/me/features';
+        fetch(userAttributeUrl, {
             mode: 'cors',
             credentials: 'include'
         })
-        .then(persistResponse)
+        .then(function(resp) {
+            if (resp.ok || resp.status == 404) {
+                persistResponse(resp.json());
+            } else {
+                if (!resp.status) {
+                    // IE9 uses XDomainRequest which doesn't set the response status thus failing
+                    // even when the response was actually valid
+                    resp.text().then(function (responseText) {
+                        try {
+                            persistResponse(JSON.parse(responseText));
+                        } catch (ex) {
+                            throw new Error('Fetch error while requesting ' + userAttributeUrl + ': Invalid JSON response');
+                        }
+                    });
+                } else {
+                    throw new Error('Fetch error while requesting ' + userAttributeUrl + ': ' + resp.statusText);
+                }
+            }
+        })
         .catch(function () {});
     }
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Treats a 404 as a valid response from the members data API when it comes to setting the cookie that determines whether a logged in user is a paying member.

## What is the value of this and can you measure success?

It allows us to serve membership and contributions messages to logged in users that are not members. This will be a success if we see increased rates of sign up to membership and contributions whilst avoiding showing promotional messages to those who are already paying members.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment

This is horrid to test since the members data API can't be successfully accessed from localhost or code. Any advice on a sane way to test this would be most welcome.

I can understand nervousness about integrating this change, but this bug is currently meaning a significant part of membership/contributions target audience are not seeing the messages intended for them.

cc @dominickendrick @paulbrown1982 @rtyley 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

Before the refactoring to use fetch-json, any response was treated as valid, including the 404 that members data API uses to indicate that the user is not a known member. This reintroduces that behaviour, but limits it to just 404s, so 5xx statuses don't result in us setting a cookie indicating the user is not a paying member.