### PR TITLE
Update the styling for paid cards to use two neutral greys.

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -174,6 +174,7 @@ $paid-article-header:       #bfbfbf;
 $paid-article-header-bg:    #b8b8b8;
 $paid-article-subheader:    #cccccc;
 $paid-article-subheader-bg: #c4c4c4;
+$paid-article-card-bg:      #d7d7d7;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;
@@ -181,7 +182,7 @@ $paid-article-mpu:          #cccccc;
 $paid-article-richlink:     #65a897;
 $rainbow-red:               #ed1c24; // from Guss
 
-$paid-card-kicker:        #65a897;
+$paid-card-kicker:        #626262;
 
 $c-top-header-background: $guardian-brand-dark; // one-off colour for header bg
 

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -236,7 +236,7 @@
 
 .advert--paidfor {
     @include f-textSans;
-    background: $paid-article-subheader;
+    background: $paid-article-card-bg;
     border-top-color: $paid-article-brand;
 
     &:hover,


### PR DESCRIPTION
## What does this change?
People can't read kickers and people, rather reasonably, _want_ to be able to read kickers. This is an addendum to #15016.

## What is the value of this and can you measure success?
People can read the kickers!

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
**before**:
![image](https://cloud.githubusercontent.com/assets/1821099/21057130/427f4bc6-be30-11e6-97c5-7940911bfc5f.png)


**after**:
![image](https://cloud.githubusercontent.com/assets/1821099/21057110/2a7c6ebe-be30-11e6-80ff-f1e6d99edfaa.png)

