### PR TITLE
Include untested files in coverage results

### DIFF
--- a/static/test/javascripts/conf/settings.js
+++ b/static/test/javascripts/conf/settings.js
@@ -49,7 +49,8 @@ module.exports = function (config) {
                     dir: 'tmp/coverage/'
                 },
                 {type: 'text-summary'}
-            ]
+            ],
+            includeAllSources: true
         },
         preprocessors: {
             'static/src/javascripts/!(*components|vendor)/**/*.js': ['coverage'],


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Include untested files in coverage results

## What is the value of this and can you measure success?

Coverage is kind of useless if you can't see the files where you don't have any coverage!

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

Internal change only

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

