### PR TITLE
Remove Raven loader type

### DIFF
--- a/static/src/javascripts/projects/common/utils/raven.js
+++ b/static/src/javascripts/projects/common/utils/raven.js
@@ -26,8 +26,7 @@ define([
             tags: {
                 edition: config.page.edition,
                 contentType: config.page.contentType,
-                revisionNumber: config.page.revisionNumber,
-                loaderType: 'Curl'
+                revisionNumber: config.page.revisionNumber
             },
             dataCallback: function (data) {
                 if (data.culprit) {


### PR DESCRIPTION
This tag is not needed in Sentry, it's always Curl.