### PR TITLE
Remove AkkaAsync object (relies on Play global object, expired in Play 2.5)

### DIFF
--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -1,9 +1,8 @@
 package common
 
 import akka.agent.Agent
-import play.api.libs.concurrent.{Akka => PlayAkka}
 import scala.concurrent.duration._
-import play.api.{Mode, Environment, Play}
+import play.api.{Mode, Environment}
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 
@@ -33,8 +32,3 @@ class AkkaAsync(env: Environment, actorSystem: ActorSystem) {
     actorSystem.scheduler.scheduleOnce(delay)(body)
   }
 }
-
-object AkkaAsync extends AkkaAsync(
-  env = Environment(Play.current.path, Play.current.classloader, Play.current.mode),
-  actorSystem = PlayAkka.system(Play.current)
-)

--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -4,7 +4,7 @@ import app.LifecycleComponent
 import common._
 import conf.Configuration
 import play.api.inject.ApplicationLifecycle
-
+import scala.concurrent.duration._
 import scala.concurrent.{Future, ExecutionContext}
 
 class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)
@@ -15,6 +15,9 @@ class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
   }}
 
   override def start(): Unit = {
+
+    Switches.all.foreach(_.failInitializationAfter(2.minutes)(akkaAsync))
+
     jobs.deschedule("SwitchBoardRefreshJob")
     //run every minute, 47 seconds after the minute
     jobs.schedule("SwitchBoardRefreshJob", "47 * * * * ?") {

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeoutException
 
 import common._
 import org.joda.time.{DateTime, DateTimeZone, Days, LocalDate}
-import play.api.Play
 
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
@@ -40,19 +39,15 @@ trait Initializable[T] extends ExecutionContexts with Logging {
 
   private val initialized = Promise[T]()
 
-  protected val initializationTimeout: FiniteDuration = 2.minutes
-
-  if (Play.maybeApplication.isDefined) {
-    AkkaAsync.after(initializationTimeout) {
+  def initialize(t: T): Unit = initialized.trySuccess(t)
+  def onInitialized: Future[T] = initialized.future
+  def failInitializationAfter(initializationTimeout: FiniteDuration)(akkaAsync: AkkaAsync) = {
+    akkaAsync.after(initializationTimeout) {
       initialized.tryFailure {
         new TimeoutException(s"Initialization timed out after $initializationTimeout")
       }
     }
   }
-
-  def initialized(t: T): Unit = initialized.trySuccess(t)
-
-  def onInitialized: Future[T] = initialized.future
 }
 
 case class Owner(name: Option[String], github: Option[String], email: Option[String])
@@ -88,13 +83,13 @@ case class Switch(
     if (isSwitchedOff) {
       delegate.switchOn()
     }
-    initialized(this)
+    initialize(this)
   }
   def switchOff(): Unit = {
     if (isSwitchedOn) {
       delegate.switchOff()
     }
-    initialized(this)
+    initialize(this)
   }
   def switchToSafeState(): Unit = {
     if (safeState == On) {
@@ -102,7 +97,7 @@ case class Switch(
     } else {
       delegate.switchOff()
     }
-    initialized(this)
+    initialize(this)
   }
 
   Switch.switches.send(this :: _)


### PR DESCRIPTION
## What does this change?

Remove AkkaAsync object (relies on Play global object, expired in Play 2.5)

Instead of having each switch responsible for failing if not initialized after timeout, this responsibility falls in the SwitchboardLifecycle

## What is the value of this and can you measure success?
=> Play 2.5

## Request for comment
@alexduf @jfsoul @DiegoVazquezNanini 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
