### PR TITLE
Reintroduce kickers onto paid cards with same style as rich links in paid content

### DIFF
--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -20,6 +20,9 @@
         >
         <h2 class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
+            @for(kicker <- item.kicker){
+                <span class="advert__kicker">@kicker</span>
+            }
             @item.headline
         </h2>
         <div class="advert__image-container @for(imgRatio <- optImgRatio){u-responsive-ratio u-responsive-ratio--@imgRatio}">

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -181,6 +181,8 @@ $paid-article-mpu:          #cccccc;
 $paid-article-richlink:     #65a897;
 $rainbow-red:               #ed1c24; // from Guss
 
+$paid-card-kicker:        #65a897;
+
 $c-top-header-background: $guardian-brand-dark; // one-off colour for header bg
 
 // MPU

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -115,6 +115,18 @@
     }
 }
 
+.advert__kicker {
+    &:after {
+        content: '/';
+        display: inline-block;
+        margin-left: .2em;
+        color: mix(#ffffff, $news-support-6, 20%);
+
+    }
+
+    color: $paid-card-kicker;
+}
+
 .advert--branded {
     padding-bottom: $gs-row-height + $gs-baseline * 5; //96px = $gs-row-height + height of the logo
 }

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -116,7 +116,7 @@
 }
 
 .advert__kicker {
-    &:after {
+    &::after {
         content: '/';
         display: inline-block;
         margin-left: .2em;


### PR DESCRIPTION
## What does this change?
Commercial containers and cards were refactored a few months ago. During this refactor the ability to add kickers to commercial cards - i.e. paid-for or sponsored content- in containers was removed. It turns out that this is useful, so this PR (re)introduces this functionality.

> Erm, excuse me but what's a kicker?

A kicker is a short tagline that appears before (and inline with) the headline of a card.

Input from design is that these kickers should look the same as those on [rich-links within paid-for articles](https://www.theguardian.com/progress-personified/2016/nov/08/mount-everest-wounded-veteran-amputee-mountaineer-marine).

## What is the value of this and can you measure success?
This allows Central Production to better style the cards and improve brand awareness. It is also a prerequisite for launching paid-for containers on fronts.

## Screenshots
**before**
![image](https://cloud.githubusercontent.com/assets/1821099/20345877/11d9d10e-abf1-11e6-8dfe-efec9e8d44b2.png)

**after**
![image](https://cloud.githubusercontent.com/assets/1821099/20345805/b9a7d0d0-abf0-11e6-917e-7553244cfae2.png)


## Request for comment
@guardian/commercial-dev 
