### PR TITLE
Update 'popular' and 'most popular' to 'most viewed'

### DIFF
--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -13,7 +13,7 @@
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
                     @popular.zipWithRowInfo.map{ case (section, info) =>
                     <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
-                        <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
+                        <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Most viewed </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
                     </li>
                     }
                 </ol>

--- a/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
@@ -2,33 +2,36 @@
 @import common.LinkTo
 @import model.MostPopular
 
-<div class="fc-container__header js-container__header">
-    @containerDefinition.displayName.map { title =>
-        <div class="fc-container__header__title">
-            <span tabindex="0">
-                @containerDefinition.href.map { href =>
-                    <a data-link-name="section heading" href="@LinkTo{/@href}">popular</a>
-                }.getOrElse{
-                    popular
-                }
-            </span>
-        </div>
-    }
-</div>
+@defining("most viewed") { containerTitle =>
 
-<div class="fc-container__body fc-container--rolled-up-hide js-popular-trails">
-@defining(Seq(
-    MostPopular(
-        containerDefinition.displayName.getOrElse("popular"),
-        "popular",
-        containerDefinition.items.take(10)
-    ),
-    MostPopular(
-        "across the guardian",
-        "popular",
-        Nil
-    )
-)){ popular =>
-    @fragments.collections.popular(popular, Some(containerDefinition))
+    <div class="fc-container__header js-container__header">
+        @containerDefinition.displayName.map { title =>
+            <div class="fc-container__header__title">
+                <span tabindex="0">
+                    @containerDefinition.href.map { href =>
+                    <a data-link-name="section heading" href="@LinkTo {/@href}">@containerTitle</a>
+                    }.getOrElse {
+                        @containerTitle
+                    }
+                </span>
+            </div>
+        }
+    </div>
+
+    <div class="fc-container__body fc-container--rolled-up-hide js-popular-trails">
+    @defining(Seq(
+        MostPopular(
+            containerDefinition.displayName.getOrElse(containerTitle),
+            containerTitle,
+            containerDefinition.items.take(10)
+        ),
+        MostPopular(
+            "across the guardian",
+            containerTitle,
+            Nil
+        )
+    )) { popular =>
+        @fragments.collections.popular(popular, Some(containerDefinition))
+    }
+    </div>
 }
-</div>

--- a/common/app/views/fragments/mostPopularPlaceholder.scala.html
+++ b/common/app/views/fragments/mostPopularPlaceholder.scala.html
@@ -10,7 +10,7 @@
         <div class="fc-container__inner">
             <div class="fc-container__header js-container__header">
                 <h2 class="fc-container__header__title">
-                    <a href="@LinkTo(url)" data-link-name="Most viewed @section">popular</a>
+                    <a href="@LinkTo(url)" data-link-name="Most viewed @section">most viewed</a>
                 </h2>
             </div>
             <div class="fc-container__body fc-container--rolled-up-hide js-popular-trails">

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -93,7 +93,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
       JsonComponent(
         "items" -> JsArray(Seq(
           Json.obj(
-            "displayName" -> "popular",
+            "displayName" -> "most viewed",
             "showContent" -> mostPopular.nonEmpty,
             "content" ->  JsArray(mostPopular.map(content => isCuratedContent(content.faciaContent)))
           )

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -36,7 +36,7 @@ class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent) exte
 
   private def renderMostViewedAudio(audios: Seq[RelatedContentItem], mediaType: String)(implicit request: RequestHeader) = Cached(900) {
     val dataId = s"$mediaType/most-viewed"
-    val displayName = Some(s"popular in $mediaType")
+    val displayName = Some(s"most viewed in $mediaType")
     val config = CollectionConfig.empty.copy(displayName = displayName)
 
     val html = views.html.fragments.containers.facia_cards.container(

--- a/onward/app/views/fragments/mostViewedVideo.scala.html
+++ b/onward/app/views/fragments/mostViewedVideo.scala.html
@@ -6,7 +6,7 @@
     data-component="most-viewed-video">
 
     <div class="most-viewed-container__header">
-        <h3 class="most-viewed-container__heading">Popular videos</h3>
+        <h3 class="most-viewed-container__heading">Most viewed videos</h3>
     </div>
     <ul class="u-cf u-unstyled most-viewed--media most-viewed--video items--media items--video" data-link-name="Most viewed video">
         @videos.zipWithRowInfo.map{ case (video, row) =>

--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -9,7 +9,7 @@
 
 @popular.map { pop =>
     <div class="js-right-most-popular right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="right-most-popular" data-importance="-1">
-        <h3 class="content__meta-heading">Most popular</h3>
+        <h3 class="content__meta-heading">Most viewed</h3>
         <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular">
             @pop.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
                 <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">

--- a/onward/app/views/mostPopular.scala.html
+++ b/onward/app/views/mostPopular.scala.html
@@ -5,10 +5,10 @@
 @main(page){
 }{
     <main itemprop="mainContentOfPage" role="main" class="monocolumn-wrapper content">
-        <h1 class="u-h">Most popular</h1>
+        <h1 class="u-h">Most viewed</h1>
     @popular.zipWithRowInfo.map{ case (section, info) =>
         <section class="zone-@section.section">
-            <h2 class="content__inline-section">Most popular @Html(section.heading)</h2>
+            <h2 class="content__inline-section">Most viewed @Html(section.heading)</h2>
             <div class="headline-list"
                  data-link-name="@section.heading">
                 <ul class="u-unstyled">

--- a/onward/test/MostPopularFeatureTest.scala
+++ b/onward/test/MostPopularFeatureTest.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConversions._
       goTo("/most-read/world") { browser =>
         import browser._
         Then("I should see a list of 'world' content")
-        findFirst(".zone-world").findFirst("h2").getText should be("Most popular in world news")
+        findFirst(".zone-world").findFirst("h2").getText should be("Most viewed in world news")
         And("it should contain world news")
         $(".zone-world li").size should be > (0)
 

--- a/static/test/javascripts/spec/common/onward/popular.spec.js
+++ b/static/test/javascripts/spec/common/onward/popular.spec.js
@@ -12,7 +12,7 @@ define([
                     '<div class="js-popular"></div><div class="ad-slot--inline"></div><div class="ad-slot--inline"></div>'
                 ]
             },
-            html = '<b>popular</b>',
+            html = '<b>most viewed</b>',
             server,
             injector = new Injector(),
             Popular, config, mediator, detect, commercialFeatures;
@@ -62,7 +62,7 @@ define([
             server.respondWith('/most-read/' + section + '.json', [200, {}, '{ "html": "' + html + '" }']);
             mediator.once('modules:popular:loaded', function (el) {
                 var innerHtml = el.innerHTML;
-                expect(innerHtml).toBe('popular');
+                expect(innerHtml).toBe('most viewed');
                 done();
             });
 
@@ -75,7 +75,7 @@ define([
             server.respondWith('/most-read.json', [200, {}, '{ "html": "' + html + '" }']);
             mediator.once('modules:popular:loaded', function (el) {
                 var innerHtml = el.innerHTML;
-                expect(innerHtml).toBe('popular');
+                expect(innerHtml).toBe('most viewed');
                 done();
             });
 


### PR DESCRIPTION
## What does this change?

Updates *most popular* to *most viewed* in labelling across the site.

## What is the value of this and can you measure success?

Most viewed was deemed in poor taste by some readers when referring to stories that aren't semantically 'popular' but more specifically 'most viewed'. Improves the semantics of the labelling.

## Does this affect other platforms - Amp, Apps, etc?

Yes. It updates Amp. Apps also need to do this work (@rcrphillips).

## Screenshots

![image](https://cloud.githubusercontent.com/assets/638051/20220201/7cbaaa32-a824-11e6-954c-9b86b5aae364.png)

![image](https://cloud.githubusercontent.com/assets/638051/20220356/1ccbde88-a825-11e6-9f09-de6675c66ab8.png)


## Request for comment

@guardian/dotcom-platform 

Question - Is there the concept of dictionaries that would mean we could store titles like this (i.e i18n txt files) and update in one location?

