### PR TITLE
Fix bug where containers aren't showing section branding

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -101,6 +101,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
   val showFields = "body,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalPageCode"
   val searchApiQuery: AdjustSearchQuery = (searchQuery: SearchQuery) =>
     searchQuery
+      .showSection(true)
       .showFields(showFields)
       .showElements("all")
       .showTags("all")
@@ -108,6 +109,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
 
   val itemApiQuery: AdjustItemQuery = (itemQuery: ItemQuery) =>
     itemQuery
+      .showSection(true)
       .showFields(showFields)
       .showElements("all")
       .showTags("all")


### PR DESCRIPTION
There wasn't enough data being pressed to tell if a container should be branded because of the section of its content.  So only tag-level branding was having any effect.

/cc @guardian/commercial-dev 