### PR TITLE
Add epic usa cta test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,8 +37,18 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-limited-impressions",
-    "Run the epic with a limit of 4 impressions per user (for non US, US there is no limit)",
+    "ab-contributions-epic-limited-impressions-not-usa",
+    "Run the epic with a limit of 4 impressions per user",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 11, 22),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-usa-cta",
+    "Test just contributions vs contributions or membership in the US'",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 22),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -6,8 +6,8 @@ define([
     ab
 ) {
 
-    var contributionsEpicPostElectionCopyTest = {
-        name: 'ContributionsEpicLimitedImpressions',
+    var contributionsEpicLimitedImpressionsNotUsa = {
+        name: 'ContributionsEpicLimitedImpressionsNotUsa',
         variants: ['control']
     };
 
@@ -16,8 +16,13 @@ define([
         variants: ['control']
     };
 
+    var contributionsEpicUsaCta = {
+        name: 'ContributionsEpicUsaCta',
+        variants: ['control', 'justContribute']
+    };
+
     function userIsInAClashingAbTest() {
-        var clashingTests = [contributionsEpicPostElectionCopyTest, contributionsEpicThankyou];
+        var clashingTests = [contributionsEpicLimitedImpressionsNotUsa, contributionsEpicThankyou, contributionsEpicUsaCta];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,7 +10,8 @@ define([
     'common/modules/experiments/tests/hosted-onward-journey',
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-international-experiment',
-    'common/modules/experiments/tests/contributions-epic-limited-impressions',
+    'common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa',
+    'common/modules/experiments/tests/contributions-epic-usa-cta',
     'common/modules/experiments/tests/contributions-epic-thank-you',
     'common/modules/experiments/tests/platform-sticky-ad-viewability'
 ], function (reportError,
@@ -24,7 +25,8 @@ define([
              HostedOnwardJourney,
              WeekendReadingEmail,
              MembershipEngagementInternationalExperiment,
-             ContributionsEpicLimitedImpressions,
+             ContributionsEpicLimitedImpressionsNotUsa,
+             ContributionsEpicUsaCta,
              ContributionsEpicThankYou,
              PlatformStickyAdViewability
     ) {
@@ -32,7 +34,8 @@ define([
         new HostedOnwardJourney(),
         new WeekendReadingEmail(),
         new MembershipEngagementInternationalExperiment(),
-        new ContributionsEpicLimitedImpressions(),
+        new ContributionsEpicLimitedImpressionsNotUsa(),
+        new ContributionsEpicUsaCta(),
         new ContributionsEpicThankYou(),
         new PlatformStickyAdViewability()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa.js
@@ -1,0 +1,216 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection',
+    'common/utils/element-inview'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             ajax,
+             commercialFeatures,
+             intersection,
+             ElementInview) {
+
+    return function () {
+
+        this.id = 'ContributionsEpicLimitedImpressionsNotUsa';
+        this.start = '2016-11-15';
+        this.expiry = '2016-11-22';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Run the epic with a limit of 4 impressions per user (for non US, US there is no limit)';
+        this.showForSensitive = false;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
+        this.audienceCriteria = 'Everywhere but the US';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We improve our conversion rate by not showing the epic to those less likely to contribute (i.e those who have seen it more than 4 times).';
+        this.canRun = function () {
+            var includedKeywordIds = [
+                'us-news/us-elections-2016',
+                'us-news/us-politics'
+            ];
+
+            var excludedKeywordIds = ['music/leonard-cohen'];
+
+            var hasKeywordsMatch = function() {
+                var pageKeywords = config.page.keywordIds;
+                if (typeof(pageKeywords) != 'undefined') {
+                    var keywordList = pageKeywords.split(',');
+                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        intersection(includedKeywordIds, keywordList).length > 0;
+                } else {
+                    return false;
+                }
+            };
+
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
+        };
+
+        function getValue(name){
+            return parseInt(cookies.get(name));
+        }
+
+        function setValue(name, value){
+            cookies.add(name, value, 7);
+        }
+
+        function addInviewListener(epicViewCounter) {
+            mediator.on('contributions-embed:insert', function () {
+                $('.contributions__epic').each(function (el) {
+                    //top offset of 18 ensures view only counts when half of element is on screen
+                    var elementInview = ElementInview(el, window, {top: 18});
+                    elementInview.on('firstview', function () {
+                        mediator.emit('contributions-embed:view');
+                        setValue('gu.epicViewCount', epicViewCounter + 1);
+                    });
+                });
+            });
+        }
+
+        var epicViewCount = getValue('gu.epicViewCount') || 0;
+
+
+
+        var contributeUrlPrefix = 'co_global_epic_limited';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_limited';
+
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+        
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+        var messages  = {
+            control: {
+                title: 'Since you’re here …',
+                p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_control'
+            }
+        };
+
+        var cta = {
+            equal: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution',
+                url1: makeUrl(membershipUrl, membershipUrlPrefix ),
+                url2:  makeUrl(contributeUrl, contributeUrlPrefix ),
+                hidden: ''
+            },
+
+            justContribute: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Make a contribution',
+                cta2: '',
+                url1:  makeUrl(contributeUrl, contributeUrlPrefix + '_backup'),
+                url2: '',
+                hidden: 'hidden'
+            },
+
+            justSupporter: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: '',
+                url1: makeUrl(membershipUrl, membershipUrlPrefix + '_backup'),
+                url2: '',
+                hidden: 'hidden'
+            }
+
+
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if (epicViewCount < 4 && 'country' in resp && resp.country !== 'US'){
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        if (submetaElement.length > 0) {
+                            component.insertBefore(submetaElement);
+                            addInviewListener(epicViewCount);
+                            mediator.emit('contributions-embed:insert', component);
+                        }
+                    });
+                }
+            });
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:view', complete);
+        };
+
+        var getCta = function() {
+            if (config.switches.turnOffSupporterEpic) {
+                return cta.justContribute;
+            }
+            if (config.switches.turnOffContributionsEpic) {
+                return cta.justSupporter;
+            }
+            return cta.equal;
+        };
+
+
+        this.variants = [
+            {
+                id: 'control',
+
+                test: function () {
+                    var ctaType = getCta();
+                    var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp,
+                        linkUrl2: ctaType.url2 + message.intcmp,
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta.js
@@ -13,8 +13,7 @@ define([
     'common/utils/cookies',
     'common/utils/ajax',
     'common/modules/commercial/commercial-features',
-    'lodash/arrays/intersection',
-    'common/utils/element-inview'
+    'lodash/arrays/intersection'
 
 ], function (bean,
              qwery,
@@ -30,23 +29,22 @@ define([
              cookies,
              ajax,
              commercialFeatures,
-             intersection,
-             ElementInview) {
+             intersection) {
 
     return function () {
 
-        this.id = 'ContributionsEpicLimitedImpressions';
+        this.id = 'ContributionsEpicUsaCta';
         this.start = '2016-11-15';
         this.expiry = '2016-11-22';
         this.author = 'Jonathan Rankin';
-        this.description = 'Run the epic with a limit of 4 impressions per user (for non US, US there is no limit)';
+        this.description = 'Test just contributions vs contributions or membership in the US';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
-        this.audienceCriteria = 'Global';
+        this.audienceCriteria = 'Just the US';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We improve our conversion rate by not showing the epic to those less likely to contribute (i.e those who have seen it more than 4 times).';
+        this.idealOutcome = 'We prove or disprove our hypothesis that just offering contributions will result in an overall boost in money taken in the USA';
         this.canRun = function () {
             var includedKeywordIds = [
                 'us-news/us-elections-2016',
@@ -71,41 +69,13 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
-        function getValue(name){
-            return parseInt(cookies.get(name));
-        }
-
-        function setValue(name, value){
-            cookies.add(name, value, 7);
-        }
-
-        function addInviewListener(epicViewCounter) {
-            mediator.on('contributions-embed:insert', function () {
-                $('.contributions__epic').each(function (el) {
-                    //top offset of 18 ensures view only counts when half of element is on screen
-                    var elementInview = ElementInview(el, window, {top: 18});
-                    elementInview.on('firstview', function () {
-                        mediator.emit('contributions-embed:view');
-                        setValue('gu.epicViewCount', epicViewCounter + 1);
-                    });
-
-                });
-
-            });
-        }
-
-        var epicViewCount = getValue('gu.epicViewCount') || 0;
-
-
-
-        var contributeUrlPrefix = 'co_global_epic_limited';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_limited';
+        var contributeUrlPrefix = 'co_global_epic_usa_cta';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_usa_cta';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
             return urlPrefix + 'INTCMP=' + intcmp;
         };
-
 
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
         var contributeUrl = 'https://contribute.theguardian.com/?';
@@ -115,6 +85,12 @@ define([
                 title: 'Since you’re here …',
                 p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 intcmp: '_control'
+            },
+
+            justContribute: {
+                title: 'Since you’re here …',
+                p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_justContribute'
             }
         };
 
@@ -159,20 +135,17 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if ((epicViewCount < 4) || ('country' in resp && resp.country === 'US')){
+                if ('country' in resp && resp.country === 'US'){
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         if (submetaElement.length > 0) {
                             component.insertBefore(submetaElement);
-                            addInviewListener(epicViewCount);
                             mediator.emit('contributions-embed:insert', component);
                         }
                     });
                 }
             });
         };
-
-
 
         var completer = function (complete) {
             mediator.on('contributions-embed:view', complete);
@@ -188,7 +161,6 @@ define([
             return cta.equal;
         };
 
-
         this.variants = [
             {
                 id: 'control',
@@ -196,6 +168,33 @@ define([
                 test: function () {
                     var ctaType = getCta();
                     var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp,
+                        linkUrl2: ctaType.url2 + message.intcmp,
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'justContribute',
+
+                test: function () {
+                    var ctaType = cta.justContribute;
+                    var message = messages.justContribute;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.url1 + message.intcmp,
                         linkUrl2: ctaType.url2 + message.intcmp,


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

We think that just showing a contributions button on the epic in the USA may be more effective than both the contributions button and the become a supporter button, especially now with all the news in the USA about media organisations receiving increased levels of contributions. Before we make this call, we need to prove it. This test will inform that decision.

This also limits the ContributionsEpicLimitedImpressions test to everywhere but the USA. Once we have the results of this test, we can merge it back into one test. 

## What is the value of this and can you measure success?

We find the most profitable CTA for the USA in the epic . 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
![screenshot at nov 17 12-01-36](https://cloud.githubusercontent.com/assets/2844554/20388689/f0297e1a-acbd-11e6-9fc2-5b7ab7309106.png)
![screenshot at nov 17 12-02-28](https://cloud.githubusercontent.com/assets/2844554/20388690/f02a0042-acbd-11e6-99f4-0ee5277b37dd.png)
## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

