### PR TITLE
Remove temporary route for archive switchover

### DIFF
--- a/archive/conf/routes
+++ b/archive/conf/routes
@@ -5,10 +5,5 @@
 
 GET        /_healthcheck                            controllers.HealthCheck.healthCheck()
 
-# Adding this here to support transition while removing www.theguardian.com from the router redirect
-# We want to temporarily support both /404/www.theguardian.com/path AND /404/path in the same way
-GET        /404/www.theguardian.com$path<.*>        controllers.ArchiveController.lookup(path)
-
 # 404
 GET        /404$path</.*>                           controllers.ArchiveController.lookup(path)
-


### PR DESCRIPTION
## What does this change?
Removes a redundant route which should no longer be hit by the router now after https://github.com/guardian/platform/pull/1145 was merged.

## What is the value of this and can you measure success?
Less redundant code.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

