### PR TITLE
Add some crossword setters to the search dropdown

### DIFF
--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -59,6 +59,7 @@ final case class CrosswordSearchPage(override val metadata: MetaData) extends St
     "Beale",
     "Biggles",
     "Boatman",
+    "Bogus",
     "Bonxie",
     "Brendan",
     "Brummie",
@@ -96,14 +97,17 @@ final case class CrosswordSearchPage(override val metadata: MetaData) extends St
     "Picaroon",
     "Pinkie",
     "Plodge",
+    "Provis",
     "Puck",
     "Qaos",
     "Quantum",
     "Rover",
     "Rufus",
+    "Screw",
     "Shed",
     "Taupi",
     "Tramp",
-    "Troll"
+    "Troll",
+    "Vlad"
   )
 }


### PR DESCRIPTION
## What does this change?

Adds some setters to the crossword search.

## What is the value of this and can you measure success?

Total crossword setting action. :latin_cross: 📖 

@guardian/dotcom-platform 