### PR TITLE
Hide US minute logo for other briefing/minutes

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -565,8 +565,9 @@ final case class Tags(
   lazy val isRugbyMatch = (isMatchReport || isLiveBlog) &&
     tags.exists(t => t.id == "sport/rugby-union")
 
-  lazy val isClimateChangeSeries = tags.exists(t => t.id =="environment/series/keep-it-in-the-ground")
+  lazy val isClimateChangeSeries = tags.exists(t => t.id == "environment/series/keep-it-in-the-ground")
   lazy val isTheMinuteArticle = tags.exists(t => t.id == "tone/minute")
+  lazy val isUsMinuteBriefing = tags.exists(t => t.id == "us-news/series/the-campaign-minute-2016")
 
   lazy val isUSElection = tags.exists(t => t.id == "us-news/us-elections-2016")
   lazy val isAusElection = tags.exists(t => t.id == "australia-news/australian-election-2016")

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -10,9 +10,10 @@
 
 @defining((
     page.item.tags.isTheMinuteArticle,
+    page.item.tags.isUsMinuteBriefing,
     page.item.elements.hasMainEmbed,
     page.item.fields.main.nonEmpty
-)) { case (isTheMinuteArticle, hasEmbed, hasMainMedia) =>
+)) { case (isTheMinuteArticle, isUsMinuteBriefing, hasEmbed, hasMainMedia) =>
 
     <div class="@RenderClasses(Map(
             "content--minute-article" -> isTheMinuteArticle,
@@ -85,7 +86,7 @@
                         "content__headline--immersive--with-main-media" -> hasMainMedia
                     ), "content__headline", "content__headline--immersive", "content__headline--immersive-article")
                 ">
-                    @if(isTheMinuteArticle) {
+                    @if(isUsMinuteBriefing) {
                         <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
                             <span class="u-h">The Minute - </span>
                             @fragments.inlineSvg("minute-logo", "logo")


### PR DESCRIPTION
## What does this change?

Removes the "the minute" circular logo from minute/briefing tone articles apart from those tagged with us-news/series/the-campaign-minute-2016

## What is the value of this and can you measure success?

The logo links to the-campaign-minute-2016 series, so only makes sense for articles in that series.

## Does this affect other platforms - Amp, Apps, etc?

No
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
![screen shot 2016-11-23 at 16 31 27](https://cloud.githubusercontent.com/assets/2619836/20570533/e5d0be78-b19b-11e6-9cca-990c8dd3110e.png)

## Request for comment

@superfrank 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

