### PR TITLE
Fix failing Books "Best Sellers" feed fetching

### DIFF
--- a/commercial/app/model/feeds/FeedMetaData.scala
+++ b/commercial/app/model/feeds/FeedMetaData.scala
@@ -44,7 +44,7 @@ case class SoulmatesFeedMetaData(baseUrl: String, agent: SoulmatesAgent) extends
 case class BestsellersFeedMetaData(domain: String) extends FeedMetaData {
 
   val name = "bestsellers"
-  val url = s"http://$domain/bertrams/feed/independentsTop20"
+  val url = s"https://$domain/bertrams/feed/independentsTop20"
 
   override val fetchSwitch = Switches.GuBookshopFeedsSwitch
   override val parseSwitch = Switches.GuBookshopFeedsSwitch


### PR DESCRIPTION
### El Problemo
We periodically fetch a feed of "bestsellers" for our books components. In the last day or so, instead of an XML feed in our S3 bucket, we have an entirely static (and surprisingly functional) HTML document.

After a bit of digging around it turns out that our fetcher isn't handling redirects very well, because it was using HTTP instead of HTTPS to query the feed, the feed was automatically upgrading it to HTTPS which then confuses the fetcher.

### La Solución
Instead of fundamentally fixing the way feed fetchers and parsers interact and handle edge cases, I've opted to add an 's' to the protocol being used to request the feed 🙃 .

**tl;dr** just make requests secure and then everyone wins.

@guardian/commercial-dev 