### PR TITLE
Unify the deploy using Riff-Raff's the new riff-raff.yaml configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,8 @@ indent_size = 2
 [package.json]
 indent_size = 2
 
+[riff-raff.yaml]
+indent_size = 2
+
 [makefile]
 indent_style = tab

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -1,6 +1,7 @@
 package com.gu
 
 import com.gu.Dependencies._
+import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import com.typesafe.sbt.web.Import._
 import play.routes.compiler.InjectedRoutesGenerator
 import play.sbt.Play.autoImport._
@@ -251,5 +252,29 @@ object Frontend extends Build with Prototypes {
     trainingPreview,
     rss,
     adminJobs
+  ).settings(
+    riffRaffBuildIdentifier := System.getenv().getOrDefault("BUILD_NUMBER", "0").replaceAll("\"",""),
+    riffRaffUploadArtifactBucket := Some(System.getenv().getOrDefault("RIFF_RAFF_ARTIFACT_BUCKET", "aws-frontend-teamcity")),
+    riffRaffUploadManifestBucket := Some(System.getenv().getOrDefault("RIFF_RAFF_BUILD_BUCKET", "aws-frontend-teamcity")),
+    riffRaffManifestProjectName := s"dotcom:all",
+    riffRaffArtifactResources := Seq(
+      (riffRaffPackageType in admin).value -> s"${(name in admin).value}/${(riffRaffPackageType in admin).value.getName}",
+      (riffRaffPackageType in adminJobs).value -> s"${(name in adminJobs).value}/${(riffRaffPackageType in adminJobs).value.getName}",
+      (riffRaffPackageType in applications).value -> s"${(name in applications).value}/${(riffRaffPackageType in applications).value.getName}",
+      (riffRaffPackageType in archive).value -> s"${(name in archive).value}/${(riffRaffPackageType in archive).value.getName}",
+      (riffRaffPackageType in article).value -> s"${(name in article).value}/${(riffRaffPackageType in article).value.getName}",
+      (riffRaffPackageType in commercial).value -> s"${(name in commercial).value}/${(riffRaffPackageType in commercial).value.getName}",
+      (riffRaffPackageType in diagnostics).value -> s"${(name in diagnostics).value}/${(riffRaffPackageType in diagnostics).value.getName}",
+      (riffRaffPackageType in discussion).value -> s"${(name in discussion).value}/${(riffRaffPackageType in discussion).value.getName}",
+      (riffRaffPackageType in identity).value -> s"${(name in identity).value}/${(riffRaffPackageType in identity).value.getName}",
+      (riffRaffPackageType in facia).value -> s"${(name in facia).value}/${(riffRaffPackageType in facia).value.getName}",
+      (riffRaffPackageType in faciaPress).value -> s"${(name in faciaPress).value}/${(riffRaffPackageType in faciaPress).value.getName}",
+      (riffRaffPackageType in onward).value -> s"${(name in onward).value}/${(riffRaffPackageType in onward).value.getName}",
+      (riffRaffPackageType in preview).value -> s"${(name in preview).value}/${(riffRaffPackageType in preview).value.getName}",
+      (riffRaffPackageType in rss).value -> s"${(name in rss).value}/${(riffRaffPackageType in rss).value.getName}",
+      (riffRaffPackageType in sport).value -> s"${(name in sport).value}/${(riffRaffPackageType in sport).value.getName}",
+      (riffRaffPackageType in trainingPreview).value -> s"${(name in trainingPreview).value}/${(riffRaffPackageType in trainingPreview).value.getName}",
+      baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml"
+    )
   )
 }

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -110,7 +110,7 @@ trait Prototypes {
 
   def frontendRootSettings= List(
     testAll := (test in Test).all(ScopeFilter(inAggregates(ThisProject, includeRoot = false))).value,
-    uploadAll := riffRaffUpload.all(ScopeFilter(inAggregates(ThisProject, includeRoot = false))).value,
+    uploadAll := riffRaffUpload.all(ScopeFilter(inAggregates(ThisProject, includeRoot = true))).value,
 
     testThenUpload := Def.taskDyn({
      testAll.result.value match {
@@ -146,7 +146,7 @@ trait Prototypes {
     }
   )
 
-  def root() = Project("root", base = file(".")).enablePlugins(PlayScala)
+  def root() = Project("root", base = file(".")).enablePlugins(PlayScala, RiffRaffArtifact)
     .settings(frontendCompilationSettings)
     .settings(frontendRootSettings)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.2.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.1")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,54 @@
+stacks:
+- frontend
+regions:
+- eu-west-1
+
+templates:
+  frontend:
+    type: autoscaling
+    parameters:
+      bucket: aws-frontend-artifacts
+    dependencies:
+    - static
+
+deployments:
+  admin:
+    template: frontend
+  admin-jobs:
+    template: frontend
+  applications:
+    template: frontend
+  archive:
+    template: frontend
+  article:
+    template: frontend
+  commercial:
+    template: frontend
+  diagnostics:
+    template: frontend
+  discussion:
+    template: frontend
+  facia:
+    template: frontend
+  facia-press:
+    template: frontend
+  identity:
+    template: frontend
+  onward:
+    template: frontend
+# this only exists in prod - a dummy zero sized ASG exists in code
+  preview:
+    template: frontend
+  rss:
+    template: frontend
+  sport:
+    template: frontend
+  static:
+    type: aws-s3
+    parameters:
+      bucket: aws-frontend-static
+      cacheControl: public, max-age=315360000
+      prefixStack: false
+# this only exists in prod - a dummy zero sized ASG exists in code
+  training-preview:
+    template: frontend


### PR DESCRIPTION
## What does this change?
Adds a unified deploy artifact to allow the whole of frontend to be deployed at once.

## What is the value of this and can you measure success?
This will simplify the deployment process considerably:
 - Fewer deploys visible in Riff-Raff (the individual applications will be grouped into one deploy)
 - No longer any need to use `goo`

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Request for comment
It should be possible to merge this without impacting any existing processes. 

At the moment we create both the existing individual deploys and also the unified deploy. The SBT config can be simplified once the old deploys are no longer used.

The new SBT config could also do with simplification, although so far I my weak SBT macro knowledge has not been able to solve it.

**WARNING:** Once merged it will be possible to deploy both types of deploy. Doing so simultaneously could cause serious issues with the stack, potentially leaving it in an inconsistent state.

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->