### PR TITLE
Calmer logging in verbose mode

### DIFF
--- a/tools/run-task-verbose-formater.js
+++ b/tools/run-task-verbose-formater.js
@@ -15,7 +15,7 @@ const render = (tasks, parents = []) => {
             }
             if (event.type === 'STATE') {
                 if (task.isPending()) {
-                    log(task.title, parents);
+                    log(task.title, parents, chalk.dim('...'));
                 }
                 if (task.hasFailed()) {
                     log(task.title, parents, chalk.red(figures.cross));
@@ -23,9 +23,12 @@ const render = (tasks, parents = []) => {
                 if (task.isSkipped()) {
                     log(task.title, parents, `${chalk.dim(figures.arrowDown)} (${task.output})`);
                 }
+                if (task.isCompleted() && !task.hasFailed() && !task.isSkipped()) {
+                    log(task.title, parents, chalk.dim.green(figures.tick));
+                }
             }
             if (event.type === 'DATA') {
-               log(task.title, parents, event.data);
+               console.log(event.data);
            }
         });
 	}


### PR DESCRIPTION
## What does this change?

calms the logging down a bit, esp when there's tasks logging too

## What is the value of this and can you measure success?

easier on the eye, easier on the screen

## Screenshots

![screen shot 2016-12-09 at 11 39 51](https://cloud.githubusercontent.com/assets/867233/21047883/3b0fb1e0-be04-11e6-8bf3-8c337ce31f1e.png)

