### PR TITLE
Messenger: unify resize slot handling

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -13,11 +13,14 @@ define([
 ) {
     var stickyElement = null;
     var rightSlotId = 'dfp-ad--right';
+    var rightSlot;
 
     function stickyMpu($adSlot) {
         if ($adSlot.data('name') !== 'right' || stickyElement) {
             return;
         }
+
+        rightSlot = $adSlot[0];
 
         var referenceElement = document.querySelector(config.page.hasShowcaseMainElement ? '.media-primary' : '.content__article-body,.js-liveblog-body-content');
         if (!referenceElement) {
@@ -35,19 +38,15 @@ define([
             var options = config.page.isAdvertisementFeature ? {top: 43} : {};
             stickyElement = new Sticky($adSlot[0], options);
             stickyElement.init();
-            messenger.register('set-ad-height', onAppNexusResize);
+            messenger.register('resize', onResize);
             return stickyElement;
         });
     }
 
-    function onAppNexusResize(specs, _, iframe) {
-        var adSlot = closest(iframe, '.js-ad-slot');
-        if (adSlot.id === rightSlotId) {
-            messenger.unregister('set-ad-height', onAppNexusResize);
-            fastdom.write(function () {
-                iframe.style.height = specs.height + 'px';
-                stickyElement.updatePosition();
-            });
+    function onResize(specs, _, iframe) {
+        if (rightSlot.contains(iframe)) {
+            messenger.unregister('resize', onResize);
+            stickyElement.updatePosition();
         }
     }
 

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -12,7 +12,6 @@ define([
     messenger
 ) {
     var stickyElement = null;
-    var rightSlotId = 'dfp-ad--right';
     var rightSlot;
 
     function stickyMpu($adSlot) {

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -17,7 +17,7 @@ define([
 ) {
     var topSlotId = 'dfp-ad--top-above-nav';
     var updateQueued = false;
-    var win, header, headerHeight, topSlot, topSlotHeight, stickyBanner, scrollY;
+    var win, header, headerHeight, topSlot, topSlotHeight, topSlotStyles, stickyBanner, scrollY;
 
     return {
         init: init,
@@ -84,17 +84,18 @@ define([
     }
 
     function onResize(specs, _, iframe) {
-        update(specs.height, closest(iframe, '.js-ad-slot'));
+        if (topSlot.contains(iframe)) {
+            update(specs.height);
+            messenger.unregister('resize', onResize);
+        }
     }
 
-    function update(newHeight, adSlot) {
-        return adSlot.id === topSlotId ?
-            fastdom.read(function () {
-                var adStyles = win.getComputedStyle(adSlot);
-                return newHeight + parseInt(adStyles.paddingTop) + parseInt(adStyles.paddingBottom);
-            })
-            .then(resizeStickyBanner) :
-            Promise.resolve(-1);
+    function update(newHeight) {
+        return fastdom.read(function () {
+            topSlotStyles || (topSlotStyles = win.getComputedStyle(topSlot));
+            return newHeight + parseInt(adStyles.paddingTop) + parseInt(adStyles.paddingBottom);
+        })
+        .then(resizeStickyBanner);
     }
 
     function onScroll() {

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -67,7 +67,6 @@ define([
     // We also listen for scroll events if we need to, to snap the slot in
     // place when it reaches the end of the header.
     function setupListeners() {
-        messenger.register('set-ad-height', onRubiconResize);
         messenger.register('resize', onResize);
         if (!config.page.hasSuperStickyBanner) {
             win.addEventListener('scroll', onScroll);
@@ -82,15 +81,6 @@ define([
             })
             .then(resizeStickyBanner);
         }
-    }
-
-    function onRubiconResize(specs, _, iframe) {
-        update(parseInt(specs.height), closest(iframe, '.js-ad-slot'))
-        .then(function (ret) {
-            if( ret > -1 ) {
-                messenger.unregister('set-ad-height', onRubiconResize);
-            }
-        });
     }
 
     function onResize(specs, _, iframe) {

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -88,7 +88,7 @@ define([
     function update(newHeight) {
         return fastdom.read(function () {
             topSlotStyles || (topSlotStyles = win.getComputedStyle(topSlot));
-            return newHeight + parseInt(adStyles.paddingTop) + parseInt(adStyles.paddingBottom);
+            return newHeight + parseInt(topSlotStyles.paddingTop) + parseInt(topSlotStyles.paddingBottom);
         })
         .then(resizeStickyBanner);
     }

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -39,6 +39,7 @@ define([
             // Second, start listening for height and scroll changes
             .then(setupListeners);
         } else {
+            topSlot = null;
             return Promise.resolve();
         }
     }

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -57,13 +57,8 @@ define([
         });
     }
 
-    // The height of the top slot changes on 2 occasions:
-    // 1. when the ad is rendered: the ad slot may be manipulated in many ways
-    //    and its geomatry may change
-    // 2. when the ad is dynamically resized: the creative may send a message
-    //    at any point to signal a change of height. Rubicon ads use a legacy
-    //    version of the message system for handling this
-    //
+    // Register a message listener for when the creative wants to resize
+    // its container
     // We also listen for scroll events if we need to, to snap the slot in
     // place when it reaches the end of the header.
     function setupListeners() {

--- a/static/test/javascripts/spec/commercial/messenger/messenger.spec.js
+++ b/static/test/javascripts/spec/commercial/messenger/messenger.spec.js
@@ -136,12 +136,12 @@ define([
 
         it('should respond to Rubicon messages with no IDs', function (done) {
             var payload = { type: 'set-ad-height', value: { id: 'test', height: '20px' } };
-            messenger.register('set-ad-height', routines.rubicon, { window: mockWindow });
+            messenger.register('resize', routines.rubicon, { window: mockWindow });
             onMessage({ origin: dfpOrigin, data: JSON.stringify(payload), source: mockFrame })
             .then(function () {
                 expect(mockFrame.postMessage).toHaveBeenCalled();
                 expect(response.result).toBe('rubicon');
-                messenger.unregister('set-ad-height', routines.respond, { window: mockWindow });
+                messenger.unregister('resize', routines.rubicon, { window: mockWindow });
             })
             .then(done)
             .catch(done.fail);

--- a/static/test/javascripts/spec/commercial/sticky-top-banner.spec.js
+++ b/static/test/javascripts/spec/commercial/sticky-top-banner.spec.js
@@ -60,7 +60,7 @@ define([
         it('should add listeners and classes', function (done) {
             sticky.init(moduleName, mockWindow)
             .then(function () {
-                expect(register.calls.count()).toBe(2);
+                expect(register.calls.count()).toBe(1);
                 expect(mockWindow.addEventListener).toHaveBeenCalled();
                 expect(header.classList.contains('l-header--animate')).toBe(true);
                 expect(stickyBanner.classList.contains('sticky-top-banner-ad--animate')).toBe(true);


### PR DESCRIPTION
Historically, we have introduced the ability to resize the top slot for Rubicon ads, in the particular case where even though DFP returned a 728x90 creative size, the Rubicon ad turned out to be 970x250. It was handled via a `window.postMessage` call that sends a message of type `set-ad-height`.

Later on, native ads had a very similar use case. We introduced the more general [`resize`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/commercial/modules/messenger/resize.js) event into our cross-frame protocol. This event takes care of resizing the iframe and its slot container.

Recently, AppNexus has had the very same need, although in the right-hand slot. We thus reused the `set-ad-height` message in yet another module, and it worked. But they have also asked for the same thing in the top slot. In theory, it should work, and indeed it does ... except that the `set-ad-height` does not resize the iframe (only the slot) and the AppNexus creative does not do it either. The result is we end up with a top slot that is the correct size, but the creative appears truncated.

Well, I thought that was enough forking. First, it is not good to rely on the creative to resize the iframe. In a SafeFrame context, this must be done by the parent page. Second, there was too much duplication and message handling.

In this PR, we morph the `set-ad-height` message into a `resize` one. This greatly simplifies the logic and makes everything work exactly the same.