### PR TITLE
adds a call to tailor.guardianapis.com - behind a switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,7 +484,7 @@ trait FeatureSwitches {
     "Adds a placeholder attribute to interactives on amp so that they are allowed to display in the top part of the page",
     owners = Seq(Owner.withGithub("michaelwmcnamara")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 15),
+    sellByDate = new LocalDate(2017, 1, 20),
     exposeClientSide = true
   )
 
@@ -507,6 +507,17 @@ trait FeatureSwitches {
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 12, 20),
+    exposeClientSide = true
+  )
+
+  //Owner Michael McNamara
+  val StressTestTailor = Switch(
+    SwitchGroup.Feature,
+    "stress-test-tailor-healthcheck",
+    "Sends a healthcheck metric for every page",
+    owners = Seq(Owner.withGithub("michaelwmcnamara")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 1, 20),
     exposeClientSide = true
   )
 }

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -41,8 +41,8 @@
     </div>
 </noscript>
 
-@if(Configuration.environment.isProd){<img src="https://tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
-@if(Configuration.environment.isCode){<img src="http://code.tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
+@if(StressTestTailor.isSwitchedOn && Configuration.environment.isProd){<img src="https://tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
+@if(StressTestTailor.isSwitchedOn && Configuration.environment.isCode){<img src="http://code.tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
 <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -2,6 +2,7 @@
 @import conf.Configuration
 @import conf.Static
 @import views.support.FBPixel
+@import conf.switches.Switches.StressTestTailor
 
 
 @******************************************************************************
@@ -39,6 +40,9 @@
         <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0"/>
     </div>
 </noscript>
+
+@if(Configuration.environment.isProd){<img src="https://tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
+@if(Configuration.environment.isCode){<img src="http://code.tailor.guardianapis.com/test" alt="" style="display : none ;" rel="nofollow"/>}
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
 <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />


### PR DESCRIPTION
This adds an analytics call to tailor.guardianapis.com as part of a stress test, behind a switch "stress-test-tailor-healthcheck"
See https://trello.com/c/kcZbJNt8/179-stress-test-tailor for more details.

There is a code only version of the call also which is to be sent for pages visited on CODE.

- No impact on other platforms
- All tests in sbt pass
- AMP validation passes
