### PR TITLE
Add Webpack control group to server-side tests

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -111,7 +111,8 @@ object ActiveTests extends ServerSideABTests {
     ABNewNavVariantFive,
     ABNewNavControl,
     CommercialClientLoggingVariant,
-    WebpackTest
+    WebpackTest,
+    WebpackControl
   )
 }
 


### PR DESCRIPTION
## What does this change?

Track a control group of users who do not receive Webpack bundles, for comparison with users who do receive Webpack bundles 

## Request for comment

@gtrufitt @NataliaLKB 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

