### PR TITLE
Extend expired switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     "Promote the comments with a sticky bottom banner",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 11, 11),
+    sellByDate = new LocalDate(2016, 11, 14),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
To avoid breaking build.