### PR TITLE
us-pre-end-of-year test tidy-up

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test which Epic variant to use in the US end of year campaign",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 12),
+    sellByDate = new LocalDate(2016, 12, 19),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -24,7 +24,7 @@ define([
 
     var ContributionsEpicUsPreEndOfYear = {
         name: 'ContributionsEpicUsPreEndOfYear',
-        variants: ['control', 'bolder', 'endOfYear']
+        variants: ['control', 'endOfYear']
     };
 
     var ContributionsEpicAlwaysAskStrategy = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-pre-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-pre-end-of-year.js
@@ -73,11 +73,6 @@ define([
                 p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.'
             },
-            bolder: {
-                title: 'Take a moment…',
-                p1: '…to support independent journalism. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. We need your support. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If you read and like our reporting, help us make our future more secure.'
-            },
             endOfYear: {
                 title: 'As 2016 comes to a close…',
                 p1: '…we would like to ask for your support. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why now is the right time to ask. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
@@ -142,30 +137,6 @@ define([
                     var component = $.create(template(contributionsEpicEqualButtons, {
                         linkUrl1: ctaType.url1 + '_control',
                         linkUrl2: ctaType.url2 + '_control',
-                        title: message.title,
-                        p1: message.p1,
-                        p2: message.p2,
-                        p3: ctaType.p3,
-                        cta1: ctaType.cta1,
-                        cta2: ctaType.cta2,
-                        hidden: ctaType.hidden
-                    }));
-                    componentWriter(component);
-                },
-
-                impression: registerInsertionListener,
-
-                success: registerViewListener
-            },
-            {
-                id: 'bolder',
-
-                test: function () {
-                    var ctaType = cta.equal;
-                    var message = messages.bolder;
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + '_bolder',
-                        linkUrl2: ctaType.url2 + '_bolder',
                         title: message.title,
                         p1: message.p1,
                         p2: message.p2,


### PR DESCRIPTION
## What does this change?

Removes the bolder variant. Extends the date of the test - @alexduf pointed out to me that the Team City builds would break tomorrow if left as is.

## What is the value of this and can you measure success?

Allows us to determine faster which of the two remaining variants is better.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

#15239 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 
