### PR TITLE
Fix UK membership engagement message experiment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,10 +27,10 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-engagement-message-copy-experiment",
+    "ab-membership-engagement-message-copy-experiment-restart",
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = On, // so we don't inadvertently turn off during deployment
+    safeState = Off,
     sellByDate = new LocalDate(2016, 12, 1), // Thursday 1st December
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -66,18 +66,20 @@ define([
         };
 
         function doUkCopyTest(content) {
-            var variant = getVariant('MembershipEngagementMessageCopyExperiment');
+            var variant = getVariant('MembershipEngagementMessageCopyExperimentRestart');
             if (variant && variant !== notInTest) {
                 var variantMessages = {
-                    Get_round_to: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
-                    Give_upfront: 'Give £5 a month to help support our journalism and make the Guardian’s future more secure',
-                    Together_informed: 'Together we can keep the world informed. Give £5 a month to support our journalism',
-                    Coffee_5: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
+                    Get_round_to_2: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
+                    Give_upfront_2: 'Give £5 a month to help support our journalism and make the Guardian’s future more secure',
+                    Together_informed_2: 'Together we can keep the world informed. Give £5 a month to support our journalism',
+                    Coffee_5_2: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'
                 };
                 var campaignCode = 'gdnwb_copts_mem_banner_ukbanner__' + variant;
                 content.campaignCode = campaignCode;
                 content.linkHref = formatEndpointUrl('UK', campaignCode);
-                content.messageText = variant === 'control' ? undefined : variantMessages[variant];
+                if (variant !== 'control_2') {
+                    content.messageText = variantMessages[variant];
+                }
             }
         }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -69,7 +69,7 @@ define([
             var variant = getVariant('MembershipEngagementMessageCopyExperimentRestart');
             if (variant && variant !== notInTest) {
                 var variantMessages = {
-                    Get_round_to_2: 'Not got round to supporting us yet? Now is the time. Give £5 a month today',
+                    Get_round_to_2: 'Not got around to supporting us yet? Now is the time. Give £5 a month today',
                     Give_upfront_2: 'Give £5 a month to help support our journalism and make the Guardian’s future more secure',
                     Together_informed_2: 'Together we can keep the world informed. Give £5 a month to support our journalism',
                     Coffee_5_2: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month'

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-message-copy-experiment.js
@@ -18,8 +18,8 @@ define([
     mediator
 ) {
     return function () {
-        this.id = 'MembershipEngagementMessageCopyExperiment';
-        this.start = '2016-11-10';
+        this.id = 'MembershipEngagementMessageCopyExperimentRestart';
+        this.start = '2016-11-16';
         this.expiry = '2016-12-1';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on engagement banner';
@@ -47,27 +47,27 @@ define([
 
         this.variants = [
             {
-                id: 'control',
+                id: 'control_2',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'Get_round_to',
+                id: 'Get_round_to_2',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'Give_upfront',
+                id: 'Give_upfront_2',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'Together_informed',
+                id: 'Together_informed_2',
                 test: function () {},
                 success: success.bind(this)
             },
             {
-                id: 'Coffee_5',
+                id: 'Coffee_5_2',
                 test: function () {},
                 success: success.bind(this)
             }


### PR DESCRIPTION
## What does this change?
Prevents the text from being eliminated for the control group. Redefines the test with new name, start date, variant names (and by extension, campaign codes) and master switch.

Also fixes the typo in the "Not got round..." message. It now reads "Not got around..." 

## What is the value of this and can you measure success?
The error rendered the data from at least one day unreliable. We'll have to restart the test and collect fresh numbers.
 
## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
<img width="808" alt="screen shot 2016-11-16 at 12 02 27" src="https://cloud.githubusercontent.com/assets/690395/20346658/35a1a3a6-abf5-11e6-8c8d-cf37bc2a3195.png">
--
<img width="809" alt="screen shot 2016-11-16 at 12 03 24" src="https://cloud.githubusercontent.com/assets/690395/20346671/41ba2776-abf5-11e6-89a3-9dd1a53db8f0.png">
--
<img width="809" alt="screen shot 2016-11-16 at 12 04 16" src="https://cloud.githubusercontent.com/assets/690395/20346687/52fa8292-abf5-11e6-910e-14b992988654.png">
--
<img width="810" alt="screen shot 2016-11-16 at 12 05 04" src="https://cloud.githubusercontent.com/assets/690395/20346697/6411a844-abf5-11e6-9254-097d561e697e.png">
--
<img width="810" alt="screen shot 2016-11-16 at 12 05 59" src="https://cloud.githubusercontent.com/assets/690395/20346701/6ec6f56e-abf5-11e6-977d-d3a603459530.png">

## Request for comment
@rupertbates @Ap0c @rtyley @svillafe 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
