### PR TITLE
date of us pre election test extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "Test which Epic variant to use in the US end of year campaign",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 12),
+    sellByDate = new LocalDate(2016, 12, 19),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-pre-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-pre-end-of-year.js
@@ -34,7 +34,7 @@ define([
     return function () {
         this.id = 'ContributionsEpicUsPreEndOfYear';
         this.start = '2016-12-06';
-        this.expiry = '2016-12-12';
+        this.expiry = '2016-12-19';
         this.author = 'Guy Dawson';
         this.description = 'Test which Epic variant to use in the US end of year campaign';
         this.showForSensitive = false;


### PR DESCRIPTION
## What does this change?

Extends the pre us end of year epic test.

## What is the value of this and can you measure success?

Allows us to determine which is the best variant.

## Does this affect other platforms - Amp, Apps, etc?

No

