### PR TITLE
Email card design

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -7,6 +7,7 @@ sealed trait EmailMetadata[T] extends Product with Serializable {
   def name: String
   def banner: Option[String] = None
   def address: Option[String] = None
+  def toneColour: Option[String] = None
   def test(c: T): Boolean
 }
 
@@ -130,11 +131,13 @@ case object KeepItInTheGround extends ArticleEmailMetadata {
 case object TheFlyer extends FrontEmailMetadata {
   val name = "The Flyer"
   override val banner = Some("the-flyer.png")
+  override val toneColour = Some("#ffbdc6")
 }
 
 object EmailAddons {
   private val defaultAddress = "Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396"
   private val defaultBanner = "generic.png"
+  private val defaultToneColour = "#005689"
   private val articleEmails     = Seq(
     ArtWeekly,
     DocumentariesUpdate,
@@ -172,6 +175,8 @@ object EmailAddons {
       val banner = email flatMap (_.banner) getOrElse defaultBanner
       Static(s"images/email/banners/$banner")
     }
+
+    lazy val toneColour = email flatMap (_.toneColour) getOrElse defaultToneColour
 
     lazy val address = email flatMap (_.address) getOrElse defaultAddress
   }

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -1,4 +1,6 @@
-@()
+@(page: model.Page)
+
+@import model.EmailAddons.EmailContentType
 
 <style>
     body, .body {
@@ -20,27 +22,28 @@
     }
 
     .container-title {
-        color: #005689;
+        color: #323333;
         padding-top: 4px;
     }
     .container-title--not-first {
-        border-top: 3px solid #4bc6df;
+        border-top: 3px solid @page.toneColour;
     }
 
     .facia-card {
         display: block;
         text-decoration: none;
+        padding-bottom: 20px;
     }
 
     .headline, .trail-text {
-        font-weight: bold;
         font-size: 16px;
         line-height: 20px;
         margin: 0;
         color: inherit;
     }
 
-    .facia-card .headline {
+    .facia-card .headline,
+    .facia-card .trail-text {
         padding: 5px 10px;
     }
 
@@ -48,11 +51,6 @@
         font-size: 20px;
         line-height: 24px;
         color: inherit;
-        padding: 5px 10px;
-    }
-
-    .facia-card--large .trail-text {
-        padding: 5px 10px 20px;
     }
 
     .kicker-separator {

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -60,4 +60,27 @@
     .headline .icon {
         height: 0.8em;
     }
+
+
+    /* Reduce max width */
+
+    table.twelve {
+        width: 500px;
+    }
+
+    table.twelve center {
+        min-width: 500px;
+    }
+
+    .block-grid {
+        max-width: 500px;
+    }
+
+    center {
+        min-width: 500px;
+    }
+
+    table.container {
+        width: 500px;
+    }
 </style>

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -17,7 +17,7 @@
     }
 
     .panel {
-        padding: 5px 10px !important;
+        padding: 5px 0 !important;
         border: none;
     }
 

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -4,7 +4,7 @@
 
 <style>
     body, .body {
-        background: #e5e5e5;
+        background: #ffffff;
     }
 
     .full-width {
@@ -13,7 +13,7 @@
 
     .container,
     .panel {
-        background: #eaeaea;
+        background: #ffffff;
     }
 
     .panel {

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -23,6 +23,7 @@
         border-top: 1px solid pink;
         background-color: #951c55;
     }
+
     .tone-feature .headline {
         color: #fff;
     }

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -32,7 +32,7 @@
         @fragments.email.stylesheets.footer()
 
         @if(page.metadata.isFront) {
-            @fragments.email.stylesheets.front()
+            @fragments.email.stylesheets.front(page)
             @fragments.email.stylesheets.tones()
         }
     </head>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -48,21 +48,10 @@
 }
 
 @faciaCardSmall(pressedContent: PressedContent) = {
-    @paddedRow(Seq("sub-grid")) {
+    @paddedRow {
         @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
             <a @Html(href) class="facia-card @toneClass(pressedContent)">
-                <table>
-                    <tr>
-                        <td class="seven sub-columns">
-                            @headline(pressedContent)
-                        </td>
-                        <td class="five sub-columns last">
-                            @imageUrlFromPressedContent(pressedContent).map { url =>
-                                <img width="580" class="full-width" src="@url" />
-                            }
-                        </td>
-                    </tr>
-                </table>
+                @headline(pressedContent)
             </a>
         }
     }


### PR DESCRIPTION
Myriad design tweaks to the front email:

- no internal padding on container
- remove the ugly faux-bold
- border colour, configurable per email
- white background
- black container titles
- reduce fixed width of desktop container
- no images on small cards
- as a consequence, bottom padding on cards themselves rather than trail text (since we now need it on cards which don’t have trail text)

#### before
![picture 339](https://cloud.githubusercontent.com/assets/5122968/20709620/5cd83f3c-b62e-11e6-8454-2cc2f3e8e752.png)

#### after
![picture 340](https://cloud.githubusercontent.com/assets/5122968/20709628/63e078a8-b62e-11e6-9879-cb48ebc6c36a.png)

@superfrank @desbo 
