### PR TITLE
require yarn 0.17

### DIFF
--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ check-node: # PRIVATE
 
 # Make sure yarn is installed, and it's at least v0.16.
 check-yarn: # PRIVATE
-	@if [ -z "$$(which yarn)" ] || [ $$(echo $$(yarn --version | cut -d . -f 1,2) '< 0.17' | bc) = 1 ]; then npm i -g yarn@\$<=0.17; fi
+	@if [ -z "$$(which yarn)" ] || [ $$(echo $$(yarn --version | cut -d . -f 1,2) '< 0.17' | bc) = 1 ]; then npm i -g yarn@~0.17; fi
 
 # *********************** DEVELOPMENT ***********************
 

--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ check-node: # PRIVATE
 
 # Make sure yarn is installed, and it's at least v0.16.
 check-yarn: # PRIVATE
-	@if [ -z "$$(which yarn)" ] || [ $$(echo $$(yarn --version | cut -d . -f 1,2) '< 0.16' | bc) = 1 ]; then npm i -g yarn@\$<=0.16; fi
+	@if [ -z "$$(which yarn)" ] || [ $$(echo $$(yarn --version | cut -d . -f 1,2) '< 0.17' | bc) = 1 ]; then npm i -g yarn@\$<=0.17; fi
 
 # *********************** DEVELOPMENT ***********************
 


### PR DESCRIPTION
## What does this change?

require yarn 0.17

## What is the value of this and can you measure success?

0.17 reorders the `yarn.lock` file which i appear to have inadvertently committed, having updated locally. now anyone on 0.16 will find an updated `yarn.lock` just by installing (which all make tasks now do by default).

## Request for comment

@SiAdcock 