### PR TITLE
Load interactives inline in interactiveBody

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -68,7 +68,7 @@
         </div>
     }
 
-    @if(WebpackTest.isParticipating) {
+    @if(!WebpackTest.isParticipating) {
         <script>
             @HtmlFormat.raw(common.Assets.js.curl)
 

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -30,7 +30,8 @@
 @if(WebpackTest.isParticipating &&
     (
         page.metadata.contentType == "Article" ||
-        page.metadata.contentType == "LiveBlog"
+        page.metadata.contentType == "LiveBlog" ||
+        page.metadata.contentType == "Interactive"
     )
 ) {
 


### PR DESCRIPTION
## What does this change?

In Interactive articles, interactive boot scripts are loaded if user is participating in the Webpack test.

This change ensures interactive boot scripts are loaded regardless of whether the user is participating in the Webpack test. 

## What is the value of this and can you measure success?

Fixes interactive articles for non-Webpack users.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Request for comment

@gtrufitt @jfsoul @NataliaLKB 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

