### PR TITLE
Block asking for contributions on Leonard Cohen pieces

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -48,7 +48,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'We learn to what extend using messages that chime with current events have an impact on contributor/supporter conversion';
         this.canRun = function () {
-            var whitelistedKeywordIds = [
+            var includedKeywordIds = [
                 'australia-news/australia-news',
                 'politics/politics',
                 'politics/eu-referendum',
@@ -65,9 +65,17 @@ define([
                 'world/world'
             ];
 
+            var excludedKeywordIds = ['music/leonard-cohen'];
+
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
-                return pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
+                if (typeof(pageKeywords) != 'undefined') {
+                    var keywordList = pageKeywords.split(',');
+                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        intersection(includedKeywordIds, keywordList).length > 0;
+                } else {
+                    return false;
+                }
             };
 
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Ensures we don't ask for contributions/membership on any Cohen pieces. I don't think we are, but this seems a sensible precaution.

## Does this affect other platforms - Amp, Apps, etc?
No
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Request for comment

@jranks123 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

