### PR TITLE
Commerical galleries

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -232,8 +232,7 @@
     }
 
     > .badge__link {
-        border-bottom: 1px dotted $neutral-5;
-        margin: 3 / 4 * $gs-baseline 0 $gs-baseline / 3;
+        margin: 3 / 4 * $gs-baseline 0 $gs-baseline;
     }
 
     > .badge__help {
@@ -286,9 +285,12 @@
 .content--media--video:not(.paid-content--advertisement-feature),
 .content--media--audio:not(.paid-content--advertisement-feature),
 .content--gallery:not(.paid-content--advertisement-feature) {
-    .badge,
+    .badge {
+        color: $neutral-3;
+    }
+
     .badge__help {
-        color: $neutral-6;
+        color: #ffffff;
     }
 }
 

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -190,8 +190,7 @@
         }
     }
 
-    .badge--alt,
-    .badge--alt > .badge__link {
+    .badge--alt {
         border-color: $neutral-2;
     }
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -246,6 +246,17 @@
         border: 0;
     }
 
+    .badge--alt {
+        margin-top: 0;
+        margin-bottom: $gs-baseline;
+        border-top: 1px dotted $neutral-1;
+
+        @include mq(desktop) {
+            position: absolute;
+            width: gs-span(3);
+        }
+    }
+
 }
 
 // TODO:

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -34,7 +34,6 @@
             &:focus {
                 background-color: transparent;
                 border-color: $neutral-6;
-                background-color: red;
             }
         }
 

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -34,6 +34,7 @@
             &:focus {
                 background-color: transparent;
                 border-color: $neutral-6;
+                background-color: red;
             }
         }
 

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -49,6 +49,10 @@
         }
     }
 
+    .badge--alt {
+        border-color: $neutral-1;
+    }
+
     .brandbadge__header,
     .brandbadge__help {
         color: $neutral-6;


### PR DESCRIPTION
Thanks @JamieKMorrison for spotting this. 

In Galleries the sponsored content badge was forcing everything onto a new line (And was tonally way too zingy). 

![screen shot 2016-11-25 at 14 11 04](https://cloud.githubusercontent.com/assets/14570016/20627716/c8391ffc-b319-11e6-9f38-da36e8e10deb.png)


Have sorted out the positioning from desktop and above, and tamed the colours.

![screen shot 2016-11-25 at 14 10 54](https://cloud.githubusercontent.com/assets/14570016/20627723/d0dfa216-b319-11e6-967a-d30b7e1ae010.png)


Have also removed the extra dividing line, we can always do with making things a bit less liney*.

*That's the technical term

@gtrufitt or @NataliaLKB ?

Thanks