### PR TITLE
add world of work tag to tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa.js
@@ -53,14 +53,20 @@ define([
                 'us-news/us-politics'
             ];
 
+            var includedNonKeywordTagIds = [
+                'uk-news/series/the-new-world-of-work'
+            ];
+
             var excludedKeywordIds = ['music/leonard-cohen'];
 
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
-                if (typeof(pageKeywords) != 'undefined') {
+                var pageNonKeywordTagIds = config.page.nonKeywordTagIds;
+                if (typeof(pageKeywords) !== 'undefined' && typeof(pageNonKeywordTagIds) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
-                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
-                        intersection(includedKeywordIds, keywordList).length > 0;
+                    var nonKeywordTagIdsList = pageNonKeywordTagIds.split(',');
+                    return (intersection(excludedKeywordIds, keywordList).length == 0 
+                        && (intersection(includedKeywordIds, keywordList).length > 0) || intersection(includedNonKeywordTagIds, nonKeywordTagIdsList).length > 0);
                 } else {
                     return false;
                 }


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

The world of work series is proving very popular so we want to ask for contributions/supporter sign ups on these articles. This PR adds that tag. 

## What is the value of this and can you measure success?

More contributions/supporters. 


<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment

@jfsoul @NataliaLKB @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

