### PR TITLE
Include section sponsorships in pressed content

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -63,7 +63,9 @@ object MetaDataFormat {
     id: String,
     url: String,
     webUrl: String,
+    // todo remove section property in another PR
     section: String,
+    sectionSummary: Option[SectionSummary],
     webTitle: String,
     analyticsName: String,
     adUnitSuffix: String,
@@ -139,7 +141,9 @@ object MetaDataFormat {
           meta.id,
           meta.url,
           meta.webUrl,
+          // todo remove section property in another PR
           meta.sectionId,
+          meta.section,
           meta.webTitle,
           meta.analyticsName,
           meta.adUnitSuffix,

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -4,7 +4,7 @@ import campaigns.PersonalInvestmentsCampaign
 import com.gu.contentapi.client.model.v1.{Section => ApiSection}
 import common.commercial.{BrandHunter, Branding}
 import common.{Edition, Pagination}
-import play.api.libs.json.{JsBoolean, JsString, JsValue}
+import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 
 object Section {
   def make(section: ApiSection, pagination: Option[Pagination] = None): Section = {
@@ -64,6 +64,8 @@ case class SectionSummary(
 )
 
 object SectionSummary {
+
+  implicit val jsonFormat = Json.format[SectionSummary]
 
   def fromCapiSection(section: ApiSection): SectionSummary = {
     SectionSummary(


### PR DESCRIPTION
This is a follow-up to #14973 and #14983

Currently only tag sponsorships are stored in the metadata of pressed pages. So we lose any section sponsorships that have been set up.

This PR should allow fronts to be re-pressed safely without breaking anything.
The result should be that the pressed page will hold the data but the rendered page won't use it yet.

/cc @guardian/commercial-dev @guardian/dotcom-platform