### PR TITLE
Fix unclear error in CSS task failure

### DIFF
--- a/tools/__tasks__/compile/css/transpile-sass.js
+++ b/tools/__tasks__/compile/css/transpile-sass.js
@@ -18,16 +18,26 @@ const renderSass = (filePath, dest) => new Promise((resolve, reject) => {
         file: filePath,
         outFile: dest
     }, options), (err, result) => {
-        if (err) reject(err);
-        resolve(result.css.toString());
+        if (err) {
+            reject(err);
+        } else {
+            try {
+                resolve(result.css.toString());
+            } catch (e) {
+                reject(e);
+            }
+        }
     });
 });
 
 const saveSass = (sass, dest) => new Promise((resolve, reject) => {
     mkdirp.sync(path.parse(dest).dir);
     fs.writeFile(dest, sass, err => {
-        if (err) reject(err);
-        resolve();
+        if (err) {
+            reject(err);
+        } else {
+            resolve();
+        }
     });
 });
 

--- a/tools/__tasks__/compile/images/icons.js
+++ b/tools/__tasks__/compile/images/icons.js
@@ -15,13 +15,16 @@ const svgo = new SVGO();
 function getSVG (iconPath) {
     return new Promise((resolve, reject) => {
         fs.readFile(iconPath, { encoding: 'utf-8' }, (err, data) => {
-            if (err) { reject(err); }
-            svgo.optimize(data, result => {
-                resolve({
-                    name: path.parse(iconPath).name,
-                    data: result
+            if (err) {
+                reject(err);
+            } else {
+                svgo.optimize(data, result => {
+                    resolve({
+                        name: path.parse(iconPath).name,
+                        data: result
+                    });
                 });
-            });
+            }
         });
     });
 }
@@ -67,8 +70,11 @@ function saveSass (sass, dest, fileName) {
                     ${sass}
                 }
             `.trim().replace(/ {16}/g, ''), err => {
-                if (err) reject(err);
-                resolve();
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
             }
         );
     });

--- a/tools/__tasks__/compile/images/icons.js
+++ b/tools/__tasks__/compile/images/icons.js
@@ -18,12 +18,16 @@ function getSVG (iconPath) {
             if (err) {
                 reject(err);
             } else {
-                svgo.optimize(data, result => {
-                    resolve({
-                        name: path.parse(iconPath).name,
-                        data: result
+                try {
+                    svgo.optimize(data, result => {
+                        resolve({
+                            name: path.parse(iconPath).name,
+                            data: result
+                        });
                     });
-                });
+                } catch (e) {
+                    reject(e);
+                }
             }
         });
     });


### PR DESCRIPTION
## What does this change?

today I learned from @regiskuckaertz that promises can both `reject()` and `resolve()`, so some of the promises I've written were not branching as i thought they would. this makes those success/failure branches explicit. thanks @regiskuckaertz!

## What is the value of this and can you measure success?

badly formatted sass now produces a more useful error in compilation

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

<img width="650" alt="screen shot 2016-11-17 at 11 42 15" src="https://cloud.githubusercontent.com/assets/867233/20388134/6fb24624-acbb-11e6-9a01-f4e51993c269.png">

## Request for comment

@regiskuckaertz @zeftilldeath 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
