### PR TITLE
DO NOT MERGE - WIP - Remove ref to global Play object in Configuration.scala

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -10,10 +10,10 @@ object AdminConfiguration {
   import GuardianConfiguration._
 
   object pa {
-    lazy val footballApiKey = configuration.getStringProperty("pa.api.key")
+    lazy val footballApiKey = guardianConfiguration.getStringProperty("pa.api.key")
         .getOrElse(throw new RuntimeException("unable to load pa football api key"))
 
-    lazy val cricketApiKey = configuration.getStringProperty("pa.cricket.api.key")
+    lazy val cricketApiKey = guardianConfiguration.getStringProperty("pa.cricket.api.key")
         .getOrElse(throw new RuntimeException("unable to load pa cricket api key"))
 
     lazy val footballHost = PaClientConfig.baseUrl
@@ -21,42 +21,42 @@ object AdminConfiguration {
     lazy val apiExplorer = "http://developer.press.net/io-docs"
   }
 
-  lazy val topStoriesKey = configuration.getStringProperty("top-stories.config").getOrElse(throw new RuntimeException("Top Stories file name is not setup"))
+  lazy val topStoriesKey = guardianConfiguration.getStringProperty("top-stories.config").getOrElse(throw new RuntimeException("Top Stories file name is not setup"))
 
   object fastly {
-    lazy val key = configuration.getStringProperty("fastly.key").getOrElse(throw new RuntimeException("Fastly key not configured"))
-    lazy val serviceId = configuration.getStringProperty("fastly.serviceId").getOrElse(throw new RuntimeException("Fastly service id not configured"))
+    lazy val key = guardianConfiguration.getStringProperty("fastly.key").getOrElse(throw new RuntimeException("Fastly key not configured"))
+    lazy val serviceId = guardianConfiguration.getStringProperty("fastly.serviceId").getOrElse(throw new RuntimeException("Fastly service id not configured"))
   }
 
   object imgix {
-    lazy val key = configuration.getStringProperty("imgix.key").getOrElse(throw new RuntimeException("Imgix key not configured"))
+    lazy val key = guardianConfiguration.getStringProperty("imgix.key").getOrElse(throw new RuntimeException("Imgix key not configured"))
   }
 
   object dfpApi {
-    lazy val clientId = configuration.getStringProperty("api.dfp.clientId")
-    lazy val clientSecret = configuration.getStringProperty("api.dfp.clientSecret")
-    lazy val refreshToken = configuration.getStringProperty("api.dfp.refreshToken")
-    lazy val appName = configuration.getStringProperty("api.dfp.applicationName")
+    lazy val clientId = guardianConfiguration.getStringProperty("api.dfp.clientId")
+    lazy val clientSecret = guardianConfiguration.getStringProperty("api.dfp.clientSecret")
+    lazy val refreshToken = guardianConfiguration.getStringProperty("api.dfp.refreshToken")
+    lazy val appName = guardianConfiguration.getStringProperty("api.dfp.applicationName")
   }
 
   lazy val oauthCredentials: Option[OAuthCredentialsWithMultipleCallbacks] =
       for {
-        oauthClientId <- configuration.getStringProperty("admin.oauth.clientid")
-        oauthSecret <- configuration.getStringProperty("admin.oauth.secret")
-      } yield OAuthCredentialsWithMultipleCallbacks(oauthClientId, oauthSecret, configuration.getStringPropertiesSplitByComma("admin.oauth.callbacks"))
+        oauthClientId <- guardianConfiguration.getStringProperty("admin.oauth.clientid")
+        oauthSecret <- guardianConfiguration.getStringProperty("admin.oauth.secret")
+      } yield OAuthCredentialsWithMultipleCallbacks(oauthClientId, oauthSecret, guardianConfiguration.getStringPropertiesSplitByComma("admin.oauth.callbacks"))
 
   lazy val omnitureCredentials: Option[OmnitureCredentials] =
     for {
-      userName <- configuration.getStringProperty("admin.omniture.username")
-      secret <- configuration.getStringProperty("admin.omniture.secret")
+      userName <- guardianConfiguration.getStringProperty("admin.omniture.username")
+      secret <- guardianConfiguration.getStringProperty("admin.omniture.secret")
     } yield OmnitureCredentials(userName, secret)
 
   object db {
     object default {
-      lazy val driver = configuration.getStringProperty("default.driver")
-      lazy val url = configuration.getStringProperty("default.url")
-      lazy val user = configuration.getStringProperty("default.user")
-      lazy val password = configuration.getStringProperty("default.password")
+      lazy val driver = guardianConfiguration.getStringProperty("default.driver")
+      lazy val url = guardianConfiguration.getStringProperty("default.url")
+      lazy val user = guardianConfiguration.getStringProperty("default.user")
+      lazy val password = guardianConfiguration.getStringProperty("default.password")
     }
   }
 }

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -51,7 +51,7 @@ trait FrontendComponents
   lazy val jobScheduler = new JobScheduler(environment)
   lazy val akkaAsync = new AkkaAsync(environment, actorSystem)
   lazy val appMetrics = ApplicationMetrics()
-  lazy val guardianConf = new GuardianConfiguration
+  lazy val guardianConf = new GuardianConfiguration(configuration, environment)
   lazy val mode = environment.mode
 
   // this is a workaround to make wsapi and the actorsystem available to the injector.

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -2,7 +2,6 @@ package common
 
 import java.io.{File, FileInputStream}
 import java.util.Map.Entry
