### PR TITLE
Update guardian.page.host to https

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -68,7 +68,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 11
+    val s3ConfigVersion = 12
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
The host parameter below has not been updated since the move to https:

    guardian.page.host="http://www.theguardian.com" -> guardian.page.host="https://www.theguardian.com"

We use this parameter to set the origin parameter in the YouTube player [initialisation](https://developers.google.com/youtube/player_parameters#origin)

The actual config update is in the config file rather than this PR.

