### PR TITLE
Add 2 variants to epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,7 +68,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-contributions-epic-post-election-copy-test-two",
-    "Try out 2 new epic variants to try an beat our control",
+    "Try out 2 new epic variants and try an beat our control",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 17),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,9 +67,9 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-post-election-copy-test",
-    "Test a version of the epic centered around the election result against one that is not related to the election",
-    owners = Seq(Owner.withGithub("desbo")),
+    "ab-contributions-epic-post-election-copy-test-two",
+    "Try out 2 new epic variants to try an beat our control",
+    owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 17),
     exposeClientSide = true

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -7,8 +7,8 @@ define([
 ) {
 
     var contributionsEpicPostElectionCopyTest = {
-        name: 'ContributionsEpicPostElectionCopyTest',
-        variants: ['control']
+        name: 'ContributionsEpicPostElectionCopyTestTwo',
+        variants: ['control', 'v1', 'v2']
     };
 
     var contributionsEpicThankyou = {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -8,7 +8,7 @@ define([
 
     var contributionsEpicPostElectionCopyTest = {
         name: 'ContributionsEpicPostElectionCopyTestTwo',
-        variants: ['control', 'v1', 'v2']
+        variants: ['control', 'despair', 'belief']
     };
 
     var contributionsEpicThankyou = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -35,16 +35,16 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEpicPostElectionCopyTest';
-        this.start = '2016-11-09';
+        this.id = 'ContributionsEpicPostElectionCopyTestTwo';
+        this.start = '2016-11-14';
         this.expiry = '2016-11-18';
-        this.author = 'Sam Desborough';
-        this.description = 'Test a version of the epic centered around the election result against one that is not related to the election';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Try out 2 new epic variants to try an beat our control';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
-        this.audienceCriteria = 'All readers who are in the US, who are reading about US politics or the US election';
+        this.audienceCriteria = 'Global ';
         this.dataLinkNames = '';
         this.idealOutcome = 'We learn to what extend using messages that chime with current events have an impact on contributor/supporter conversion';
         this.canRun = function () {
@@ -53,10 +53,8 @@ define([
                 'politics/politics',
                 'politics/eu-referendum',
                 'society/society',
-                'uk/commentisfree',
                 'uk/media',
                 'uk/uk',
-                'us/commentisfree',
                 'us/environment',
                 'us-news/us-news',
                 'us-news/us-politics',
@@ -83,8 +81,8 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
-        var contributeUrlPrefix = 'co_global_epic_';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_post_';
+        var contributeUrlPrefix = 'co_global_epic_two_';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_post_two_';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
@@ -95,7 +93,9 @@ define([
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
         var messages  = {
-            control:  '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+            control:  '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            v1:  'NEW COPY',
+            v2:  'NEW COPY 2'
         };
 
         var cta = {
@@ -150,29 +150,85 @@ define([
             mediator.on('contributions-embed:insert', complete);
         };
 
+        var getCta = function() {
+            if (config.switches.turnOffSupporterEpic) {
+                return cta.justContribute;
+            }
+            if (config.switches.turnOffContributionsEpic) {
+                return cta.justSupporter;
+            }
+            return cta.equal;
+        };
+
 
         this.variants = [
             {
                 id: 'control',
 
                 test: function () {
-                    var epicType = cta.equal;
-                    if(config.switches.turnOffSupporterEpic){
-                        epicType = cta.justContribute;
-                    }
-                    if(config.switches.turnOffContributionsEpic){
-                        epicType = cta.justSupporter;
-                    }
 
+                    var ctaType = getCta();
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: epicType.intcmp1,
-                        linkUrl2: epicType.intcmp2,
+                        linkUrl1: ctaType.intcmp1,
+                        linkUrl2: ctaType.intcmp2,
                         p1: messages.control,
-                        p2:epicType.p2,
-                        p3: epicType.p3,
-                        cta1: epicType.cta1,
-                        cta2: epicType.cta2,
-                        hidden: epicType.hidden
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'v1',
+
+                test: function () {
+
+                    var ctaType = getCta();
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.intcmp1,
+                        linkUrl2: ctaType.intcmp2,
+                        p1: messages.v1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'v2',
+
+                test: function () {
+
+                    var ctaType = getCta();
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.intcmp1,
+                        linkUrl2: ctaType.intcmp2,
+                        p1: messages.v2,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
                     }));
                     componentWriter(component);
                 },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-post-election-copy-test.js
@@ -39,12 +39,12 @@ define([
         this.start = '2016-11-14';
         this.expiry = '2016-11-18';
         this.author = 'Jonathan Rankin';
-        this.description = 'Try out 2 new epic variants to try an beat our control';
+        this.description = 'Try out 2 new epic variants and try an beat our control';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions/supporter signups';
-        this.audienceCriteria = 'Global ';
+        this.audienceCriteria = 'Global';
         this.dataLinkNames = '';
         this.idealOutcome = 'We learn to what extend using messages that chime with current events have an impact on contributor/supporter conversion';
         this.canRun = function () {
@@ -93,9 +93,18 @@ define([
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
         var messages  = {
-            control:  '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            v1:  'NEW COPY',
-            v2:  'NEW COPY 2'
+            control: {
+                title: 'Since you’re here …',
+                p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+            },
+            despair: {
+                title: 'After despair …',
+                p1: '… comes action. When US policy on climate change, race and immigration, reproductive rights, gun control, surveillance and LGBT rights all hang in the balance, journalism rooted in progressive values has never been more important. Now is the time to fund our fearless reporting and diverse voices, to help us hold President-elect Donald Trump and his administration to account. The Guardian’s independent, investigative journalism is expensive and difficult to produce. But we do it because we believe our perspective matters.'
+            },
+            belief: {
+                title: 'When politicians defy belief …',
+                p1: '… you need journalism that defies politicians. President-elect Donald Trump has threatened to weaken first amendment protections for reporters. He has said he will sue news organisations. He has labelled the press “dishonest” and “scum”. At times like this, free and fearless investigative journalism is never more important. The Guardian is not for dividend. We have no billionaire owner. All proceeds are reinvested in our independent journalism, which over the next four years will continue to uncover the truth, sort fact from fiction, and hold the new administration to account.'
+            }
         };
 
         var cta = {
@@ -168,10 +177,12 @@ define([
                 test: function () {
 
                     var ctaType = getCta();
+                    var message = messages.control;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.intcmp1,
                         linkUrl2: ctaType.intcmp2,
-                        p1: messages.control,
+                        title: message.title,
+                        p1: message.p1,
                         p2:ctaType.p2,
                         p3: ctaType.p3,
                         cta1: ctaType.cta1,
@@ -189,15 +200,17 @@ define([
             },
 
             {
-                id: 'v1',
+                id: 'despair',
 
                 test: function () {
 
                     var ctaType = getCta();
+                    var message = messages.despair;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.intcmp1,
                         linkUrl2: ctaType.intcmp2,
-                        p1: messages.v1,
+                        title: message.title,
+                        p1: message.p1,
                         p2:ctaType.p2,
                         p3: ctaType.p3,
                         cta1: ctaType.cta1,
@@ -215,15 +228,17 @@ define([
             },
 
             {
-                id: 'v2',
+                id: 'belief',
 
                 test: function () {
 
                     var ctaType = getCta();
+                    var message = messages.belief;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.intcmp1,
                         linkUrl2: ctaType.intcmp2,
-                        p1: messages.v2,
+                        title: message.title,
+                        p1: message.p1,
                         p2:ctaType.p2,
                         p3: ctaType.p3,
                         cta1: ctaType.cta1,

--- a/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
@@ -1,7 +1,7 @@
 <div class="contributions__epic">
     <div>
         <h2 class="contributions__title contributions__title--epic">
-            Since you're here ...</h2>
+            <%=title%></h2>
         <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
         <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
     </div>


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

We have 2 new contenders to try and beat the epic's current control. This PR adds them in, and changes the name of the test to make the data analysis easier. 

## What is the value of this and can you measure success?

We might find a message that converts better than our current control. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

![screenshot at nov 14 16-48-42](https://cloud.githubusercontent.com/assets/2844554/20273754/6ac64b2a-aa8a-11e6-8bf4-ad464cb69b2a.png)
![screenshot at nov 14 16-49-04](https://cloud.githubusercontent.com/assets/2844554/20273753/6ac5b1a6-aa8a-11e6-9dca-b86c2b7d0583.png)
![screenshot at nov 14 16-49-31](https://cloud.githubusercontent.com/assets/2844554/20273755/6acc7a2c-aa8a-11e6-83af-722402e47cbd.png)

## Request for comment

@jfsoul @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

