### PR TITLE
Opt-in controller and control group for Webpack test

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -32,6 +32,7 @@ class OptInController extends Controller {
       case "headerthree" => headerThree.opt(choice)
       case "headerfour" => headerFour.opt(choice)
       case "headerfive" => headerFive.opt(choice)
+      case "webpack" => webpack.opt(choice)
       case _ => NotFound
     }))
   }
@@ -39,4 +40,5 @@ class OptInController extends Controller {
   val headerThree = OptInFeature("new_header_three_opt_in")
   val headerFour = OptInFeature("new_header_four_opt_in")
   val headerFive = OptInFeature("new_header_five_opt_in")
+  val webpack = OptInFeature("webpack_opt_in")
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -82,6 +82,17 @@ object WebpackTest extends TestDefinition(
   }
 }
 
+object WebpackControl extends TestDefinition(
+  name = "ab-webpack-control",
+  description = "control for Webpack test",
+  owners = Seq(Owner.withGithub("siadcock")),
+  sellByDate = new LocalDate(2017, 1, 9)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-webpack").contains("control")
+  }
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 


### PR DESCRIPTION
## What does this change?

This change adds an OptInController and a control group for the Webpack test. 

## What is the value of this and can you measure success?

We need to be able to test the success of Webpack in the frontend. To do so, it is convenient to set up an `OptInController`, allowing us to test Webpack in production. 

We also need a control group, whose experience will be compared with the Webpack trial group.

I have started setting up the Fastly cache splitting here: guardian/fastly-edge-cache#721 

## Does this affect other platforms - Amp, Apps, etc?

No

## Request for comment

@guardian/dotcom-platform

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
