### PR TITLE
Improve printing

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -38,8 +38,14 @@ figure {
     display: none !important;
 }
 
-.sudoku figure {
-    display: block !important;
+figure {
+    &.element-image,
+    &.media-primary,
+
+    .sudoku &,
+    .gallery__item & {
+        display: block !important;
+    }
 }
 
 * {
@@ -56,10 +62,20 @@ figure {
     position: static;
 }
 
-.responsive-img,
-.gu-image {
+.element-image {
+    display: block;
+    position: relative !important;
     width: 50% !important;
     margin-right: 10px !important;
+}
+
+.gu-image,
+.u-responsive-ratio img {
+    position: relative !important;
+}
+
+.is-immersive-interactive .element-interactive {
+    display: block !important;
 }
 
 figcaption {


### PR DESCRIPTION
## What does this change?

Quick fix of some print styles to make printing stuff a bit better.

## What is the value of this and can you measure success?

We've never had those most beautiful printed articles, but this at least adds images back in and allows printing things like cartoons, immersive interactives and galleries for user's enjoyment.

## Screenshots

| Before        | After           | 
| ------------- |-------------:|
| ![screen shot 2016-11-29 at 12 08 15](https://cloud.githubusercontent.com/assets/638051/20709393/fd46c10c-b62c-11e6-9e98-d504e2a2916e.jpg)  |  ![screen shot 2016-11-29 at 11 53 08](https://cloud.githubusercontent.com/assets/638051/20709407/0c86ee44-b62d-11e6-8200-1026024920c3.jpg)  | 
| ![screen shot 2016-11-29 at 11 55 19](https://cloud.githubusercontent.com/assets/638051/20709418/1abb8100-b62d-11e6-9276-d880a3f1c522.jpg)    |  ![screen shot 2016-11-29 at 11 57 26](https://cloud.githubusercontent.com/assets/638051/20709422/22c4dfa4-b62d-11e6-8d08-b92659fb7e29.jpg)   | 
|  ![screen shot 2016-11-29 at 11 58 12](https://cloud.githubusercontent.com/assets/638051/20709429/2da3a018-b62d-11e6-8f5f-0c1bf304dbec.jpg) | ![screen shot 2016-11-29 at 12 04 19](https://cloud.githubusercontent.com/assets/638051/20709435/366d8056-b62d-11e6-8454-0039024176e5.jpg) |
| ![screen shot 2016-11-29 at 12 06 14](https://cloud.githubusercontent.com/assets/638051/20709439/436e0fb4-b62d-11e6-8d81-1f48c0126d21.jpg) | ![screen shot 2016-11-29 at 12 06 18](https://cloud.githubusercontent.com/assets/638051/20709443/4a89c126-b62d-11e6-96cf-43eb3f631ee2.jpg) Because @desbo would kill me if I broke this one. |

 

## Request for comment

@guardian/dotcom-platform 

