### PR TITLE
Update default section to News for the New Nav

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -422,7 +422,7 @@ object NewNavigation {
       }
 
       if (sectionList.isEmpty) {
-        ("", List())
+        ("News", News.getEditionalisedNavLinks(edition).drop(1))
       } else {
         val section = sectionList.head
         val parentSections = section.parentSection.getEditionalisedNavLinks(edition).drop(1)


### PR DESCRIPTION
## What does this change?
This change effects this:
![image](https://cloud.githubusercontent.com/assets/8774970/20664988/9eda9954-b555-11e6-8f67-c17ed0c413e4.png)

In this:
![image](https://cloud.githubusercontent.com/assets/8774970/20665000/aa1b4d40-b555-11e6-9467-33ce88af6bbb.png)

There are some sections which don't easily belong to a top level section. For these, the default should be News.

## What is the value of this and can you measure success?
There will always be a secondary/tertiary nav (need to get the terminology right)

## Does this affect other platforms - Amp, Apps, etc?
Nope!

## Request for comment
@guardian/dotcom-platform 
