### PR TITLE
Taste the rainbow! 🌈 tones for the email forms

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -33,7 +33,7 @@ POST           /notification/delete                                             
 
 # Email paths
 GET        /email                                                               controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain|plaindark>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -42,6 +42,7 @@ object ListIds {
   val greenLight = 28
   val povertyMatters = 113
   val theLongRead = 3322
+  val weekendReading = 3743
   val morningMail = 2636
   val australianPolitics = 1866
 

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -14,6 +14,7 @@
     theFiver -> "feature",
     mediaBriefing -> "media",
     theLongRead -> "feature",
+    weekendReading -> "feature",
     theBreakdown -> "feature",
     theSpin -> "feature",
     closeUp -> "review",
@@ -26,7 +27,7 @@
 @inputId = @{ componentClass + "-email-sub-input" }
 
 @wrapperClass = @{ "email-sub js-email-sub" + " email-sub--" + componentClass + " js-email-sub--" + componentClass }
-@wrapperToneClass = @{ if (componentClass == "article") "email-sub--tone-" + listIdTones.getOrElse(listId, "news") }
+@wrapperToneClass = @{ if (componentClass == "article" || componentClass == "plaintone") "email-sub--tone-" + listIdTones.getOrElse(listId, "news") }
 @formClass = @{ "email-sub__form js-email-sub__form" + " email-sub__form--" + componentClass }
 
 <div class="@wrapperClass @wrapperToneClass">

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -42,7 +42,7 @@ GET            /crosswords/lookup                                               
 
 # Email paths
 GET            /email                                                                                                            controllers.EmailSignupController.renderPage()
-GET            /email/form/$emailType<article|footer|plain|plaindark>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET            /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()
 OPTIONS        /email                                                                                                            controllers.EmailSignupController.options()

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -173,7 +173,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    
 
 # Email paths
 GET        /email                                                                              controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer|plain|plaindark>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -268,7 +268,8 @@
 
 .email-sub__form--article,
 .email-sub__form--plain,
-.email-sub__form--plaindark
+.email-sub__form--plaindark,
+.email-sub__form--plaintone
 {
     .label__icon {
         display: inline-block;
@@ -321,6 +322,17 @@
 
     .email-sub__message__headline {
         color: #ffffff;
+    }
+}
+
+// PLAIN-TONE MODS
+.email-sub__form--plaintone {
+    padding: 0;
+
+    .email-sub__submit-input {
+        background-color: $neutral-4;
+        border-color: $neutral-4;
+        color: $neutral-1;
     }
 }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -374,7 +374,7 @@
 }
 
 // TONE SPECIFIC MODS
-@each $tone-class, $tone-colour-accent, $tone-colour-headline in $tones {
+@each $tone-class, $tone-colour-accent, $tone-colour-headline, $tone-colour-border in $tones {
 
 
     .email-sub--tone-#{$tone-class} {
@@ -408,6 +408,17 @@
 
         .email-sub__small {
             color: $tone-colour-headline;
+        }
+    }
+
+    .email-sub--tone-#{$tone-class}.email-sub--plaintone {
+
+        .email-sub__text-input {
+            border-color: $tone-colour-border;
+        }
+
+        .email-sub__submit-input {
+            border-color: $tone-colour-border;
         }
     }
 }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -52,7 +52,8 @@ body {
     .email-sub__form--footer,
     .email-sub__form--article,
     .email-sub__form--plain,
-    .email-sub__form--plaindark {
+    .email-sub__form--plaindark,
+    .email-sub__form--plaintone {
         // Rounded inline input
         .email-sub__text-input {
             border-right: 0;
@@ -87,7 +88,8 @@ body {
 
     .email-sub__form--footer,
     .email-sub__form--plain,
-    .email-sub__form--plaindark {
+    .email-sub__form--plaindark,
+    .email-sub__form--plaintone {
         .email-sub__submit-input {
             padding-left: $gs-gutter / 2;
         }
@@ -98,7 +100,8 @@ body {
 @include mq(183px, 183px) {
     .email-sub__form--footer,
     .email-sub__form--plain,
-    .email-sub__form--plaindark {
+    .email-sub__form--plaindark,
+    .email-sub__form--plaintone {
         padding-right: $gs-gutter / 2;
 
         .email-sub__text-input {
@@ -145,8 +148,8 @@ body {
 * IFRAME PLAIN MODS
 */
 .email-sub--plain,
-.email-sub--plaindark
-{
+.email-sub--plaindark,
+.email-sub--plaintone {
     .email-sub__header,
     .email-sub__label,
     .email-sub__small {

--- a/static/src/stylesheets/module/email/_vars.scss
+++ b/static/src/stylesheets/module/email/_vars.scss
@@ -9,7 +9,7 @@ $rounded-adjustment: .66em;
 $tones: (
     (analysis, $analysis-accent, $news-default),
     (comment, $comment-support-4, $comment-support-4),
-    (feature, $feature-default, $feature-accent),
+    (feature, $feature-default, $feature-accent, $feature-mute),
     (live, $live-default, $live-accent),
     (media, $neutral-1, $neutral-1),
     (news, $news-default, $news-default),


### PR DESCRIPTION
This PR is all about email forms, they live in routes like [this](https://www.theguardian.com/email/form/article/2635) and [this](https://www.theguardian.com/email/form/plain/2635). These forms are used inside iframes to create our email CTAs

Email forms are useful - they allow us to give the subscription confirmation in an iframe and avoid a whole page refresh

## What does this change?

Adds `plaintone` as a new type of email sign up form to cover gap between `article` and `plain`

Adds a option to have an accent colour (other than grey) as the border around the input and submit. Currently only `feature` has this accent:

<img width="441" alt="picture 379" src="https://cloud.githubusercontent.com/assets/8607683/20630661/426f05b0-b32a-11e6-918f-d3e26e118533.png">

`plaintone` will inherit colours based on the theme/tone specified in `EmailSignupController.scala` (feature, media, comment)

## What is the value of this and can you measure success?

🌈 Colour! 🌈

Ever wanted to have an email sign up with the fabulous colourations of the `article` version, without the pesky headline and label? Now you can!

The standalone [sign up pages](https://www.theguardian.com/signup/weekendreading) can start using these colourful iframes to prevent the new page on `submit`.

Allows a migration of email CTAs that are currently using `article` for colour, that have to run JS over the page to hide or alter the headline. (Go [here](https://www.theguardian.com/info/2016/feb/15/sign-up-to-the-media-briefing), disable JS and see what happens)

Gives the potential to retire `plaindark` (which I think is used for Documentaries) as `plaintone` could be used in it's place, with the `media` theme. Target for a future PR once usages have been checked.

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

###### `article` version of the email sign up (contains the headline and label)

<img width="440" alt="picture 382" src="https://cloud.githubusercontent.com/assets/8607683/20630730/a1d88fc6-b32a-11e6-955c-0adaad532e98.png">

###### `plain` version is always brand blue

<img width="440" alt="picture 381" src="https://cloud.githubusercontent.com/assets/8607683/20630797/0c5ef862-b32b-11e6-8f9f-39cb1b3f9a8d.png">

###### new, shiny `plaintone` version will be whatever colour you specify in `EmailSignupController.scala`

<img width="442" alt="picture 383" src="https://cloud.githubusercontent.com/assets/8607683/20632408/3570a534-b335-11e6-90de-9005cb0b51de.png">


<img width="442" alt="picture 380" src="https://cloud.githubusercontent.com/assets/8607683/20630724/9b2a63c0-b32a-11e6-9b73-909cbcdcba95.png">

###### example usage (bonus - this is in an interactive atom):

<img width="652" alt="picture 376" src="https://cloud.githubusercontent.com/assets/8607683/20632144/42dd35cc-b333-11e6-8e84-e02222b038d3.png">

## Request for comment

@shtukas @superfrank 
