### PR TITLE
Extend expiry of contributions US test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,7 +31,7 @@ trait ABTestSwitches {
     "Test just contributions vs contributions or membership vs just membership in the US",
     owners = Seq(Owner.withGithub("philwills")),
     safeState = Off,
-    sellByDate =  new LocalDate(2016, 11, 25),
+    sellByDate =  new LocalDate(2016, 11, 28),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-three-way.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-three-way.js
@@ -35,7 +35,7 @@ define([
 
         this.id = 'ContributionsEpicUsaCtaThreeWay';
         this.start = '2016-11-18';
-        this.expiry = '2016-11-25';
+        this.expiry = '2016-11-29';
         this.author = 'Phil Wills';
         this.description = 'Test just contributions vs contributions or membership or just membership in the US';
         this.showForSensitive = false;


### PR DESCRIPTION
## What does this change?

Extends the expiry of the contributions message in the US

## What is the value of this and can you measure success?

Continued high conversion rates

## Does this affect other platforms - Amp, Apps, etc?

No

