### PR TITLE
Add curlConfig guidance to docs

### DIFF
--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -297,7 +297,7 @@ Finally, to tell curl - the module loader - where to fetch a bundle from, when h
 'bootstraps/enhanced/facia':         '@Static("javascripts/bootstraps/enhanced/facia.js")'
 ```
 
-Run make compile and add `useHashedAssets=true` to your devOverrides to test the bundle as it would run on PROD.
+Run `make compile` and add `assets.useHashedBundles=true` to your devOverrides in frontend.conf to test the bundle as it would run on PROD.
 
 ### Components
 

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -268,7 +268,7 @@ if ((config.isMedia || qwery('video, audio').length) && !config.page.isHosted) {
 }
 ```
 
-Each bundle is created via the [requirejs config](https://github.com/guardian/frontend/blob/master/grunt-configs/requirejs.js), e.g.:
+Each bundle is created via the [bundle.js config](https://github.com/guardian/frontend/blob/master/tools/__tasks__/compile/javascript/bundle.js), e.g.:
 
 ```js
 facia: {
@@ -290,6 +290,14 @@ facia: {
 and each must return an `init` function that is called from `enhanced.js` once required.
 
 All the enhanced bootstraps are in [bootstraps/enhanced](https://github.com/guardian/frontend/tree/master/static/src/javascripts/bootstraps/enhanced), where you'll be able to see what each bootstrap initialises.
+
+Finally, to tell curl - the module loader - where to fetch a bundle from, when hashed, you will need to add it to the [curlConfig.scala.js](https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/blocking/curlConfig.scala.js):
+
+```
+'bootstraps/enhanced/facia':         '@Static("javascripts/bootstraps/enhanced/facia.js")'
+```
+
+Run make compile and add `useHashedAssets=true` to your devOverrides to test the bundle as it would run on PROD.
 
 ### Components
 


### PR DESCRIPTION
## What does this change?

Updates the docs to describe adding a bundle to the curl config.

@guardian/dotcom-platform 