### PR TITLE
Engagement banner us copy test 2

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -138,6 +138,8 @@ define([
                 var buttonCaption = $('#membership__engagement-message-button-caption'),
                     buttonEl = $('#membership__engagement-message-button');
                 fastdom.write(function () {
+                    buttonEl.removeClass('is-hidden');
+                    buttonEl.addClass('prominent');
                     buttonEl.addClass(thisColour);
                     buttonCaption.text(buttonMessage);
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -47,8 +47,8 @@ define([
             messageText: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for just £49 per year.'
         },
         US: {
-            campaign: 'mem_us_banner',
-            messageText: 'We need your help to support our fearless, independent journalism. Become a Guardian US Member for just $69 a year.'
+            campaign: 'control',
+            messageText: 'If you use it, if you like it, then why not pay for it? It’s only fair.'
         },
         AU: {
             campaign: 'mem_au_banner',
@@ -97,6 +97,7 @@ define([
             customOpts = {},
             messagingTestVariant = ab.testCanBeRun('MembershipEngagementMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementMessageCopyExperiment') : undefined,
             usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
+            buttonMessage='Become a Supporter';
             linkHref = formatEndpointUrl(edition, message);
 
         if (messagingTestVariant && messagingTestVariant !== 'notintest') {
@@ -117,12 +118,11 @@ define([
 
         if (usMessagingTestVariant && usMessagingTestVariant !== 'notintest') {
             var usVariantMessages = {
-                coffee: 'For less than the price of a coffee a week you could help secure the Guardian\'s future. Become a Guardian US member for just $49 a year.',
-                defies: 'When politicians defy belief you need journalism that defies politicians. Become a Guardian US member for just $49 a year.',
-                value: 'If you value our independent, international journalism, you can support it. Become a Guardian US member for just $49 a year.'
+                informed: 'Fund our journalism and together we can keep the world informed.'
             };
-            campaignCode = 'gdnwb_copts_mem_banner_messaging1us' + '__' + usMessagingTestVariant;
-            linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
+            buttonMessage = 'Make a Contribution';
+            campaignCode = 'co_us_engageb_' + usMessagingTestVariant;
+            linkHref = 'https://contribute.theguardian.com?INTCMP=' + campaignCode;
             customOpts = {
                 testName: 'messaging-test-us-1',
                 setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
@@ -130,7 +130,7 @@ define([
             customJs = getCustomJs;
         }
 
-        if (config.page.edition.toLowerCase() === 'uk' && config.switches['prominentMembershipEngagementBannerUk']) {
+        if (config.switches['prominentMembershipEngagementBannerUk']) {
             colours = ['yellow', 'purple', 'bright-blue', 'dark-blue'];
             thisColour = thisInstanceColour(colours);
             cssModifierClass = 'membership-prominent ' + thisColour;
@@ -138,10 +138,8 @@ define([
                 var buttonCaption = $('#membership__engagement-message-button-caption'),
                     buttonEl = $('#membership__engagement-message-button');
                 fastdom.write(function () {
-                    buttonEl.removeClass('is-hidden');
-                    buttonEl.addClass('prominent');
                     buttonEl.addClass(thisColour);
-                    buttonCaption.text('Become a Supporter');
+                    buttonCaption.text(buttonMessage);
                 });
             };
             customJs = getCustomJs;

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -97,7 +97,7 @@ define([
             customOpts = {},
             messagingTestVariant = ab.testCanBeRun('MembershipEngagementMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementMessageCopyExperiment') : undefined,
             usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
-            buttonMessage='Become a Supporter';
+            buttonMessage='Become a Supporter',
             linkHref = formatEndpointUrl(edition, message);
 
         if (messagingTestVariant && messagingTestVariant !== 'notintest') {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -23,10 +23,10 @@ define([
         this.expiry = '2016-11-15';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
-        this.audience = 0.5;
+        this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'More US membership sign-ups';
-        this.audienceCriteria = '50 percent of (non-member) US edition readers';
+        this.audienceCriteria = '100 percent of (non-member) US edition readers';
         this.dataLinkNames = '';
         this.idealOutcome = 'More US readers engage with the banner and then complete membership sign-up';
         this.hypothesis = 'More persuasive copy will improve US membership conversions from impressions';
@@ -52,17 +52,7 @@ define([
                 success: success.bind(this)
             },
             {
-                id: 'coffee',
-                test: function () {},
-                success: success.bind(this)
-            },
-            {
-                id: 'defies',
-                test: function () {},
-                success: success.bind(this)
-            },
-            {
-                id: 'value',
+                id: 'informed',
                 test: function () {},
                 success: success.bind(this)
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'MembershipEngagementUsMessageCopyExperiment';
         this.start = '2016-10-27';
-        this.expiry = '2016-11-15';
+        this.expiry = '2016-11-17';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -3,7 +3,7 @@
         <span id="membership__engagement-message-text">
             <%=messageText%>
         </span>
-        <span id="membership__engagement-message-button" class="message-button-rounded__cta is-hidden">
+        <span id="membership__engagement-message-button" class="message-button-rounded__cta prominent">
             <span id="membership__engagement-message-button-caption"></span><span id="membership__engagement-message-button-arrow"><%=arrowWhiteRight%></span>
         </span>
     </div>

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -3,7 +3,7 @@
         <span id="membership__engagement-message-text">
             <%=messageText%>
         </span>
-        <span id="membership__engagement-message-button" class="message-button-rounded__cta prominent">
+        <span id="membership__engagement-message-button" class="message-button-rounded__cta is-hidden">
             <span id="membership__engagement-message-button-caption"></span><span id="membership__engagement-message-button-arrow"><%=arrowWhiteRight%></span>
         </span>
     </div>


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
Extends the Membership US copy test, adds new variants and uses the new design

## What is the value of this and can you measure success?
The new engagement banner design has been shown to be more effective so we are now rolling it out to the US.
<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?
Web only
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment

@Ap0c
<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
