### PR TITLE
Recommendations styling

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -120,6 +120,8 @@ define([
                 return imageFromTemplate(item.headerImage.urlTemplate);
             } else if (item.headerVideo) {
                 return imageFromTemplate(item.headerVideo.stillImage.urlTemplate);
+            } else if (item.video) {
+                return imageFromTemplate(item.video.stillImage.urlTemplate);
             } else {
                 return null;
             }

--- a/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
+++ b/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
@@ -26,14 +26,22 @@
                     <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
                         <div class="fc-item fc-item--has-image fc-item--has-sublinks-1 js-fc-item tone-news--item fc-item--list-media-mobile fc-item--standard-tablet fc-item--rfy js-snappable">
                             <div class="fc-item__container">
-                                <div class="fc-item__media-wrapper"><% if (item.imageUrl) { %><img src="<%= item.imageUrl %>" /><% } else { %><%= guardianLogo %><% } %></div>
+                                <div class="fc-item__media-wrapper">
+                                    <% if (item.imageUrl) { %><div class="fc-item__image-container u-responsive-ratio inlined-image"><img src="<%= item.imageUrl %>" /></div><% } else { %><%= guardianLogo %><% } %>
+                                </div>
                                 <div class="fc-item__content">
                                     <div class="fc-item__header">
-                                        <h2 class="fc-item__title"><a href="/<%= item.id %>" class="fc-item__link" data-link-name="article">
-                                            <span class="u-faux-block-link__cta fc-item__headline"><span class="js-headline-text"><%= item.title %></span></span></a></h2>
+                                        <h2 class="fc-item__title">
+                                            <a href="/<%= item.id %>" class="fc-item__link" data-link-name="article">
+                                                <span class="u-faux-block-link__cta fc-item__headline">
+                                                    <span class="js-headline-text"><%= item.title %></span>
+                                                </span>
+                                            </a>
+                                        </h2>
                                     </div>
                                     <div class="fc-item__standfirst"><%= item.standFirst %></div>
                                 </div>
+                                <a href="/<%= item.id %>" class="u-faux-block-link__overlay js-headline-text" tabindex="-1">Growth slows as weak pound pushes up prices</a>
                             </div>
                         </div>
                     </li>

--- a/static/src/stylesheets/module/experiments/_recommended-for-you.scss
+++ b/static/src/stylesheets/module/experiments/_recommended-for-you.scss
@@ -6,7 +6,7 @@
     @include mq(tablet) {
         margin: 10px 0;
     }
-    
+
     background-color: $neutral-3;
 
     line-height: 14px;
@@ -62,7 +62,7 @@
         height: 76px;
 
         @include mq(tablet) {
-            height: 76px;
+            height: 96px;
         }
 
         @include mq(desktop) {


### PR DESCRIPTION
Fix some styling issues with #15071, detailed below, plus a JS change to fix a bug where video articles didn't have a main image.

There is still an issue with some images having a different size ratio than the container they need to fit into (you can see it in the Selasi Bake-off image below) - I'll look at that in another PR

@davidfurey @katebee @lmath 

### mobile/tablet before
![picture 346](https://cloud.githubusercontent.com/assets/5122968/20845344/82070eb0-b8bc-11e6-8dda-33dfa9ebf35a.png)
![picture 347](https://cloud.githubusercontent.com/assets/5122968/20845345/82074740-b8bc-11e6-87b0-427d3308415b.png)

### mobile/tablet after
![picture 348](https://cloud.githubusercontent.com/assets/5122968/20845478/2b646af2-b8bd-11e6-8b31-e70831ae5b5b.png)
![picture 349](https://cloud.githubusercontent.com/assets/5122968/20845477/2b646228-b8bd-11e6-9253-88cf38b27554.png)


### link behaviour before
![recommended-links-before](https://cloud.githubusercontent.com/assets/5122968/20845428/f45c5fb0-b8bc-11e6-8dce-9213f7d2c696.gif)

### link behaviour after
![recommended-links-after](https://cloud.githubusercontent.com/assets/5122968/20845429/f469f27e-b8bc-11e6-92ce-ad36930bf44c.gif)




