### PR TITLE
Allow sonobi to run with pageskins

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js
@@ -18,7 +18,7 @@ define([
         prebidEnabled: config.page.edition == 'US' && !('tests' in config && config.tests.commercialHbSonobi),
 
         /* sonobiEnabled: boolean. Set to true if sonobi real-time-bidding is enabled*/
-        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi && !(config.page.hasPageSkin && config.page.isProd),
+        sonobiEnabled: 'tests' in config && config.tests.commercialHbSonobi,
 
         /* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
         lazyLoadEnabled: false,


### PR DESCRIPTION
This re-enables sonobi on fronts with pageskins, an issue with the sonobi script has been found and fixed.