### PR TITLE
Remove unnecessary wrapper for Youtube embed

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-player.js
@@ -21,18 +21,6 @@ define([
         }, this);
     }
 
-    function prepareWrapper(el) {
-        var wrapper = document.createElement('div');
-        wrapper.className += el.className;
-
-        fastdom.write(function () {
-            el.parentNode.insertBefore(wrapper, el);
-            wrapper.appendChild(el);
-        });
-
-        return wrapper;
-    }
-
     function _onPlayerStateChange(event, handlers, wrapper) {
         //change class according to the current state
         //TODO: Fix this so we can add poster image.
@@ -61,17 +49,15 @@ define([
     }
 
     function init(el, handlers, videoId) {
-        //wrap <iframe/> in a div with dynamically updating class attributes
         loadYoutubeJs();
-        var wrapper = prepareWrapper(el);
 
         return promise.then(function () {
             function onPlayerStateChange(event) {
-                _onPlayerStateChange(event, handlers, wrapper);
+                _onPlayerStateChange(event, handlers, el);
             }
 
             function onPlayerReady(event) {
-                _onPlayerReady(event, handlers, wrapper);
+                _onPlayerReady(event, handlers, el);
             }
 
             return setupPlayer(videoId, onPlayerReady, onPlayerStateChange);


### PR DESCRIPTION
<!--
[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
All the questions are optional. Any amount of feedback is great!
-->

## What does this change?
The iframe for embedded Youtube videos is no longer wrapped in a div when the page is initialised.

## What is the value of this and can you measure success?
Remove some code, and avoid some styling complications around css classes that were set on both the wrapper and iframe.

## Request for comment
@gidsg @kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

