### PR TITLE
Change capitalisation of scroll to comments event

### DIFF
--- a/docs/03-dev-howtos/14-implement-google-analytics.md
+++ b/docs/03-dev-howtos/14-implement-google-analytics.md
@@ -102,7 +102,7 @@ The comments event is a custom event defined in [analytics/discussion](https://g
 
 Most discussion events can be tracked with click events so the only GA custom event for discussion is for 'scroll'.
 
-The custom category for tracking a user scrolling to the comments is *ElementView* with an action of *Onpage item* and a label of *Scroll to comments*.
+The custom category for tracking a user scrolling to the comments is *element view* with an action of *onpage item* and a label of *scroll to comments*.
 
 ### Forsee
 

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -34,7 +34,7 @@ define([
         var fieldsObject = assign({
             nonInteraction: true // to avoid affecting bounce rate
         }, (customDimensions || {}));
-        ga(gaTracker + '.send', 'event', 'ElementView', 'Onpage item', label, fieldsObject);
+        ga(gaTracker + '.send', 'event', 'element view', 'onpage item', label, fieldsObject);
     }
 
     track.jumpedToComments = function () {
@@ -51,7 +51,7 @@ define([
 
     track.scrolledToComments = function () {
         if (!track.seen) {
-            sendToGA('Scroll to comments');
+            sendToGA('scroll to comments');
             track.seen = true;
         }
     };


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Capitalisation of scroll to comments event

## What is the value of this and can you measure success?

We're moving to all lower case event categories, actions and labels to improve GA reporting.

## Does this affect other platforms - Amp, Apps, etc?

It doesn't really

## Screenshots

## Request for comment

@dominickendrick got started with this one, looks good?

