### PR TITLE
Hosted article page - AMP validation

### DIFF
--- a/article/test/ArticleAmpValidityTest.scala
+++ b/article/test/ArticleAmpValidityTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.DoNotDiscover
     "/football/2016/jul/10/france-portugal-euro-2016-match-report", // Match summary
     "/us-news/live/2016/aug/12/donald-trump-republicans-hillary-clinton-us-election-live", // Live blog
     "/sport/live/2016/aug/20/rio-2016-olympics-day-15-mo-farah-relays-tom-daley-nicola-adams-football-live", // Sport live blog
-    "/somerset-county-council-partner-zone/2016/sep/21/somerset-offers-opportunities-develop-social-work-career" // Paid for by page
+    "/somerset-county-council-partner-zone/2016/sep/21/somerset-offers-opportunities-develop-social-work-career", // Paid for by page
+    "/advertiser-content/audi-history-of-audi/audi-and-innovation" // Hosted article page
   ).foreach(testAmpPageValidity)
 }

--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -1,10 +1,11 @@
 @import common.commercial.hosted.HostedArticlePage
-@import common.commercial.hosted.hardcoded.Support.makeshiftPage
-@import conf.Configuration
-@import model.hosted.HostedAmp.ampify
-@import views.html.hosted._
-@import views.support.FBPixel
 @(page: HostedArticlePage)(implicit request: RequestHeader)
+@import model.hosted.HostedAmp.ampify
+@import common.commercial.hosted.hardcoded.Support.makeshiftPage
+@import views.html.hosted._
+@import common.{AnalyticsHost, CanonicalLink, LinkTo}
+@import conf.Configuration
+@import views.support.FBPixel
 
 <!doctype html>
 <html AMP>

--- a/tools/amp-validation/endpoints/fixed.js
+++ b/tools/amp-validation/endpoints/fixed.js
@@ -61,6 +61,11 @@ module.exports = (() => {
         /*
             Paid for by pages
          */
-        '/somerset-county-council-partner-zone/2016/sep/21/somerset-offers-opportunities-develop-social-work-career'
+        '/somerset-county-council-partner-zone/2016/sep/21/somerset-offers-opportunities-develop-social-work-career',
+
+        /*
+            Hosted pages
+         */
+        '/advertiser-content/audi-history-of-audi/audi-and-innovation' //hosted article page
     ];
 })();


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
The hosted article page is finally passing the Amp validation.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Request for comment
@kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

