### PR TITLE
AWS credentials: always throw exception when credentials are not configured

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -527,11 +527,7 @@ class GuardianConfiguration extends Logging {
       } catch {
         case ex: AmazonClientException =>
           log.error("amazon client cross account exception", ex)
-
-          // We really, really want to ensure that PROD is configured before saying a box is OK
-          if (Play.isProd) throw ex
-          // this means that on dev machines you only need to configure keys if you are actually going to use them
-          None
+          throw ex
       }
     }
   }
@@ -578,11 +574,7 @@ class GuardianConfiguration extends Logging {
       } catch {
         case ex: AmazonClientException =>
           log.error(ex.getMessage, ex)
-
-          // We really, really want to ensure that PROD is configured before saying a box is OK
-          if (Play.isProd) throw ex
-          // this means that on dev machines you only need to configure keys if you are actually going to use them
-          None
+          throw ex
       }
     }
   }


### PR DESCRIPTION
## What does this change?
AWS credentials: always throws exception when credentials are not configured
This is legacy code that would not throw an exception when in dev mode. However an exception is already thrown earlier in the process of loading configuration, so no need to have different logic at the credentials level

## What is the value of this and can you measure success?
The goal of this PR and the next few ones would be to make the Configuration object totally stateless (ie: no dependency on Play conf or environment)

## Does this affect other platforms - Amp, Apps, etc?
No

## Request for comment
@DiegoVazquezNanini @jfsoul @guardian/dotcom-platform 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->