### PR TITLE
Enable images in hosted pages to be rendered in amp pages

### DIFF
--- a/commercial/app/model/hosted/HostedAmp.scala
+++ b/commercial/app/model/hosted/HostedAmp.scala
@@ -1,0 +1,21 @@
+package model.hosted
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+
+import scala.collection.JavaConverters._
+
+object HostedAmp {
+
+  def ampify(html: String): String = {
+
+    def ampifyImage(img: Element): Element = img.tagName("amp-img").attr("layout", "fixed")
+
+    val doc = Jsoup.parseBodyFragment(html)
+    val imgs = doc.select("img")
+    for (img <- imgs.asScala) {
+      ampifyImage(img)
+    }
+    doc.body.html()
+  }
+}

--- a/commercial/app/model/hosted/HostedAmp.scala
+++ b/commercial/app/model/hosted/HostedAmp.scala
@@ -9,7 +9,7 @@ object HostedAmp {
 
   def ampify(html: String): String = {
 
-    def ampifyImage(img: Element): Element = img.tagName("amp-img").attr("layout", "fixed")
+    def ampifyImage(img: Element): Element = img.tagName("amp-img").attr("layout", "responsive")
 
     val doc = Jsoup.parseBodyFragment(html)
     val imgs = doc.select("img")

--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -1,10 +1,10 @@
 @import common.commercial.hosted.HostedArticlePage
-@(page: HostedArticlePage)(implicit request: RequestHeader)
 @import common.commercial.hosted.hardcoded.Support.makeshiftPage
-@import views.html.hosted._
-@import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
+@import model.hosted.HostedAmp.ampify
+@import views.html.hosted._
 @import views.support.FBPixel
+@(page: HostedArticlePage)(implicit request: RequestHeader)
 
 <!doctype html>
 <html AMP>
@@ -70,7 +70,7 @@
                                         case "overview" => { @singaporeF1Overview() }
                                         case "offtrack" => { @singaporeF1Offtrack() }
                                         case "packages" => { @singaporeF1Packages() }
-                                        case _ => { @Html(page.body) }
+                                        case _ => { @Html(ampify(page.body)) }
                                     }
 
                                 </div>


### PR DESCRIPTION
This will transform img elements into amp-img elements.

Use it in a play scala template like this:
```
@import model.hosted.HostedAmp.ampify
...
    { @Html(ampify(page.body)) }
...
```
ie. replace `page.body` with `ampify(page.body)` where you want it to render for amp.

/cc @Calanthe 