### PR TITLE
Remove Play.isProd in DevParametersHttpRequestHandler

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -2,16 +2,17 @@ package dev
 
 import play.api.http.{HttpFilters, HttpConfiguration, HttpErrorHandler, DefaultHttpRequestHandler}
 import play.api.routing.Router
-import play.api.Play
 import play.api.mvc.RequestHeader
-import Play.isProd
 import common.CanonicalLink
+import play.api.Environment
+import play.api.Mode.Prod
 
 class DevParametersHttpRequestHandler(
     router: Router,
     errorHandler: HttpErrorHandler,
     configuration: HttpConfiguration,
-    filters: HttpFilters
+    filters: HttpFilters,
+    environment: Environment
   ) extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters) with implicits.Requests {
 
 
@@ -66,25 +67,22 @@ class DevParametersHttpRequestHandler(
 
   override def routeRequest(request: RequestHeader) = {
 
-    Play.maybeApplication.foreach{ implicit application =>
-      // json requests have no SEO implication but will affect caching
-
-      if (
-        !isProd &&
-        !request.isJson &&
-        !request.uri.startsWith("/oauth2callback") &&
-        !request.uri.startsWith("/px.gif")  && // diagnostics box
-        !request.uri.startsWith("/tech-feedback") &&
-        !request.uri.startsWith("/crosswords/search") &&
-        !request.uri.startsWith("/crosswords/lookup") &&
-        !request.uri.startsWith("/commercial/anx/anxresize.js") // this is used by commercial for advert resizing, served through api.nextgen
-      ) {
-        val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
-        if (illegalParams.nonEmpty) {
-          // it is pretty hard to spot what is happening in tests without this println
-          println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")
-          throw new RuntimeException(s"illegal parameter(s) found ${illegalParams.mkString(",")}")
-        }
+    // json requests have no SEO implication but will affect caching
+    if (
+      environment.mode != Prod &&
+      !request.isJson &&
+      !request.uri.startsWith("/oauth2callback") &&
+      !request.uri.startsWith("/px.gif")  && // diagnostics box
+      !request.uri.startsWith("/tech-feedback") &&
+      !request.uri.startsWith("/crosswords/search") &&
+      !request.uri.startsWith("/crosswords/lookup") &&
+      !request.uri.startsWith("/commercial/anx/anxresize.js") // this is used by commercial for advert resizing, served through api.nextgen
+    ) {
+      val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
+      if (illegalParams.nonEmpty) {
+        // it is pretty hard to spot what is happening in tests without this println
+        println(s"\n\nILLEGAL PARAMETER(S) FOUND : ${illegalParams.mkString(",")}\n\n")
+        throw new RuntimeException(s"illegal parameter(s) found ${illegalParams.mkString(",")}")
       }
     }
 

--- a/dev-build/app/http/DevBuildParametersHttpRequestHandler.scala
+++ b/dev-build/app/http/DevBuildParametersHttpRequestHandler.scala
@@ -2,19 +2,22 @@ package http
 
 import common.CanonicalLink
 import dev.DevParametersHttpRequestHandler
-import play.api.http.{HttpFilters, HttpConfiguration, HttpErrorHandler}
+import play.api.Environment
+import play.api.http.{HttpConfiguration, HttpErrorHandler, HttpFilters}
 import play.api.routing.Router
 
 class DevBuildParametersHttpRequestHandler(
   router: Router,
   errorHandler: HttpErrorHandler,
   configuration: HttpConfiguration,
-  filters: HttpFilters
+  filters: HttpFilters,
+  environment: Environment
 ) extends DevParametersHttpRequestHandler(
   router = router,
   errorHandler = errorHandler,
   configuration = configuration,
-  filters = filters
+  filters = filters,
+  environment = environment
 ) {
   override val allowedParams: Seq[String] =
     CanonicalLink.significantParams ++ commercialParams ++ insignificantParams ++ Seq("query")


### PR DESCRIPTION
## What does this change?
Remove Play.isProd in DevParametersHttpRequestHandler

## What is the value of this and can you measure success?
`Play` global object is deprecated in Play 2.5

## Request for comment
@DiegoVazquezNanini @jfsoul @alexduf 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

