### PR TITLE
Add youtube atom caption

### DIFF
--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -46,6 +46,6 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
 
     val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model)
 
-    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.mediaEmbed(page, displayCaption = true)))
+    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.mediaEmbed(page, displayCaption = false)))
   }
 }

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -46,6 +46,6 @@ class MediaAtomEmbedController(contentApiClient: ContentApiClient) extends Contr
 
     val page: MediaAtomEmbedPage = MediaAtomEmbedPage(model)
 
-    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.mediaEmbed(page)))
+    Cached(600)(RevalidatableResult.Ok(views.html.fragments.atoms.mediaEmbed(page, displayCaption = true)))
   }
 }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -51,7 +51,7 @@ class MediaController(contentApiClient: ContentApiClient) extends Controller wit
 
   private def renderMedia(model: MediaPage)(implicit request: RequestHeader): Result = {
     val htmlResponse = () => views.html.media(model)
-    val jsonResponse = () => views.html.fragments.mediaBody(model)
+    val jsonResponse = () => views.html.fragments.mediaBody(model, displayCaption = false)
     renderFormat(htmlResponse, jsonResponse, model, Switches.all)
   }
 

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -1,4 +1,4 @@
-@(page: MediaPage)(implicit request: RequestHeader)
+@(page: MediaPage, displayCaption: Boolean)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}
@@ -89,7 +89,7 @@
                                                 <meta itemprop="thumbnail" content="@Html(video.content.signedArticleImage)" />
                                                 <meta itemprop="thumbnailUrl" content="@Html(video.content.signedArticleImage)" />
 
-                                              @fragments.atoms.media(mediaAtom)
+                                              @fragments.atoms.media(mediaAtom, displayCaption = false)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -89,7 +89,7 @@
                                                 <meta itemprop="thumbnail" content="@Html(video.content.signedArticleImage)" />
                                                 <meta itemprop="thumbnailUrl" content="@Html(video.content.signedArticleImage)" />
 
-                                              @fragments.atoms.media(mediaAtom, displayCaption = false)
+                                              @fragments.atoms.media(mediaAtom, displayCaption = displayCaption)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>

--- a/applications/app/views/media.scala.html
+++ b/applications/app/views/media.scala.html
@@ -2,6 +2,6 @@
 
 @main(page){ }{
 
-    @fragments.mediaBody(page)
+    @fragments.mediaBody(page, displayCaption = true)
 
 }

--- a/applications/app/views/media.scala.html
+++ b/applications/app/views/media.scala.html
@@ -2,6 +2,6 @@
 
 @main(page){ }{
 
-    @fragments.mediaBody(page, displayCaption = true)
+    @fragments.mediaBody(page, displayCaption = false)
 
 }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,11 +1,11 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, displayCaption: Boolean)(implicit request: RequestHeader)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean)(implicit request: RequestHeader)
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz}
 
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
-        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption)
+        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,11 +1,11 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean)(implicit request: RequestHeader)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, displayCaption: Boolean)(implicit request: RequestHeader)
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz}
 
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
-        case media: MediaAtom => views.html.fragments.atoms.media(media, amp)
+        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,8 +1,8 @@
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false)(implicit request: RequestHeader)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean = true)(implicit request: RequestHeader)
 
 @{
     media match {
-            case youtube if media.assets.head.platform == "Youtube" => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media)
+            case youtube if media.assets.head.platform == "Youtube" => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,4 +1,4 @@
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean = true)(implicit request: RequestHeader)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader)
 
 @{
     media match {

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -1,7 +1,7 @@
 @import conf.Static
 @import model.MediaAtomEmbedPage
 
-@(page: MediaAtomEmbedPage)(implicit request: RequestHeader)
+@(page: MediaAtomEmbedPage, displayCaption: Boolean)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-video-embed-html">
@@ -15,7 +15,7 @@
         <base target="_parent"/>
     </head>
     <body>
-        @views.html.fragments.atoms.media(page.atom)
+        @views.html.fragments.atoms.media(page.atom, displayCaption = displayCaption)
 
         @fragments.analytics.base(page)
     </body>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,7 +1,7 @@
 @import conf.Configuration.site.host
 @import views.support.RenderClasses
 
-@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
@@ -14,7 +14,11 @@
             src="https://www.youtube.com/embed/@media.assets.head.id?modestbranding=1&enablejsapi=1&rel=0&showinfo=0@origin" frameborder="0"
             allowfullscreen="">
             </iframe>
-
     </div>
+
+
+    @if(displayCaption) {
+        <figcaption class="caption caption--main" itemprop="description">@media.title</figcaption>
+    }
 }
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -602,7 +602,7 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, amp: Boolean = false)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, displayCaption: Boolean = true)(implicit val request: RequestHeader) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -615,7 +615,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean, amp: Boolean
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp).toString()
+        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, displayCaption).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -602,7 +602,7 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, displayCaption: Boolean = true)(implicit val request: RequestHeader) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false)(implicit val request: RequestHeader) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -615,7 +615,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, displayCaption).toString()
+        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -42,6 +42,7 @@ class AtomCleanerTest extends FlatSpec with Matchers with FakeRequests {
     val result: Document = clean(doc, youTubeAtom, amp = false)
     result.select("iframe").attr("id") shouldBe("youtube-nQuN9CUsdVg")
     result.select("iframe").attr("src") should include("enablejsapi=1")
+    result.select("figcaption").html should include("Bird")
   }
 
   "AtomsCleaner" should "use amp-iframe markup if amp is true" in {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -32,7 +32,7 @@ class AtomCleanerTest extends FlatSpec with Matchers with FakeRequests {
 
 
  private def clean(document: Document, atom:Option[Atoms], amp: Boolean): Document = {
-    val cleaner = AtomsCleaner(youTubeAtom, shouldFence = false, amp = amp)(TestRequest())
+    val cleaner = AtomsCleaner(youTubeAtom, amp = amp)(TestRequest())
     cleaner.clean(document)
     document
   }


### PR DESCRIPTION
## What does this change?
Adds caption equivalent to that currently shown on non-atom videos when embedded in articles and live blogs. Note, this does not link to the video page, as there may not be one in the Atom model.

## What is the value of this and can you measure success?

Needed for feature parity for YouTube PFP trial.


## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You 
should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
<img width="822" alt="screen shot 2016-11-23 at 12 39 36" src="https://cloud.githubusercontent.com/assets/1764158/20566308/79972f08-b18c-11e6-9d35-19103d198bec.png">

Live blog main media (this one is really low-contrast I know but not sure what if anything we should change it to?)

<img width="679" alt="screen shot 2016-11-23 at 12 13 29" src="https://cloud.githubusercontent.com/assets/1764158/20566318/84afd19c-b18c-11e6-927a-49b77cf880bc.png">

Article page


## Request for comment

CC @duarte @markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
