### PR TITLE
Enable ad targeting of Observer content

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -170,6 +170,7 @@ define([
                 ref:     getReferrer(),
                 co:      parseIds(page.authorIds),
                 bl:      parseIds(page.blogIds),
+                ob:      config.page.publication === 'The Observer' ? 't' : '',
                 ms:      formatTarget(page.source),
                 fr:      getVisitedValue(),
                 tn:      uniq(compact([page.sponsorshipType].concat(parseIds(page.tones)))),

--- a/static/test/javascripts/spec/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/commercial/build-page-targeting.spec.js
@@ -148,7 +148,7 @@ define([
         });
 
         it('should not set Observer flag for Guardian content', function () {
-            config.page.publication = 'theguardian.com';
+            config.page.publication = 'The Guardian';
             expect(buildPageTargeting().ob).toEqual(undefined);
         });
 

--- a/static/test/javascripts/spec/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/commercial/build-page-targeting.spec.js
@@ -38,18 +38,19 @@ define([
                     krux = arguments[7];
 
                     config.page = {
-                        edition:     'US',
-                        contentType: 'Video',
-                        isSurging:   true,
-                        source: 'ITN',
-                        tones: 'News',
-                        authorIds: 'profile/gabrielle-chan',
-                        sponsorshipType: 'advertisement-features',
-                        seriesId: 'film/series/filmweekly',
-                        pageId: 'football/series/footballweekly',
-                        keywordIds: 'uk-news/prince-charles-letters,uk/uk,uk/prince-charles',
-                        blogIds: 'a/blog',
-                        videoDuration: 63
+                        authorIds:          'profile/gabrielle-chan',
+                        blogIds:            'a/blog',
+                        contentType:        'Video',
+                        edition:            'US',
+                        isSurging:          true,
+                        keywordIds:         'uk-news/prince-charles-letters,uk/uk,uk/prince-charles',
+                        pageId:             'football/series/footballweekly',
+                        publication:        'The Observer',
+                        seriesId:           'film/series/filmweekly',
+                        source:             'ITN',
+                        sponsorshipType:    'advertisement-features',
+                        tones:              'News',
+                        videoDuration:      63
                     };
 
                     config.ophan = {
@@ -140,6 +141,15 @@ define([
 
         it('should set correct krux params', function () {
             expect(buildPageTargeting().x).toEqual(['E012712', 'E012390', 'E012478']);
+        });
+
+        it('should set Observer flag for Observer content', function () {
+            expect(buildPageTargeting().ob).toEqual('t');
+        });
+
+        it('should not set Observer flag for Guardian content', function () {
+            config.page.publication = 'theguardian.com';
+            expect(buildPageTargeting().ob).toEqual(undefined);
         });
 
         it('should remove empty values', function () {


### PR DESCRIPTION
This change adds a parameter to ad calls to identify Observer content.

The ad call will have an extra parameter, `ob=t`, in Observer content, and this param will be omitted in ad calls for other content.

/cc @guardian/commercial-dev 