### PR TITLE
We're going to recycle this test in a few days and will redo the switch then

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 8), // Thursday 8th December
+    sellByDate = new LocalDate(2016, 12, 22), // Thursday 22nd December
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
Extends an AB test master switch. The test this controls ends today but we know we're going to recycle it within the next few days. Rather than take all the code out only to put it back in again very soon, we can just extend this switch and do the whole lot in one pass later.

## What is the value of this and can you measure success?
Don't want to break the build. If builds don't break, success!

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
N/A

## Request for comment
@Ap0c @svillafe 
