### PR TITLE
Use series as the minute logo link

### DIFF
--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -11,8 +11,9 @@
 @defining((
     page.item.tags.isTheMinuteArticle,
     page.item.elements.hasMainEmbed,
-    page.item.fields.main.nonEmpty
-)) { case (isTheMinuteArticle, hasEmbed, hasMainMedia) =>
+    page.item.fields.main.nonEmpty,
+    page.item.tags.series.headOption
+)) { case (isTheMinuteArticle, hasEmbed, hasMainMedia, optSeries) =>
 
     <div class="@RenderClasses(Map(
             "content--minute-article" -> isTheMinuteArticle,
@@ -86,10 +87,17 @@
                     ), "content__headline", "content__headline--immersive", "content__headline--immersive-article")
                 ">
                     @if(isTheMinuteArticle) {
-                        <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
-                            <span class="u-h">The Minute - </span>
-                            @fragments.inlineSvg("minute-logo", "logo")
-                        </a>
+                        @optSeries.map { series =>
+                            <a href="@LinkTo { /@series.id }" class="logo--minute-article">
+                                <span class="u-h">The Minute - </span>
+                                @fragments.inlineSvg("minute-logo", "logo")
+                            </a>
+                        }.getOrElse {
+                            <div class="logo--minute-article">
+                                <span class="u-h">The Minute - </span>
+                                @fragments.inlineSvg("minute-logo", "logo")
+                            </div>
+                        }
                     }
                     @Html(page.item.trail.headline)
                 </h1>


### PR DESCRIPTION
## What does this change?

Fixes the link on "the minute" circular logo from minute/briefing tone articles.  Previously this always linked to the US minute.  Now it links to the series page.  If there is no series then it isn't a link.

## What is the value of this and can you measure success?

Avoids confusing user experience.

## Does this affect other platforms - Amp, Apps, etc?

No
<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots
![screen shot 2016-11-23 at 16 31 27](https://cloud.githubusercontent.com/assets/2619836/20570533/e5d0be78-b19b-11e6-9cca-990c8dd3110e.png)

## Request for comment

@superfrank @gtrufitt @katebee 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

