### PR TITLE
Add dimensions to hosted logo model

### DIFF
--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -6,7 +6,7 @@
         <div class="hosted__banner" style="background-image: url(@{cta.image});">
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">
                 <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown hosted-tone-bg">
-                    <img class="hostedbadge__logo" src="@{page.campaign.logoUrl}" alt="logo @{page.campaign.owner}">
+                    <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
                 </div>
                 @if(cta.btnText.isEmpty) {
                     <div class="hosted__cta-wrapper">

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -6,7 +6,7 @@
         <div class="hostedbadge hostedbadge--shouldscale hosted-tone-bg">
             <p class="hostedbadge__info">Advertiser content</p>
             <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
-                <img class="hostedbadge__logo" src="@page.campaign.logoUrl" alt="logo @page.campaign.owner"/>
+                <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
             </a>
         </div>
         <div class="paidfor-label paidfor-meta__more hosted__label has-popup">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -90,7 +90,7 @@
                         </div>
                         <div class="hostedbadge hostedbadge--shouldscale">
                             <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
-                                <img class="hostedbadge__logo" src="@{page.campaign.logoUrl}" alt="logo @{page.campaign.owner}">
+                                <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
                             </a>
                         </div>
                     </div>

--- a/common/app/common/commercial/Branding.scala
+++ b/common/app/common/commercial/Branding.scala
@@ -72,6 +72,11 @@ case class Logo(url: String, dimensions: Option[Dimensions])
 object Logo {
 
   implicit val logoFormat = Json.format[Logo]
+
+  def make(url: String, dimensions: Option[SponsorshipLogoDimensions]) = Logo(
+    url,
+    dimensions map (d => Dimensions(d.width, d.height))
+  )
 }
 
 case class Branding(
@@ -119,9 +124,6 @@ object Branding {
 
   def make(sectionOrTagName: String)(sponsorship: ApiSponsorship): Branding = {
 
-    def mkLogo(url: String, dimensions: Option[SponsorshipLogoDimensions]) =
-      Logo(url, dimensions map (d => Dimensions(d.width, d.height)))
-
     Branding(
       sponsorshipType = sponsorship.sponsorshipType match {
         case ApiSponsorshipType.PaidContent => PaidContent
@@ -129,9 +131,9 @@ object Branding {
         case _ => Sponsored
       },
       sponsorName = sponsorship.sponsorName,
-      sponsorLogo = mkLogo(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions),
+      sponsorLogo = Logo.make(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions),
       highContrastSponsorLogo = sponsorship.highContrastSponsorLogo map { url =>
-        mkLogo(url, sponsorship.highContrastSponsorLogoDimensions)
+        Logo.make(url, sponsorship.highContrastSponsorLogoDimensions)
       },
       sponsorLink = sponsorship.sponsorLink,
       aboutThisLink = sponsorship.aboutLink getOrElse "/sponsored-content",

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -5,6 +5,7 @@ import java.net.URLEncoder
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.model.v1.ContentType.{Article, Gallery, Video}
 import common.Logging
+import common.commercial.Logo
 import conf.Configuration.site
 import model.StandalonePage
 
@@ -55,7 +56,7 @@ case class HostedCampaign(
   id: String,
   name: String,
   owner: String,
-  logoUrl: String,
+  logo: Logo,
   fontColour: Colour
 )
 
@@ -72,7 +73,7 @@ object HostedCampaign {
         id = section.id.stripPrefix("advertiser-content/"),
         name = section.webTitle,
         owner = sponsorship.sponsorName,
-        logoUrl = sponsorship.sponsorLogo,
+        logo = Logo.make(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions),
         fontColour = Colour(hostedTag.paidContentCampaignColour getOrElse "")
       )
     }

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -1,6 +1,7 @@
 package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
+import common.commercial.{Dimensions, Logo}
 import conf.switches.Switches
 
 object ChesterZooHostedPages {
@@ -9,7 +10,10 @@ object ChesterZooHostedPages {
     id = "chester-zoo-act-for-wildlife",
     name = "What we fight for",
     owner = "Chester Zoo",
-    logoUrl = "https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png",
+    logo = Logo(
+      "https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png",
+      Some(Dimensions(width = 280, height = 261))
+    ),
     fontColour = Colour("#E31B22")
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -1,5 +1,6 @@
 package common.commercial.hosted.hardcoded
 
+import common.commercial.{Dimensions, Logo}
 import common.commercial.hosted._
 
 object Formula1HostedPages {
@@ -8,7 +9,10 @@ object Formula1HostedPages {
     id = "singapore-grand-prix",
     name = "Singapore Grand Prix",
     owner = "First Stop Singapore",
-    logoUrl = "https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg",
+    logo = Logo(
+      "https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg",
+      Some(Dimensions(width = 500, height = 500))
+    ),
     fontColour = Colour("#063666")
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -1,5 +1,6 @@
 package common.commercial.hosted.hardcoded
 
+import common.commercial.{Dimensions, Logo}
 import common.commercial.hosted._
 import conf.Static
 
@@ -15,7 +16,10 @@ object LeffeHostedPages {
     id = "leffe-rediscover-time",
     name = "Leffe - Rediscover Time",
     owner = "Leffe",
-    logoUrl = Static("images/commercial/leffe.jpg"),
+    logo = Logo(
+      Static("images/commercial/leffe.jpg"),
+      Some(Dimensions(width = 132, height = 132))
+    ),
     fontColour = Colour("#dec190")
   )
 

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -1,5 +1,6 @@
 package common.commercial.hosted.hardcoded
 
+import common.commercial.{Dimensions, Logo}
 import common.commercial.hosted._
 import conf.Static
 
@@ -13,7 +14,10 @@ object RenaultHostedPages {
     id = "renault-car-of-the-future",
     name = "Discover your Renault Zoe",
     owner = "Renault",
-    logoUrl = Static("images/commercial/logo_renault.jpg"),
+    logo = Logo(
+      Static("images/commercial/logo_renault.jpg"),
+      Some(Dimensions(width = 132, height = 132))
+    ),
     fontColour = Colour("#ffc421")
   )
 
@@ -28,7 +32,7 @@ object RenaultHostedPages {
   private val videoSrcRoot = "https://cdn.theguardian.tv/interactive"
 
   private val teaserWithoutNextPage: HostedVideoPage = {
-    val id = s"commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser"
+    val id = "commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser"
     val pageName = teaserPageName
     val standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at " +
                      "Central St Martins are working with Renault to design the interior for cars that will drive " +
@@ -74,7 +78,7 @@ object RenaultHostedPages {
   }
 
   private val episode1WithoutNextPage: HostedVideoPage = {
-    val id = s"commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1"
+    val id = "commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1"
     val pageName = episode1PageName
     val standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning " +
                      "design will be announced at Clerkenwell Design Week (and on this site). Watch this short video " +
@@ -119,7 +123,7 @@ object RenaultHostedPages {
   }
 
   private val episode2WithoutNextPage: HostedVideoPage = {
-    val id = s"commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2"
+    val id = "commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2"
     val pageName = episode2PageName
     val standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the " +
                      "future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may" +

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -1,6 +1,7 @@
 package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
+import common.commercial.{Dimensions, Logo}
 
 object VisitBritainHostedPages {
 
@@ -12,7 +13,10 @@ object VisitBritainHostedPages {
     id = "visit-britain",
     name = "#OMGB. Home of Amazing Moments. Great Britain & Northern Ireland",
     owner = "OMGB",
-    logoUrl = "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
+    logo = Logo(
+      "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
+      Some(Dimensions(width = 1378, height = 957))
+    ),
     fontColour = Colour("#E41F13")
   )
 
@@ -220,7 +224,7 @@ object VisitBritainHostedPages {
   }
 
   val cityGallery: HostedGalleryPage = {
-    val id = s"advertiser-content/visit-britain/city"
+    val id = "advertiser-content/visit-britain/city"
     val images = cityImages
     val pageName = cityPageName
     val title = "Take a city break from the norm"


### PR DESCRIPTION
Because in amp pages logos need to have dimensions.

/cc @Calanthe 