### PR TITLE
Reduce PR template noise

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,13 @@
-<!--
-[We'd love some feedback on any struggles you had with this PR](https://goo.gl/forms/QRQaco334CdpfmNF2).
-All the questions are optional. Any amount of feedback is great!
--->
-
 ## What does this change?
 
 ## What is the value of this and can you measure success?
 
-<!--
-If setting up an AB test, make sure you have read our [AB testing doc](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md).
--->
-
 ## Does this affect other platforms - Amp, Apps, etc?
-
-<!--
-Run the AMP test suite with `make validate-amp`
-
-You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1
-
-The AMP validation results will appear in your console.
--->
 
 ## Screenshots
 
 ## Request for comment
 
-
-<!--
-*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
--->
+<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
+<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
+<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

--- a/docs/03-dev-howtos/17-working-with-amp.md
+++ b/docs/03-dev-howtos/17-working-with-amp.md
@@ -1,0 +1,40 @@
+# Working with Google AMP
+
+**tl;dr - AMP is important, validate your changes (`make validate-amp`)**
+
+## What is AMP?
+AMP (Accelerated Mobile Pages) in Google's own words:
+> AMP is a way to build web pages for static content that render fast. AMP in action consists of three different parts:
+>
+> **AMP HTML** is HTML with some restrictions for reliable performance and some extensions for building rich content beyond basic HTML. The **AMP JS** library ensures the fast rendering of AMP HTML pages. The **Google AMP Cache** can be used to serve cached AMP HTML pages.
+
+## Why do I care?
+At the time of writing, Google is trialling wide roll-outs of AMP blue links in specific regions.  This means that all mobile traffic in these regions coming from Google search results will see AMP versions of our content (if available).  As a result we have to ensure that as much of our content as possible works with AMP.
+
+## Getting started
+* Read the [docs](https://www.ampproject.org/docs/reference/components)
+* Check out the existing AMP work in frontend (in IntelliJ: `shift` `shift` `amp`)
+* Get to know the [tools](#tools)
+
+## <a name="tools"></a>Tools & Hints
+
+### Running AMP
+AMP content can be reached in various ways:
+* **Production** - `amp.theguardian.com/<path>`
+* **Code & local** - append an `amp` parameter to your query string e.g. `localhost:9000/an-article?amp`
+* **Beta** - `beta.amp.theguardian.com/<path>`
+
+### Validation
+In order for content to be discoverable (via search) and served in Google's cache (at `cdn.ampproject.org`) it must adhere to specific rules.  You can and should check your content passes validation in the following ways.
+
+* Validate in your browser - Add `#development=1` to your URL, and check the developer console for messages
+* [Google validation UI](https://validator.ampproject.org/)
+* [Scala validation tests (example)](https://github.com/guardian/frontend/blob/master/article/test/ArticleAmpValidityTest.scala)
+    * Run these like any other scala test using `sbt` - e.g. `test-only *ArticleTestSuite`
+    * If adding a new endpoint to the tests, make sure you run the test and commit the auto-generated test fixture - you should find a new file generated with a hash filename.
+    * We do not use a live version of the validator, so if you find a discrepancy between the results of these tests and another validation method, this may be the reason.  All you need to do to update the validator itself is delete the file under `data/amp-validator`, re-run the tests and commit the new validator fixture.
+* [Guardian amp validation tool](https://github.com/guardian/frontend/tree/master/tools/amp-validation)
+    * 3 ways this tool can be used:
+        1. Validate your local changes on a hardcoded set of endpoints - `make validate-amp`
+        2. Validate `amp.theguardian.com` on the same endpoints - `node ./tools/amp-validation/index.js`
+        3. Validate `amp.theguardian.com` on today's top 50 most-read articles (according to Ophan) - `node ./tools/amp-validation/top-traffic.js`

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@
 - [Implement Google Analytics](03-dev-howtos/14-implement-google-analytics.md)
 - [Overriding default configuration](03-dev-howtos/15-override-default-configuration.md)
 - [Updating the test database](03-dev-howtos/16-updating-test-database.md)
+- [Working with Google AMP](03-dev-howtos/17-working-with-amp.md)
 
 ##[Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)


### PR DESCRIPTION
## What does this change?
This reduces the PR template size.  When you first open a PR, the text box is 10 lines tall - I always find myself just deleting all those comments so I can answer the actual sections of the PR.  With this the important things we want to capture are front and centre.

Changes:
* First 10 lines are the important headings we want every PR to include
* Removed questionnaire comment (don't think anyone was answering this anyway, I think we will get more value from continuing to encourage people to come talk to us)
* Replaced lengthy comments regarding AB tests and AMP with links to docs and moved to the bottom
* Added some docs for AMP, because they didn't exist and I needed something to link to (could do with improvements still I'm sure)

## What is the value of this and can you measure success?
We have some docs on AMP, particularly on validation.  PR template is cleaner and simpler.

## Does this affect other platforms - Amp, Apps, etc?
No

## Request for comment
@guardian/dotcom-platform

