### PR TITLE
Update docs to add `awscli` install

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -21,6 +21,7 @@ Follow [this link](https://www.google.co.uk) and enter the relevant search strin
 1. Fork [Janus](https://github.com/guardian/janus) and follow the readme (**Note:** you will need permission to access the Janus repo to do this, and 2FA set up on your Google account)
 2. Make your change and push to a new branch (you can review the closed PRs for help)
 3. Submit a PR
+4. You may need to `pip install awscli` and add `/Library/Frameworks/Python.framework/Versions/Current/bin` to your `$PATH` to run the commands Janus gives you.
 
 # Local Test Server setup
 


### PR DESCRIPTION
## What does this change?

Adds section on getting the `aws` profile commands working

## What is the value of this and can you measure success?

Easier dev setup

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Request for comment

@guardian/dotcom-platform 

Closes #14272 

