### PR TITLE
Fix masterclasses parsing failure

### DIFF
--- a/commercial/app/model/capi/Lookup.scala
+++ b/commercial/app/model/capi/Lookup.scala
@@ -54,10 +54,6 @@ class Lookup(contentApiClient: ContentApiClient) extends ExecutionContexts with 
         Nil
     }
 
-    result onSuccess {
-      case keywords => log.info(s"Looking up [$term] gave ${keywords.map(_.id)}")
-    }
-
     result
   }
 }

--- a/commercial/app/model/merchandise/events/Eventbrite.scala
+++ b/commercial/app/model/merchandise/events/Eventbrite.scala
@@ -130,7 +130,7 @@ object Eventbrite extends ExecutionContexts with Logging {
   trait TicketHandler {
     def tickets: Seq[Ticket]
 
-    lazy val displayPriceRange: Option[String] = {
+    val displayPriceRange: Option[String] = {
 
       def determinePriceRange: String = {
 

--- a/commercial/app/model/merchandise/events/Eventbrite.scala
+++ b/commercial/app/model/merchandise/events/Eventbrite.scala
@@ -130,22 +130,32 @@ object Eventbrite extends ExecutionContexts with Logging {
   trait TicketHandler {
     def tickets: Seq[Ticket]
 
-    val displayPriceRange = {
+    lazy val displayPriceRange: Option[String] = {
 
-      def format(price: Double): String = f"£$price%,.2f"
+      def determinePriceRange: String = {
 
-      val prices = tickets.map(_.price)
-      val (low, high) = (prices.min, prices.max)
+        def format(price: Double): String = f"£$price%,.2f"
 
-      if (low == high) {
-        format(high)
+        val prices: Seq[Double] = tickets.map(_.price)
+        val (low, high) = (prices.min, prices.max)
+
+        if (low == high)
+          format(high)
+        else
+          s"${format(low)} to ${format(high)}"
       }
-      else {
-        s"${format(low)} to ${format(high)}"
-      }
+
+      if (tickets.isEmpty)
+        None
+      else
+        Some(determinePriceRange)
     }
 
-    val ratioTicketsLeft = 1 - (tickets.map(_.quantitySold).sum.toDouble / tickets.map(_.quantityTotal).sum)
+    val ratioTicketsLeft: Option[Double] =
+      if (tickets.isEmpty)
+        None
+      else
+        Some(1 - (tickets.map(_.quantitySold).sum.toDouble / tickets.map(_.quantityTotal).sum))
   }
 
   trait EventHandler {

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -275,7 +275,7 @@
                         var adSlot = document.querySelector('.ad-slot--inline-event')
                         new CommercialComponent(adSlot, {
                             type: 'liveevents',
-                            id: '26078306918',
+                            id: '29479196069',
                             clickMacro: '%%CLICK_URL_ESC%%',
                             omnitureId: '[%OmnitureID%]'
                         }).create().then(function () {

--- a/commercial/app/views/liveevents/liveEvent.scala.html
+++ b/commercial/app/views/liveevents/liveEvent.scala.html
@@ -30,7 +30,7 @@
                 }
                 @for(displayPriceRange <- event.displayPriceRange) {
                     <div class="advert__standfirst">
-                        <strong>displayPriceRange</strong>
+                        <strong>@displayPriceRange</strong>
                     </div>
                     <span class="advert__more button button--small button--primary">
                         Book now @fragments.inlineSvg("arrow-right", "icon", List("i-right"))

--- a/commercial/app/views/liveevents/liveEvent.scala.html
+++ b/commercial/app/views/liveevents/liveEvent.scala.html
@@ -28,12 +28,14 @@
                         <div class="advert__meta advert__meta--scarcity">Last few tickets remaining</div>
                     }
                 }
-                <div class="advert__standfirst">
-                    <strong>@event.displayPriceRange</strong>
-                </div>
-                <span class="advert__more button button--small button--primary">
-                    Book now @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
-                </span>
+                @for(displayPriceRange <- event.displayPriceRange) {
+                    <div class="advert__standfirst">
+                        <strong>displayPriceRange</strong>
+                    </div>
+                    <span class="advert__more button button--small button--primary">
+                        Book now @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
+                    </span>
+                }
             </a>
         </div>
     </aside>

--- a/commercial/app/views/liveevents/liveEvent.scala.html
+++ b/commercial/app/views/liveevents/liveEvent.scala.html
@@ -23,8 +23,10 @@
                 <div class="advert__meta">
                     @event.date.toString("dd MMM yyyy"), @event.venue.description
                 </div>
-                @if(event.ratioTicketsLeft <= 0.1){
-                    <div class="advert__meta advert__meta--scarcity">Last few tickets remaining</div>
+                @for(ratioTicketsLeft <- event.ratioTicketsLeft) {
+                    @if(ratioTicketsLeft <= 0.1) {
+                        <div class="advert__meta advert__meta--scarcity">Last few tickets remaining</div>
+                    }
                 }
                 <div class="advert__standfirst">
                     <strong>@event.displayPriceRange</strong>

--- a/commercial/app/views/masterclasses/masterclassCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassCard.scala.html
@@ -17,8 +17,10 @@
     <div class="advert__meta">
         <strong>@event.readableDate</strong> &#20; <span class="commercial--tone__highlight">@event.displayPriceRange</span><br/>
         @event.venue.description
-        @if(event.ratioTicketsLeft <= 0.1){
-            <br><span class="lineitem__scarcity">Last few tickets remaining</span>
+        @for(ratioTicketsLeft <- event.ratioTicketsLeft) {
+            @if(ratioTicketsLeft <= 0.1) {
+                <br><span class="lineitem__scarcity">Last few tickets remaining</span>
+            }
         }
     </div>
     <span class="advert__more button button--primary button--small">

--- a/commercial/app/views/masterclasses/masterclassCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassCard.scala.html
@@ -15,7 +15,8 @@
         }
     }
     <div class="advert__meta">
-        <strong>@event.readableDate</strong> &#20; <span class="commercial--tone__highlight">@event.displayPriceRange</span><br/>
+        <strong>@event.readableDate</strong>
+        @for(displayPriceRange <- event.displayPriceRange){&#20; <span class="commercial--tone__highlight">@displayPriceRange</span><br/> }
         @event.venue.description
         @for(ratioTicketsLeft <- event.ratioTicketsLeft) {
             @if(ratioTicketsLeft <= 0.1) {

--- a/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
@@ -20,8 +20,10 @@
         <div class="advert__meta">
             <strong>@event.readableDate</strong> &#20; <span class="commercial--tone__highlight">@event.displayPriceRange</span></span><br/>
             @event.venue.description
-            @if(event.ratioTicketsLeft <= 0.1){
-                <br><span class="lineitem__scarcity">Last few tickets remaining</span>
+            @for(ratioTicketsLeft <- event.ratioTicketsLeft) {
+                @if(ratioTicketsLeft <= 0.1) {
+                    <br><span class="lineitem__scarcity">Last few tickets remaining</span>
+                }
             }
         </div>
         <span class="advert__more button button--primary button--small">

--- a/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassLargeCard.scala.html
@@ -18,7 +18,8 @@
     <div class="advert__text">
         <h2 class="advert__title">@event.name</h2>
         <div class="advert__meta">
-            <strong>@event.readableDate</strong> &#20; <span class="commercial--tone__highlight">@event.displayPriceRange</span></span><br/>
+            <strong>@event.readableDate</strong>
+            @for(displayPriceRange <- event.displayPriceRange){&#20; <span class="commercial--tone__highlight">@displayPriceRange</span><br/> }
             @event.venue.description
             @for(ratioTicketsLeft <- event.ratioTicketsLeft) {
                 @if(ratioTicketsLeft <= 0.1) {

--- a/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
+++ b/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
@@ -18,8 +18,8 @@ class SingleEventbriteMasterclassParsingTest extends FlatSpec with Matchers with
 
     masterclass.name should be("Travel writing weekend")
     masterclass shouldBe 'open
-    masterclass.displayPriceRange should be ("£400.00")
-    masterclass.ratioTicketsLeft should be (0.5)
+    masterclass.displayPriceRange should be (Some("£400.00"))
+    masterclass.ratioTicketsLeft should be (Some(0.5))
     masterclass.guardianUrl should be ("http://www.theguardian.com/guardian-masterclasses/how-to-use-twitter-effectively-david-schneider-david-levin-social-media-course")
     masterclass.readableDate should be ("20 April 2013")
     masterclass.capacity should be (18)
@@ -35,8 +35,8 @@ class SingleEventbriteMasterclassParsingTest extends FlatSpec with Matchers with
 
     masterclass.name should be("Travel writing weekend")
     masterclass shouldBe 'open
-    masterclass.displayPriceRange should be ("£400.00 to £2,600.00")
-    masterclass.ratioTicketsLeft should be (0.5)
+    masterclass.displayPriceRange should be (Some("£400.00 to £2,600.00"))
+    masterclass.ratioTicketsLeft should be (Some(0.5))
   }
 
   "Generated masterclass object" should "have a description text that is truncated to 250 chars" in {


### PR DESCRIPTION
## Background
We parse Eventbrite feeds to drive our Masterclasses and Live Events components. Currently, we expect each event to have at least one ticket that can be booked. It turns out that this was a _foolish_ assumption and it has indeed made an ass out of me.

## What does this change?
All properties derived from the `tickets` of an event are now optional.

Sneaky change - there is a logging statement that basically spams the logs with information we very very rarely care about. I've taken it out for now as it makes the logs a lot easier to grep/parse/read.

## What is the value of this and can you measure success?
Despite the fact that we will probably never serve one of these events to the end user, we will no longer get parsing failures when parsing these events.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Request for comment
@guardian/commercial-dev 
