### PR TITLE
Fix illegible rich links on paid articles

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -263,8 +263,6 @@ object ContentTypeFormat {
 
        val sharelinks = ShareLinks.apply(tags, fields, metadata)
        val commercial = Commercial.apply(
-         tags,
-         metadata,
          jsonCommercial.isInappropriateForSponsorship,
          jsonCommercial.hasInlineMerchandise
        )

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -336,7 +336,7 @@ object Content {
     val metadata = MetaData.make(fields, apiContent)
     val elements = Elements.make(apiContent)
     val tags = Tags.make(apiContent)
-    val commercial = Commercial.make(metadata, tags, apiContent)
+    val commercial = Commercial.make(tags, apiContent)
     val trail = Trail.make(tags, fields, commercial, elements, metadata, apiContent)
     val sharelinks = ShareLinks(tags, fields, metadata)
     val atoms = Atoms.make(apiContent)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -18,7 +18,6 @@ import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
 import play.api.mvc.RequestHeader
-import play.twirl.api.Html
 
 object Commercial {
 
@@ -31,7 +30,7 @@ object Commercial {
     )
   }
 
-  def make: model.Commercial = {
+  val empty: model.Commercial = {
     model.Commercial(
       isInappropriateForSponsorship = false,
       hasInlineMerchandise = false
@@ -221,9 +220,6 @@ final case class MetaData (
       sectionId == "identity" ||
       contentType.toLowerCase == "survey" ||
       contentType.toLowerCase == "signup"
-
-  // Special means "Next Gen platform only".
-  private val special = id.contains("-sp-")
 
   // this is here so it can be included in analytics.
   // Basically it helps us understand the impact of changes and needs

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -6,6 +6,7 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import common.commercial.{AdUnitMaker, BrandHunter, Branding}
 import common.dfp._
 import common.{Edition, ManifestData, NavItem, Pagination}
+import contentapi.{Content => CapiContent}
 import conf.Configuration
 import cricketPa.CricketTeams
 import model.content.MediaAtom
@@ -21,33 +22,17 @@ import play.twirl.api.Html
 
 object Commercial {
 
-  private def make(metadata: MetaData, tags: Tags, maybeApiContent: Option[contentapi.Content]): model.Commercial = {
-
-    val section = Some(metadata.sectionId)
-
-    val isInappropriateForSponsorship =
-      maybeApiContent exists (_.fields.flatMap(_.isInappropriateForSponsorship).getOrElse(false))
+  def make(tags: Tags, apiContent: CapiContent): model.Commercial = {
+    val isInappropriateForSponsorship: Boolean = apiContent.fields.exists(_.isInappropriateForSponsorship.contains(true))
 
     model.Commercial(
-      tags,
-      metadata,
       isInappropriateForSponsorship,
       hasInlineMerchandise = DfpAgent.hasInlineMerchandise(tags.tags)
     )
   }
 
-  def make(metadata: MetaData, tags: Tags, apiContent: contentapi.Content): model.Commercial = {
-    make(metadata, tags, Some(apiContent))
-  }
-
-  def make(metadata: MetaData, tags: Tags): model.Commercial = {
-    make(metadata, tags, None)
-  }
-
-  def make(section: Section): model.Commercial = {
+  def make: model.Commercial = {
     model.Commercial(
-      tags = Tags(Nil),
-      metadata = section.metadata,
       isInappropriateForSponsorship = false,
       hasInlineMerchandise = false
     )
@@ -55,11 +40,8 @@ object Commercial {
 }
 
 final case class Commercial(
-  tags: Tags,
-  metadata: MetaData,
   isInappropriateForSponsorship: Boolean,
-  hasInlineMerchandise: Boolean
-)
+  hasInlineMerchandise: Boolean)
 
 /**
  * MetaData represents a page on the site, whether facia or content

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -40,7 +40,7 @@ object IndexPage {
     date: DateTime,
     tzOverride: Option[DateTimeZone]
   ): IndexPage = {
-    IndexPage(page, contents, tags, date, tzOverride, commercial = Commercial.make)
+    IndexPage(page, contents, tags, date, tzOverride, commercial = Commercial.empty)
   }
 
   def fastContainerWithMpu(numberOfItems: Int): Option[ContainerDefinition] = numberOfItems match {

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -40,7 +40,7 @@ object IndexPage {
     date: DateTime,
     tzOverride: Option[DateTimeZone]
   ): IndexPage = {
-    IndexPage(page, contents, tags, date, tzOverride, commercial = Commercial.make(page.metadata, tags))
+    IndexPage(page, contents, tags, date, tzOverride, commercial = Commercial.make)
   }
 
   def fastContainerWithMpu(numberOfItems: Int): Option[ContainerDefinition] = numberOfItems match {

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -146,7 +146,7 @@ trait Index extends ConciergeRepository with Collections {
     val editorsPicksIds = editorsPicks.map(_.id)
     val latestContent = response.results.getOrElse(Nil).filterNot(c => editorsPicksIds contains c.id)
     val trails = (editorsPicks ++ latestContent).map(IndexPageItem(_))
-    val commercial = Commercial.make(section)
+    val commercial = Commercial.make
 
     IndexPage(page = section, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None, commercial)
   }

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -146,7 +146,7 @@ trait Index extends ConciergeRepository with Collections {
     val editorsPicksIds = editorsPicks.map(_.id)
     val latestContent = response.results.getOrElse(Nil).filterNot(c => editorsPicksIds contains c.id)
     val trails = (editorsPicks ++ latestContent).map(IndexPageItem(_))
-    val commercial = Commercial.make
+    val commercial = Commercial.empty
 
     IndexPage(page = section, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None, commercial)
   }

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -178,6 +178,7 @@ $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;
 $paid-article-mpu:          #cccccc;
+$paid-article-richlink:     #65a897;
 $rainbow-red:               #ed1c24; // from Guss
 
 $c-top-header-background: $guardian-brand-dark; // one-off colour for header bg

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -760,6 +760,24 @@
         }
     }
 
+    .tone-media--item {
+        color: $neutral-1;
+
+        .rich-link__standfirst {
+            color: $neutral-1;
+        }
+
+        .rich-link__kicker, .rich-link__read-more-text {
+            color: $paid-article-richlink;
+        }
+
+        .rich-link__arrow-icon {
+            fill: $paid-article-richlink;
+        }
+    }
+
+
+
     .tone-news--item.rich-link {
         background: $paid-article-subheader;
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -763,6 +763,10 @@
     .tone-media--item {
         color: $neutral-1;
 
+        .rich-link__container:before{
+            background-color: $news-support-3
+        }
+
         .rich-link__standfirst {
             color: $neutral-1;
         }


### PR DESCRIPTION
### What does this change?
It's really good when people can read our rich-links on articles. On paid-content articles, this isn't currently possible due to the grey background:

![image](https://cloud.githubusercontent.com/assets/1821099/20220909/3d547230-a827-11e6-9dd5-493ff2d05647.png)

These changes make it possible:
![image](https://cloud.githubusercontent.com/assets/1821099/20221231/6acfc45c-a828-11e6-9e22-7b46501ca44e.png)


### Additional Notes
Originally looking into this, I thought I'd need to add a class to the rich-link based on whether the content type had branding. It turns out I didn't need to do this, but did a tiny amount of refactoring of the commercial metadata properties while I was at it. Yes, it probably shouldn't be in this PR, but the changes are minor and it _is_ Friday....

### Request for comment
@guardian/commercial-dev 