### PR TITLE
Remove deprecated Play.api.Crypto packages

### DIFF
--- a/admin/app/conf/AdminFilters.scala
+++ b/admin/app/conf/AdminFilters.scala
@@ -2,9 +2,10 @@ package conf
 
 import akka.stream.Materializer
 import com.gu.googleauth.FilterExemption
-import googleAuth.GoogleAuthFilters
+import googleAuth.GoogleAuthFilters.AuthFilterWithExemptions
 import play.api.Environment
 import play.api.http.HttpFilters
+import play.api.libs.crypto.CryptoConfig
 import play.api.mvc.EssentialFilter
 
 object FilterExemptions {
@@ -20,12 +21,13 @@ object FilterExemptions {
 
 class AdminFilters(
                     mat: Materializer,
-                    environment: Environment
+                    environment: Environment,
+                    cryptoConfig: CryptoConfig
                   ) extends HttpFilters {
 
-  val adminAuthFilter = new GoogleAuthFilters.AuthFilterWithExemptions(
+  val adminAuthFilter = new AuthFilterWithExemptions(
     FilterExemptions.loginExemption,
-    FilterExemptions.exemptions)(mat, environment)
+    FilterExemptions.exemptions)(mat, environment, cryptoConfig)
 
   val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common(mat)
 }

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -9,6 +9,7 @@ import jobs.VideoEncodingsJob
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.api.i18n.Messages
+import play.api.libs.crypto.CryptoConfig
 import services.{OphanApi, RedirectService}
 
 trait AdminControllers {
@@ -18,6 +19,7 @@ trait AdminControllers {
   def ophanApi: OphanApi
   implicit def environment: Environment
   def redirects: RedirectService
+  def cryptoConfig: CryptoConfig
   implicit val messages: Messages
   lazy val oAuthLoginController = wire[OAuthLoginAdminController]
   lazy val uncachedWebAssets = wire[UncachedWebAssets]

--- a/admin/app/controllers/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/OAuthLoginAdminController.scala
@@ -3,10 +3,11 @@ package controllers.admin
 import com.gu.googleauth.GoogleAuthConfig
 import googleAuth.OAuthLoginController
 import play.api.Environment
+import play.api.libs.crypto.CryptoConfig
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, Request}
 
-class OAuthLoginAdminController(val wsClient: WSClient)(implicit env: Environment) extends OAuthLoginController {
+class OAuthLoginAdminController(val wsClient: WSClient, val cryptoConfig: CryptoConfig)(implicit env: Environment) extends OAuthLoginController {
   override def login = Action { implicit request =>
     val error = request.flash.get("error")
     Ok(views.html.auth.login(error))

--- a/common/app/common/Crypto.scala
+++ b/common/app/common/Crypto.scala
@@ -1,0 +1,37 @@
+package common
+
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.{IvParameterSpec, SecretKeySpec}
+import org.apache.commons.codec.binary.Base64
+
+object Crypto {
+
+  private def secretKeyWithSha256(privateKey: String, algorithm: String) = {
+    val messageDigest = MessageDigest.getInstance("SHA-256")
+    messageDigest.update(privateKey.getBytes("utf-8"))
+    val maxAllowedKeyLength = Cipher.getMaxAllowedKeyLength(algorithm) / 8 // max allowed length in bits / (8 bits to a byte)
+    val raw = messageDigest.digest().slice(0, maxAllowedKeyLength)
+    new SecretKeySpec(raw, algorithm)
+  }
+
+  def encryptAES(value: String, key: String): String = {
+    val skeySpec = secretKeyWithSha256(key, "AES")
+    val cipher = Cipher.getInstance("AES/CTR/NoPadding")
+    cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
+    val encryptedValue = cipher.doFinal(value.getBytes("utf-8"))
+    Base64.encodeBase64String(cipher.getIV() ++ encryptedValue)
+  }
+
+  def decryptAES(value: String, key: String): String = {
+    val data = Base64.decodeBase64(value)
+    val skeySpec = secretKeyWithSha256(key, "AES")
+    val cipher = Cipher.getInstance("AES/CTR/NoPadding")
+    val blockSize = cipher.getBlockSize
+    val iv = data.slice(0, blockSize)
+    val payload = data.slice(blockSize, data.size)
+    cipher.init(Cipher.DECRYPT_MODE, skeySpec, new IvParameterSpec(iv))
+    new String(cipher.doFinal(payload), "utf-8")
+  }
+}
+

--- a/common/app/googleAuth/OAuthLoginController.scala
+++ b/common/app/googleAuth/OAuthLoginController.scala
@@ -1,10 +1,10 @@
 package googleAuth
 
 import com.gu.googleauth.{GoogleAuth, GoogleAuthConfig, UserIdentity}
-import common.{ExecutionContexts, Logging}
+import common.{Crypto, ExecutionContexts, Logging}
 import conf.Configuration
 import org.joda.time.DateTime
-import play.api.libs.Crypto
+import play.api.libs.crypto.CryptoConfig
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -16,6 +16,9 @@ trait OAuthLoginController extends Controller with ExecutionContexts with implic
   def wsClient: WSClient
   def login: Action[AnyContent]
   def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig]
+  def cryptoConfig: CryptoConfig
+
+  val authCookie = new AuthCookie(cryptoConfig)
 
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
   val ANTI_FORGERY_KEY = "antiForgeryToken"
@@ -78,7 +81,7 @@ trait OAuthLoginController extends Controller with ExecutionContexts with implic
                 .addingToSession(sessionAdd: _*)
                 .removingFromSession(ANTI_FORGERY_KEY, LOGIN_ORIGIN_KEY)
 
-            AuthCookie.from(userIdentity).map(authCookie => result.withCookies(authCookie))
+            authCookie.from(userIdentity).map(authCookie => result.withCookies(authCookie))
               .getOrElse(result)
           } recover {
             case t =>
@@ -96,20 +99,20 @@ trait OAuthLoginController extends Controller with ExecutionContexts with implic
   }
 }
 
-object AuthCookie extends Logging {
+class AuthCookie(cryptoConfig: CryptoConfig) extends Logging {
 
   private val cookieName = "GU_PV_AUTH"
   private val oneDayInSeconds: Int = 86400
 
   def from(id: UserIdentity): Option[Cookie] = {
     val idWith30DayExpiry = id.copy(exp = (System.currentTimeMillis() / 1000) + oneDayInSeconds )
-    Some(Cookie(cookieName,  Crypto.encryptAES(Json.toJson(idWith30DayExpiry).toString), Some(oneDayInSeconds)))
+    Some(Cookie(cookieName,  Crypto.encryptAES(Json.toJson(idWith30DayExpiry).toString, cryptoConfig.secret), Some(oneDayInSeconds)))
   }
 
   def toUserIdentity(request: RequestHeader): Option[UserIdentity] = {
     try {
       request.cookies.get(cookieName).flatMap{ cookie =>
-        UserIdentity.fromJson(Json.parse(Crypto.decryptAES(cookie.value)))
+        UserIdentity.fromJson(Json.parse(Crypto.decryptAES(cookie.value, cryptoConfig.secret)))
       }
     } catch { case e: Exception =>
       log.error("Could not parse Auth Cookie", e)

--- a/common/test/common/CryptoTest.scala
+++ b/common/test/common/CryptoTest.scala
@@ -1,0 +1,25 @@
+package common
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class CryptoTest extends FlatSpec with Matchers {
+
+  val privateKey = "6FA3BE741DE87141F90EB3E67EB51976"
+  val message = "Les sanglots longs des violons de l'automne blessent mon cœur d'une langueur monotone."
+
+  "A valid encrypted string" should "be successfully decrypted" in {
+    val encrypted = Crypto.encryptAES(message, privateKey)
+    Crypto.decryptAES(encrypted, privateKey) should equal(message)
+  }
+
+  "A valid encrypted string created with the wrong key" should "not be successfully decrypted" in {
+    val encrypted = Crypto.encryptAES(message, "this is not the appropriate key")
+    Crypto.decryptAES(encrypted, privateKey) should not equal(message)
+  }
+
+  "A valid encrypted string" should "not be successfully decrypted with the wrong key" in {
+    val encrypted = Crypto.encryptAES(message, privateKey)
+    Crypto.decryptAES(encrypted, "this is not the appropriate key") should not equal(message)
+  }
+}
+

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -10,6 +10,7 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play._
 import play.api._
+import play.api.libs.crypto.CryptoConfig
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSClient
 import play.api.test._
@@ -150,4 +151,8 @@ trait WithTestContentApiClient {
 
   lazy val recorderHttpClient = new recorderHttpClient(new CapiHttpClient(wsClient))
   lazy val testContentApiClient = new ContentApiClient(recorderHttpClient)
+}
+
+trait WithTestCryptoConfig {
+  val testCryptoConfig = new CryptoConfig(secret = "this is the test secret")
 }

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.ExecutionContexts
-import model.{IdentityPage, NoCache}
+import model.{NoCache, IdentityPage}
 import play.api.mvc._
 import play.api.data.{Form, Forms}
 import play.api.data.Forms._
@@ -12,10 +12,10 @@ import idapiclient.IdApiClient
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import actions.AuthenticatedActions
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
-
+import play.api.libs.crypto.CryptoConfig
+import play.api.Environment
 import scala.concurrent.Future
 import idapiclient.requests.PasswordUpdate
-import play.api.Environment
 
 class ChangePasswordController( api: IdApiClient,
                                 authenticatedActions: AuthenticatedActions,
@@ -24,7 +24,8 @@ class ChangePasswordController( api: IdApiClient,
                                 idUrlBuilder: IdentityUrlBuilder,
                                 val messagesApi: MessagesApi,
                                 csrfCheck: CSRFCheck,
-                                csrfAddToken: CSRFAddToken)(implicit env: Environment)
+                                csrfAddToken: CSRFAddToken,
+                                val cryptoConfig: CryptoConfig)(implicit env: Environment)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms with I18nSupport{
 
   import authenticatedActions.authAction

--- a/identity/app/controllers/IdentityControllers.scala
+++ b/identity/app/controllers/IdentityControllers.scala
@@ -6,6 +6,7 @@ import form.FormComponents
 import formstack.FormStackComponents
 import idapiclient.IdApiComponents
 import play.api.Environment
+import play.api.libs.crypto.CryptoConfig
 import play.api.libs.ws.WSClient
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import services.IdentityServices
@@ -19,6 +20,7 @@ trait IdentityControllers extends IdApiComponents
 
   def csrfCheck: CSRFCheck
   def csrfAddToken: CSRFAddToken
+  def cryptoConfig: CryptoConfig
 
   lazy val authenticatedActions = wire[AuthenticatedActions]
   lazy val changePasswordController = wire[ChangePasswordController]

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -10,6 +10,7 @@ import play.api.Environment
 import play.api.data._
 import play.api.data.validation.Constraints
 import play.api.i18n.{Messages, MessagesApi}
+import play.api.libs.crypto.CryptoConfig
 import play.api.mvc._
 import services.{IdRequestParser, IdentityUrlBuilder, PlaySigninService, ReturnUrlVerifier}
 import utils.SafeLogging
@@ -23,8 +24,8 @@ class ReauthenticationController(returnUrlVerifier: ReturnUrlVerifier,
                                  idUrlBuilder: IdentityUrlBuilder,
                                  authenticatedActions: AuthenticatedActions,
                                  signInService : PlaySigninService,
-                                 val messagesApi: MessagesApi)
-                                (implicit env: Environment)
+                                 val messagesApi: MessagesApi,
+                                 val cryptoConfig: CryptoConfig)(implicit env: Environment)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
 
   val page = IdentityPage("/reauthenticate", "Re-authenticate")

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Future
 import services._
 import form.Mappings
 import play.api.Environment
+import play.api.libs.crypto.CryptoConfig
 
 class RegistrationController(returnUrlVerifier : ReturnUrlVerifier,
                              userCreationService : UserCreationService,
@@ -21,8 +22,8 @@ class RegistrationController(returnUrlVerifier : ReturnUrlVerifier,
                              idRequestParser : TorNodeLoggingIdRequestParser,
                              idUrlBuilder : IdentityUrlBuilder,
                              signinService : PlaySigninService,
-                             val messagesApi: MessagesApi)
-                            (implicit env: Environment)
+                             val messagesApi: MessagesApi,
+                             val cryptoConfig: CryptoConfig)(implicit env: Environment)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
 
   val page = IdentityPage("/register", "Register")

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -1,26 +1,28 @@
 package controllers
 
 import common.ExecutionContexts
-import model.{NoCache, IdentityPage}
-import play.api.data.{Forms, Form}
+import model.{IdentityPage, NoCache}
+import play.api.data.{Form, Forms}
 import play.api.mvc._
 import idapiclient.IdApiClient
-import services.{AuthenticationService, IdentityUrlBuilder, IdRequestParser}
-import play.api.i18n.{MessagesApi, Messages}
+import services.{AuthenticationService, IdRequestParser, IdentityUrlBuilder}
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.data.validation._
 import play.api.data.Forms._
 import play.api.data.format.Formats._
 import form.Mappings
 import play.api.Environment
+import play.api.libs.crypto.CryptoConfig
 import utils.SafeLogging
+
 import scala.concurrent.Future
 
-class ResetPasswordController(api : IdApiClient,
-                              idRequestParser: IdRequestParser,
-                              idUrlBuilder: IdentityUrlBuilder,
-                              authenticationService: AuthenticationService,
-                              val messagesApi: MessagesApi)
-                             (implicit env: Environment)
+class ResetPasswordController(  api : IdApiClient,
+                                idRequestParser: IdRequestParser,
+                                idUrlBuilder: IdentityUrlBuilder,
+                                authenticationService: AuthenticationService,
+                                val messagesApi: MessagesApi,
+                                val cryptoConfig: CryptoConfig)(implicit env: Environment)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
 
   val page = IdentityPage("/reset-password", "Reset Password")

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -15,6 +15,8 @@ import utils.SafeLogging
 import form.Mappings
 import play.api.Environment
 
+import play.api.libs.crypto.CryptoConfig
+
 import scala.concurrent.Future
 
 
@@ -23,8 +25,8 @@ class SigninController(returnUrlVerifier: ReturnUrlVerifier,
                        idRequestParser: IdRequestParser,
                        idUrlBuilder: IdentityUrlBuilder,
                        signInService : PlaySigninService,
-                       val messagesApi: MessagesApi)
-                      (implicit env: Environment)
+                       val messagesApi: MessagesApi,
+                       val cryptoConfig: CryptoConfig)(implicit env: Environment)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
 
   val page = IdentityPage("/signin", "Sign in")

--- a/identity/app/implicits/Forms.scala
+++ b/identity/app/implicits/Forms.scala
@@ -1,13 +1,15 @@
 package implicits
 
+import common.Crypto
 import play.api.data.{Form, FormError}
-import play.api.libs.Crypto
 import play.api.libs.json._
 import play.api.mvc.{Flash, RequestHeader}
 import play.api.i18n.I18nSupport
+import play.api.libs.crypto.CryptoConfig
 
 trait Forms extends I18nSupport {
 
+  val cryptoConfig: CryptoConfig
   private val formKey = "form-data"
 
   private implicit val errorReads = new Reads[Seq[FormError]]{
@@ -21,12 +23,12 @@ trait Forms extends I18nSupport {
     def bindFromFlash(implicit request: RequestHeader): Option[Form[A]] = {
 
       val errors = request.flash.get(s"$formKey-errors")
-        .map(Crypto.decryptAES)
+        .map(encryptedValue => Crypto.decryptAES(encryptedValue, cryptoConfig.secret))
         .map(Json.parse)
         .map(_.as[Seq[FormError]])
         .getOrElse(Nil)
 
-      request.flash.get(formKey).map(Crypto.decryptAES).map(Json.parse).map { data =>
+      request.flash.get(formKey).map(encryptedValue => Crypto.decryptAES(encryptedValue, cryptoConfig.secret)).map(Json.parse).map { data =>
         errors.foldLeft(form.bind(data)) { (formFold, error) => formFold.withError(error) }
       }
     }
@@ -34,8 +36,8 @@ trait Forms extends I18nSupport {
     def toFlash: Flash = {
       val formJson: String = JsObject(form.data.toSeq.map { case (k, v) => k -> JsString(v)}).toString()
       Flash(Map(
-        formKey -> Crypto.encryptAES(formJson),
-        s"$formKey-errors" -> Crypto.encryptAES(form.errorsAsJson.toString())
+        formKey -> Crypto.encryptAES(formJson, cryptoConfig.secret),
+        s"$formKey-errors" -> Crypto.encryptAES(form.errorsAsJson.toString(), cryptoConfig.secret)
       ))
     }
 

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -3,7 +3,7 @@ package controllers
 import org.scalatest.path
 import org.scalatest.{Matchers => ShouldMatchers}
 import org.scalatest.mock.MockitoSugar
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment , WithTestCryptoConfig}
 import idapiclient.{EmailPassword, IdApiClient, TrackingData}
 import services._
 import play.api.test.Helpers._
@@ -19,10 +19,12 @@ import org.joda.time.DateTime
 import play.api.mvc.Cookies
 import conf.IdentityConfiguration
 
-class RegistrationControllerTest extends path.FreeSpec
+class RegistrationControllerTest
+  extends path.FreeSpec
   with ShouldMatchers
+  with MockitoSugar
   with WithTestEnvironment
-  with MockitoSugar  {
+  with WithTestCryptoConfig {
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val api = mock[IdApiClient]
@@ -44,7 +46,15 @@ class RegistrationControllerTest extends path.FreeSpec
   when(requestParser.apply(Matchers.anyObject(), Matchers.anyString())).thenReturn(identityRequest)
   when(trackingData.ipAddress).thenReturn(Some("123.456.789.12"))
 
-  lazy val registrationController = new RegistrationController(returnUrlVerifier, userCreationService, api, requestParser, urlBuilder, signinService, I18NTestComponents.messagesApi)
+  lazy val registrationController = new RegistrationController(
+    returnUrlVerifier,
+    userCreationService,
+    api,
+    requestParser,
+    urlBuilder,
+    signinService,
+    I18NTestComponents.messagesApi,
+    testCryptoConfig)
 
   "the renderRegistrationForm" - {
     "should render the registration form" in Fake {

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.mock.MockitoSugar
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import idapiclient.{IdApiClient, TrackingData}
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment, WithTestCryptoConfig}
 import play.api.test._
 import play.api.test.Helpers._
 import client.Error
@@ -16,10 +16,12 @@ import com.gu.identity.model.User
 import org.mockito.{ArgumentMatcher, Matchers}
 import services.{AuthenticationService, IdRequestParser, IdentityRequest, IdentityUrlBuilder}
 
-class ResetPasswordControllerTest extends path.FreeSpec
+class ResetPasswordControllerTest
+  extends path.FreeSpec
   with ShouldMatchers
+  with MockitoSugar
   with WithTestEnvironment
-  with MockitoSugar {
+  with WithTestCryptoConfig {
 
   val api = mock[IdApiClient]
   val requestParser = mock[IdRequestParser]
@@ -28,7 +30,14 @@ class ResetPasswordControllerTest extends path.FreeSpec
   val authenticationService = mock[AuthenticationService]
   val identityRequest = IdentityRequest(trackingData, None, None, Some("123.456.789.10"), Some(false), true)
 
-  lazy val resetPasswordController = new ResetPasswordController(api, requestParser, idUrlBuilder, authenticationService, I18NTestComponents.messagesApi)
+  lazy val resetPasswordController = new ResetPasswordController(
+    api,
+    requestParser,
+    idUrlBuilder,
+    authenticationService,
+    I18NTestComponents.messagesApi,
+    testCryptoConfig)
+
   when(requestParser.apply(anyObject())).thenReturn(identityRequest)
 
   val userNotFound = List(Error("Not found", "Resource not found", 404))

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -8,7 +8,7 @@ import org.mockito.Matchers._
 import services._
 import idapiclient.IdApiClient
 import play.api.test._
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test._
 
 import scala.concurrent.Future
 import client.Auth
@@ -24,10 +24,13 @@ import play.api.test.Helpers._
 import play.api.mvc.RequestHeader
 
 
-class SigninControllerTest extends path.FreeSpec
+class SigninControllerTest
+  extends path.FreeSpec
   with ShouldMatchers
+  with MockitoSugar
   with WithTestEnvironment
-  with MockitoSugar {
+  with WithTestCryptoConfig {
+
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val requestParser = mock[IdRequestParser]
   val idUrlBuilder = mock[IdentityUrlBuilder]
@@ -37,7 +40,15 @@ class SigninControllerTest extends path.FreeSpec
   val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None, None, Some(false), true)
   val signInService = new PlaySigninService(conf)
 
-  lazy val signinController = new SigninController(returnUrlVerifier, api, requestParser, idUrlBuilder, signInService, I18NTestComponents.messagesApi)
+  lazy val signinController = new SigninController(
+    returnUrlVerifier,
+    api,
+    requestParser,
+    idUrlBuilder,
+    signInService,
+    I18NTestComponents.messagesApi,
+    testCryptoConfig)
+
   when(requestParser.apply(anyObject())).thenReturn(identityRequest)
   when(returnUrlVerifier.getVerifiedReturnUrl(any[RequestHeader])).thenReturn(None)
 

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -8,11 +8,12 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 @DoNotDiscover class CompetitionListControllerTest
   extends FlatSpec
     with Matchers
+    with ConfiguredTestSuite
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
     with WithTestEnvironment
-	with WithMaterializer
+	  with WithMaterializer
     with WithTestWsClient {
 
   val url = "/football/competitionsService"

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -8,10 +8,11 @@ import org.scalatest._
 @DoNotDiscover class FixturesControllerTest
   extends FreeSpec
     with ShouldMatchers
+    with ConfiguredTestSuite
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-	with WithMaterializer
+	  with WithMaterializer
     with WithTestEnvironment
     with WithTestWsClient {
 

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -8,10 +8,11 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 @DoNotDiscover class LeagueTableControllerTest
   extends FlatSpec
     with Matchers
+    with ConfiguredTestSuite
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-	with WithMaterializer
+	  with WithMaterializer
     with WithTestEnvironment
     with WithTestWsClient {
 

--- a/standalone/app/conf/StandaloneFilters.scala
+++ b/standalone/app/conf/StandaloneFilters.scala
@@ -1,12 +1,14 @@
 package conf
 
 import akka.stream.Materializer
-import com.gu.googleauth.{UserIdentity, FilterExemption}
+import com.gu.googleauth.FilterExemption
 import common.ExecutionContexts
-import googleAuth.GoogleAuthFilters
+import googleAuth.GoogleAuthFilters.AuthFilterWithExemptions
 import play.api.Environment
 import play.api.http.HttpFilters
+import play.api.libs.crypto.CryptoConfig
 import play.api.mvc.{Filter, RequestHeader, Result}
+
 import scala.concurrent.Future
 
 // OBVIOUSLY this is only for the preview server
@@ -32,12 +34,13 @@ object FilterExemptions {
 
 class StandaloneFilters(
   mat: Materializer,
-  env: Environment
+  env: Environment,
+  cryptoConfig: CryptoConfig
 ) extends HttpFilters {
 
-  val previewAuthFilter = new GoogleAuthFilters.AuthFilterWithExemptions(
+  val previewAuthFilter = new AuthFilterWithExemptions(
     FilterExemptions.loginExemption,
-    FilterExemptions.exemptions)(mat, env)
+    FilterExemptions.exemptions)(mat, env, cryptoConfig)
 
   val filters = previewAuthFilter :: new NoCacheFilter()(mat) :: Filters.common(mat)
 }

--- a/standalone/app/controllers/OAuthLoginStandaloneController.scala
+++ b/standalone/app/controllers/OAuthLoginStandaloneController.scala
@@ -5,9 +5,10 @@ import googleAuth.OAuthLoginController
 import play.api.mvc.{Action, AnyContent, Request}
 import conf.Configuration
 import conf.Configuration.environment.projectName
+import play.api.libs.crypto.CryptoConfig
 import play.api.libs.ws.WSClient
 
-class OAuthLoginStandaloneController(val wsClient: WSClient) extends OAuthLoginController {
+class OAuthLoginStandaloneController(val wsClient: WSClient, val cryptoConfig: CryptoConfig) extends OAuthLoginController {
   override def login = Action { request =>
     Ok(views.html.standalone_auth(projectName, "Dev", UserIdentity.fromRequest(request)))
   }


### PR DESCRIPTION
## What does this change?
Remove deprecated Play.api.Crypto packages

See https://www.playframework.com/documentation/2.5.x/CryptoMigration25
for more info about Crypto migration for Play 2.5

We only use Crypto to encrypt/decrypt cookie values (using AES
algorithm), which are relatively simple operations that can simply be
built using javax.crypto primitives
Therefore I have extracted the 2 methods (encryptAES and decryptAES) into our own Crypto object.
Given our simple use case I don't feel like adding a complex 3rd-partydependency like Kalium and Keyczar is required

Let me know what do you think

## What is the value of this and can you measure success?
➡️  Play 2.5

## Request for comment
@alexduf @DiegoVazquezNanini @adamnfish @markjamesbutler 