### PR TITLE
GA: Match the apps labelling of 'international' edition

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -24,7 +24,8 @@
     }
 
     function getAnalyticsEdition() {
-        return (guardian.config.page.edition || '').toLowerCase();
+        var edition = (guardian.config.page.edition || '').toLowerCase()
+        return edition === 'int' ? 'international' : edition;
     }
 
     function getAnalyticsTitle() {


### PR DESCRIPTION
## What does this change?

Makes the international edition use 'international' instead of 'int' when sending data to GA to match the apps.

## What is the value of this and can you measure success?

Data integrity. 

@guardian/dotcom-platform 