### PR TITLE
method `route` in trait RouteInvokers is deprecated

### DIFF
--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -12,13 +12,13 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
 @DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with ExecutionContexts with ConfiguredTestSuite {
 
   "test redirects player card form submission to correct player page" in {
-    val Some(result) = route(FakeRequest(POST, "/admin/football/player/card", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("player" -> List("123456"), "team" -> List("1"), "competition" -> List("100"), "playerCardType" -> List("attack")))))
+    val Some(result) = route(app, FakeRequest(POST, "/admin/football/player/card", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("player" -> List("123456"), "team" -> List("1"), "competition" -> List("100"), "playerCardType" -> List("attack")))))
     status(result) should equal(SEE_OTHER)
     redirectLocation(result) should equal(Some("/admin/football/player/card/competition/attack/123456/1/100"))
   }
 
   "test player card renders correctly" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/player/card/competition/attack/237670/19/100"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/player/card/competition/attack/237670/19/100"))
     status(result) should equal(OK)
     val content = contentAsString(result)
 
@@ -26,7 +26,7 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
   }
 
   "test player card renders correctly for date instead of competition" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/player/card/date/attack/237670/19/20140101"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/player/card/date/attack/237670/19/20140101"))
     status(result) should equal(OK)
     val content = contentAsString(result)
 
@@ -34,14 +34,14 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
   }
 
   "test can load autocomplete JSON for a team's squad" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/api/squad/19"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/api/squad/19"))
     status(result) should equal(OK)
     val content = contentAsJson(result)
     (content \ "players").as[List[JsObject]] should contain(JsObject(Seq("label" -> JsString("Hugo Lloris"), "value" -> JsString("299285"))))
   }
 
   "test can return json when json format supplied" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/player/card/date/attack/237670/19/20140101.json"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/player/card/date/attack/237670/19/20140101.json"))
     status(result) should equal(OK)
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -15,7 +15,7 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
 
 
   "test index page loads" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football"))
     status(result) should equal(OK)
   }
 }

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -23,7 +23,7 @@ import scala.language.postfixOps
     with WithTestEnvironment {
 
   "test tables index page loads with leagues" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/tables"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/tables"))
     status(result) should equal(OK)
     val content = contentAsString(result)
     PA.competitionNames
@@ -33,25 +33,25 @@ import scala.language.postfixOps
   }
 
   "submitting a choice of league redirects to the correct table page" in {
-    val Some(result) = route(FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("none")))))
+    val Some(result) = route(app, FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("none")))))
     status(result) should equal(SEE_OTHER)
     redirectLocation(result) should equal(Some("/admin/football/tables/league/100"))
   }
 
   "submitting league with 'focus' redirects to focus of selected league" in {
-    val Some(resultTop) = route(FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("top")))))
+    val Some(resultTop) = route(app, FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("top")))))
     status(resultTop) should equal(SEE_OTHER)
     redirectLocation(resultTop) should equal(Some("/admin/football/tables/league/100/top"))
 
-    val Some(resultBottom) = route(FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("bottom")))))
+    val Some(resultBottom) = route(app, FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("bottom")))))
     status(resultBottom) should equal(SEE_OTHER)
     redirectLocation(resultBottom) should equal(Some("/admin/football/tables/league/100/bottom"))
 
-    val Some(resultTeam) = route(FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("team"), ("teamId", List("19"))))))
+    val Some(resultTeam) = route(app, FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("competitionId" -> List("100"), "focus" -> List("team"), ("teamId", List("19"))))))
     status(resultTeam) should equal(SEE_OTHER)
     redirectLocation(resultTeam) should equal(Some("/admin/football/tables/league/100/19"))
 
-    val Some(resultTeams) = route(FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(
+    val Some(resultTeams) = route(app, FakeRequest(POST, "/admin/football/tables/league", FakeHeaders(), AnyContentAsFormUrlEncoded(
       Map("competitionId" -> List("100"), "focus" -> List("team"), ("teamId", List("19")), ("team2Id", List("1006")))
     )))
     status(resultTeams) should equal(SEE_OTHER)
@@ -59,7 +59,7 @@ import scala.language.postfixOps
   }
 
   "can show full table for selected league" in {
-    val Some(result) = route(FakeRequest(GET, "/admin/football/tables/league/100"))
+    val Some(result) = route(app, FakeRequest(GET, "/admin/football/tables/league/100"))
     status(result) should equal(OK)
     val content = contentAsString(result)
     content should include("Tottenham Hotspur")

--- a/onward/test/RelatedControllerTest.scala
+++ b/onward/test/RelatedControllerTest.scala
@@ -26,7 +26,7 @@ import services.OphanApi
       .withHeaders("host" -> "http://localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val Some(result) = route(fakeRequest)
+    val Some(result) = route(app, fakeRequest)
     status(result) should be(200)
     contentType(result).get should be("application/json")
     contentAsString(result) should startWith("{\"html\"")


### PR DESCRIPTION
## What does this change?
Using the version of `route` method that takes an application as param

## What is the value of this and can you measure success?
remove depreciation warning in Play 2.5

## Request for comment
@alexduf @jfsoul @DiegoVazquezNanini 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
