### PR TITLE
Revert "Fix inline ad slot when containing books component"

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -156,7 +156,6 @@ define([
      * @param {Object=} params
      */
     function CommercialComponent(adSlot, params) {
-        if(params.type == 'book') fastdom.write(function() { $(adSlot).addClass('ad-slot--books-inline');});
         this.params = params || {};
         this.type = this.params.type;
         // remove type from params

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -347,12 +347,6 @@
     }
 }
 
-.ad-slot--books-inline {
-    @include mq(mobileLandscape) {
-        width: gs-span(2);
-    }
-}
-
 .fc-container--sponsored .fc-container:first-child,
 .fc-container--advertisement-feature .fc-container:first-child,
 .fc-container--foundation-supported .fc-container:first-child,


### PR DESCRIPTION
Reverts guardian/frontend#14967 as failing switch test