### PR TITLE
Remove US Election 2016 from US edition nav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -46,7 +46,7 @@ trait Navigation {
   val world = SectionLink("world", "world", "World", "/world")
   val uk = SectionLink("uk-news", "UK", "UK News", "/uk-news")
   val us = SectionLink("us-news", "US", "US News", "/us-news")
-  val usElection2016 = SectionLink("us-elections-2016", "election 2016", "Election 2016", "/us-news/us-elections-2016")
+  val usPolitics = SectionLink("politics", "politics", "Politics", "/us-news/us-politics")
   val politics = SectionLink("politics", "politics", "Politics", "/politics")
   val australiaPolitics = SectionLink("politics", "politics", "Politics", "/australia-news/australian-politics")
   val technology = SectionLink("technology", "tech", "Technology", "/technology")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -26,7 +26,6 @@ object NewNavigation {
   var auPolitics = NavLink("australian politics", "/australia-news/australian-politics")
   var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum")
   var indigenousAustralia = NavLink("indigenous australia", "/australia-news/indigenous-australians")
-  var usElections = NavLink("US election", "/us-news/us-elections-2016")
   var usNews = NavLink("US news", "/us-news", uniqueSection = "us-news")
   var usPolitics = NavLink("US politics", "/us-news/us-politics")
 
@@ -122,7 +121,7 @@ object NewNavigation {
 
     val uk = List(headlines, ukNews, world, politics, environment, business, tech, science, money)
     val au = List(headlines, australiaNews, world, auPolitics, environment, economy, auImmigration, indigenousAustralia, media, tech)
-    val us = List(headlines, usElections, usNews, world, environment, business, usPolitics, tech, science, money)
+    val us = List(headlines, usNews, usPolitics, world, environment, business, tech, science, money)
     val int = List(headlines, world, ukNews, environment, business, tech, science, cities, globalDevelopment)
   }
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -56,8 +56,8 @@ object Us extends Edition(
   override val navigation: Seq[NavItem] = {
     Seq(
       NavItem(home),
-      NavItem(usElection2016),
       NavItem(us),
+      NavItem(usPolitics),
       NavItem(world, worldLocalNav),
       NavItem(opinion),
       NavItem(sports, Seq(soccer, mls, nfl, mlb, nba, nhl)),
@@ -78,8 +78,8 @@ object Us extends Edition(
 
   override def briefNav: Seq[NavItem] = Seq(
     NavItem(home),
-    NavItem(usElection2016),
     NavItem(us),
+    NavItem(usPolitics),
     NavItem(world, worldLocalNav),
     NavItem(opinion),
     NavItem(sports, Seq(soccer, mls, nfl, mlb, nba, nhl)),


### PR DESCRIPTION
## What does this change?
In standard header:
- removes US election 2016 link from US edition nav
- adds "politics" link to US edition nav - points to /us-news/us-politics

In new header:
- replaces US election 2016 link in new nav with "US politics" link that points to 
/us-news/us-politics

This has been done on request of Francisco Navas from central prod.



