### PR TITLE
move asset monitor to bash script in the repo

### DIFF
--- a/dev/teamcity/dist-assetmonitor-tc
+++ b/dev/teamcity/dist-assetmonitor-tc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o xtrace
+set -o nounset
+set -o errexit
+
+./grunt-tc assetmonitor:common
+
+exit 0 #always ignore grunt tasks result


### PR DESCRIPTION
## What does this change?

moves the call to `grunt assetmonitor` from teamcity admin to the main repo (will update TC once merged)

## What is the value of this and can you measure success?

nearly missed that this was being called when grepping for remaining grunt tasks

## Does this affect other platforms - Amp, Apps, etc?

no

## Request for comment

@TBonnin

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