-import java.util.{Properties => JavaProperties}
 
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
@@ -12,7 +11,8 @@ import com.typesafe.config.ConfigException
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import org.apache.commons.io.IOUtils
-import play.api.Play
+import play.api.{Environment, Configuration => PlayConfiguration}
+import play.api.Mode.Prod
 
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
@@ -65,7 +65,7 @@ object GuardianConfiguration extends Logging {
   import com.typesafe.config.Config
   import InstallVars.InstallationVars._
 
-  lazy val configuration = {
+  lazy val guardianConfiguration: Config = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
     val s3ConfigVersion = 12
@@ -122,35 +122,34 @@ object GuardianConfiguration extends Logging {
 
 }
 
-class GuardianConfiguration extends Logging {
+class GuardianConfiguration(playConfiguration: PlayConfiguration, playEnvironment: Environment) extends Logging {
   import GuardianConfiguration._
-  import play.api.Play.current
 
   case class OAuthCredentials(oauthClientId: String, oauthSecret: String, oauthCallback: String)
   case class OAuthCredentialsWithMultipleCallbacks(oauthClientId: String, oauthSecret: String, authorizedOauthCallbacks: List[String])
 
   object business {
-    lazy val stocksEndpoint = configuration.getMandatoryStringProperty("business_data.url")
+    lazy val stocksEndpoint = guardianConfiguration.getMandatoryStringProperty("business_data.url")
   }
 
   object weather {
-    lazy val apiKey = configuration.getStringProperty("weather.api.key")
+    lazy val apiKey = guardianConfiguration.getStringProperty("weather.api.key")
   }
 
   object indexes {
     lazy val tagIndexesBucket =
-      configuration.getMandatoryStringProperty("tag_indexes.bucket")
+      guardianConfiguration.getMandatoryStringProperty("tag_indexes.bucket")
 
     lazy val adminRebuildIndexRateInMinutes =
-      configuration.getIntegerProperty("tag_indexes.rebuild_rate_in_minutes").getOrElse(60)
+      guardianConfiguration.getIntegerProperty("tag_indexes.rebuild_rate_in_minutes").getOrElse(60)
   }
 
   object environment {
     import InstallVars._
 
     lazy val stage = InstallationVars.stage
-    lazy val projectName = Play.application.configuration.getString("guardian.projectName").getOrElse("frontend")
-    lazy val secure = Play.application.configuration.getBoolean("guardian.secure").getOrElse(false)
+    lazy val projectName = playConfiguration.getString("guardian.projectName").getOrElse("frontend")
+    lazy val secure = playConfiguration.getBoolean("guardian.secure").getOrElse(false)
 
     lazy val isProd = stage.equalsIgnoreCase("prod")
     lazy val isCode = stage.equalsIgnoreCase("code")
@@ -160,97 +159,97 @@ class GuardianConfiguration extends Logging {
   }
 
   object switches {
-    lazy val key = configuration.getMandatoryStringProperty("switches.key")
+    lazy val key = guardianConfiguration.getMandatoryStringProperty("switches.key")
   }
 
   object healthcheck {
-    lazy val properties = configuration.getPropertyNames filter {
+    lazy val properties = guardianConfiguration.getPropertyNames filter {
       _ matches """healthcheck\..*\.url"""
     }
 
     lazy val urls = properties map { property =>
-      configuration.getStringProperty(property).get
+      guardianConfiguration.getStringProperty(property).get
     }
-    lazy val updateIntervalInSecs: Int = configuration.getIntegerProperty("healthcheck.updateIntervalInSecs").getOrElse(5)
+    lazy val updateIntervalInSecs: Int = guardianConfiguration.getIntegerProperty("healthcheck.updateIntervalInSecs").getOrElse(5)
   }
 
   object debug {
-    lazy val enabled: Boolean = configuration.getStringProperty("debug.enabled").forall(_.toBoolean)
-    lazy val beaconUrl: String = configuration.getStringProperty("beacon.url").getOrElse("")
+    lazy val enabled: Boolean = guardianConfiguration.getStringProperty("debug.enabled").forall(_.toBoolean)
+    lazy val beaconUrl: String = guardianConfiguration.getStringProperty("beacon.url").getOrElse("")
   }
 
-  override def toString = configuration.toString
+  override def toString = guardianConfiguration.toString
 
   case class Auth(user: String, password: String)
 
   object contentApi {
-    val contentApiHost: String = configuration.getMandatoryStringProperty("content.api.host")
+    val contentApiHost: String = guardianConfiguration.getMandatoryStringProperty("content.api.host")
 
     def contentApiDraftHost: String =
-        configuration.getStringProperty("content.api.draft.host")
+        guardianConfiguration.getStringProperty("content.api.draft.host")
           .filter(_ => Switches.FaciaToolDraftContent.isSwitchedOn)
           .getOrElse(contentApiHost)
 
-    val previewHost: String = configuration.getStringProperty("content.api.preview.host").getOrElse(contentApiHost)
+    val previewHost: String = guardianConfiguration.getStringProperty("content.api.preview.host").getOrElse(contentApiHost)
 
-    lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
-    lazy val timeout: Int = configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000)
+    lazy val key: Option[String] = guardianConfiguration.getStringProperty("content.api.key")
+    lazy val timeout: Int = guardianConfiguration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000)
 
     lazy val circuitBreakerErrorThreshold =
-      configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(5)
+      guardianConfiguration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(5)
 
     lazy val circuitBreakerResetTimeout =
-      configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(20000)
+      guardianConfiguration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(20000)
 
     lazy val previewAuth: Option[Auth] = for {
-      user <- configuration.getStringProperty("content.api.preview.user")
-      password <- configuration.getStringProperty("content.api.preview.password")
+      user <- guardianConfiguration.getStringProperty("content.api.preview.user")
+      password <- guardianConfiguration.getStringProperty("content.api.preview.password")
     } yield Auth(user, password)
   }
 
   object ophanApi {
-    lazy val key = configuration.getStringProperty("ophan.api.key")
-    lazy val host = configuration.getStringProperty("ophan.api.host")
+    lazy val key = guardianConfiguration.getStringProperty("ophan.api.key")
+    lazy val host = guardianConfiguration.getStringProperty("ophan.api.host")
   }
 
   object ophan {
-    lazy val jsLocation = configuration.getStringProperty("ophan.js.location").getOrElse("//j.ophan.co.uk/ophan.ng")
-    lazy val embedJsLocation = configuration.getStringProperty("ophan.embed.js.location").getOrElse("//j.ophan.co.uk/ophan.embed")
+    lazy val jsLocation = guardianConfiguration.getStringProperty("ophan.js.location").getOrElse("//j.ophan.co.uk/ophan.ng")
+    lazy val embedJsLocation = guardianConfiguration.getStringProperty("ophan.embed.js.location").getOrElse("//j.ophan.co.uk/ophan.embed")
   }
 
   object omniture {
-    lazy val account = configuration.getStringProperty("guardian.page.omnitureAccount").getOrElse("guardiangu-network")
-    lazy val ampAccount = configuration.getStringProperty("guardian.page.omnitureAmpAccount").getOrElse("guardiangudev-code")
-    lazy val thirdPartyAppsAccount = configuration.getStringProperty("guardian.page.thirdPartyAppsAccount").getOrElse("guardiangu-thirdpartyapps")
+    lazy val account = guardianConfiguration.getStringProperty("guardian.page.omnitureAccount").getOrElse("guardiangu-network")
+    lazy val ampAccount = guardianConfiguration.getStringProperty("guardian.page.omnitureAmpAccount").getOrElse("guardiangudev-code")
+    lazy val thirdPartyAppsAccount = guardianConfiguration.getStringProperty("guardian.page.thirdPartyAppsAccount").getOrElse("guardiangu-thirdpartyapps")
   }
 
   object googletag {
-    lazy val jsLocation = configuration.getStringProperty("googletag.js.location").getOrElse("//www.googletagservices.com/tag/js/gpt.js")
+    lazy val jsLocation = guardianConfiguration.getStringProperty("googletag.js.location").getOrElse("//www.googletagservices.com/tag/js/gpt.js")
   }
 
   object sonobi {
-    lazy val jsLocation = configuration.getStringProperty("sonobi.js.location").getOrElse("//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js")
+    lazy val jsLocation = guardianConfiguration.getStringProperty("sonobi.js.location").getOrElse("//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12911.js")
   }
 
   object frontend {
-    lazy val store = configuration.getMandatoryStringProperty("frontend.store")
-    lazy val webEngineersEmail = configuration.getStringProperty("email.web.engineers")
+    lazy val store = guardianConfiguration.getMandatoryStringProperty("frontend.store")
+    lazy val webEngineersEmail = guardianConfiguration.getStringProperty("email.web.engineers")
   }
 
   object site {
-    lazy val host = configuration.getStringProperty("guardian.page.host").getOrElse("")
+    lazy val host = guardianConfiguration.getStringProperty("guardian.page.host").getOrElse("")
   }
 
   object cookies {
     lazy val lastSeenKey: String = "lastseen"
-    lazy val sessionExpiryTime = configuration.getIntegerProperty("auth.timeout").getOrElse(60000)
+    lazy val sessionExpiryTime = guardianConfiguration.getIntegerProperty("auth.timeout").getOrElse(60000)
   }
 
   object db {
-    lazy val sentry_db_driver = configuration.getStringProperty("db.sentry.driver").getOrElse("")
-    lazy val sentry_db_url = configuration.getStringProperty("db.sentry.url").getOrElse("")
-    lazy val sentry_db_username = configuration.getStringProperty("db.sentry.user").getOrElse("")
-    lazy val sentry_db_password = configuration.getStringProperty("db.sentry.password").getOrElse("")
+    lazy val sentry_db_driver = guardianConfiguration.getStringProperty("db.sentry.driver").getOrElse("")
+    lazy val sentry_db_url = guardianConfiguration.getStringProperty("db.sentry.url").getOrElse("")
+    lazy val sentry_db_username = guardianConfiguration.getStringProperty("db.sentry.user").getOrElse("")
+    lazy val sentry_db_password = guardianConfiguration.getStringProperty("db.sentry.password").getOrElse("")
   }
 
   object proxy {
@@ -269,86 +268,86 @@ class GuardianConfiguration extends Logging {
   }
 
   object github {
-    lazy val token = configuration.getStringProperty("github.token")
+    lazy val token = guardianConfiguration.getStringProperty("github.token")
   }
 
   object teamcity {
-    lazy val host = configuration.getMandatoryStringProperty("teamcity.host")
-    lazy val internalHost = configuration.getMandatoryStringProperty("teamcity.internalhost")
+    lazy val host = guardianConfiguration.getMandatoryStringProperty("teamcity.host")
+    lazy val internalHost = guardianConfiguration.getMandatoryStringProperty("teamcity.internalhost")
   }
 
   object ajax {
-    lazy val url = configuration.getStringProperty("ajax.url").getOrElse("")
+    lazy val url = guardianConfiguration.getStringProperty("ajax.url").getOrElse("")
     lazy val nonSecureUrl =
-      configuration.getStringProperty("ajax.url").getOrElse("")
-    lazy val corsOrigins: Seq[String] = configuration.getStringProperty("ajax.cors.origin").map(_.split(",")
+      guardianConfiguration.getStringProperty("ajax.url").getOrElse("")
+    lazy val corsOrigins: Seq[String] = guardianConfiguration.getStringProperty("ajax.cors.origin").map(_.split(",")
       .map(_.trim).toSeq).getOrElse(Nil)
   }
 
   object amp {
-    private lazy val scheme = configuration.getStringProperty("amp.scheme").getOrElse("")
-    lazy val host = configuration.getStringProperty("amp.host").getOrElse("")
+    private lazy val scheme = guardianConfiguration.getStringProperty("amp.scheme").getOrElse("")
+    lazy val host = guardianConfiguration.getStringProperty("amp.host").getOrElse("")
     lazy val baseUrl = scheme + host
   }
 
   object id {
-    lazy val url = configuration.getStringProperty("id.url").getOrElse("")
-    lazy val apiRoot = configuration.getStringProperty("id.apiRoot").getOrElse("")
+    lazy val url = guardianConfiguration.getStringProperty("id.url").getOrElse("")
+    lazy val apiRoot = guardianConfiguration.getStringProperty("id.apiRoot").getOrElse("")
     lazy val domain = """^https?://(?:profile\.)?([^/:]+)""".r.unapplySeq(url).flatMap(_.headOption).getOrElse("theguardian.com")
-    lazy val apiClientToken = configuration.getStringProperty("id.apiClientToken").getOrElse("")
-    lazy val oauthUrl = configuration.getStringProperty("id.oauth.url").getOrElse("")
-    lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
-    lazy val digitalPackUrl = configuration.getStringProperty("id.digitalpack.url").getOrElse("https://subscribe.theguardian.com")
-    lazy val membersDataApiUrl = configuration.getStringProperty("id.members-data-api.url").getOrElse("https://members-data-api.theguardian.com")
-    lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
+    lazy val apiClientToken = guardianConfiguration.getStringProperty("id.apiClientToken").getOrElse("")
+    lazy val oauthUrl = guardianConfiguration.getStringProperty("id.oauth.url").getOrElse("")
+    lazy val membershipUrl = guardianConfiguration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
+    lazy val digitalPackUrl = guardianConfiguration.getStringProperty("id.digitalpack.url").getOrElse("https://subscribe.theguardian.com")
+    lazy val membersDataApiUrl = guardianConfiguration.getStringProperty("id.members-data-api.url").getOrElse("https://members-data-api.theguardian.com")
+    lazy val stripePublicToken =  guardianConfiguration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
   }
 
   object static {
     lazy val path =
-      if (environment.secure) configuration.getMandatoryStringProperty("static.securePath")
-      else configuration.getMandatoryStringProperty("static.path")
+      if (environment.secure) guardianConfiguration.getMandatoryStringProperty("static.securePath")
+      else guardianConfiguration.getMandatoryStringProperty("static.path")
   }
 
   object images {
-    lazy val path = configuration.getMandatoryStringProperty("images.path")
+    lazy val path = guardianConfiguration.getMandatoryStringProperty("images.path")
     val fallbackLogo = Static("images/fallback-logo.png")
     object backends {
-      lazy val mediaToken: String = configuration.getMandatoryStringProperty("images.media.token")
-      lazy val staticToken: String = configuration.getMandatoryStringProperty("images.static.token")
-      lazy val uploadsToken: String = configuration.getMandatoryStringProperty("images.uploads.token")
+      lazy val mediaToken: String = guardianConfiguration.getMandatoryStringProperty("images.media.token")
+      lazy val staticToken: String = guardianConfiguration.getMandatoryStringProperty("images.static.token")
+      lazy val uploadsToken: String = guardianConfiguration.getMandatoryStringProperty("images.uploads.token")
     }
   }
 
   object headlines {
-    lazy val spreadsheet = configuration.getMandatoryStringProperty("headlines.spreadsheet")
+    lazy val spreadsheet = guardianConfiguration.getMandatoryStringProperty("headlines.spreadsheet")
   }
 
   object assets {
-    lazy val path = configuration.getMandatoryStringProperty("assets.path")
+    lazy val path = guardianConfiguration.getMandatoryStringProperty("assets.path")
 
-    // This configuration value determines if this server will load and resolve assets using the asset map.
+    // This guardianConfiguration value determines if this server will load and resolve assets using the asset map.
     // Set this to true if you want to run the Play server in dev, and emulate prod mode asset-loading.
     // If true in dev, assets are locally loaded from the `hash` build output, otherwise assets come from 'target' for css, and 'src' for js.
-    lazy val useHashedBundles =  configuration.getStringProperty("assets.useHashedBundles")
+    lazy val useHashedBundles =  guardianConfiguration.getStringProperty("assets.useHashedBundles")
       .map(_.toBoolean)
       .getOrElse(environment.isProd || environment.isCode)
   }
 
   object staticSport {
-    lazy val path = configuration.getMandatoryStringProperty("staticSport.path")
+    lazy val path = guardianConfiguration.getMandatoryStringProperty("staticSport.path")
   }
 
   object sport {
-    lazy val apiUrl = configuration.getStringProperty("sport.apiUrl").getOrElse(ajax.nonSecureUrl)
+    lazy val apiUrl = guardianConfiguration.getStringProperty("sport.apiUrl").getOrElse(ajax.nonSecureUrl)
   }
 
   object oas {
-    lazy val siteIdHost = configuration.getStringProperty("oas.siteId.host").getOrElse(".guardian.co.uk")
-    lazy val url = configuration.getStringProperty("oas.url").getOrElse("http://oas.theguardian.com/RealMedia/ads/")
+    lazy val siteIdHost = guardianConfiguration.getStringProperty("oas.siteId.host").getOrElse(".guardian.co.uk")
+    lazy val url = guardianConfiguration.getStringProperty("oas.url").getOrElse("http://oas.theguardian.com/RealMedia/ads/")
   }
 
   object facebook {
-    lazy val appId = configuration.getMandatoryStringProperty("guardian.page.fbAppId")
+    lazy val appId = guardianConfiguration.getMandatoryStringProperty("guardian.page.fbAppId")
   }
 
   object ios {
@@ -357,42 +356,42 @@ class GuardianConfiguration extends Logging {
   }
 
   object discussion {
-    lazy val apiRoot = configuration.getMandatoryStringProperty("guardian.page.discussionApiUrl")
-    lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
-    lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
-    lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
-    lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
+    lazy val apiRoot = guardianConfiguration.getMandatoryStringProperty("guardian.page.discussionApiUrl")
+    lazy val apiTimeout = guardianConfiguration.getMandatoryStringProperty("discussion.apiTimeout")
+    lazy val apiClientHeader = guardianConfiguration.getMandatoryStringProperty("discussion.apiClientHeader")
+    lazy val d2Uid = guardianConfiguration.getMandatoryStringProperty("discussion.d2Uid")
+    lazy val frontendAssetsMap = guardianConfiguration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
     lazy val frontendAssetsVersion = "v1.5.0"
   }
 
   object witness {
-    lazy val witnessApiRoot = configuration.getMandatoryStringProperty("witness.apiRoot")
+    lazy val witnessApiRoot = guardianConfiguration.getMandatoryStringProperty("witness.apiRoot")
   }
 
   object commercial {
 
     lazy val testDomain =
       if (environment.isProd) "http://m.code.dev-theguardian.com"
-      else configuration.getStringProperty("guardian.page.host") getOrElse ""
+      else guardianConfiguration.getStringProperty("guardian.page.host") getOrElse ""
 
-    lazy val dfpAdUnitGuRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
-    lazy val dfpFacebookIaAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.facebookIaAdUnitRoot")
-    lazy val dfpMobileAppsAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
-    lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
+    lazy val dfpAdUnitGuRoot = guardianConfiguration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
+    lazy val dfpFacebookIaAdUnitRoot = guardianConfiguration.getMandatoryStringProperty("guardian.page.dfp.facebookIaAdUnitRoot")
+    lazy val dfpMobileAppsAdUnitRoot = guardianConfiguration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
+    lazy val dfpAccountId = guardianConfiguration.getMandatoryStringProperty("guardian.page.dfpAccountId")
 
-    lazy val books_url = configuration.getMandatoryStringProperty("commercial.books_url")
+    lazy val books_url = guardianConfiguration.getMandatoryStringProperty("commercial.books_url")
     lazy val masterclasses_url =
-      configuration.getMandatoryStringProperty("commercial.masterclasses_url")
-    lazy val soulmates_url = configuration.getMandatoryStringProperty("commercial.soulmates_url")
-    lazy val soulmatesApiUrl = configuration.getStringProperty("soulmates.api.url")
-    lazy val travelFeedUrl = configuration.getStringProperty("travel.feed.url")
+      guardianConfiguration.getMandatoryStringProperty("commercial.masterclasses_url")
+    lazy val soulmates_url = guardianConfiguration.getMandatoryStringProperty("commercial.soulmates_url")
+    lazy val soulmatesApiUrl = guardianConfiguration.getStringProperty("soulmates.api.url")
+    lazy val travelFeedUrl = guardianConfiguration.getStringProperty("travel.feed.url")
     lazy val guMerchandisingAdvertiserId =
-      configuration.getMandatoryStringProperty("commercial.dfp.guMerchandising.advertiserId")
+      guardianConfiguration.getMandatoryStringProperty("commercial.dfp.guMerchandising.advertiserId")
 
     // root dir relative to S3 bucket
     private lazy val commercialRoot = {
-      configuration.getStringProperty("commercial.s3.root") getOrElse s"${environment.stage.toUpperCase}/commercial"
+      guardianConfiguration.getStringProperty("commercial.s3.root") getOrElse s"${environment.stage.toUpperCase}/commercial"
     }
 
     private lazy val dfpRoot = s"$commercialRoot/dfp"
@@ -412,32 +411,32 @@ class GuardianConfiguration extends Logging {
     private lazy val merchandisingFeedsRoot = s"$commercialRoot/merchandising"
     lazy val merchandisingFeedsLatest = s"$merchandisingFeedsRoot/latest"
 
-    lazy val masterclassesToken = configuration.getStringProperty("masterclasses.token")
-    lazy val liveEventsToken = configuration.getStringProperty("live-events.token")
+    lazy val masterclassesToken = guardianConfiguration.getStringProperty("masterclasses.token")
+    lazy val liveEventsToken = guardianConfiguration.getStringProperty("live-events.token")
     lazy val liveEventsMembershipUrl = "https://membership.theguardian.com/events.json"
-    lazy val jobsUrl= configuration.getStringProperty("jobs.api.url")
+    lazy val jobsUrl= guardianConfiguration.getStringProperty("jobs.api.url")
 
     object magento {
-      lazy val domain = configuration.getStringProperty("magento.domain")
-      lazy val consumerKey = configuration.getStringProperty("magento.consumer.key")
-      lazy val consumerSecret = configuration.getStringProperty("magento.consumer.secret")
-      lazy val accessToken = configuration.getStringProperty("magento.access.token.key")
-      lazy val accessTokenSecret = configuration.getStringProperty("magento.access.token.secret")
-      lazy val authorizationPath = configuration.getStringProperty("magento.auth.path")
-      lazy val isbnLookupPath = configuration.getStringProperty("magento.isbn.lookup.path")
+      lazy val domain = guardianConfiguration.getStringProperty("magento.domain")
+      lazy val consumerKey = guardianConfiguration.getStringProperty("magento.consumer.key")
+      lazy val consumerSecret = guardianConfiguration.getStringProperty("magento.consumer.secret")
+      lazy val accessToken = guardianConfiguration.getStringProperty("magento.access.token.key")
+      lazy val accessTokenSecret = guardianConfiguration.getStringProperty("magento.access.token.secret")
+      lazy val authorizationPath = guardianConfiguration.getStringProperty("magento.auth.path")
+      lazy val isbnLookupPath = guardianConfiguration.getStringProperty("magento.isbn.lookup.path")
     }
 
-    lazy val adOpsTeam = configuration.getStringProperty("email.adOpsTeam")
-    lazy val adOpsAuTeam = configuration.getStringProperty("email.adOpsTeamAu")
-    lazy val adOpsUsTeam = configuration.getStringProperty("email.adOpsTeamUs")
-    lazy val adTechTeam = configuration.getStringProperty("email.adTechTeam")
-    lazy val gLabsTeam = configuration.getStringProperty("email.gLabsTeam")
+    lazy val adOpsTeam = guardianConfiguration.getStringProperty("email.adOpsTeam")
+    lazy val adOpsAuTeam = guardianConfiguration.getStringProperty("email.adOpsTeamAu")
+    lazy val adOpsUsTeam = guardianConfiguration.getStringProperty("email.adOpsTeamUs")
+    lazy val adTechTeam = guardianConfiguration.getStringProperty("email.adTechTeam")
+    lazy val gLabsTeam = guardianConfiguration.getStringProperty("email.gLabsTeam")
 
     lazy val expiredAdFeatureUrl = s"${site.host}/info/2015/feb/06/paid-content-removal-policy"
   }
 
   object open {
-    lazy val ctaApiRoot = configuration.getMandatoryStringProperty("open.cta.apiRoot")
+    lazy val ctaApiRoot = guardianConfiguration.getMandatoryStringProperty("open.cta.apiRoot")
   }
 
   object interactive {
@@ -463,52 +462,52 @@ class GuardianConfiguration extends Logging {
     )
 
     lazy val pageData: Map[String, String] = {
-      val keys = configuration.getPropertyNames.filter(_.startsWith("guardian.page."))
+      val keys = guardianConfiguration.getPropertyNames.filter(_.startsWith("guardian.page."))
       keys.foldLeft(Map.empty[String, String]) {
-        case (map, key) => map + (key -> configuration.getMandatoryStringProperty(key))
+        case (map, key) => map + (key -> guardianConfiguration.getMandatoryStringProperty(key))
       }
     }
   }
 
   object front {
-    lazy val config = configuration.getMandatoryStringProperty("front.config")
+    lazy val config = guardianConfiguration.getMandatoryStringProperty("front.config")
   }
 
   object targeting {
-    lazy val campaignsUrl = configuration.getStringProperty("targeting.campaignsUrl")
+    lazy val campaignsUrl = guardianConfiguration.getStringProperty("targeting.campaignsUrl")
   }
 
   object facia {
-    lazy val stage = configuration.getStringProperty("facia.stage").getOrElse(environment.stage)
+    lazy val stage = guardianConfiguration.getStringProperty("facia.stage").getOrElse(environment.stage)
     lazy val collectionCap: Int = 35
   }
 
   object faciatool {
-    lazy val crossAccountSourceBucket = configuration.getMandatoryStringProperty("aws.cmsFronts.frontCollections.bucket")
-    lazy val outputBucket = configuration.getMandatoryStringProperty("aws.bucket")
+    lazy val crossAccountSourceBucket = guardianConfiguration.getMandatoryStringProperty("aws.cmsFronts.frontCollections.bucket")
+    lazy val outputBucket = guardianConfiguration.getMandatoryStringProperty("aws.bucket")
 
-    lazy val frontPressCronQueue = configuration.getStringProperty("frontpress.sqs.cron_queue_url")
-    lazy val frontPressToolQueue = configuration.getStringProperty("frontpress.sqs.tool_queue_url")
-    lazy val frontPressStatusNotificationStream = configuration.getStringProperty("frontpress.kinesis.status_notification_stream")
+    lazy val frontPressCronQueue = guardianConfiguration.getStringProperty("frontpress.sqs.cron_queue_url")
+    lazy val frontPressToolQueue = guardianConfiguration.getStringProperty("frontpress.sqs.tool_queue_url")
+    lazy val frontPressStatusNotificationStream = guardianConfiguration.getStringProperty("frontpress.kinesis.status_notification_stream")
 
     lazy val configBeforePressTimeout: Int = 1000
 
     val showTestContainers =
-      configuration.getStringProperty("faciatool.show_test_containers").contains("true")
+      guardianConfiguration.getStringProperty("faciatool.show_test_containers").contains("true")
 
     lazy val adminPressJobStandardPushRateInMinutes: Int =
-      Try(configuration.getStringProperty("admin.pressjob.standard.push.rate.inminutes").get.toInt)
+      Try(guardianConfiguration.getStringProperty("admin.pressjob.standard.push.rate.inminutes").get.toInt)
         .getOrElse(5)
 
     lazy val adminPressJobHighPushRateInMinutes: Int =
-      Try(configuration.getStringProperty("admin.pressjob.high.push.rate.inminutes").get.toInt)
+      Try(guardianConfiguration.getStringProperty("admin.pressjob.high.push.rate.inminutes").get.toInt)
         .getOrElse(1)
 
     lazy val adminPressJobLowPushRateInMinutes: Int =
-      Try(configuration.getStringProperty("admin.pressjob.low.push.rate.inminutes").get.toInt)
+      Try(guardianConfiguration.getStringProperty("admin.pressjob.low.push.rate.inminutes").get.toInt)
         .getOrElse(60)
 
-    lazy val stsRoleToAssume = configuration.getStringProperty("aws.cmsFronts.account.role")
+    lazy val stsRoleToAssume = guardianConfiguration.getStringProperty("aws.cmsFronts.account.role")
 
     def crossAccountMandatoryCredentials: AWSCredentialsProvider =
       crossAccountCredentials.getOrElse(throw new BadConfigurationException("AWS credentials for cross account are not configured"))
@@ -529,7 +528,7 @@ class GuardianConfiguration extends Logging {
           log.error("amazon client cross account exception", ex)
 
           // We really, really want to ensure that PROD is configured before saying a box is OK
-          if (Play.isProd) throw ex
+          if (playEnvironment.mode == Prod) throw ex
           // this means that on dev machines you only need to configure keys if you are actually going to use them
           None
       }
@@ -537,31 +536,31 @@ class GuardianConfiguration extends Logging {
   }
 
   object r2Press {
-    lazy val sqsQueueUrl = configuration.getStringProperty("admin.r2.page.press.sqs.queue.url")
-    lazy val sqsTakedownQueueUrl = configuration.getStringProperty("admin.r2.page.press.takedown.sqs.queue.url")
-    lazy val pressRateInSeconds = configuration.getIntegerProperty("admin.r2.page.press.rate.seconds").getOrElse(60)
-    lazy val pressQueueWaitTimeInSeconds = configuration.getIntegerProperty("admin.r2.press.queue.wait.seconds").getOrElse(10)
-    lazy val pressQueueMaxMessages = configuration.getIntegerProperty("admin.r2.press.queue.max.messages").getOrElse(10)
-    lazy val fallbackCachebustId = configuration.getStringProperty("admin.r2.press.fallback.cachebust.id").getOrElse("")
+    lazy val sqsQueueUrl = guardianConfiguration.getStringProperty("admin.r2.page.press.sqs.queue.url")
+    lazy val sqsTakedownQueueUrl = guardianConfiguration.getStringProperty("admin.r2.page.press.takedown.sqs.queue.url")
+    lazy val pressRateInSeconds = guardianConfiguration.getIntegerProperty("admin.r2.page.press.rate.seconds").getOrElse(60)
+    lazy val pressQueueWaitTimeInSeconds = guardianConfiguration.getIntegerProperty("admin.r2.press.queue.wait.seconds").getOrElse(10)
+    lazy val pressQueueMaxMessages = guardianConfiguration.getIntegerProperty("admin.r2.press.queue.max.messages").getOrElse(10)
+    lazy val fallbackCachebustId = guardianConfiguration.getStringProperty("admin.r2.press.fallback.cachebust.id").getOrElse("")
   }
 
   object memcached {
-    lazy val host = configuration.getStringProperty("memcached.host")
+    lazy val host = guardianConfiguration.getStringProperty("memcached.host")
   }
 
   object redis {
-    lazy val endpoint = configuration.getStringProperty("redis.host")
+    lazy val endpoint = guardianConfiguration.getStringProperty("redis.host")
   }
 
   object aws {
 
-    lazy val region = configuration.getMandatoryStringProperty("aws.region")
-    lazy val bucket = configuration.getMandatoryStringProperty("aws.bucket")
-    lazy val notificationSns: String = configuration.getMandatoryStringProperty("sns.notification.topic.arn")
-    lazy val videoEncodingsSns: String = configuration.getMandatoryStringProperty("sns.missing_video_encodings.topic.arn")
-    lazy val frontPressSns: Option[String] = configuration.getStringProperty("frontpress.sns.topic")
-    lazy val r2PressSns: Option[String] = configuration.getStringProperty("r2press.sns.topic")
-    lazy val r2PressTakedownSns: Option[String] = configuration.getStringProperty("r2press.takedown.sns.topic")
+    lazy val region = guardianConfiguration.getMandatoryStringProperty("aws.region")
+    lazy val bucket = guardianConfiguration.getMandatoryStringProperty("aws.bucket")
+    lazy val notificationSns: String = guardianConfiguration.getMandatoryStringProperty("sns.notification.topic.arn")
+    lazy val videoEncodingsSns: String = guardianConfiguration.getMandatoryStringProperty("sns.missing_video_encodings.topic.arn")
+    lazy val frontPressSns: Option[String] = guardianConfiguration.getStringProperty("frontpress.sns.topic")
+    lazy val r2PressSns: Option[String] = guardianConfiguration.getStringProperty("r2press.sns.topic")
+    lazy val r2PressTakedownSns: Option[String] = guardianConfiguration.getStringProperty("r2press.takedown.sns.topic")
 
     def mandatoryCredentials: AWSCredentialsProvider = credentials.getOrElse(throw new BadConfigurationException("AWS credentials are not configured"))
     val credentials: Option[AWSCredentialsProvider] = {
@@ -580,7 +579,7 @@ class GuardianConfiguration extends Logging {
           log.error(ex.getMessage, ex)
 
           // We really, really want to ensure that PROD is configured before saying a box is OK
-          if (Play.isProd) throw ex
+          if (playEnvironment.mode == Prod) throw ex
           // this means that on dev machines you only need to configure keys if you are actually going to use them
           None
       }
@@ -588,56 +587,56 @@ class GuardianConfiguration extends Logging {
   }
 
   object riffraff {
-    lazy val url = configuration.getMandatoryStringProperty("riffraff.url")
-    lazy val apiKey = configuration.getMandatoryStringProperty("riffraff.apikey")
+    lazy val url = guardianConfiguration.getMandatoryStringProperty("riffraff.url")
+    lazy val apiKey = guardianConfiguration.getMandatoryStringProperty("riffraff.apikey")
   }
 
   object formstack {
-    lazy val url = configuration.getMandatoryStringProperty("formstack.url")
-    lazy val oAuthToken = configuration.getMandatoryStringProperty("formstack.oauthToken")
+    lazy val url = guardianConfiguration.getMandatoryStringProperty("formstack.url")
+    lazy val oAuthToken = guardianConfiguration.getMandatoryStringProperty("formstack.oauthToken")
   }
 
   object standalone {
     lazy val oauthCredentials: Option[OAuthCredentials] = for {
-      oauthClientId <- configuration.getStringProperty("standalone.oauth.clientid")
+      oauthClientId <- guardianConfiguration.getStringProperty("standalone.oauth.clientid")
       // TODO needs the orElse fallback till we roll out new properties files
-      oauthSecret <- configuration.getStringProperty("standalone.oauth.secret").orElse(configuration.getStringProperty("preview.oauth.secret"))
-      oauthCallback <- configuration.getStringProperty("standalone.oauth.callback")
+      oauthSecret <- guardianConfiguration.getStringProperty("standalone.oauth.secret").orElse(guardianConfiguration.getStringProperty("preview.oauth.secret"))
+      oauthCallback <- guardianConfiguration.getStringProperty("standalone.oauth.callback")
     } yield OAuthCredentials(oauthClientId, oauthSecret, oauthCallback)
   }
 
   object pngResizer {
-    val cacheTimeInSeconds = configuration.getIntegerProperty("png_resizer.image_cache_time").getOrElse(86400)
-    val ttlInSeconds = configuration.getIntegerProperty("png_resizer.image_ttl").getOrElse(86400)
+    val cacheTimeInSeconds = guardianConfiguration.getIntegerProperty("png_resizer.image_cache_time").getOrElse(86400)
+    val ttlInSeconds = guardianConfiguration.getIntegerProperty("png_resizer.image_ttl").getOrElse(86400)
   }
 
 
   object emailSignup {
-    val url = configuration.getMandatoryStringProperty("email.signup.url")
+    val url = guardianConfiguration.getMandatoryStringProperty("email.signup.url")
   }
 
   object NewsAlert {
-    lazy val apiKey = configuration.getStringProperty("news-alert.api.key")
+    lazy val apiKey = guardianConfiguration.getStringProperty("news-alert.api.key")
   }
 
   object Notifications {
-    lazy val latestMessageUrl = configuration.getMandatoryStringProperty("notifications.latest_message.url")
-    lazy val notificationSubscriptionTable = configuration.getMandatoryStringProperty("notifications.subscriptions_table")
+    lazy val latestMessageUrl = guardianConfiguration.getMandatoryStringProperty("notifications.latest_message.url")
+    lazy val notificationSubscriptionTable = guardianConfiguration.getMandatoryStringProperty("notifications.subscriptions_table")
   }
 
   object DeploysNotify {
-    lazy val apiKey = configuration.getStringProperty("deploys-notify.api.key")
+    lazy val apiKey = guardianConfiguration.getStringProperty("deploys-notify.api.key")
   }
 
   object Logstash {
-    lazy val enabled = configuration.getStringProperty("logstash.enabled").exists(_.toBoolean)
-    lazy val stream = configuration.getStringProperty("logstash.stream.name")
-    lazy val streamRegion = configuration.getStringProperty("logstash.stream.region")
+    lazy val enabled = guardianConfiguration.getStringProperty("logstash.enabled").exists(_.toBoolean)
+    lazy val stream = guardianConfiguration.getStringProperty("logstash.stream.name")
+    lazy val streamRegion = guardianConfiguration.getStringProperty("logstash.stream.region")
   }
 
   object Elk {
-    lazy val kibanaUrl = configuration.getStringProperty("elk.kibana.url")
-    lazy val elasticsearchHeadUrl = configuration.getStringProperty("elk.elasticsearchHead.url")
+    lazy val kibanaUrl = guardianConfiguration.getStringProperty("elk.kibana.url")
+    lazy val elasticsearchHeadUrl = guardianConfiguration.getStringProperty("elk.elasticsearchHead.url")
   }
 
   object Survey {
@@ -645,7 +644,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object Media {
-    lazy val externalEmbedHost = configuration.getMandatoryStringProperty("guardian.page.externalEmbedHost")
+    lazy val externalEmbedHost = guardianConfiguration.getMandatoryStringProperty("guardian.page.externalEmbedHost")
   }
 
 }

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -1,6 +1,6 @@
 package dev
 
-import play.api.http.{HttpFilters, HttpConfiguration, HttpErrorHandler, DefaultHttpRequestHandler}
+import play.api.http.{DefaultHttpRequestHandler, HttpConfiguration, HttpErrorHandler, HttpFilters}
 import play.api.routing.Router
 import play.api.Play
 import play.api.mvc.RequestHeader

--- a/identity/app/conf/IdentityConfiguration.scala
+++ b/identity/app/conf/IdentityConfiguration.scala
@@ -11,11 +11,11 @@ class IdentityConfiguration extends GuardianConfiguration with SafeLogging {
 
   object exacttarget {
     lazy val factory = for {
-      accountName <- configuration.getStringProperty("exacttarget.accountname")
-      password <- configuration.getStringProperty("exacttarget.password")
-      endpointUrl <- configuration.getStringProperty("exacttarget.endpoint")
+      accountName <- guardianConfiguration.getStringProperty("exacttarget.accountname")
+      password <- guardianConfiguration.getStringProperty("exacttarget.password")
+      endpointUrl <- guardianConfiguration.getStringProperty("exacttarget.endpoint")
     } yield {
-      logger.info(s"Found configuration for ExactTarget with endpoint $endpointUrl")
+      logger.info(s"Found guardianConfiguration for ExactTarget with endpoint $endpointUrl")
       new ExactTargetFactory(accountName, password, new URI(endpointUrl))
     }
   }

--- a/sport/app/conf/SportConfiguration.scala
+++ b/sport/app/conf/SportConfiguration.scala
@@ -9,14 +9,14 @@ object SportConfiguration {
 
   object pa {
     lazy val footballHost = "http://football-api.gu-web.net/v1.5"
-    lazy val footballKey = configuration.getMandatoryStringProperty("pa.api.key")
-    lazy val cricketKey = configuration.getStringProperty("pa.cricket.api.key")
+    lazy val footballKey = guardianConfiguration.getMandatoryStringProperty("pa.api.key")
+    lazy val cricketKey = guardianConfiguration.getStringProperty("pa.cricket.api.key")
   }
 
   object optaRugby {
-    lazy val endpoint = configuration.getStringProperty("opta.rugby.api.endpoint")
-    lazy val apiKey = configuration.getStringProperty("opta.rugby.api.key")
-    lazy val apiUser = configuration.getStringProperty("opta.rugby.api.user")
+    lazy val endpoint = guardianConfiguration.getStringProperty("opta.rugby.api.endpoint")
+    lazy val apiKey = guardianConfiguration.getStringProperty("opta.rugby.api.key")
+    lazy val apiUser = guardianConfiguration.getStringProperty("opta.rugby.api.user")
   }
 
 }


### PR DESCRIPTION
cc @DiegoVazquezNanini 

## What does this change?
Remove ref to global Play object in Configuration.scala

## What is the value of this and can you measure success?
`Play` global object is deprecated in Play 2.5

## Request for comment

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

