### PR TITLE
Give the plaintone form a widescreen layout, and a placeholder

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -49,6 +49,7 @@ object ListIds {
   val theBreakdown = 219
   val theSpin = 220
 
+  val documentaries = 3745
   val sleeveNotes = 39
   val closeUp = 40
   val filmToday = 1950
@@ -73,37 +74,6 @@ object ListIds {
   val UsElection = 3599
 
   val morningMailUk = 3640
-
-  val allWithoutTrigger: List[Int] = List(
-    theBestOfOpinion,
-    theFiver,
-    mediaBriefing,
-    greenLight,
-    povertyMatters,
-    theLongRead,
-    morningMail,
-    australianPolitics,
-    theBreakdown,
-    theSpin,
-    sleeveNotes,
-    closeUp,
-    filmToday,
-    bookmarks,
-    artWeekly,
-    zipFile,
-    theFlyer,
-    moneyTalks,
-    fashionStatement,
-    crosswordEditorUpdate,
-    theObserverFoodMonthly,
-    firstDogOnTheMoon,
-    bestOfOpinionAUS,
-    bestOfOpinionUS,
-    theGuardianMasterclasses,
-    theGuardianGardener,
-    theGuardianBookshop,
-    UsElection,
-    morningMailUk)
 }
 
 object EmailTypes {

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -11,10 +11,14 @@
 
 @listIdTones = @{ Map[Int, String] (
     theBestOfOpinion -> "comment",
+    bestOfOpinionAUS -> "comment",
+    bestOfOpinionUS -> "comment",
     theFiver -> "feature",
     mediaBriefing -> "media",
     theLongRead -> "feature",
     weekendReading -> "feature",
+    documentaries -> "plaindark",
+    theFlyer -> "feature",
     theBreakdown -> "feature",
     theSpin -> "feature",
     closeUp -> "review",

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -38,8 +38,12 @@
     <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-id="@listId">
         <div class="email-sub__form-wrapper">
             <div class="email-sub__inline-label js-email-sub__inline-label">
-                <label class="email-sub__label js-email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))@labelText</label>
-                <input class="email-sub__text-input js-email-sub__text-input" type="email" name="email" id="@inputId" required />
+                @if(componentClass == "plaintone") {
+                   <input class="email-sub__text-input js-email-sub__text-input" type="email" name="email" id="@inputId" placeholder="Email address" required />
+               } else {
+                    <label class="email-sub__label js-email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))@labelText</label>
+                    <input class="email-sub__text-input js-email-sub__text-input" type="email" name="email" id="@inputId" required />
+                }
                 <input class="js-email-sub__listid-input" type="hidden" name="listId" value="@listId" />
             </div>
             <button type="submit" class="email-sub__submit-input js-email-sub__submit-input button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))@submitText</button>

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -374,7 +374,7 @@
 }
 
 // TONE SPECIFIC MODS
-@each $tone-class, $tone-colour-accent, $tone-colour-headline, $tone-colour-border in $tones {
+@each $tone-class, $tone-colour-accent, $tone-colour-headline, $tone-colour-border, $tone-colour-text in $tones {
 
 
     .email-sub--tone-#{$tone-class} {
@@ -419,6 +419,7 @@
 
         .email-sub__submit-input {
             border-color: $tone-colour-border;
+            color: $tone-colour-text;
         }
     }
 }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -154,7 +154,7 @@ body {
            border: thin solid;
            border-radius: 1000px;
            width: 25%;
-           margin: 0rem 0rem 0.75rem 3%;
+           margin: 0 0 0 3%;
        }
    }
 }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -142,6 +142,21 @@ body {
         }
     }
 
