### PR TITLE
Cut the messaging variants from the US and ROW epic cta tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -58,7 +58,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-contributions-membership-epic-cta-united-states-two",
-    "Find optimal way to present contributions and membershuip asks in Epic component for US",
+    "Find optimal way to present contributions and membership asks in Epic component for US",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 11),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,8 +57,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-membership-epic-cta-united-states",
-    "1) Find optimal way to present contributions and membershuip asks in Epic component. 2) Test 3 different messages for the Epic in the United States ",
+    "ab-contributions-membership-epic-cta-united-states-two",
+    "Find optimal way to present contributions and membershuip asks in Epic component for US",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 11),
@@ -67,8 +67,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-membership-epic-cta-rest-of-world",
-    "1) Find optimal way to present contributions and membershuip asks in Epic component. 2) Test 3 different messages for the Epic not in the United States ",
+    "ab-contributions-membership-epic-cta-rest-of-world-two",
+    "Find optimal way to present contributions and membership asks in Epic component for not US",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 11),

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -486,4 +486,24 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 11, 14),
     exposeClientSide = false
   )
+
+  val EpicMembershipOnly = Switch(
+    SwitchGroup.Feature,
+    "epic-membership-only",
+    "If this switch is turned on, we will only place membership links on our epic component ads",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 11),
+    exposeClientSide = true
+  )
+
+  val EpicContributionsOnly = Switch(
+    SwitchGroup.Feature,
+    "epic-contributions-only",
+    "If this switch is turned on, we will only place contributions links on our epic component ads",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 11),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -486,24 +486,4 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 11, 14),
     exposeClientSide = false
   )
