### PR TITLE
Hosted video page design updates

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -1,13 +1,13 @@
 @mixin hosted-fade-in {
     visibility: visible;
     opacity: 1;
-    transition: opacity 1s linear, visibility 0s;
+    transition: opacity 1s linear, visibility 0s, margin 200ms ease;
 }
 
 @mixin hosted-fade-out {
     visibility: hidden;
     opacity: 0;
-    transition: opacity 1s linear, visibility 1s;
+    transition: opacity 1s linear, visibility 1s, margin 200ms ease;
 }
 
 @mixin hosted-slide-in {
@@ -76,6 +76,28 @@
             margin-right: 80px;
         }
     }
+
+    .hosted__video .vjs-control.vjs-current-time {
+        @include mq(leftCol) {
+            margin-left: 17px;
+        }
+    }
+
+    .hosted__video.gu-media--video:not(.vjs-playing) .vjs-play-control {
+        @include mq($until: leftCol) {
+            margin-left: -50px;
+        }
+        @include mq($until: mobileLandscape) {
+            margin-left: -35px;
+        }
+    }
+
+    .hosted__video.gu-media--video .vjs-progress-control {
+        @include mq(leftCol) {
+            left: 100px;
+        }
+    }
+
 }
 
 .hosted__youtube-poster-image {
@@ -149,8 +171,13 @@
     background-color: unset;
     font-size: 16px;
     padding-top: 2px;
-    left: 88px;
+    left: 98px;
     pointer-events: none;
+    padding-left: 2px;
+
+    @include mq($until: leftCol) {
+        left: $gs-gutter;
+    }
 }
 
 .youtube__video-started:not(.youtube__video-ended) {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -442,13 +442,16 @@ $hosted-video-height: 551px;
 
 .hosted__meta {
     position: absolute;
-    left: 88px;
-    right: 88px;
+    left: 98px;
+    right: 98px;
     bottom: 44px;
     color: #ffffff;
 
     @include mq($until: tablet) {
         display: none;
+    }
+    @include mq($until: leftCol) {
+        left: $gs-gutter;
     }
 }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -469,7 +469,7 @@ $hosted-video-height: 551px;
     }
 
     .hosted__heading {
-        font-size: 24px;
+        font-size: 28px;
         line-height: 22px;
     }
 }
@@ -528,16 +528,12 @@ $hosted-video-height: 551px;
 
 // Headings
 .hosted__heading {
-    @include f-textSans;
+    @include f-headlineSans;
+    letter-spacing: -0.5px;
 
     margin: 0;
-    font-size: 22px;
-    line-height: 24px;
-
-    @include mq(tablet) {
-        font-size: 26px;
-        line-height: 26px;
-    }
+    font-size: 28px;
+    line-height: 28px;
 
     @include mq(desktop) {
         font-size: 36px;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -470,7 +470,7 @@ $hosted-video-height: 551px;
 
     .hosted__heading {
         font-size: 28px;
-        line-height: 22px;
+        line-height: 28px;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Fix the alignments of the heading, video timer and standfirst at all breakpoints, and update fonts etc.

The play button and the timer text slide in to the right when the video starts playing.

## Screenshots
Desktop

![image](https://cloud.githubusercontent.com/assets/6290008/20758536/09c50e26-b712-11e6-9500-d3e8c209662d.png)

![image](https://cloud.githubusercontent.com/assets/6290008/20758262/24681792-b711-11e6-928b-642ecb1d5f6e.png)

Tablet

![image](https://cloud.githubusercontent.com/assets/6290008/20758479/d8aa148a-b711-11e6-9c7a-eef7c938df04.png)

![image](https://cloud.githubusercontent.com/assets/6290008/20758280/35ca23e0-b711-11e6-889c-7390ffe4f0a8.png)

Mobile

![image](https://cloud.githubusercontent.com/assets/6290008/20758419/abbbf47a-b711-11e6-9eaf-1aa5c200efb9.png)

![image](https://cloud.githubusercontent.com/assets/6290008/20758323/5397afa0-b711-11e6-842b-990a46d1debe.png)

## Request for comment
@guardian/labs-beta 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
