### PR TITLE
Inline MPUs: offset to the right on desktop

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -464,6 +464,10 @@
 }
 
 .ad-slot--offset-right {
+    @include mq(destkop) {
+        margin-right: -20em;
+    }
+
     @include mq(wide) {
         margin-right: -25em;
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -464,7 +464,7 @@
 }
 
 .ad-slot--offset-right {
-    @include mq(destkop) {
+    @include mq(desktop) {
         margin-right: -20em;
     }
 


### PR DESCRIPTION
I forgot to add the correct layout rule for inline MPUs on desktop.

Before:
![picture 7](https://cloud.githubusercontent.com/assets/629976/21052684/12bd38ce-be1e-11e6-8b70-3130c2e7abbe.jpg)

After:
![picture 8](https://cloud.githubusercontent.com/assets/629976/21052689/15bf2e7e-be1e-11e6-80d9-12db25530293.jpg)
