### PR TITLE
Auto-install deps when running make tasks that need them

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -1,8 +1,0 @@
-#/usr/bin/env bash
-
-# Modified version of [Sindre Sorhus's gist](https://gist.github.com/sindresorhus/7996717),
-# to run the Guardian installation procedures after a `git pull`, if necessary.
-
-changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
-
-echo $changed_files | grep 'package.json' --quiet && node tools/messages.js dependency-update

--- a/makefile
+++ b/makefile
@@ -50,36 +50,36 @@ watch: compile-dev
 # *********************** ASSETS ***********************
 
 # Compile all assets for production.
-compile: check-node
+compile: install
 	@./tools/run-task compile
 
 # Compile all assets for development.
-compile-dev: check-node
+compile-dev: install
 	@./tools/run-task compile --dev
 
-compile-javascript: check-node # PRIVATE
+compile-javascript: install # PRIVATE
 	@./tools/run-task compile/javascript
 
-compile-javascript-dev: check-node # PRIVATE
+compile-javascript-dev: install # PRIVATE
 	@./tools/run-task compile/javascript --dev
 
-compile-css: check-node # PRIVATE
+compile-css: install # PRIVATE
 	@./tools/run-task compile/css
 
-compile-images: check-node # PRIVATE
+compile-images: install # PRIVATE
 	@./tools/run-task compile/images
 
-compile-svgs: check-node # PRIVATE
+compile-svgs: install # PRIVATE
 	@./tools/run-task compile/inline-svgs
 
-compile-fonts: check-node # PRIVATE
+compile-fonts: install # PRIVATE
 	@./tools/run-task compile/fonts
 
-atomise-css: check-node # PRIVATE
+atomise-css: install # PRIVATE
 	@node tools/atomise-css
 
 # * Not ready for primetime use yet... *
-pasteup: check-node # PRIVATE
+pasteup: install # PRIVATE
 	@cd static/src/stylesheets/pasteup && npm --silent i && node publish.js
 
 
@@ -87,24 +87,24 @@ pasteup: check-node # PRIVATE
 # *********************** CHECKS ***********************
 
 # Run the JS test suite.
-test: check-node
+test: install
 	@./tools/run-task test/javascript
 
 # Check the JS test suite coverage.
-coverage: check-node
+coverage: install
 	@./tools/run-task test/javascript/coverage --stdout
 
 # Lint all assets.
-validate: check-node
+validate: install
 	@./tools/run-task lint
 
 # Lint all SCSS.
-validate-sass: check-node # PRIVATE
+validate-sass: install # PRIVATE
 	@./tools/run-task lint/sass
 
 # Lint all JS.
-validate-javascript: check-node # PRIVATE
+validate-javascript: install # PRIVATE
 	@./tools/run-task lint/javascript
 
-validate-amp: check-node # PRIVATE
+validate-amp: install # PRIVATE
 	@cd tools/amp-validation && npm install && NODE_ENV=dev node index.js

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -77,18 +77,11 @@ switch (process.argv[2]) {
         }, 'error');
         break;
 
-    case 'dependency-update':
-        notify('Run `make install`.', {
-            heading: 'Dependencies have changed'
-        }, 'warn');
-        break;
-
     case 'pasteup':
         notify('You will need to release a new version of pasteup to NPM once you’ve merged this branch to master.\n\nTo begin a new release, run `make pasteup`.', {
             heading: 'Pasteup files have changed'
         }, 'info');
         break;
-
 
     case 'install-steps':
       notify('Please run the following to complete your installation:', {


### PR DESCRIPTION
## What does this change?

- updates `make` tasks to install deps on demand
- removes the prompt to `make install` if deps change

## What is the value of this and can you measure success?

since `yarn` takes less than a second to run if it has nothing to do, its not big overhead if we just run it before every `make` command that relies on them, and stop prompting people to install when they've changed.

in this way, `make` behaves more like SBT, and kind of treats the presence of dependencies as a dependency itself...

<img width="500" alt="screen shot 2016-11-17 at 12 52 05" src="https://cloud.githubusercontent.com/assets/867233/20390028/ae63e57c-acc4-11e6-8c8d-6bfc9bbf5b1c.png">


## Request for comment

I wonder if this is too 'magic'? maybe it's useful?

@guardian/dotcom-platform @regiskuckaertz @rich-nguyen 


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
