### PR TITLE
The Australia test started a bit late and needs more time to complete

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -70,8 +70,8 @@ trait ABTestSwitches {
     "ab-au-memb-engagement-msg-copy-test-8",
     "Test alternate short messages on AU membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 22), // Thursday 22nd December
+    safeState = On, // the test is live - don't switch off accidentally
+    sellByDate = new LocalDate(2017, 1, 5), // Thursday 5th January
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/au-membership-engagement-message-test-8.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/au-membership-engagement-message-test-8.js
@@ -20,7 +20,7 @@ define([
     return function () {
         this.id = 'AuMembEngagementMsgCopyTest8';
         this.start = '2016-11-24';
-        this.expiry = '2016-12-22';
+        this.expiry = '2017-1-5';
         this.author = 'Justin Pinner';
         this.description = 'Test alternate short messages on AU engagement banner (test 8)';
         this.audience = 1;    // 100% (of AU audience)


### PR DESCRIPTION
## What does this change?
The Australia membership engagement banner copy test (#8) started several days later than planned so we need to extend its lifespan to achieve statistical significance. And we don't want it to end during the holiday period, so we've pushed the end date out to January.

## What is the value of this and can you measure success?
If we don't extend it the test will probably not have a useful outcome.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
N/A

## Request for comment
I'll try using the new review request thingy.

