### PR TITLE
Remove CommercialSonobiRubiconAdapter Test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -82,17 +82,6 @@ object CommercialHeaderBiddingControl extends TestDefinition(
   }
 }
 
-object CommercialSonobiRubiconAdapter extends TestDefinition(
-  name = "commercial-sonobi-rubicon",
-  description = "A test url for the new sonobi integration",
-  owners = Seq(Owner.withGithub("rich-nguyen"), Owner.withGithub("janua")),
-  sellByDate = new LocalDate(2016, 11, 30) // Wednesday
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.path.endsWith("politics/2016/oct/24/nicola-sturgeon-says-brexit-meeting-was-deeply-frustrating")
-  }
-}
-
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -111,8 +100,7 @@ object ActiveTests extends ServerSideABTests {
     ABNewNavControl,
     CommercialClientLoggingVariant,
     CommercialHeaderBiddingSonobiVariant,
-    CommercialHeaderBiddingControl,
-    CommercialSonobiRubiconAdapter
+    CommercialHeaderBiddingControl
   )
 }
 

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -29,13 +29,7 @@ window.curlConfig = {
             'bootstraps/enhanced/profile':       '@Static("javascripts/bootstraps/enhanced/profile.js")',
             'foresee.js':                        'vendor/foresee/20150703/foresee-trigger.js',
             'googletag.js':                      '@{Configuration.javascript.config("googletagJsUrl")}',
-            'sonobi.js': '@{
-                if (CommercialSonobiRubiconAdapter.isParticipating) {
-                    "//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js"
-                } else {
-                    Configuration.javascript.config("sonobiHeaderBiddingJsUrl")
-                }
-            }',
+            'sonobi.js':                        '@{Configuration.javascript.config("sonobiHeaderBiddingJsUrl")}',
             react:                               '@Static("javascripts/vendor/react/react.js")',
             'ophan/ng':                          '@{Configuration.javascript.config("ophanJsUrl")}',
             'prebid.js':                         '@Static("javascripts/vendor/prebid/0.8.1/prebid.js")',
@@ -68,13 +62,7 @@ window.curlConfig = {
             reqwest:                        'components/reqwest/reqwest',
             'foresee.js':                   'vendor/foresee/20150703/foresee-trigger.js',
             'googletag.js':                 '@{Configuration.javascript.config("googletagJsUrl")}',
-            'sonobi.js': '@{
-               if (CommercialSonobiRubiconAdapter.isParticipating) {
-                   "//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js"
-               } else {
-                   Configuration.javascript.config("sonobiHeaderBiddingJsUrl")
-               }
-             }',
+            'sonobi.js':                    '@{Configuration.javascript.config("sonobiHeaderBiddingJsUrl")}',
             'ophan/ng':                     '@{Configuration.javascript.config("ophanJsUrl")}',
             'prebid.js':                    'vendor/prebid/0.8.1/prebid.js',
             'discussion-frontend-react':    '@DiscussionAsset("discussion-frontend.react.amd")',

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -1,7 +1,6 @@
 @()(implicit request: RequestHeader)
 @import conf.Static
 @import conf.Configuration
-@import mvt.CommercialSonobiRubiconAdapter
 
 window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

This removes `CommercialSonobiRubiconAdapter` which was used to test region Sonobi scripts on a specific article.

It is no longer needed as the variant that it tests is currently released on `PROD`.

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->


## Request for comment

@rich-nguyen 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
