### PR TITLE
Contributions Epic Thankyou Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,4 +65,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-contributions-epic-thankyou",
+    "Test a version of the epic centered around the election result against one that is not related to the election",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 11, 14),
+    exposeClientSide = true
+  )
+
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,11 +67,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-thankyou",
+    "ab-contributions-epic-thank-you",
     "Test a version of the epic centered around the election result against one that is not related to the election",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate =  new LocalDate(2016, 11, 14),
+    sellByDate =  new LocalDate(2016, 11, 17),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -11,8 +11,13 @@ define([
         variants: ['control']
     };
 
+    var contributionsEpicThankyou = {
+        name: 'ContributionsEpicThankYou',
+        variants: ['control']
+    };
+
     function userIsInAClashingAbTest() {
-        var clashingTests = [contributionsEpicPostElectionCopyTest];
+        var clashingTests = [contributionsEpicPostElectionCopyTest, contributionsEpicThankyou];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,8 @@ define([
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
-    'common/modules/experiments/tests/contributions-epic-post-election-copy-test'
+    'common/modules/experiments/tests/contributions-epic-post-election-copy-test',
+    'common/modules/experiments/tests/contributions-epic-thankyou'
 ], function (
     reportError,
     config,
@@ -27,7 +28,8 @@ define([
     WeekendReadingEmail,
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
-    ContributionsEpicPostElectionCopyTest
+    ContributionsEpicPostElectionCopyTest,
+    ContributionsEpicThankyou
 ) {
 
     var TESTS = [
@@ -36,7 +38,8 @@ define([
         new WeekendReadingEmail(),
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
-        new ContributionsEpicPostElectionCopyTest()
+        new ContributionsEpicPostElectionCopyTest(),
+        new ContributionsEpicThankyou()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,7 +13,7 @@ define([
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
     'common/modules/experiments/tests/contributions-epic-post-election-copy-test',
-    'common/modules/experiments/tests/contributions-epic-thankyou'
+    'common/modules/experiments/tests/contributions-epic-thank-you'
 ], function (
     reportError,
     config,
@@ -29,7 +29,7 @@ define([
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
     ContributionsEpicPostElectionCopyTest,
-    ContributionsEpicThankyou
+    ContributionsEpicThankYou
 ) {
 
     var TESTS = [
@@ -39,7 +39,7 @@ define([
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
         new ContributionsEpicPostElectionCopyTest(),
-        new ContributionsEpicThankyou()
+        new ContributionsEpicThankYou()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
@@ -6,7 +6,7 @@ define([
     'common/views/svg',
     'common/utils/fastdom-promise',
     'common/utils/mediator',
-    'text!common/views/contributions-epic-equal-buttons.html',
+    'text!common/views/contributions-epic-thank-you.html',
     'common/utils/robust',
     'inlineSvg!svgs/icon/arrow-right',
     'common/utils/config',
@@ -23,7 +23,7 @@ define([
              svg,
              fastdom,
              mediator,
-             contributionsEpicEqualButtons,
+             contributionsEpicThankyou,
              robust,
              arrowRight,
              config,
@@ -35,10 +35,10 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEpicPostElectionCopyTest';
+        this.id = 'ContributionsEpicThankyou';
         this.start = '2016-11-09';
         this.expiry = '2016-11-14';
-        this.author = 'Sam Desborough';
+        this.author = 'Jonathan Rankin';
         this.description = 'Test a version of the epic centered around the election result against one that is not related to the election';
         this.showForSensitive = false;
         this.audience = 1;
@@ -121,16 +121,7 @@ define([
                 id: 'control',
 
                 test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'equal_postelection_1c'),
-                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'equal_postelection_1c'),
-                        p1: messages.control,
-                        p2: cta.equal.p2,
-                        p3: cta.equal.p3,
-                        cta1: cta.equal.cta1,
-                        cta2: cta.equal.cta2,
-                        hidden: ''
-                    }));
+                    var component = $.create(template(contributionsEpicThankyou, {}));
                     componentWriter(component);
                 },
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
@@ -1,0 +1,145 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/modules/experiments/embed',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             embed,
+             ajax,
+             commercialFeatures,
+             intersection) {
+
+    return function () {
+
+        this.id = 'ContributionsEpicPostElectionCopyTest';
+        this.start = '2016-11-09';
+        this.expiry = '2016-11-14';
+        this.author = 'Sam Desborough';
+        this.description = 'Test a version of the epic centered around the election result against one that is not related to the election';
+        this.showForSensitive = false;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Impressions to number of contributions/supporter signups';
+        this.audienceCriteria = 'All readers who are in the US, who are reading about US politics or the US election';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We learn to what extend using messages that chime with current events have an impact on contributor/supporter conversion';
+        this.canRun = function () {
+            var whitelistedKeywordIds = [
+                'australia-news/australia-news',
+                'politics/politics',
+                'politics/eu-referendum',
+                'society/society',
+                'uk/commentisfree',
+                'uk/media',
+                'uk/uk',
+                'us/commentisfree',
+                'us/environment',
+                'us-news/us-news',
+                'us-news/us-politics',
+                'us-news/us-elections-2016',
+                'us/business',
+                'world/world'
+            ];
+
+            var hasKeywordsMatch = function() {
+                var pageKeywords = config.page.keywordIds;
+                return pageKeywords && intersection(whitelistedKeywordIds, pageKeywords.split(',')).length > 0;
+            };
+
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
+        };
+
+
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+        var messages  = {
+            control:  '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+        };
+
+        var cta = {
+            equal: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution'
+            }
+        };
+
+        var componentWriter = function (component) {
+            fastdom.write(function () {
+                var submetaElement = $('.submeta');
+
+                if (submetaElement.length > 0) {
+                    component.insertBefore(submetaElement);
+                    embed.init();
+                    mediator.emit('contributions-embed:insert', component);
+                }
+            });
+        };
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:insert', complete);
+        };
+
+        var contributeUrlPrefix = 'co_global_epic_';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_post_';
+
+        this.variants = [
+            {
+                id: 'control',
+
+                test: function () {
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: makeUrl(membershipUrl, membershipUrlPrefix + 'equal_postelection_1c'),
+                        linkUrl2: makeUrl(contributeUrl, contributeUrlPrefix + 'equal_postelection_1c'),
+                        p1: messages.control,
+                        p2: cta.equal.p2,
+                        p3: cta.equal.p3,
+                        cta1: cta.equal.cta1,
+                        cta2: cta.equal.cta2,
+                        hidden: ''
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
@@ -26,12 +26,12 @@ define([
              arrowRight,
              config,
             cookies,
-            userFeatures, 
+            userFeatures,
              ElementInview) {
 
     return function () {
         var isContributor = cookies.get('gu.contributions.contrib-timestamp');
-        var isPayingMember = userFeatures.isPayingMember;
+        var isPayingMember = userFeatures.isPayingMember();
 
         this.id = 'ContributionsEpicThankYou';
         this.start = '2016-11-09';
@@ -71,11 +71,11 @@ define([
         }
 
         function setValue(name, value){
-            cookies.add(name, value, 14);
+            cookies.add(name, value, 18);
         }
 
 
-        function addInviewLIstener(thankYouCounter) {
+        function addInviewListener(thankYouCounter) {
             mediator.on('contributions-embed:insert', function () {
                 $('.contributions__epic').each(function (el) {
                         //top offset of 18 ensures view only counts when half of element is on screen
@@ -89,66 +89,30 @@ define([
             });
         }
 
-        var makeUrl = function(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        };
-
-        var membershipUrl = 'https://membership.theguardian.com/supporter?';
-        var contributeUrl = 'https://contribute.theguardian.com/?';
         var thankyouCount = getValue('gu.thankyouCount') || 0;
-        var campaignCode = 'epic_thankyou_' + thankyouCount;
 
-
-        var link = isPayingMember? makeUrl(contributeUrl, campaignCode) : makeUrl(membershipUrl, campaignCode);
-
-        var cta = {
-            v1: {
-                title: 'We\'d like to say thanks &#8230;',
-                p1: 'Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more.',
-                p2: 'If you know someone who might want to support us, why not tell them how they can by <a target=\"_blank\" href=\"' + link + '\">sharing this link?</a>'
-            },
-
-            v2: {
-                title: 'Thank you for your support',
-                p1: 'Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more.',
-                p2: 'If you know someone who might share that perspective and want to support us, why not tell them how they can by <a target=\"_blank\" href=\"' + link + '\">sharing this link?</a>'
-
-            }
-
+        var makeUrl = function() {
+            var membershipUrl = 'https://membership.theguardian.com/supporter?';
+            var contributeUrl = 'https://contribute.theguardian.com/?';
+            var urlPrefix =  isPayingMember ? membershipUrl : contributeUrl;
+            return urlPrefix + 'INTCMP=epic_thankyou_' + thankyouCount;
         };
 
+
+
+        var messages  =  {
+            title: 'Thank you',
+            p1: 'Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more.',
+            p2: 'If you know someone who might share that perspective and want to support us, why not tell them how they can by <a target=\"_blank\" href=\"' + makeUrl() + '\">sharing this link?</a>'
+        };
 
         this.variants = [
             {
                 id: 'control',
 
                 test: function () {
-                    addInviewLIstener(thankyouCount);
+                    addInviewListener(thankyouCount);
                     if(thankyouCount < 4) {
-                        var messages = cta.v1;
-                        var component = $.create(template(contributionsEpicThankYou, {
-                            title: messages.title,
-                            p1: messages.p1,
-                            p2: messages.p2
-                        }));
-                        componentWriter(component);
-                    }
-                },
-
-                impression: function(track) {
-                    mediator.on('contributions-embed:insert', track);
-                },
-
-                success: completer
-            },
-
-            {
-                id: 'other',
-
-                test: function () {
-                    addInviewLIstener(thankyouCount);
-                    if(thankyouCount < 4) {
-                        var messages = cta.v2;
                         var component = $.create(template(contributionsEpicThankYou, {
                             title: messages.title,
                             p1: messages.p1,

--- a/static/src/javascripts/projects/common/views/contributions-epic-thank-you.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-thank-you.html
@@ -1,0 +1,6 @@
+<div class="contributions__epic contributions__epic--thankyou">
+    <h2 class="contributions__title contributions__title--thankyou">
+        <%=title%></h2>
+    <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
+    <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
+</div>

--- a/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
@@ -1,21 +1,3 @@
 <div class="contributions__epic">
-    <div>
-        <h2 class="contributions__title contributions__title--epic">
-            Since you're here ...</h2>
-        <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
-        <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
-    </div>
-    <flex class="contributions__amount-field">
-        <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top" href="<%=linkUrl1%>" target="_blank">
-                <%=cta1%>
-            </a>
-        </div>
-
-        <div class="contributions__<%=hidden%>">
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member" href="<%=linkUrl2%>" target="_blank">
-                <%=cta2%>
-            </a>
-        </div>
-    </flex>
+    <p class="contributions__paragraph contributions__paragraph--epic"> Thank you for supporting us. Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more. If you know someone who might want to support us, why not tell them how they can by sharing this link?<p class="contributions__paragraph contributions__paragraph--epic">
 </div>

--- a/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
@@ -1,0 +1,21 @@
+<div class="contributions__epic">
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Since you're here ...</h2>
+        <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
+        <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
+    </div>
+    <flex class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top" href="<%=linkUrl1%>" target="_blank">
+                <%=cta1%>
+            </a>
+        </div>
+
+        <div class="contributions__<%=hidden%>">
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member" href="<%=linkUrl2%>" target="_blank">
+                <%=cta2%>
+            </a>
+        </div>
+    </flex>
+</div>

--- a/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-thankyou.html
@@ -1,3 +1,0 @@
-<div class="contributions__epic">
-    <p class="contributions__paragraph contributions__paragraph--epic"> Thank you for supporting us. Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more. If you know someone who might want to support us, why not tell them how they can by sharing this link?<p class="contributions__paragraph contributions__paragraph--epic">
-</div>

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -15,8 +15,19 @@
 
 
 .contributions__title {
-    @include fs-header(2);
+     @include fs-header(2);
+     margin: 0;
+ }
+
+.contributions__title--thankyou {
+    font-size: 28px;
+    line-height: 32px;
+    font-weight:normal;
     margin: 0;
+}
+
+.contributions__epic--thankyou {
+    padding-bottom: $gs-baseline/4;
 }
 
 .contributions__title--epic {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
A test that adds a epic like componenet at the end of articles for existing contributors and members, just saying thanks and suggesting they share a link to the supporter page/contributions page to their friends. 

The link will be different if they are a supporter or contributor, and they will only see it 4 times. 


## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

![screenshot at nov 11 15-36-35](https://cloud.githubusercontent.com/assets/2844554/20220251/b3afc41e-a824-11e6-9357-45c8c429faf3.png)

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
