### PR TITLE
Return 404 instead of 500 on no capi results round

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -5,7 +5,7 @@ import common.{Edition, ExecutionContexts, Logging}
 import conf.Static
 import contentapi.ContentApiClient
 import crosswords.{AccessibleCrosswordRows, CrosswordPage, CrosswordSearchPage, CrosswordSvg}
-import model.Cached.RevalidatableResult
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import org.joda.time.{DateTime, LocalDate}
 import play.api.data.Forms._
@@ -51,7 +51,7 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
 
 class CrosswordPageController(val contentApiClient: ContentApiClient) extends CrosswordController {
 
-  def noResults()(implicit request: RequestHeader) = NoCache(NotFound)
+  def noResults()(implicit request: RequestHeader) = Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
 
   def crossword(crosswordType: String, id: Int) = Action.async { implicit request =>
     renderCrosswordPage(crosswordType, id)

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -51,7 +51,7 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
 
 class CrosswordPageController(val contentApiClient: ContentApiClient) extends CrosswordController {
 
-  def noResults()(implicit request: RequestHeader) = InternalServerError("Content API query returned an error.")
+  def noResults()(implicit request: RequestHeader) = NoCache(NotFound)
 
   def crossword(crosswordType: String, id: Int) = Action.async { implicit request =>
     renderCrosswordPage(crosswordType, id)


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?

Crosswords to return 404 instead of 500 when no capi data found

## What is the value of this and can you measure success?

Proper status codes

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

## Request for comment


<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
