### PR TITLE
Extend the membership international engagement banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -10,7 +10,7 @@ trait ABTestSwitches {
     "ab-membership-engagement-international-experiment",
     "Test varying the number of visits before showing the membership engagement banner",
     owners = Seq(Owner.withGithub("rupert.bates")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2017, 1, 16),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     "Test varying the number of visits before showing the membership engagement banner",
     owners = Seq(Owner.withGithub("rupert.bates")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 1, 15),
+    sellByDate = new LocalDate(2017, 1, 16),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     "Test varying the number of visits before showing the membership engagement banner",
     owners = Seq(Owner.withGithub("rupert.bates")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 12, 5),
+    sellByDate = new LocalDate(2017, 1, 15),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'MembershipEngagementInternationalExperiment';
         this.start = '2016-11-10';
-        this.expiry = '2016-12-1';
+        this.expiry = '2017-1-15';
         this.author = 'Rupert Bates';
         this.description = 'Test varying the number of visits before showing the membership engagement banner';
         this.audience = 1;    // 100% (of International audience)

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'MembershipEngagementInternationalExperiment';
         this.start = '2016-11-10';
-        this.expiry = '2017-1-15';
+        this.expiry = '2017-1-16';
         this.author = 'Rupert Bates';
         this.description = 'Test varying the number of visits before showing the membership engagement banner';
         this.audience = 1;    // 100% (of International audience)

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-international-experiment.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'MembershipEngagementInternationalExperiment';
         this.start = '2016-11-10';
-        this.expiry = '2017-1-16';
+        this.expiry = '2016-12-1';
         this.author = 'Rupert Bates';
         this.description = 'Test varying the number of visits before showing the membership engagement banner';
         this.audience = 1;    // 100% (of International audience)


### PR DESCRIPTION
## What does this change?
Extends the membership international engagement banner test

## What is the value of this and can you measure success?
This test is currently expired so I'm extending it until we get a proper decision what to do next

## Does this affect other platforms - Amp, Apps, etc?
No

## Request for comment

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

