### PR TITLE
Attach raven to window.guardian.app

### DIFF
--- a/static/src/javascripts/projects/common/utils/raven.js
+++ b/static/src/javascripts/projects/common/utils/raven.js
@@ -7,7 +7,14 @@ define([
     config,
     detect
 ) {
-    raven.config(
+    var guardian = window.guardian;
+
+    var app = guardian.app = guardian.app || {};
+
+    // attach raven to global object
+    app.raven = raven;
+
+    app.raven.config(
         'https://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
         {
             whitelistUrls: [
@@ -47,7 +54,7 @@ define([
     );
 
     // Report uncaught exceptions
-    raven.install();
+    app.raven.install();
 
-    return raven;
+    return app.raven;
 });


### PR DESCRIPTION
Re-instating the window-raven attachment, after all the windows phone shenanigans. @SiAdcock 