### PR TITLE
Hosted thrasher - fix invalid flex values

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted-thrasher.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-thrasher.scss
@@ -24,7 +24,7 @@ $renaultColor: #ffc421;
             }
             @include mq(tablet) {
                 .has-flex & {
-                    flex: calc(100% - 20px);
+                    flex: 1;
                 }
             }
         }
@@ -47,7 +47,7 @@ $renaultColor: #ffc421;
             }
             @include mq(tablet) {
                 .has-flex & {
-                    flex: calc(50% - 20px);
+                    flex: 1;
                 }
             }
         }
@@ -70,7 +70,7 @@ $renaultColor: #ffc421;
             }
             @include mq(tablet) {
                 .has-flex & {
-                    flex: calc(33% - 20px);
+                    flex: 1;
                 }
             }
         }
@@ -100,7 +100,7 @@ $renaultColor: #ffc421;
             }
             @include mq(tablet) {
                 .has-flex & {
-                    flex: calc(25% - 20px);
+                    flex: 1;
                 }
             }
         }


### PR DESCRIPTION
Invalid CSS is breaking the layout in IE11:

![image](https://cloud.githubusercontent.com/assets/6290008/20315343/71ec7926-ab55-11e6-811e-8d97d832207a.png)

cc @guardian/labs-beta @guardian/commercial-dev 