### PR TITLE
remove old .git/hooks using rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "postcss-reporter": "^1.4.1",
     "require-dir": "^0.3.0",
     "requirejs": "^2.3.2",
+    "rimraf": "^2.5.4",
     "sass-lint": "^1.9.1",
     "sorted-object": "^1.0.0",
     "strip-ansi": "^3.0.1",

--- a/tools/__tasks__/githooks/index.js
+++ b/tools/__tasks__/githooks/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const rimraf = require('rimraf');
 const {root} = require('../config').paths;
 
 const src = path.resolve(root, 'git-hooks');
@@ -8,9 +9,10 @@ const target = path.resolve(root, '.git', 'hooks');
 module.exports = {
     description: 'Update githooks',
     task: () => {
+
         // always try and remove any old ones
         try {
-            fs.unlinkSync(target);
+            rimraf.sync(target);
         } catch (e) { /* do nothing */ }
 
         // TC doesn't want them, but everyone else does

--- a/yarn.lock
+++ b/yarn.lock
@@ -6114,7 +6114,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.3.3, rimraf@~2.5.0, rimraf@~2.5.1, rimraf@2:
+rimraf, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@~2.5.0, rimraf@~2.5.1, rimraf@2:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:


### PR DESCRIPTION
## What does this change?

On a clean install of this repo `.git/hooks` is a directory, not a symlink. The `githooks` task throws (and catches) an error when it tries to unlink it, then throws an uncaught error when it tries to relink it.

![screen shot 2016-11-12 at 12 43 43](https://cloud.githubusercontent.com/assets/5931528/20237850/b9b3af9a-a8d5-11e6-99c8-03c1a73b677a.png)
_[Note: the output in this screenshot was added to demonstrate the error]_

This change fixes the problem by not assuming that `.git/hooks` will be a symlink. It uses the `rimraf` library to remove `.git/hooks` regardless of whether it is a symlink or a physical directory.

## What is the value of this and can you measure success?

Installation no longer fails on fresh install.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![screen shot 2016-11-12 at 12 29 27](https://cloud.githubusercontent.com/assets/5931528/20237785/b0c32278-a8d3-11e6-8226-6b1c7ed4f055.png)

## Request for comment

@sndrs 


