### PR TITLE
Hosted AMP Youtube videos fix

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -42,14 +42,17 @@
                 @page.video.youtubeId.map { youtubeId =>
                     <amp-youtube
                     data-videoid="@youtubeId"
+                    data-param-modestbranding="1"
+                    data-param-showinfo="0"
+                    data-param-rel="0"
                     layout="responsive"
                     width="480" height="270">
                     </amp-youtube>
                 }.getOrElse {
                     <amp-video
                     controls
-                    width="5"
-                    height="3"
+                    width="16"
+                    height="9"
                     layout="responsive"
                     poster="@{page.video.posterUrl}"
                     >


### PR DESCRIPTION
## What does this change?
Apply proper URL parameters to the AMP youtube player, and fix the ratio for non-youtube hosted AMP video pages.

## What is the value of this and can you measure success?
We need to use modest branding parameter to comply with Youtube contract, and make it look the same as non-AMP page.

## Does this affect other platforms - Amp, Apps, etc?
Just AMP.

## Screenshots
Youtube:
![image](https://cloud.githubusercontent.com/assets/6290008/20923331/d3d5f37a-bba3-11e6-8a85-90a765853d01.png)
Not Youtube:
![image](https://cloud.githubusercontent.com/assets/6290008/20923402/24a66e38-bba4-11e6-85e8-c34128da440e.png)

## Request for comment
@guardian/labs-beta 