### PR TITLE
Fix show more replies error

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -280,7 +280,11 @@ Loader.prototype.ready = function() {
     mediator.on('discussion:commentbox:post:success', this.removeState.bind(this, 'empty'));
 
     mediator.on('module:clickstream:click', function(clickspec) {
-        if ('hash' in clickspec.target && clickspec.target.hash === '#comments') {
+        if (
+            clickspec &&
+            'hash' in clickspec.target &&
+            clickspec.target.hash === '#comments'
+        ) {
             this.removeTruncation();
         }
     }.bind(this));

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -105,7 +105,7 @@ Loader.prototype.initMainComments = function() {
     this.comments.on('untruncate-thread', this.removeTruncation.bind(this));
 
     this.on('click,', '.js-discussion-author-link', this.removeTruncation.bind(this));
-    this.on('click', '.js-discussion-change-page, .js-discussion-show-button, .d-show-more-replies__button', function () {
+    this.on('click', '.js-discussion-change-page, .js-discussion-show-button', function () {
         mediator.emit('discussion:comments:get-more-replies');
         self.removeTruncation();
     });

--- a/static/src/javascripts/projects/common/modules/ui/clickstream.js
+++ b/static/src/javascripts/projects/common/modules/ui/clickstream.js
@@ -47,6 +47,8 @@ define([
                 return !urlHost || urlHost === host;
             },
             getClickSpec = function (spec, forceValid) {
+
+                // element was removed from the DOM
                 if (!spec.el) {
                     return false;
                 }


### PR DESCRIPTION
## What does this change?

Whenever a user expands a discussion comment thread by clicking the "Show x more replies" button, an error is thrown. This has been reported in Sentry [over 7000 times](https://sentry.io/the-guardian/client-side-prod/?query=is%3Aunresolved+hash&sort=freq&statsPeriod=14d) in the last 2 weeks.

Clicking anywhere on the page triggers the `module:clickstream:click` event. Handlers listening to this event receive a payload representing the element that was clicked, or the Boolean `false` if that element was removed from DOM. The "Show x more replies" button is [removed from the DOM](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/discussion/comments.js#L269) as soon as it is clicked.

 [`modules/discussion/loader`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/discussion/loader.js#L283) listens to this event, but does not guard against the possibility of the payload being Boolean `false`, and hence throws an error.

## What is the value of this and can you measure success?

I have added a guard in the loader component to ensure `clickspec` is truthy before attempting to access its properties. I have also added a comment explaining why `clickspec` might be false, as it is not obvious.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 138](https://cloud.githubusercontent.com/assets/5931528/20757226/5d5d14c0-b70d-11e6-88b9-c99f716ea383.png)

## Request for comment

@guardian/dotcom-platform @rich-nguyen @regiskuckaertz 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
