### PR TITLE
Include owners of expiring switches in email

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -95,7 +95,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
         AdsStatusEmailJob(emailService).run()
       }
       jobs.scheduleWeekdayJob("ExpiringSwitchesEmailJob", 48, 8, londonTime) {
-        log.info(s"Starting ExpiringSwitchesEmailJob")
+        log.info("Starting ExpiringSwitchesEmailJob")
         ExpiringSwitchesEmailJob(emailService).run()
       }
 


### PR DESCRIPTION
If only the email properties were populated, this could be quite useful.
(That can be worked out later.)