### PR TITLE
Add missing / from new archive route

### DIFF
--- a/archive/conf/routes
+++ b/archive/conf/routes
@@ -10,5 +10,5 @@ GET        /_healthcheck                            controllers.HealthCheck.heal
 GET        /404/www.theguardian.com$path<.*>        controllers.ArchiveController.lookup(path)
 
 # 404
-GET        /404/$path<.*>                           controllers.ArchiveController.lookup(path)
+GET        /404$path</.*>                           controllers.ArchiveController.lookup(path)
 


### PR DESCRIPTION
## What does this change?
Corrects the new(ish) archive route to include a missing /.  This route wouldn't have worked as expected but luckily we aren't using it until we merge https://github.com/guardian/platform/pull/1145.

## What is the value of this and can you measure success?
We can merge platform PR, and later remove the unused route.  Everything looks tidier `/404/www.theguardian.com/...` -> `/404/...`

## Does this affect other platforms - Amp, Apps, etc?
No

## Request for comment
@TBonnin 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

