### PR TITLE
Engagement banner copy test 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = On, // so we don't inadvertently turn off during deployment
-    sellByDate = new LocalDate(2016, 11, 10), // Thursday night
+    sellByDate = new LocalDate(2016, 11, 17), // Thursday night
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -78,7 +78,7 @@ define([
 
         if (opts.setEngagementText) {
             var engagementText = $('#membership__engagement-message-text');
-            if (engagementText && opts.setEngagementText) {
+            if (engagementText) {
                 engagementText[0].textContent = opts.setEngagementText;
             }
         }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -41,11 +41,11 @@ define([
 
     // change messageCode to force redisplay of the message to users who already closed it.
     // messageCode is also consumed by .../test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
-    var messageCode = 'engagement-banner-2016-10-12';
+    var messageCode = 'engagement-banner-2016-11-10';
 
     var messages = {
         UK: {
-            campaign: 'mem_uk_banner',
+            campaign: 'Coffee_49',
             messageText: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.'
         },
         US: {
@@ -114,11 +114,12 @@ define([
             var messagingTestName = 'messaging-test-1';
             if (messagingTestVariant !== 'notintest') {
                 var variantMessages = {
-                    fairer: 'We all want to make the world a fairer place. We believe journalism can help – but producing it is expensive. That\'s why we need Supporters. Join for £49 per year.',
-                    appreciate: 'Become a Supporter and appreciate every article, knowing you\'ve helped bring it to the page. Be part of the Guardian. Join for £49 per year.',
-                    secure: 'Secure the future of independent journalism. Help us create a fairer world. Support the Guardian for £49 per year.'
+                    Get_round_to: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
+                    Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian\'s future more secure',
+                    Together_informed: 'Together we can keep the world informed. Give £5 a month to support our journalism',
+                    Coffee_5: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
                 };
-                campaignCode = 'gdnwb_copts_mem_banner_messaging1uk' + '__' + messagingTestVariant;
+                campaignCode = 'gdnwb_copts_mem_banner_ukbanner__' + messagingTestVariant;
                 linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
                 customOpts = {
                     testName: messagingTestName,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -61,7 +61,7 @@ define([
     };
 
     function formatEndpointUrl(edition, message) {
-        return endpoints[edition] + '?INTCMP=' + message.campaign + "_prominent";
+        return endpoints[edition] + '?INTCMP=' + message.campaign + '_prominent';
     }
 
     function thisInstanceColour(colours) {
@@ -139,7 +139,7 @@ define([
                     buttonEl = $('#membership__engagement-message-button');
                 fastdom.write(function () {
                     buttonEl.removeClass('is-hidden');
-                    buttonEl.addClass("prominent");
+                    buttonEl.addClass('prominent');
                     buttonEl.addClass(thisColour);
                     buttonCaption.text('Become a Supporter');
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -14,23 +14,21 @@ define([
     'common/modules/experiments/ab',
     'common/utils/$',
     'common/views/svgs'
-], function (
-    bean,
-    qwery,
-    config,
-    storage,
-    template,
-    Message,
-    messageTemplate,
-    commercialFeatures,
-    userFeatures,
-    mediator,
-    Promise,
-    fastdom,
-    ab,
-    $,
-    svgs
-) {
+], function (bean,
+             qwery,
+             config,
+             storage,
+             template,
+             Message,
+             messageTemplate,
+             commercialFeatures,
+             userFeatures,
+             mediator,
+             Promise,
+             fastdom,
+             ab,
+             $,
+             svgs) {
 
     var endpoints = {
         UK: 'https://membership.theguardian.com/uk/supporter',
@@ -71,7 +69,7 @@ define([
         return colours[storage.local.get('gu.alreadyVisited') % colours.length];
     }
 
-    var getCustomJs = function(options) {
+    var getCustomJs = function (options) {
         if (options === undefined) {
             return;
         }
@@ -91,7 +89,7 @@ define([
     };
 
     function show(edition, message) {
-        var colours = ['default','vibrant-blue','yellow','light-blue','deep-purple','teal'],
+        var colours = ['default', 'vibrant-blue', 'yellow', 'light-blue', 'deep-purple', 'teal'],
             thisColour = thisInstanceColour(colours),
             cssModifierClass = 'membership-message-' + thisColour,
             campaignCode = message.campaign,
@@ -101,44 +99,39 @@ define([
             usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
             linkHref = formatEndpointUrl(edition, message);
 
-        if (messagingTestVariant) {
-            var messagingTestName = 'messaging-test-1';
-            if (messagingTestVariant !== 'notintest') {
-                var variantMessages = {
-                    Get_round_to: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
-                    Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian\'s future more secure',
-                    Together_informed: 'Together we can keep the world informed. Give £5 a month to support our journalism',
-                    Coffee_5: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
-                };
-                campaignCode = 'gdnwb_copts_mem_banner_ukbanner__' + messagingTestVariant;
-                linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
-                customOpts = {
-                    testName: messagingTestName,
-                    setEngagementText: messagingTestVariant === 'control' ? undefined : variantMessages[messagingTestVariant]
-                };
-                customJs = getCustomJs;
-            }
+        if (messagingTestVariant && messagingTestVariant !== 'notintest') {
+            var variantMessages = {
+                Get_round_to: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
+                Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian\'s future more secure',
+                Together_informed: 'Together we can keep the world informed. Give £5 a month to support our journalism',
+                Coffee_5: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
+            };
+            campaignCode = 'gdnwb_copts_mem_banner_ukbanner__' + messagingTestVariant;
+            linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
+            customOpts = {
+                testName: 'messaging-test-1',
+                setEngagementText: messagingTestVariant === 'control' ? undefined : variantMessages[messagingTestVariant]
+            };
+            customJs = getCustomJs;
         }
 
-        if (usMessagingTestVariant) {
-            if (usMessagingTestVariant !== 'notintest') {
-                var usVariantMessages = {
-                    coffee: 'For less than the price of a coffee a week you could help secure the Guardian\'s future. Become a Guardian US member for just $49 a year.',
-                    defies: 'When politicians defy belief you need journalism that defies politicians. Become a Guardian US member for just $49 a year.',
-                    value: 'If you value our independent, international journalism, you can support it. Become a Guardian US member for just $49 a year.'
-                };
-                campaignCode = 'gdnwb_copts_mem_banner_messaging1us' + '__' + usMessagingTestVariant;
-                linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
-                customOpts = {
-                    testName: 'messaging-test-us-1',
-                    setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
-                };
-                customJs = getCustomJs;
-            }
+        if (usMessagingTestVariant && usMessagingTestVariant !== 'notintest') {
+            var usVariantMessages = {
+                coffee: 'For less than the price of a coffee a week you could help secure the Guardian\'s future. Become a Guardian US member for just $49 a year.',
+                defies: 'When politicians defy belief you need journalism that defies politicians. Become a Guardian US member for just $49 a year.',
+                value: 'If you value our independent, international journalism, you can support it. Become a Guardian US member for just $49 a year.'
+            };
+            campaignCode = 'gdnwb_copts_mem_banner_messaging1us' + '__' + usMessagingTestVariant;
+            linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
+            customOpts = {
+                testName: 'messaging-test-us-1',
+                setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
+            };
+            customJs = getCustomJs;
         }
 
         if (config.page.edition.toLowerCase() === 'uk' && config.switches['prominentMembershipEngagementBannerUk']) {
-            colours = ['yellow','purple','bright-blue','dark-blue'];
+            colours = ['yellow', 'purple', 'bright-blue', 'dark-blue'];
             thisColour = thisInstanceColour(colours);
             cssModifierClass = 'membership-prominent ' + thisColour;
             customOpts.execute = function () {
@@ -154,7 +147,11 @@ define([
             customJs = getCustomJs;
         }
 
-        var renderedBanner = template(messageTemplate, { messageText: message.messageText, linkHref: linkHref, arrowWhiteRight: svgs('arrowWhiteRight') });
+        var renderedBanner = template(messageTemplate, {
+            messageText: message.messageText,
+            linkHref: linkHref,
+            arrowWhiteRight: svgs('arrowWhiteRight')
+        });
         var messageShown = new Message(
             messageCode,
             {
@@ -179,7 +176,7 @@ define([
         var message = messages[edition];
         if (message) {
             var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
-            if(userHasMadeEnoughVisits) {
+            if (userHasMadeEnoughVisits) {
                 return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
                     if (canShow) {
                         show(edition, message);

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -63,7 +63,7 @@ define([
     };
 
     function formatEndpointUrl(edition, message) {
-        return endpoints[edition] + '?INTCMP=' + message.campaign;
+        return endpoints[edition] + '?INTCMP=' + message.campaign + "_prominent";
     }
 
     function thisInstanceColour(colours) {
@@ -78,19 +78,10 @@ define([
 
         var opts = options || {};
 
-        if (opts.testName) {
-            if (opts.testName === 'messaging-test-1') {
-                var engagementText = $('.site-message__message.site-message__message--membership');
-                if (engagementText && opts.setEngagementText) {
-                    engagementText[0].textContent = opts.setEngagementText;
-                }
-            }
-
-            if (opts.testName === 'messaging-test-us-1') {
-                var usEngagementText = $('.site-message__message.site-message__message--membership');
-                if (usEngagementText && opts.setEngagementText) {
-                    usEngagementText[0].textContent = opts.setEngagementText;
-                }
+        if (opts.setEngagementText) {
+            var engagementText = $('#membership__engagement-message-text');
+            if (engagementText && opts.setEngagementText) {
+                engagementText[0].textContent = opts.setEngagementText;
             }
         }
 
@@ -146,18 +137,16 @@ define([
             }
         }
 
-        if (config.page.edition.toLowerCase() === 'uk' && config.switches['prominentMembershipEngagementBannerUk'] && (!messagingTestVariant || messagingTestVariant === 'notintest')) {
-            var prominentMarker = 'prominent';
-            linkHref = endpoints[edition] + '?INTCMP=' + message.campaign + '_' + prominentMarker;
+        if (config.page.edition.toLowerCase() === 'uk' && config.switches['prominentMembershipEngagementBannerUk']) {
             colours = ['yellow','purple','bright-blue','dark-blue'];
             thisColour = thisInstanceColour(colours);
-            cssModifierClass = 'membership-' + prominentMarker + ' ' + thisColour;
+            cssModifierClass = 'membership-prominent ' + thisColour;
             customOpts.execute = function () {
                 var buttonCaption = $('#membership__engagement-message-button-caption'),
                     buttonEl = $('#membership__engagement-message-button');
                 fastdom.write(function () {
                     buttonEl.removeClass('is-hidden');
-                    buttonEl.addClass(prominentMarker);
+                    buttonEl.addClass("prominent");
                     buttonEl.addClass(thisColour);
                     buttonCaption.text('Become a Supporter');
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -102,7 +102,7 @@ define([
         if (messagingTestVariant && messagingTestVariant !== 'notintest') {
             var variantMessages = {
                 Get_round_to: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
-                Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian\'s future more secure',
+                Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian’s future more secure',
                 Together_informed: 'Together we can keep the world informed. Give £5 a month to support our journalism',
                 Coffee_5: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
             };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
@@ -23,10 +23,10 @@ define([
         this.expiry = '2016-11-17';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
-        this.audience = 0.6;    // 60% (of UK audience)
-        this.audienceOffset = 0.3;  // allow offset to engage different readers from MembershipEngagementWarpFactorOne test
+        this.audience = 1;    // 100% (of UK audience)
+        this.audienceOffset = 0;
         this.successMeasure = 'More membership sign-ups';
-        this.audienceCriteria = '60 percent of (non-member) UK edition readers';
+        this.audienceCriteria = '100 percent of (non-member) UK edition readers';
         this.dataLinkNames = '';
         this.idealOutcome = 'More readers engage with the banner and then complete membership sign-up';
         this.hypothesis = 'More persuasive copy will improve membership conversions from impressions';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
@@ -19,8 +19,8 @@ define([
 ) {
     return function () {
         this.id = 'MembershipEngagementMessageCopyExperiment';
-        this.start = '2016-10-26';
-        this.expiry = '2016-11-8';
+        this.start = '2016-11-10';
+        this.expiry = '2016-11-17';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
         this.audience = 0.6;    // 60% (of UK audience)
@@ -52,17 +52,22 @@ define([
                 success: success.bind(this)
             },
             {
-                id: 'fairer',
+                id: 'Get_round_to',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'appreciate',
+                id: 'Give_upfront',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'secure',
+                id: 'Together_informed',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: 'Coffee_5',
                 test: function () {},
                 success: success.bind(this)
             }

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,6 +1,8 @@
 <div id="site-message__message">
     <div class="site-message__message site-message__message--membership">
-        <%=messageText%>
+        <span id="membership__engagement-message-text">
+            <%=messageText%>
+        </span>
         <span id="membership__engagement-message-button" class="message-button-rounded__cta is-hidden">
             <span id="membership__engagement-message-button-caption"></span><span id="membership__engagement-message-button-arrow"><%=arrowWhiteRight%></span>
         </span>


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Extends the membership engagement banner copy test, adds new message variants and uses the new prominent banner style

Tracking codes are defined [here](https://docs.google.com/spreadsheets/d/1ymFXK9eSf2TV_jjniaCdrS2omzAWjTHUHKobSj4Ceqo/edit?ts=58246161#gid=0)
New text is [here](https://docs.google.com/document/d/16kbjk6yp96SS9sYa7z88yPdmjlZHuSfnjE2JxOQz834/edit?ts=58245f54)

## What is the value of this and can you measure success?
We hope to discover the most effective copy to use to increase membership sign-ups.

## Does this affect other platforms - Amp, Apps, etc?

No web only

## Screenshots

## Request for comment
@rtyley @Ap0c

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
