### PR TITLE
Do not attach raven to window app

### DIFF
--- a/static/src/javascripts/projects/common/utils/raven.js
+++ b/static/src/javascripts/projects/common/utils/raven.js
@@ -1,21 +1,13 @@
 define([
     'raven',
+    'common/utils/config',
     'common/utils/detect'
 ], function (
     raven,
+    config,
     detect
 ) {
-    var guardian = window.guardian;
-    var config = guardian.config;
-    var app = guardian.app = guardian.app || {};
-
-    if (app.raven) {
-        return app.raven;
-    }
-
-    // attach raven to global object
-    app.raven = raven;
-    app.raven.config(
+    raven.config(
         'https://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
         {
             whitelistUrls: [
@@ -55,7 +47,7 @@ define([
     );
 
     // Report uncaught exceptions
-    app.raven.install();
+    raven.install();
 
-    return app.raven;
+    return raven;
 });

--- a/static/test/javascripts/main.js
+++ b/static/test/javascripts/main.js
@@ -26,7 +26,6 @@ requirejs.config({
         picturefill:  'projects/common/utils/picturefill',
         Promise:      'components/when/Promise',
         qwery:        'components/qwery/qwery',
-        raven:        'components/raven-js/raven',
         reqwest:      'components/reqwest/reqwest',
         analytics:    'projects/common/modules/analytics/analytics',
         // Test specific paths
@@ -37,7 +36,9 @@ requirejs.config({
         svgs:         '../inline-svgs',
         // plugins
         text:         'components/requirejs-text/text',
-        inlineSvg:    'projects/common/utils/inlineSvg'
+        inlineSvg:    'projects/common/utils/inlineSvg',
+        // skip the raven configuration module
+        'common/utils/raven':        'components/raven-js/raven',
     },
     shim: {
         googletag: {

--- a/static/test/javascripts/setup.js
+++ b/static/test/javascripts/setup.js
@@ -38,17 +38,5 @@ window.guardian = {
     adBlockers: {
         active: undefined,
         onDetect: []
-    },
-    app: {
-        raven: {
-            captureException: function() {},
-            wrap: function (options, callback) {
-                if (typeof options === 'function') {
-                    return options;
-                } else {
-                    return callback;
-                }
-            }
-        }
     }
 };

--- a/static/test/javascripts/spec/common/content/space-filler.spec.js
+++ b/static/test/javascripts/spec/common/content/space-filler.spec.js
@@ -1,4 +1,3 @@
-/* global guardian */
 define([
     'helpers/injector'
 ], function (

--- a/static/test/javascripts/spec/common/content/space-filler.spec.js
+++ b/static/test/javascripts/spec/common/content/space-filler.spec.js
@@ -9,23 +9,26 @@ define([
     describe('Space filler', function () {
         var spaceFiller,
             spaceFinder,
-            raven = guardian.app.raven,
+            raven,
             Promise,
             rules = {},
             spacefinderResult,
             writeError = new Error('Mock writer exception');
 
         beforeEach(function (done) {
-            spyOn(raven, 'captureException');
 
             injector.require([
                 'common/modules/article/space-filler',
                 'common/modules/article/spacefinder',
-                'Promise'
+                'Promise',
+                'common/utils/raven'
             ], function () {
                 spaceFiller = arguments[0];
                 spaceFinder = arguments[1];
                 Promise = arguments[2];
+                raven = arguments[3];
+
+                spyOn(raven, 'captureException');
 
                 spyOn(spaceFinder, 'findSpace').and.callFake(function () {
                     return spacefinderResult;


### PR DESCRIPTION
This change removes the raven attachment, I'm speculating that this may be behind the cause of the high volume of sentry errors seen since November 15. Related to this one, maybe: https://github.com/guardian/frontend/pull/14982 @SiAdcock 