### PR TITLE
Fix regression bug where logo is unclickable

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -387,6 +387,7 @@
     box-sizing: border-box;
     padding-top: $gs-baseline / 6;
     margin-bottom: $gs-baseline / 2;
+    clear: left; // a dateline may be preceded by a floated sponsor logo
 
     time {
         display: inline-block;


### PR DESCRIPTION
This is a reinstatement of the change that @rich-nguyen made in #14728, which appears to have dropped out again recently.

/cc @guardian/commercial-dev 