### PR TITLE
Fetch hosted onward amp container from ajax domain

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -1,10 +1,7 @@
 @import common.commercial.hosted.HostedArticlePage
 @(page: HostedArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
 @import model.hosted.HostedAmp.ampify
-@import common.commercial.hosted.hardcoded.Support.makeshiftPage
 @import views.html.hosted._
-@import common.{AnalyticsHost, CanonicalLink, LinkTo}
-@import conf.Configuration
 @import views.support.FBPixel
 
 <!doctype html>
@@ -64,7 +61,7 @@
 
                                 </div>
                                 <div class="hide-on-desktop">
-                                    @hostedOnwardAmp(s"${page.url}/article/onward.json")
+                                    @hostedOnwardAmp("article", page.id)
                                 </div>
                                 <div class="hosted__standfirst">
                                     <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser.
@@ -72,7 +69,7 @@
                                 </div>
                             </div>
                             <div class="content__secondary-column">
-                                @hostedOnwardAmp(s"${page.url}/article/onward.json")
+                                @hostedOnwardAmp("article", page.id)
                             </div>
                         </div>
                     </div>

--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -1,8 +1,6 @@
 @import common.commercial.hosted.HostedVideoPage
 @import views.html.hosted._
 @import views.support.FBPixel
-@import conf.Configuration.environment
-@import conf.Configuration.site.host
 @(page: HostedVideoPage)(implicit request: RequestHeader, env: play.api.Environment)
 
 <!doctype html>
@@ -81,7 +79,7 @@
                     </div>
                 </div>
             </div>
-            @hostedOnwardAmp(s"${page.url}/video/onward.json")
+            @hostedOnwardAmp("video", page.id)
         </section>
         @guardianHostedCta(page, page.cta, isAMP = true)
       </div>

--- a/commercial/app/views/hosted/hostedOnwardAmp.scala.html
+++ b/commercial/app/views/hosted/hostedOnwardAmp.scala.html
@@ -1,7 +1,7 @@
-@(path: String)(implicit request: RequestHeader)
+@(hostPageType: String, hostPageId: String)(implicit request: RequestHeader)
 @import common.AmpLinkTo
 
-<amp-list src="@AmpLinkTo(path)" width="400" height="148" layout="responsive">
+<amp-list src="@AmpLinkTo.ajaxUrl(s"/$hostPageId/$hostPageType/amp/onward.json")" width="400" height="148" layout="responsive">
     <template type="amp-mustache">
         {{^trails}}
             <div></div>

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -3,61 +3,62 @@
 # ~~~~
 
 # For dev machines
-GET         /assets/*path                                                   dev.DevAssetsController.at(path)
-GET         /commercial/test-page                                           commercial.controllers.CreativeTestPage.allComponents(k: List[String])
-GET         /_healthcheck                                                   commercial.controllers.HealthCheck.healthCheck()
+GET         /assets/*path                                                       dev.DevAssetsController.at(path)
+GET         /commercial/test-page                                               commercial.controllers.CreativeTestPage.allComponents(k: List[String])
+GET         /_healthcheck                                                       commercial.controllers.HealthCheck.healthCheck()
 
 # Travel offer merchandising components
-GET         /commercial/travel/offers.json                                  commercial.controllers.TravelOffersController.renderTravel
-GET         /commercial/travel/api/offers.json                              commercial.controllers.TravelOffersController.getTravel
+GET         /commercial/travel/offers.json                                      commercial.controllers.TravelOffersController.renderTravel
+GET         /commercial/travel/api/offers.json                                  commercial.controllers.TravelOffersController.getTravel
 
 # Job merchandising components
-GET         /commercial/jobs.json                                           commercial.controllers.JobsController.renderJobs
-GET         /commercial/jobs/api/jobs.json                                  commercial.controllers.JobsController.getJobs
+GET         /commercial/jobs.json                                               commercial.controllers.JobsController.renderJobs
+GET         /commercial/jobs/api/jobs.json                                      commercial.controllers.JobsController.getJobs
 
 # Masterclass merchandising components
-GET         /commercial/masterclasses.json                                  commercial.controllers.MasterclassesController.renderMasterclasses
+GET         /commercial/masterclasses.json                                      commercial.controllers.MasterclassesController.renderMasterclasses
 
 # Soulmates merchandising components
-GET        /commercial/soulmates/$subgroup<\w+>.json                        commercial.controllers.SoulmatesController.renderSoulmates(subgroup)
-GET        /commercial/api/soulmates.json                                   commercial.controllers.SoulmatesController.getSoulmates
+GET        /commercial/soulmates/$subgroup<\w+>.json                            commercial.controllers.SoulmatesController.renderSoulmates(subgroup)
+GET        /commercial/api/soulmates.json                                       commercial.controllers.SoulmatesController.getSoulmates
 
 # Book merchandising components
-GET         /commercial/books/book.json                                     commercial.controllers.BookOffersController.renderBook
-GET         /commercial/books/books.json                                    commercial.controllers.BookOffersController.renderBooks
-GET         /commercial/books/api/books.json                                commercial.controllers.BookOffersController.getBooks
+GET         /commercial/books/book.json                                         commercial.controllers.BookOffersController.renderBook
+GET         /commercial/books/books.json                                        commercial.controllers.BookOffersController.renderBooks
+GET         /commercial/books/api/books.json                                    commercial.controllers.BookOffersController.getBooks
 
 # Live events merchandising components
-GET         /commercial/liveevents/event.json                               commercial.controllers.LiveEventsController.renderEvent
-GET         /commercial/api/liveevent.json                                  commercial.controllers.LiveEventsController.getLiveEvent
+GET         /commercial/liveevents/event.json                                   commercial.controllers.LiveEventsController.renderEvent
+GET         /commercial/api/liveevent.json                                      commercial.controllers.LiveEventsController.getLiveEvent
 
 # Multiple offer merchandising components
-GET         /commercial/multi.json                                          commercial.controllers.Multi.renderMulti
-GET         /commercial/api/multi.json                                      commercial.controllers.Multi.getMulti
+GET         /commercial/multi.json                                              commercial.controllers.Multi.renderMulti
+GET         /commercial/api/multi.json                                          commercial.controllers.Multi.getMulti
 # Content API merchandising components
-GET         /commercial/capi.json                                           commercial.controllers.ContentApiOffersController.itemsJson
-GET         /commercial/capi                                                commercial.controllers.ContentApiOffersController.itemsHtml
-GET         /commercial/capi-single.json                                    commercial.controllers.ContentApiOffersController.itemJson
-GET         /commercial/api/capi-single.json                                commercial.controllers.ContentApiOffersController.nativeJson
-GET         /commercial/api/capi-multiple.json                              commercial.controllers.ContentApiOffersController.nativeJsonMulti
-GET         /commercial/capi-single                                         commercial.controllers.ContentApiOffersController.itemHtml
-GET         /commercial/capi-single-merch.json                              commercial.controllers.ContentApiOffersController.itemJson
-GET         /commercial/capi-single-merch                                   commercial.controllers.ContentApiOffersController.itemHtml
-GET         /commercial/api/traffic-driver.json                             commercial.controllers.TrafficDriverController.renderJson
-GET         /commercial/paid.json                                           commercial.controllers.PaidContentCardController.cardJson
-GET         /commercial/paid                                                commercial.controllers.PaidContentCardController.cardHtml
+GET         /commercial/capi.json                                               commercial.controllers.ContentApiOffersController.itemsJson
+GET         /commercial/capi                                                    commercial.controllers.ContentApiOffersController.itemsHtml
+GET         /commercial/capi-single.json                                        commercial.controllers.ContentApiOffersController.itemJson
+GET         /commercial/api/capi-single.json                                    commercial.controllers.ContentApiOffersController.nativeJson
+GET         /commercial/api/capi-multiple.json                                  commercial.controllers.ContentApiOffersController.nativeJsonMulti
+GET         /commercial/capi-single                                             commercial.controllers.ContentApiOffersController.itemHtml
+GET         /commercial/capi-single-merch.json                                  commercial.controllers.ContentApiOffersController.itemJson
+GET         /commercial/capi-single-merch                                       commercial.controllers.ContentApiOffersController.itemHtml
+GET         /commercial/api/traffic-driver.json                                 commercial.controllers.TrafficDriverController.renderJson
+GET         /commercial/paid.json                                               commercial.controllers.PaidContentCardController.cardJson
+GET         /commercial/paid                                                    commercial.controllers.PaidContentCardController.cardHtml
 
 # Piggyback pixel from AppNexus, used for resizing mpus
-GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize
+GET         /commercial/anx/anxresize.js                                        commercial.controllers.PiggybackPixelController.resize
 
 # Hosted content
-GET         /commercial/advertiser-content/:campaignName/:pageName          commercial.controllers.HostedContentController.renderLegacyHostedPage(campaignName, pageName)
-GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
-GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json  commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
+GET         /commercial/advertiser-content/:campaignName/:pageName              commercial.controllers.HostedContentController.renderLegacyHostedPage(campaignName, pageName)
+GET         /advertiser-content/:campaignName/:pageName                         commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
+GET         /advertiser-content/:campaignName/:pageName/:cType/onward.json      commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
+GET         /advertiser-content/:campaignName/:pageName/:cType/amp/onward.json  commercial.controllers.HostedContentController.fetchAmpOnwardComponent(campaignName, pageName, cType)
 
 # Iframe buster and 3rd-party ads
-GET         /rockabox/rockabox_buster.html                                  controllers.Assets.at(path="/public", file="rockabox_buster.html")
+GET         /rockabox/rockabox_buster.html                                      controllers.Assets.at(path="/public", file="rockabox_buster.html")
 
 # Off-platform ads
-GET         /amp/remote.html                                                controllers.Assets.at(path="/public", file="amp_remote.html")
-GET         /facebook-ia/remote.html                                        controllers.Assets.at(path="/public", file="facebook_ia_remote.html")
+GET         /amp/remote.html                                                    controllers.Assets.at(path="/public", file="amp_remote.html")
+GET         /facebook-ia/remote.html                                            controllers.Assets.at(path="/public", file="facebook_ia_remote.html")

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -128,18 +128,23 @@ object SubscribeLink {
 trait AmpLinkTo extends LinkTo {
   override lazy val host = Configuration.amp.baseUrl
 
-  def pvBeaconUrl(implicit request: RequestHeader): String = {
-    val beaconHost = Configuration.debug.beaconUrl
-    val isLocalBeacon = beaconHost.isEmpty
-    val path = "count/pv.gif"
-    if (isLocalBeacon) s"//${request.host}/$path" else s"$beaconHost/$path"
-  }
-}
-
-object AmpLinkTo extends AmpLinkTo {
-
   override def processUrl(url: String, edition: Edition) = {
     val ampUrl = if (host.isEmpty) s"$url?amp=1" else url
     super.processUrl(ampUrl, edition)
   }
+
+  private def nonAmpUrl(serviceHost: String, path: String)(implicit request: RequestHeader): String = {
+    val isLocalEnv = serviceHost.isEmpty
+    if (isLocalEnv) s"//${request.host}$path" else s"$serviceHost$path"
+  }
+
+  def pvBeaconUrl(implicit request: RequestHeader): String = {
+    nonAmpUrl(serviceHost = Configuration.debug.beaconUrl, path = "/count/pv.gif")
+  }
+
+  def ajaxUrl(path: String)(implicit request: RequestHeader): String = {
+    nonAmpUrl(serviceHost = Configuration.ajax.url, path)
+  }
 }
+
+object AmpLinkTo extends AmpLinkTo

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -51,9 +51,18 @@ trait Controllers
   lazy val apiSandbox = wire[ApiSandbox]
   lazy val assets = wire[Assets]
   lazy val devAssetsController = wire[DevAssetsController]
-  lazy val emailSignupController = wire[EmailSignupController]
-  lazy val surveyPageController = wire[SurveyPageController]
-  lazy val signupPageController = wire[SignupPageController]
+  lazy val emailSignupController = {
+    implicit val env = self.environment
+    wire[EmailSignupController]
+  }
+  lazy val surveyPageController = {
+    implicit val env = self.environment
+    wire[SurveyPageController]
+  }
+  lazy val signupPageController = {
+    implicit val env = self.environment
+    wire[SignupPageController]
+  }
 }
 
 trait AppComponents

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -311,6 +311,7 @@ GET            /$path<commercial-containers>                                    
 GET            /commercial/advertiser-content/:campaignName/:pageName                                                            commercial.controllers.HostedContentController.renderLegacyHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
+GET            /advertiser-content/:campaignName/:pageName/:cType/amp/onward.json                                                commercial.controllers.HostedContentController.fetchAmpOnwardComponent(campaignName, pageName, cType)
 GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize
 
 # Commercial Admin

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -27,6 +27,7 @@ GET        /commercial/books/book.json                                          
 GET        /commercial/books/books.json                                                        commercial.controllers.BookOffersController.renderBooks
 GET        /advertiser-content/:campaignName/:pageName                                         commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET        /advertiser-content/:campaignName/:pageName/:cType/onward.json                      commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
+GET        /advertiser-content/:campaignName/:pageName/:cType/amp/onward.json                  commercial.controllers.HostedContentController.fetchAmpOnwardComponent(campaignName, pageName, cType)
 
 
 # Onward


### PR DESCRIPTION
This fixes a bug in #15149 where the amp onward container isn't being fetched because the request is being made on the wrong domain.

/cc @guardian/labs-beta 