### PR TITLE
Pass title with correct capitalisation to GA

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -30,8 +30,8 @@
     }
 
     function getAnalyticsTitle() {
-        var analyticsTitle = (guardian.config.page.webTitle || '').toLowerCase();
-        return (analyticsTitle === 'network front') ? getAnalyticsEdition() + ' ' + analyticsTitle : analyticsTitle;
+        var analyticsTitle = (guardian.config.page.webTitle || '');
+        return (analyticsTitle === 'Network Front') ? getAnalyticsEdition() + ' network front' : analyticsTitle;
     }
 
     var identityId = null;


### PR DESCRIPTION
## What does this change?

This patch changes the title field for GA calls.

Due to misscommunication, the title field started being lowercased for all page views about a week ago. The title field is a cornerstone in the definition of the pageview and is now inconsistent with every other platform and with historical web data.

## What is the value of this and can you measure success?

This is a significant bug that affects our base reporting and needs to be fixed asap. The title has been tracked like this for over a week now.

## Does this affect other platforms - Amp, Apps, etc?

The code change doesn't affect other platforms per se.

## Screenshots

Here's an example GA report using the Total Views aggregate metric that brings together pageviews from various platforms.

<img width="774" alt="inconsistent_capitalisation_-_analytics_" src="https://cloud.githubusercontent.com/assets/1672034/20837010/025db816-b89a-11e6-89d7-dff9b26f329d.png">


## Request for comment

@gtrufitt @dominickendrick @mkopka 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
