### PR TITLE
Tone stylesheets for emails have a background color for headlines & trail text

### DIFF
--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -7,6 +7,7 @@
     }
     .tone-news .headline {
         color: #333333;
+        background-color: #f6f6f6;
     }
     .tone-news .fc-item__kicker {
         color: #005689;
@@ -16,6 +17,7 @@
     }
     .tone-news .trail-text {
         color: #767676;
+        background-color: #f6f6f6;
     }
 
 
@@ -26,6 +28,7 @@
 
     .tone-feature .headline {
         color: #fff;
+        background-color: #951c55;
     }
     .tone-feature .fc-item__kicker {
         color: #fdadba;
@@ -35,6 +38,7 @@
     }
     .tone-feature .trail-text {
         color: #ead2dd;
+        background-color: #951c55;
     }
 
 
@@ -44,6 +48,7 @@
     }
     .tone-media .headline {
         color: #fff;
+        background-color: #333;
     }
     .tone-media .fc-item__kicker {
         color: #ffbb00;
@@ -53,6 +58,7 @@
     }
     .tone-media .trail-text {
         color: #bdbdbd;
+        background-color: #333;
     }
 
 
@@ -62,6 +68,7 @@
     }
     .tone-review .headline {
         color: #fff;
+        background-color: #7d7569;
     }
     .tone-review .fc-item__kicker {
         color: #ffce4b;
@@ -71,6 +78,7 @@
     }
     .tone-review .trail-text {
         color: #cbc8c3;
+        background-color: #7d7569;
     }
 
 
@@ -80,6 +88,7 @@
     }
     .tone-editorial .headline {
         color: #fff;
+        background-color: #005689;
     }
     .tone-editorial .fc-item__kicker {
         color: #aad8f1;
@@ -89,6 +98,7 @@
     }
     .tone-editorial .trail-text {
         color: #aad8f1;
+        background-color: #005689;
     }
 
 
@@ -98,6 +108,7 @@
     }
     .tone-external .headline {
         color: #333333;
+        background-color: #f6f6f6;
     }
     .tone-external .fc-item__kicker {
         color: #005689;
@@ -107,6 +118,7 @@
     }
     .tone-external .trail-text {
         color: #767676;
+        background-color: #f6f6f6;
     }
 
 
@@ -116,6 +128,7 @@
     }
     .tone-live .headline {
         color: #fff;
+        background-color: #b51800;
     }
     .tone-live .fc-item__kicker {
         color: #fdadba;
@@ -125,6 +138,7 @@
     }
     .tone-live .trail-text {
         color: #f0d1cc;
+        background-color: #b51800;
     }
 
 
@@ -134,6 +148,7 @@
     }
     .tone-analysis .headline {
         color: #005689;
+        background-color: #f6f6f6;
     }
     .tone-analysis .fc-item__kicker {
         color: #767676;
@@ -143,6 +158,7 @@
     }
     .tone-analysis .trail-text {
         color: #767676;
+        background-color: #f6f6f6;
     }
 
 
@@ -152,6 +168,7 @@
     }
     .tone-special-report .headline {
         color: #fff;
+        background-color: #63717a;
     }
     .tone-special-report .fc-item__kicker {
         color: #fce800;
@@ -161,6 +178,7 @@
     }
     .tone-special-report .trail-text {
         color: #e0e3e4;
+        background-color: #63717a;
     }
 
 
@@ -170,6 +188,7 @@
     }
     .tone-comment .headline {
         color: #333333;
+        background-color: #e3e3de;
     }
     .tone-comment .fc-item__kicker {
         color: #e6711b;
@@ -179,6 +198,7 @@
     }
     .tone-comment .trail-text {
         color: #767676;
+        background-color: #e3e3de;
     }
 
 
@@ -188,6 +208,7 @@
     }
     .tone-dead .headline {
         color: #333333;
+        background-color: #f6f6f6;
     }
     .tone-dead .fc-item__kicker {
         color: #cc2b12;
@@ -197,5 +218,6 @@
     }
     .tone-dead .trail-text {
         color: #767676;
+        background-color: #f6f6f6;
     }
 </style>


### PR DESCRIPTION
## What does this change?
This is an update to the style sheet for tones used for the email format. 

This means that when displaying an email, that headlines and trail texts have an explicitly set background-color.

## What is the value of this and can you measure success?
This improves how emails are rendered on gmail for android app.

I used litmus to check that how emails were rendered in other clients remained consistent with how they appeared previously. 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

How the email appeared in gmail for android app before adding the background color
![image](https://cloud.githubusercontent.com/assets/3072877/20924255/82050234-bba8-11e6-8a0c-32f7207139b4.png)

after adding background colors for headlines and trail texts:
![image](https://cloud.githubusercontent.com/assets/3072877/20924237/678bf49e-bba8-11e6-9c1f-8e7e3d060ab6.png)


## Request for comment
@joelochlann 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

