### PR TITLE
Exchange '-' for '_' in campaign code

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-fake-news.js
@@ -102,8 +102,8 @@ define([
 
 
 
-        var contributeUrlPrefix = 'co_global_epic_fake-non-us';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_fake-non-us';
+        var contributeUrlPrefix = 'co_global_epic_fake_not_us';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_fake_not_us';
 
 
         var makeUrl = function(urlPrefix, intcmp) {


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Hyphens don't go down well with membership so they shouldn't be in campaign codes. This PR fixes that. 

## What is the value of this and can you measure success?

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

