### PR TITLE
Remove grunt mkdir

### DIFF
--- a/grunt-configs/mkdir.js
+++ b/grunt-configs/mkdir.js
@@ -4,11 +4,6 @@ module.exports = function (grunt, options) {
             options: {
                 create: [options.staticTargetDir + 'fonts']
             }
-        },
-        css: {
-            options: {
-                create: [options.staticTargetDir + 'stylesheets']
-            }
         }
     };
 };

--- a/grunt-configs/mkdir.js
+++ b/grunt-configs/mkdir.js
@@ -1,9 +1,3 @@
 module.exports = function (grunt, options) {
-    return {
-        fontsTarget: {
-            options: {
-                create: [options.staticTargetDir + 'fonts']
-            }
-        }
-    };
+    return {   };
 };

--- a/grunt-configs/mkdir.js
+++ b/grunt-configs/mkdir.js
@@ -1,3 +1,0 @@
-module.exports = function (grunt, options) {
-    return {   };
-};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "grunt-asset-hash": "0.1.6",
     "grunt-asset-monitor": "0.2.0",
     "grunt-frequency-graph": "^0.1.6",
-    "grunt-mkdir": "0.1.2",
     "grunt-postcss": "^0.8.0",
     "grunt-px-to-rem": "0.4.0",
     "grunt-svgmin": "^4.0.0",

--- a/tools/__tasks__/compile/css/mkdir.js
+++ b/tools/__tasks__/compile/css/mkdir.js
@@ -1,4 +1,7 @@
+const mkdirp = require('mkdirp');
+const {target} = require('../../config').paths;
+
 module.exports = {
     description: 'Create CSS target directory',
-    task: 'grunt mkdir:css'
+    task: () => mkdirp.sync(`${target}/stylesheets`)
 };

--- a/tools/__tasks__/compile/fonts/mkdir.js
+++ b/tools/__tasks__/compile/fonts/mkdir.js
@@ -1,4 +1,7 @@
+const mkdirp = require('mkdirp');
+const {target} = require('../../config').paths;
+
 module.exports = {
     description: 'Create fonts target directory',
-    task: 'grunt mkdir:fontsTarget'
+    task: () => mkdirp.sync(`${target}/fonts`)
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,10 +2979,6 @@ grunt-legacy-util@~0.2.0:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-grunt-mkdir@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz#073dc2c9440b73c9bdbcceaca73cdf4d08e07241"
-
 grunt-postcss@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/grunt-postcss/-/grunt-postcss-0.8.0.tgz#8f30a8af607903ce0c45f01f0be42c60e31ceb0e"


### PR DESCRIPTION
## What does this change?

- removes grunt mkdir

## What is the value of this and can you measure success?

chipping away at grunt

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

no diff in compile vs master:

<img width="966" alt="screen shot 2016-11-15 at 16 23 50" src="https://cloud.githubusercontent.com/assets/867233/20313829/07130d54-ab50-11e6-8bb8-4a4a9f637672.png">


## Request for comment

@NataliaLKB @gtrufitt @SiAdcock 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
