### PR TITLE
use bonzo to access element attributes

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -179,7 +179,7 @@ define([
         events.addPrerollEvents(player, mediaId, mediaType);
         events.bindGoogleAnalyticsEvents(player, gaEventLabel);
 
-        videoMetadata.getVideoInfo(el).then(function(videoInfo) {
+        videoMetadata.getVideoInfo($el).then(function(videoInfo) {
             if (videoInfo.expired) {
                 player.ready(function() {
                     player.error({
@@ -407,7 +407,7 @@ define([
         initFacia();
 
         initMoreInSection();
-        
+
         initOnwardContainer();
     }
 

--- a/static/src/javascripts/projects/common/modules/video/metadata.js
+++ b/static/src/javascripts/projects/common/modules/video/metadata.js
@@ -30,12 +30,12 @@ define([
         }
     }
 
-    function getVideoInfo(el) {
-        var shouldHideAdverts = el.dataset.blockVideoAds !== 'false';
-        var embedPath = el.dataset.embedPath;
+    function getVideoInfo($el) {
+        var shouldHideAdverts = $el.attr('data-block-video-ads') !== 'false';
+        var embedPath = $el.attr('data-embed-path');
 
         // we need to look up the embedPath for main media videos
-        var canonicalUrl = el.dataset.canonicalUrl || (embedPath ? embedPath : null);
+        var canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? embedPath : null);
 
         return new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Fixes [this bug](https://sentry.io/the-guardian/client-side-prod/issues/177496140/) which is caused by `dataset` not being available on IE < 11.

This is a regression from https://github.com/guardian/frontend/pull/14880.

## What is the value of this and can you measure success?
Fewer errors.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
No.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
n/a

## Request for comment
@gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

