### PR TITLE
Remove reference to Play.unsafeApplication

### DIFF
--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -1,15 +1,11 @@
 package common
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
-import play.api.Play
+import org.scalatest.{FlatSpec, Matchers}
 import common.editions.{Au, Us, International, Uk}
-import play.api.mvc.RequestHeader
 import test._
 import play.api.test.FakeRequest
 
 class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
-
-  Play.unsafeApplication
 
   implicit val edition = Uk
   implicit val editions = Seq(Uk,Us,Au)

--- a/common/test/model/UrlsTest.scala
+++ b/common/test/model/UrlsTest.scala
@@ -5,11 +5,8 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichJodaDateTime
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.play.OneAppPerSuite
-import play.api.Play
 
 class UrlsTest extends FlatSpec with Matchers with OneAppPerSuite {
-
-  Play.unsafeApplication
 
   "Urls" should "be created relative for articles" in {
 


### PR DESCRIPTION
## What does this change?
Remove reference to Play.unsafeApplication

## What is the value of this and can you measure success?
There are useless.

## Request for comment
@jfsoul @DiegoVazquezNanini 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

