### PR TITLE
add missing 75% tracking call for youtube atoms

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/youtube.js
+++ b/static/src/javascripts/bootstraps/enhanced/youtube.js
@@ -37,7 +37,7 @@ define([
     function onPlayerEnded(atomId) {
         killProgressTracker(atomId);
         tracking.track('end', atomId);
-        players[atomId].pendingTrackingCalls = [25, 50];
+        players[atomId].pendingTrackingCalls = [25, 50, 75];
     }
 
     function setProgressTracker(atomId)  {
@@ -74,7 +74,7 @@ define([
     function onPlayerReady(atomId, event) {
         players[atomId] = {
             player: event.target,
-            pendingTrackingCalls: [25, 50]
+            pendingTrackingCalls: [25, 50, 75]
         };
     }
 


### PR DESCRIPTION
## What does this change?

Add missing 75% tracking call for youtube atoms

## What is the value of this and can you measure success?

We get to track 75% of a video has been played

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Request for comment

Hi @SiAdcock this a very small PR related to the last one I made, not sure how I missed this call in the first place!