### PR TITLE
Increase discussion assets version

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -363,7 +363,7 @@ class GuardianConfiguration extends Logging {
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
-    lazy val frontendAssetsVersion = "v1.4.0"
+    lazy val frontendAssetsVersion = "v1.5.0"
   }
 
   object witness {
@@ -661,4 +661,3 @@ object ManifestData {
   lazy val build = ManifestFile.asKeyValuePairs.getOrElse("Build", "DEV").dequote.trim
   lazy val revision = ManifestFile.asKeyValuePairs.getOrElse("Revision", "DEV").dequote.trim
 }
-


### PR DESCRIPTION
This simply uses the latest version of discussion-frontend, which removed code relating to the (now removed) promote-comments test. See:

https://github.com/guardian/frontend/pull/14979
https://github.com/guardian/discussion-frontend/pull/17
