### PR TITLE
The static files need to be uploaded into the unified artifact

### DIFF
--- a/dev/teamcity/dist-publish-assets-tc
+++ b/dev/teamcity/dist-publish-assets-tc
@@ -47,6 +47,9 @@ sed -e "s|<%build_number%>|$BUILD_NUMBER|" \
 aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static_folder s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:static/$BUILD_NUMBER
 aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_BUILD_BUCKET --key dotcom:static/$BUILD_NUMBER/build.json  --body $static_folder/build.json
 
+# upload static files for the build - it is critical that this is done before the main sbt-riffraff-artifact plugin runs
+aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static_folder/packages/frontend-static s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:all/$BUILD_NUMBER/static
+
 set +x
 echo "##teamcity[progressFinish 'asset publish']"
 set -x


### PR DESCRIPTION
## What does this change?
The unified artifact introduced in #15151 is missing the static files. This tweaks the dist-publish-assets-tc script to upload the static files into the `dotcom:all` project as well as creating the `dotcom:static` project.

## What is the value of this and can you measure success?
I don't know how to put this, static files are kinda a big deal around here. Success is when there are 200 or so files to upload rather than 0.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
Before:
![screen shot 2016-11-30 at 12 52 35](https://cloud.githubusercontent.com/assets/1236466/20752970/f8f511d8-b6fb-11e6-95b9-befb139570eb.png)
Now:
![screen shot 2016-11-30 at 12 52 48](https://cloud.githubusercontent.com/assets/1236466/20752971/fa7797b0-b6fb-11e6-9f8d-52826fa5ae55.png)

## Request for comment

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

