### PR TITLE
Fix the standfirst font on richlinks within paid content

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -772,6 +772,7 @@
 
         .rich-link__standfirst {
             color: $neutral-1;
+            font-family: $f-sans-serif-text;
         }
 
         .rich-link__kicker, .rich-link__read-more-text {


### PR DESCRIPTION
In #14972, rich links that are within paid-content were given a bit of a makeover. However the `.rich-link__standfirst` class overrides the font of standfirsts to be serif regardless of context. As a result, I have to override the font on `rich-link__standfirst` specifically when within a `.paid-content--advertisement-feature`.