### PR TITLE
Add the epic to Observer 225th anniversary and Brexit coverage

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -47,6 +47,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-brexit-supreme",
+    "Gather contributions and supporters around Brexit supreme court case",
+    owners = Seq(Owner.withGithub("philwills")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 12, 12),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-uk-memb-engagement-msg-copy-test-10",
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -37,6 +37,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-observer-anniversary",
+    "Gather contributions and supporters around Observer 225th anniversary",
+    owners = Seq(Owner.withGithub("philwills")),
+    safeState = Off,
+    sellByDate =  new LocalDate(2016, 12, 12),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-uk-memb-engagement-msg-copy-test-10",
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -12,8 +12,13 @@ define([
         variants: ['mixed', 'just-contribute', 'just-supporter']
     };
 
+    var ContributionsEpicObserverAnniversary = {
+        name: 'ContributionsEpicObserverAnniversary',
+        variants: ['mixed']
+    };
+
     function userIsInAClashingAbTest() {
-        var clashingTests = [ContributionsEpicUsaCtaThreeWay];
+        var clashingTests = [ContributionsEpicUsaCtaThreeWay, ContributionsEpicObserverAnniversary];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -17,8 +17,13 @@ define([
         variants: ['mixed']
     };
 
+    var ContributionsEpicBrexitSupreme = {
+        name: 'ContributionsEpicBrexitSupreme',
+        variants: ['mixed']
+    };
+
     function userIsInAClashingAbTest() {
-        var clashingTests = [ContributionsEpicUsaCtaThreeWay, ContributionsEpicObserverAnniversary];
+        var clashingTests = [ContributionsEpicUsaCtaThreeWay, ContributionsEpicObserverAnniversary, ContributionsEpicBrexitSupreme];
         return _testABClash(ab.isInVariant, clashingTests);
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,6 +10,7 @@ define([
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/membership-engagement-international-experiment',
     'common/modules/experiments/tests/contributions-epic-usa-cta-three-way',
+    'common/modules/experiments/tests/contributions-epic-observer-anniversary',
     'common/modules/experiments/tests/uk-membership-engagement-message-test-10',
     'common/modules/experiments/tests/au-membership-engagement-message-test-8'
 ], function (reportError,
@@ -23,6 +24,7 @@ define([
              RecommendedForYou,
              MembershipEngagementInternationalExperiment,
              ContributionsEpicUsaCtaThreeWay,
+             ContributionsEpicObserverAnniversary,
              UkMembershipEngagementMessageTest10,
              AuMembershipEngagementMessageTest8
     ) {
@@ -30,6 +32,7 @@ define([
         new RecommendedForYou(),
         new MembershipEngagementInternationalExperiment(),
         new ContributionsEpicUsaCtaThreeWay(),
+        new ContributionsEpicObserverAnniversary(),
         new UkMembershipEngagementMessageTest10(),
         new AuMembershipEngagementMessageTest8()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,6 +11,7 @@ define([
     'common/modules/experiments/tests/membership-engagement-international-experiment',
     'common/modules/experiments/tests/contributions-epic-usa-cta-three-way',
     'common/modules/experiments/tests/contributions-epic-observer-anniversary',
+    'common/modules/experiments/tests/contributions-epic-brexit-supreme',
     'common/modules/experiments/tests/uk-membership-engagement-message-test-10',
     'common/modules/experiments/tests/au-membership-engagement-message-test-8'
 ], function (reportError,
@@ -25,6 +26,7 @@ define([
              MembershipEngagementInternationalExperiment,
              ContributionsEpicUsaCtaThreeWay,
              ContributionsEpicObserverAnniversary,
+             ContributionsEpicBrexitSupreme,
              UkMembershipEngagementMessageTest10,
              AuMembershipEngagementMessageTest8
     ) {
@@ -33,6 +35,7 @@ define([
         new MembershipEngagementInternationalExperiment(),
         new ContributionsEpicUsaCtaThreeWay(),
         new ContributionsEpicObserverAnniversary(),
+        new ContributionsEpicBrexitSupreme(),
         new UkMembershipEngagementMessageTest10(),
         new AuMembershipEngagementMessageTest8()
     ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
@@ -1,0 +1,146 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             ajax,
+             commercialFeatures,
+             intersection) {
+
+    return function () {
+
+        this.id = 'ContributionsEpicBrexitSupreme';
+        this.start = '2016-12-02';
+        this.expiry = '2016-12-12';
+        this.author = 'Phil Wills';
+        this.description = 'Appeal linked to the Brexit appeal in the Supreme Court';
+        this.showForSensitive = false;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'N/A';
+        this.audienceCriteria = 'All';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We receive contributions and membership sign-ups';
+        this.canRun = function () {
+
+            var includedKeywordIds = ['politics/eu-referendum'];
+
+            var includedSeriesIds = [];
+
+            var excludedKeywordIds = [];
+
+            var tagsMatch = function() {
+                var pageKeywords = config.page.keywordIds;
+                if (typeof(pageKeywords) !== 'undefined') {
+                    var keywordList = pageKeywords.split(',');
+                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        (intersection(includedKeywordIds, keywordList).length > 0 || includedSeriesIds.indexOf(config.page.seriesId) !== -1);
+                } else {
+                    return false;
+                }
+            };
+
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && tagsMatch();
+        };
+
+        var contributeUrlPrefix = 'co_global_epic_brexit_supreme';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_brexit_supreme';
+
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+        var messages  = {
+            control: {
+                title: 'Since you’re here …',
+                p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+            }
+        };
+
+        var cta = {
+            equal: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution',
+                url1: makeUrl(membershipUrl, membershipUrlPrefix ),
+                url2:  makeUrl(contributeUrl, contributeUrlPrefix ),
+                hidden: ''
+            }
+
+        };
+
+        var componentWriter = function (component) {
+            fastdom.write(function () {
+                var submetaElement = $('.submeta');
+                if (submetaElement.length > 0) {
+                    component.insertBefore(submetaElement);
+                    mediator.emit('contributions-embed:insert', component);
+                }
+            });
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:view', complete);
+        };
+
+        this.variants = [
+            {
+                id: 'mixed',
+
+                test: function () {
+                    var ctaType = cta.equal;
+                    var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + '_mixed',
+                        linkUrl2: ctaType.url2 + '_mixed',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
@@ -89,7 +89,7 @@ define([
 
         var cta = {
             equal: {
-                p2: 'Fund our journalism and together we can keep the world informed.',
+                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure. You can give money to the Guardian in less than a minute.',
                 p3: '',
                 cta1: 'Become a Supporter',
                 cta2: 'Make a contribution',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-observer-anniversary.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-observer-anniversary.js
@@ -1,0 +1,157 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'lodash/arrays/intersection'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             ajax,
+             commercialFeatures,
+             intersection) {
+
+    return function () {
+
+        this.id = 'ContributionsEpicObserverAnniversary';
+        this.start = '2016-12-02';
+        this.expiry = '2016-12-12';
+        this.author = 'Phil Wills';
+        this.description = 'Appeal linked to the Observer\'s 225th anniversary';
+        this.showForSensitive = false;
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'N/A';
+        this.audienceCriteria = 'UK';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We receive contributions and membership sign-ups';
+        this.canRun = function () {
+
+            var includedKeywordIds = [];
+
+            var includedSeriesIds = [
+                'theobserver/series/the-observer-at-225'
+            ];
+
+            var excludedKeywordIds = [];
+
+            var tagsMatch = function() {
+                var pageKeywords = config.page.keywordIds;
+                if (typeof(pageKeywords) !== 'undefined') {
+                    var keywordList = pageKeywords.split(',');
+                    return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        (intersection(includedKeywordIds, keywordList).length > 0 || includedSeriesIds.indexOf(config.page.seriesId) !== -1);
+                } else {
+                    return false;
+                }
+            };
+
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate && tagsMatch();
+        };
+
+        var contributeUrlPrefix = 'co_global_epic_uk_observer_225';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_uk_observer_225';
+
+
+        var makeUrl = function(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        };
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+        var messages  = {
+            control: {
+                title: 'Since you’re here …',
+                p1: '…we have a small favour to ask. More people are reading the Guardian and Observer than ever, but far fewer are paying for our work. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. Our independent journalism takes a lot of time, money and hard work to produce. But we do it because we believe a free media and plurality of voices matter now more than ever – because you might believe that too.'
+            }
+        };
+
+        var cta = {
+            equal: {
+                p2: 'Fund our journalism and together we can keep the world informed.',
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution',
+                url1: makeUrl(membershipUrl, membershipUrlPrefix ),
+                url2:  makeUrl(contributeUrl, contributeUrlPrefix ),
+                hidden: ''
+            }
+
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if ('country' in resp && resp.country === 'GB'){
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        if (submetaElement.length > 0) {
+                            component.insertBefore(submetaElement);
+                            mediator.emit('contributions-embed:insert', component);
+                        }
+                    });
+                }
+            });
+        };
+
+        var completer = function (complete) {
+            mediator.on('contributions-embed:view', complete);
+        };
+
+        this.variants = [
+            {
+                id: 'mixed',
+
+                test: function () {
+                    var ctaType = cta.equal;
+                    var message = messages.control;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1 + '_mixed',
+                        linkUrl2: ctaType.url2 + '_mixed',
+                        title: message.title,
+                        p1: message.p1,
+                        p2:ctaType.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: function(track) {
+                    mediator.on('contributions-embed:insert', track);
+                },
+
+                success: completer
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?
Adds the Epic to Observer anniversary and Brexit coverage

## What is the value of this and can you measure success?
High conversion rate to supporters and contributors

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

![image](https://cloud.githubusercontent.com/assets/68329/20838142/2a3466aa-b89f-11e6-9147-11b5a4ff6111.png)

## Request for comment

@guardian/contributions 
<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

I really hope that one day I'll say that this is the last one we'll do like this and it won't be a massive lie.