### PR TITLE
CSRFAddToken and CSRFCheck object are deprecated

### DIFF
--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -15,6 +15,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
+import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -45,4 +46,8 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
+
+  // this is a workaround while waiting for https://github.com/playframework/playframework/pull/6325/files to be merged and release as a play-2.5.x version
+  lazy val csrfCheck: CSRFCheck = new CSRFCheck(csrfConfig, csrfTokenSigner)
+  lazy val csrfAddToken: CSRFAddToken = new CSRFAddToken(csrfConfig, csrfTokenSigner)
 }

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -11,14 +11,13 @@ import play.api.data.Forms._
 import play.api.data._
 import play.api.data.validation._
 import play.api.mvc.{Action, RequestHeader, Result}
-import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
+import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import conf.switches.Switches.LongCacheCommentsSwitch
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionApiLike) extends DiscussionController with ExecutionContexts {
+class CommentsController(val discussionApi: DiscussionApiLike, csrfCheck: CSRFCheck, csrfAddToken: CSRFAddToken) extends DiscussionController with ExecutionContexts {
 
   val userForm = Form(
     Forms.mapping(
@@ -69,7 +68,7 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
     Some(SectionSummary.fromId("Discussion")),
     "Report Abuse"
   ))
-  def reportAbuseForm(commentId: Int) = CSRFAddToken({
+  def reportAbuseForm(commentId: Int) = csrfAddToken.apply {
     Action {
       implicit request =>
 
@@ -77,7 +76,7 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
           Ok(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm))
         }
     }
-  }, csrfConfig)
+  }
 
   val reportAbuseThankYouPage = SimplePage(MetaData.make(
     "/reportAbuseThankYou",
@@ -105,7 +104,7 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
 
   }
 
-  def reportAbuseSubmission(commentId: Int) = CSRFCheck({
+  def reportAbuseSubmission(commentId: Int) = csrfAddToken.apply {
     Action.async { implicit request =>
     val scGuU = request.cookies.get("SC_GU_U")
       userForm.bindFromRequest.fold(
@@ -121,7 +120,7 @@ class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionAp
         }
       )
     }
-  }, config = csrfConfig)
+  }
 
   private def getComments(key: DiscussionKey, optParams: Option[DiscussionParams] = None)(implicit request: RequestHeader): Future[Result] = {
     val params = optParams.getOrElse(DiscussionParams(request))

--- a/discussion/app/controllers/DiscussionControllers.scala
+++ b/discussion/app/controllers/DiscussionControllers.scala
@@ -3,11 +3,13 @@ package controllers
 import com.softwaremill.macwire._
 import discussion.api.DiscussionApi
 import play.api.libs.ws.WSClient
-import play.filters.csrf.CSRFComponents
+import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFComponents}
 
-trait DiscussionControllers extends CSRFComponents {
+trait DiscussionControllers {
   def wsClient: WSClient
   def discussionApi: DiscussionApi
+  def csrfCheck: CSRFCheck
+  def csrfAddToken: CSRFAddToken
   lazy val commentCountController = wire[CommentCountController]
   lazy val commentsController = wire[CommentsController]
   lazy val ctaController = wire[CtaController]

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -4,12 +4,17 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import controllers.CommentsController
 import discussion.model.DiscussionKey
-import play.filters.csrf.CSRFConfig
+import play.api.libs.crypto.CSRFTokenSigner
+import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
 
 @DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithMaterializer with WithTestWsClient {
 
+  lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(app.configuration)
+  lazy val csrfCheck = new CSRFCheck(csrfConfig, app.injector.instanceOf[CSRFTokenSigner])
+  lazy val csrfAddToken = new CSRFAddToken(csrfConfig, app.injector.instanceOf[CSRFTokenSigner])
+
   "Discussion" should "return 200" in {
-    val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration), new DiscussionApiStub(wsClient))
+    val commentsController = new CommentsController(new DiscussionApiStub(wsClient), csrfCheck, csrfAddToken)
     val result = commentsController.comments(DiscussionKey("p/37v3a"))(TestRequest())
     status(result) should be(200)
   }

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -20,7 +20,9 @@ class ChangePasswordController( api: IdApiClient,
                                 authenticationService: AuthenticationService,
                                 idRequestParser: IdRequestParser,
                                 idUrlBuilder: IdentityUrlBuilder,
-                                val messagesApi: MessagesApi)
+                                val messagesApi: MessagesApi,
+                                csrfCheck: CSRFCheck,
+                                csrfAddToken: CSRFAddToken)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms with I18nSupport{
 
   import authenticatedActions.authAction
@@ -49,7 +51,7 @@ class ChangePasswordController( api: IdApiClient,
       )
   )
 
