### PR TITLE
Article Refresh: Remove less successful tests

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -39,7 +39,7 @@
                 @fragments.guBand()
             }
 
-            @if(!(mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating)) {
+            @if(!mvt.ABNewNavVariantFour.isParticipating) {
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
                 @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
@@ -70,7 +70,7 @@
                             @fragments.mainMedia(article, amp)
                         }
 
-                        @if(mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating) {
+                        @if(mvt.ABNewNavVariantFour.isParticipating) {
                             <div class="mobile-only">
                                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
                             </div>

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -16,16 +16,6 @@ import conf.switches.Switches.ServerSideTests
 //    val tests = List(ExampleTest)
 // }
 
-object ABNewNavVariantThree extends TestDefinition(
-  name = "ab-new-nav-variant-three",
-  description = "users in this test will see the new header third variant",
-  owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 8) // Thursday
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variantthree")
-  }
-}
 
 object ABNewNavVariantFour extends TestDefinition(
   name = "ab-new-nav-variant-four",
@@ -35,17 +25,6 @@ object ABNewNavVariantFour extends TestDefinition(
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variantfour")
-  }
-}
-
-object ABNewNavVariantFive extends TestDefinition(
-  name = "ab-new-nav-variant-five",
-  description = "users in this test will see the new header fifth variant",
-  owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 8) // Thursday
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variantfive")
   }
 }
 
@@ -106,9 +85,7 @@ trait ServerSideABTests {
 
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
-    ABNewNavVariantThree,
     ABNewNavVariantFour,
-    ABNewNavVariantFive,
     ABNewNavControl,
     CommercialClientLoggingVariant,
     WebpackTest,

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -21,7 +21,7 @@ object ABNewNavVariantFour extends TestDefinition(
   name = "ab-new-nav-variant-four",
   description = "users in this test will see the new header fourth variant",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 8) // Thursday
+  sellByDate = new LocalDate(2016, 12, 21) // Wednesday
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variantfour")
@@ -32,7 +32,7 @@ object ABNewNavControl extends TestDefinition(
   name = "ab-new-nav-control",
   description = "control for the new header test",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 8) // Thursday
+  sellByDate = new LocalDate(2016, 12, 21) // Wednesday
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("control")

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating) {hide-on-mobile}">
+                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariantFour.isParticipating) {hide-on-mobile}">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,11 +4,11 @@
 @import conf.Configuration
 @import conf.switches.Switches._
 
