### PR TITLE
Serve hidden PROD fronts as email-friendly HTML

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -487,4 +487,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 12, 15),
     exposeClientSide = true
   )
+
+  // Owner: Joseph Smith
+  val DisplayHiddenFrontsAsEmails = Switch(
+    SwitchGroup.Feature,
+    "display-hidden-fronts-as-emails",
+    "Allows hidden fronts to be rendered as email-friendly HTML by passing ?format=email",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 12, 20),
+    exposeClientSide = true
+  )
 }

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -12,6 +12,7 @@ import model.pressed.CollectionConfig
 import model.{FrontProperties, SeoDataJson}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
+import conf.switches.Switches
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -135,7 +136,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
     configAgent.get().exists(_.fronts.get(id).flatMap(_.isHidden).exists(identity))
 
   def shouldServeFront(id: String, isEmailRequest: Boolean = false) = getPathIds.contains(id) &&
-    (Configuration.environment.isPreview || isEmailRequest || !isFrontHidden(id))
+    (Configuration.environment.isPreview || (Switches.DisplayHiddenFrontsAsEmails.isSwitchedOn && isEmailRequest) || !isFrontHidden(id))
 
   def shouldServeEditionalisedFront(edition: Edition, id: String) = {
     shouldServeFront(s"${edition.id.toLowerCase}/$id")

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -134,8 +134,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   def isFrontHidden(id: String): Boolean =
     configAgent.get().exists(_.fronts.get(id).flatMap(_.isHidden).exists(identity))
 
-  def shouldServeFront(id: String) = getPathIds.contains(id) &&
-    (Configuration.environment.isPreview || !isFrontHidden(id))
+  def shouldServeFront(id: String, isEmailRequest: Boolean = false) = getPathIds.contains(id) &&
+    (Configuration.environment.isPreview || isEmailRequest || !isFrontHidden(id))
 
   def shouldServeEditionalisedFront(edition: Edition, id: String) = {
     shouldServeFront(s"${edition.id.toLowerCase}/$id")

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -85,7 +85,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     log.info(s"Serving Path: $path")
     if (shouldEditionRedirect(path))
       redirectTo(Editionalise(path, Edition(request)))
-    else if (!ConfigAgent.shouldServeFront(path) || request.getQueryString("page").isDefined)
+    else if (!ConfigAgent.shouldServeFront(path, request.isEmail) || request.getQueryString("page").isDefined)
       applicationsRedirect(path)
     else
       renderFrontPressResult(path)


### PR DESCRIPTION
This week, the Travel desk are going to be putting together their email ("The Flyer") using the new fronts tool functionality (#14236). Previously we'd been using code fronts for this purpose. We need to give them a way to create their front in the prod fronts tool, but not have it accessible via the website as a real front. So we'll tell them to make it a hidden front, and for that to work we need to `?format=email` endpoint to work for hidden fronts (which it doesn't currently).

@lmath @davidfurey @guardian/dotcom-platform 