### PR TITLE
Adding missing class for main media images

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -122,7 +122,7 @@
                     }
                 </figcaption>
             } else {
-                <figcaption class="caption caption--img" itemprop="description">
+                <figcaption class="caption caption--img @if(isMain) {caption--main}" itemprop="description">
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))


### PR DESCRIPTION
## What does this change?
Fixes the bug I introduced in #15097 where main captions were no longer getting the class they needed if they were not in the article refresh tests.

## What is the value of this and can you measure success?
Fixing a bug!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/20605619/498be820-b264-11e6-8576-6441a22e8b13.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/20605626/53634bea-b264-11e6-826d-fe4b33d53d19.png)

## Request for comment
@gtrufitt @zeftilldeath 

