### PR TITLE
Track sponsor logo impressions

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -46,7 +46,7 @@
     }
 </div>
 <div class="l-side-margins">
-    @fragments.contentFooter(page.item, page.related, "media", isPaidContent(page.item, page))
+    @fragments.contentFooter(page.item, page.related, "media", isPaidContent(page))
 </div>
 
 @galleryItem(adSlots: Seq[String], adInterval: Int, image: ImageAsset, rowNum: Int, imageElement: ImageElement) = {

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -8,16 +8,16 @@
 <div class="l-side-margins l-side-margins--media">
     <article
         class="@RenderClasses(Map(
-            "content--advertisement-feature paid-content--advertisement-feature" -> isPaidContent(page.image, page),
-            "content--sponsored" -> isSponsoredContent(page.image, page),
-            "content--foundation-supported" -> isFoundationFundedContent(page.image, page)
+            "content--advertisement-feature paid-content--advertisement-feature" -> isPaidContent(page),
+            "content--sponsored" -> isSponsoredContent(page),
+            "content--foundation-supported" -> isFoundationFundedContent(page)
         ), "content content--media content--image tonal tonal--tone-media")"
         itemprop="mainContentOfPage"
         itemscope
         itemtype="@image.metadata.schemaType"
         role="main">
 
-        @if(isPaidContent(page.image, page)) {
+        @if(isPaidContent(page)) {
             @fragments.guBand()
         }
 
@@ -44,7 +44,7 @@
     </article>
 </div>
 <div class="l-side-margins">
-    @fragments.contentFooter(image, page.related, isPaidContent = isPaidContent(image, page))
+    @fragments.contentFooter(image, page.related, isPaidContent = isPaidContent(page))
 </div>
 
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -5,7 +5,7 @@
 @import views.InteractiveBodyCleaner
 @import views.support.Commercial._
 
-@body(page.interactive, page.item.content.isImmersive, isPaidContent(page.interactive, page))
+@body(page.interactive, page.item.content.isImmersive, isPaidContent(page))
 
 @bodyRaw(interactive: model.Interactive) = {
     @interactive.maybeBody.map { body =>
@@ -28,8 +28,8 @@
             <article id="article" class="@RenderClasses(
                     Map(
                         "content--advertisement-feature" -> isPaidContent,
-                        "content--sponsored" -> isSponsoredContent(interactive, page),
-                        "content--foundation-supported" -> isFoundationFundedContent(interactive, page),
+                        "content--sponsored" -> isSponsoredContent(page),
+                        "content--foundation-supported" -> isFoundationFundedContent(page),
                         "paid-content--advertisement-feature" -> isPaidContent
                     ),
                     "content", "content--interactive", "tonal", s"tonal--${toneClass(interactive)}"
@@ -45,7 +45,7 @@
                 <div class="content__main tonal__main tonal__main--@toneClass(interactive)">
                     <div class="gs-container u-cf">
                         <div class="content__main-column">
-                            @fragments.contentMeta(interactive, page, showBadge = false)
+                            @fragments.contentMeta(interactive, page)
                         </div>
                     </div>
 
@@ -57,7 +57,7 @@
 
                     <div class="gs-container u-cf">
                         <div class="content__main-column content__meta-footer">
-                            @fragments.contentMeta(interactive, page, showBadge = false)
+                            @fragments.contentMeta(interactive, page)
                         </div>
                     </div>
                 </div>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -7,7 +7,7 @@
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
-    @defining(isPaidContent(media, page)) { isPaidContent =>
+    @defining(isPaidContent(page)) { isPaidContent =>
         <div class="l-side-margins @if(!isPaidContent) {l-side-margins--media}">
 
             <article id="article" class="@RenderClasses(

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -17,7 +17,7 @@
 }
 
 @defining(model.article) { article =>
-  @defining(isPaidContent(article, model)) { isPaidContent =>
+  @defining(isPaidContent(model)) { isPaidContent =>
 
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"

--- a/article/app/views/fragments/articleBodyExplore.scala.html
+++ b/article/app/views/fragments/articleBodyExplore.scala.html
@@ -56,6 +56,6 @@
                 </div>
             </div>
         </article>
-        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(article, model))
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(model))
     </div>
 }

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -6,7 +6,7 @@
 @import views.support.TrailCssClasses.toneClass
 
 @defining(model.article) { article =>
-  @defining(isPaidContent(article, model)) { isPaidContent =>
+  @defining(isPaidContent(model)) { isPaidContent =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
             class="content content--article content--immersive content--immersive-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -6,7 +6,7 @@
 @import views.support.TrailCssClasses.toneClass
 
 @defining(model.article) {  article =>
-  @defining(isPaidContent(article, model)) { isPaidContent =>
+  @defining(isPaidContent(model)) { isPaidContent =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
         class="content content--article content--minute-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -150,7 +150,7 @@
     </article>
 
     @if(!amp) {
-        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(article, model))
+        @fragments.contentFooter(article, model.related, isPaidContent = isPaidContent(model))
     }
 
 </div>

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -1,4 +1,5 @@
-@(page: model.Page)
+@(page: model.Page)(implicit request: RequestHeader)
+@import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.GoogleAnalyticsAccount
 
 <script id='google_analytics'>
@@ -77,6 +78,9 @@
         ga('@{trackerName}.set', 'dimension26', (!!guardian.config.page.isHosted).toString());
         ga('@{trackerName}.set', 'dimension27', navigator.userAgent);
         ga('@{trackerName}.set', 'dimension29', window.location.href);
+        @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
+          ga('@{trackerName}.set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
+        }
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -3,10 +3,10 @@
 
 @(metaData: model.MetaData, edition: common.Edition, maybeTags: Option[Tags])
 
-<div class="@topAboveNavSlot.cssClasses(metaData, edition, maybeTags)">
+<div class="@topAboveNavSlot.cssClasses">
     @fragments.commercial.standardAd(
         "top-above-nav",
         topAboveNavSlot.slotCssClasses,
-        topAboveNavSlot.adSizes(metaData, edition, maybeTags)
+        topAboveNavSlot.adSizes
     )
 </div>

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,4 +1,4 @@
-@(item: model.ContentType, page: model.Page, showBadge: Boolean = true, showExtras: Boolean = true)(implicit request: RequestHeader)
+@(item: model.ContentType, page: model.Page, showExtras: Boolean = true)(implicit request: RequestHeader)
 @import conf.switches.Switches.SaveForLaterSwitch
 @import model._
 @import views.support.Commercial.isPaidContent
@@ -68,7 +68,7 @@
 
 
     @if(
-        item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(item, page))
+        item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))
     ) {
         @fragments.commercial.badge(item, page)
     }

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -90,7 +90,7 @@
                     </div>
                 }
 
-                @if(showBadge && !isPaidContent(item, page)) {
+                @if(showBadge && !isPaidContent(page)) {
                     @fragments.commercial.badge(item, page)
                 }
 
@@ -102,7 +102,7 @@
         @if(item.fields.standfirst.isDefined) {
             <div class="gs-container">
                 <div class="content__main-column">
-                    @if(showBadge && isPaidContent(item, page)) {
+                    @if(showBadge && isPaidContent(page)) {
                         <div class="content__meta-container js-content-meta js-football-meta u-cf">
                             @fragments.commercial.badge(item, page)
                         </div>

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -1,6 +1,5 @@
 package views.support
 
-import common.Edition.defaultEdition
 import model.{MetaData, SectionSummary}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers, OptionValues}
 import views.support.Commercial.topAboveNavSlot
@@ -15,7 +14,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
 
   def pageShouldRequestAdSizes(pageId: String)(sizes: Seq[String]): Unit = {
     val metaData = metaDataFromId(pageId)
-    topAboveNavSlot.adSizes(metaData, defaultEdition, None).get("desktop").value shouldBe sizes
+    topAboveNavSlot.adSizes.get("desktop").value shouldBe sizes
   }
 
   "topAboveNavSlot ad sizes" should "be variable for all pages" in {
@@ -44,11 +43,6 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
   // }
 
   they should "be default for any other page" in {
-    topAboveNavSlot.cssClasses(metaDataFromId("uk/culture"), defaultEdition, None, Nil) should
-      endWith("js-top-banner")
-    topAboveNavSlot.cssClasses(metaDataFromId(
-      "business/2015/jul/07/eurozone-calls-on-athens-to-get-serious-over-greece-debt-crisis"),
-      defaultEdition, None, Nil)
-      .should(endWith("js-top-banner"))
+    topAboveNavSlot.cssClasses should endWith("js-top-banner")
   }
 }


### PR DESCRIPTION
This is the follow-up to #14931. 

Includes custom dimension 31 in page-view hits to hold the name of the page sponsor on all sponsored pages, and any container sponsors on a front.

Eg.
Article:
![image](https://cloud.githubusercontent.com/assets/1722550/20146433/d6452314-a69b-11e6-9689-771b0d089c94.png)

Front:
![image](https://cloud.githubusercontent.com/assets/1722550/20146497/039ca83c-a69c-11e6-8ff8-52f00115453a.png)


There's also some refactoring.


/cc @mkopka @dominickendrick @guardian/commercial-dev 