### PR TITLE
Add module to check an A/B test against the targeting tool

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4"
   val logback = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
-  val targetingClient = "com.gu" %% "targeting-client-play24" % "0.8.0"
+  val targetingClient = "com.gu" %% "targeting-client-play24" % "0.10.0"
   val scanamo = "com.gu" %% "scanamo" % "0.8.0"
 
   // Web jars

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-targeting.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-targeting.js
@@ -13,10 +13,10 @@ define([
      * @param test      an A/B test object (with an 'id' property)
      * @return {Array}  campaigns associated with this test
      */
-    function campaignsFor(test) {
+    function campaignsFor(id) {
         try {
             return config.page.campaigns.filter(function (campaign) {
-                return campaign.fields && clean(campaign.fields.campaignId) === clean(test.id);
+                return campaign.fields && clean(campaign.fields.campaignId) === clean(id);
             });
         } catch (e) {
             return [];
@@ -30,7 +30,7 @@ define([
      * @return {Boolean}
      */
     function isAbTestTargeted(test) {
-        return campaignsFor(test).length > 0;
+        return campaignsFor(test.id).length > 0;
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-targeting.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-targeting.js
@@ -1,0 +1,39 @@
+define([
+    'common/utils/config',
+], function(
+    config
+) {
+    function clean(string) {
+        return string.trim().toLowerCase();
+    }
+
+    /**
+     * Get the campaigns for a test.
+     *
+     * @param test      an A/B test object (with an 'id' property)
+     * @return {Array}  campaigns associated with this test
+     */
+    function campaignsFor(test) {
+        try {
+            return config.page.campaigns.filter(function (campaign) {
+                return campaign.fields && clean(campaign.fields.campaignId) === clean(test.id);
+            });
+        } catch (e) {
+            return [];
+        }
+    }
+
+    /**
+     * Check if any of the active campaigns (from the targeting tool) apply to a given A/B test.
+     *
+     * @param test        an A/B test object (with an 'id' property)
+     * @return {Boolean}
+     */
+    function isAbTestTargeted(test) {
+        return campaignsFor(test).length > 0;
+    }
+
+    return {
+        isAbTestTargeted: isAbTestTargeted
+    };
+});


### PR DESCRIPTION
## What does this change?
The contributions team is planning to use the [targeting
tool](https://github.com/guardian/targeting) to manage the tags used in
Epic messages, so we can control where it shows up without having to
make any code changes. To help with this I've added a small module that
checks the campaigns in `guardian.config` (populated by the targeting
tool) against a given A/B test, which will give us a value to use in the
test's `canRun` criteria.

## What is the value of this and can you measure success?
It'll allow us to make changes to the tags in Epic tests without raising PRs so there should be a bit less work for the frontend team. 
Note that this definitely won't rule out PRs for Epic tests altogether, but it's a step in that direction. 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Request for comment
@philwills @guardian/contributions  @guardian/dotcom-platform 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->