### PR TITLE
fix a couple issues around youtube atoms and tracking

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -82,9 +82,9 @@ define([
         fastdom.read(function () {
             $('.atom--media--youtube').each(function (el) {
                 var atomId = el.getAttribute('data-media-atom-id');
-                var iframe = el.firstElementChild;
+                var iframe = el.querySelector('iframe');
                 var youtubeId = iframe.id;
-                
+
                 tracking.init(atomId);
 
                 youtubePlayer.init(iframe, {

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -12,79 +12,85 @@ define([
 
     var players = {};
 
-    function init() {
+    var STATES = {
+        'ENDED': onPlayerEnded,
+        'PLAYING': onPlayerPlaying,
+        'PAUSED': onPlayerPaused
+    };
 
+    function checkState(atomId, state, status) {
+        if (state === window.YT.PlayerState[status] && STATES[status]) {
+            STATES[status](atomId);
+        }
+    }
+
+    function onPlayerPlaying(atomId) {
+        killProgressTracker(atomId);
+        setProgressTracker(atomId);
+        tracking.track('play', atomId);
+    }
+
+    function onPlayerPaused(atomId) {
+        killProgressTracker(atomId);
+    }
+
+    function onPlayerEnded(atomId) {
+        killProgressTracker(atomId);
+        tracking.track('end', atomId);
+    }
+
+    function setProgressTracker(atomId)  {
+        players[atomId].progressTracker = setInterval(recordPlayerProgress.bind(null, atomId), 1000); 
+    }
+
+    function killProgressTracker(atomId) {
+        if (players[atomId].progressTracker) {
+            clearInterval(players[atomId].progressTracker);
+        }
+    }
+
+    function recordPlayerProgress(atomId) {
+        var player = players[atomId].player;
+
+        if (!player.duration) {
+            player.duration = player.getDuration();
+        }
+
+        var currentTime = player.getCurrentTime();
+        var percentPlayed = Math.round(((currentTime / player.duration) * 100));
+
+        if (percentPlayed > 0 && percentPlayed < 100 &&
+            percentPlayed % 25 === 0,
+            players[atomId].trackingCalls.indexOf(percentPlayed) === -1) {
+            players[atomId].trackingCalls.push(percentPlayed);
+            tracking.track(percentPlayed, atomId);
+        }
+    }
+
+    function onPlayerReady(atomId, event) {
+        players[atomId] = {
+            player: event.target,
+            trackingCalls: []
+        };
+    }
+
+    function onPlayerStateChange(atomId, event) {
+        Object.keys(STATES).forEach(checkState.bind(null, atomId, event.data));
+    }
+
+    function init() {
         fastdom.read(function () {
             $('.atom--media--youtube').each(function (el) {
                 var atomId = el.getAttribute('data-media-atom-id');
-                var youtubeId = el.firstElementChild.id;
+                var iframe = el.firstElementChild;
+                var youtubeId = iframe.id;
+                
                 tracking.init(atomId);
-                players[youtubeId] = youtubePlayer.init(el,
-                    {
-                        onPlayerStateChange: function (event) {
 
-                            var STATES = {
-                                'ENDED': onPlayerEnded,
-                                'PLAYING': onPlayerPlaying,
-                                'PAUSED': onPlayerPaused
-                            };
-
-                            var progressTracker = {};
-
-                            function checkState(state, status) {
-                                if (state === window.YT.PlayerState[status] && STATES[status]) {
-                                    STATES[status]();
-                                }
-                            }
-
-                            function onPlayerPlaying() {
-                                setProgressTracker();
-                                tracking.track('play', atomId);
-                            }
-
-                            function onPlayerPaused() {
-                                killProgressTracker(false, youtubeId);
-                            }
-
-                            function onPlayerEnded() {
-                                killProgressTracker(false, youtubeId);
-                                tracking.track('end', atomId);
-                            }
-
-                            function setProgressTracker()  {
-                                killProgressTracker(true);
-                                progressTracker.id = youtubeId;
-                                progressTracker.tracker = setInterval(recordPlayerProgress.bind(null), 1000);
-                            }
-
-                            function killProgressTracker(force, id) {
-                                if (progressTracker.tracker &&
-                                    (force || id === progressTracker.id)) {
-                                    clearInterval(progressTracker.tracker);
-                                    progressTracker = {};
-                                }
-                            }
-
-                            function recordPlayerProgress() {
-                                var player = event.target;
-
-                                if (!player.duration) {
-                                    player.duration = player.getDuration();
-                                }
-
-                                var currentTime = player.getCurrentTime();
-                                var percentPlayed = Math.round(((currentTime / player.duration) * 100));
-
-                                if (percentPlayed > 0 && percentPlayed < 100 &&
-                                    percentPlayed % 25 === 0) {
-                                    tracking.track(percentPlayed, atomId);
-                                }
-                            }
-
-                            Object.keys(STATES).forEach(checkState.bind(null, event.data));
-                        }
-                    }
-                    , youtubeId);
+                youtubePlayer.init(iframe, {
+                    onPlayerReady: onPlayerReady.bind(null, atomId),
+                    onPlayerStateChange: onPlayerStateChange.bind(null, atomId)
+                }, youtubeId);
             });
         });
     }


### PR DESCRIPTION
## What does this change?

This fixes a couple issues around youtube atoms and tracking:

- Prevents a youtube atom's progressTracker from continuing to execute (tick) once a video has been paused or has ended.
- Prevents multiple instances of the progressTracker for a youtube atom ticking in unison after the video has been restarted after a pause/end event.
- For long videos the progressTracker might tick more than once for a percentPlayed value and therefore the percentPlayed might be tracked more than once, therefore I've added a check to see whether percentPlayed has been tracked already.

## What is the value of this and can you measure success?

Prevents needless and potentially confusing tracking calls from being made

## Does this affect other platforms - Amp, Apps, etc?

No

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->

## Screenshots

N/A

## Request for comment

@markjamesbutler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
