### PR TITLE
Stop multiple epics appearing when tags overlap

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
@@ -53,11 +53,14 @@ define([
 
             var excludedKeywordIds = [];
 
+            var excludedSeriesIds = ['theobserver/series/the-observer-at-225'];
+
             var tagsMatch = function() {
                 var pageKeywords = config.page.keywordIds;
                 if (typeof(pageKeywords) !== 'undefined') {
                     var keywordList = pageKeywords.split(',');
                     return intersection(excludedKeywordIds, keywordList).length == 0 &&
+                        excludedSeriesIds.indexOf(config.page.seriesId) === -1 &&
                         (intersection(includedKeywordIds, keywordList).length > 0 || includedSeriesIds.indexOf(config.page.seriesId) !== -1);
                 } else {
                     return false;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-three-way.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-usa-cta-three-way.js
@@ -55,7 +55,7 @@ define([
                 'us-news/series/diy-abortion-in-america'
             ];
 
-            var excludedKeywordIds = ['music/leonard-cohen'];
+            var excludedKeywordIds = ['music/leonard-cohen', 'politics/eu-referendum'];
 
             var hasKeywordsMatch = function() {
                 var pageKeywords = config.page.keywordIds;


### PR DESCRIPTION
## What does this change?
Stop multiple epics appearing when tags overlap

## What is the value of this and can you measure success?
Not looking daft

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
This is what we don't want:
![image](https://cloud.githubusercontent.com/assets/68329/20858266/11f7b47a-b93a-11e6-9381-83ca61fe78f4.png)


## Request for comment

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

