### PR TITLE
Add cors to quiz endpoints

### DIFF
--- a/diagnostics/app/controllers/QuizzesController.scala
+++ b/diagnostics/app/controllers/QuizzesController.scala
@@ -1,12 +1,10 @@
 package controllers
 
 import common._
-import model.Cached.WithoutRevalidationResult
-import model.{Cors, TinyResponse, Cached}
+import model.{TinyResponse, Cors}
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext.Implicits
-import scala.concurrent.Future
 
 // Deprecated service, we won't support quiz results soon.
 class QuizzesController extends Controller with Logging {
@@ -15,9 +13,7 @@ class QuizzesController extends Controller with Logging {
 
   def results(quizId: String) = Action { implicit request => Cors(NotFound("")) }
 
-  def update() = Action.async(parse.json) { implicit request =>
-    Future.successful(Cached(3600)(WithoutRevalidationResult(NotFound(""))))
-  }
+  def update() = Action { implicit request => Cors(NotFound("")) }
 
   def resultsOptions(id: String) = Action { implicit request =>
     TinyResponse.noContent(Some("GET, OPTIONS"))

--- a/diagnostics/app/controllers/QuizzesController.scala
+++ b/diagnostics/app/controllers/QuizzesController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import common._
 import model.Cached.WithoutRevalidationResult
-import model.{TinyResponse, Cached}
+import model.{Cors, TinyResponse, Cached}
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext.Implicits
@@ -13,9 +13,7 @@ class QuizzesController extends Controller with Logging {
 
   implicit val ec = Implicits.global
 
-  def results(quizId: String) = Action.async { implicit request =>
-    Future.successful(Cached(3600)(WithoutRevalidationResult(NotFound(""))))
-  }
+  def results(quizId: String) = Action { implicit request => Cors(NotFound("")) }
 
   def update() = Action.async(parse.json) { implicit request =>
     Future.successful(Cached(3600)(WithoutRevalidationResult(NotFound(""))))


### PR DESCRIPTION
The quiz service is deprecated, but still needs cors whilst https://github.com/guardian/quiz-builder/blob/e9ba5bccc89a188a9192ba1ab75675db93d83708/static/js/quizzes/scores.js still exists.