### PR TITLE
Remove unused discussion switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -7,16 +7,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-discussion-promote-comments",
-    "Promote the comments with a sticky bottom banner",
-    owners = Seq(Owner.withGithub("nicl")),
-    safeState = On,
-    sellByDate = new LocalDate(2016, 11, 15),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-weekend-reading-email",
     "Try out two formats for the Weekend Reading email",
     owners = Seq(Owner.withGithub("katebee")),


### PR DESCRIPTION
Removes the 'ab-discussion-promote-comments' AB switch. The calling code has already been removed - see https://github.com/guardian/frontend/pull/14979 - but somehow I forgot to remove the switch itself! 😢 

cc @kelvin-chappell 
