### PR TITLE
Remove old references to goo

### DIFF
--- a/docs/01-start-here/03-how-to-deploy.md
+++ b/docs/01-start-here/03-how-to-deploy.md
@@ -10,25 +10,20 @@ Congratulations, you can deploy your code to production. Here are the steps to d
 3. Once the build is done, it will be automatically deployed to CODE (The Guardian staging environment)
 4. Verify that your change works properly on CODE
 5. You can find out who is also currently deploying by using the [Deploy Radiator](https://frontend.gutools.co.uk/deploys-radiator) (Private)
-6. If several people are pushing to PROD at the same time, please coordinates with each other. Slack channel #dotcom-push is a good place to do so.
-7. When ready use `goo` tool to deploy the build to production. (ex: `./goo deploy --prod -b BUILD_NUMBER` and then confirm). You will need valid AWS credentials. Please use [Janus](https://janus.gutools.co.uk/#) to obtain them. The `BUILD_NUMBER` can be found in Teamcity ([example](images/build-number-tc.png))
-8. Wait for all the services to be deployed. You can follow the advancement using [Riff-Raff](https://riffraff.gutools.co.uk/) (Private)
-9. Verify that your changes are working in production and check the [logs](https://kibana.gu-web.net/goto/7c4f5f1b8b3c0b49055b3611d5d7810e) (Private) for any issue related to the deployment.
+6. If several people are pushing to PROD at the same time, please coordinate with each other. Slack channel #dotcom-push is a good place to do so.
+7. When ready use [Riff-Raff to deploy](https://riffraff.gutools.co.uk/deployment/request) (Private) the `dotcom:all` artifact to production. The build to deploy can be found in Teamcity ([example](images/build-number-tc.png)) or on the [Deploy Radiator](https://frontend.gutools.co.uk/deploys-radiator) (Private)
+8. Verify that your changes are working in production and check the [logs](https://kibana.gu-web.net/goto/7c4f5f1b8b3c0b49055b3611d5d7810e) (Private) for any issue related to the deployment.
 
 
 ##Blocking deployment
 
-In order to prevent anybody to deploy you can lock deployment. To do so, use the `goo` tool:
-`./goo deploy block`
+In order to prevent anybody to deploy you can block deployment. To do so, add a [restriction in Riff-Raff](https://riffraff.gutools.co.uk/deployment/restrictions) (Private) for `dotcom:all` and the stage you want to lock (PROD or .* for all stages).
 
-Use `./goo deploy unblock` to unblock deployment
+Delete the restriction to unblock deploys.
 
 ##  Frequently asked questions
 
-- Where is the `goo` tool?
-`goo` is available in The Guardian platform [repo](https://github.com/guardian/platform/) (Private)
-
 - When something goes wrong during deployment, a service cluster might be left in an inconsistent state (ie: running servers count doesn't match the expected count)
-Developers would need to fix this inconsistency before to start any subsequent deploy.
+Developers would need to fix this inconsistency before to start any subsequent deploy (a consistency check is done as the first step of a deploy so all successive deploys will fail until this is resolved).
 To do so, you can modify the expected number of instance for a given Autoscaling group using the AWS console or `goo` tool (ex: `./goo groups update AUTOSCALING-GROUP-ID 3 3 12`)
 

--- a/docs/03-dev-howtos/06-repressing.md
+++ b/docs/03-dev-howtos/06-repressing.md
@@ -56,7 +56,7 @@ If you just ship new facia without pressing things will break until the presser 
 * Choose a quiet time of day, and this will take an hour
 * Can you `ssh` onto the facia-press instances for `CODE` and `PROD`? [No?](https://github.com/guardian/platform/blob/master/doc/manual/chapters/1.04.ssh-keys.md)
 * Turn off continuous integration of `Preview` and `CODE facia` (via riff-raff)
-* Block deploys: `./goo deploy block`
+* Block deploys: Add a restriction to [Riff-Raff](https://riffraff.gutools.co.uk/deployment/restrictions)
 * Let team know what you're doing
 * Email core central prod to let them know preview fronts may error 
 * Merge to Master
@@ -93,7 +93,7 @@ If you just ship new facia without pressing things will break until the presser 
 * Set the `facia-press` AWS auto scaling group desired value back to what it was
 * Turn on auto deploys again
 * Change your local machine back to DEV facia bucket!
-* Unblock deploys
+* Unblock deploys (remove the restriction in [Riff-Raff](https://riffraff.gutools.co.uk/deployment/restrictions))
 * Let Central Prod know things are hunky-dory
 * Celebrate! 🎉 
 


### PR DESCRIPTION
## What does this change?
Updates the deployment documentation to use the unified deploy instead of goo.

## What is the value of this and can you measure success?
Future team members should know the correct way to deploy frontend.