### PR TITLE
YouTube Tracking

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -3,9 +3,10 @@
 
 @(media: model.content.MediaAtom)(implicit request: RequestHeader)
 
-    <div class="@RenderClasses(Map(
+    <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
-        "u-responsive-ratio--hd" -> true
+        "u-responsive-ratio--hd" -> true,
+        "atom--media--youtube" -> true
     ))">
 
         @defining(if(!host.isEmpty) "&origin=" + host else "") { origin =>

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -162,6 +162,14 @@ define([
             });
         }
 
+        fastdom.read(function() {
+            if ( $('.atom--media--youtube').length > 0) {
+                require(['bootstraps/enhanced/youtube'], function (youtube) {
+                    bootstrapContext('youtube', youtube);
+                });
+            }
+        });
+
         // Mark the end of synchronous execution.
         userTiming.mark('App End');
     };

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -22,20 +22,20 @@ define([
     function init() {
 
         fastdom.read(function () {
-                        $('.atom--media--youtube').each(function (el) {
-                            var atomId = el.getAttribute('data-media-atom-id');
-                            var videoId = el.firstElementChild.id;
-                            tracking.init(atomId);
-                            players[videoId] = youtubePlayer.init(el,
-                                {
-                                    onPlayerStateChange: function (event) {
-                                        Object.keys(STATES).forEach(checkState.bind(null, videoId, atomId, event.data, event.target));
-                                    },
-                                    onPlayerReady: function (event) {
-                                        var player = event.target;
-                                        // Record the duration for percentage calculation.
-                                        player.duration = player.getDuration();
-                                    }
+            $('.atom--media--youtube').each(function (el) {
+                var atomId = el.getAttribute('data-media-atom-id');
+                var videoId = el.firstElementChild.id;
+                tracking.init(atomId);
+                players[videoId] = youtubePlayer.init(el,
+                    {
+                        onPlayerStateChange: function (event) {
+                            Object.keys(STATES).forEach(checkState.bind(null, videoId, atomId, event.data, event.target));
+                        },
+                        onPlayerReady: function (event) {
+                            var player = event.target;
+                            // Record the duration for percentage calculation.
+                            player.duration = player.getDuration();
+                        }
                     }
                     , videoId);
             });
@@ -77,13 +77,13 @@ define([
     }
 
     function recordPlayerProgress(atomId, player) {
-            var currentTime = player.getCurrentTime();
-            var percentPlayed = Math.round(((currentTime / player.duration) * 100));
+        var currentTime = player.getCurrentTime();
+        var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
-            if (percentPlayed > 0 && percentPlayed < 100 &&
-                percentPlayed % 25 === 0) {
-                tracking.track(percentPlayed, atomId);
-            }
+        if (percentPlayed > 0 && percentPlayed < 100 &&
+            percentPlayed % 25 === 0) {
+            tracking.track(percentPlayed, atomId);
+        }
     }
 
     return {

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -24,12 +24,12 @@ define([
         fastdom.read(function () {
             $('.atom--media--youtube').each(function (el) {
                 var atomId = el.getAttribute('data-media-atom-id');
-                var videoId = el.firstElementChild.id;
+                var youtubeId = el.firstElementChild.id;
                 tracking.init(atomId);
-                players[videoId] = youtubePlayer.init(el,
+                players[youtubeId] = youtubePlayer.init(el,
                     {
                         onPlayerStateChange: function (event) {
-                            Object.keys(STATES).forEach(checkState.bind(null, videoId, atomId, event.data, event.target));
+                            Object.keys(STATES).forEach(checkState.bind(null, youtubeId, atomId, event.data, event.target));
                         },
                         onPlayerReady: function (event) {
                             var player = event.target;
@@ -37,7 +37,7 @@ define([
                             player.duration = player.getDuration();
                         }
                     }
-                    , videoId);
+                    , youtubeId);
             });
         });
     }

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -38,7 +38,7 @@ define([
                                     }
                     }
                     , videoId);
-            })
+            });
         });
     }
 
@@ -77,8 +77,8 @@ define([
     }
 
     function recordPlayerProgress(atomId, player) {
-            var currentTime = player.getCurrentTime(),
-                percentPlayed = Math.round(((currentTime / player.duration) * 100));
+            var currentTime = player.getCurrentTime();
+            var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
             if (percentPlayed > 0 && percentPlayed < 100 &&
                 percentPlayed % 25 === 0) {
@@ -88,5 +88,5 @@ define([
 
     return {
         init: init
-    }
+    };
 });

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -1,0 +1,92 @@
+define([
+    'fastdom',
+    'common/modules/video/youtube-player',
+    'common/modules/video/youtube-tracking',
+    'common/utils/$'
+], function (
+    fastdom,
+    youtubePlayer,
+    tracking,
+    $
+) {
+
+    var STATES = {
+        'ENDED': _onPlayerEnded,
+        'PLAYING': _onPlayerPlaying,
+        'PAUSED': _onPlayerPaused
+    };
+
+    var progressTracker = {};
+    var players = {};
+
+    function init() {
+
+        fastdom.read(function () {
+                        $('.atom--media--youtube').each(function (el) {
+                            var atomId = el.getAttribute('data-media-atom-id');
+                            var videoId = el.firstElementChild.id;
+                            tracking.init(atomId);
+                            players[videoId] = youtubePlayer.init(el,
+                                {
+                                    onPlayerStateChange: function (event) {
+                                        Object.keys(STATES).forEach(checkState.bind(null, videoId, atomId, event.data, event.target));
+                                    },
+                                    onPlayerReady: function (event) {
+                                        var player = event.target;
+                                        // Record the duration for percentage calculation.
+                                        player.duration = player.getDuration();
+                                    }
+                    }
+                    , videoId);
+            })
+        });
+    }
+
+    function checkState(id, atomId, state, player, status) {
+        if (state === window.YT.PlayerState[status] && STATES[status]) {
+            STATES[status](id, atomId, player);
+        }
+    }
+
+    function _onPlayerPlaying(id, atomId, player) {
+        setProgressTracker(id, atomId, player);
+        tracking.track('play', atomId);
+    }
+
+    function _onPlayerPaused(id) {
+        killProgressTracker(false, id);
+    }
+
+    function _onPlayerEnded(id, atomId) {
+        killProgressTracker(false, id);
+        tracking.track('end', atomId);
+    }
+
+    function setProgressTracker(id, atomId, player)  {
+        killProgressTracker(true);
+        progressTracker.id = id;
+        progressTracker.tracker = setInterval(recordPlayerProgress.bind(null, atomId, player), 1000);
+    }
+
+    function killProgressTracker(force, id) {
+        if (progressTracker.tracker &&
+            (force || id === progressTracker.id)) {
+            clearInterval(progressTracker.tracker);
+            progressTracker = {};
+        }
+    }
+
+    function recordPlayerProgress(atomId, player) {
+            var currentTime = player.getCurrentTime(),
+                percentPlayed = Math.round(((currentTime / player.duration) * 100));
+
+            if (percentPlayed > 0 && percentPlayed < 100 &&
+                percentPlayed % 25 === 0) {
+                tracking.track(percentPlayed, atomId);
+            }
+    }
+
+    return {
+        init: init
+    }
+});

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -67,6 +67,11 @@ define([
 
                             function recordPlayerProgress() {
                                 var player = event.target;
+
+                                if (!player.duration) {
+                                    player.duration = player.getDuration();
+                                }
+
                                 var currentTime = player.getCurrentTime();
                                 var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
@@ -77,11 +82,6 @@ define([
                             }
 
                             Object.keys(STATES).forEach(checkState.bind(null, event.data));
-                        },
-                        onPlayerReady: function (event) {
-                            var player = event.target;
-                            // Record the duration for percentage calculation.
-                            player.duration = player.getDuration();
                         }
                     }
                     , youtubeId);

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -104,7 +104,7 @@ define([
                     nextVideoAutoplay.triggerAutoplay(event.target.getCurrentTime.bind(event.target), duration);
                 }
             }
-        });
+        }, el.id);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -111,16 +111,6 @@ define([
         bindCustomMediaEvents(eventsMap, player, mediaId, mediaType, true);
     }
 
-    function getGoogleAnalyticsEventAction(mediaEvent) {
-        var action = mediaEvent.mediaType + ' ';
-        if (mediaEvent.isPreroll) {
-            action += 'preroll';
-        } else {
-            action += 'content';
-        }
-        return action;
-    }
-
     function bindGoogleAnalyticsEvents(player, canonicalUrl) {
         var events = {
             'play': 'metric1',
@@ -136,7 +126,7 @@ define([
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
                 ga(gaTracker + '.send', 'event', gaHelper.buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl,
-                    'guardian-videojs', getGoogleAnalyticsEventAction, mediaEvent.mediaId));
+                    'guardian-videojs', gaHelper.getGoogleAnalyticsEventAction, mediaEvent.mediaId));
             });
         });
     }

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -10,7 +10,8 @@ define([
     'common/modules/onward/history',
     'lodash/arrays/indexOf',
     'lodash/functions/throttle',
-    'lodash/objects/forOwn'
+    'lodash/objects/forOwn',
+    'common/modules/video/ga-helper'
 ], function (
     bean,
     qwery,
@@ -22,7 +23,8 @@ define([
     history,
     indexOf,
     throttle,
-    forOwn
+    forOwn,
+    gaHelper
 ) {
     var isDesktop = detect.isBreakpoint({ min: 'desktop' }),
         isEmbed = !!guardian.isEmbed,
@@ -119,25 +121,6 @@ define([
         return action;
     }
 
-    function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl) {
-        var category = 'Media';
-        var playerName = 'guardian-videojs';
-        var action = getGoogleAnalyticsEventAction(mediaEvent);
-        var fieldsObject = {
-            eventCategory: category,
-            eventAction: action,
-            eventLabel: canonicalUrl,
-            dimension19: mediaEvent.mediaId,
-            dimension20: playerName
-        };
-        // Increment the appropriate metric based on the event type
-        var metricId = metrics[mediaEvent.eventType];
-        if (metricId) {
-            fieldsObject[metricId] = 1;
-        }
-        return fieldsObject;
-    }
-
     function bindGoogleAnalyticsEvents(player, canonicalUrl) {
         var events = {
             'play': 'metric1',
@@ -152,7 +135,8 @@ define([
             return 'media:' + eventName;
         }).forEach(function(playerEvent) {
             player.on(playerEvent, function(_, mediaEvent) {
-                ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl));
+                ga(gaTracker + '.send', 'event', gaHelper.buildGoogleAnalyticsEvent(mediaEvent, events, canonicalUrl,
+                    'guardian-videojs', getGoogleAnalyticsEventAction, mediaEvent.mediaId));
             });
         });
     }

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -1,0 +1,27 @@
+define([
+], function (
+) {
+
+    function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl, playerName, eventAction, videoId) {
+
+        var category = 'Media';
+        var playerName = playerName;
+        var action = eventAction(mediaEvent);
+        var fieldsObject = {
+            eventCategory: category,
+            eventAction: action,
+            eventLabel: canonicalUrl,
+            dimension19: videoId,
+            dimension20: playerName
+        };
+        // Increment the appropriate metric based on the event type
+        var metricId = metrics[mediaEvent.eventType];
+        if (metricId) {
+            fieldsObject[metricId] = 1;
+        }
+        return fieldsObject;
+    }
+    return {
+        buildGoogleAnalyticsEvent: buildGoogleAnalyticsEvent
+    };
+});

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -1,7 +1,5 @@
-define([
-], function (
+define(function (
 ) {
-
     function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl, player, eventAction, videoId) {
 
         var category = 'Media';

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -19,7 +19,19 @@ define(function (
         }
         return fieldsObject;
     }
+
+    function getGoogleAnalyticsEventAction(mediaEvent) {
+        var action = mediaEvent.mediaType + ' ';
+        if (mediaEvent.isPreroll) {
+            action += 'preroll';
+        } else {
+            action += 'content';
+        }
+        return action;
+    }
+
     return {
-        buildGoogleAnalyticsEvent: buildGoogleAnalyticsEvent
+        buildGoogleAnalyticsEvent: buildGoogleAnalyticsEvent,
+        getGoogleAnalyticsEventAction: getGoogleAnalyticsEventAction
     };
 });

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -2,10 +2,10 @@ define([
 ], function (
 ) {
 
-    function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl, playerName, eventAction, videoId) {
+    function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl, player, eventAction, videoId) {
 
         var category = 'Media';
-        var playerName = playerName;
+        var playerName = player;
         var action = eventAction(mediaEvent);
         var fieldsObject = {
             eventCategory: category,

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -86,26 +86,20 @@ define([
         if (handlers && typeof handlers.onPlayerReady === 'function') {
             handlers.onPlayerReady(event, player);
         }
-
-        tracking.track(videoId, "video:content:ready");
     }
 
     function _onPlayerPlaying(id) {
         setProgressTracker(id);
-        var currentTime = Math.round(players[id].player.getCurrentTime());
-        if (currentTime === 0) {
-            tracking.track(id, "video:content:start");
-        }
+        tracking.track("play");
     }
 
     function _onPlayerPaused(id) {
         killProgressTracker(false, id);
-        tracking.track(id, "video:content:pause");
     }
 
     function _onPlayerEnded(id) {
         killProgressTracker(false, id);
-        tracking.track(id, "video:content:end");
+        tracking.track("end");
     }
 
     function setProgressTracker(id) {
@@ -126,7 +120,7 @@ define([
         //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
         var wrapper = prepareWrapper(el);
-        var videoId = el.firstElementChild.id; // Of type iframe. Select iframe.
+        var videoId = el.firstElementChild.id; //TODO: Of type iframe. Select iframe.
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
@@ -140,6 +134,9 @@ define([
             players[videoId] = {
                 player: setupPlayer(videoId, onPlayerReady, onPlayerStateChange)
             };
+            
+            var atomId = el.getAttribute("data-media-atom-id");
+            tracking.init(atomId);
 
             return players[videoId].player;
         });
@@ -161,7 +158,7 @@ define([
 
         if (percentPlayed > 0 &&
             percentPlayed % 25 === 0) {
-            tracking.track(id, 'video:content:' + percentPlayed);
+            tracking.track(percentPlayed);
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -2,17 +2,26 @@ define([
     'fastdom',
     'Promise',
     'common/utils/$',
-    'common/utils/load-script'
+    'common/utils/load-script',
+    'common/modules/video/youtube-tracking'
 ], function (
     fastdom,
     Promise,
     $,
-    loadScript
+    loadScript,
+    tracking
 ) {
     var scriptId = 'youtube-player';
     var scriptSrc = 'https://www.youtube.com/player_api';
     var promise = new Promise(function(resolve) {
         window.onYouTubeIframeAPIReady = resolve;
+    });
+
+    //TODO: Check if page include you-tube atoms and if it does init this file...
+    fastdom.read(function() {
+        $('.atom--media--youtube').each(function(el) {
+            init(el.parentElement, null);
+        });
     });
 
     function loadYoutubeJs() {
@@ -24,8 +33,7 @@ define([
     function prepareWrapper(el) {
         var wrapper = document.createElement('div');
         wrapper.className += el.className;
-
-
+        
         fastdom.write(function () {
             el.parentNode.insertBefore(wrapper, el);
             wrapper.appendChild(el);
@@ -58,7 +66,6 @@ define([
 
     function init(el, handlers) {
         //wrap <iframe/> in a div with dynamically updating class attributes
-
         loadYoutubeJs();
 
         var wrapper = prepareWrapper(el);
@@ -72,6 +79,7 @@ define([
                 _onPlayerReady(event, handlers, wrapper);
             }
 
+            //TODO: Pass array of you tube videos to YT Player.
             return new window.YT.Player(el.id, {
                 events: {
                     'onReady': onPlayerReady,

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -60,6 +60,7 @@ define([
 
     function _onPlayerStateChange(event, handlers, wrapper, videoId) {
         //change class according to the current state
+        //TODO: Fix this so we can add poster image.
         fastdom.write(function () {
             ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
                 wrapper.classList.toggle('youtube__video-' + status.toLocaleLowerCase(), event.data === window.YT.PlayerState[status]);
@@ -77,7 +78,7 @@ define([
     function _onPlayerReady(event, handlers, wrapper, videoId) {
 
         // Record the duration for percentage calculation.
-        players[videoId].player.duration = players[videoId].player.getDuration();
+        players[videoId].duration = players[videoId].player.getDuration();
 
         fastdom.write(function () {
             wrapper.classList.add('youtube__video-ready');
@@ -125,7 +126,7 @@ define([
         //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
         var wrapper = prepareWrapper(el);
-        var videoId = el.firstElementChild.id;
+        var videoId = el.firstElementChild.id; // Of type iframe. Select iframe.
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
@@ -156,7 +157,7 @@ define([
     function recordPlayerProgress(id) {
 
         var currentTime = players[id].player.getCurrentTime(),
-            percentPlayed = Math.round(((currentTime / players[id].player.duration) * 100));
+            percentPlayed = Math.round(((currentTime / players[id].duration) * 100));
 
         if (percentPlayed > 0 &&
             percentPlayed % 25 === 0) {

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -16,7 +16,7 @@ define([
     var promise = new Promise(function(resolve) {
         window.onYouTubeIframeAPIReady = resolve;
     });
-
+    
     //TODO: Check if page include you-tube atoms and if it does init this file...
     fastdom.read(function() {
         $('.atom--media--youtube').each(function(el) {
@@ -79,12 +79,16 @@ define([
             }
 
             //TODO: Pass array of you tube videos to YT Player.
-            return new window.YT.Player(el.firstElementChild.id, {
-                events: {
-                    'onReady': onPlayerReady,
-                    'onStateChange': onPlayerStateChange
-                }
-            });
+            return setupPlayer(el.firstElementChild.id, onPlayerReady, onPlayerStateChange);
+        });
+    }
+
+    function setupPlayer(id, onPlayerReady, onPlayerStateChange) {
+        return new window.YT.Player(id, {
+            events: {
+                'onReady': onPlayerReady,
+                'onStateChange': onPlayerStateChange
+            }
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -30,9 +30,14 @@ define([
 
     fastdom.read(function() {
         $('.atom--media--youtube').each(function(el) {
-            init(el, tracking);
+            init(el, tracking, el.firstElementChild.id, initTracking);
         });
     });
+
+    function initTracking(el) {
+        var atomId = el.getAttribute('data-media-atom-id');
+        tracking.init(atomId);
+    }
 
     function loadYoutubeJs() {
         fastdom.write(function () {
@@ -116,11 +121,14 @@ define([
         }
     }
 
-    function init(el, handlers) {
+    function init(el, handlers, videoId, tracking) {
         //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
         var wrapper = prepareWrapper(el);
-        var videoId = el.firstElementChild.id; //TODO: Of type iframe. Select iframe.
+
+        if (tracking && typeof tracking === 'function') {
+            tracking(el);
+        }
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
@@ -134,9 +142,6 @@ define([
             players[videoId] = {
                 player: setupPlayer(videoId, onPlayerReady, onPlayerStateChange)
             };
-
-            var atomId = el.getAttribute('data-media-atom-id');
-            tracking.init(atomId);
 
             return players[videoId].player;
         });

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -11,8 +11,8 @@ define([
     loadScript,
     tracking
 ) {
-    var scriptId = 'youtube-player';
-    var scriptSrc = 'https://www.youtube.com/player_api';
+    var scriptId = 'youtube-script';
+    var scriptSrc = 'https://www.youtube.com/iframe_api';
     var promise = new Promise(function(resolve) {
         window.onYouTubeIframeAPIReady = resolve;
     });
@@ -20,7 +20,7 @@ define([
     //TODO: Check if page include you-tube atoms and if it does init this file...
     fastdom.read(function() {
         $('.atom--media--youtube').each(function(el) {
-            init(el.parentElement, null);
+            init(el, tracking);
         });
     });
 
@@ -33,7 +33,7 @@ define([
     function prepareWrapper(el) {
         var wrapper = document.createElement('div');
         wrapper.className += el.className;
-        
+
         fastdom.write(function () {
             el.parentNode.insertBefore(wrapper, el);
             wrapper.appendChild(el);
@@ -67,7 +67,6 @@ define([
     function init(el, handlers) {
         //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
-
         var wrapper = prepareWrapper(el);
 
         return promise.then(function () {
@@ -80,7 +79,7 @@ define([
             }
 
             //TODO: Pass array of you tube videos to YT Player.
-            return new window.YT.Player(el.id, {
+            return new window.YT.Player(el.firstElementChild.id, {
                 events: {
                     'onReady': onPlayerReady,
                     'onStateChange': onPlayerStateChange

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -16,8 +16,18 @@ define([
     var promise = new Promise(function(resolve) {
         window.onYouTubeIframeAPIReady = resolve;
     });
-    
-    //TODO: Check if page include you-tube atoms and if it does init this file...
+
+    var players = {},
+        progressTracker = {};
+
+    var STATES = {
+        'ENDED': _onPlayerEnded,
+        'PLAYING': _onPlayerPlaying,
+        'PAUSED': _onPlayerPaused,
+        'BUFFERING': null,
+        'CUED': null
+    };
+
     fastdom.read(function() {
         $('.atom--media--youtube').each(function(el) {
             init(el, tracking);
@@ -42,7 +52,13 @@ define([
         return wrapper;
     }
 
-    function _onPlayerStateChange(event, handlers, wrapper) {
+    function checkState(id, state, status) {
+        if (state === window.YT.PlayerState[status] && STATES[status]) {
+            STATES[status](id);
+        }
+    }
+
+    function _onPlayerStateChange(event, handlers, wrapper, videoId) {
         //change class according to the current state
         fastdom.write(function () {
             ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(function (status) {
@@ -50,17 +66,58 @@ define([
             });
             wrapper.classList.add('youtube__video-started');
         });
+
+        Object.keys(STATES).forEach(checkState.bind(null, videoId, event.data));
+
         if (handlers && typeof handlers.onPlayerStateChange === 'function') {
             handlers.onPlayerStateChange(event);
         }
     }
 
-    function _onPlayerReady(event, handlers, wrapper) {
+    function _onPlayerReady(event, handlers, wrapper, videoId) {
+
+        // Record the duration for percentage calculation.
+        players[videoId].player.duration = players[videoId].player.getDuration();
+
         fastdom.write(function () {
             wrapper.classList.add('youtube__video-ready');
         });
         if (handlers && typeof handlers.onPlayerReady === 'function') {
-            handlers.onPlayerReady(event);
+            handlers.onPlayerReady(event, player);
+        }
+
+        tracking.track(videoId, "video:content:ready");
+    }
+
+    function _onPlayerPlaying(id) {
+        setProgressTracker(id);
+        var currentTime = Math.round(players[id].player.getCurrentTime());
+        if (currentTime === 0) {
+            tracking.track(id, "video:content:start");
+        }
+    }
+
+    function _onPlayerPaused(id) {
+        killProgressTracker(false, id);
+        tracking.track(id, "video:content:pause");
+    }
+
+    function _onPlayerEnded(id) {
+        killProgressTracker(false, id);
+        tracking.track(id, "video:content:end");
+    }
+
+    function setProgressTracker(id) {
+        killProgressTracker(true);
+        progressTracker.id = id;
+        progressTracker.tracker = setInterval(recordPlayerProgress.bind(null, id), 1000);
+    }
+
+    function killProgressTracker(force, id) {
+        if (progressTracker.tracker &&
+            (force || id === progressTracker.id)) {
+            clearInterval(progressTracker.tracker);
+            progressTracker = {};
         }
     }
 
@@ -68,18 +125,22 @@ define([
         //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
         var wrapper = prepareWrapper(el);
+        var videoId = el.firstElementChild.id;
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
-                _onPlayerStateChange(event, handlers, wrapper);
+                _onPlayerStateChange(event, handlers, wrapper, videoId);
             }
 
             function onPlayerReady(event) {
-                _onPlayerReady(event, handlers, wrapper);
+                _onPlayerReady(event, handlers, wrapper, videoId);
             }
 
-            //TODO: Pass array of you tube videos to YT Player.
-            return setupPlayer(el.firstElementChild.id, onPlayerReady, onPlayerStateChange);
+            players[videoId] = {
+                player: setupPlayer(videoId, onPlayerReady, onPlayerStateChange)
+            };
+
+            return players[videoId].player;
         });
     }
 
@@ -90,6 +151,17 @@ define([
                 'onStateChange': onPlayerStateChange
             }
         });
+    }
+
+    function recordPlayerProgress(id) {
+
+        var currentTime = players[id].player.getCurrentTime(),
+            percentPlayed = Math.round(((currentTime / players[id].player.duration) * 100));
+
+        if (percentPlayed > 0 &&
+            percentPlayed % 25 === 0) {
+            tracking.track(id, 'video:content:' + percentPlayed);
+        }
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -97,7 +97,7 @@ define([
         tracking.track('play', atomId);
     }
 
-    function _onPlayerPaused(id, atomId) {
+    function _onPlayerPaused(id) {
         killProgressTracker(false, id);
     }
 

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -159,7 +159,7 @@ define([
         var currentTime = players[id].player.getCurrentTime(),
             percentPlayed = Math.round(((currentTime / players[id].duration) * 100));
 
-        if (percentPlayed > 0 &&
+        if (percentPlayed > 0 && percentPlayed < 100 &&
             percentPlayed % 25 === 0) {
             tracking.track(percentPlayed, atomId);
         }

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -84,13 +84,13 @@ define([
             wrapper.classList.add('youtube__video-ready');
         });
         if (handlers && typeof handlers.onPlayerReady === 'function') {
-            handlers.onPlayerReady(event, player);
+            handlers.onPlayerReady(event);
         }
     }
 
     function _onPlayerPlaying(id) {
         setProgressTracker(id);
-        tracking.track("play");
+        tracking.track('play');
     }
 
     function _onPlayerPaused(id) {
@@ -99,7 +99,7 @@ define([
 
     function _onPlayerEnded(id) {
         killProgressTracker(false, id);
-        tracking.track("end");
+        tracking.track('end');
     }
 
     function setProgressTracker(id) {
@@ -134,8 +134,8 @@ define([
             players[videoId] = {
                 player: setupPlayer(videoId, onPlayerReady, onPlayerStateChange)
             };
-            
-            var atomId = el.getAttribute("data-media-atom-id");
+
+            var atomId = el.getAttribute('data-media-atom-id');
             tracking.init(atomId);
 
             return players[videoId].player;

--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -23,9 +23,7 @@ define([
     var STATES = {
         'ENDED': _onPlayerEnded,
         'PLAYING': _onPlayerPlaying,
-        'PAUSED': _onPlayerPaused,
-        'BUFFERING': null,
-        'CUED': null
+        'PAUSED': _onPlayerPaused
     };
 
     fastdom.read(function() {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -1,0 +1,19 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/fastdom-promise',
+    'raven',
+    'Promise',
+    'common/modules/video/events',
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    fastdomPromise,
+    raven,
+    Promise,
+    events
+) {
+
+}

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -5,7 +5,7 @@ define([
     'common/utils/fastdom-promise',
     'raven',
     'Promise',
-    'common/modules/video/events',
+    'common/modules/video/events'
 ], function (
     bean,
     bonzo,
@@ -16,4 +16,4 @@ define([
     events
 ) {
 
-}
+});

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -14,6 +14,10 @@ define([
         return 'video content';
     }
 
+    function buildEventId(event, videoId) {
+        return event + ':' + videoId;
+    }
+
     function initYoutubeEvents(videoId) {
 
         var ga = window.ga,
@@ -40,7 +44,7 @@ define([
         var eventsList = ['play', '25', '50', '75', 'end'];
 
         forEach(eventsList, function(event) {
-            mediator.once(event, function(id) {
+            mediator.once(buildEventId(event, videoId), function(id) {
                 ophanRecord(event, id);
                 ga(gaTracker + '.send', 'event',
                     gaHelper.buildGoogleAnalyticsEvent(event, events, window.location.pathname,
@@ -66,7 +70,7 @@ define([
     }
 
     function track(event, id) {
-        mediator.emit(event, id);
+        mediator.emit(buildEventId(event, id), id);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -45,24 +45,41 @@ define([
 
         forEach(eventsList, function(event) {
             mediator.once(buildEventId(event, videoId), function(id) {
-                ophanRecord(event, id);
+                var mediaEvent = MediaEvent(videoId, "video", event);
+                ophanRecord(mediaEvent);
                 ga(gaTracker + '.send', 'event',
-                    gaHelper.buildGoogleAnalyticsEvent(event, events, videoId,
+                    gaHelper.buildGoogleAnalyticsEvent(mediaEvent, events.metricMap, id,
                         'gu-video-youtube', eventAction, id));
             });
         });
 
-        function ophanRecord(event, id) {
+        function ophanRecord(event) {
             require(['ophan/ng'], function (ophan) {
                 var eventObject = {
                     video: {
-                        id: 'gu-video-youtube-' + id,
-                        eventType: 'video:content:' + event
+                        id: 'gu-video-youtube-' + event.mediaId,
+                        eventType: 'video:content:' + event.eventType
                     }
                 };
                 ophan.record(eventObject);
             });
         }
+    }
+
+    /**
+     *
+     * @param mediaId {string}
+     * @param mediaType {string} audio|video
+     * @param eventType {string} e.g. firstplay, firstend
+     * @param isPreroll {boolean}
+     * @returns {{mediaId: string, mediaType: string, eventType: string, isPreroll: boolean}}
+     */
+    function MediaEvent(mediaId, mediaType, eventType) {
+        return {
+            mediaId: mediaId,
+            mediaType: mediaType,
+            eventType: eventType
+        };
     }
 
     function init(videoId) {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -20,8 +20,8 @@ define([
 
     function initYoutubeEvents(videoId) {
 
-        var ga = window.ga,
-            gaTracker = config.googleAnalytics.trackers.editorial;
+        var ga = window.ga;
+        var gaTracker = config.googleAnalytics.trackers.editorial;
 
         var events = {
             metricMap: {
@@ -35,7 +35,7 @@ define([
             baseEventObject: {
                 eventCategory: 'Media',
                 eventAction: 'video content',
-                eventLabel: window.location.pathname,
+                eventLabel: videoId,
                 dimension19: videoId,
                 dimension20: 'guardian-youtube'
             }
@@ -47,7 +47,7 @@ define([
             mediator.once(buildEventId(event, videoId), function(id) {
                 ophanRecord(event, id);
                 ga(gaTracker + '.send', 'event',
-                    gaHelper.buildGoogleAnalyticsEvent(event, events, window.location.pathname,
+                    gaHelper.buildGoogleAnalyticsEvent(event, events, videoId,
                         'gu-video-youtube', eventAction, id));
             });
         });

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -45,7 +45,7 @@ define([
 
         forEach(eventsList, function(event) {
             mediator.once(buildEventId(event, videoId), function(id) {
-                var mediaEvent = MediaEvent(videoId, "video", event);
+                var mediaEvent = MediaEvent(videoId, 'video', event);
                 ophanRecord(mediaEvent);
                 ga(gaTracker + '.send', 'event',
                     gaHelper.buildGoogleAnalyticsEvent(mediaEvent, events.metricMap, id,

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -16,12 +16,30 @@ define([
     events
 ) {
 
+    function onPlayerStateChange(event) {
+        track(event);
+    }
+
+    function onPlayerReady(event) {
+        track(event);
+    }
+
     function track(event) {
-        console.log("Tracking: " + event);
+
+        if (event.data === YT.PlayerState.PLAYING) {
+            console.log('Tracking: play');
+        }
+        if (event.data === YT.PlayerState.PAUSED) {
+            console.log('Tracking: paused');
+        }
+        if (event.data === YT.PlayerState.ENDED) {
+            console.log('Tracking: ended');
+        }
     }
 
     return {
-        track: track
+        onPlayerStateChange: onPlayerStateChange,
+        onPlayerReady: onPlayerReady
     };
 
 });

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -2,11 +2,17 @@ define([
     'common/utils/mediator',
     'lodash/collections/forEach',
     'common/utils/config',
+    'common/modules/video/ga-helper'
 ], function (
     mediator,
     forEach,
-    config
+    config,
+    gaHelper
 ) {
+
+    function eventAction() {
+        return 'video content';
+    }
 
     function initYoutubeEvents(videoId) {
 
@@ -36,7 +42,9 @@ define([
         forEach(eventList, function(event) {
             mediator.once(event, function() {
                 ophanRecord(event);
-                ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(event, events, window.location.pathname, videoId));
+                ga(gaTracker + '.send', 'event',
+                    gaHelper.buildGoogleAnalyticsEvent(event, events, window.location.pathname,
+                        'gu-video-youtube', eventAction, videoId));
             });
         });
 
@@ -51,27 +59,6 @@ define([
                 ophan.record(eventObject);
             });
         }
-
-
-        function buildGoogleAnalyticsEvent(event, metrics, canonicalUrl, videoId) {
-            var category = 'Media';
-            var playerName = 'gu-video-youtube';
-            var action = 'video content';
-            var fieldsObject = {
-                eventCategory: category,
-                eventAction: action,
-                eventLabel: canonicalUrl,
-                dimension19: videoId,
-                dimension20: playerName
-            };
-            // Increment the appropriate metric based on the event type
-            var metricId = metrics[event];
-            if (metricId) {
-                fieldsObject[metricId] = 1;
-            }
-            return fieldsObject;
-        }
-
     }
 
     function init(videoId) {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -1,21 +1,42 @@
 define([
     'common/utils/mediator',
-    'lodash/collections/forEach'
+    'lodash/collections/forEach',
+    'common/utils/config',
 ], function (
     mediator,
-    forEach
+    forEach,
+    config
 ) {
 
-    function track(property) {
-        mediator.emit(property);
-    }
-
     function initYoutubeEvents(videoId) {
+
+        var ga = window.ga,
+            gaTracker = config.googleAnalytics.trackers.editorial;
+
+        var events = {
+            metricMap: {
+                'play': 'metric1',
+                'skip': 'metric2',
+                '25': 'metric3',
+                '50': 'metric4',
+                '75': 'metric5',
+                'end': 'metric6'
+            },
+            baseEventObject: {
+                eventCategory: 'Media',
+                eventAction: 'video content',
+                eventLabel: window.location.pathname,
+                dimension19: self.trackingId,
+                dimension20: 'guardian-youtube'
+            }
+        };
+
         var eventList = ['play', '25', '50', '75', 'end'];
 
         forEach(eventList, function(event) {
             mediator.once(event, function() {
                 ophanRecord(event);
+                ga(gaTracker + '.send', 'event', buildGoogleAnalyticsEvent(event, events, window.location.pathname, videoId));
             });
         });
 
@@ -30,10 +51,52 @@ define([
                 ophan.record(eventObject);
             });
         }
+
+
+        function buildGoogleAnalyticsEvent(event, metrics, canonicalUrl, videoId) {
+            var category = 'Media';
+            var playerName = 'gu-video-youtube';
+            var action = 'video content'
+            var fieldsObject = {
+                eventCategory: category,
+                eventAction: action,
+                eventLabel: canonicalUrl,
+                dimension19: videoId,
+                dimension20: playerName
+            };
+            // Increment the appropriate metric based on the event type
+            var metricId = metrics[event];
+            if (metricId) {
+                fieldsObject[metricId] = 1;
+            }
+            return fieldsObject;
+        }
+
+        /**
+         *
+         * @param mediaId {string}
+         * @param mediaType {string} audio|video
+         * @param eventType {string} e.g. firstplay, firstend
+         * @param isPreroll {boolean}
+         * @returns {{mediaId: string, mediaType: string, eventType: string, isPreroll: boolean}}
+         */
+        function MediaEvent(mediaId, mediaType, eventType, isPreroll) {
+            return {
+                mediaId: mediaId,
+                mediaType: mediaType,
+                eventType: eventType,
+                isPreroll: isPreroll
+            };
+        }
+
     }
 
     function init(videoId) {
         initYoutubeEvents(videoId);
+    }
+
+    function track(property) {
+        mediator.emit(property);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -56,7 +56,7 @@ define([
         function buildGoogleAnalyticsEvent(event, metrics, canonicalUrl, videoId) {
             var category = 'Media';
             var playerName = 'gu-video-youtube';
-            var action = 'video content'
+            var action = 'video content';
             var fieldsObject = {
                 eventCategory: category,
                 eventAction: action,
@@ -70,23 +70,6 @@ define([
                 fieldsObject[metricId] = 1;
             }
             return fieldsObject;
-        }
-
-        /**
-         *
-         * @param mediaId {string}
-         * @param mediaType {string} audio|video
-         * @param eventType {string} e.g. firstplay, firstend
-         * @param isPreroll {boolean}
-         * @returns {{mediaId: string, mediaType: string, eventType: string, isPreroll: boolean}}
-         */
-        function MediaEvent(mediaId, mediaType, eventType, isPreroll) {
-            return {
-                mediaId: mediaId,
-                mediaType: mediaType,
-                eventType: eventType,
-                isPreroll: isPreroll
-            };
         }
 
     }

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -32,7 +32,7 @@ define([
                 eventCategory: 'Media',
                 eventAction: 'video content',
                 eventLabel: window.location.pathname,
-                dimension19: self.trackingId,
+                dimension19: videoId,
                 dimension20: 'guardian-youtube'
             }
         };

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -37,9 +37,9 @@ define([
             }
         };
 
-        var events = ['play', '25', '50', '75', 'end'];
+        var eventsList = ['play', '25', '50', '75', 'end'];
 
-        forEach(events, function(event) {
+        forEach(eventsList, function(event) {
             mediator.once(event, function(id) {
                 ophanRecord(event, id);
                 ga(gaTracker + '.send', 'event',

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -34,7 +34,7 @@ define([
             },
             baseEventObject: {
                 eventCategory: 'Media',
-                eventAction: 'video content',
+                eventAction: eventAction(),
                 eventLabel: videoId,
                 dimension19: videoId,
                 dimension20: 'guardian-youtube'

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -14,25 +14,13 @@ define([
     Promise
 ) {
 
-    function onPlayerStateChange(event) {
-        track(event);
-    }
-
-    function track(event) {
-
-        if (event.data === YT.PlayerState.PLAYING) {
-            console.log('Tracking: play');
-        }
-        if (event.data === YT.PlayerState.PAUSED) {
-            console.log('Tracking: paused');
-        }
-        if (event.data === YT.PlayerState.ENDED) {
-            console.log('Tracking: ended');
-        }
+    function track(id, event) {
+        console.log(id + " " + event);
     }
 
     return {
-        onPlayerStateChange: onPlayerStateChange
+        track: track
     };
+
 
 });

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -37,22 +37,22 @@ define([
             }
         };
 
-        var eventList = ['play', '25', '50', '75', 'end'];
+        var events = ['play', '25', '50', '75', 'end'];
 
-        forEach(eventList, function(event) {
-            mediator.once(event, function() {
-                ophanRecord(event);
+        forEach(events, function(event) {
+            mediator.once(event, function(id) {
+                ophanRecord(event, id);
                 ga(gaTracker + '.send', 'event',
                     gaHelper.buildGoogleAnalyticsEvent(event, events, window.location.pathname,
-                        'gu-video-youtube', eventAction, videoId));
+                        'gu-video-youtube', eventAction, id));
             });
         });
 
-        function ophanRecord(event) {
+        function ophanRecord(event, id) {
             require(['ophan/ng'], function (ophan) {
                 var eventObject = {
                     video: {
-                        id: 'gu-video-youtube-' + videoId,
+                        id: 'gu-video-youtube-' + id,
                         eventType: 'video:content:' + event
                     }
                 };
@@ -65,8 +65,8 @@ define([
         initYoutubeEvents(videoId);
     }
 
-    function track(property) {
-        mediator.emit(property);
+    function track(event, id) {
+        mediator.emit(event, id);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -1,26 +1,44 @@
 define([
-    'bean',
-    'bonzo',
-    'fastdom',
-    'common/utils/fastdom-promise',
-    'raven',
-    'Promise'
+    'common/utils/mediator',
+    'lodash/collections/forEach'
 ], function (
-    bean,
-    bonzo,
-    fastdom,
-    fastdomPromise,
-    raven,
-    Promise
+    mediator,
+    forEach
 ) {
 
-    function track(id, event) {
-        console.log(id + " " + event);
+    function track(property) {
+        mediator.emit(property);
+    }
+
+    function initYoutubeEvents(videoId) {
+        var eventList = ['play', '25', '50', '75', 'end'];
+
+        forEach(eventList, function(event) {
+            mediator.once(event, function() {
+                ophanRecord(event);
+            });
+        });
+
+        function ophanRecord(event) {
+            require(['ophan/ng'], function (ophan) {
+                var eventObject = {
+                    video: {
+                        id: 'gu-video-youtube-' + videoId,
+                        eventType: 'video:content:' + event
+                    }
+                };
+                ophan.record(eventObject);
+            });
+        }
+    }
+
+    function init(videoId) {
+        initYoutubeEvents(videoId);
     }
 
     return {
-        track: track
+        track: track,
+        init: init
     };
-
 
 });

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -16,4 +16,12 @@ define([
     events
 ) {
 
+    function track(event) {
+        console.log("Tracking: " + event);
+    }
+
+    return {
+        track: track
+    };
+
 });

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -4,23 +4,17 @@ define([
     'fastdom',
     'common/utils/fastdom-promise',
     'raven',
-    'Promise',
-    'common/modules/video/events'
+    'Promise'
 ], function (
     bean,
     bonzo,
     fastdom,
     fastdomPromise,
     raven,
-    Promise,
-    events
+    Promise
 ) {
 
     function onPlayerStateChange(event) {
-        track(event);
-    }
-
-    function onPlayerReady(event) {
         track(event);
     }
 
@@ -38,8 +32,7 @@ define([
     }
 
     return {
-        onPlayerStateChange: onPlayerStateChange,
-        onPlayerReady: onPlayerReady
+        onPlayerStateChange: onPlayerStateChange
     };
 
 });


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Adds GA and Ophan tracking to You Tube atoms.

## What is the value of this and can you measure success?

None really except parity with existing video.js tracking (except pre-roll events which are not supported.)

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
