### PR TITLE
Use custom banner for front emails

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -1,6 +1,8 @@
 @import layout.{FaciaCard, FaciaCardHeader}
 @import model.pressed.PressedContent
 @import layout.EditionalisedLink
+@import model.EmailAddons.EmailContentType
+
 @(page: model.PressedPage)(implicit request: RequestHeader)
 
 @import conf.Static
@@ -69,7 +71,7 @@
 }
 
 @fullRow {
-    <img width="580" class="full-width" src="@Static("images/email/banners/generic.png")">
+    @img(src = page.banner, alt = page.email.map(_.name))
 }
 
 @page.frontProperties.onPageDescription.map { description =>


### PR DESCRIPTION
Allow us to use the banner associated with a front email, so we can take advantage of work such as #15141 

This functionality already exists for article emails, so just ensuring front emails work the same way:
https://github.com/guardian/frontend/blob/master/article/app/views/fragments/emailArticleBody.scala.html#L11
https://github.com/guardian/frontend/blob/master/common/app/model/EmailAddons.scala

@superfrank @desbo 
@guardian/dotcom-platform 