### PR TITLE
Ensure we don't show the US engagement banner to users who have already contributed

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-us-message-copy-experiment.js
@@ -5,6 +5,7 @@ define([
     'qwery',
     'common/utils/$',
     'common/utils/config',
+    'common/utils/cookies',
     'common/modules/commercial/commercial-features',
     'common/utils/mediator'
 ], function (
@@ -14,6 +15,7 @@ define([
     qwery,
     $,
     config,
+    cookies,
     commercialFeatures,
     mediator
 ) {
@@ -34,6 +36,7 @@ define([
         this.canRun = function () {
             return config.page.edition.toLowerCase() === 'us' &&
                 commercialFeatures.canReasonablyAskForMoney &&
+                !cookies.get('gu.contributions.contrib-timestamp') && //exclude users who have already contributed
                 config.page.contentType !== 'signup';
         };
 


### PR DESCRIPTION
## What does this change?
Stops the US engagement banner (which now asks for contributions) being shown to users who have already contributed.

## What is the value of this and can you measure success?
It is just a courtesy measure for users who have already contributed.

## Does this affect other platforms - Amp, Apps, etc?
Web only

## Request for comment
@jranks123 
