### PR TITLE
add switches to leave just membership or just contributions buttons on the Epic

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -486,4 +486,24 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 11, 14),
     exposeClientSide = false
   )
+
+  val turnOffSupporterEpic = Switch(
+    SwitchGroup.Membership,
+    "turn-off-supporter-epic",
+    "Turning this on will hide the Become a Supporter button on the epic, leaving just the Contribute button",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 14),
+    exposeClientSide = true
+  )
+
+  val turnOffContributionsEpic = Switch(
+    SwitchGroup.Membership,
+    "turn-off-contributions-epic",
+    "Turning this on will hide the Make a Contribution button on the epic, leaving just the Become a Supporter button",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 14),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -75,7 +75,13 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
+        var contributeUrlPrefix = 'co_global_epic_';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_post_';
 
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
         var contributeUrl = 'https://contribute.theguardian.com/?';
@@ -89,8 +95,33 @@ define([
                 p2: 'Fund our journalism and together we can keep the world informed.',
                 p3: '',
                 cta1: 'Become a Supporter',
-                cta2: 'Make a contribution'
+                cta2: 'Make a contribution',
+                intcmp1: makeUrl(membershipUrl, membershipUrlPrefix + 'equal_postelection_1c'),
+                intcmp2:  makeUrl(contributeUrl, contributeUrlPrefix + 'equal_postelection_1c'),
+                hidden: ''
+            },
+
+            justContribute: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Make a contribution',
+                cta2: '',
+                intcmp1:  makeUrl(contributeUrl, contributeUrlPrefix + 'equal_postelection_1c_backup'),
+                intcmp2: '',
+                hidden: 'hidden'
+            },
+
+            justSupporter: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: '',
+                intcmp1: makeUrl(membershipUrl, membershipUrlPrefix + 'equal_postelection_1c_backup'),
+                intcmp2: '',
+                hidden: 'hidden'
             }
+
+
         };
 
         var componentWriter = function (component) {
@@ -105,31 +136,35 @@ define([
             });
         };
 
-        var makeUrl = function(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        };
+
 
         var completer = function (complete) {
             mediator.on('contributions-embed:insert', complete);
         };
 
-        var contributeUrlPrefix = 'co_global_epic_';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_post_';
 
         this.variants = [
             {
                 id: 'control',
 
                 test: function () {
+                    var epicType = cta.equal;
+                    if(config.switches.turnOffSupporterEpic){
+                        epicType = cta.justContribute;
+                    }
+                    if(config.switches.turnOffContributionsEpic){
+                        epicType = cta.justSupporter;
+                    }
+
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'equal_postelection_1c'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'equal_postelection_1c'),
+                        linkUrl1: epicType.intcmp1,
+                        linkUrl2: epicType.intcmp2,
                         p1: messages.control,
-                        p2: cta.equal.p2,
-                        p3: cta.equal.p3,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
+                        p2:epicType.p2,
+                        p3: epicType.p3,
+                        cta1: epicType.cta1,
+                        cta2: epicType.cta2,
+                        hidden: epicType.hidden
                     }));
                     componentWriter(component);
                 },

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -173,7 +173,7 @@
     margin-bottom: $gs-baseline;
 }
 
-@include mq($from: phablet) {
+@include mq($from: mobileLandscape) {
     .contributions__option-button--bottom {
         width: 70px;
     }
@@ -191,7 +191,7 @@
     }
 
     .contributions__contribute--epic-member-top {
-        margin-bottom: $gs-baseline;
+        margin-bottom: 0;
     }
 
 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

This PR adds two switches, turnOffSupporterEpic and turnOffContributionsEpic, which add the ability to turn off either button on the epic across the board. 

If both are turned on, just the Supporter button will show, due to the logic. But obviously this would be silly and shouldn't be done!

Also fix a CSS bug whereby we were using 2 different breakpoints (phablet and mobile landscape) to affect the same element, resulting in a slight visual bug. 

## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment
@gtrufitt @jfsoul @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

