### PR TITLE
Fix ELBs names

### DIFF
--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -16,22 +16,22 @@ object LoadBalancer extends Logging {
   import conf.Configuration.aws.credentials
 
     private val loadBalancers = Seq(
-      LoadBalancer("frontend-RouterLo-1HHMP4C9L33QJ", "Router", "frontend-router"),
+      LoadBalancer("frontend-PROD-router", "Router", "frontend-router"),
       LoadBalancer(
-        "frontend-ArticleL-T0BUR121RZIG", "Article", "frontend-article",
+        "frontend-PROD-article", "Article", "frontend-article",
         testPath = Some("/uk-news/2014/jan/21/drax-protesters-convictions-quashed-police-spy-mark-kennedy")
       ),
-      LoadBalancer("frontend-FaciaLoa-I92TZ7OEAX7W", "Front", "frontend-facia", testPath = Some("/uk")),
-      LoadBalancer("frontend-Applicat-V36EHVHAEI15", "Applications", "frontend-applications", testPath = Some("/books")),
-      LoadBalancer("frontend-Discussi-KC65SADEVHIE", "Discussion", "frontend-discussion"),
-      LoadBalancer("frontend-Identity-1ITBJ706CLQIC", "Identity", "frontend-identity"),
-      LoadBalancer("frontend-SportLoa-GLJK02HUD48W", "Sport", "frontend-sport"),
-      LoadBalancer("frontend-Commerci-12ZQ79RIOLIYE", "Commercial", "frontend-commercial"),
-      LoadBalancer("frontend-OnwardLo-14YIUHL6HIW63", "Onward", "frontend-onward"),
-      LoadBalancer("frontend-Diagnost-11YL3E40NW4C2", "Diagnostics", "frontend-diagnostics" ),
-      LoadBalancer("frontend-ArchiveL-C2GJNZE0TS7", "Archive", "frontend-archive"),
-      LoadBalancer("frontend-AdminJob-X3KHAAPYCDQK", "AdminJobs", "frontend-adminJobs"),
-      LoadBalancer("frontend-RssLoadB-13ARAHHNKEUTL", "Rss", "frontend-rss")
+      LoadBalancer("frontend-PROD-facia", "Front", "frontend-facia", testPath = Some("/uk")),
+      LoadBalancer("frontend-PROD-applications", "Applications", "frontend-applications", testPath = Some("/books")),
+      LoadBalancer("frontend-PROD-discussion", "Discussion", "frontend-discussion"),
+      LoadBalancer("frontend-PROD-identity", "Identity", "frontend-identity"),
+      LoadBalancer("frontend-PROD-sport", "Sport", "frontend-sport"),
+      LoadBalancer("frontend-PROD-commercial", "Commercial", "frontend-commercial"),
+      LoadBalancer("frontend-PROD-onward", "Onward", "frontend-onward"),
+      LoadBalancer("frontend-PROD-diagnostics", "Diagnostics", "frontend-diagnostics" ),
+      LoadBalancer("frontend-PROD-archive", "Archive", "frontend-archive"),
+      LoadBalancer("frontend-PROD-admin-jobs", "AdminJobs", "frontend-adminJobs"),
+      LoadBalancer("frontend-PROD-rss", "Rss", "frontend-rss")
     )
 
 


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
ELBs names were hardcoded. Moving apps into the vpc leads to new elbs being created and this change broke the admin loadbalancer metrics page, troubleshooter, etc...
This patch is setting new ELB names

## What is the value of this and can you measure success?
Working dashboards :)

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Request for comment
@jfsoul 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

