### PR TITLE
Betterer meta

### DIFF
--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -96,31 +96,9 @@
     text-align: left;
     float: left;
     min-width: 15px; // Min width is the width of the icons
-    padding-right: ($gs-gutter / 2) + 1px;
 
     @include mq($until: leftCol) {
         text-align: right;
-    }
-
-    @include mq(leftCol, wide) {
-        padding-right: 6px;
-    }
-
-    // Use margin-right for the space between penultimate and last child
-    //so that meta-numbers on the right don't have a space if last item
-    // is hidden
-
-    &:nth-last-child(2) {
-        padding-right: 0;
-    }
-
-    &:last-child {
-        margin-left: ($gs-gutter / 2) + 1px;
-        padding-right: 0;
-
-        @include mq(leftCol, wide) {
-            margin-left: 6px;
-        }
     }
 }
 
@@ -164,7 +142,5 @@
 .meta__number:not(.u-h) + .meta__number {
     border-left: 1px solid $neutral-7;
     padding-left: $gs-gutter / 2;
-    @include mq(leftCol, wide) {
-        padding-left: 6px;
-    }
+    margin-left: $gs-gutter / 2;
 }

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -235,6 +235,7 @@
         position: relative;
         border: 0 none;
         height: auto;
+        padding: $gs-baseline/2 0;
     }
 
     .meta__number {

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -25,36 +25,27 @@
     .byline .tone-colour:hover,
     .content__dateline,
     .meta__numbers .sharecount__heading,
-    .meta__numbers .commentcount2__heading {
+    .meta__numbers .commentcount2__heading,
+    .meta__numbers .sharecount__value {
         color: $neutral-3;
     }
 
-    .meta__numbers .sharecount__value,
     .meta__numbers .commentcount2__value {
         color: $neutral-4;
     }
 
-    .meta__numbers .inline-share,
     .meta__numbers .inline-comment-16 {
+        fill: $neutral-4;
+    }
+
+    .meta__numbers .inline-share {
         fill: $neutral-3;
     }
 
     .commentcount2 {
         &:hover,
         &:focus {
-            text-decoration: none;
-
-            .commentcount2__heading {
-                color: $neutral-4;
-            }
-
-            .inline-comment-16 {
-                fill: $neutral-4;
-            }
-
-            .commentcount2__value {
-                color: $neutral-6;
-            }
+            color: $neutral-4;
         }
     }
 


### PR DESCRIPTION
Couple of tidy ups to the meta changes. 

When there was just comments or just shares showing we were sometimes getting the count not sitting flush to the edge. Gross huh!? 

before:
![screen shot 2016-11-22 at 11 36 23](https://cloud.githubusercontent.com/assets/14570016/20523186/bcf8045c-b0ab-11e6-9834-4187d1578899.png)

After:
![screen shot 2016-11-22 at 12 06 29](https://cloud.githubusercontent.com/assets/14570016/20523271/270f915c-b0ac-11e6-80a4-489b9687b57e.png)


Also gallery spacing was a bit whacky, as were the tones. 

Before:
![screen shot 2016-11-22 at 12 01 34](https://cloud.githubusercontent.com/assets/14570016/20523138/8c75113a-b0ab-11e6-8736-058801d12d9f.png)

After: 
![screen shot 2016-11-22 at 12 00 42](https://cloud.githubusercontent.com/assets/14570016/20523137/8c60a100-b0ab-11e6-8b7e-ca44f461d07c.png)

I'll put my Nit comb away now.
![article-2312124-1966b4b7000005dc-612_306x434](https://cloud.githubusercontent.com/assets/14570016/20523221/de179396-b0ab-11e6-97d6-9554daf43114.jpg)

@gtrufitt ? X