-@if(mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating) {
+@if(mvt.ABNewNavVariantFour.isParticipating) {
     @fragments.newHeader(page)
 }
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantFour.isParticipating) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -107,7 +107,7 @@
 @caption(picture: model.ImageMedia, imageOption: Option[ImageAsset], isMain: Boolean) = {
     @imageOption.map { img =>
         @if(img.showCaption) {
-            @if(isMain && (mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating)) {
+            @if(isMain && mvt.ABNewNavVariantFour.isParticipating) {
 
                 <input type="checkbox" id="show-caption" class="mobile-only u-h">
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -37,12 +37,7 @@
             </nav>
         </div>
 
-        <div class="@RenderClasses(Map(
-            "tertiary-container" -> true,
-            "tertiary__variant-three" -> mvt.ABNewNavVariantThree.isParticipating,
-            "tertiary__variant-four" -> mvt.ABNewNavVariantFour.isParticipating,
-            "tertiary__variant-five" -> mvt.ABNewNavVariantFive.isParticipating
-        ))">
+        <div class="tertiary-container">
             <ul class="tertiary-navigation">
 
                 @if(page.metadata.isFront) {

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -56,7 +56,7 @@
                     }
                 }
                 @sections.map { link =>
-                    <li class="tertiary-navigation__item">
+                    <li class="tertiary-navigation__item @if((link.uniqueSection == page.metadata.sectionId) && !page.metadata.isFront){tertiary-navigation__item--current-section}">
                         <a class="tertiary-navigation__link" href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @link.title">
                         @Html(link.title)
                         </a>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -39,7 +39,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
-            ("has-new-header", mvt.ABNewNavVariantThree.isParticipating || mvt.ABNewNavVariantFour.isParticipating || mvt.ABNewNavVariantFive.isParticipating),
+            ("has-new-header", mvt.ABNewNavVariantFour.isParticipating),
             ("is-immersive", getContent(page).exists(_.content.isImmersive)),
             ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -717,56 +717,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
 
 .tertiary-container {
     overflow: hidden;
-
-    // Scrolly variant
-    &.tertiary__variant-three {
-        position: relative;
-        // Hides the scrollbar
-        height: $gs-baseline*2.5;
-        overflow: hidden;
-
-        @include mq($from: mobile, $until: mobileLandscape) {
-            height: $gs-baseline*2.5;
-            height: 9.8vw;
-        }
-
-        @include mq($from: mobileLandscape) {
-            height: $gs-baseline*3.3;
-        }
-
-        // Crazy radial hidey fade
-        &:after {
-            content: '';
-            position: absolute;
-            height: $gutter-small + $veggie-burger-small - $gs-gutter/2;
-            width: $gutter-small + $veggie-burger-small - $gs-gutter/2;
-            border-top-left-radius: 50%;
-            border-bottom-left-radius: 50%;
-            background-color: $neutral-2;
-            box-shadow: 0 0 20px 10px $neutral-2;
-            top: -30px;
-            right: 0;
-            pointer-events: none;
-
-            @include mq($mobile-medium) {
-                height: $gutter-medium + $veggie-burger-medium - $gs-gutter/2;
-                width: $gutter-medium + $veggie-burger-medium - $gs-gutter/2;
-                top: -40px;
-            }
-
-            @include mq(mobileLandscape) {
-                height: $gutter-large + $veggie-burger-medium - $gs-gutter/2;
-                width: $gutter-large + $veggie-burger-medium - $gs-gutter/2;
-                top: -50px;
-            }
-        }
-    }
-
-    // Single line limited variant, stacked variant
-    &.tertiary__variant-four,
-    &.tertiary__variant-five {
-        border-bottom: $gs-baseline/2 solid #747a81;
-    }
+    border-bottom: $gs-baseline/2 solid #747a81;
 }
 
 .tertiary-navigation {
@@ -777,51 +728,19 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
     list-style: none;
     white-space: nowrap;
     display: flex;
-
-    // Scrolly variant
-    .tertiary__variant-three & {
-        overflow-x: scroll;
-        padding-bottom: $gs-baseline*3;
-    }
-
-    // Stacked variant
-    .tertiary__variant-four & {
         padding-top: $gs-baseline/2;
-        max-height: $gs-baseline*3.4;
-        flex-wrap: wrap;
+    max-height: $gs-baseline*3.4;
+    flex-wrap: wrap;
 
-        @include mq($from: mobile, $until: mobileLandscape) {
-            max-height: $gs-baseline*4;
-            max-height: 14.8vw;
-        }
-
-        @include mq($from: mobileLandscape) {
-            max-height: $gs-baseline*5.5;
-        }
+    @include mq($from: mobile, $until: mobileLandscape) {
+        max-height: $gs-baseline*4;
+        max-height: 14.8vw;
     }
 
     @include mq($from: mobileLandscape) {
+        max-height: $gs-baseline*5.5;
         padding-left: $gs-gutter;
         padding-right: $gs-gutter;
-    }
-
-    // Single line limited variant
-    .tertiary__variant-five & {
-        height: $gs-baseline * 2;
-        flex-wrap: wrap;
-        padding-right: $gutter-small + $veggie-burger-small;
-        overflow: hidden;
-
-        @include mq($from: mobile, $until: mobileLandscape) {
-            height: $gs-baseline * 2.2;
-            height:  8vw;
-            padding-right: $gutter-medium + $veggie-burger-small;
-        }
-
-        @include mq(mobileLandscape) {
-            height: $gs-baseline * 2.8;
-            padding-right: $gutter-large + $veggie-burger-medium;
-        }
     }
 }
 
@@ -830,6 +749,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
     @include fs-textSans(4);
     color: $neutral-4;
     display: block;
+    line-height: 1.5em;
 
     &:hover,
     &:focus {
@@ -850,76 +770,14 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
         pointer-events: none;
         content: '/';
         color: rgba(255, 255, 255, .3);
-    }
-
-    // Scrolly variant, Single line limited variant
-    .tertiary__variant-three &,
-    .tertiary__variant-five & {
-        line-height: 2.2em;
-        padding: 0 .4em;
-
-        @include mq($from: mobile, $until: mobileLandscape) {
-            line-height: 1.9em;
-        }
-
-        @include mq($from: mobileLandscape) {
-            line-height: 1.8em;
-        }
-
-        &:after {
-            position: absolute;
-            left: -.17em;
-        }
-    }
-
-    // Stacked variant
-    .tertiary__variant-four & {
-        line-height: 1.5em;
-
-        &:after {
-            margin-left: -.1em;
-            padding: 0 $gs-gutter/10;
-        }
+        margin-left: -.1em;
+        padding: 0 $gs-gutter/10;
     }
 }
 
-// Scrolly variant, Single line limited variant
-.tertiary__variant-three,
-.tertiary__variant-five {
-    .tertiary-navigation__item:first-of-type .tertiary-navigation__link {
-        padding-left: 0;
-
-        &:after {
-            content: none;
-        }
-    }
-}
-
-// Scrolly variant
-.tertiary__variant-three {
-    .tertiary-navigation__item {
-        flex: 0 0 auto;
-
-        &:last-of-type .tertiary-navigation__link {
-            margin-right: $gutter-small + $veggie-burger-small;
-
-            @include mq($mobile-medium) {
-                margin-right: $gutter-medium + $veggie-burger-medium - $gs-gutter/2;
-            }
-
-            @include mq(mobileLandscape) {
-                margin-right: $gutter-large + $veggie-burger-medium - $gs-gutter/2;
-            }
-        }
-    }
-}
-
-// Stacked variant
-.tertiary__variant-four {
-    .tertiary-navigation__item:last-of-type .tertiary-navigation__link {
-        &:after {
-            content: '';
-        }
+.tertiary-navigation__item:last-of-type .tertiary-navigation__link {
+    &:after {
+        content: '';
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -757,6 +757,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
         color: #ffffff;
     }
 
+    .tertiary-navigation__item--current-section & {
+        color: $news-support-1;
+    }
+
     @include mq($from: mobile, $until: mobileLandscape) {
         font-size: 16px;
         font-size: 5.1vw;


### PR DESCRIPTION
## What does this change?
* Removes variant 3 and 5 (also see https://github.com/guardian/fastly-edge-cache/pull/723)
* Extends variant 4
* Puts back the styling deleted here https://github.com/guardian/frontend/pull/15185

## What is the value of this and can you measure success?
Variant three is the most successful of the 3 variants. The plan now is to remove the others and increase the percentage of this variant. This will allow us to iron out more possible bugs before going 100% on mobile.

## Does this affect other platforms - Amp, Apps, etc?
Nope!

## Screenshots
The variant that has won is this one:
![image](https://cloud.githubusercontent.com/assets/8774970/20930718/77f0ca76-bbc6-11e6-88f0-cfe6aff8bf5d.png)

## Request for comment
@guardian/dotcom-platform 