### PR TITLE
Move page skin ad slot at the top

### DIFF
--- a/common/app/views/fragments/commercial/pageSkin.scala.html
+++ b/common/app/views/fragments/commercial/pageSkin.scala.html
@@ -1,7 +1,7 @@
 @fragments.commercial.standardAd(
     "pageskin-inread",
     Seq("page-skin"),
-    Map("wide" -> Seq("1,1", "2,2")),
+    Map("wide" -> Seq("1,1")),
     showLabel=false,
     refresh=false,
     outOfPage=true

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -48,6 +48,10 @@
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
+        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+            @fragments.commercial.pageSkin()
+        }
+
         @page match {
             case page: model.ContentPage if (page.item.content.isImmersiveGallery && !page.item.content.tags.isInteractive) => {
                 <div class="immersive-header-container">
@@ -109,11 +113,6 @@
         @fragments.inlineJSNonBlocking()
 
         @fragments.analytics.base(page)
-
-        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
-            @fragments.commercial.pageSkin()
-        }
-
     </body>
     </html>
 }


### PR DESCRIPTION
We are experiencing two issues with page skins:

1- when the takeover targets a whole section, the pageskin shows up in article (it should only on fronts)
2- sometimes, some creatives do not render at all

The former issue is because skins are using the Out of Page size (1x1) and all the slots in the page have that size. And so, depending on how the campaign has been configured in DFP, it is possible that a page skin ends up being delivered when an MPU should have been.

The latter issue happens on fronts and at its root is the same reason as the above. But it is more subtle, it turns out [the order in which `googletag.defineSlot` is called matters](https://support.google.com/dfp_premium/answer/1697712?hl=en). And so if, for instance, we have

```
googletag.defineSlot("...", [[1, 1], [300, 250]], "top-above-nav");
googletag.defineSlot("...", [[1, 1]], "pageskin");
```

then, if the first creative in the line item is a 1x1, then it will fill the first slot, `top-above-nav`, instead of `pageskin`; and the second creative (presumably a 300x250) **will not be delivered**.

Currently, the pageskin slot is the last in the page, and so it is the last to be defined. We are moving it to the top, hence giving it a higher priority over the others. Since it only has the 1x1 size (I removed the 2x2 because it is of no use), it won't ever steal the creative from another slot, but will always get the out of page one (which can be a pageskin, or a survey, for all we know).