### PR TITLE
Switch to HTTPS recommendations endpoint

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -46,7 +46,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'People will visit more often';
 
-        var endpoint = 'http://engine.mobile-aws.guardianapis.com/recommendations';
+        var endpoint = 'https://engine.mobile-aws.guardianapis.com/recommendations';
         var cachedRecommendationsKey = 'gu.cachedRecommendations';
         var numberOfRecommendations = 4;
 


### PR DESCRIPTION
## What does this change?

Changes recommendations test endpoint to be https

## What is the value of this and can you measure success?

Makes recommendations test work in production

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Request for comment

@katebee 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

