### PR TITLE
Email sign up page tone corrections and banner removal

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -59,6 +59,8 @@ object ListIds {
 
   val zipFile = 1902
   val theFlyer = 2211
+  val theFlyerCards = 3806
+  val theFlyerConnected = 3807
   val moneyTalks = 1079
   val fashionStatement = 105
   val crosswordEditorUpdate = 101

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -19,6 +19,8 @@
     weekendReading -> "feature",
     documentaries -> "plaindark",
     theFlyer -> "feature",
+    theFlyerCards -> "feature",
+    theFlyerConnected -> "feature",
     theBreakdown -> "feature",
     theSpin -> "feature",
     closeUp -> "review",

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -14,6 +14,7 @@ object Commercial {
     case c: model.ContentPage if c.item.content.shouldHideAdverts => false
     case p: model.Page if p.metadata.sectionId == "identity" => false
     case s: model.SimplePage if s.metadata.contentType == "Signup" => false
+    case e: model.ContentPage if e.metadata.webTitle == "Sign up for The Flyer" => false
     case p: model.CommercialExpiryPage => false
     case _ => true
   }


### PR DESCRIPTION
## What does this change?

- Makes the Flyer variants keep the feature tones
- Removes the top banner from our signup page ⚡️

https://www.theguardian.com/info/ng-interactive/2016/dec/07/sign-up-for-the-flyer

## What is the value of this and can you measure success?

Smooth email launch... 😶

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Request for comment

@joelochlann 