### PR TITLE
remove the sharing line from the thank you component

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-thank-you.js
@@ -91,19 +91,9 @@ define([
 
         var thankyouCount = getValue('gu.thankyouCount') || 0;
 
-        var makeUrl = function() {
-            var membershipUrl = 'https://membership.theguardian.com/supporter?';
-            var contributeUrl = 'https://contribute.theguardian.com/?';
-            var urlPrefix =  isPayingMember ? membershipUrl : contributeUrl;
-            return urlPrefix + 'INTCMP=epic_thankyou_' + thankyouCount;
-        };
-
-
-
         var messages  =  {
             title: 'Thank you',
             p1: 'Your crucial financial support makes our journalism possible. We do it because we believe, like you, that the world has never needed fearless, independent media more.',
-            p2: 'If you know someone who might share that perspective and want to support us, why not tell them how they can by <a target=\"_blank\" href=\"' + makeUrl() + '\">sharing this link?</a>'
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/views/contributions-epic-thank-you.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-thank-you.html
@@ -2,5 +2,4 @@
     <h2 class="contributions__title contributions__title--thankyou">
         <%=title%></h2>
     <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
-    <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
 </div>


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

The line on the thank you component asking readers to share a link did not result in many contributions or supporter sign ups so we have decided to remove it and just show the thank you message. 

## What is the value of this and can you measure success?

Move warm fuzzinesss for our readers, without being tainted by being asked to do something. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

BEFORE: 

![screenshot at nov 11 15-46-53](https://cloud.githubusercontent.com/assets/2844554/20269351/a7fcd2b2-aa7a-11e6-8312-2c78facf6ade.png)



NOW:

![a](https://cloud.githubusercontent.com/assets/2844554/20269356/ad401680-aa7a-11e6-9107-b7a9a238c7b4.png)


## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

