### PR TITLE
Use lowercase names to track logo interactions

### DIFF
--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -19,7 +19,7 @@
 }
 
 @branding.label
-<a class="badge__link" href="@branding.sponsorLink" data-sponsor="@branding.sponsorName">
+<a class="badge__link" href="@branding.sponsorLink" data-sponsor="@branding.sponsorName.toLowerCase">
     @if(request.isAmp) {
         @if(onDarkBackground && branding.highContrastSponsorLogo.nonEmpty) {
             @for(highContrastLogo <- branding.highContrastSponsorLogo) {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -46,7 +46,7 @@ object Commercial {
   def listSponsorLogosOnPage(page: Page)(implicit request: RequestHeader): Option[Seq[String]] = {
 
     val edition = Edition(request)
-    def sponsor(branding: Edition => Option[Branding]) = branding(edition) map (_.sponsorName)
+    def sponsor(branding: Edition => Option[Branding]) = branding(edition) map (_.sponsorName.toLowerCase)
 
     val pageSponsor = sponsor(page.branding)
 

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -22,27 +22,27 @@ define([
     }
 
     function trackSamePageLinkClick(target, tag) {
-        ga(send, 'event', 'Click', 'In Page', tag, {
+        ga(send, 'event', 'click', 'in page', tag, {
             nonInteraction: true, // to avoid affecting bounce rate
             dimension13: extractLinkText(target)
         });
     }
 
     function trackExternalLinkClick(target, tag) {
-        ga(send, 'event', 'Click', 'External', tag, {
+        ga(send, 'event', 'click', 'external', tag, {
             dimension13: extractLinkText(target)
         });
     }
 
     function trackSponsorLogoLinkClick(target) {
         var sponsorName = target.dataset.sponsor;
-        ga(send, 'event', 'Click', 'Sponsor Logo', sponsorName, {
+        ga(send, 'event', 'click', 'sponsor logo', sponsorName, {
             nonInteraction: true
         });
     }
 
     function trackNativeAdLinkClick(slotName, tag) {
-        ga(send, 'event', 'Click', 'Native Ad', tag, {
+        ga(send, 'event', 'click', 'native ad', tag, {
             nonInteraction: true,
             dimension25: slotName
         });


### PR DESCRIPTION
GA has recently been reconfigured to store event categories, actions and labels in lowercase to avoid duplicate values.

This PR sends tracking events in lowercase in the hope that it will avoid any confusion.

/cc @guardian/commercial-dev @dominickendrick @gtrufitt 