### PR TITLE
Extend expiry of contributions epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -61,7 +61,7 @@ trait ABTestSwitches {
     "Test a version of the epic centered around the election result against one that is not related to the election",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
-    sellByDate =  new LocalDate(2016, 11, 14),
+    sellByDate =  new LocalDate(2016, 11, 17),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -37,7 +37,7 @@ define([
 
         this.id = 'ContributionsEpicPostElectionCopyTest';
         this.start = '2016-11-09';
-        this.expiry = '2016-11-14';
+        this.expiry = '2016-11-18';
         this.author = 'Sam Desborough';
         this.description = 'Test a version of the epic centered around the election result against one that is not related to the election';
         this.showForSensitive = false;


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Extends the contributions epic for another few days

## What is the value of this and can you measure success?

Continued high conversion rate for contributions and membership.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

