### PR TITLE
Fix inline ad slot when containing books component

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,6 +156,7 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
+        if(params.type == 'book') adSlot.addClass('ad-slot--books-inline');
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,7 +156,7 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
-        if(params.type == 'book') fastdom.write(adSlot.addClass('ad-slot--books-inline'));
+        if(params.type == 'book') fastdom.write(function() { adSlot.addClass('ad-slot--books-inline')});
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,7 +156,7 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
-        if(params.type == 'book') fastdom.write(function() { adSlot.addClass('ad-slot--books-inline')});
+        if(params.type == 'book') fastdom.write(function() { adSlot.addClass('ad-slot--books-inline');});
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,7 +156,7 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
-        if(params.type == 'book') fastdom.write(function() { adSlot.addClass('ad-slot--books-inline');});
+        if(params.type == 'book') fastdom.write(function() { $(adSlot).addClass('ad-slot--books-inline');});
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,7 +156,7 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
-        if(params.type == 'book') adSlot.addClass('ad-slot--books-inline');
+        if(params.type == 'book') fastdom.write(adSlot.addClass('ad-slot--books-inline'));
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -348,7 +348,6 @@
 }
 
 .ad-slot--books-inline {
-    width: $gs-gutter * 6.5;
     @include mq(mobileLandscape) {
         width: gs-span(2);
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -347,6 +347,13 @@
     }
 }
 
+.ad-slot--books-inline {
+    width: $gs-gutter * 6.5;
+    @include mq(mobileLandscape) {
+        width: gs-span(2);
+    }
+}
+
 .fc-container--sponsored .fc-container:first-child,
 .fc-container--advertisement-feature .fc-container:first-child,
 .fc-container--foundation-supported .fc-container:first-child,


### PR DESCRIPTION

## What does this change?
 - Fix width of slot that holds the books inline component 


## Does this affect other platforms - Amp, Apps, etc?
no

## Screenshots
![image](https://cloud.githubusercontent.com/assets/14179210/20220175/6a7e6548-a824-11e6-94b8-839995dd2939.png)

![image](https://cloud.githubusercontent.com/assets/14179210/20220160/5a7bfc5a-a824-11e6-86c7-f19b6001a4f0.png)


## Request for comment
@regiskuckaertz @JonNorman 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

