### PR TITLE
Correct the static component of the artifact generation

### DIFF
--- a/dev/teamcity/dist-publish-assets-tc
+++ b/dev/teamcity/dist-publish-assets-tc
@@ -48,7 +48,7 @@ aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static
 aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_BUILD_BUCKET --key dotcom:static/$BUILD_NUMBER/build.json  --body $static_folder/build.json
 
 # upload static files for the build - it is critical that this is done before the main sbt-riffraff-artifact plugin runs
-aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static_folder/packages/frontend-static s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:all/$BUILD_NUMBER/static
+aws s3 cp --acl bucket-owner-full-control --region=eu-west-1 --recursive $static_folder/packages/frontend-static s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:all/$BUILD_NUMBER/frontend-static
 
 set +x
 echo "##teamcity[progressFinish 'asset publish']"

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -43,7 +43,7 @@ deployments:
     template: frontend
   sport:
     template: frontend
-  static:
+  frontend-static:
     type: aws-s3
     parameters:
       bucket: aws-frontend-static


### PR DESCRIPTION
## What does this change?
Fixes the naming of the static files in the unified deploy so that they are uploaded into the correct part of the S3 bucket.

## What is the value of this and can you measure success?
The unified deploy uploads the static files into the correct location.

## Does this affect other platforms - Amp, Apps, etc?
No
