### PR TITLE
Track hosted youtube videos

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -57,6 +57,7 @@
                 <div class="u-responsive-ratio u-responsive-ratio--hd">
                     @page.video.youtubeId.map { youtubeId =>
                         <iframe id="hosted-video-@youtubeId"
+                        data-media-id="@{page.video.mediaId}"
                         data-duration="@{page.video.duration}"
                         class="js-hosted-youtube-video hosted__youtube-video"
                         src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(environment.isProd && !environment.isPreview) "&origin=https://www.theguardian.com" else if(host != "") s"&origin=$host" else ""}"

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -48,7 +48,7 @@ object HostedVideoPage extends Logging {
         pageName = "only used in hardcoded content",
         standfirst,
         video = HostedVideo(
-          mediaId = campaignId,
+          mediaId = videoAtom.id,
           title = video.title,
           duration = video.duration.map(_.toInt) getOrElse 0,
           posterUrl = video.posterUrl getOrElse "",

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.js
@@ -2,6 +2,7 @@
 define([
     'commercial/modules/hosted/next-video-autoplay',
     'common/modules/video/youtube-player',
+    'common/modules/video/youtube-tracking',
     'common/utils/$',
     'common/utils/detect',
     'common/utils/mediator',
@@ -10,36 +11,17 @@ define([
 ], function (
     nextVideoAutoplay,
     youtubePlayer,
+    tracking,
     $,
     detect,
     mediator,
     contains,
     forEach
 ) {
+    var atomId;
+
     function isDesktop() {
         return contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint());
-    }
-
-    function initYoutubeEvents(videoId) {
-        var eventList = ['play', '25', '50', '75', 'end'];
-
-        forEach(eventList, function(event) {
-            mediator.once(event, function() {
-                ophanRecord(event);
-            });
-        });
-
-        function ophanRecord(event) {
-            require(['ophan/ng'], function (ophan) {
-                var eventObject = {
-                    video: {
-                        id: 'gu-video-youtube-' + videoId,
-                        eventType: 'video:content:' + event
-                    }
-                };
-                ophan.record(eventObject);
-            });
-        }
     }
 
     function sendPercentageCompleteEvents(youtubePlayer, playerTotalTime) {
@@ -54,23 +36,27 @@ define([
 
         forEach(playbackEvents, function(value, key) {
             if (youtubePlayer.getCurrentTime() > value) {
+                tracking.track(key, atomId);
                 mediator.emit(key);
             }
         });
     }
 
     function init(el) {
+        var atomId = $(el).data('media-id');
         var duration = $(el).data('duration');
         var $currentTime = $('.js-youtube-current-time');
+        var playTimer;
 
+        tracking.init(atomId);
         youtubePlayer.init(el, {
             onPlayerStateChange: function (event) {
-                var playTimer;
                 var player = event.target;
                 var ophanId = 'hosted-youtube-video';
 
                 //show end slate when movie finishes
                 if (event.data === window.YT.PlayerState.ENDED) {
+                    tracking.track('end', atomId);
                     $currentTime.text('0:00');
                     if (nextVideoAutoplay.canAutoplay()) {
                         //on mobile show the next video link in the end of the currently watching video
@@ -88,7 +74,7 @@ define([
 
                 //calculate completion and send event to ophan
                 if (event.data === window.YT.PlayerState.PLAYING) {
-                    initYoutubeEvents(player.getVideoData()['video_id']);
+                    tracking.track('play', atomId);
                     var playerTotalTime = player.getDuration();
 
                     playTimer = setInterval(function() {

--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -2,7 +2,7 @@ define(function (
 ) {
     function buildGoogleAnalyticsEvent(mediaEvent, metrics, canonicalUrl, player, eventAction, videoId) {
 
-        var category = 'Media';
+        var category = 'media';
         var playerName = player;
         var action = eventAction(mediaEvent);
         var fieldsObject = {

--- a/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
+++ b/static/src/javascripts/projects/common/modules/video/youtube-tracking.js
@@ -33,7 +33,7 @@ define([
                 'end': 'metric6'
             },
             baseEventObject: {
-                eventCategory: 'Media',
+                eventCategory: 'media',
                 eventAction: eventAction(),
                 eventLabel: videoId,
                 dimension19: videoId,


### PR DESCRIPTION
This is to track advertisers' hosted youtube videos in GA and Ophan.
It seems to send the right tracking events from what I can see in the console.

It uses the work done in #14965

/cc @Calanthe @lps88 @guardian/labs-beta @markjamesbutler @akash1810 
