### PR TITLE
Support interactive atoms in the main media slot on articles and live blogs

### DIFF
--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -39,3 +39,4 @@
    ========================================================================== */
 
 @import 'module/atoms/_quiz';
+@import 'module/atoms/_interactive';

--- a/static/src/stylesheets/module/atoms/_interactive.scss
+++ b/static/src/stylesheets/module/atoms/_interactive.scss
@@ -1,0 +1,4 @@
+.interactive-atom-fence {
+    width: 100%;
+    border: 0;
+}


### PR DESCRIPTION
Add some CSS to support iframed interactive embeds in the main media slot

## Before
![image](https://cloud.githubusercontent.com/assets/2084823/20833808/7973df36-b889-11e6-8823-6c2c5fd5794c.png)

![image](https://cloud.githubusercontent.com/assets/2084823/20833799/6f788e78-b889-11e6-9560-619114ae42a5.png)

## After
![image](https://cloud.githubusercontent.com/assets/2084823/20832880/abd10198-b884-11e6-8ec4-23a27d5132fc.png)

![image](https://cloud.githubusercontent.com/assets/2084823/20833543/38b82b92-b888-11e6-94bf-e36ed65688ea.png)