-
-  val EpicMembershipOnly = Switch(
-    SwitchGroup.Feature,
-    "epic-membership-only",
-    "If this switch is turned on, we will only place membership links on our epic component ads",
-    owners = Seq(Owner.withGithub("jranks123")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 11, 11),
-    exposeClientSide = true
-  )
-
-  val EpicContributionsOnly = Switch(
-    SwitchGroup.Feature,
-    "epic-contributions-only",
-    "If this switch is turned on, we will only place contributions links on our epic component ads",
-    owners = Seq(Owner.withGithub("jranks123")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 11, 11),
-    exposeClientSide = true
-  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -8,18 +8,18 @@ define([
 
     function userIsInAClashingAbTest() {
 
-        var contributionsMembershipEpicCtaUnitedStates = {
-            name: 'ContributionsMembershipEpicCtaUnitedStates',
-            variants: ['control', 'contributions2', 'contributions3', 'membership1', 'membership2', 'membership3', 'equal1', 'equal2', 'equal3']
+        var contributionsMembershipEpicCtaUnitedStatesTwo = {
+            name: 'ContributionsMembershipEpicCtaUnitedStatesTwo',
+            variants: ['control', 'membership', 'equal']
         };
 
-        var contributionsMembershipEpicCtaRestOfWorld = {
-            name: 'ContributionsMembershipEpicCtaRestOfWorld',
-            variants: ['control', 'contributions2', 'contributions3', 'membership1', 'membership2', 'membership3', 'equal1', 'equal2', 'equal3']
+        var contributionsMembershipEpicCtaRestOfWorldTwo = {
+            name: 'ContributionsMembershipEpicCtaRestOfWorldTwo',
+            variants: ['control', 'membership', 'equal']
         };
 
 
-        var clashingTests = [contributionsMembershipEpicCtaUnitedStates, contributionsMembershipEpicCtaRestOfWorld];
+        var clashingTests = [contributionsMembershipEpicCtaUnitedStatesTwo, contributionsMembershipEpicCtaRestOfWorldTwo];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
@@ -37,18 +37,18 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsMembershipEpicCtaRestOfWorld';
-        this.start = '2016-11-07';
+        this.id = 'ContributionsMembershipEpicCtaRestOfWorldTwo';
+        this.start = '2016-11-08';
         this.expiry = '2016-11-11';
         this.author = 'Jonathan Rankin';
-        this.description = '1) Find optimal way to present contributions and membership asks in Epic component. 2) Test 3 different messages for the Epic';
+        this.description = 'Find optimal way to present contributions and membership asks in Epic component';
         this.showForSensitive = true;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
         this.audienceCriteria = 'All readers who are not the US, who are reading about US politics OR the US election, as well as not reading a Brexit articles ';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component, and we lean what the most effective of the 3 messages is';
+        this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component';
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             if('keywordIds' in config.page && 'nonKeywordTagIds' in config.page) {
@@ -69,25 +69,11 @@ define([
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
 
-        var messages = {
-            m1  : '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues are falling fast. ' +
+        var message = '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. ' +
             'So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do ' +
-            'it because we believe our perspective matters – because it might well be your perspective, too.',
-
-            m2: '... we’ve got a favour to ask. The US election has revealed the deep divides that run through American society, and the dangers of a politics based on untruths' +
-            ' and innuendo. When politicians lie and basic facts are disputed, independent journalism is more important than ever. The Guardian will hold the new President to account,' +
-            ' just as we have held the candidates to account with fearless, honest, in-depth reporting and a diverse range of commentary. When rumours swirl, we deal in facts; when other ' +
-            'outlets deliver soundbites, we give voters a voice. But these are tough times for independent news organisations and producing quality, global journalism is difficult and expensive.',
-
-
-            m3: '... we’ve got a favour to ask. The Guardian believes that good journalism gives people a voice, so we’ve travelled far and wide to bring you our coverage of the US election.' +
-            ' We’ve asked not just who people are voting for, but why – and which issues they care about most. And we’ve shown how the effects of this election are being felt in other countries, ' +
-            'too. Political reporting with a global perspective helps all of us understand the bigger picture. But producing this kind of quality journalism is expensive and these are tough times for ' +
-            'independent news organisations.'
-
-
-        };
-
+            'it because we believe our perspective matters – because it might well be your perspective, too.';
+        
+        
         var cta = {
             contributionsMain : {
                 p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
@@ -147,9 +133,9 @@ define([
                 id: 'control',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_row'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_contributions_main_row'),
-                        p1: messages.m1,
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_row_2'),
+                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_contributions_main_row_2'),
+                        p1: message,
                         p2: cta.contributionsMain.p2,
                         p3: cta.contributionsMain.p3,
                         cta1: cta.contributionsMain.cta1,
@@ -163,53 +149,14 @@ define([
                 },
                 success: completer
             },
+
             {
-                id: 'contributions2',
+                id: 'membership',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_contributions_main_row'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix +'m2_contributions_main_row'),
-                        p1: messages.m2,
-                        p2: cta.contributionsMain.p2,
-                        p3: cta.contributionsMain.p3,
-                        cta1: cta.contributionsMain.cta1,
-                        cta2: cta.contributionsMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'contributions3',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_contributions_main_row'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_contributions_main_row'),
-                        p1: messages.m3,
-                        p2: cta.contributionsMain.p2,
-                        p3: cta.contributionsMain.p3,
-                        cta1: cta.contributionsMain.cta1,
-                        cta2: cta.contributionsMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'membership1',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix  + 'm1_membership_main_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_membership_main_row'),
-                        p1: messages.m1,
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix  + 'm1_membership_main_row_2'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_membership_main_row_2'),
+                        p1: message,
                         p2: cta.membershipMain.p2,
                         p3: cta.membershipMain.p3,
                         cta1: cta.membershipMain.cta1,
@@ -223,91 +170,14 @@ define([
                 },
                 success: completer
             },
+
             {
-                id: 'membership2',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_membership_main_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_membership_main_row'),
-                        p1: messages.m2,
-                        p2: cta.membershipMain.p2,
-                        p3: cta.membershipMain.p3,
-                        cta1: cta.membershipMain.cta1,
-                        cta2: cta.membershipMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'membership3',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_membership_main_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_membership_main_row'),
-                        p1: messages.m3,
-                        p2: cta.membershipMain.p2,
-                        p3: cta.membershipMain.p3,
-                        cta1: cta.membershipMain.cta1,
-                        cta2: cta.membershipMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal1',
+                id: 'equal',
                 test: function () {
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_equal_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_equal_row'),
-                        p1: messages.m1,
-                        p2: cta.equal.p2,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal2',
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_equal_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_equal_row'),
-                        p1: messages.m2,
-                        p2: cta.equal.p2,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal13',
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_equal_row'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_equal_row'),
-                        p1: messages.m3,
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_equal_row_2'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_equal_row_2'),
+                        p1: message,
                         p2: cta.equal.p2,
                         cta1: cta.equal.cta1,
                         cta2: cta.equal.cta2,
@@ -320,7 +190,6 @@ define([
                 },
                 success: completer
             }
-
 
         ];
     };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-rest-of-world.js
@@ -14,7 +14,8 @@ define([
     'common/utils/cookies',
     'common/modules/experiments/embed',
     'common/utils/ajax',
-    'common/modules/commercial/commercial-features'
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection'
 
 ], function (bean,
              qwery,
@@ -31,7 +32,8 @@ define([
              cookies,
              embed,
              ajax,
-             commercialFeatures
+             commercialFeatures,
+             intersection
 ) {
 
 
@@ -41,7 +43,7 @@ define([
         this.start = '2016-11-08';
         this.expiry = '2016-11-11';
         this.author = 'Jonathan Rankin';
-        this.description = 'Find optimal way to present contributions and membership asks in Epic component';
+        this.description = 'Test 3 different CTA configurations for the Epic, not in the US';
         this.showForSensitive = true;
         this.audience = 1;
         this.audienceOffset = 0;
@@ -50,20 +52,20 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component';
         this.canRun = function () {
+            var whitelistedKeywordIds = ['us-news/us-elections-2016', 'us-news/us-politics'];
+
+            var hasKeywordsMatch = function() {
+                var pageKeywords = config.page.keywordIds;
+                return pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
+            };
+            
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
-            if('keywordIds' in config.page && 'nonKeywordTagIds' in config.page) {
-                var worksWellWithPageTemplate = (config.page.contentType === 'Article'); // may render badly on other types
-                var keywords = config.page.keywordIds.split(',');
-                var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
-                var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
-                var isMinuteArticle = ('isMinuteArticle' in config.page && config.page.isMinuteArticle);
-                var isAboutUsElectionOrUsPolitics = (keywords.indexOf('us-news/us-elections-2016') !== -1) || (nonKeywordTagIds.indexOf('us-news/us-politics') !== -1);
-                return !isMinuteArticle && !isAboutBrexit && isAboutUsElectionOrUsPolitics && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
-            } else {
-                return false;
-            }
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
 
         };
+
+
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
         var contributeUrl = 'https://contribute.theguardian.com/?';
@@ -72,8 +74,8 @@ define([
         var message = '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. ' +
             'So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do ' +
             'it because we believe our perspective matters – because it might well be your perspective, too.';
-        
-        
+
+
         var cta = {
             contributionsMain : {
                 p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-united-states.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-cta-united-states.js
@@ -37,18 +37,18 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsMembershipEpicCtaUnitedStates';
-        this.start = '2016-11-07';
+        this.id = 'ContributionsMembershipEpicCtaUnitedStatesTwo';
+        this.start = '2016-11-08';
         this.expiry = '2016-11-11';
         this.author = 'Jonathan Rankin';
-        this.description = '1) Find optimal way to present contributions and membershuip asks in Epic component. 2) Test 3 different messages for the Epic';
-        this.showForSensitive = true;
+        this.description = 'Test 3 different messages for the Epic';
+        this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
         this.audienceCriteria = 'All readers in the US reading about US politics OR the US election, as well as not on Brexit articles ';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component, and we lean what the most effective of the 3 messages is';
+        this.idealOutcome = 'We learn the best way to present contributions and membership asks in Epic component';
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             if('keywordIds' in config.page && 'nonKeywordTagIds' in config.page) {
@@ -57,8 +57,7 @@ define([
                 var nonKeywordTagIds = config.page.nonKeywordTagIds.split(',');
                 var isAboutBrexit = (keywords.indexOf('politics/eu-referendum') !== -1) && (nonKeywordTagIds.indexOf('tone/news') !== -1);
                 var isMinuteArticle = ('isMinuteArticle' in config.page && config.page.isMinuteArticle);
-                var isAboutUsElectionOrUsPolitics = (keywords.indexOf('us-news/us-elections-2016') !== -1) || (nonKeywordTagIds.indexOf('us-news/us-politics') !== -1);
-                return !isMinuteArticle && !isAboutBrexit && isAboutUsElectionOrUsPolitics && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+                return !isMinuteArticle && !isAboutBrexit && userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
             } else {
                 return false;
             }
@@ -69,23 +68,9 @@ define([
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
 
-        var messages = {
-            m1  : '...we have a small favor to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues are falling fast. So you can see why we need to ask for your' +
+        var message = '...we have a small favor to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your' +
             ' help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your ' +
-            'perspective, too.',
-
-            m2: '... we’ve got a favor to ask. The presidential election has revealed the deep divides that run through American society, and the dangers of politics based on distorted facts and innuendo. ' +
-            'When politicians lie and basic truths are disputed, independent journalism is more important than ever. The Guardian will hold the new President to account, just as we have held the candidates to ' +
-            'account with fearless, honest, in-depth reporting and a diverse range of commentary. When rumors swirl, we deal in facts; when other outlets deliver soundbites, we give voters a voice. But these are tough ' +
-            'times for independent news organizations and producing quality, global journalism is difficult and expensive.',
-
-
-            m3: '... we’ve got a favor to ask. The Guardian believes that good journalism gives people a voice, so we’ve travelled far and wide to bring you our coverage of the US election. We’ve asked not just who people are voting for, but why – and which issues they care about most. ' +
-            'And we’ve shown how the effects of this election are being felt in other countries, too. Political reporting with a global perspective helps all of us understand the bigger picture. But ' +
-            'producing this kind of quality journalism is expensive and these are tough times for independent news organizations.'
-
-
-        };
+            'perspective, too.';
 
         var cta = {
             contributionsMain : {
@@ -146,9 +131,9 @@ define([
                 id: 'control',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_us'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_contributions_main_us'),
-                        p1: messages.m1,
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_us_2'),
+                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_contributions_main_us_2'),
+                        p1: message,
                         p2: cta.contributionsMain.p2,
                         p3: cta.contributionsMain.p3,
                         cta1: cta.contributionsMain.cta1,
@@ -163,52 +148,12 @@ define([
                 success: completer
             },
             {
-                id: 'contributions2',
+                id: 'membership',
                 test: function () {
                     var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_contributions_main_us'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix +'m2_contributions_main_us'),
-                        p1: messages.m2,
-                        p2: cta.contributionsMain.p2,
-                        p3: cta.contributionsMain.p3,
-                        cta1: cta.contributionsMain.cta1,
-                        cta2: cta.contributionsMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'contributions3',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_contributions_main_us'),
-                        linkUrl2: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_contributions_main_us'),
-                        p1: messages.m3,
-                        p2: cta.contributionsMain.p2,
-                        p3: cta.contributionsMain.p3,
-                        cta1: cta.contributionsMain.cta1,
-                        cta2: cta.contributionsMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'membership1',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix  + 'm1_membership_main_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_membership_main_us'),
-                        p1: messages.m1,
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix  + 'm1_membership_main_us_2'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_membership_main_us_2'),
+                        p1: message,
                         p2: cta.membershipMain.p2,
                         p3: cta.membershipMain.p3,
                         cta1: cta.membershipMain.cta1,
@@ -223,90 +168,12 @@ define([
                 success: completer
             },
             {
-                id: 'membership2',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_membership_main_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_membership_main_us'),
-                        p1: messages.m2,
-                        p2: cta.membershipMain.p2,
-                        p3: cta.membershipMain.p3,
-                        cta1: cta.membershipMain.cta1,
-                        cta2: cta.membershipMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'membership3',
-                test: function () {
-                    var component = $.create(template(contributionsEpic, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_membership_main_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_membership_main_us'),
-                        p1: messages.m3,
-                        p2: cta.membershipMain.p2,
-                        p3: cta.membershipMain.p3,
-                        cta1: cta.membershipMain.cta1,
-                        cta2: cta.membershipMain.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal1',
+                id: 'equal',
                 test: function () {
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_equal_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_equal_us'),
-                        p1: messages.m1,
-                        p2: cta.equal.p2,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal2',
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm2_equal_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm2_equal_us'),
-                        p1: messages.m2,
-                        p2: cta.equal.p2,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
-                    }));
-                    componentWriter(component);
-                },
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-                success: completer
-            },
-            {
-                id: 'equal13',
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm3_equal_us'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm3_equal_us'),
-                        p1: messages.m3,
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'm1_equal_us_2'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_equal_us_2'),
+                        p1: message,
                         p2: cta.equal.p2,
                         cta1: cta.equal.cta1,
                         cta2: cta.equal.cta2,


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
From the test yesterday, we have learn which one of the 3 messages performs strongest, in both the US and ROW. The results are not significant for the different configuration of Membership and Contributions calls to action on the epic element yet, so we are keeping those 3 variants. 

There is also a slight copy change, as requested from commercial.

I have renamed the test name and the campaign codes to distinguish these results from the previous test. 

A few of the rules have also changed. The US has now whitelisted the tags:

us-election
us-politics
society
world
australia-news
politics
us-news
us-environment
eu-referendum

## What is the value of this and can you measure success?
We will continue to learn the best way to present contributions and membership asks in Epic component.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

![v1row](https://cloud.githubusercontent.com/assets/2844554/20096131/5d784926-a5a0-11e6-933b-fca515c1d3a4.png)
![v2row](https://cloud.githubusercontent.com/assets/2844554/20096130/5d768d3e-a5a0-11e6-9198-45fd9e6a8e29.png)
![v3row](https://cloud.githubusercontent.com/assets/2844554/20096132/5d79d7e6-a5a0-11e6-9f91-3982849659f6.png)


## Request for comment
@jfsoul @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

