### PR TITLE
Load interactives from standard if not in Webpack test

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -76,7 +76,7 @@ define([
          *  Interactives are content, we want them booting as soon (and as stable) as possible.
          */
 
-        if (!config.switches.abWebpack && /Article|LiveBlog/.test(config.page.contentType)) {
+        if (!config.tests.abWebpack && /Article|LiveBlog/.test(config.page.contentType)) {
             qwery('figure.interactive').forEach(function (el) {
                 var mainJS = el.getAttribute('data-interactive');
                 if (!mainJS) {


### PR DESCRIPTION
## What does this change?

If user is not participating in the Webpack test, we should load interactives in the standard JS bootstrap. Previously, we prevented interactives from loading if the Webpack switch was on.

## What is the value of this and can you measure success?

Fix interactives for users not participating in the Webpack test

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 137](https://cloud.githubusercontent.com/assets/5931528/20705708/f395f6d4-b61b-11e6-8213-2c506d25ea84.png)

## Request for comment

@gtrufitt @jfsoul 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

