### PR TITLE
Add in a new AB test for International edition engagement banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,6 +57,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-membership-engagement-international-experiment",
+    "Test varying the number of visits before showing the membership engagement banner",
+    owners = Seq(Owner.withGithub("rupert.bates")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 11, 17),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-post-election-copy-test",
     "Test a version of the epic centered around the election result against one that is not related to the election",
     owners = Seq(Owner.withGithub("desbo")),

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -97,7 +97,8 @@ define([
             customOpts = {},
             messagingTestVariant = ab.testCanBeRun('MembershipEngagementMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementMessageCopyExperiment') : undefined,
             usMessagingTestVariant = ab.testCanBeRun('MembershipEngagementUsMessageCopyExperiment') ? ab.getTestVariantId('MembershipEngagementUsMessageCopyExperiment') : undefined,
-            buttonMessage='Become a Supporter',
+            internationalTestVariant = ab.testCanBeRun('MembershipEngagementInternationalExperiment') ? ab.getTestVariantId('MembershipEngagementInternationalExperiment') : undefined,
+            buttonMessage = 'Become a Supporter',
             linkHref = formatEndpointUrl(edition, message);
 
         if (messagingTestVariant && messagingTestVariant !== 'notintest') {
@@ -128,6 +129,11 @@ define([
                 setEngagementText: usMessagingTestVariant === 'control' ? undefined : usVariantMessages[usMessagingTestVariant]
             };
             customJs = getCustomJs;
+        }
+
+        if (internationalTestVariant && internationalTestVariant !== 'notintest') {
+            campaignCode = 'gdnwb_copts_mem_banner_ROWbanner__' + internationalTestVariant;
+            linkHref = endpoints[edition] + '?INTCMP=' + campaignCode;
         }
 
         if (config.switches['prominentMembershipEngagementBannerUk']) {
@@ -175,8 +181,7 @@ define([
         var edition = config.page.edition;
         var message = messages[edition];
         if (message) {
-            var userHasMadeEnoughVisits = (storage.local.get('gu.alreadyVisited') || 0) >= 10;
-            if (userHasMadeEnoughVisits) {
+            if (userHasMadeEnoughVisits(edition)) {
                 return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
                     if (canShow) {
                         show(edition, message);
@@ -185,6 +190,16 @@ define([
             }
         }
         return Promise.resolve();
+    }
+
+    function userHasMadeEnoughVisits(edition) {
+        if (edition == 'INT') {
+            var internationalTestVariant = ab.testCanBeRun('MembershipEngagementInternationalExperiment') ? ab.getTestVariantId('MembershipEngagementInternationalExperiment') : undefined;
+            if (internationalTestVariant == 'first')
+                return true;
+        }
+
+        return (storage.local.get('gu.alreadyVisited') || 0) >= 10;
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -195,7 +195,7 @@ define([
     function userHasMadeEnoughVisits(edition) {
         if (edition == 'INT') {
             var internationalTestVariant = ab.testCanBeRun('MembershipEngagementInternationalExperiment') ? ab.getTestVariantId('MembershipEngagementInternationalExperiment') : undefined;
-            if (internationalTestVariant == 'first')
+            if (internationalTestVariant == '1st_article')
                 return true;
         }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -193,7 +193,7 @@ define([
     }
 
     function userHasMadeEnoughVisits(edition) {
-        if (edition == 'INT') {
+        if (edition === 'INT') {
             var internationalTestVariant = ab.testCanBeRun('MembershipEngagementInternationalExperiment') ? ab.getTestVariantId('MembershipEngagementInternationalExperiment') : undefined;
             if (internationalTestVariant == '1st_article')
                 return true;

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -15,24 +15,22 @@ define([
     'common/modules/experiments/tests/membership-engagement-international-experiment',
     'common/modules/experiments/tests/contributions-epic-post-election-copy-test',
     'common/modules/experiments/tests/contributions-epic-thank-you'
-], function (
-    reportError,
-    config,
-    cookies,
-    mediator,
-    store,
-    mvtCookie,
-    memoize,
-    noop,
-    DiscussionPromoteBottomBanner,
-    HostedOnwardJourney,
-    WeekendReadingEmail,
-    MembershipEngagementMessageCopyExperiment,
-    MembershipEngagementUSMessageCopyExperiment,
-    MembershipEngagementInternationalExperiment,
-    ContributionsEpicPostElectionCopyTest,
-    ContributionsEpicThankYou
-) {
+], function (reportError,
+             config,
+             cookies,
+             mediator,
+             store,
+             mvtCookie,
+             memoize,
+             noop,
+             DiscussionPromoteBottomBanner,
+             HostedOnwardJourney,
+             WeekendReadingEmail,
+             MembershipEngagementMessageCopyExperiment,
+             MembershipEngagementUSMessageCopyExperiment,
+             MembershipEngagementInternationalExperiment,
+             ContributionsEpicPostElectionCopyTest,
+             ContributionsEpicThankYou) {
 
     var TESTS = [
         new DiscussionPromoteBottomBanner(),
@@ -42,7 +40,7 @@ define([
         new MembershipEngagementUSMessageCopyExperiment(),
         new MembershipEngagementInternationalExperiment(),
         new ContributionsEpicPostElectionCopyTest(),
-	new ContributionsEpicThankYou()
+        new ContributionsEpicThankYou()
     ];
 
     var participationsKey = 'gu.ab.participations';
@@ -67,7 +65,9 @@ define([
     function removeParticipation(test) {
         var participations = getParticipations();
         var filteredParticipations = Object.keys(participations)
-            .filter(function (participation) { return participation !== test.id; })
+            .filter(function (participation) {
+                return participation !== test.id;
+            })
             .reduce(function (result, input) {
                 result[input] = participations[input];
                 return result;
@@ -80,14 +80,14 @@ define([
         // renamed/deleted from the backend
         Object.keys(getParticipations()).forEach(function (k) {
             if (typeof config.switches['ab' + k] === 'undefined') {
-                removeParticipation({ id: k });
+                removeParticipation({id: k});
             } else {
                 var testExists = TESTS.some(function (element) {
                     return element.id === k;
                 });
 
                 if (!testExists) {
-                    removeParticipation({ id: k });
+                    removeParticipation({id: k});
                 }
             }
         });
@@ -117,7 +117,7 @@ define([
             isSensitive = config.page.shouldHideAdverts;
 
         return ((isSensitive ? test.showForSensitive : true)
-            && isTestSwitchedOn(test)) && !expired && test.canRun() ;
+            && isTestSwitchedOn(test)) && !expired && test.canRun();
     }
 
     function getId(test) {
@@ -214,7 +214,7 @@ define([
         var data = {};
         data[test.id] = abData(variantId, String(complete));
 
-        return function() {
+        return function () {
             recordOphanAbEvent(data);
         };
     }
@@ -242,7 +242,7 @@ define([
      *
      * @return {String} variant ID
      */
-    var variantIdFor = memoize(function(test) {
+    var variantIdFor = memoize(function (test) {
         var smallestTestId = mvtCookie.getMvtNumValues() * test.audienceOffset;
         var largestTestId = smallestTestId + mvtCookie.getMvtNumValues() * test.audience;
         var mvtCookieId = mvtCookie.getMvtValue();
@@ -299,7 +299,7 @@ define([
      * @returns {boolean}
      */
     function defersImpression(test) {
-        return test.variants.every(function(variant) {
+        return test.variants.every(function (variant) {
             return typeof variant.impression === 'function';
         });
     }
@@ -334,7 +334,9 @@ define([
 
     // These kinds of tests are both server and client side.
     function getServerSideTests() {
-        return Object.keys(config.tests).filter(function (test) { return !!config.tests[test]; });
+        return Object.keys(config.tests).filter(function (test) {
+            return !!config.tests[test];
+        });
     }
 
     function not(f) {
@@ -367,12 +369,12 @@ define([
             });
         },
 
-        forceVariantCompleteFunctions: function(testId, variantId) {
+        forceVariantCompleteFunctions: function (testId, variantId) {
             var test = getTest(testId);
 
             var variant = test && test.variants.filter(function (v) {
-                return v.id.toLowerCase() === variantId.toLowerCase();
-            })[0];
+                    return v.id.toLowerCase() === variantId.toLowerCase();
+                })[0];
 
             var impression = variant && variant.impression || noop;
             var complete = variant && variant.success || noop;
@@ -405,7 +407,7 @@ define([
             getActiveTests().forEach(run);
         },
 
-        registerCompleteEvents: function() {
+        registerCompleteEvents: function () {
             getActiveTests().forEach(registerCompleteEvent(true));
         },
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,6 +12,7 @@ define([
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-message-copy-experiment',
     'common/modules/experiments/tests/membership-engagement-us-message-copy-experiment',
+    'common/modules/experiments/tests/membership-engagement-international-experiment',
     'common/modules/experiments/tests/contributions-epic-post-election-copy-test'
 ], function (
     reportError,
@@ -27,6 +28,7 @@ define([
     WeekendReadingEmail,
     MembershipEngagementMessageCopyExperiment,
     MembershipEngagementUSMessageCopyExperiment,
+    MembershipEngagementInternationalExperiment,
     ContributionsEpicPostElectionCopyTest
 ) {
 
@@ -36,6 +38,7 @@ define([
         new WeekendReadingEmail(),
         new MembershipEngagementMessageCopyExperiment(),
         new MembershipEngagementUSMessageCopyExperiment(),
+        new MembershipEngagementInternationalExperiment(),
         new ContributionsEpicPostElectionCopyTest()
     ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
@@ -1,0 +1,61 @@
+define([
+    'bean',
+    'reqwest',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/modules/commercial/commercial-features',
+    'common/utils/mediator'
+], function (
+    bean,
+    reqwest,
+    fastdom,
+    qwery,
+    $,
+    config,
+    commercialFeatures,
+    mediator
+) {
+    return function () {
+        this.id = 'MembershipEngagementInternationalExperiment';
+        this.start = '2016-11-10';
+        this.expiry = '2016-11-17';
+        this.author = 'Rupert Bates';
+        this.description = 'Test varying the number of visits before showing the membership engagement banner';
+        this.audience = 1;    // 100% (of UK audience)
+        this.audienceOffset = 0;
+        this.successMeasure = 'More membership sign-ups';
+        this.audienceCriteria = '100 percent of (non-member) UK edition readers';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'More readers engage with the banner and then complete membership sign-up';
+        this.hypothesis = 'Showing the banner to users who have visited us less frequently gives us a larger pool of potential supporters';
+
+        this.canRun = function () {
+            return config.page.edition.toLowerCase() === 'int' &&
+                commercialFeatures.canReasonablyAskForMoney &&
+                config.page.contentType.toLowerCase() !== 'signup';
+        };
+
+        var success = function (complete) {
+            if (this.canRun()) {
+                mediator.on('membership-message:display', function () {
+                    bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+                });
+            }
+        };
+
+        this.variants = [
+            {
+                id: '10th_article',
+                test: function () {},
+                success: success.bind(this)
+            },
+            {
+                id: '1st_article',
+                test: function () {},
+                success: success.bind(this)
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
@@ -23,10 +23,10 @@ define([
         this.expiry = '2016-11-17';
         this.author = 'Rupert Bates';
         this.description = 'Test varying the number of visits before showing the membership engagement banner';
-        this.audience = 1;    // 100% (of UK audience)
+        this.audience = 1;    // 100% (of International audience)
         this.audienceOffset = 0;
         this.successMeasure = 'More membership sign-ups';
-        this.audienceCriteria = '100 percent of (non-member) UK edition readers';
+        this.audienceCriteria = '100 percent of (non-member) International edition readers';
         this.dataLinkNames = '';
         this.idealOutcome = 'More readers engage with the banner and then complete membership sign-up';
         this.hypothesis = 'Showing the banner to users who have visited us less frequently gives us a larger pool of potential supporters';


### PR DESCRIPTION
## What does this change?
Adds in a new engagement banner test for users on the international edition.
They are now segmented into 2 groups: A control who will be shown the engagement banner after 10 visits and a second group who will be shown it from their first visit.

## What is the value of this and can you measure success?
We hope to increase the number of membership sign ups by showing the engagement banner to a larger pool of users.
## Does this affect other platforms - Amp, Apps, etc?
Web only
## Screenshots

## Request for comment
@Ap0c 

