### PR TITLE
remove omniture calls from static pages

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -88,11 +88,6 @@
         @* Get iframes parent url: http://www.nczonline.net/blog/2013/04/16/getting-the-url-of-an-iframes-parent/ *@
         var parentUrl = (!!window.parent && window.parent !== window) ? document.referrer : '';
 
-        @* Hack to correctly track external embeds which have been incorrectly embedded on theguardian.com *@
-        var sAccount = (/www\.theguardian\.com/.test(parentUrl)) ? 'guardiangu-network' : 'guardiangu-thirdpartyapps';
-
-        window.s_account = sAccount;
-
         function hasSvgSupport() {
             var ns = {'svg': 'http://www.w3.org/2000/svg'};
             return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;

--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -97,10 +97,6 @@
         </div><!-- /.fluid-wrap -->
 
         <script>
-            var s_account="guardiangu-network";
-        </script>
-        
-        <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/identity/app/views/errors/error.scala.html
+++ b/identity/app/views/errors/error.scala.html
@@ -96,18 +96,5 @@
             </div>
         </div><!-- /.fluid-wrap -->
 
-        <script>
-            var s_account = "guardiangu-network";
-        </script>
-        <script src="https://static-secure.guim.co.uk/omni/omniture-H.25.3.js"></script>
-        <script>
-            s.pageName = "@code Error:" + window.location.href;
-            s.pageType = "errorPage";
-            s.prop19 = "frontend";
-            s.t();
-        </script>
-        <noscript>
-            <img src="http://hits.guardian.co.uk/b/ss/guardiangu-network/1/H.24.2/?v19=frontend&v7=@code&ns=guardian&c19=frontend&c9=@code&c30=non-content&c6=&c13=&pageType=errorPage&pageName=@code&g=http%3A%2F%2Fm.guardian.co.uk%2F/@code&" alt="" style="display: none;" />
-        </noscript>
     </body>
 </html>


### PR DESCRIPTION
## What does this change?
Remove some calls to Omniture from error pages

## What is the value of this and can you measure success?
🔴 

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Request for comment
@mkopka @akash1810 @TBonnin 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

