### PR TITLE
Hosted Video Page design updates

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -29,10 +29,7 @@
         color: @{page.campaign.fontColour.hexCode};
     }
 
-    .hosted-page ~ .survey-overlay-simple .
-
-
-    survey-text__header {
+    .hosted-page ~ .survey-overlay-simple .survey-text__header {
         background-color: @{page.campaign.fontColour.hexCode};
     }
 

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -70,7 +70,7 @@
             </div>
             <div class="content__main">
                 <div class="gs-container">
-                    <div class="content__main-column content__main-column--article js-content-main-column">
+                    <div class="hosted-article__main-column content__main-column content__main-column--article js-content-main-column">
                         <div class="content__meta-container js-content-meta js-football-meta u-cf content__meta-container--showcase">
                             <div class="meta__extras" data-component="share">
                             @guardianHostedShareButtons(page)
@@ -86,9 +86,15 @@
                                 case "packages" => { @singaporeF1Packages() }
                                 case _ => { @Html(page.body) }
                             }
-
+                            <div class="hosted__standfirst">
+                                <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
+                                    <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
+                                        <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about hosted-tone" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div class="hide-on-desktop">
+                        <div class="hosted__onward-journey">
                             @if(page.nextPages.nonEmpty) {
                                 @hostedOnwardJourney(page.nextPages.map { nextPage =>
                                     makeshiftPage(nextPage, page.campaign)
@@ -97,22 +103,6 @@
                                 <div class="js-onward-placeholder"></div>
                             }
                         </div>
-                        <div class="hosted__standfirst">
-                            <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
-                                <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
-                                    <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about hosted-tone" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="content__secondary-column">
-                        @if(page.nextPages.nonEmpty) {
-                            @hostedOnwardJourney(page.nextPages.map { nextPage =>
-                                makeshiftPage(nextPage, page.campaign)
-                            }, 2, 4)
-                        } else {
-                            <div class="js-onward-placeholder"></div>
-                        }
                     </div>
                 </div>
             </div>

--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -5,7 +5,7 @@
     <section class="host hosted__container--full">
         <div class="hosted__banner" @if(!isAMP) {style="background-image: url(@{cta.image});"}>
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">
-                <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown hosted-tone-bg">
+                <div class="hostedbadge hostedbadge--pushdown hosted-tone-bg">
                     @if(isAMP) {
                         <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}"></amp-img>
                     } else {

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -3,7 +3,7 @@
 
 <div class="hosted__header @pageCssClass">
     <div class="hosted__headerwrap js-hosted-headerwrap">
-        <div class="hostedbadge hostedbadge--shouldscale hosted-tone-bg">
+        <div class="hostedbadge hosted-tone-bg">
             <p class="hostedbadge__info">Advertiser content</p>
             <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
             @if(isAMP) {

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -147,9 +147,11 @@
             </div>
 
             @page.nextPage.map { nextPage =>
-                @hostedOnwardJourney(List(makeshiftPage(nextPage, page.campaign)), 1, 1)
+                <div class="hosted__next-page-wrapper">
+                    @hostedOnwardJourney(List(makeshiftPage(nextPage, page.campaign)), 1, 1)
+                </div>
             }.getOrElse {
-                <div class="js-onward-placeholder hosted__next-page-placeholder"></div>
+                <div class="js-onward-placeholder hosted__next-page-wrapper"></div>
             }
         </section>
         @guardianHostedCta(page, page.cta, isAMP = false)

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -89,7 +89,7 @@
                         <div class="hosted__meta">
                             <h1 class="hosted__heading">@{page.video.title}</h1>
                         </div>
-                        <div class="hostedbadge hostedbadge--shouldscale">
+                        <div class="hostedbadge">
                             <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
                                 <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
                             </a>

--- a/commercial/app/views/hosted/hostedOnwardJourney.scala.html
+++ b/commercial/app/views/hosted/hostedOnwardJourney.scala.html
@@ -8,7 +8,7 @@
 @if(trails.isEmpty) {
     <div></div>
 } else {
-    <div class="hosted__next-page hosted-article__next-page">
+    <div class="hosted__next-page">
         <div class="hosted__next-page--header">
             <div class="hosted__next-page-header--border hosted-tone-bg"></div>
             <h2 class="hosted__text hosted__next-page--more-from">More from</h2>

--- a/common/app/views/fragments/amp/stylesheets/hosted.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/hosted.scala.html
@@ -495,12 +495,6 @@
     margin: 0 0 0 90px;
 }
 
-.hosted-video__next-page-title {
-    padding: 10px;
-    font-size: 18px;
-    line-height: 20px;
-}
-
 .hosted__header {
     font-family: Helvetica, Arial sans-serif;
     width: 100%;

--- a/static/src/stylesheets/module/commercial/_hostedbadge.scss
+++ b/static/src/stylesheets/module/commercial/_hostedbadge.scss
@@ -8,11 +8,12 @@
     &:focus {
         text-decoration: none;
     }
-}
-
-.hostedbadge--shouldscale {
     @include mq(desktop) {
         width: 132px;
+        .hostedbadge__info {
+            text-align: center;
+            margin: 2px 0;
+        }
     }
 }
 
@@ -25,14 +26,12 @@
     font-size: 14px;
     font-weight: 600;
     letter-spacing: .5px;
-    line-height: 16px;
-
+    line-height: 15px;
     height: auto;
-    padding-top: $gs-gutter / 4;
-    padding-bottom: $gs-gutter / 2.5;
+    padding: 5px 6px 4px;
     color: $neutral-1;
     margin: 0;
-    text-align: center;
+    text-align: left;
 }
 
 .hostedbadge .hostedbadge__logo {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -1,4 +1,3 @@
-
 .hosted-article-page {
     .media-primary.media-primary--showcase {
         position: relative;
@@ -21,6 +20,9 @@
         .gs-container {
             height: 100%;
         }
+    }
+    article.content--article {
+        background: #ffffff;
     }
     .title {
         @include fs-textSans(4);
@@ -167,33 +169,30 @@
         }
     }
 
-    .hide-on-desktop {
-        .hosted__next-page {
-            margin: 30px 0 20px;
+    .hosted__onward-journey {
+        position: relative;
+        margin-top: $gs-baseline;
+
+        @include mq(tablet, desktop) {
+            margin-right: gs-span(1) + $gs-gutter;
+        }
+    }
+
+    @include mq(leftCol) {
+        .gs-container {
             position: relative;
         }
-        .hosted__next-page--header {
-            margin: 0;
+        .hosted-article__main-column {
+            position: static;
         }
-        .hosted__next-page--tile {
-            margin: 10px 0;
-        }
-    }
-    .content__secondary-column {
-        .hosted__next-page {
-            width: auto;
+        .hosted__onward-journey {
+            width: 300px;
             position: absolute;
-            margin: 70px 0;
-            top: 0;
-            right: 0;
-            left: #{2 * $gs-gutter};
-            .hosted__next-page--header,
-            .hosted__next-page--tile {
-                margin-right: 0;
-                margin-top: 0;
-            }
+            top: 58px;
+            right: $gs-gutter;
         }
     }
+
     .from-content-api {
         ul > li:before {
             border-radius: 0;
@@ -237,16 +236,11 @@
     margin-bottom: 10px;
 }
 
-.hosted__next-page .hosted__next-page--header {
-    border: 0;
-    padding: 0;
-}
-
 /* Hosted More From Carousel AB test */
 .hosted__next-page__carousel-arrows {
     position: absolute;
     right: 0;
-    top: 24px;
+    top: 16px;
 
     .inline-icon {
         display: inline-block;
@@ -378,7 +372,7 @@
         background: rgba(255, 255, 255, .9);
     }
 
-    &:hover .hosted-next-page__wrapper  {
+    &:hover .hosted-next-page__wrapper {
         background: rgba(255, 255, 255, .8);
     }
 }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -37,6 +37,15 @@
             }
         }
     }
+
+    .hosted__next-page {
+        margin: $gs-baseline $gs-gutter;
+        position: relative;
+        @include mq(leftCol) {
+            width: 300px;
+        }
+    }
+
 }
 
 .hosted__youtube-poster-image {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -23,11 +23,8 @@
 .hosted-video-page {
     .hosted__headerwrap {
         .hostedbadge {
-            @include mq(leftCol) {
+            @include mq(leftCol, wide) {
                 margin-left: 100px;
-            }
-            @include mq(wide) {
-                margin-left: 20px;
             }
         }
         .hostedbadge__logo {
@@ -38,13 +35,12 @@
         }
     }
 
-    .hosted__next-page {
+    .hosted__next-page-wrapper {
         margin: $gs-baseline $gs-gutter;
         position: relative;
-        @include mq(leftCol) {
-            width: 300px;
-        }
-        @include mq($until: tablet) {
+        order: 3;
+        overflow: hidden;
+        @include mq($until: leftCol) {
             margin: $gs-gutter 0 0;
             padding: 0 $gs-gutter $gs-baseline/2;
             background-color: $neutral-7;
@@ -56,8 +52,30 @@
                 width: 150%;
             }
         }
+        @include mq(leftCol) {
+            width: 300px;
+        }
+        @include mq(wide) {
+            margin-left: 170px;
+        }
     }
 
+    .hosted__container.host {
+        position: relative;
+        background: transparent;
+        color: #ffffff;
+
+        @include mq($until: desktop) {
+            padding: 0;
+        }
+    }
+
+    .hosted__glogo,
+    .hosted__next-page-wrapper {
+        @include mq(leftCol, wide) {
+            margin-right: 80px;
+        }
+    }
 }
 
 .hosted__youtube-poster-image {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -44,6 +44,18 @@
         @include mq(leftCol) {
             width: 300px;
         }
+        @include mq($until: tablet) {
+            margin: $gs-gutter 0 0;
+            padding: 0 $gs-gutter $gs-baseline/2;
+            background-color: $neutral-7;
+            .hosted__next-page__carousel-arrows {
+                right: $gs-gutter;
+            }
+            .hosted__next-page-header--border {
+                margin-left: -$gs-gutter;
+                width: 150%;
+            }
+        }
     }
 
 }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -838,6 +838,7 @@ $hosted-video-height: 540px;
     margin-left: 10px;
     color: #ffffff;
     border: 0;
+    padding-top: 2px;
 
     @include mq(mobile) {
         margin-top: 20px;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -131,7 +131,7 @@ $hosted-video-height: 540px;
 .hosted__banner .hosted-tone-btn,
 .hosted-tone-btn:focus,
 .hosted-tone-btn:hover {
-    color:  #333333;
+    color: #333333;
     svg {
         fill: #333333;
     }
@@ -912,9 +912,7 @@ $hosted-video-height: 540px;
 }
 
 .hosted__next-page--header {
-    padding-bottom: 10px;
-    margin: $gs-baseline 0 10px;
-    border-bottom: 1px solid #eeeeee;
+    margin-bottom: 10px;
 }
 
 .hosted__container .host__body {
@@ -933,14 +931,6 @@ $hosted-video-height: 540px;
 .hosted-video-page .hosted__next-page-placeholder,
 .hosted-video-page .hosted__next-page {
     order: 3;
-}
-
-.hosted__next-page {
-    @include mq(leftCol) {
-        width: 300px;
-    }
-    margin: 0 $gs-gutter $gs-gutter;
-    position: relative;
 }
 
 .hosted__next-page--more-from {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -1,6 +1,6 @@
 $hosted-stripe: 28px;
-$hosted-video-width: 960px;
-$hosted-video-height: 540px;
+$hosted-video-width: 980px;
+$hosted-video-height: 551px;
 
 @import '_hosted-video.scss';
 @import '_hosted-gallery.scss';
@@ -222,28 +222,6 @@ $hosted-video-height: 540px;
     }
 }
 
-.hosted-video-page {
-    .hosted__container.host {
-        position: relative;
-        background: transparent;
-        color: #ffffff;
-
-        @include mq($until: desktop) {
-            padding: 0;
-        }
-    }
-
-    .hosted__glogo {
-        @include mq(leftCol) {
-            margin-right: 90px;
-        }
-
-        @include mq(wide) {
-            margin-right: 170px;
-        }
-    }
-}
-
 .hosted__container--content {
     @include mq($until: leftCol) {
         display: flex;
@@ -269,6 +247,7 @@ $hosted-video-height: 540px;
             padding-bottom: $hosted-video-height;
             margin: 0 auto;
             overflow: hidden;
+
         }
     }
 }
@@ -530,10 +509,6 @@ $hosted-video-height: 540px;
 
     .hostedbadge {
         position: absolute;
-
-        @include mq(desktop) {
-            margin-left: $gs-gutter / 2;
-        }
     }
     .hostedbadge__logo.hostedbadge__logo {
         position: relative;
@@ -929,11 +904,6 @@ $hosted-video-height: 540px;
     @include f-textSans;
 }
 
-.hosted-video-page .hosted__next-page-placeholder,
-.hosted-video-page .hosted__next-page {
-    order: 3;
-}
-
 .hosted__next-page--more-from {
     font-weight: bolder;
 }
@@ -989,16 +959,6 @@ $nextPageThumbWidthMobile: #{$nextPageThumbHeightMobile * 5 / 3};
     margin: 0 0 0 $nextPageThumbWidth;
     @include mq($until: phablet) {
         margin-left: $nextPageThumbWidthMobile;
-    }
-}
-
-.hosted-video__next-page-title {
-    padding: 10px;
-    font-size: 20px;
-    line-height: 23px;
-    @include mq($until: phablet) {
-        font-size: 18px;
-        line-height: 20px;
     }
 }
 


### PR DESCRIPTION
## What does this change?
- fix header colour of 'About' dialog on article pages
- New layouts at different breakpoints (see screenshots)
- general refactoring

## Screenshots
On mobile, different design for onward journey:

![image](https://cloud.githubusercontent.com/assets/6290008/20721354/6f0fa1c8-b65a-11e6-8b92-1883f0d920fc.png)

On leftCol, the onward journey is pulled in to line up with the video/logo:
- Before
![image](https://cloud.githubusercontent.com/assets/6290008/20721499/d91ce922-b65a-11e6-8760-59602a6dab05.png)

- After
![image](https://cloud.githubusercontent.com/assets/6290008/20721453/b37639f8-b65a-11e6-93b9-4d9e07983004.png)

On wide, the logo is moved out to the edge of the page, and the standfirst maintains its size from leftCol width:
- Before
![image](https://cloud.githubusercontent.com/assets/6290008/20721549/17f28594-b65b-11e6-9d66-b1d3ab5e5419.png)

- After
![image](https://cloud.githubusercontent.com/assets/6290008/20721666/983a1bea-b65b-11e6-979b-746fdc8d938a.png)


## Request for comment
@guardian/labs-beta 