### PR TITLE
Remove useless 'secure' conf param ans isSSL js page config

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,7 +150,6 @@ class GuardianConfiguration extends Logging {
 
     lazy val stage = InstallationVars.stage
     lazy val projectName = Play.application.configuration.getString("guardian.projectName").getOrElse("frontend")
-    lazy val secure = Play.application.configuration.getBoolean("guardian.secure").getOrElse(false)
 
     lazy val isProd = stage.equalsIgnoreCase("prod")
     lazy val isCode = stage.equalsIgnoreCase("code")
@@ -301,12 +300,6 @@ class GuardianConfiguration extends Logging {
     lazy val digitalPackUrl = configuration.getStringProperty("id.digitalpack.url").getOrElse("https://subscribe.theguardian.com")
     lazy val membersDataApiUrl = configuration.getStringProperty("id.members-data-api.url").getOrElse("https://members-data-api.theguardian.com")
     lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
-  }
-
-  object static {
-    lazy val path =
-      if (environment.secure) configuration.getMandatoryStringProperty("static.securePath")
-      else configuration.getMandatoryStringProperty("static.path")
   }
 
   object images {

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -60,7 +60,6 @@ object JavaScriptPage {
       ("isProd", JsBoolean(Configuration.environment.isProd)),
       ("idUrl", JsString(Configuration.id.url)),
       ("beaconUrl", JsString(Configuration.debug.beaconUrl)),
-      ("isSSL", JsBoolean(Configuration.environment.secure)),
       ("assetsPath", JsString(Configuration.assets.path)),
       ("isPreview", JsBoolean(environment.isPreview)),
       ("allowUserGeneratedContent", JsBoolean(allowUserGeneratedContent)),

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -235,9 +235,7 @@ define([
             },
 
             startRegister: function () {
-                if (!config.page.isSSL) {
-                    register.initialise();
-                }
+                register.initialise();
             },
 
             showMoreTagsLink: function () {

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -27,7 +27,6 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
                 config.page = {
                     contentType : 'Article',
                     isMinuteArticle : false,
-                    isSSL : false,
                     section : 'politics',
                     shouldHideAdverts : false,
                     isFront : false,


### PR DESCRIPTION
## What does this change?
isSSL was only [used in one place](https://github.com/guardian/frontend/search?utf8=%E2%9C%93&q=isSSL) to historically prevent ophan to be
initialized on identity page (which were on https). I guess ophan was
not on https at the moment.
See:
https://github.com/guardian/frontend/commit/d4c915c4654605ff7c753f7b1f3c246cbe0ca757
and 
https://github.com/guardian/frontend/commit/076278de4925ecf9b50ad39bfe52740c62ce84f8

This check is useless now ophan is on https (as well as all pages of the
guardian). Hence removing it.
'secure' configuration parameter was only used to set isSSL. Therefore
removing it now it is not used anywhere

## What is the value of this and can you measure success?
Configuration should be stateless, not depending on Play config or environment

## Request for comment
@gtrufitt @jfsoul @markjamesbutler @guardian/dotcom-platform 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->
