### PR TITLE
Article refresh test bug with liveblogs

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -794,7 +794,7 @@ $caption-button-size: 32px;
 
     // When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
     // TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
-    .content__head {
+    .content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live) {
         @include mq($until: mobileLandscape) {
             margin-right: -$gs-gutter /2;
             margin-left: -$gs-gutter /2;


### PR DESCRIPTION
Liveblogs both alive and dead, were getting a bit too friendly with the edges of the page.

![screen shot 2016-12-08 at 11 23 15](https://cloud.githubusercontent.com/assets/14570016/21008245/c4863a06-bd38-11e6-901c-35d75223c5bb.png)

Call me a prude, but I had to put a stop to that...
![screen shot 2016-12-08 at 11 22 59](https://cloud.githubusercontent.com/assets/14570016/21008246/c494dfac-bd38-11e6-8e53-2e4bfda46bb5.png)

@stephanfowler 
