### PR TITLE
Remove reference to Play.isDev in js template

### DIFF
--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -3,9 +3,10 @@ package controllers
 import common.{ExecutionContexts, Logging}
 import model.Cached.RevalidatableResult
 import model._
+import play.api.Environment
 import play.api.mvc.{Action, Controller}
 
-class WebAppController extends Controller with ExecutionContexts with Logging {
+class WebAppController(implicit env: Environment) extends Controller with ExecutionContexts with Logging {
 
   def serviceWorker() = Action { implicit request =>
     Cached(60) { RevalidatableResult.Ok(templates.js.serviceWorker()) }
@@ -15,5 +16,3 @@ class WebAppController extends Controller with ExecutionContexts with Logging {
     Cached(3600) { RevalidatableResult.Ok(templates.js.webAppManifest()) }
   }
 }
-
-object WebAppController extends WebAppController

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -1,7 +1,7 @@
-@()
+@()(implicit env: play.api.Environment)
 @import conf.Static
 @import conf.switches.Switches._
-
+@import play.api.Mode.Dev
 /*eslint quotes: [2, "single"], curly: [2, "multi-line"], strict: 0*/
 /*eslint-env browser*/
 /*global self*/
@@ -41,7 +41,7 @@ var isRequestForAsset = (function () {
     var assetPathRegex = new RegExp('^@Configuration.assets.path');
     return function (request) {
         var url = new URL(request.url);
-        @if(play.Play.isDev()) {
+        @if(env.mode == Dev) {
             return assetPathRegex.test(url.pathname);
         } else {
             return assetPathRegex.test(url.href);

--- a/common/app/templates/inlineJS/blocking/loadFonts.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadFonts.scala.js
@@ -1,4 +1,6 @@
-@()
+@()(implicit env: play.api.Environment)
+
+@import play.api.Mode.Dev
 
 /*
 bypass normal browser font-loading to avoid the FOIT. works like this:
@@ -35,7 +37,7 @@ do you have fonts in localStorage?
                 }
             }
         } catch (e) {
-            @if(play.Play.isDev){throw(e)}
+            @if(env.mode == Dev){throw(e)}
         }
         return hinting;
     })();
@@ -64,7 +66,7 @@ do you have fonts in localStorage?
                                     return true;
                                 }
                             } catch (e) {
-                                @if(play.Play.isDev){throw(e)}
+                                @if(env.mode == Dev){throw(e)}
                             }
                         }
 
@@ -158,7 +160,7 @@ do you have fonts in localStorage?
                 return true;
             }
         } catch (e) {
-            @if(play.Play.isDev){throw(e)}
+            @if(env.mode == Dev){throw(e)}
         }
         return false;
     }
@@ -179,7 +181,7 @@ do you have fonts in localStorage?
                 thisScript.parentNode.insertBefore(fonts, thisScript);
             });
         } catch (e) {
-            @if(play.Play.isDev){throw(e)}
+            @if(env.mode == Dev){throw(e)}
         }
     }
 
@@ -241,7 +243,7 @@ do you have fonts in localStorage?
                         }
                     }
                 } catch (e) {
-                    @if(play.Play.isDev){throw(e)}
+                    @if(env.mode == Dev){throw(e)}
                 }
                 // Didn't find any non-black pixels or something went wrong (for example,
                 // non-blink Opera cannot use the canvas fillText() method) so we assume
@@ -253,7 +255,7 @@ do you have fonts in localStorage?
                 return true;
             }
         } catch (e) {
-            @if(play.Play.isDev){throw(e)}
+            @if(env.mode == Dev){throw(e)}
         }
     }
 

--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -1,4 +1,6 @@
-@(item: model.MetaData)(implicit request: RequestHeader)
+@(item: model.MetaData)(implicit request: RequestHeader, env: play.api.Environment)
+
+@import play.api.Mode.Dev
 
 // Determine whether we want to run the enhanced app or not.
 // It can come either from a preference in localStorage (see `enhancedKey`)
@@ -57,7 +59,7 @@
     window.shouldEnhance = mustNotEnhance() ? false : mustEnhance() ? true : couldEnhance() && weWantToEnhance();
 
     // just so we can tell…
-    @if(play.Play.isDev()) {
+    @if(env.mode == Dev) {
         window.console && window.console.info(`THIS IS ${window.shouldEnhance ? 'ENHANCED' : 'STANDARD ONLY'}`);
     }
 })(window);

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -1,3 +1,7 @@
+@()(implicit env: play.api.Environment)
+
+@import play.api.Mode.Dev
+
 try {
     ((document, window) => {
         if (typeof window.getComputedStyle !== 'function') {
@@ -47,5 +51,5 @@ try {
         });
     })(document, window);
 } catch (e) {
-    @if(play.Play.isDev) {throw (e)}
+    @if(env.mode == Dev) {throw (e)}
 }

--- a/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
@@ -1,3 +1,7 @@
+@()(implicit env: play.api.Environment)
+
+@import play.api.Mode.Dev
+
 // If the browser cuts the mustard and supports `atob`
 // then read the user data from cookies and add it to `guardian`
 
@@ -38,5 +42,5 @@ try {
         }
     })(guardian.isEnhanced && 'atob' in window, document, window);
 } catch (e) {
-    @if(play.Play.isDev) {throw (e)}
+    @if(env.mode == Dev) {throw (e)}
 }

--- a/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
@@ -1,3 +1,7 @@
+@()(implicit env: play.api.Environment)
+
+@import play.api.Mode.Dev
+
 try {
     ((isVeryModern, document, window) => {
         var user = window.guardian.config.user;
@@ -33,6 +37,6 @@ try {
         }
     })('classList' in document.documentElement, document, window);
 } catch (e) {
-    @if(play.Play.isDev) {throw (e)}
+    @if(env.mode == Dev) {throw (e)}
 }
 


### PR DESCRIPTION
## What does this change?
Remove reference to Play.isDev in js template
Instead passing Environment as an implicit parameter to the template

## What is the value of this and can you measure success?
`Play` global is deprecated in Play 2.5

## Request for comment
@alexduf @DiegoVazquezNanini @jfsoul @gtrufitt 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
