### PR TITLE
prevent progress tracker skipping percent played on short videos

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -37,6 +37,7 @@ define([
     function onPlayerEnded(atomId) {
         killProgressTracker(atomId);
         tracking.track('end', atomId);
+        players[atomId].pendingTrackingCalls = [25, 50];
     }
 
     function setProgressTracker(atomId)  {
@@ -51,6 +52,11 @@ define([
 
     function recordPlayerProgress(atomId) {
         var player = players[atomId].player;
+        var pendingTrackingCalls = players[atomId].pendingTrackingCalls;
+
+        if (!pendingTrackingCalls.length) {
+            return;
+        }
 
         if (!player.duration) {
             player.duration = player.getDuration();
@@ -59,10 +65,9 @@ define([
         var currentTime = player.getCurrentTime();
         var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
-        if (players[atomId].pendingTrackingCalls.length &&
-            percentPlayed >= players[atomId].pendingTrackingCalls[0]) {
-            tracking.track(players[atomId].pendingTrackingCalls[0], atomId);
-            players[atomId].pendingTrackingCalls.shift();
+        if (percentPlayed >= pendingTrackingCalls[0]) {
+            tracking.track(pendingTrackingCalls[0], atomId);
+            pendingTrackingCalls.shift();
         }
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -60,17 +60,17 @@ define([
         var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
         if (percentPlayed > 0 && percentPlayed < 100 &&
-            percentPlayed % 25 === 0,
-            players[atomId].trackingCalls.indexOf(percentPlayed) === -1) {
-            players[atomId].trackingCalls.push(percentPlayed);
-            tracking.track(percentPlayed, atomId);
+            players[atomId].pendingTrackingCalls.length &&
+            percentPlayed >= players[atomId].pendingTrackingCalls[0]) {
+            tracking.track(players[atomId].pendingTrackingCalls[0], atomId);
+            players[atomId].pendingTrackingCalls.shift();
         }
     }
 
     function onPlayerReady(atomId, event) {
         players[atomId] = {
             player: event.target,
-            trackingCalls: []
+            pendingTrackingCalls: [25, 50]
         };
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -59,8 +59,7 @@ define([
         var currentTime = player.getCurrentTime();
         var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
-        if (percentPlayed > 0 && percentPlayed < 100 &&
-            players[atomId].pendingTrackingCalls.length &&
+        if (players[atomId].pendingTrackingCalls.length &&
             percentPlayed >= players[atomId].pendingTrackingCalls[0]) {
             tracking.track(players[atomId].pendingTrackingCalls[0], atomId);
             players[atomId].pendingTrackingCalls.shift();


### PR DESCRIPTION
## What does this change?

- Fixes bug where progress tracker polls every 1s and sometimes misses percentages played on short videos (eg. would record 24% and 26% but miss 25% and therefore fail to track 25% played)

## What is the value of this and can you measure success?

- Accurate tracking

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Request for comment

@SiAdcock this fixes the bug we saw earler!