### PR TITLE
Resolve stickyMpu.whenRendered when receiving a half-page

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -5,6 +5,7 @@ define([
     'common/utils/raven',
     'common/utils/fastdom-promise',
     'common/utils/closest',
+    'common/utils/mediator',
     'common/modules/commercial/ad-sizes',
     'commercial/modules/sticky-mpu',
     'commercial/modules/dfp/apply-creative-template',
@@ -17,6 +18,7 @@ define([
     raven,
     fastdom,
     closest,
+    mediator,
     adSizes,
     stickyMpu,
     applyCreativeTemplate,
@@ -66,6 +68,13 @@ define([
         } else {
             return addFluid(['ad-slot--facebook', 'ad-slot--revealer'])(_, advert);
         }
+    };
+
+    /**
+     * Resolve the stickyMpu.whenRendered promise
+     */
+    sizeCallbacks[adSizes.halfPage] = function () {
+        mediator.emit('page:commercial:sticky-mpu');
     };
 
     /**


### PR DESCRIPTION
One learns something new every day. DMPUs do not trigger the sticky MPU module, and the `whenRendered` promise never resolves. The "offset to the right" test is waiting on that promise, so it is currently stuck when the right hand slot receives a DMPU.