### PR TITLE
Read section summary when rendering pressed content

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -63,8 +63,6 @@ object MetaDataFormat {
     id: String,
     url: String,
     webUrl: String,
-    // todo remove section property in another PR
-    section: String,
     sectionSummary: Option[SectionSummary],
     webTitle: String,
     analyticsName: String,
@@ -103,7 +101,7 @@ object MetaDataFormat {
       part1.id,
       part1.url,
       part1.webUrl,
-      Some(SectionSummary.fromId(part1.section)),
+      part1.sectionSummary,
       part1.webTitle,
       part1.analyticsName,
       part1.adUnitSuffix,
@@ -141,8 +139,6 @@ object MetaDataFormat {
           meta.id,
           meta.url,
           meta.webUrl,
-          // todo remove section property in another PR
-          meta.sectionId,
           meta.section,
           meta.webTitle,
           meta.analyticsName,


### PR DESCRIPTION
The final step! 

As a result of #14987 we're now pressing section-level branding data but not using it during rendering.  This PR uses the data during rendering.

Facia has to be deployed before facia-press for this to work.

/cc @guardian/commercial-dev @guardian/dotcom-platform 