### PR TITLE
Display correct quiz bucket message

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/quiz.js
+++ b/static/src/javascripts/projects/common/modules/atoms/quiz.js
@@ -22,7 +22,7 @@ define([
                 if ($quizzes.length > 0) {
                     bean.on(document, 'click', toArray($quizzes), function (e) {
                         var quiz = e.currentTarget,
-                            total =  $(':checked + .atom-quiz__answer__item', quiz).length;
+                            total =  $(':checked + .atom-quiz__answer__item--is-correct', quiz).length;
 
                         if (quiz.checkValidity()) { // the form (quiz) is complete
                             var $bucket__message = null;


### PR DESCRIPTION
## What does this change?

The quiz always displays the bucket message for the top score, regardless of how many questions were answered correctly. This change shows the bucket message relevant to the user's score

![picture 144](https://cloud.githubusercontent.com/assets/5931528/21048155/a48f16c8-be05-11e6-8421-a2cf155cd4f2.png)

## Request for comment

@sndrs 

<!-- AB test? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/01-ab-testing.md -->
<!-- AMP question? https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission -->

