### PR TITLE
Contributions Epic Fake News Copy Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,8 +37,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-limited-impressions-not-usa",
-    "Run the epic with a limit of 4 impressions per user",
+    "ab-contributions-epic-fake-news",
+    "Try and beat the epic copy with e version that mentions the hot topic of fake news",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 22),
@@ -47,8 +47,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-usa-cta",
-    "Test just contributions vs contributions or membership in the US'",
+    "ab-contributions-epic-usa-cta-fake-news",
+    "Test just contributions vs contributions or membership in the US, and test a new copy variant against the control",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 22),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -6,9 +6,9 @@ define([
     ab
 ) {
 
-    var contributionsEpicLimitedImpressionsNotUsa = {
-        name: 'ContributionsEpicLimitedImpressionsNotUsa',
-        variants: ['control']
+    var contributionsEpicFakeNews = {
+        name: 'ContributionsEpicFakeNews',
+        variants: ['control', 'fake']
     };
 
     var contributionsEpicThankyou = {
@@ -16,13 +16,13 @@ define([
         variants: ['control']
     };
 
-    var contributionsEpicUsaCta = {
-        name: 'ContributionsEpicUsaCta',
-        variants: ['control', 'justContribute']
+    var contributionsEpicUsaCtaFakeNews = {
+        name: 'ContributionsEpicUsaCtaFakeNews',
+        variants: ['mixed-control', 'mixed-fake', 'just-contribute-control', 'just-contribute-fake']
     };
 
     function userIsInAClashingAbTest() {
-        var clashingTests = [contributionsEpicLimitedImpressionsNotUsa, contributionsEpicThankyou, contributionsEpicUsaCta];
+        var clashingTests = [contributionsEpicFakeNews, contributionsEpicThankyou, contributionsEpicUsaCtaFakeNews];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,8 +10,8 @@ define([
     'common/modules/experiments/tests/hosted-onward-journey',
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-international-experiment',
-    'common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa',
-    'common/modules/experiments/tests/contributions-epic-usa-cta',
+    'common/modules/experiments/tests/contributions-epic-fake-news',
+    'common/modules/experiments/tests/contributions-epic-usa-cta-fake-news',
     'common/modules/experiments/tests/contributions-epic-thank-you',
     'common/modules/experiments/tests/platform-sticky-ad-viewability'
 ], function (reportError,
@@ -25,8 +25,8 @@ define([
              HostedOnwardJourney,
              WeekendReadingEmail,
              MembershipEngagementInternationalExperiment,
-             ContributionsEpicLimitedImpressionsNotUsa,
-             ContributionsEpicUsaCta,
+             ContributionsEpicFakeNews,
+             ContributionsEpicUsaCtaFakeNews,
              ContributionsEpicThankYou,
              PlatformStickyAdViewability
     ) {
@@ -34,8 +34,8 @@ define([
         new HostedOnwardJourney(),
         new WeekendReadingEmail(),
         new MembershipEngagementInternationalExperiment(),
-        new ContributionsEpicLimitedImpressionsNotUsa(),
-        new ContributionsEpicUsaCta(),
+        new ContributionsEpicFakeNews(),
+        new ContributionsEpicUsaCtaFakeNews(),
         new ContributionsEpicThankYou(),
         new PlatformStickyAdViewability()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
@@ -35,18 +35,18 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEpicLimitedImpressionsNotUsa';
-        this.start = '2016-11-15';
+        this.id = 'ContributionsEpicFakeNews';
+        this.start = '2016-11-18';
         this.expiry = '2016-11-22';
         this.author = 'Jonathan Rankin';
-        this.description = 'Run the epic with a limit of 4 impressions per user (for non US, US there is no limit)';
+        this.description = 'Try and beat the epic copy with a version that mentions the hot topic of fake news';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
         this.audienceCriteria = 'Everywhere but the US';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We improve our conversion rate by not showing the epic to those less likely to contribute (i.e those who have seen it more than 4 times).';
+        this.idealOutcome = 'We find a message that beats our copy, and learn that we can beat the current control copy with news-relevant references in the copy';
         this.canRun = function () {
             var includedKeywordIds = [
                 'us-news/us-elections-2016',
@@ -65,7 +65,7 @@ define([
                 if (typeof(pageKeywords) !== 'undefined' && typeof(pageNonKeywordTagIds) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
                     var nonKeywordTagIdsList = pageNonKeywordTagIds.split(',');
-                    return (intersection(excludedKeywordIds, keywordList).length == 0 
+                    return (intersection(excludedKeywordIds, keywordList).length == 0
                         && (intersection(includedKeywordIds, keywordList).length > 0) || intersection(includedNonKeywordTagIds, nonKeywordTagIdsList).length > 0);
                 } else {
                     return false;
@@ -102,14 +102,14 @@ define([
 
 
 
-        var contributeUrlPrefix = 'co_global_epic_limited';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_limited';
+        var contributeUrlPrefix = 'co_global_epic_fake-non-us';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_fake-non-us';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
             return urlPrefix + 'INTCMP=' + intcmp;
         };
-        
+
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
@@ -118,6 +118,12 @@ define([
                 title: 'Since you’re here …',
                 p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 intcmp: '_control'
+            },
+
+            fake: {
+                title: 'Since you’re here …',
+                p1: '… we have a small favour to ask. In these post-truth times, when fake news swirls, we need independent journalism more than ever. But while more people are reading the Guardian, far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. Our journalism takes time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_fake'
             }
         };
 
@@ -197,6 +203,33 @@ define([
                 test: function () {
                     var ctaType = getCta();
                     var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp,
+                        linkUrl2: ctaType.url2 + message.intcmp,
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'fake',
+
+                test: function () {
+                    var ctaType = getCta();
+                    var message = messages.fake;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.url1 + message.intcmp,
                         linkUrl2: ctaType.url2 + message.intcmp,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-fake-news.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-fake-news.js
@@ -33,18 +33,18 @@ define([
 
     return function () {
 
-        this.id = 'ContributionsEpicUsaCta';
-        this.start = '2016-11-15';
+        this.id = 'ContributionsEpicUsaCtaFakeNews';
+        this.start = '2016-11-18';
         this.expiry = '2016-11-22';
         this.author = 'Jonathan Rankin';
-        this.description = 'Test just contributions vs contributions or membership in the US';
+        this.description = 'Test just contributions vs contributions or membership in the US, and test a new copy variant against the control';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
         this.audienceCriteria = 'Just the US';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We prove or disprove our hypothesis that just offering contributions will result in an overall boost in money taken in the USA';
+        this.idealOutcome = 'We prove or disprove our hypothesis that just offering contributions will result in an overall boost in money taken in the USA, whilst simultanously running a test to try and beat the epic control copy';
         this.canRun = function () {
             var includedKeywordIds = [
                 'us-news/us-elections-2016',
@@ -55,7 +55,7 @@ define([
 
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
-                if (typeof(pageKeywords) != 'undefined') {
+                if (typeof(pageKeywords) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
                     return intersection(excludedKeywordIds, keywordList).length == 0 &&
                         intersection(includedKeywordIds, keywordList).length > 0;
@@ -69,8 +69,8 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
-        var contributeUrlPrefix = 'co_global_epic_usa_cta';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_usa_cta';
+        var contributeUrlPrefix = 'co_global_epic_usa_cta_fake';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_usa_cta_fake';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
@@ -87,10 +87,10 @@ define([
                 intcmp: '_control'
             },
 
-            justContribute: {
+            fake: {
                 title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                intcmp: '_justContribute'
+                p1: '… we have a small favour to ask. In these post-truth times, when fake news swirls, we need independent journalism more than ever. But while more people are reading the Guardian, far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. Our journalism takes time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_fake'
             }
         };
 
@@ -163,14 +163,14 @@ define([
 
         this.variants = [
             {
-                id: 'control',
+                id: 'mixed-control',
 
                 test: function () {
                     var ctaType = getCta();
                     var message = messages.control;
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + message.intcmp,
-                        linkUrl2: ctaType.url2 + message.intcmp,
+                        linkUrl1: ctaType.url1 + message.intcmp + '_mixed',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_mixed',
                         title: message.title,
                         p1: message.p1,
                         p2:ctaType.p2,
@@ -190,14 +190,68 @@ define([
             },
 
             {
-                id: 'justContribute',
+                id: 'mixed-fake',
+
+                test: function () {
+                    var ctaType = getCta();
+                    var message = messages.fake;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp + '_mixed',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_mixed',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'just-contribute-control',
 
                 test: function () {
                     var ctaType = cta.justContribute;
-                    var message = messages.justContribute;
+                    var message = messages.control;
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + message.intcmp,
-                        linkUrl2: ctaType.url2 + message.intcmp,
+                        linkUrl1: ctaType.url1 + message.intcmp + '_contribute',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_contribute',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'just-contribute-fake',
+
+                test: function () {
+                    var ctaType = cta.justContribute;
+                    var message = messages.fake;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp + '_contribute',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_contribute',
                         title: message.title,
                         p1: message.p1,
                         p2:ctaType.p2,


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

We want to test out a new variant of the copy which references the fake news agenda that is a hot topic right now, and we hope it will beat the control. This PR splits the 2 current Contribution Epic tests live at the moment into 2, so the non US test which previously had 1 variant now has 2, and the US test that is already testing 2 different CTA messages will be split into 4 variants:  CTA1/Copy1, CTA1/Copy2, CTA2/Copy1, CTA2/Copy2.

I realise I could have split the US test into 2 separate tests, but this would have resulted in more JS and we would have also had to decide which CTA to use for the new US test, which would have been a big political debate because the CTA test hasn't finished running yet and would waste precious time.

## What is the value of this and can you measure success?

We will hopefully finally beat our epic control copy. 

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

I've included screenshots of both versions of copy. 

![screenshot at nov 18 14-45-51](https://cloud.githubusercontent.com/assets/2844554/20434450/bbd67f72-ad9f-11e6-8933-2843b1f1ed16.png)
![screenshot at nov 18 14-46-00](https://cloud.githubusercontent.com/assets/2844554/20434451/bbde51d4-ad9f-11e6-8fbc-284a755f6682.png)


## Request for comment

@gtrufitt @jfsoul @akash1810 @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

