### PR TITLE
GA: Add user timing metrics

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -53,7 +53,8 @@
     ***************************************************************************************@
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest)) {
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
-            'sampleRate': @{ if (env.mode == Dev) 100 else tracker.samplePercentage }
+            'sampleRate': @{ if (env.mode == Dev) 100 else tracker.samplePercentage },
+            'siteSpeedSampleRate': @{ if (env.mode == Dev) 100 else tracker.siteSpeedSamplePercentage }
         });
     }
 

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -4,7 +4,8 @@ import conf.Configuration.environment
 
 object GoogleAnalyticsAccount {
 
-  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100)
+  // NOTE that the 'samples rates' when set to 0, seem to be 100%
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 0.1)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -24,7 +24,8 @@ define([
     'commercial/modules/third-party-tags',
     'commercial/modules/paidfor-band',
     'commercial/modules/paid-containers',
-    'commercial/modules/dfp/performance-logging'
+    'commercial/modules/dfp/performance-logging',
+    'common/modules/analytics/google'
 ], function (
     Promise,
     config,
@@ -51,7 +52,8 @@ define([
     thirdPartyTags,
     paidforBand,
     paidContainers,
-    performanceLogging
+    performanceLogging,
+    ga
 ) {
     var primaryModules = [
         ['cm-thirdPartyTags', thirdPartyTags.init],
@@ -73,6 +75,9 @@ define([
         ['cm-ready', function () {
             mediator.emit('page:commercial:ready');
             userTiming.mark('commercial end');
+            robust.catchErrorsAndLog('ga-user-timing-commercial-end', function () {
+                ga.trackPerformance('Javascript Load', 'commercialEnd', 'Commercial end parse time');
+            });
             return Promise.resolve();
         }]
     ];
@@ -132,6 +137,9 @@ define([
             }
 
             userTiming.mark('commercial start');
+            robust.catchErrorsAndLog('ga-user-timing-commercial-start', function () {
+                ga.trackPerformance('Javascript Load', 'commercialStart', 'Commercial start parse time');
+            });
 
             // Stub the command queue
             window.googletag = { cmd: [] };

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -11,7 +11,7 @@ define([
     'common/modules/experiments/ab',
     './common',
     './sport',
-    'enhanced-common'
+    'common/modules/analytics/google'
 ], function (
     fastdom,
     bean,
@@ -24,7 +24,8 @@ define([
     robust,
     ab,
     common,
-    sport
+    sport,
+    ga
 ) {
     return function () {
         var bootstrapContext = function (featureName, bootstrap) {
@@ -37,6 +38,10 @@ define([
 
 
         userTiming.mark('App Begin');
+        robust.catchErrorsAndLog('ga-user-timing-enhanced-start', function () {
+            ga.trackPerformance('Javascript Load', 'enhancedStart', 'Enhanced start parse time');
+        });
+
         bootstrapContext('common', common);
 
         //
@@ -170,5 +175,8 @@ define([
 
         // Mark the end of synchronous execution.
         userTiming.mark('App End');
+        robust.catchErrorsAndLog('ga-user-timing-enhanced-end', function () {
+            ga.trackPerformance('Javascript Load', 'enhancedEnd', 'Enhanced end parse time');
+        });
     };
 });

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -25,7 +25,8 @@ define([
     'common/utils/cookies',
     'common/utils/robust',
     'common/utils/user-timing',
-    'common/modules/navigation/newHeaderNavigation'
+    'common/modules/navigation/newHeaderNavigation',
+    'common/modules/analytics/google'
 ], function (
     qwery,
     fastdom,
@@ -40,13 +41,17 @@ define([
     cookies,
     robust,
     userTiming,
-    newHeaderNavigation
+    newHeaderNavigation,
+    ga
 ) {
     return function () {
         var guardian = window.guardian;
         var config = guardian.config;
 
         userTiming.mark('standard start');
+        robust.catchErrorsAndLog('ga-user-timing-standard-start', function () {
+            ga.trackPerformance('Javascript Load', 'standardStart', 'Standard start parse time');
+        });
 
         var oldOnError = window.onerror;
         window.onerror = function (message, filename, lineno, colno, error) {
@@ -254,5 +259,8 @@ define([
         newHeaderNavigation();
 
         userTiming.mark('standard end');
+        robust.catchErrorsAndLog('ga-user-timing-standard-end', function () {
+            ga.trackPerformance('Javascript Load', 'standardEnd', 'Standard end parse time');
+        });
     };
 });

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -48,11 +48,24 @@ define([
         });
     }
 
+    // Track important user timing metrics so that we can be notified and measure over time in GA
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/user-timings
+    // Tracks into Behaviour > Site Speed > User Timings in GA
+    function trackPerformance(timingCategory, timingVar, timingLabel) {
+        // Feature detect Navigation Timing API support.
+        if (window.performance) {
+            // Value must be an integer - grabs the number of milliseconds since page load
+            var timeSincePageLoad = Math.round(window.performance.now());
+            ga(send, 'timing', timingCategory, timingVar, timeSincePageLoad, timingLabel);
+        }
+    }
+
     return {
         trackNonClickInteraction: trackNonClickInteraction,
         trackSamePageLinkClick: trackSamePageLinkClick,
         trackExternalLinkClick: trackExternalLinkClick,
         trackSponsorLogoLinkClick: trackSponsorLogoLinkClick,
-        trackNativeAdLinkClick: trackNativeAdLinkClick
+        trackNativeAdLinkClick: trackNativeAdLinkClick,
+        trackPerformance: trackPerformance
     };
 });


### PR DESCRIPTION
## What does this change?

GA allows you to push 'timing' metrics to page views, this adds the current user timing metrics to a 0.1% of page views sample size. Also reduces the current site speed sample size from 1% to 0.1% which reduces the overall requests to GA.

## What is the value of this and can you measure success?

We can see the start and parse times for our JS over time in GA and easily compare segments to help identify issues.

## Request for comment

@dominickendrick @rich-nguyen @mkopka 