### PR TITLE
Add fluid size support in Facebook IA

### DIFF
--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -127,7 +127,7 @@
         }
 
         function buildAdtestTargeting() {
-            var adtest = slot.getAttribute('data-adtest');
+            var adtest = slot.getAttribute('at');
             return adtest ? ".setTargeting('at', '" + adtest + "')" : "";
         }
 

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -137,7 +137,12 @@
             }
             var size = slot.getAttribute("data-ad-size");
             var adUnitName = slot.getAttribute("data-ad-unit");
-            var slotDeclaration = "googletag.cmd.push(function() { googletag.defineSlot('/59666047/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + (buildSegments()) + ".addService(googletag.pubads()); });";
+            var slotDeclaration = "googletag.cmd.push(function() {" +
+                "googletag.defineSlot('/59666047/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" +
+                (buildCustomTargeting()) +
+                (buildSegments()) +
+                ".addService(googletag.pubads());" +
+                " });";
             return insertScript(slotDeclaration);
         }
 

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -126,6 +126,10 @@
             return targeting;
         }
 
+        function buildAdtestTargeting() {
+            var adtest = slot.getAttribute('data-adtest');
+            return adtest ? ".setTargeting('at', '" + adtest + "')" : "";
+        }
 
         function insertAdConfig() {
             var isFirstAd = scripts.length === 1;
@@ -140,6 +144,7 @@
             var slotDeclaration = "googletag.cmd.push(function() {" +
                 "googletag.defineSlot('/59666047/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" +
                 (buildCustomTargeting()) +
+                (buildAdtestTargeting()) +
                 (buildSegments()) +
                 ".addService(googletag.pubads());" +
                 " });";

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -99,9 +99,15 @@
             return script.text = content;
         }
 
-        function buildTargetSize(size) {
-            var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
-            return "[[" + formatted + "]]";
+        function buildTargetSize(sizes) {
+            return "[" +
+                sizes
+                .split(',')
+                .map(function (size) {
+                    return size === "fluid" ? "'fluid'" : "[" + size.replace('x', ',') + "]"
+                })
+                .join(',') +
+            "]";
         }
 
         function buildCustomTargeting() {


### PR DESCRIPTION
Native ads are coming through dotcom, the Android/iOS apps and AMP pages. Next in line is Facebook IA. This change allows us to:

- use the `fluid` size in the call to `defineSlot`
- specify an ad test value, useful to render specific creatives coming from DFP

... and here is a screenshot(tm)

![picture 3](https://cloud.githubusercontent.com/assets/629976/20399107/a9fe6a8e-ace7-11e6-84e2-6cf9c8a72d62.jpg)

(it is fluid, that's why it takes up all the space)

NB: I may not get all of it, but boy this script does things the complicated way. For once, I don't get how it is possible to have more than one ad slot, huh?

cc @LATaylor-guardian 