### PR TITLE
GA: Add edition custom dimension and edition to network front title

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -23,6 +23,15 @@
             .map(function(xs) { return xs[1] })[0];
     }
 
+    function getAnalyticsEdition() {
+        return (guardian.config.page.edition || '').toLowerCase();
+    }
+
+    function getAnalyticsTitle() {
+        var analyticsTitle = (guardian.config.page.webTitle || '').toLowerCase();
+        return (analyticsTitle === 'network front') ? getAnalyticsEdition() + ' ' + analyticsTitle : analyticsTitle;
+    }
+
     var identityId = null;
     if (guardian.config.user) {
         identityId = guardian.config.user.id;
@@ -49,7 +58,7 @@
     @for(trackerName <- Seq(GoogleAnalyticsAccount.editorialProd.trackerName, GoogleAnalyticsAccount.editorialTest.trackerName)) {
         ga('@{trackerName}.set', 'forceSSL', true);
 
-        ga('@{trackerName}.set', 'title', guardian.config.page.webTitle);
+        ga('@{trackerName}.set', 'title', getAnalyticsTitle());
 
         @***************************************************************************************
         * Custom dimensions common to all platforms across the whole Guardian estate           *
@@ -78,6 +87,7 @@
         ga('@{trackerName}.set', 'dimension26', (!!guardian.config.page.isHosted).toString());
         ga('@{trackerName}.set', 'dimension27', navigator.userAgent);
         ga('@{trackerName}.set', 'dimension29', window.location.href);
+        ga('@{trackerName}.set', 'dimension30', getAnalyticsEdition());
         @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
           ga('@{trackerName}.set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
         }


### PR DESCRIPTION
## What does this change?

- Adds edition custom dimension to allow filtering in GA (lowercased) and updates `network front` web title to add the edition to differentiate the editionalised fronts.
- Lowercases web title as per conversation with @mkopka - worth being aware that this data will be different than historic because of this.
- Slight difference than the request is that the international edition passes through 'int' as the edition code instead of 'international'.
- As discussed with @mkopka, AMP does not have 'editions' on the pageview (only onward journeys) and the current business case doesn't not require editionalised AMP at this time.

![image](https://cloud.githubusercontent.com/assets/638051/20485524/d7911ca8-aff3-11e6-9869-ac8b4ca61618.png)

![image](https://cloud.githubusercontent.com/assets/638051/20485528/decc6b62-aff3-11e6-9aac-2f4e7edd02c8.png)


cc/ @RobertChilvers @dominickendrick 