### PR TITLE
Missed the dependency declaration

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,7 @@ templates:
     parameters:
       bucket: aws-frontend-artifacts
     dependencies:
-    - static
+    - frontend-static
 
 deployments:
   admin:


### PR DESCRIPTION
## What does this change?
Whilst renaming the static deployment in #15221 I missed the dependency.
