### PR TITLE
Fix history for pagination of comments in profile

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -64,7 +64,7 @@ define([
         this.removeState('loading');
 
         var activeTab = $('.tabs__tab--selected');
-        if (activeTab.data('stream-type') != streamType) {
+        if (activeTab.data('stream-type') !== streamType) {
            selectTab(streamType, this.defaultOptions.streamType);
         }
 
@@ -101,7 +101,7 @@ define([
         var from = $('.tabs__tab--selected');
         var to = $('a[data-stream-type=' + streamType + ']');
 
-        if (to.length == 0) {
+        if (to.length === 0) {
             to = $('a[data-stream-type=' + fallback + ']');
         }
 

--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -65,7 +65,7 @@ define([
 
         var activeTab = $('.tabs__tab--selected');
         if (activeTab.data('stream-type') !== streamType) {
-           selectTab(streamType, this.defaultOptions.streamType);
+           selectTab(streamType === 'comments' ? 'discussions' : streamType);
         }
 
         // update opts
@@ -97,19 +97,14 @@ define([
         });
     }
 
-    function selectTab(streamType, fallback) {
-        var from = $('.tabs__tab--selected');
-        var to = $('a[data-stream-type=' + streamType + ']');
+    function selectTab(streamType) {
+        // Blur so that when pressing forward/back the focus is not retained on
+        // the old tab Note, without the focus first, the blur doesn't seem to
+        // work for some reason
+        $('.js-activity-stream-change').focus().blur();
 
-        if (to.length === 0) {
-            to = $('a[data-stream-type=' + fallback + ']');
-        }
-
-        from.removeClass('tabs__tab--selected');
-        var link = $('a', from);
-        link.blur();
-
-        bonzo(to).parent().addClass('tabs__tab--selected');
+        $('.tabs__tab--selected').removeClass('tabs__tab--selected');
+        bonzo($('a[data-stream-type=' + streamType + ']')).parent().addClass('tabs__tab--selected');
     }
 
     return ActivityStream;

--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -2,12 +2,14 @@ define([
     'bonzo',
     'bean',
     'common/utils/$',
+    'common/utils/url',
     'common/modules/component',
     'common/modules/discussion/api'
 ], function (
     bonzo,
     bean,
     $,
+    url,
     component,
     discussionApi
 ) {
@@ -17,6 +19,7 @@ define([
     component.define(ActivityStream);
     ActivityStream.prototype.endpoint = '/discussion/profile/:userId/:streamType.json?page=:page';
     ActivityStream.prototype.componentClass = 'activity-stream';
+
     ActivityStream.prototype.defaultOptions = {
         page: 1,
         streamType: 'discussions',
@@ -26,6 +29,13 @@ define([
         this.removeState('loading');
         this.on('click', '.js-disc-recommend-comment', this.recommendComment);
         $('.js-disc-recommend-comment').addClass('disc-comment__recommend--open');
+
+        window.onpopstate = function (event) {
+            if (url.hasHistorySupport) {
+                this.applyState(event.state.resp.html, event.state.streamType);
+            }
+        }.bind(this);
+
         pagination(this);
     };
     ActivityStream.prototype.recommendComment = function (e) {
@@ -37,15 +47,43 @@ define([
         });
     };
     ActivityStream.prototype.change = function (opts) {
+        this.setOptions(opts);
+        return this._fetch();
+    };
+    ActivityStream.prototype.fetched = function (resp) {
+        this.applyState(resp.html, this.options.streamType);
+        this.updateHistory(resp);
+    };
+    ActivityStream.prototype.applyState = function (html, streamType) {
+        // update display
         var $el = bonzo(this.elem).empty();
         this.setState('loading');
-        this.setOptions(opts);
-        return this._fetch().then(function (resp) {
-            $.create(resp.html).each(function (el) {
-                $el.html($(el).html()).attr({ 'class': el.className });
-            });
-            this.removeState('loading');
-        }.bind(this));
+        $.create(html).each(function (el) {
+            $el.html($(el).html()).attr({ 'class': el.className });
+        });
+        this.removeState('loading');
+
+        var activeTab = $('.tabs__tab--selected');
+        if (activeTab.data('stream-type') != streamType) {
+           selectTab(streamType, this.defaultOptions.streamType);
+        }
+
+        // update opts
+        this.options.streamType = streamType;
+    };
+    ActivityStream.prototype.updateHistory = function (resp) {
+        var page = this.options.page;
+        var pageParam = url.getUrlVars().page;
+        var streamType = this.options.streamType !== 'discussions' ? '/' + this.options.streamType : '';
+        var qs = '/user/id/' + this.options.userId + streamType + '?' + url.constructQuery({page: page});
+        var state = { resp: resp, streamType: this.options.streamType};
+        var params = {querystring: qs, state: state};
+
+        if (typeof pageParam === 'undefined') { // If first load and without page param, add it and overwrite history
+            url.replaceQueryString(params);
+        } else {
+            url.pushQueryString(params);
+        }
     };
 
     function pagination(activityStream) {
@@ -57,6 +95,21 @@ define([
                 page: page
             });
         });
+    }
+
+    function selectTab(streamType, fallback) {
+        var from = $('.tabs__tab--selected');
+        var to = $('a[data-stream-type=' + streamType + ']');
+
+        if (to.length == 0) {
+            to = $('a[data-stream-type=' + fallback + ']');
+        }
+
+        from.removeClass('tabs__tab--selected');
+        var link = $('a', from);
+        link.blur();
+
+        bonzo(to).parent().addClass('tabs__tab--selected');
     }
 
     return ActivityStream;

--- a/static/src/javascripts/projects/common/modules/identity/public-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/public-profile.js
@@ -18,14 +18,18 @@ define([
     mapValues
 ) {
     function getActivityStream(cb) {
-        var activityStream, opts = {
+        var activityStream, dataOpts = {
             userId: 'data-user-id',
             streamType: 'data-stream-type'
         };
         $('.js-activity-stream').each(function (el) {
-            (activityStream = new ActivityStream(mapValues(opts, function (key) {
+            var opts = mapValues(dataOpts, function (key) {
                 return el.getAttribute(key);
-            }))).fetch(el).then(function () {
+            });
+
+            opts.page = url.getUrlVars().page || 1;
+
+            (activityStream = new ActivityStream(opts)).fetch(el).then(function () {
                 bonzo(el).removeClass('activity-stream--loading');
             });
         }).addClass('activity-stream--loading');
@@ -49,8 +53,7 @@ define([
                 page: 1,
                 streamType: streamType
             }).then(function () {
-                url.pushUrl({}, null,
-                    '/user/id/' + activityStream.options.userId + (streamType !== 'discussions' ? '/' + streamType : ''), true);
+
             });
         });
     }

--- a/static/src/javascripts/projects/common/utils/url.js
+++ b/static/src/javascripts/projects/common/utils/url.js
@@ -44,6 +44,23 @@ define([
                 }
             },
 
+            // equivalent to pushQueryString but uses history.replaceState to
+            // overwrite history
+            replaceQueryString: function (params) {
+                if (!params.querystring) {
+                    return;
+                }
+                if (supportsPushState) {
+                    if (model.getCurrentQueryString() !== params.querystring) {
+                        history.replaceState(
+                                params.state || {},
+                                params.title || window.title,
+                                params.querystring + window.location.hash
+                        );
+                    }
+                }
+            },
+
             // take an object, construct into a query, e.g. {page: 1, pageSize: 10} => page=1&pageSize=10
             constructQuery: function (query) {
                 return Object.keys(query).map(function (param) {
@@ -79,7 +96,8 @@ define([
         constructQuery: model.constructQuery,
         back: model.back,
         hasHistorySupport: supportsPushState,
-        pushQueryString: model.pushQueryString
+        pushQueryString: model.pushQueryString,
+        replaceQueryString: model.replaceQueryString
     };
 
 });

--- a/static/src/javascripts/projects/common/utils/url.js
+++ b/static/src/javascripts/projects/common/utils/url.js
@@ -25,40 +25,30 @@ define([
                 return window.location.search.replace(/^\?/, '');
             },
 
+            updateQueryString: function (params, historyFn) {
+                var querystringChanged = model.getCurrentQueryString() !== params.querystring;
+
+                if (params.querystring && querystringChanged && supportsPushState) {
+                    historyFn(
+                        params.state || {},
+                        params.title || window.title,
+                        params.querystring + window.location.hash
+                    );
+                }
+            },
+
             // this will replace anything after the root/domain of the URL
             // and add an item to the browser history.
             // params object requires a "querystring" property
             // and optionally takes a "state" and "title" property too
             pushQueryString: function (params) {
-                if (!params.querystring) {
-                    return;
-                }
-                if (supportsPushState) {
-                    if (model.getCurrentQueryString() !== params.querystring) {
-                        history.pushState(
-                                params.state || {},
-                                params.title || window.title,
-                                params.querystring + window.location.hash
-                        );
-                    }
-                }
+                return model.updateQueryString(params, history.pushState.bind(history));
             },
 
             // equivalent to pushQueryString but uses history.replaceState to
-            // overwrite history
+            // overwrite history rather than history.pushState
             replaceQueryString: function (params) {
-                if (!params.querystring) {
-                    return;
-                }
-                if (supportsPushState) {
-                    if (model.getCurrentQueryString() !== params.querystring) {
-                        history.replaceState(
-                                params.state || {},
-                                params.title || window.title,
-                                params.querystring + window.location.hash
-                        );
-                    }
-                }
+               return model.updateQueryString(params, history.replaceState.bind(history));
             },
 
             // take an object, construct into a query, e.g. {page: 1, pageSize: 10} => page=1&pageSize=10


### PR DESCRIPTION
## What does this change?

Ensures browser back/forward work with pagination and tab switching on the Identity profile comments listing pages. E.g. pages like:

https://profile.theguardian.com/user/id/3024198

## What is the value of this and can you measure success?

* better linking (linking to pages other than the first now works)
* better UX - can navigate as expected

It is difficult to measure the impact here. We could look at requests to these pages perhaps, but I'm not keen on an AB test as this PR is a bug fix more than anything.

<!--
If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
-->

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

## Request for comment

The code is pretty messy here. I found it difficult to work with the existing code to be honest and using the browser history API is also complex. All advice on how to improve things welcome. I'm obviously not very familiar with things like bonzo, qwery, or the component approach that Frontend takes here. Looking at the git history this code hasn't really been touched for 2 years and I'm not sure the people who worked on it are around any more.

cc @gtrufitt 