### PR TITLE
Extend Brexit test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Gather contributions and supporters around Brexit supreme court case",
     owners = Seq(Owner.withGithub("philwills")),
     safeState = Off,
-    sellByDate =  new LocalDate(2016, 12, 12),
+    sellByDate =  new LocalDate(2016, 12, 16),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit-supreme.js
@@ -35,7 +35,7 @@ define([
 
         this.id = 'ContributionsEpicBrexitSupreme';
         this.start = '2016-12-02';
-        this.expiry = '2016-12-12';
+        this.expiry = '2016-12-16';
         this.author = 'Phil Wills';
         this.description = 'Appeal linked to the Brexit appeal in the Supreme Court';
         this.showForSensitive = false;


### PR DESCRIPTION
## What does this change?

Extend Brexit test until next Friday

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Request for comment

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