-  def displayForm() = CSRFAddToken {
+  def displayForm() = csrfAddToken.apply {
     authAction.async {
       implicit request =>
 
@@ -70,7 +72,7 @@ class ChangePasswordController( api: IdApiClient,
     NoCache(Ok(views.html.password.passwordResetConfirmation(page, idRequest, idUrlBuilder, userIsLoggedIn)))
   }
 
-  def submitForm() = CSRFCheck{
+  def submitForm() = csrfCheck {
     authAction.async {
       implicit request =>
         val idRequest = idRequestParser(request)

--- a/identity/app/controllers/EmailController.scala
+++ b/identity/app/controllers/EmailController.scala
@@ -22,7 +22,9 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
                       idRequestParser: IdRequestParser,
                       idUrlBuilder: IdentityUrlBuilder,
                       authenticatedActions: AuthenticatedActions,
-                      val messagesApi: MessagesApi)
+                      val messagesApi: MessagesApi,
+                      csrfCheck: CSRFCheck,
+                      csrfAddToken: CSRFAddToken)
   extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
   import EmailPrefsData._
   import authenticatedActions.authAction
@@ -30,7 +32,7 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
   val page = IdentityPage("/email-prefs", "Email preferences")
   protected def formActionUrl(idUrlBuilder: IdentityUrlBuilder, idRequest: IdentityRequest): String = idUrlBuilder.buildUrl("/email-prefs", idRequest)
 
-  def preferences = CSRFAddToken {
+  def preferences = csrfAddToken {
     authAction.async { implicit request =>
       val idRequest = idRequestParser(request)
       val userId = request.user.getId()
@@ -63,7 +65,7 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
     }
   }
 
-  def savePreferences = CSRFCheck {
+  def savePreferences = csrfCheck {
     authAction.async { implicit request =>
 
       val idRequest = idRequestParser(request)

--- a/identity/app/controllers/IdentityControllers.scala
+++ b/identity/app/controllers/IdentityControllers.scala
@@ -6,13 +6,14 @@ import form.FormComponents
 import formstack.FormStackComponents
 import idapiclient.IdApiComponents
 import play.api.libs.ws.WSClient
-import play.filters.csrf.CSRFCheck
+import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import services.IdentityServices
 
 trait IdentityControllers extends IdApiComponents with IdentityServices with FormStackComponents with FormComponents {
   def wsClient: WSClient
 
   def csrfCheck: CSRFCheck
+  def csrfAddToken: CSRFAddToken
 
   lazy val authenticatedActions = wire[AuthenticatedActions]
   lazy val changePasswordController = wire[ChangePasswordController]

--- a/identity/app/controllers/ThirdPartyConditionsController.scala
+++ b/identity/app/controllers/ThirdPartyConditionsController.scala
@@ -10,7 +10,7 @@ import idapiclient.IdApiClient
 import model.{IdentityPage, NoCache}
 import play.api.i18n.MessagesApi
 import play.api.mvc._
-import play.filters.csrf.CSRFAddToken
+import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import services._
 import utils.SafeLogging
 
@@ -22,14 +22,15 @@ class ThirdPartyConditionsController(returnUrlVerifier: ReturnUrlVerifier,
                                      api: IdApiClient,
                                      idUrlBuilder: IdentityUrlBuilder,
                                      authenticatedActions: AuthenticatedActions,
-                                     val messagesApi: MessagesApi)
+                                     val messagesApi: MessagesApi,
+                                     csrfAddToken: CSRFAddToken)
   extends Controller with ExecutionContexts with SafeLogging with Mappings {
 
   import authenticatedActions.{agreeAction, authAction}
 
   val page = IdentityPage("/agree", "Terms and Conditions")
 
-  def renderAgree(groupCode: String) = CSRFAddToken {
+  def renderAgree(groupCode: String) = csrfAddToken {
     agreeAction(redirectToSignInWithThirdPartyConditions).async { implicit request =>
       val userId = request.user.getId()
       val idRequest = idRequestParser(request)
@@ -59,7 +60,7 @@ class ThirdPartyConditionsController(returnUrlVerifier: ReturnUrlVerifier,
     }
   }
 
-  def agree(groupCode: String, returnUrl: Option[String]) = CSRFAddToken {
+  def agree(groupCode: String, returnUrl: Option[String]) = csrfAddToken {
     authAction.async { implicit request =>
       api.addUserToGroup(groupCode, request.user.auth).map(_ =>
         SeeOther(returnUrlVerifier.getVerifiedReturnUrl(returnUrl).getOrElse(returnUrlVerifier.defaultReturnUrl))

--- a/identity/test/controllers/EmailControllerTest.scala
+++ b/identity/test/controllers/EmailControllerTest.scala
@@ -5,7 +5,7 @@ import com.gu.identity.cookie.GuUCookieData
 import org.mockito.Matchers
 import org.scalatest.{DoNotDiscover, ShouldMatchers, WordSpec}
 import play.api.libs.crypto.CSRFTokenSigner
-import play.filters.csrf.{CSRFAddToken, CSRFConfig}
+import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
 import services._
 import services.{ReturnUrlVerifier, IdRequestParser, IdentityUrlBuilder}
 import idapiclient.{ScGuU, IdApiClient}
@@ -27,6 +27,7 @@ import actions.AuthenticatedActions
 @DoNotDiscover class EmailControllerTest extends WordSpec with ShouldMatchers with MockitoSugar with ConfiguredTestSuite {
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(app.configuration)
+  lazy val csrfCheck = new CSRFCheck(csrfConfig, app.injector.instanceOf[CSRFTokenSigner])
   lazy val csrfAddToken = new CSRFAddToken(csrfConfig, app.injector.instanceOf[CSRFTokenSigner])
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]
@@ -54,7 +55,7 @@ import actions.AuthenticatedActions
   when(idRequest.trackingData) thenReturn trackingData
 
   when(idUrlBuilder.buildUrl(any[String], any[IdentityRequest], any[(String, String)])) thenReturn "/email-prefs"
-  lazy val emailController = new EmailController(returnUrlVerifier, conf, api, idRequestParser, idUrlBuilder, authenticatedActions, I18NTestComponents.messagesApi)
+  lazy val emailController = new EmailController(returnUrlVerifier, conf, api, idRequestParser, idUrlBuilder, authenticatedActions, I18NTestComponents.messagesApi, csrfCheck, csrfAddToken)
 
   "The preferences method" when {
     val testRequest = TestRequest()


### PR DESCRIPTION
## What does this change?
Using the class instead

## What is the value of this and can you measure success?
Play 2.5 compliant 🎉 

## Request for comment
@alexduf @DiegoVazquezNanini @jfsoul 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