+    .email-sub--plaintone {
+       .email-sub__text-input {
+           border: thin solid;
+           border-radius: 1000px;
+           float: left;
+           width: 70%;
+       }
+
+       .email-sub__submit-input {
+           border: thin solid;
+           border-radius: 1000px;
+           width: 25%;
+           margin: 0rem 0rem 0.75rem 3%;
+       }
+   }
 }
 
 /**

--- a/static/src/stylesheets/module/email/_vars.scss
+++ b/static/src/stylesheets/module/email/_vars.scss
@@ -8,11 +8,12 @@ $rounded-adjustment: .66em;
 
 $tones: (
     (analysis, $analysis-accent, $news-default),
-    (comment, $comment-support-4, $comment-support-4),
+    (comment, $comment-support-4, $comment-support-4, $comment-support-4),
     (feature, $feature-default, $feature-accent, $feature-mute),
     (live, $live-default, $live-accent),
     (media, $neutral-1, $neutral-1),
     (news, $news-default, $news-default),
     (review, $review-background, darken($review-background, 10%)),
-    (special-feature, $news-support-6, $news-support-6)
+    (special-feature, $news-support-6, $news-support-6),
+    (plaindark, $neutral-4, $neutral-4, $neutral-4, $multimedia-main-1)
 );


### PR DESCRIPTION
This PR is all about email forms, they live in routes like [this](https://www.theguardian.com/email/form/article/2635) and [this](https://www.theguardian.com/email/form/plain/2635). These forms are used inside iframes to create our email CTAs

See #15129 for some background.

## What does this change?

- Gives the [plaintone form](https://www.theguardian.com/email/form/plaintone/37) a prettier layout on widescreen (above Phablet width)

- Puts a placeholder in the input field of `plaintone` forms

- Makes a new theme for the `plaintone` route that copies the style of the [custom form](https://www.theguardian.com/email/form/plaindark/3745) for Documentaries

- Adds a few more colour schemes to `emailSignUp.scala.html`

- Deletes `allWithoutTrigger`, which does nothing, to anything 🔥💀

## What is the value of this and can you measure success?

- Doing stuff with css, rather than routing
- A [placeholder](http://caniuse.com/#feat=input-placeholder) is better than no placeholder
- Better email sign up forms in [interactives](https://composer.gutools.co.uk/content/58357e91e4b0e0ad2d75c128)
- Expands the styling of email sign up forms, without altering existing ones (since these forms are often embedded in content by Editorial, it is hard to track usage)

- To my knowledge, only the Documentaries email is using the `plaindark` route... lets migrate!

No need for adding new routes for new colour schemes, particularly if it is a one-off theme for a specific page or [interactive](
https://theguardian.com/world/ng-interactive/2016/sep/16/gun-nation-a-journey-to-the-heart-of-americas-gun-culture-video):

1. Add the theme into [_vars.scss](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/email/_vars.scss) with a name and whatever colours you want to apply:

```(plaindark, $neutral-4, $neutral-4, $neutral-4, $multimedia-main-1)```

2. Update the [EmailSignupController](https://github.com/guardian/frontend/blob/master/common/app/controllers/EmailSignupController.scala) so that the `listId` can be used to identify the email:

```val documentaries = 3745```

3. In [emailSignUp.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/email/signup/emailSignUp.scala.html), specify the theme you want the named email to use:

```documentaries -> "plaindark"```

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

<img width="610" alt="picture 391" src="https://cloud.githubusercontent.com/assets/8607683/20721916/8d52a840-b65c-11e6-9015-0fe4a4925cb4.png">
<img width="611" alt="picture 392" src="https://cloud.githubusercontent.com/assets/8607683/20721925/950ccc82-b65c-11e6-9a7a-084be551bdea.png">
<img width="609" alt="picture 393" src="https://cloud.githubusercontent.com/assets/8607683/20721934/9d719718-b65c-11e6-9f8e-b5f105f904e9.png">
<img width="463" alt="picture 396" src="https://cloud.githubusercontent.com/assets/8607683/20721942/a5b5e154-b65c-11e6-8480-4c78f45678b5.png">
<img width="464" alt="picture 395" src="https://cloud.githubusercontent.com/assets/8607683/20721950/aba068f0-b65c-11e6-8176-a347443fbeff.png">
<img width="463" alt="picture 394" src="https://cloud.githubusercontent.com/assets/8607683/20721962/b3238724-b65c-11e6-95c7-8ba9825fd06b.png">


###### Above Phablet (~600px):
<img width="813" alt="picture 388" src="https://cloud.githubusercontent.com/assets/8607683/20721189/ef3e2f78-b659-11e6-8eb2-cdf1ba451d3d.png">

###### Below Phablet:

<img width="578" alt="picture 397" src="https://cloud.githubusercontent.com/assets/8607683/20721877/67efe694-b65c-11e6-832d-62bef45237d1.png">

###### Using `plaintone` form with Documentaries theme in the interactive:
<img width="730" alt="picture 390" src="https://cloud.githubusercontent.com/assets/8607683/20722019/f29a1378-b65c-11e6-8c1d-245a7699cb40.png">


## Request for comment

@superfrank @joelochlann @lmath 
