### PR TITLE
add fake news tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,8 +37,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-limited-impressions-not-usa",
-    "Run the epic with a limit of 4 impressions per user",
+    "ab-contributions-epic-fake-news",
+    "Try and beat the epic copy with e version that mentions the hot topic of fake news",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 22),
@@ -47,8 +47,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-usa-cta",
-    "Test just contributions vs contributions or membership in the US'",
+    "ab-contributions-epic-usa-cta-fake-news",
+    "Test just contributions vs contributions or membership in the US, and test a new copy variant against the control",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate =  new LocalDate(2016, 11, 22),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -6,9 +6,9 @@ define([
     ab
 ) {
 
-    var contributionsEpicLimitedImpressionsNotUsa = {
-        name: 'ContributionsEpicLimitedImpressionsNotUsa',
-        variants: ['control']
+    var contributionsEpicFakeNews = {
+        name: 'ContributionsEpicFakeNews',
+        variants: ['control', 'fake']
     };
 
     var contributionsEpicThankyou = {
@@ -16,13 +16,13 @@ define([
         variants: ['control']
     };
 
-    var contributionsEpicUsaCta = {
-        name: 'ContributionsEpicUsaCta',
-        variants: ['control', 'justContribute']
+    var contributionsEpicUsaCtaFakeNews = {
+        name: 'ContributionsEpicUsaCtaFakeNews',
+        variants: ['mixed-control', 'mixed-fake', 'just-contribute-control', 'just-contribute-fake']
     };
 
     function userIsInAClashingAbTest() {
-        var clashingTests = [contributionsEpicLimitedImpressionsNotUsa, contributionsEpicThankyou, contributionsEpicUsaCta];
+        var clashingTests = [contributionsEpicFakeNews, contributionsEpicThankyou, contributionsEpicUsaCtaFakeNews];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,8 +10,8 @@ define([
     'common/modules/experiments/tests/hosted-onward-journey',
     'common/modules/experiments/tests/weekend-reading-email',
     'common/modules/experiments/tests/membership-engagement-international-experiment',
-    'common/modules/experiments/tests/contributions-epic-limited-impressions-not-usa',
-    'common/modules/experiments/tests/contributions-epic-usa-cta',
+    'common/modules/experiments/tests/contributions-epic-fake-news',
+    'common/modules/experiments/tests/contributions-epic-usa-cta-fake-news',
     'common/modules/experiments/tests/contributions-epic-thank-you',
     'common/modules/experiments/tests/platform-sticky-ad-viewability'
 ], function (reportError,
@@ -25,8 +25,8 @@ define([
              HostedOnwardJourney,
              WeekendReadingEmail,
              MembershipEngagementInternationalExperiment,
-             ContributionsEpicLimitedImpressionsNotUsa,
-             ContributionsEpicUsaCta,
+             ContributionsEpicFakeNews,
+             ContributionsEpicUsaCtaFakeNews,
              ContributionsEpicThankYou,
              PlatformStickyAdViewability
     ) {
@@ -34,8 +34,8 @@ define([
         new HostedOnwardJourney(),
         new WeekendReadingEmail(),
         new MembershipEngagementInternationalExperiment(),
-        new ContributionsEpicLimitedImpressionsNotUsa(),
-        new ContributionsEpicUsaCta(),
+        new ContributionsEpicFakeNews(),
+        new ContributionsEpicUsaCtaFakeNews(),
         new ContributionsEpicThankYou(),
         new PlatformStickyAdViewability()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
@@ -13,7 +13,8 @@ define([
     'common/utils/cookies',
     'common/utils/ajax',
     'common/modules/commercial/commercial-features',
-    'lodash/arrays/intersection'
+    'lodash/arrays/intersection',
+    'common/utils/element-inview'
 
 ], function (bean,
              qwery,
@@ -29,36 +30,43 @@ define([
              cookies,
              ajax,
              commercialFeatures,
-             intersection) {
+             intersection,
+             ElementInview) {
 
     return function () {
 
-        this.id = 'ContributionsEpicUsaCta';
-        this.start = '2016-11-15';
+        this.id = 'ContributionsEpicFakeNews';
+        this.start = '2016-11-18';
         this.expiry = '2016-11-22';
         this.author = 'Jonathan Rankin';
-        this.description = 'Test just contributions vs contributions or membership in the US';
+        this.description = 'Try and beat the epic copy with a version that mentions the hot topic of fake news';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
-        this.audienceCriteria = 'Just the US';
+        this.audienceCriteria = 'Everywhere but the US';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We prove or disprove our hypothesis that just offering contributions will result in an overall boost in money taken in the USA';
+        this.idealOutcome = 'We find a message that beats our copy, and learn that we can beat the current control copy with news-relevant references in the copy';
         this.canRun = function () {
             var includedKeywordIds = [
                 'us-news/us-elections-2016',
                 'us-news/us-politics'
             ];
 
+            var includedNonKeywordTagIds = [
+                'uk-news/series/the-new-world-of-work'
+            ];
+
             var excludedKeywordIds = ['music/leonard-cohen'];
 
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
-                if (typeof(pageKeywords) != 'undefined') {
+                var pageNonKeywordTagIds = config.page.nonKeywordTagIds;
+                if (typeof(pageKeywords) !== 'undefined' && typeof(pageNonKeywordTagIds) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
-                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
-                        intersection(includedKeywordIds, keywordList).length > 0;
+                    var nonKeywordTagIdsList = pageNonKeywordTagIds.split(',');
+                    return (intersection(excludedKeywordIds, keywordList).length == 0
+                        && (intersection(includedKeywordIds, keywordList).length > 0) || intersection(includedNonKeywordTagIds, nonKeywordTagIdsList).length > 0);
                 } else {
                     return false;
                 }
@@ -69,8 +77,33 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
-        var contributeUrlPrefix = 'co_global_epic_usa_cta';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_usa_cta';
+        function getValue(name){
+            return parseInt(cookies.get(name));
+        }
+
+        function setValue(name, value){
+            cookies.add(name, value, 7);
+        }
+
+        function addInviewListener(epicViewCounter) {
+            mediator.on('contributions-embed:insert', function () {
+                $('.contributions__epic').each(function (el) {
+                    //top offset of 18 ensures view only counts when half of element is on screen
+                    var elementInview = ElementInview(el, window, {top: 18});
+                    elementInview.on('firstview', function () {
+                        mediator.emit('contributions-embed:view');
+                        setValue('gu.epicViewCount', epicViewCounter + 1);
+                    });
+                });
+            });
+        }
+
+        var epicViewCount = getValue('gu.epicViewCount') || 0;
+
+
+
+        var contributeUrlPrefix = 'co_global_epic_fake_non_us';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_fake_non_us';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
@@ -87,10 +120,10 @@ define([
                 intcmp: '_control'
             },
 
-            justContribute: {
+            fake: {
                 title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                intcmp: '_justContribute'
+                p1: '… we have a small favour to ask. In these post-truth times, when fake news swirls, we need independent journalism more than ever. But while more people are reading the Guardian, far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. Our journalism takes time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_fake'
             }
         };
 
@@ -135,11 +168,12 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if ('country' in resp && resp.country === 'US'){
+                if (epicViewCount < 4 && 'country' in resp && resp.country !== 'US'){
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         if (submetaElement.length > 0) {
                             component.insertBefore(submetaElement);
+                            addInviewListener(epicViewCount);
                             mediator.emit('contributions-embed:insert', component);
                         }
                     });
@@ -160,6 +194,7 @@ define([
             }
             return cta.equal;
         };
+
 
         this.variants = [
             {
@@ -190,11 +225,11 @@ define([
             },
 
             {
-                id: 'justContribute',
+                id: 'fake',
 
                 test: function () {
-                    var ctaType = cta.justContribute;
-                    var message = messages.justContribute;
+                    var ctaType = getCta();
+                    var message = messages.fake;
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.url1 + message.intcmp,
                         linkUrl2: ctaType.url2 + message.intcmp,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-fake-news.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-fake-news.js
@@ -13,8 +13,7 @@ define([
     'common/utils/cookies',
     'common/utils/ajax',
     'common/modules/commercial/commercial-features',
-    'lodash/arrays/intersection',
-    'common/utils/element-inview'
+    'lodash/arrays/intersection'
 
 ], function (bean,
              qwery,
@@ -30,43 +29,36 @@ define([
              cookies,
              ajax,
              commercialFeatures,
-             intersection,
-             ElementInview) {
+             intersection) {
 
     return function () {
 
-        this.id = 'ContributionsEpicLimitedImpressionsNotUsa';
-        this.start = '2016-11-15';
+        this.id = 'ContributionsEpicUsaCtaFakeNews';
+        this.start = '2016-11-18';
         this.expiry = '2016-11-22';
         this.author = 'Jonathan Rankin';
-        this.description = 'Run the epic with a limit of 4 impressions per user (for non US, US there is no limit)';
+        this.description = 'Test just contributions vs contributions or membership in the US, and test a new copy variant against the control';
         this.showForSensitive = false;
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Impressions to number of contributions / supporter sign ups';
-        this.audienceCriteria = 'Everywhere but the US';
+        this.audienceCriteria = 'Just the US';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We improve our conversion rate by not showing the epic to those less likely to contribute (i.e those who have seen it more than 4 times).';
+        this.idealOutcome = 'We prove or disprove our hypothesis that just offering contributions will result in an overall boost in money taken in the USA, whilst simultanously running a test to try and beat the epic control copy';
         this.canRun = function () {
             var includedKeywordIds = [
                 'us-news/us-elections-2016',
                 'us-news/us-politics'
             ];
 
-            var includedNonKeywordTagIds = [
-                'uk-news/series/the-new-world-of-work'
-            ];
-
             var excludedKeywordIds = ['music/leonard-cohen'];
 
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
-                var pageNonKeywordTagIds = config.page.nonKeywordTagIds;
-                if (typeof(pageKeywords) !== 'undefined' && typeof(pageNonKeywordTagIds) !== 'undefined') {
+                if (typeof(pageKeywords) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
-                    var nonKeywordTagIdsList = pageNonKeywordTagIds.split(',');
-                    return (intersection(excludedKeywordIds, keywordList).length == 0 
-                        && (intersection(includedKeywordIds, keywordList).length > 0) || intersection(includedNonKeywordTagIds, nonKeywordTagIdsList).length > 0);
+                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        intersection(includedKeywordIds, keywordList).length > 0;
                 } else {
                     return false;
                 }
@@ -77,39 +69,14 @@ define([
             return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && hasKeywordsMatch();
         };
 
-        function getValue(name){
-            return parseInt(cookies.get(name));
-        }
-
-        function setValue(name, value){
-            cookies.add(name, value, 7);
-        }
-
-        function addInviewListener(epicViewCounter) {
-            mediator.on('contributions-embed:insert', function () {
-                $('.contributions__epic').each(function (el) {
-                    //top offset of 18 ensures view only counts when half of element is on screen
-                    var elementInview = ElementInview(el, window, {top: 18});
-                    elementInview.on('firstview', function () {
-                        mediator.emit('contributions-embed:view');
-                        setValue('gu.epicViewCount', epicViewCounter + 1);
-                    });
-                });
-            });
-        }
-
-        var epicViewCount = getValue('gu.epicViewCount') || 0;
-
-
-
-        var contributeUrlPrefix = 'co_global_epic_limited';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_limited';
+        var contributeUrlPrefix = 'co_global_epic_usa_cta_fake';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_usa_cta_fake';
 
 
         var makeUrl = function(urlPrefix, intcmp) {
             return urlPrefix + 'INTCMP=' + intcmp;
         };
-        
+
         var membershipUrl = 'https://membership.theguardian.com/supporter?';
         var contributeUrl = 'https://contribute.theguardian.com/?';
 
@@ -118,6 +85,12 @@ define([
                 title: 'Since you’re here …',
                 p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 intcmp: '_control'
+            },
+
+            fake: {
+                title: 'Since you’re here …',
+                p1: '… we have a small favour to ask. In these post-truth times, when fake news swirls, we need independent journalism more than ever. But while more people are reading the Guardian, far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. Our journalism takes time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                intcmp: '_fake'
             }
         };
 
@@ -162,12 +135,11 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if (epicViewCount < 4 && 'country' in resp && resp.country !== 'US'){
+                if ('country' in resp && resp.country === 'US'){
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         if (submetaElement.length > 0) {
                             component.insertBefore(submetaElement);
-                            addInviewListener(epicViewCount);
                             mediator.emit('contributions-embed:insert', component);
                         }
                     });
@@ -189,17 +161,97 @@ define([
             return cta.equal;
         };
 
-
         this.variants = [
             {
-                id: 'control',
+                id: 'mixed-control',
 
                 test: function () {
                     var ctaType = getCta();
                     var message = messages.control;
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + message.intcmp,
-                        linkUrl2: ctaType.url2 + message.intcmp,
+                        linkUrl1: ctaType.url1 + message.intcmp + '_mixed',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_mixed',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'mixed-fake',
+
+                test: function () {
+                    var ctaType = getCta();
+                    var message = messages.fake;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp + '_mixed',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_mixed',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'just-contribute-control',
+
+                test: function () {
+                    var ctaType = cta.justContribute;
+                    var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp + '_contribute',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_contribute',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            },
+
+            {
+                id: 'just-contribute-fake',
+
+                test: function () {
+                    var ctaType = cta.justContribute;
+                    var message = messages.fake;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + message.intcmp + '_contribute',
+                        linkUrl2: ctaType.url2 + message.intcmp + '_contribute',
                         title: message.title,
                         p1: message.p1,
                         p2:ctaType.p2,


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

You shoudn't put hyphens in campaign codes, as I just notices I've done. This PR fixes that. 

## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

