### PR TITLE
Branding overlay images to not slash faces in half

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -104,13 +104,14 @@ object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 1
 abstract class ShareImage(shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
   override val heightParam = "h=630"
   override val fitParam = "fit=crop"
+  val cropParam = "crop=faces,entropy"  
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=bottom%2Cleft"
   val blendImageParam: String
 
   override def resizeString = {
     if(shouldIncludeOverlay) {
-      val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
+      val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, cropParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
       s"?$params"
     } else {
       super.resizeString


### PR DESCRIPTION
Hello,

## What does this change?
Crops sharing images a bit better.
## What is the value of this and can you measure success?
Success is overrated. This change means that some stuff will look a bit less naff. Sometimes.
## Does this affect other platforms - Amp, Apps, etc?
Amp carries og:image and twitter:image, so yes.

---

I don't know what I'm doing and have not tested anything (this extra comma there won't brake anything, won't it?). I'm not even sure where this what I'm writing will appear after I hit Propose file change! [EDIT: now I know and I can't remove it from there 😆]

Currently, social images may crop off important image parts because they are of different ratio than the original crops like so:

[Current](https://i.guim.co.uk/img/media/6ede56d85ef9343b64cb49ca7aa6c36c350c85c8/0_187_2233_2791/master/2233.jpg?w=1200&h=630&q=55&auto=format&usm=12&fit=crop&bm=normal&ba=bottom%2Cleft&blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n&s=016f6a13b8264742dd4512bab44334b1)
![2233_current](https://cloud.githubusercontent.com/assets/6032869/20807072/62e524bc-b7f5-11e6-991c-455f1f2496ee.jpeg)


I propose to introduce additional [imgIX params](https://docs.imgix.com/apis/url/size/crop) only to this sharing image type, so that, hopefully, important image parts won't be cropped off, like so:

[Proposed](https://i.guim.co.uk/img/media/6ede56d85ef9343b64cb49ca7aa6c36c350c85c8/0_187_2233_2791/master/2233.jpg?w=1200&h=630&q=55&auto=format&usm=12&fit=crop&crop=faces,entropy&bm=normal&ba=bottom%2Cleft&blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n&s=016f6a13b8264742dd4512bab44334b1)
![2233_proposed](https://cloud.githubusercontent.com/assets/6032869/20807090/6e80a35a-b7f5-11e6-937b-7011806dec24.jpeg)

This will inevitably mean some other errors in crops, but I've tested images without faces and it was never worse than the current output (tested also `edges` and inconclusively settled on `entropy`).

@katebee: because it's all her fault for suggesting I should look at code. Oh, and @paperboyo: stay, the f*&%k away with your non-PR-related comments, okay?!

Scared to death
Mateusz

[Heck, let's see what happens when I click this thingy here!]