### PR TITLE
Ask for front email images at 500 width

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -35,7 +35,7 @@ object EmailHelpers {
   def imageUrlFromPressedContent(pressedContent: PressedContent): Option[String] = {
     for {
       InlineImage(imageMedia) <- InlineImage.fromFaciaContent(pressedContent)
-      url <- EmailImage.bestFor(imageMedia)
+      url <- FrontEmailImage.bestFor(imageMedia)
     } yield url
   }
 
@@ -55,6 +55,10 @@ object EmailHelpers {
 
   def img(src: String, alt: Option[String] = None) = Html {
     s"""<img width="580" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
+  }
+
+  def imgFromPressedContent(pressedContent: PressedContent) = imageUrlFromPressedContent(pressedContent).map { url =>
+    img(src = url, alt = Some(pressedContent.header.headline))
   }
 
   object Images {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -129,6 +129,7 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {
   override val qualityparam = "q=40"
 }
+
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
   override val fitParam = "fit=crop"
   override val qualityparam = "q=40"
@@ -140,6 +141,10 @@ object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
     val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
     s"?$params"
   }
+}
+
+object FrontEmailImage extends Profile(width = Some(500), autoFormat = false) {
+  override val qualityparam = "q=40"
 }
 
 // The imager/images.js base image.

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -37,9 +37,7 @@
     @paddedRow {
         @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
             <a @Html(href) class="facia-card facia-card--large @toneClass(pressedContent)">
-                @imageUrlFromPressedContent(pressedContent).map { url =>
-                    <img width="580" class="full-width" src="@url" />
-                }
+                @imgFromPressedContent(pressedContent)
                 @headline(pressedContent)
                 @pressedContent.card.trailText.map { trailText =>
                     <h4 class="trail-text">@trailText</h4>


### PR DESCRIPTION
Thanks to #15148 the max width of front emails is 500px, so we can save some bandwidth and increase loading speed by requesting these at 500 width rather than 580. (Article emails still have 580 max width).

There may be more optimisations we can do like this once we know sizes of the smaller images too. The Flyer, which is our first test case, only has large images.

cc @paperboyo because he loves images


