### PR TITLE
Support atoms in immersive main media

### DIFF
--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -5,8 +5,9 @@
 @import model.ContentPage
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
+@import views.support.ImmersiveMainCleaner
 
-@(page: ContentPage)(implicit request: RequestHeader)
+@(page: ContentPage)(implicit request: RequestHeader, env: play.api.Environment)
 
 @defining((
     page.item.tags.isTheMinuteArticle,
@@ -60,7 +61,14 @@
                         <div class="immersive-main-media__loading-animation is-updating"></div>
                         <span class="u-h">Loading header</span>
                     </div>
-                    @Html(page.item.fields.main)
+                    @page.item match {
+                        case article: model.Article => {
+                            @ImmersiveMainCleaner(article, article.fields.main, amp=false)
+                        }
+                        case content => {
+                            @Html(content.fields.main)
+                        }
+                    }
                 }
             }
         </div>

--- a/common/app/views/support/ImmersiveMainCleaner.scala
+++ b/common/app/views/support/ImmersiveMainCleaner.scala
@@ -1,0 +1,15 @@
+package views.support
+
+import common.Edition
+import model.Article
+import play.api.Environment
+import play.api.mvc.RequestHeader
+
+object ImmersiveMainCleaner {
+  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, env: Environment) = {
+    implicit val edition = Edition(request)
+    withJsoup(BulletCleaner(html))(
+      AtomsCleaner(article.content.atoms, shouldFence = true, amp)
+    )
+  }
+}

--- a/static/src/stylesheets/module/atoms/_interactive.scss
+++ b/static/src/stylesheets/module/atoms/_interactive.scss
@@ -1,4 +1,9 @@
 .interactive-atom-fence {
     width: 100%;
     border: 0;
+
+    .immersive-main-media__media & {
+        // Don't allow the iframe to change its height, must be 100% in immersive main media slot
+        height: 100% !important;
+    }
 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -42,6 +42,7 @@
     // Remove inline spacing
     display: block;
 
+    .element-atom,
     .element-embed {
         margin-top: 0;
         margin-bottom: 0;


### PR DESCRIPTION
## What does this change?
Support atoms in the immersive article main media slot. ~~It uses the `MainCleaner`, in line with how the main media slot is handled in other content types (live blogs, non-immersive articles, etc.), which I think makes sense.~~

~~However, `MainCleaner` includes a number of cleaners and not just `AtomCleaner`. This solution means that all of those cleaners will now be applied, which may have been deliberately avoided in the past? A more conservative approach would be to just enable the `AtomCleaner`.~~

Now uses a new `ImmersiveMainCleaner`

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/2084823/20883238/f8b47652-badc-11e6-9b66-a783bf391356.png)

After:
![image](https://cloud.githubusercontent.com/assets/2084823/20883117/547e97ca-badc-11e6-8605-e8504dcda0a6.png)