### PR TITLE
Add sonobi test url in code environment

### DIFF
--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -2,6 +2,7 @@
 @import conf.Static
 @import conf.Configuration
 @import mvt.WebpackTest
+@import conf.Configuration.environment
 
 window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',
@@ -59,7 +60,7 @@ window.curlConfig = {
             }
             'foresee.js':                       'vendor/foresee/20150703/foresee-trigger.js',
             'googletag.js':                     '@{Configuration.javascript.config("googletagJsUrl")}',
-            'sonobi.js':                        '@{Configuration.javascript.config("sonobiHeaderBiddingJsUrl")}',
+            'sonobi.js':                        '@{ if(!environment.isCode) Configuration.javascript.config("sonobiHeaderBiddingJsUrl") else "//mtrx.go.sonobi.com/morpheus.theguardian.12911_us_.js"}',
             react:                              '@Static("javascripts/vendor/react/react.js")',
             'discussion-frontend-react':        '@DiscussionAsset("discussion-frontend.react.amd")',
             'discussion-frontend-preact':       '@DiscussionAsset("discussion-frontend.preact.amd")',
@@ -90,7 +91,7 @@ window.curlConfig = {
             reqwest:                        'components/reqwest/reqwest',
             'foresee.js':                   'vendor/foresee/20150703/foresee-trigger.js',
             'googletag.js':                 '@{Configuration.javascript.config("googletagJsUrl")}',
-            'sonobi.js':                    '@{Configuration.javascript.config("sonobiHeaderBiddingJsUrl")}',
+            'sonobi.js':                    '@{ if(!environment.isCode) Configuration.javascript.config("sonobiHeaderBiddingJsUrl") else "//mtrx.go.sonobi.com/morpheus.theguardian.12911_us_.js"}',
             'ophan/ng':                     '@{Configuration.javascript.config("ophanJsUrl")}',
             'discussion-frontend-react':    '@DiscussionAsset("discussion-frontend.react.amd")',
             'discussion-frontend-preact':   '@DiscussionAsset("discussion-frontend.preact.amd")',

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -1,10 +1,12 @@
 define([
     'Promise',
+    'common/utils/config',
     'common/modules/commercial/commercial-features',
     'commercial/modules/dfp/dfp-env',
     'lodash/functions/memoize'
 ], function(
     Promise,
+    config,
     commercialFeatures,
     dfpEnv,
     memoize
@@ -18,6 +20,12 @@ define([
     // then the resulting "Access Denied" error will be caught. Without this, the error is always delivered to Sentry,
     // but does not pass through window.onerror. More info here: https://github.com/paulmillr/es6-shim/issues/333
     function catchPolyfillErrors(){
+
+        // Skip polyfill error-catch in dev environments.
+        if (config.page.isDev){
+            return Promise.resolve();
+        }
+
         var nativeGetOwnPropertyNames = Object.getOwnPropertyNames;
         Object.getOwnPropertyNames = function(obj){
             try {


### PR DESCRIPTION
Adds the test url for sonobi, so that we can test the new version of the script which shouldn't throw IE11 errors.