### PR TITLE
Run faulty pageskins in code

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
@@ -18,7 +18,7 @@ define([
         prebidEnabled: config.page.edition == 'US' && !('tests' in config && config.tests.commercialHbSonobi),
 
         /* sonobiEnabled: boolean. Set to true if sonobi real-time-bidding is enabled*/
-        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && (!config.page.hasPageSkin || !config.page.isProd),
+        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && !(config.page.hasPageSkin && config.page.isProd),
 
         /* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
         lazyLoadEnabled: false,

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
@@ -18,7 +18,7 @@ define([
         prebidEnabled: config.page.edition == 'US' && !('tests' in config && config.tests.commercialHbSonobi),
 
         /* sonobiEnabled: boolean. Set to true if sonobi real-time-bidding is enabled*/
-        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && !config.page.hasPageSkin,
+        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && (!config.page.hasPageSkin || !config.page.isProd),
 
         /* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
         lazyLoadEnabled: false,


### PR DESCRIPTION
Enabling page skins in code will allow me to pass the Sonobi team a link to a page which exposes an error in their js module. 