### PR TITLE
Save for later tones, and meta fixes

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -46,10 +46,10 @@
         <div class="meta__extras @if(!ageNotice.isEmpty){ meta__extras--notice }">
             <div class="meta__social" data-component="share">
                 @fragments.social(socialLinks, "top", iconModifier = iconModifier)
-                @if(item.content.tags.tags.exists(_.id == "tone/news")) {
-                    @fragments.contentAgeNotice(ageNotice)
-                }
             </div>
+            @if(item.content.tags.tags.exists(_.id == "tone/news")) {
+                @fragments.contentAgeNotice(ageNotice)
+            }
             @if(!item.content.isExplore) {
                 <div class="meta__numbers">
                     <div class="u-h meta__number js-sharecount">

--- a/common/app/views/fragments/meta/contactAuthor.scala.html
+++ b/common/app/views/fragments/meta/contactAuthor.scala.html
@@ -7,7 +7,7 @@
                     @fragments.inlineSvg("twitter-bird", "icon", Seq("inline-tone-fill", "i-left"))
                     <div class="contact hide-until-leftcol">@@@twitter</div>
             </a>
-      </div>
+        </div>
     }
     @profile.properties.emailAddress.map { email =>
         <div class="meta__email">

--- a/static/src/stylesheets/module/_media.scss
+++ b/static/src/stylesheets/module/_media.scss
@@ -20,12 +20,7 @@ Nicole Sullivan's OOCSS CSS markup extraction pattern.
 
 .media,
 .media__body {
-    @if $old-ie {
-        overflow: visible;
-        zoom: 1;
-    } @else {
-        overflow: hidden;
-    }
+    @include clearfix;
 }
 
 .media__img {

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -1,36 +1,5 @@
 $sfl-button-height: 30px;
 
-@mixin sfl-button-style($foreground: $neutral-2, $background: #ffffff) {
-    .save-for-later__button {
-        color: $foreground;
-
-        .inline-icon {
-            border-color: $foreground;
-        }
-    }
-
-    .save-for-later__button--save,
-    .save-for-later__button--saved:hover {
-        .inline-icon {
-            fill: $foreground;
-        }
-    }
-
-    .save-for-later__button--saved,
-    .save-for-later__button--save:hover {
-        .inline-icon {
-            fill: $background;
-            background-color: $foreground;
-        }
-    }
-}
-
-@mixin sfl-button-toned($tone, $foreground: $news-main-1, $background: #ffffff) {
-    .tonal--tone-#{$tone} {
-        @include sfl-button-style($foreground, $background);
-    }
-}
-
 // size etc
 .save-for-later__button {
     @include button-height($sfl-button-height);
@@ -38,6 +7,7 @@ $sfl-button-height: 30px;
     border: 0;
     background-color: transparent;
     padding: 0;
+    color: $news-main-1;
 
     .inline-icon {
         text-align: center;
@@ -45,8 +15,8 @@ $sfl-button-height: 30px;
         margin-right: .5em;
         width: $sfl-button-height;
         height: $sfl-button-height;
-        border-width: 1px;
-        border-style: solid;
+        border: 1px solid $news-main-1;
+        fill: $news-main-1;
 
         svg {
             width: 8px;
@@ -54,47 +24,52 @@ $sfl-button-height: 30px;
     }
 }
 
-// colours per state
-@include sfl-button-style();
-@include sfl-button-toned(analysis, $analysis-accent);
-@include sfl-button-toned(comment, $comment-default);
-@include sfl-button-toned(dead, $live-default, $neutral-7);
-@include sfl-button-toned(editorial, $editorial-default);
-@include sfl-button-toned(feature, $feature-default);
-@include sfl-button-toned(letters, $comment-default);
-@include sfl-button-toned(live, $live-default, $neutral-8);
-@include sfl-button-toned(media, $media-default, $media-background);
-@include sfl-button-toned(news);
-@include sfl-button-toned(review, $review-background);
+.save-for-later__button--saved,
+.save-for-later__button--save:hover {
+    .inline-icon {
+        fill: #ffffff;
+        background-color: $news-main-1;
+    }
+}
 
-// Specific fix for pages that are special-report & media
-.content--media.tonal--tone-special-report {
-    .save-for-later__button {
-        color: $news-support-1;
+.social--expanded-top {
+    .save-for-later__button--saved,
+    .save-for-later__button--save:hover {
         .inline-icon {
-            fill: $news-support-1;
-            border-color: $news-support-1;
-            background-color: $news-support-6;
-        }
-        &:hover {
-            .inline-icon {
-                fill: $news-support-6;
-                background-color: $news-support-1;
-            }
+            fill: $neutral-5;
         }
     }
 }
 
-.content--media.tonal--tone-media {
+// media tone
+.tonal--tone-media {
     .save-for-later__button {
-        &:hover {
+        color: $neutral-4;
+
+        .inline-icon {
+            border-color: $neutral-2;
+            fill: $neutral-4;
+        }
+    }
+
+    .save-for-later__button--saved,
+    .save-for-later__button--save:hover {
+        .inline-icon {
+            fill: $multimedia-support-5;
+            border-color: $neutral-4;
+            background-color: $neutral-4;
+        }
+    }
+
+    .social--expanded-top {
+        .save-for-later__button--saved,
+        .save-for-later__button--save:hover {
             .inline-icon {
                 fill: $neutral-1;
             }
         }
     }
 }
-
 
 // button labels per state
 .save-for-later__label {

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -25,7 +25,8 @@ $sfl-button-height: 30px;
 }
 
 .save-for-later__button--saved,
-.save-for-later__button--save:hover {
+.save-for-later__button--save:hover,
+.save-for-later__button--save:focus {
     .inline-icon {
         fill: #ffffff;
         background-color: $news-main-1;
@@ -34,7 +35,8 @@ $sfl-button-height: 30px;
 
 .social--expanded-top {
     .save-for-later__button--saved,
-    .save-for-later__button--save:hover {
+    .save-for-later__button--save:hover,
+    .save-for-later__button--save:focus {
         .inline-icon {
             fill: $neutral-5;
         }
@@ -53,7 +55,8 @@ $sfl-button-height: 30px;
     }
 
     .save-for-later__button--saved,
-    .save-for-later__button--save:hover {
+    .save-for-later__button--save:hover,
+    .save-for-later__button--save:focus {
         .inline-icon {
             fill: $multimedia-support-5;
             border-color: $neutral-4;
@@ -63,7 +66,8 @@ $sfl-button-height: 30px;
 
     .social--expanded-top {
         .save-for-later__button--saved,
-        .save-for-later__button--save:hover {
+        .save-for-later__button--save:hover,
+        .save-for-later__button--save:focus {
             .inline-icon {
                 fill: $neutral-1;
             }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -586,7 +586,7 @@
 .byline {
     @include fs-bodyHeading(2);
     margin-bottom: 0;
-    display: inline;
+    display: inline-block;
     padding-top: $gs-baseline/3;
     line-height: 20px;
     color: $neutral-2;
@@ -1113,7 +1113,7 @@
 
         @include mq($until: leftCol) {
             position: relative;
-            margin-top: -4px;
+            margin-top: -$gs-baseline/4;
             margin-bottom: -$gs-baseline/2;
             width: 32px;
             height: 32px;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -387,7 +387,6 @@
     box-sizing: border-box;
     padding-top: $gs-baseline / 6;
     margin-bottom: $gs-baseline / 2;
-    clear: left; // a dateline may be preceded by a floated badge.
 
     time {
         display: inline-block;
@@ -587,8 +586,7 @@
 .byline {
     @include fs-bodyHeading(2);
     margin-bottom: 0;
-    float: left;
-    margin-right: $gs-gutter/4;
+    display: inline;
     padding-top: $gs-baseline/3;
     line-height: 20px;
     color: $neutral-2;
@@ -599,7 +597,6 @@
 
     @include mq(leftCol) {
         clear: both;
-        float: none;
         margin-right: 0;
         display: block;
         padding-top: $gs-baseline/6;
@@ -1115,9 +1112,8 @@
         }
 
         @include mq($until: leftCol) {
-            float: left;
             position: relative;
-            margin-top: -$gs-baseline/4;
+            margin-top: -4px;
             margin-bottom: -$gs-baseline/2;
             width: 32px;
             height: 32px;


### PR DESCRIPTION
Yay more deletions than additions.

# Byline image
When there's a byline image the date stamp wasn't playing nicely with the float, and was stacking beneath despite there being plenty of room.

Before
![screen shot 2016-11-23 at 16 33 52](https://cloud.githubusercontent.com/assets/14570016/20570290/f8fef588-b19a-11e6-9b91-476a62c799b9.png)

After
![screen shot 2016-11-23 at 16 34 01](https://cloud.githubusercontent.com/assets/14570016/20570291/fa8e6b54-b19a-11e6-940e-e887ee0444f3.png)


# Byline image
The expanded state of the sharing buttons was being clipped by an overflow:hidden coming from a clearfix script, updated it to a newer one that doesn't rely on overflow. 

Before
![screen shot 2016-11-23 at 15 37 20](https://cloud.githubusercontent.com/assets/14570016/20570296/fe0a4a14-b19a-11e6-851d-fae3e9692d50.png)

After
![screen shot 2016-11-23 at 15 36 26](https://cloud.githubusercontent.com/assets/14570016/20570427/76c12ce8-b19b-11e6-921d-83f7c6784a8f.png)

# Content age notice
Moved it outside of the sharing buttons div, resulting in no jump when you open the sharing options.

# Save for later
Save for later appears in a different tone colour all over the shop, considering the button performs the same action, it may as well remain consistent, unless it's a media tone of course. Furthermore the hover state of saved had a disappearing icon.

![screen shot 2016-11-23 at 15 36 10](https://cloud.githubusercontent.com/assets/14570016/20570459/93abeece-b19b-11e6-8f78-998c16540e6c.png)

Now it is consistently blue, as a lot of our link language is. 
![screen shot 2016-11-23 at 16 41 23](https://cloud.githubusercontent.com/assets/14570016/20570505/bab30728-b19b-11e6-9630-a181e1b3ccb2.png)

Have a gander please @gtrufitt 👁 👁 
