### PR TITLE
Caption cleanup

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -28,9 +28,6 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
         val figcaption = element.getElementsByTag("figcaption")
         if (figcaption.length < 1) {
           element.addClass("fig--no-caption")
-        } else {
-            val informationIcon = views.html.fragments.inlineSvg("information", "icon", List("centered-icon", "rounded-icon")).toString()
-            figcaption.prepend(informationIcon)
         }
       }
     })
@@ -43,6 +40,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
     document.getElementsByClass("element-video").foreach { figure: Element =>
       val canonicalUrl = figure.attr("data-canonical-url")
+      val figcaption = figure.getElementsByTag("figcaption")
 
       figure.attr("data-component", "video-inbody-embed")
       figure.getElementsByClass("gu-video").foreach { element: Element =>
@@ -54,6 +52,11 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
         if (! canonicalUrl.isEmpty) {
           element.attr("data-canonical-url", new URL(canonicalUrl).getPath.stripPrefix("/"))
+        }
+
+        if (figcaption.nonEmpty) {
+            val informationIcon = views.html.fragments.inlineSvg("information", "icon", List("centered-icon", "rounded-icon")).toString()
+            figcaption.prepend(informationIcon)
         }
 
         val mediaId = element.attr("data-media-id")

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -99,6 +99,7 @@ figure.element.element--supporting,
 figure.element-video {
     figcaption {
         padding-top: ($gs-baseline/3)*2;
+        padding-bottom: ($gs-baseline/3)*2;
     }
     @include mq(leftCol) {
         figcaption {


### PR DESCRIPTION
Previously the caption icon wasn't showing alongside videos in live blogs. It is now. 
![screen shot 2016-12-05 at 11 31 46](https://cloud.githubusercontent.com/assets/14570016/20884544/d2c5e91a-bae3-11e6-8210-d1a3852ac639.png)

Also, video sharing buttons were being clipped, as far as I could see this is due to an overflow hidden. 

Before:
![screen shot 2016-12-05 at 12 09 56](https://cloud.githubusercontent.com/assets/14570016/20884545/d2c60a62-bae3-11e6-84f1-5a6a174a270b.png)

After:
![screen shot 2016-12-05 at 12 09 45](https://cloud.githubusercontent.com/assets/14570016/20884543/d2c571f6-bae3-11e6-9f56-73b71b2c3499.png)

Thank you @NataliaLKB for helping! 