### PR TITLE
Add epic contributions back up

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "A backup contributions-only test for the event of membership going down",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate =  new LocalDate(2016, 11, 11),
+    sellByDate =  new LocalDate(2016, 11, 14),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,4 +65,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-contributions-membership-epic-backup",
+    "A backup contributions-only test for the event of membership going down",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 11, 11),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -7,7 +7,19 @@ define([
 ) {
 
     function userIsInAClashingAbTest() {
-        var clashingTests = [];
+
+        var contributionsEpicPostElectionCopyTest = {
+            name: 'ContributionsEpicPostElectionCopyTest',
+            variants: ['control']
+        };
+
+        var contributionsEpicPostElectionConBackup= {
+            name: 'ContributionsMembershipEpicBackup',
+            variants: ['control']
+        };
+        
+        
+        var clashingTests = [contributionsEpicPostElectionConBackup, contributionsEpicPostElectionCopyTest];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,8 @@ define([
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
-    'common/modules/experiments/tests/contributions-epic-post-election-copy-test'
+    'common/modules/experiments/tests/contributions-epic-post-election-copy-test',
+    'common/modules/experiments/tests/contributions-membership-epic-backup'
 ], function (
     reportError,
     config,
@@ -27,7 +28,8 @@ define([
     WeekendReadingEmail,
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
-    ContributionsEpicPostElectionCopyTest
+    ContributionsEpicPostElectionCopyTest,
+    ContributionsEpicMembershipBackup
 ) {
 
     var TESTS = [
@@ -36,7 +38,8 @@ define([
         new WeekendReadingEmail(),
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
-        new ContributionsEpicPostElectionCopyTest()
+        new ContributionsEpicPostElectionCopyTest(),
+        new ContributionsEpicMembershipBackup()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -64,15 +64,11 @@ define([
                 'us/business',
                 'world/world'
             ];
-
-            var hasKeywordsMatch = function() {
-                var pageKeywords = config.page.keywordIds;
-                return pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
-            };
-
+            var pageKeywords = config.page.keywordIds;
+            var hasKeywordsMatch = pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
-            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch;
         };
 
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-backup.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-backup.js
@@ -1,0 +1,123 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'text!common/views/contributions-epic.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             contributionsEpic,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures,
+             intersection) {
+
+
+    return function () {
+
+        this.id = 'ContributionsMembershipEpicBackup';
+        this.start = '2016-11-08';
+        this.expiry = '2016-11-11';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Back up contributions-only epic in case membership goes down';
+        this.showForSensitive = false;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Impressions to number of contributions/supporter signups';
+        this.audienceCriteria = 'All readers reading about US politics/election';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'If membership goes down, we have a backup way of asking for support from our readers';
+        this.canRun = function () {
+            var whitelistedKeywordIds = ['us-news/us-elections-2016', 'us-news/us-politics'];
+            var pageKeywords = config.page.keywordIds;
+            var hasKeywordsMatch = pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch;
+        };
+
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+
+        var message = '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your' +
+            ' help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your ' +
+            'perspective, too.';
+
+        var cta = {
+            contributionsMain : {
+                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
+                p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
+                cta1: 'Make a contribution',
+                cta2: 'becoming a Supporter.'
+            }
+        };
+
+        var componentWriter = function (component) {
+            fastdom.write(function () {
+                var submetaElement = $('.submeta');
+                if(submetaElement.length > 0) {
+                    component.insertBefore(submetaElement);
+                    embed.init();
+                    mediator.emit('contributions-embed:insert', component);
+                }
+            });
+                
+        };
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', complete);
+        };
+
+        var contributeUrlPrefix = 'co_us_epic_footer_';
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                    var component = $.create(template(contributionsEpic, {
+                        linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_backup'),
+                        linkUrl2: '',
+                        p1: message,
+                        p2: cta.contributionsMain.p2,
+                        p3: '',
+                        cta1: cta.contributionsMain.cta1,
+                        cta2: '',
+                        hidden: 'hidden'
+                    }));
+                    componentWriter(component);
+                },
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-backup.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-membership-epic-backup.js
@@ -62,16 +62,16 @@ define([
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
 
-        var message = '...we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your' +
-            ' help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your ' +
-            'perspective, too.';
+        var message  = {
+            control:  '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+        };
 
         var cta = {
-            contributionsMain : {
-                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be more secure. You can give money to the Guardian in less than a minute.',
-                p3: 'Alternatively, you can join the Guardian and get even closer to our journalism by ',
-                cta1: 'Make a contribution',
-                cta2: 'becoming a Supporter.'
+            equal: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution'
             }
         };
 
@@ -104,10 +104,10 @@ define([
                     var component = $.create(template(contributionsEpic, {
                         linkUrl1: makeUrl(contributeUrl, contributeUrlPrefix + 'm1_contributions_main_backup'),
                         linkUrl2: '',
-                        p1: message,
-                        p2: cta.contributionsMain.p2,
+                        p1: message.control,
+                        p2: cta.equal.p2,
                         p3: '',
-                        cta1: cta.contributionsMain.cta1,
+                        cta1: cta.equal.cta1,
                         cta2: '',
                         hidden: 'hidden'
                     }));


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

UPDATE: also fixes ab-test-clash to ensure Outbrain compliance

Tonight we want to avoid deploying unless in extreme circumstances. This pull request adds a back up test to be switched on in the case of membership failing, as currently if that happens then we would have to turn off all contributions/memebership ads on the site and we'd be left with nothing, as there are currently NO contributions-only ads live. 

(If contributions goes down, there is still plenty of membership-only ads we can put on the site)

If this test is on, the other two tests (ContributionsMembershipEpicCtaUnitedStatesTwo and ContributionsMembershipEpicCtaRestOfWorldTwo)  have to be switched off first. I am in the office tonight so i will take this responsibility. 

I realise that this functionality might be better suited to a feature switch but as a last minute safe-guard I think this suffices. 

It is worldwide, encompassing the coverage that the two aforementioned live tests running at the moment cover, and it uses the most conservative parameters for deciding whether to display: only on non-sensitive articles and just US election and US politics tagged articles. 

## What is the value of this and can you measure success?

If membership goes down, we can still make money from contributions. 
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
<img width="709" alt="screenshot at nov 08 16-26-56" src="https://cloud.githubusercontent.com/assets/2844554/20107598/fa23e2e6-a5d0-11e6-9de3-a7b4ee1f4c03.png">


## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

