### PR TITLE
Add compile step to rename sourcemap

### DIFF
--- a/tools/__tasks__/compile/javascript/bundle.js
+++ b/tools/__tasks__/compile/javascript/bundle.js
@@ -12,7 +12,8 @@ const bundles = [{
     exclude: [
         'text',
         'inlineSvg'
-    ]
+    ],
+    generateSourceMaps: true
 }, {
     name: 'bootstraps/commercial',
     out: target + '/javascripts/bootstraps/commercial.js',

--- a/tools/__tasks__/compile/javascript/index.js
+++ b/tools/__tasks__/compile/javascript/index.js
@@ -6,6 +6,7 @@ module.exports = {
         require('./copy'),
         require('./bundle'),
         require('./bundle-app'),
+        require('./rename-boot-sourcemap'),
         require('./bundle-shims')
     ]
 };

--- a/tools/__tasks__/compile/javascript/rename-boot-sourcemap.js
+++ b/tools/__tasks__/compile/javascript/rename-boot-sourcemap.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const pify = require('pify');
+
+const renameP = pify(fs.rename);
+const readFileP = pify(fs.readFile);
+const writeFileP = pify(fs.writeFile);
+
+const {target} = require('../../config').paths;
+
+function replaceCommentInAppJs() {
+    const filePath = `${target}/javascripts/app.js`;
+
+    return readFileP(filePath, 'utf8')
+            .then(src => src.replace('//# sourceMappingURL=boot.js.map', '//# sourceMappingURL=app.js.map'))
+            .then(src => writeFileP(filePath, src));
+}
+
+module.exports = {
+    description: 'Rename the boot.map.js to app.map.js so that we hash it into the right folder',
+    task: () => Promise.all([
+        renameP(`${target}/javascripts/boot.js.map`, `${target}/javascripts/app.js.map`),
+        replaceCommentInAppJs()
+    ])
+};


### PR DESCRIPTION
## What does this change?

Adds hacky fix for lack of sourcemap on concat step. Sourcemaps try and load `boot.js.map` from `app.js` but `boot.js.map` gets sent to a different hashed folder. This renames the sourcemap to `app.js.map` and changes the sourcemap location comment.

![image](https://cloud.githubusercontent.com/assets/638051/20534605/b27a7e82-b0d9-11e6-83b3-8d9030196774.png)

## What is the value of this and can you measure success?

Sourcemaps should work better, maybe we'll get better sentry errors!?

@sndrs This feels super weird, but we've not had sourcemaps working for ages, right?