### PR TITLE
Remove short name for Peterboro

### DIFF
--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -20,7 +20,6 @@ object TeamMap extends ExecutionContexts with Logging {
     ("19", "Spurs"),
     ("5", "C Palace"),
     ("30", "Middlesbrough"),
-    ("84", "Peterboro"),
     ("44", "Wolves"),
     ("20", "MK Dons"),
     ("74", "Colchester"),


### PR DESCRIPTION
Doesn't override the long name _Peterborough_ with the short name _Peterboro_ anymore.

| Before        | After
| ------------- |-----|
| ![image](https://cloud.githubusercontent.com/assets/638051/20427882/048ef158-ad7e-11e6-93d9-d012680c1b91.png) | ![image](https://cloud.githubusercontent.com/assets/638051/20427817/b419b9a6-ad7d-11e6-98c2-e957678c3fa8.png)|

https://trello.com/c/P1mS5jAL/152-peterborough-misspelled-peterboro-in-football-data
