### PR TITLE
Fix structured data in articles and live blogs

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -32,14 +32,7 @@
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">
-                @if(amp) {
-                    @* AMP doesn't support sameAs *@
-                    <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-                        <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
-                    </div>
-                } else {
-                    <link itemprop="sameAs" href="http://www.theguardian.com">
-                }
+                @fragments.logo(amp)
             </div>
 
             @if(isPaidContent) {

--- a/article/app/views/fragments/logo.scala.html
+++ b/article/app/views/fragments/logo.scala.html
@@ -1,0 +1,12 @@
+@(amp: Boolean = false)(implicit request: RequestHeader)
+
+@if(amp) {
+    @* AMP doesn't support sameAs *@
+    <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+        <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
+        <meta itemprop="width" content="300">
+        <meta itemprop="height" content="60">
+    </div>
+} else {
+    <link itemprop="sameAs" href="http://www.theguardian.com">
+}

--- a/article/app/views/fragments/logo.scala.html
+++ b/article/app/views/fragments/logo.scala.html
@@ -1,4 +1,4 @@
-@(amp: Boolean = false)(implicit request: RequestHeader)
+@(amp: Boolean = false)
 
 @if(amp) {
     @* AMP doesn't support sameAs *@

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -23,9 +23,7 @@
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
         <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
             <meta itemprop="name" content="The Guardian">
-            <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-                <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
-            </div>
+            @fragments.logo(amp)
         </div>
 
         <header class="content__head tonal__head tonal__head--@toneClass(article)

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -13,7 +13,9 @@
             @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
         }
     </time>
-    <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
+    @if(isLiveBlog) {
+        <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
+    }
     @if(hasBeenModified && !isMinute) {
         <time itemprop="dateModified" datetime='@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@lastModified.getMillis" class="content__dateline-lm js-lm u-h">


### PR DESCRIPTION
## What does this change?

Structured data is broken in articles and live blogs for a number of reasons. This change fixes two things:

- Removes `coverageStartTime` from NewsArticles
- Adds correct publisher logo metadata (`height` and `width`) for AMP LiveBlogs

## What is the value of this and can you measure success?

Structured data validation failures prevent articles from being indexed for inclusion in Google's AMP search results.  

## Does this affect other platforms - Amp, Apps, etc?

This should hopefully get our articles AMP-ified in Google search results again ⚡️ 

## Request for comment

@stephanfowler @guardian/dotcom-platform 

