### PR TITLE
Fixed background: remove layer promotion hack

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -847,9 +847,7 @@
 }
 
 .creative__background-parent {
-    transform: translate3d(0, 0, 0);
-    will-change: transform;
-    contain: strict;
+    contain: size layout style;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Fixes a bug where the fixed `div` would be positioned according to its parent [which has a `transform` rule applied to it](http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/).

EDIT: ha! forgot the shiny GIFs

Before:
![fixed-background-2](https://cloud.githubusercontent.com/assets/629976/20487310/c7b718ee-affa-11e6-9c3b-64a3cf20fb9e.gif)

After:
![fixed-background](https://cloud.githubusercontent.com/assets/629976/20487315/cb782ff4-affa-11e6-8719-ee4df5988a2c.gif)
