### PR TITLE
Refactor: wrap injected Environment into ApplicationContext instance

### DIFF
--- a/admin-jobs/test/controllers/BreakingNews/BreakingNewsApiTest.scala
+++ b/admin-jobs/test/controllers/BreakingNews/BreakingNewsApiTest.scala
@@ -4,7 +4,7 @@ import common.ExecutionContexts
 import org.joda.time.DateTime
 import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
 import play.api.libs.json.{JsValue, Json}
-import test.{ConfiguredTestSuite, WithTestEnvironment}
+import test.{ConfiguredTestSuite, WithTestContext}
 
 import scala.io.Codec
 
@@ -13,9 +13,9 @@ import scala.io.Codec
     with Matchers
     with ExecutionContexts
     with ConfiguredTestSuite
-    with WithTestEnvironment {
+    with WithTestContext {
 
-  class MockS3DoNothing extends S3BreakingNews(testEnvironment) {
+  class MockS3DoNothing extends S3BreakingNews(testContext.environment) {
     override def get(key: String)(implicit codec: Codec): Option[String] = None
     override def getWithLastModified(key: String): Option[(String, DateTime)] = None
     override def getLastModified(key: String): Option[DateTime] = None

--- a/admin-jobs/test/controllers/NewsAlertControllerTest.scala
+++ b/admin-jobs/test/controllers/NewsAlertControllerTest.scala
@@ -15,13 +15,13 @@ import play.api.Environment
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.{ConfiguredTestSuite, WithTestEnvironment}
+import test.{ConfiguredTestSuite, WithTestContext}
 
 @DoNotDiscover class NewsAlertControllerTest
   extends WordSpec
     with Matchers
     with ConfiguredTestSuite
-    with WithTestEnvironment {
+    with WithTestContext {
 
   val testApiKey = "test-api-key"
 
@@ -36,7 +36,7 @@ import test.{ConfiguredTestSuite, WithTestEnvironment}
 
   def controllerWithActorReponse(mockResponse: Any) = {
     val updaterActor = actorSystem.actorOf(MockUpdaterActor.props(mockResponse))
-    val fakeApi = new BreakingNewsApi(new S3BreakingNews(testEnvironment)) // Doesn't matter, it is not used just passed to the NewsAlertController constructor
+    val fakeApi = new BreakingNewsApi(new S3BreakingNews(testContext.environment)) // Doesn't matter, it is not used just passed to the NewsAlertController constructor
     new NewsAlertController(fakeApi)(actorSystem) {
       override lazy val breakingNewsUpdater = updaterActor
       override lazy val apiKey = testApiKey

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -6,6 +6,7 @@ import controllers.admin._
 import controllers.admin.commercial.{DfpDataController, SlotController, TakeoverWithEmptyMPUsController}
 import controllers.cache.{ImageDecacheController, PageDecacheController}
 import jobs.VideoEncodingsJob
+import model.ApplicationContext
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.api.i18n.Messages
@@ -16,7 +17,7 @@ trait AdminControllers {
   def wsClient: WSClient
   def videoEncodingsJob: VideoEncodingsJob
   def ophanApi: OphanApi
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   def redirects: RedirectService
   implicit val messages: Messages
   lazy val oAuthLoginController = wire[OAuthLoginAdminController]

--- a/admin/app/controllers/AnalyticsController.scala
+++ b/admin/app/controllers/AnalyticsController.scala
@@ -2,12 +2,12 @@ package controllers.admin
 
 import play.api.mvc.{Action, Controller}
 import common.{ExecutionContexts, Logging}
-import model.NoCache
+import model.{ApplicationContext, NoCache}
 
 import scala.concurrent.Future
-import play.api.Environment
 
-class AnalyticsController(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class AnalyticsController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   def abtests() = Action.async { implicit request =>
     Future(NoCache(Ok(views.html.abtests())))
   }

--- a/admin/app/controllers/AnalyticsController.scala
+++ b/admin/app/controllers/AnalyticsController.scala
@@ -7,8 +7,7 @@ import model.{ApplicationContext, NoCache}
 import scala.concurrent.Future
 
 class AnalyticsController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  def abtests() = Action.async { implicit request =>
+    def abtests() = Action.async { implicit request =>
     Future(NoCache(Ok(views.html.abtests())))
   }
 }

--- a/admin/app/controllers/ContentPerformanceController.scala
+++ b/admin/app/controllers/ContentPerformanceController.scala
@@ -8,7 +8,6 @@ import org.joda.time.format.DateTimeFormat
 import play.api.mvc._
 
 class ContentPerformanceController(videoEncodingsJob: VideoEncodingsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   val missingVideoEncodingDateTimeFormat = DateTimeFormat.forPattern("hh:mm::ss")
 

--- a/admin/app/controllers/ContentPerformanceController.scala
+++ b/admin/app/controllers/ContentPerformanceController.scala
@@ -2,13 +2,13 @@ package controllers.admin
 
 import common.{ExecutionContexts, Logging}
 import jobs.VideoEncodingsJob
-import model.NoCache
+import model.{ApplicationContext, NoCache}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import play.api.Environment
 import play.api.mvc._
 
-class ContentPerformanceController(videoEncodingsJob: VideoEncodingsJob)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class ContentPerformanceController(videoEncodingsJob: VideoEncodingsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   val missingVideoEncodingDateTimeFormat = DateTimeFormat.forPattern("hh:mm::ss")
 

--- a/admin/app/controllers/CssReportController.scala
+++ b/admin/app/controllers/CssReportController.scala
@@ -37,8 +37,7 @@ case class CssReportResponse(
 )
 
 class CssReportController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
-  def entry = Action { implicit request =>
+    def entry = Action { implicit request =>
     Ok(views.html.cssReport())
   }
 

--- a/admin/app/controllers/CssReportController.scala
+++ b/admin/app/controllers/CssReportController.scala
@@ -1,12 +1,11 @@
 package controllers.admin
 
 import common.{ExecutionContexts, JsonComponent}
-import conf.Configuration
 import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
 import css_report.{CssReport, SelectorReport}
-import play.api.Environment
+import model.ApplicationContext
 
 object CssReportsIndex {
   implicit val jsonWrites = Json.writes[CssReportsIndex]
@@ -37,7 +36,8 @@ case class CssReportResponse(
   selectors: Map[String, UsedAndUnused]
 )
 
-class CssReportController (implicit env: Environment) extends Controller with ExecutionContexts {
+class CssReportController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
   def entry = Action { implicit request =>
     Ok(views.html.cssReport())
   }

--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -2,10 +2,11 @@ package controllers
 
 import common.{AkkaAsync, ExecutionContexts, Logging}
 import jobs.{HighFrequency, LowFrequency, RefreshFrontsJob, StandardFrequency}
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 
-class FrontPressController(akkaAsync: AkkaAsync)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class FrontPressController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def press() = Action { implicit request =>
     Ok(views.html.press())

--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -6,7 +6,6 @@ import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 
 class FrontPressController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def press() = Action { implicit request =>
     Ok(views.html.press())

--- a/admin/app/controllers/IndexController.scala
+++ b/admin/app/controllers/IndexController.scala
@@ -17,7 +17,6 @@ object AuthActions extends Actions {
 }
 
 class AdminIndexController (implicit context: ApplicationContext) extends Controller {
-  import context._
 
   def index() = Action { Redirect("/admin") }
 

--- a/admin/app/controllers/IndexController.scala
+++ b/admin/app/controllers/IndexController.scala
@@ -3,8 +3,7 @@ package controllers.admin
 import com.gu.googleauth.{Actions, GoogleAuthConfig, UserIdentity}
 import play.api.mvc.Security.AuthenticatedBuilder
 import play.api.mvc.{Action, Call, Controller}
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 
 object AuthActions extends Actions {
 
@@ -17,7 +16,8 @@ object AuthActions extends Actions {
   )
 }
 
-class AdminIndexController (implicit env: Environment) extends Controller {
+class AdminIndexController (implicit context: ApplicationContext) extends Controller {
+  import context._
 
   def index() = Action { Redirect("/admin") }
 

--- a/admin/app/controllers/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/OAuthLoginAdminController.scala
@@ -7,8 +7,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, Request}
 
 class OAuthLoginAdminController(val wsClient: WSClient)(implicit context: ApplicationContext) extends OAuthLoginController {
-  import context._
-  override def login = Action { implicit request =>
+    override def login = Action { implicit request =>
     val error = request.flash.get("error")
     Ok(views.html.auth.login(error))
   }

--- a/admin/app/controllers/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/OAuthLoginAdminController.scala
@@ -2,11 +2,12 @@ package controllers.admin
 
 import com.gu.googleauth.GoogleAuthConfig
 import googleAuth.OAuthLoginController
-import play.api.Environment
+import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, Request}
 
-class OAuthLoginAdminController(val wsClient: WSClient)(implicit env: Environment) extends OAuthLoginController {
+class OAuthLoginAdminController(val wsClient: WSClient)(implicit context: ApplicationContext) extends OAuthLoginController {
+  import context._
   override def login = Action { implicit request =>
     val error = request.flash.get("error")
     Ok(views.html.auth.login(error))

--- a/admin/app/controllers/R2PressController.scala
+++ b/admin/app/controllers/R2PressController.scala
@@ -8,7 +8,6 @@ import play.api.mvc.{Action, AnyContent, Controller}
 import services.{R2PagePressNotifier, R2PressedPageTakedownNotifier}
 
 class R2PressController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def pressForm(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty) = Action { implicit request =>
     Ok(views.html.pressR2(urlMsgs, fileMsgs))

--- a/admin/app/controllers/R2PressController.scala
+++ b/admin/app/controllers/R2PressController.scala
@@ -3,12 +3,12 @@ package controllers.admin
 import java.io.File
 
 import common.{AkkaAsync, ExecutionContexts, Logging}
-import model.R2PressMessage
-import play.api.Environment
+import model.{ApplicationContext, R2PressMessage}
 import play.api.mvc.{Action, AnyContent, Controller}
 import services.{R2PagePressNotifier, R2PressedPageTakedownNotifier}
 
-class R2PressController(akkaAsync: AkkaAsync)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class R2PressController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def pressForm(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty) = Action { implicit request =>
     Ok(views.html.pressR2(urlMsgs, fileMsgs))

--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -15,7 +15,6 @@ import model.deploys.{HttpClient, TeamCityBuild, TeamcityService}
 import scala.concurrent.Future
 
 class RadiatorController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with Requests{
-  import context._
 
   // if you are reading this you are probably being rate limited...
   // you can read about github rate limiting here http://developer.github.com/v3/#rate-limiting

--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -8,14 +8,14 @@ import play.api.libs.ws.{WSAuthScheme, WSClient}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.Json
 import conf.Configuration
-import model.NoCache
+import model.{ApplicationContext, NoCache}
 import conf.switches.{Switch, Switches}
 import model.deploys.{HttpClient, TeamCityBuild, TeamcityService}
-import play.api.Environment
 
 import scala.concurrent.Future
 
-class RadiatorController(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with Requests{
+class RadiatorController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with Requests{
+  import context._
 
   // if you are reading this you are probably being rate limited...
   // you can read about github rate limiting here http://developer.github.com/v3/#rate-limiting

--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -4,18 +4,17 @@ import java.io.File
 
 import play.api.mvc.{Action, Controller}
 import common.Logging
-import play.api.Environment
+import model.ApplicationContext
 import play.api.data._
 import play.api.data.Forms._
 import services.RedirectService.PermanentRedirect
 import services.RedirectService
 
-
 case class PageRedirect(from: String, to: String) {
   lazy val trim = this.copy(from = from.trim, to = to.trim)
 }
-class RedirectController(redirects: RedirectService)(implicit env: Environment) extends Controller with Logging {
-
+class RedirectController(redirects: RedirectService)(implicit context: ApplicationContext) extends Controller with Logging {
+  import context._
 
   val redirectForm = Form(mapping("from" -> text, "to" -> text)(PageRedirect.apply)(PageRedirect.unapply))
 

--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -14,7 +14,6 @@ case class PageRedirect(from: String, to: String) {
   lazy val trim = this.copy(from = from.trim, to = to.trim)
 }
 class RedirectController(redirects: RedirectService)(implicit context: ApplicationContext) extends Controller with Logging {
-  import context._
 
   val redirectForm = Form(mapping("from" -> text, "to" -> text)(PageRedirect.apply)(PageRedirect.unapply))
 

--- a/admin/app/controllers/SportTroubleshooterController.scala
+++ b/admin/app/controllers/SportTroubleshooterController.scala
@@ -5,7 +5,6 @@ import common.Logging
 import model.{ApplicationContext, NoCache}
 
 class SportTroubleshooterController (implicit context: ApplicationContext) extends Controller with Logging {
-  import context._
 
   def renderFootballTroubleshooter() = Action { implicit request =>
     NoCache(Ok(views.html.footballTroubleshooter()))

--- a/admin/app/controllers/SportTroubleshooterController.scala
+++ b/admin/app/controllers/SportTroubleshooterController.scala
@@ -2,10 +2,10 @@ package controllers.admin
 
 import play.api.mvc.{Action, Controller}
 import common.Logging
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 
-class SportTroubleshooterController (implicit env: Environment) extends Controller with Logging {
+class SportTroubleshooterController (implicit context: ApplicationContext) extends Controller with Logging {
+  import context._
 
   def renderFootballTroubleshooter() = Action { implicit request =>
     NoCache(Ok(views.html.footballTroubleshooter()))

--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -5,14 +5,13 @@ import common._
 import conf.switches.Switches
 import conf.Configuration
 import play.api.mvc._
-
 import scala.concurrent.Future
 import services.SwitchNotification
 import tools.Store
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 
-class SwitchboardController(akkaAsync: AkkaAsync)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class SwitchboardController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   val SwitchPattern = """([a-z\d-]+)=(on|off)""".r
 

--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -11,7 +11,6 @@ import tools.Store
 import model.{ApplicationContext, NoCache}
 
 class SwitchboardController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   val SwitchPattern = """([a-z\d-]+)=(on|off)""".r
 

--- a/admin/app/controllers/SwitchboardPlistaController.scala
+++ b/admin/app/controllers/SwitchboardPlistaController.scala
@@ -2,15 +2,15 @@ package controllers.admin
 
 import com.gu.googleauth.UserIdentity
 import common._
-import conf.switches.{SwitchState, Switches}
+import conf.switches.Switches
 import conf.Configuration
 import play.api.mvc._
 import services.SwitchNotification
 import tools.Store
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 
-class SwitchboardPlistaController(akkaAsync: AkkaAsync)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class SwitchboardPlistaController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def renderSwitchboard() = Action { implicit request =>
     log.info("loaded plista Switchboard")

--- a/admin/app/controllers/SwitchboardPlistaController.scala
+++ b/admin/app/controllers/SwitchboardPlistaController.scala
@@ -10,7 +10,6 @@ import tools.Store
 import model.{ApplicationContext, NoCache}
 
 class SwitchboardPlistaController(akkaAsync: AkkaAsync)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def renderSwitchboard() = Action { implicit request =>
     log.info("loaded plista Switchboard")

--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -3,8 +3,7 @@ package controllers.admin
 import contentapi.{CapiHttpClient, PreviewContentApi}
 import play.api.mvc.{Action, Controller}
 import common.{ExecutionContexts, Logging}
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 import play.api.libs.ws.WSClient
 import tools.LoadBalancer
 
@@ -19,7 +18,8 @@ object TestFailed{
   def apply(name: String, messages: String*) = EndpointStatus(name, false, messages:_*)
 }
 
-class TroubleshooterController(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class TroubleshooterController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   val previewContentApi = new PreviewContentApi(new CapiHttpClient(wsClient))
 

--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -19,7 +19,6 @@ object TestFailed{
 }
 
 class TroubleshooterController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   val previewContentApi = new PreviewContentApi(new CapiHttpClient(wsClient))
 

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,11 +1,12 @@
 package controllers.admin
 
 import common.{ExecutionContexts, Logging}
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 import tools._
 
-class AnalyticsConfidenceController(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class AnalyticsConfidenceController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   def renderConfidence() = Action.async { implicit request =>
     for {
       omniture <- CloudWatch.omnitureConfidence

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -6,8 +6,7 @@ import play.api.mvc.{Action, Controller}
 import tools._
 
 class AnalyticsConfidenceController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  def renderConfidence() = Action.async { implicit request =>
+    def renderConfidence() = Action.async { implicit request =>
     for {
       omniture <- CloudWatch.omnitureConfidence
       ophan <- CloudWatch.ophanConfidence

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -3,11 +3,9 @@ package controllers.admin
 import common.dfp.{GuCreativeTemplate, GuLineItem}
 import common.{ExecutionContexts, Logging}
 import conf.Configuration
-import conf.Configuration.environment
 import dfp.{CreativeTemplateAgent, DfpApi, DfpDataExtractor}
 import model._
 import ophan.SurgingContentAgent
-import play.api.Environment
 import play.api.libs.json.JsString
 import play.api.mvc.{Action, Controller}
 import tools._
@@ -22,7 +20,8 @@ case class CommercialPage() extends StandalonePage {
       "adUnit" -> JsString("/59666047/theguardian.com/global-development/ng")))
 }
 
-class CommercialController(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class CommercialController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def renderCommercialMenu() = Action { implicit request =>
     NoCache(Ok(views.html.commercial.commercialMenu()))

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -21,7 +21,6 @@ case class CommercialPage() extends StandalonePage {
 }
 
 class CommercialController(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def renderCommercialMenu() = Action { implicit request =>
     NoCache(Ok(views.html.commercial.commercialMenu()))

--- a/admin/app/controllers/admin/WhatIsDeduped.scala
+++ b/admin/app/controllers/admin/WhatIsDeduped.scala
@@ -11,7 +11,6 @@ import play.api.mvc.{Action, Controller}
 import services.ConfigAgent
 
 class WhatIsDeduped(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
    def index() = Action { implicit request =>
      val paths: List[String] = ConfigAgent.getPathIds.sorted

--- a/admin/app/controllers/admin/WhatIsDeduped.scala
+++ b/admin/app/controllers/admin/WhatIsDeduped.scala
@@ -4,14 +4,14 @@ import common.{ExecutionContexts, Logging}
 import conf.Configuration
 import layout.DedupedFrontResult
 import model.Cached.RevalidatableResult
-import model.{Cached, NoCache}
-import play.api.Environment
+import model.{ApplicationContext, Cached, NoCache}
 import play.api.libs.json.{JsError, JsSuccess}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, Controller}
 import services.ConfigAgent
 
-class WhatIsDeduped(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class WhatIsDeduped(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
    def index() = Action { implicit request =>
      val paths: List[String] = ConfigAgent.getPathIds.sorted

--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -2,11 +2,11 @@ package controllers.admin.commercial
 
 import common.ExecutionContexts
 import dfp.DfpDataCacheJob
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 import play.api.mvc.{Action, AnyContent, Controller}
 
-class DfpDataController (implicit env: Environment) extends Controller with ExecutionContexts {
+class DfpDataController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
 
   def renderCacheFlushPage(): Action[AnyContent] = Action { implicit request =>
     NoCache(Ok(views.html.commercial.dfpFlush()))

--- a/admin/app/controllers/admin/commercial/DfpDataController.scala
+++ b/admin/app/controllers/admin/commercial/DfpDataController.scala
@@ -6,7 +6,6 @@ import model.{ApplicationContext, NoCache}
 import play.api.mvc.{Action, AnyContent, Controller}
 
 class DfpDataController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
 
   def renderCacheFlushPage(): Action[AnyContent] = Action { implicit request =>
     NoCache(Ok(views.html.commercial.dfpFlush()))

--- a/admin/app/controllers/admin/commercial/SlotController.scala
+++ b/admin/app/controllers/admin/commercial/SlotController.scala
@@ -7,7 +7,6 @@ import play.api.mvc.{Action, Controller}
 import tools.Store
 
 class SlotController(implicit context: ApplicationContext) extends Controller {
-  import context._
 
   def viewSlot(slotName: String) = Action { implicit request =>
     val maybeResult = for {

--- a/admin/app/controllers/admin/commercial/SlotController.scala
+++ b/admin/app/controllers/admin/commercial/SlotController.scala
@@ -1,12 +1,13 @@
 package controllers.admin.commercial
 
 import common.dfp.LineItemReport
-import play.api.Environment
+import model.ApplicationContext
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
 import tools.Store
 
-class SlotController(implicit env: Environment) extends Controller {
+class SlotController(implicit context: ApplicationContext) extends Controller {
+  import context._
 
   def viewSlot(slotName: String) = Action { implicit request =>
     val maybeResult = for {

--- a/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
+++ b/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
@@ -1,11 +1,12 @@
 package controllers.admin.commercial
 
 import common.dfp.TakeoverWithEmptyMPUs
-import play.api.Environment
+import model.ApplicationContext
 import play.api.i18n.Messages
 import play.api.mvc.{Action, Controller}
 
-class TakeoverWithEmptyMPUsController(implicit val messages: Messages, env: Environment) extends Controller {
+class TakeoverWithEmptyMPUsController(implicit val messages: Messages, context: ApplicationContext) extends Controller {
+  import context._
 
   def viewList() = Action { implicit request =>
     Ok(views.html.commercial.takeoverWithEmptyMPUs(TakeoverWithEmptyMPUs.fetchSorted()))

--- a/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
+++ b/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
@@ -6,7 +6,6 @@ import play.api.i18n.Messages
 import play.api.mvc.{Action, Controller}
 
 class TakeoverWithEmptyMPUsController(implicit val messages: Messages, context: ApplicationContext) extends Controller {
-  import context._
 
   def viewList() = Action { implicit request =>
     Ok(views.html.commercial.takeoverWithEmptyMPUs(TakeoverWithEmptyMPUs.fetchSorted()))

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -6,8 +6,7 @@ import java.util.UUID
 import com.gu.googleauth.UserIdentity
 import common.{ExecutionContexts, Logging}
 import controllers.admin.AuthActions
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Action, AnyContent, Controller}
@@ -15,7 +14,8 @@ import play.api.mvc.{Action, AnyContent, Controller}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
-class ImageDecacheController(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class ImageDecacheController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   import ImageDecacheController._
 
   val imageServices = new ImageServices(wsClient)

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -15,8 +15,7 @@ import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
 class ImageDecacheController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  import ImageDecacheController._
+    import ImageDecacheController._
 
   val imageServices = new ImageServices(wsClient)
 

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -6,8 +6,7 @@ import cache.SurrogateKey
 import com.gu.googleauth.UserIdentity
 import common.{ExecutionContexts, Logging}
 import controllers.admin.AuthActions
-import model.NoCache
-import play.api.Environment
+import model.{ApplicationContext, NoCache}
 import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -19,7 +18,8 @@ import scala.concurrent.Future.successful
 
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
-class PageDecacheController(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class PageDecacheController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def renderPageDecache(url: Option[String] = None) = Action.async { implicit request =>
     url match {

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -19,7 +19,6 @@ import scala.concurrent.Future.successful
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
 class PageDecacheController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def renderPageDecache(url: Option[String] = None) = Action.async { implicit request =>
     url match {

--- a/admin/app/controllers/metrics/FastlyController.scala
+++ b/admin/app/controllers/metrics/FastlyController.scala
@@ -7,8 +7,7 @@ import play.api.mvc.Action
 import tools.CloudWatch
 
 class FastlyController (implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  def renderFastly() = Action.async { implicit request =>
+    def renderFastly() = Action.async { implicit request =>
     for {
       errors <- CloudWatch.fastlyErrors
       statistics <- CloudWatch.fastlyHitMissStatistics

--- a/admin/app/controllers/metrics/FastlyController.scala
+++ b/admin/app/controllers/metrics/FastlyController.scala
@@ -1,12 +1,13 @@
 package controllers.admin
 
 import common.{ExecutionContexts, Logging}
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.Controller
 import play.api.mvc.Action
 import tools.CloudWatch
 
-class FastlyController (implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class FastlyController (implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   def renderFastly() = Action.async { implicit request =>
     for {
       errors <- CloudWatch.fastlyErrors

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -5,13 +5,12 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.Controller
 import play.api.mvc.Action
 import tools._
-import model.NoCache
+import model.{ApplicationContext, NoCache}
 import conf.Configuration
-import play.api.Environment
-
 import scala.concurrent.Future
 
-class MetricsController(wsClient: WSClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class MetricsController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   // We only do PROD metrics
 
   val stage = Configuration.environment.stage.toUpperCase

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -10,8 +10,7 @@ import conf.Configuration
 import scala.concurrent.Future
 
 class MetricsController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  // We only do PROD metrics
+    // We only do PROD metrics
 
   val stage = Configuration.environment.stage.toUpperCase
 

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -4,12 +4,12 @@ import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import play.api.mvc.{Action, Controller, RequestHeader, Result => PlayResult}
 import play.api.libs.ws.WSClient
 import play.twirl.api.Html
-import play.api.Environment
 import common.{ExecutionContexts, Logging}
 import football.services.PaFootballClient
 import football.model.PA
-import model.{Cached, NoCache}
+import model.{ApplicationContext, Cached, NoCache}
 import conf.Configuration
+
 import scala.concurrent.Future
 import pa._
 import concurrent.FutureOpt
@@ -19,11 +19,11 @@ import pa.Season
 import pa.Fixture
 import pa.LiveMatch
 
-class FrontsController(val wsClient: WSClient, val environment: Environment) extends Controller with ExecutionContexts with PaFootballClient with Logging {
+class FrontsController(val wsClient: WSClient, val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
   val SNAP_TYPE = "json.html"
   val SNAP_CSS = "football"
 
-  implicit val env: Environment = environment
+  import context._
 
   def index = Action.async { implicit request =>
     fetchCompetitionsAndTeams.map {

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -19,11 +19,10 @@ import pa.Season
 import pa.Fixture
 import pa.LiveMatch
 
-class FrontsController(val wsClient: WSClient, val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
+class FrontsController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
+
   val SNAP_TYPE = "json.html"
   val SNAP_CSS = "football"
-
-  import context._
 
   def index = Action.async { implicit request =>
     fetchCompetitionsAndTeams.map {

--- a/admin/app/football/controllers/PaBrowserController.scala
+++ b/admin/app/football/controllers/PaBrowserController.scala
@@ -5,15 +5,14 @@ import play.api.mvc._
 import football.services.PaFootballClient
 import common.{ExecutionContexts, Logging}
 import java.net.URLDecoder
+
 import scala.language.postfixOps
-import model.{Cached, NoCache}
+import model.{ApplicationContext, Cached, NoCache}
 import play.api.libs.ws.WSClient
-import play.api.Environment
 
+class PaBrowserController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
-class PaBrowserController(val wsClient: WSClient, val environment: Environment) extends Controller with ExecutionContexts with PaFootballClient with Logging {
-
-  implicit val env: Environment = environment
+  import context._
 
   def browserSubstitution() = Action { implicit request =>
     val submission = request.body.asFormUrlEncoded.getOrElse { throw new Exception("Could not read POST submission") }

--- a/admin/app/football/controllers/PaBrowserController.scala
+++ b/admin/app/football/controllers/PaBrowserController.scala
@@ -12,8 +12,6 @@ import play.api.libs.ws.WSClient
 
 class PaBrowserController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
-  import context._
-
   def browserSubstitution() = Action { implicit request =>
     val submission = request.body.asFormUrlEncoded.getOrElse { throw new Exception("Could not read POST submission") }
     val query = getOneOrFail(submission, "query")

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -2,23 +2,22 @@ package controllers.admin
 
 import model.Cached.RevalidatableResult
 import play.api.mvc._
-import play.api.Environment
 import football.services.PaFootballClient
 import pa.{PlayerAppearances, PlayerProfile, StatsSummary}
 import implicits.Requests
 import common.{ExecutionContexts, JsonComponent, Logging}
 import org.joda.time.LocalDate
 import football.model.PA
+
 import scala.concurrent.Future
-import model.{Cached, Cors, NoCache}
+import model.{ApplicationContext, Cached, Cors, NoCache}
 import play.api.libs.json.{JsArray, JsObject, JsString}
 import org.joda.time.format.DateTimeFormat
 import play.twirl.api.HtmlFormat
 import play.api.libs.ws.WSClient
 
-class PlayerController(val wsClient: WSClient, val environment: Environment) extends Controller with ExecutionContexts with PaFootballClient with Requests with Logging {
-
-  implicit val env: Environment = environment
+class PlayerController(val wsClient: WSClient, val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Requests with Logging {
+  import context._
 
   def playerIndex = Action.async { implicit request =>
     fetchCompetitionsAndTeams.map {

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -16,8 +16,7 @@ import org.joda.time.format.DateTimeFormat
 import play.twirl.api.HtmlFormat
 import play.api.libs.ws.WSClient
 
-class PlayerController(val wsClient: WSClient, val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Requests with Logging {
-  import context._
+class PlayerController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Requests with Logging {
 
   def playerIndex = Action.async { implicit request =>
     fetchCompetitionsAndTeams.map {

--- a/admin/app/football/controllers/SiteController.scala
+++ b/admin/app/football/controllers/SiteController.scala
@@ -6,7 +6,6 @@ import model.Cached.RevalidatableResult
 import play.api.mvc._
 
 class SiteController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
 
   def index = Action { implicit request =>
     Cached(60)(RevalidatableResult.Ok(views.html.football.index()))

--- a/admin/app/football/controllers/SiteController.scala
+++ b/admin/app/football/controllers/SiteController.scala
@@ -1,13 +1,12 @@
 package controllers.admin
 
 import common.ExecutionContexts
-import model.Cached
+import model.{ApplicationContext, Cached}
 import model.Cached.RevalidatableResult
-import play.api.Environment
 import play.api.mvc._
 
-
-class SiteController (implicit env: Environment) extends Controller with ExecutionContexts {
+class SiteController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
 
   def index = Action { implicit request =>
     Cached(60)(RevalidatableResult.Ok(views.html.football.index()))

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -4,18 +4,17 @@ import common.{ExecutionContexts, Logging}
 import football.model.PA
 import football.services.PaFootballClient
 import model.Cached.RevalidatableResult
-import model.{Cached, Cors, NoCache}
+import model.{ApplicationContext, Cached, Cors, NoCache}
 import org.joda.time.LocalDate
 import pa._
 import play.api.mvc._
 import play.api.libs.ws.WSClient
-import play.api.Environment
 
 import scala.concurrent.Future
 
-class TablesController(val wsClient: WSClient, val environment: Environment) extends Controller with ExecutionContexts with PaFootballClient with Logging {
+class TablesController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
-  implicit val env: Environment = environment
+  import context._
 
   def tablesIndex = Action.async { implicit request =>
     for {

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -14,8 +14,6 @@ import scala.concurrent.Future
 
 class TablesController(val wsClient: WSClient)(implicit val context: ApplicationContext) extends Controller with ExecutionContexts with PaFootballClient with Logging {
 
-  import context._
-
   def tablesIndex = Action.async { implicit request =>
     for {
       allCompetitions <- client.competitions

--- a/admin/app/football/services/Client.scala
+++ b/admin/app/football/services/Client.scala
@@ -12,6 +12,7 @@ import common.{ExecutionContexts, Logging}
 import pa.{Http, PaClient, PaClientErrorsException, Response, Season, Team}
 import conf.AdminConfiguration
 import football.model.PA
+import model.ApplicationContext
 
 
 trait Client extends PaClient with Http with ExecutionContexts {
@@ -85,10 +86,9 @@ trait PaFootballClient {
 
   implicit val executionContext: ExecutionContext
   val wsClient: WSClient
-  val environment: Environment
-  val mode: Mode.Mode = environment.mode
+  val context: ApplicationContext
 
-  lazy val client: Client = if (mode == Mode.Test) TestClient(wsClient, environment) else RealClient(wsClient)
+  lazy val client: Client = if (context.environment.mode == Mode.Test) TestClient(wsClient, context.environment) else RealClient(wsClient)
 
   def fetchCompetitionsAndTeams: Future[(List[Season], List[Team])] = for {
     competitions <- client.competitions.map(PA.filterCompetitions)

--- a/admin/app/football/services/Client.scala
+++ b/admin/app/football/services/Client.scala
@@ -85,8 +85,8 @@ trait PaFootballClient {
   self: PaFootballClient with Logging =>
 
   implicit val executionContext: ExecutionContext
+  implicit val context: ApplicationContext
   val wsClient: WSClient
-  val context: ApplicationContext
 
   lazy val client: Client = if (context.environment.mode == Mode.Test) TestClient(wsClient, context.environment) else RealClient(wsClient)
 

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.CamelCase
 

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches.R2PagePressServiceSwitch
 @import conf.Configuration

--- a/admin/app/views/admin_main.scala.html
+++ b/admin/app/views/admin_main.scala.html
@@ -1,4 +1,4 @@
-@(title: String, isAuthed: Boolean = false, hasCharts: Boolean = false, autoRefresh: Boolean = false, loadJquery: Boolean =  true)(content: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(title: String, isAuthed: Boolean = false, hasCharts: Boolean = false, autoRefresh: Boolean = false, loadJquery: Boolean =  true)(content: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import controllers.admin.routes.UncachedAssets
 @import controllers.admin.routes.UncachedWebAssets
@@ -16,7 +16,7 @@
             <meta http-equiv="refresh" content="60">
         }
 
-        @if(env.mode == Dev){
+        @if(context.environment.mode == Dev){
             <link rel="shortcut icon" type="image/png" href="@UncachedAssets.at("images/favicon-dev.ico")" />
         } else {
             <link rel="shortcut icon" type="image/png" href="@UncachedAssets.at("images/favicon.ico")" />
@@ -56,7 +56,7 @@
                     <div class="navbar-header">
                         <a class="navbar-brand" href="/admin">Home</a>
                     </div>
-                    <p class="navbar-text label label-warning">Environment: @env.mode.toString.toLowerCase</p>
+                    <p class="navbar-text label label-warning">Environment: @context.environment.mode.toString.toLowerCase</p>
                     @if(isAuthed){
                         <ul class="nav navbar-nav navbar-right">
                             <li>

--- a/admin/app/views/afg.scala.html
+++ b/admin/app/views/afg.scala.html
@@ -1,4 +1,4 @@
-@(body: String)(implicit request: RequestHeader, env: play.api.Environment)
+@(body: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Dashboard", isAuthed = true, hasCharts = true) {
 

--- a/admin/app/views/auth/login.scala.html
+++ b/admin/app/views/auth/login.scala.html
@@ -1,4 +1,4 @@
-@(error: Option[String] = None)(implicit request: RequestHeader, env: play.api.Environment)
+@(error: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Login") {
         @if(error.isDefined) {

--- a/admin/app/views/cache/imageDecache.scala.html
+++ b/admin/app/views/cache/imageDecache.scala.html
@@ -1,6 +1,6 @@
 @import controllers.cache.ImageDecacheController
 
-@(messageType: ImageDecacheController.MessageType = ImageDecacheController.DefaultMessage, image: String = "", originImage: Option[String] = None)(implicit request: RequestHeader, env: play.api.Environment)
+@(messageType: ImageDecacheController.MessageType = ImageDecacheController.DefaultMessage, image: String = "", originImage: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Clear image", isAuthed = true) {
 

--- a/admin/app/views/cache/pageDecache.scala.html
+++ b/admin/app/views/cache/pageDecache.scala.html
@@ -1,4 +1,4 @@
-@(maybeTestResult: Option[controllers.cache.PrePurgeTestResult] = None, message: String = "")(implicit request: RequestHeader, env: play.api.Environment)
+@(maybeTestResult: Option[controllers.cache.PrePurgeTestResult] = None, message: String = "")(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Purge Cache", isAuthed = true) {
 

--- a/admin/app/views/commercial/adTests.scala.html
+++ b/admin/app/views/commercial/adTests.scala.html
@@ -1,7 +1,7 @@
 @import common.dfp.GuLineItem
 @import tools.DfpLink
 
-@(timestamp: String, groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader, env: play.api.Environment)
+@(timestamp: String, groupedLineItems: Seq[(String, Seq[GuLineItem])])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Ad Tests", isAuthed = true) {
 

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.Configuration.commercial.testDomain
 
 @admin_main("Commercial Tools", isAuthed = true) {

--- a/admin/app/views/commercial/commercialRadiator.scala.html
+++ b/admin/app/views/commercial/commercialRadiator.scala.html
@@ -1,4 +1,4 @@
-@(confidenceGraph: tools.AwsLineChart)(implicit request: RequestHeader, env: play.api.Environment)
+@(confidenceGraph: tools.AwsLineChart)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Commercial Radiator", isAuthed = true, hasCharts = true) {
     <h3>Commercial Radiator</h3>

--- a/admin/app/views/commercial/customTargetingKeyValues.scala.html
+++ b/admin/app/views/commercial/customTargetingKeyValues.scala.html
@@ -1,4 +1,4 @@
-@(keyValues: Seq[_root_.dfp.GuCustomTargetingKey])(implicit request: RequestHeader, env: play.api.Environment)
+@(keyValues: Seq[_root_.dfp.GuCustomTargetingKey])(implicit request: RequestHeader, context: model.ApplicationContext)
 @import tools.DfpLink
 
 @admin_main("Key Value Targeting", isAuthed = true, hasCharts = false) {

--- a/admin/app/views/commercial/dfpFlush.scala.html
+++ b/admin/app/views/commercial/dfpFlush.scala.html
@@ -1,4 +1,4 @@
-@()(implicit flash: Flash, request: RequestHeader, env: play.api.Environment)
+@()(implicit flash: Flash, request: RequestHeader, context: model.ApplicationContext)
 
 @link(cssClass: String) = {
     <a class="@cssClass" href="@controllers.admin.commercial.routes.DfpDataController.flushCache()" role="button">

--- a/admin/app/views/commercial/fluidAds.scala.html
+++ b/admin/app/views/commercial/fluidAds.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Commercial", isAuthed = true, hasCharts = true) {
 

--- a/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
@@ -1,4 +1,4 @@
-@(report: common.dfp.HighMerchandisingTargetedTagsReport)(implicit request: RequestHeader, env: play.api.Environment)
+@(report: common.dfp.HighMerchandisingTargetedTagsReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import tools.DfpLink
 
 @admin_main("Commercial High Slot", isAuthed = true, hasCharts = false) {

--- a/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/inlineMerchandisingTargetedTags.scala.html
@@ -1,7 +1,7 @@
 @import common.dfp.InlineMerchandisingTargetedTagsReport
 @import tools.{CapiLink, SiteLink}
 
-@(report: InlineMerchandisingTargetedTagsReport)(implicit request: RequestHeader, env: play.api.Environment)
+@(report: InlineMerchandisingTargetedTagsReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Commercial IM Slot", isAuthed = true, hasCharts = false) {
 

--- a/admin/app/views/commercial/invalidLineItems.scala.html
+++ b/admin/app/views/commercial/invalidLineItems.scala.html
@@ -5,7 +5,7 @@
 @(invalidPageskins: Seq[PageSkinSponsorship],
   invalidTopAbove: Seq[GuLineItem],
   invalidHighMerchandising: Seq[HighMerchandisingLineItem],
-  unknownInvalidLineItems: Seq[GuLineItem])(implicit request: RequestHeader, env: play.api.Environment)
+  unknownInvalidLineItems: Seq[GuLineItem])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Line Item Problems", isAuthed = true, hasCharts = false) {
 

--- a/admin/app/views/commercial/pageskins.scala.html
+++ b/admin/app/views/commercial/pageskins.scala.html
@@ -1,4 +1,4 @@
-@(pageSkinnedAdUnits: common.dfp.PageSkinSponsorshipReport)(implicit request: RequestHeader, env: play.api.Environment)
+@(pageSkinnedAdUnits: common.dfp.PageSkinSponsorshipReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.dfp._
 @import tools.{DfpLink, SiteLink}
 

--- a/admin/app/views/commercial/performance/browserDashboard.scala.html
+++ b/admin/app/views/commercial/performance/browserDashboard.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import controllers.admin.routes.{UncachedAssets, UncachedWebAssets}
 

--- a/admin/app/views/commercial/slotTop.scala.html
+++ b/admin/app/views/commercial/slotTop.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.LineItemReport
-@(slotReport: LineItemReport)(implicit request: RequestHeader, env: play.api.Environment)
+@(slotReport: LineItemReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Commercial: Mobile Top Slot", isAuthed = true) {
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")">

--- a/admin/app/views/commercial/slotTopAboveNav.scala.html
+++ b/admin/app/views/commercial/slotTopAboveNav.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.LineItemReport
-@(slotReport: LineItemReport)(implicit request: RequestHeader, env: play.api.Environment)
+@(slotReport: LineItemReport)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Commercial: Desktop Top-Above-Nav Slot", isAuthed = true) {
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")">

--- a/admin/app/views/commercial/specialAdUnits.scala.html
+++ b/admin/app/views/commercial/specialAdUnits.scala.html
@@ -1,4 +1,4 @@
-@(specialAdUnits: Seq[(String, String)])(implicit request: RequestHeader, env: play.api.Environment)
+@(specialAdUnits: Seq[(String, String)])(implicit request: RequestHeader, context: model.ApplicationContext)
 @import tools.DfpLink
 
 @admin_main("Commercial", isAuthed = true, hasCharts = true) {

--- a/admin/app/views/commercial/surgingpages.scala.html
+++ b/admin/app/views/commercial/surgingpages.scala.html
@@ -1,4 +1,4 @@
-@(surgingContent: ophan.SurgingContent)(implicit request: RequestHeader, env: play.api.Environment)
+@(surgingContent: ophan.SurgingContent)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import _root_.dfp.printLondonTime
 
 @admin_main("Commercial", isAuthed = true, hasCharts = true) {

--- a/admin/app/views/commercial/takeoverWithEmptyMPUs.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUs.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.TakeoverWithEmptyMPUs
-@(takeovers: Seq[TakeoverWithEmptyMPUs])(implicit request: RequestHeader, env: play.api.Environment)
+@(takeovers: Seq[TakeoverWithEmptyMPUs])(implicit request: RequestHeader, context: model.ApplicationContext)
 @import TakeoverWithEmptyMPUs.timeViewFormatter
 
 @admin_main("Takeovers with Empty MPUs", isAuthed = true) {

--- a/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
@@ -1,5 +1,5 @@
 @import common.dfp.TakeoverWithEmptyMPUs
-@(takeoverForm: Form[TakeoverWithEmptyMPUs])(implicit messages: Messages, request: RequestHeader, env: play.api.Environment)
+@(takeoverForm: Form[TakeoverWithEmptyMPUs])(implicit messages: Messages, request: RequestHeader, context: model.ApplicationContext)
 @import helper._
 
 @admin_main("Create takeover with Empty MPUs", isAuthed = true) {

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -1,4 +1,4 @@
-@(templates: Seq[common.dfp.GuCreativeTemplate])(implicit request: RequestHeader, env: play.api.Environment)
+@(templates: Seq[common.dfp.GuCreativeTemplate])(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.{MetaData, SectionSummary, SimplePage}
 @import tools.DfpLink
 

--- a/admin/app/views/contentGallery.scala.html
+++ b/admin/app/views/contentGallery.scala.html
@@ -3,7 +3,7 @@
     sentryChart: tools.FormattedChart,
     shareChart: tools.FormattedChart,
     title: String,
-    reportTimestamp: Option[String])(implicit request: RequestHeader, env: play.api.Environment)
+    reportTimestamp: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Gallery Dashboard", isAuthed = true, hasCharts = true) {
 

--- a/admin/app/views/cricketTroubleshooter.scala.html
+++ b/admin/app/views/cricketTroubleshooter.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.AdminConfiguration.pa
 @import org.joda.time.DateTime
 @import views.support.Format

--- a/admin/app/views/cssReport.scala.html
+++ b/admin/app/views/cssReport.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import controllers.admin.routes.UncachedWebAssets
 

--- a/admin/app/views/dedupePathsList.scala.html
+++ b/admin/app/views/dedupePathsList.scala.html
@@ -1,4 +1,4 @@
-@(paths: List[String])(implicit request: RequestHeader, env: play.api.Environment)
+@(paths: List[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("What is Deduped?", isAuthed = true) {
 

--- a/admin/app/views/dedupedOnPath.scala.html
+++ b/admin/app/views/dedupedOnPath.scala.html
@@ -1,5 +1,5 @@
 @import layout.DedupedFrontResult
-@(dedupedFrontResult: DedupedFrontResult)(implicit request: RequestHeader, env: play.api.Environment)
+@(dedupedFrontResult: DedupedFrontResult)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import layout.DedupedContainerResult
 @import layout.DedupedItem

--- a/admin/app/views/football/browse.scala.html
+++ b/admin/app/views/football/browse.scala.html
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 @views.html.football.main("PA API browser") {
     <div class="page-header">
       <h1>PA API browser</h1>

--- a/admin/app/views/football/error.scala.html
+++ b/admin/app/views/football/error.scala.html
@@ -1,4 +1,4 @@
-@(message: String)(implicit env: play.api.Environment)
+@(message: String)(implicit context: model.ApplicationContext)
 
 @views.html.football.main(s"Error") {
     <h1>Error!</h1>

--- a/admin/app/views/football/fronts/failedEmbed.scala.html
+++ b/admin/app/views/football/fronts/failedEmbed.scala.html
@@ -1,4 +1,4 @@
-@(message: Html, snapFields: _root_.football.model.SnapFields)(implicit env: play.api.Environment)
+@(message: Html, snapFields: _root_.football.model.SnapFields)(implicit context: model.ApplicationContext)
 
 @views.html.football.main(snapFields.fallbackHeadline) {
     <div class="row">

--- a/admin/app/views/football/fronts/index.scala.html
+++ b/admin/app/views/football/fronts/index.scala.html
@@ -1,4 +1,4 @@
-@(competitions: List[pa.Season], teams: List[pa.Team])(implicit env: play.api.Environment)
+@(competitions: List[pa.Season], teams: List[pa.Team])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Fronts components") {
     <hgroup class="page-header">

--- a/admin/app/views/football/fronts/matchesList.scala.html
+++ b/admin/app/views/football/fronts/matchesList.scala.html
@@ -1,4 +1,4 @@
-@(liveMatches: List[pa.LiveMatch], fixtures: List[pa.Fixture], results: List[pa.Result])(implicit env: play.api.Environment)
+@(liveMatches: List[pa.LiveMatch], fixtures: List[pa.Fixture], results: List[pa.Result])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Matches") {
     <hgroup class="page-header">

--- a/admin/app/views/football/fronts/viewEmbed.scala.html
+++ b/admin/app/views/football/fronts/viewEmbed.scala.html
@@ -1,4 +1,4 @@
-@(content: Html, snapFields: _root_.football.model.SnapFields)(implicit env: play.api.Environment)
+@(content: Html, snapFields: _root_.football.model.SnapFields)(implicit context: model.ApplicationContext)
 
 @views.html.football.main(snapFields.fallbackHeadline) {
     <div class="row">

--- a/admin/app/views/football/index.scala.html
+++ b/admin/app/views/football/index.scala.html
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 
 @views.html.football.main("PA browser index") {
     <div class="jumbotron">

--- a/admin/app/views/football/leagueTables/leagueTable.scala.html
+++ b/admin/app/views/football/leagueTables/leagueTable.scala.html
@@ -1,4 +1,4 @@
-@(league: pa.Season, tableEntries: List[pa.LeagueTableEntry], selectedTeams: List[String] = Nil)(implicit env: play.api.Environment)
+@(league: pa.Season, tableEntries: List[pa.LeagueTableEntry], selectedTeams: List[String] = Nil)(implicit context: model.ApplicationContext)
 
 @views.html.football.main(s"${league.name} table") {
     <hgroup class="page-header">

--- a/admin/app/views/football/leagueTables/tablesIndex.scala.html
+++ b/admin/app/views/football/leagueTables/tablesIndex.scala.html
@@ -1,4 +1,4 @@
-@(leagues: List[pa.Season], teams: List[pa.Team])(implicit env: play.api.Environment)
+@(leagues: List[pa.Season], teams: List[pa.Team])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("League tables") {
     <hgroup class="page-header">

--- a/admin/app/views/football/main.scala.html
+++ b/admin/app/views/football/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(content: Html)(implicit env: play.api.Environment)
+@(title: String)(content: Html)(implicit context: model.ApplicationContext)
 
 @import controllers.admin.routes.UncachedAssets
 @import controllers.admin.routes.UncachedWebAssets
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href='@UncachedWebAssets.at("lib/jquery-ui/jquery-ui.min.css")' />
 
             <!--[if (gt IE 9)|(IEMobile)]><!-->
-        @if(env.mode == Dev) {
+        @if(context.environment.mode == Dev) {
             <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head.content.css")" />
         } else {
             <style>

--- a/admin/app/views/football/player/cards/assist.scala.html
+++ b/admin/app/views/football/player/cards/assist.scala.html
@@ -1,4 +1,4 @@
-@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player card") {
 <hgroup class="page-header">

--- a/admin/app/views/football/player/cards/attack.scala.html
+++ b/admin/app/views/football/player/cards/attack.scala.html
@@ -1,4 +1,4 @@
-@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player card") {
 <hgroup class="page-header">

--- a/admin/app/views/football/player/cards/defence.scala.html
+++ b/admin/app/views/football/player/cards/defence.scala.html
@@ -1,4 +1,4 @@
-@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player card") {
 <hgroup class="page-header">

--- a/admin/app/views/football/player/cards/discipline.scala.html
+++ b/admin/app/views/football/player/cards/discipline.scala.html
@@ -1,4 +1,4 @@
-@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player card") {
 <hgroup class="page-header">

--- a/admin/app/views/football/player/cards/goalkeeper.scala.html
+++ b/admin/app/views/football/player/cards/goalkeeper.scala.html
@@ -1,4 +1,4 @@
-@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player card") {
 <hgroup class="page-header">

--- a/admin/app/views/football/player/playerHead2Head.scala.html
+++ b/admin/app/views/football/player/playerHead2Head.scala.html
@@ -1,4 +1,4 @@
-@(player1: pa.Head2Head, player2: pa.Head2Head, player1Appearances: pa.PlayerAppearances, player2Appearances: pa.PlayerAppearances)(implicit env: play.api.Environment)
+@(player1: pa.Head2Head, player2: pa.Head2Head, player1Appearances: pa.PlayerAppearances, player2Appearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player head to head") {
     <hgroup class="page-header">

--- a/admin/app/views/football/player/playerIndex.scala.html
+++ b/admin/app/views/football/player/playerIndex.scala.html
@@ -1,4 +1,4 @@
-@(competitions: List[pa.Season], teams: List[pa.Team])(implicit env: play.api.Environment)
+@(competitions: List[pa.Season], teams: List[pa.Team])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Player cards") {
     <div class="row">

--- a/admin/app/views/football/team/squadImages.scala.html
+++ b/admin/app/views/football/team/squadImages.scala.html
@@ -1,4 +1,4 @@
-@(currentTeamId: String, players: List[pa.Player], teams: List[pa.Team])(implicit env: play.api.Environment)
+@(currentTeamId: String, players: List[pa.Player], teams: List[pa.Team])(implicit context: model.ApplicationContext)
 
 @views.html.football.main(s"Squad images") {
 

--- a/admin/app/views/football/team/teamHead2head.scala.html
+++ b/admin/app/views/football/team/teamHead2head.scala.html
@@ -1,4 +1,4 @@
-@(team1: pa.Head2Head, team2: pa.Head2Head, team1Results: List[_root_.football.model.PrevResult], team2Results: List[_root_.football.model.PrevResult])(implicit env: play.api.Environment)
+@(team1: pa.Head2Head, team2: pa.Head2Head, team1Results: List[_root_.football.model.PrevResult], team2Results: List[_root_.football.model.PrevResult])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Team head to head") {
     <hgroup class="page-header">

--- a/admin/app/views/football/team/teamIndex.scala.html
+++ b/admin/app/views/football/team/teamIndex.scala.html
@@ -1,4 +1,4 @@
-@(teams: List[pa.Team])(implicit env: play.api.Environment)
+@(teams: List[pa.Team])(implicit context: model.ApplicationContext)
 
 @views.html.football.main("Teams") {
     <hgroup class="page-header">

--- a/admin/app/views/footballTroubleshooter.scala.html
+++ b/admin/app/views/footballTroubleshooter.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.AdminConfiguration.pa
 @import org.joda.time.{DateTime, LocalDate}
 @import views.support.Format

--- a/admin/app/views/lineCharts.scala.html
+++ b/admin/app/views/lineCharts.scala.html
@@ -1,4 +1,4 @@
-@(charts: Seq[tools.Chart], title: Option[String] = None)(implicit request: RequestHeader, env: play.api.Environment)
+@(charts: Seq[tools.Chart], title: Option[String] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Dashboard", isAuthed = true, hasCharts = true) {
 

--- a/admin/app/views/missingVideoEncodings.scala.html
+++ b/admin/app/views/missingVideoEncodings.scala.html
@@ -1,6 +1,6 @@
 @import jobs.MissingEncoding
 
-@(encodingData: List[MissingEncoding])(implicit request: RequestHeader, env: play.api.Environment)
+@(encodingData: List[MissingEncoding])(implicit request: RequestHeader, context: model.ApplicationContext)
 
     @admin_main("Videos with missing encodings", isAuthed = true )  {
 

--- a/admin/app/views/press.scala.html
+++ b/admin/app/views/press.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Facia Press pages", isAuthed = true) {
     <ul>

--- a/admin/app/views/pressR2.scala.html
+++ b/admin/app/views/pressR2.scala.html
@@ -1,4 +1,4 @@
-@(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty)(implicit request: RequestHeader, env: play.api.Environment)
+@(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches.R2PagePressServiceSwitch
 
 @admin_main("R2 page presser (archiver)", isAuthed = true) {

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -5,7 +5,7 @@
     fastlyCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
     switches: Seq[conf.switches.Switch],
-    apiKey: String)(implicit request: RequestHeader, env: play.api.Environment)
+    apiKey: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import org.joda.time.{DateTime, Days}
 

--- a/admin/app/views/redirects.scala.html
+++ b/admin/app/views/redirects.scala.html
@@ -1,4 +1,4 @@
-@(form: play.api.data.Form[controllers.admin.PageRedirect], urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty)(implicit request: RequestHeader, env: play.api.Environment)
+@(form: play.api.data.Form[controllers.admin.PageRedirect], urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Redirector", isAuthed = true) {
     <ul>

--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -1,4 +1,4 @@
-@(metrics: Seq[tools.AssetMetric])(implicit request: RequestHeader, env: play.api.Environment)
+@(metrics: Seq[tools.AssetMetric])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @change(metric: tools.AssetMetric) = {
     @defining(metric.change) { change =>

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -1,5 +1,5 @@
 @import conf.switches.Switch
-@(lastModified: Long)(implicit flash: Flash, request: RequestHeader, env: play.api.Environment)
+@(lastModified: Long)(implicit flash: Flash, request: RequestHeader, context: model.ApplicationContext)
 @import controllers.admin.routes.UncachedAssets
 @defining(conf.switches.Switches.grouped){ switchGroups =>
     @admin_main("Switchboard", isAuthed = true) {

--- a/admin/app/views/switchboardPlista.scala.html
+++ b/admin/app/views/switchboardPlista.scala.html
@@ -1,5 +1,5 @@
 @import conf.switches.Switch
-@(switch: Switch, lastModified: Long)(implicit flash: Flash, request: RequestHeader, env: play.api.Environment)
+@(switch: Switch, lastModified: Long)(implicit flash: Flash, request: RequestHeader, context: model.ApplicationContext)
 
 @import controllers.admin.routes.UncachedAssets
 

--- a/admin/app/views/troubleshooter.scala.html
+++ b/admin/app/views/troubleshooter.scala.html
@@ -1,4 +1,4 @@
-@(loadbalancers: Seq[tools.LoadBalancer])(implicit request: RequestHeader, env: play.api.Environment)
+@(loadbalancers: Seq[tools.LoadBalancer])(implicit request: RequestHeader, context: model.ApplicationContext)
 @import tools.LoadBalancer
 
 @admin_main("Troubleshooting", isAuthed = true) {

--- a/admin/app/views/troubleshooterResults.scala.html
+++ b/admin/app/views/troubleshooterResults.scala.html
@@ -1,4 +1,4 @@
-@(loadbalancer: Option[tools.LoadBalancer], results: Seq[controllers.admin.EndpointStatus])(implicit request: RequestHeader, env: play.api.Environment)
+@(loadbalancer: Option[tools.LoadBalancer], results: Seq[controllers.admin.EndpointStatus])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Troubleshooting results", isAuthed = true) {
 

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -8,7 +8,7 @@ import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import test.{ConfiguredTestSuite, WithTestEnvironment, WithTestWsClient}
+import test.{ConfiguredTestSuite, WithTestContext, WithTestWsClient}
 
 import scala.annotation.tailrec
 import scala.language.postfixOps
@@ -20,7 +20,7 @@ import scala.language.postfixOps
     with ConfiguredTestSuite
     with BeforeAndAfterAll
     with WithTestWsClient
-    with WithTestEnvironment {
+    with WithTestContext {
 
   "test tables index page loads with leagues" in {
     val Some(result) = route(app, FakeRequest(GET, "/admin/football/tables"))

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -76,7 +76,7 @@ import scala.language.postfixOps
   }
 
   "the internal surroundingItems function should work OK" in {
-    val tablesController = new TablesController(wsClient, testEnvironment)
+    val tablesController = new TablesController(wsClient)
     tablesController.surroundingItems[Int](1, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(3, 4, 5))
     tablesController.surroundingItems[Int](2, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(2, 3, 4, 5, 6))
     tablesController.surroundingItems[Int](3, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(1, 2, 3, 4, 5, 6))

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -11,7 +11,7 @@ import controllers._
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import http.CorsHttpErrorHandler
 import jobs.{SiteMapJob, SiteMapLifecycle}
-import model.ApplicationIdentity
+import model.{ApplicationContext, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
@@ -34,7 +34,6 @@ trait ApplicationsServices {
   lazy val sectionsLookUp = wire[SectionsLookUp]
   lazy val ophanApi = wire[OphanApi]
 }
-
 
 trait AppComponents extends FrontendComponents with ApplicationsControllers with ApplicationsServices {
 

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -9,14 +9,14 @@ import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.Environment
 import play.api.mvc.{Action, Controller, RequestHeader}
 import services.{ConfigAgent, IndexPage, IndexPageItem}
 import views.support.PreviousAndNext
 
 import scala.concurrent.Future
 
-class AllIndexController(contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit env: Environment) extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
+class AllIndexController(contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
+  import context._
 
   private val indexController = new IndexController(contentApiClient, sectionsLookUp)
 

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -16,7 +16,6 @@ import views.support.PreviousAndNext
 import scala.concurrent.Future
 
 class AllIndexController(contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
-  import context._
 
   private val indexController = new IndexController(contentApiClient, sectionsLookUp)
 

--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -3,6 +3,7 @@ package controllers
 import com.softwaremill.macwire._
 import contentapi.{ContentApiClient, SectionsLookUp}
 import jobs.SiteMapJob
+import model.ApplicationContext
 import play.api.Environment
 import play.api.libs.ws.WSClient
 
@@ -12,7 +13,7 @@ trait ApplicationsControllers {
   def siteMapJob: SiteMapJob
   def sectionsLookUp: SectionsLookUp
   def wsClient: WSClient
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
 
   lazy val siteMapController = wire[SiteMapController]
   lazy val crosswordPageController = wire[CrosswordPageController]

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -50,7 +50,8 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
   }
 }
 
-class CrosswordPageController(val contentApiClient: ContentApiClient)(implicit env: Environment) extends CrosswordController {
+class CrosswordPageController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends CrosswordController {
+  import context._
 
   def noResults()(implicit request: RequestHeader) = Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
 
@@ -93,7 +94,8 @@ class CrosswordPageController(val contentApiClient: ContentApiClient)(implicit e
   }
 }
 
-class CrosswordSearchController(val contentApiClient: ContentApiClient)(implicit env: Environment) extends CrosswordController {
+class CrosswordSearchController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends CrosswordController {
+  import context._
   val searchForm = Form(
     mapping(
       "crossword_type" -> nonEmptyText,

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -40,7 +40,7 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
     }
   }
 
-  def renderCrosswordPage(crosswordType: String, id: Int)(implicit request: RequestHeader, env: Environment): Future[Result] = {
+  def renderCrosswordPage(crosswordType: String, id: Int)(implicit request: RequestHeader, context: ApplicationContext): Future[Result] = {
     withCrossword(crosswordType, id) { (crossword, content) =>
       Cached(60)(RevalidatableResult.Ok(views.html.crossword(
         CrosswordPage(CrosswordContent.make(CrosswordData.fromCrossword(crossword), content)),
@@ -51,7 +51,6 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
 }
 
 class CrosswordPageController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends CrosswordController {
-  import context._
 
   def noResults()(implicit request: RequestHeader) = Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
 
@@ -95,8 +94,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient)(implicit c
 }
 
 class CrosswordSearchController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends CrosswordController {
-  import context._
-  val searchForm = Form(
+    val searchForm = Form(
     mapping(
       "crossword_type" -> nonEmptyText,
       "month" -> number,

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -5,12 +5,11 @@ import common._
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.mvc._
-
 import scala.concurrent.Future
 import contentapi.ContentApiClient
-import play.api.Environment
 
-class EmbedController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class EmbedController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def render(path: String) = Action.async { implicit request =>
     lookup(path) map {

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -9,7 +9,6 @@ import scala.concurrent.Future
 import contentapi.ContentApiClient
 
 class EmbedController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def render(path: String) = Action.async { implicit request =>
     lookup(path) map {

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -12,7 +12,6 @@ import views.support.RenderOtherStatus
 import scala.concurrent.Future
 
 class GalleryController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
-  import context._
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -5,14 +5,14 @@ import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
 import model._
-import play.api.Environment
 import play.api.mvc._
 import play.twirl.api.Html
 import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 
-class GalleryController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class GalleryController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+  import context._
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -2,11 +2,9 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
-import conf._
 import conf.switches.Switches
 import contentapi.ContentApiClient
 import model._
-import play.api.Environment
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import services.ImageQuery
 import views.support.RenderOtherStatus
@@ -17,7 +15,8 @@ case class ImageContentPage(image: ImageContent, related: RelatedContent) extend
   override lazy val item = image
 }
 
-class ImageContentController(val contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with RendersItemResponse with ImageQuery with Logging with ExecutionContexts {
+class ImageContentController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with ImageQuery with Logging with ExecutionContexts {
+  import context._
 
   def renderJson(path: String) = render(path)
 

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -16,7 +16,6 @@ case class ImageContentPage(image: ImageContent, related: RelatedContent) extend
 }
 
 class ImageContentController(val contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with ImageQuery with Logging with ExecutionContexts {
-  import context._
 
   def renderJson(path: String) = render(path)
 

--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -4,12 +4,11 @@ import common._
 import contentapi.{ContentApiClient, SectionsLookUp}
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.mvc.{RequestHeader, Result}
 import services.IndexPage
 
-class IndexController(val contentApiClient: ContentApiClient, val sectionsLookUp: SectionsLookUp)(implicit playEnv: Environment) extends IndexControllerCommon {
-  override val env: Environment = playEnv
+class IndexController(val contentApiClient: ContentApiClient, val sectionsLookUp: SectionsLookUp)(implicit val context: ApplicationContext) extends IndexControllerCommon {
+  import context._
   protected def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader): Result = {
     Cached(model.page) {
       if (request.isRss) {

--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -8,8 +8,7 @@ import play.api.mvc.{RequestHeader, Result}
 import services.IndexPage
 
 class IndexController(val contentApiClient: ContentApiClient, val sectionsLookUp: SectionsLookUp)(implicit val context: ApplicationContext) extends IndexControllerCommon {
-  import context._
-  protected def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader): Result = {
+    protected def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader): Result = {
     Cached(model.page) {
       if (request.isRss) {
         val body = TrailsToRss(model.page.metadata, model.trails.map(_.trail))

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -11,8 +11,6 @@ import play.api.mvc._
 import views.support.RenderOtherStatus
 import conf.Configuration.interactive.cdnPath
 import conf.Configuration.environment.isPreview
-import play.api.Environment
-
 import scala.concurrent.duration._
 import scala.concurrent.Future
 
@@ -20,7 +18,8 @@ case class InteractivePage (interactive: Interactive, related: RelatedContent) e
   override lazy val item = interactive
 }
 
-class InteractiveController(contentApiClient: ContentApiClient, wsClient: WSClient)(implicit env: Environment) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class InteractiveController(contentApiClient: ContentApiClient, wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+  import context._
 
   def renderInteractiveJson(path: String): Action[AnyContent] = renderInteractive(path)
   def renderInteractive(path: String): Action[AnyContent] = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -19,7 +19,6 @@ case class InteractivePage (interactive: Interactive, related: RelatedContent) e
 }
 
 class InteractiveController(contentApiClient: ContentApiClient, wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
-  import context._
 
   def renderInteractiveJson(path: String): Action[AnyContent] = renderInteractive(path)
   def renderInteractive(path: String): Action[AnyContent] = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -11,7 +11,6 @@ import contentapi.ContentApiClient
 import model.content.MediaAtom
 
 class MediaAtomEmbedController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def render(id: String) = Action.async { implicit request =>
     lookup(s"atom/media/$id") map {

--- a/applications/app/controllers/MediaAtomEmbedController.scala
+++ b/applications/app/controllers/MediaAtomEmbedController.scala
@@ -6,13 +6,12 @@ import common._
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.mvc._
-
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 import model.content.MediaAtom
-import play.api.Environment
 
-class MediaAtomEmbedController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class MediaAtomEmbedController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def render(id: String) = Action.async { implicit request =>
     lookup(s"atom/media/$id") map {

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -17,7 +17,8 @@ case class MediaPage(media: ContentType, related: RelatedContent) extends Conten
   override lazy val item = media
 }
 
-class MediaController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class MediaController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+  import context._
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -18,7 +18,6 @@ case class MediaPage(media: ContentType, related: RelatedContent) extends Conten
 }
 
 class MediaController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
-  import context._
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -4,12 +4,12 @@ import common.{ExecutionContexts, Logging}
 import contentapi.ContentApiClient
 import layout.FaciaContainer
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.{Cached, MetaData, SectionSummary, SimplePage}
-import play.api.Environment
+import model.{ApplicationContext, Cached, MetaData, SectionSummary, SimplePage}
 import play.api.mvc.{Action, Controller}
 import services.NewspaperQuery
 
-class NewspaperController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class NewspaperController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   private val newspaperQuery = new NewspaperQuery(contentApiClient)
 

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -9,7 +9,6 @@ import play.api.mvc.{Action, Controller}
 import services.NewspaperQuery
 
 class NewspaperController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   private val newspaperQuery = new NewspaperQuery(contentApiClient)
 

--- a/applications/app/controllers/PreferencesController.scala
+++ b/applications/app/controllers/PreferencesController.scala
@@ -5,7 +5,6 @@ import model.{ApplicationContext, Cached, PreferencesMetaData}
 import play.api.mvc.{Action, Controller}
 
 class PreferencesController (implicit context: ApplicationContext) extends Controller with common.ExecutionContexts {
-  import context._
 
   def indexPrefs() = Action { implicit request =>
     Cached(300) {

--- a/applications/app/controllers/PreferencesController.scala
+++ b/applications/app/controllers/PreferencesController.scala
@@ -1,11 +1,11 @@
 package controllers
 
 import model.Cached.RevalidatableResult
-import model.{Cached, PreferencesMetaData}
-import play.api.Environment
+import model.{ApplicationContext, Cached, PreferencesMetaData}
 import play.api.mvc.{Action, Controller}
 
-class PreferencesController (implicit env: Environment) extends Controller with common.ExecutionContexts {
+class PreferencesController (implicit context: ApplicationContext) extends Controller with common.ExecutionContexts {
+  import context._
 
   def indexPrefs() = Action { implicit request =>
     Cached(300) {

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -41,7 +41,6 @@ case class QuizAnswersPage(
 }
 
 class QuizController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
-  import context._
 
   def submit(quizId: String, path: String) = Action.async { implicit request =>
     form.playForm.bindFromRequest.fold(

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -5,7 +5,6 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import model._
 import model.content.{Atoms, Quiz}
-import play.api.Environment
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import quiz.form
 import views.support.RenderOtherStatus
@@ -41,7 +40,8 @@ case class QuizAnswersPage(
   val shares: ShareLinkMeta = if (results.isKnowledge) ShareLinkMeta(knowledgeShares, Nil) else ShareLinkMeta(personalityShares, Nil)
 }
 
-class QuizController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with ExecutionContexts with Logging {
+class QuizController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
+  import context._
 
   def submit(quizId: String, path: String) = Action.async { implicit request =>
     form.playForm.bindFromRequest.fold(

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -4,11 +4,11 @@ import common.{ExecutionContexts, LinkTo, Logging}
 import common.`package`._
 import campaigns.ShortCampaignCodes
 import contentapi.ContentApiClient
-import model.Cached
-import play.api.Environment
+import model.{ApplicationContext, Cached}
 import play.api.mvc.{Action, Controller, RequestHeader}
 
-class ShortUrlsController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class ShortUrlsController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
     redirectUrl(shortUrl, request.queryString)

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -8,7 +8,6 @@ import model.{ApplicationContext, Cached}
 import play.api.mvc.{Action, Controller, RequestHeader}
 
 class ShortUrlsController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
     redirectUrl(shortUrl, request.queryString)

--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -1,17 +1,15 @@
 package controllers
 
 import common.ExecutionContexts
-import model.Cached
+import model.{ApplicationContext, Cached}
 import model.Cached.RevalidatableResult
-import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, Controller}
 import staticpages.StaticPages
-
 import scala.concurrent.duration._
 
-
-class SignupPageController(wsClient: WSClient)(implicit env: Environment) extends Controller with ExecutionContexts {
+class SignupPageController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
 
   val defaultCacheDuration: Duration = 15.minutes
 

--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -9,7 +9,6 @@ import staticpages.StaticPages
 import scala.concurrent.duration._
 
 class SignupPageController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
 
   val defaultCacheDuration: Duration = 15.minutes
 

--- a/applications/app/controllers/SudokusController.scala
+++ b/applications/app/controllers/SudokusController.scala
@@ -9,8 +9,7 @@ import views.html.sudoku
 import scala.concurrent.Future
 
 class SudokusController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
-  def render(id: String) = Action.async { implicit request =>
+    def render(id: String) = Action.async { implicit request =>
     if (Switches.SudokuSwitch.isSwitchedOn) {
       SudokuApi.getData(id) map {
         case Some(sudokuData) =>

--- a/applications/app/controllers/SudokusController.scala
+++ b/applications/app/controllers/SudokusController.scala
@@ -2,14 +2,14 @@ package controllers
 
 import common.ExecutionContexts
 import conf.switches.Switches
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 import sudoku.{SudokuApi, SudokuPage}
 import views.html.sudoku
-
 import scala.concurrent.Future
 
-class SudokusController (implicit env: Environment) extends Controller with ExecutionContexts {
+class SudokusController (implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
   def render(id: String) = Action.async { implicit request =>
     if (Switches.SudokuSwitch.isSwitchedOn) {
       SudokuApi.getData(id) map {

--- a/applications/app/controllers/SurveyPageController.scala
+++ b/applications/app/controllers/SurveyPageController.scala
@@ -10,7 +10,6 @@ import staticpages.StaticPages
 import scala.concurrent.duration._
 
 class SurveyPageController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts {
-  import context._
 
   val defaultCacheDuration: Duration = 15.minutes
 

--- a/applications/app/controllers/SurveyPageController.scala
+++ b/applications/app/controllers/SurveyPageController.scala
@@ -2,17 +2,15 @@ package controllers
 
 import common.ExecutionContexts
 import conf.Configuration
-import model.{Cached, NoCache}
+import model.{ApplicationContext, Cached, NoCache}
 import model.Cached.RevalidatableResult
-import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, Controller}
 import staticpages.StaticPages
-
 import scala.concurrent.duration._
 
-
-class SurveyPageController(wsClient: WSClient)(implicit env: Environment) extends Controller with ExecutionContexts {
+class SurveyPageController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts {
+  import context._
 
   val defaultCacheDuration: Duration = 15.minutes
 

--- a/applications/app/controllers/TagIndexController.scala
+++ b/applications/app/controllers/TagIndexController.scala
@@ -7,8 +7,7 @@ import play.api.mvc.{Action, Controller}
 import services._
 
 class TagIndexController (implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
-  import context._
-  private val TagIndexCacheTime = 600
+    private val TagIndexCacheTime = 600
 
   private def forTagType(keywordType: String, title: String, page: String, metadata: MetaData) = Action { implicit request =>
     TagIndexesS3.getIndex(keywordType, page) match {

--- a/applications/app/controllers/TagIndexController.scala
+++ b/applications/app/controllers/TagIndexController.scala
@@ -3,11 +3,11 @@ package controllers
 import common.{ExecutionContexts, Logging}
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.mvc.{Action, Controller}
 import services._
 
-class TagIndexController (implicit env: Environment) extends Controller with ExecutionContexts with Logging {
+class TagIndexController (implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
+  import context._
   private val TagIndexCacheTime = 600
 
   private def forTagType(keywordType: String, title: String, page: String, metadata: MetaData) = Action { implicit request =>

--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -6,7 +6,6 @@ import model._
 import play.api.mvc.{Action, Controller}
 
 class WebAppController(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
-  import context._
 
   def serviceWorker() = Action { implicit request =>
     Cached(60) { RevalidatableResult.Ok(templates.js.serviceWorker()) }

--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -3,10 +3,10 @@ package controllers
 import common.{ExecutionContexts, Logging}
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.mvc.{Action, Controller}
 
-class WebAppController(implicit env: Environment) extends Controller with ExecutionContexts with Logging {
+class WebAppController(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
+  import context._
 
   def serviceWorker() = Action { implicit request =>
     Cached(60) { RevalidatableResult.Ok(templates.js.serviceWorker()) }

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import common.{Edition, _}
 import contentapi.ContentApiClient
 import controllers.ImageContentPage
-import model.{ApiContent2Is, Content, ImageContent, StoryPackages}
+import model.{ApiContent2Is, ApplicationContext, Content, ImageContent, StoryPackages}
 import play.api.Environment
 import play.api.mvc.{RequestHeader, Result => PlayResult}
 
@@ -14,7 +14,7 @@ trait ImageQuery extends ConciergeRepository {
 
   val contentApiClient: ContentApiClient
 
-  def image(edition: Edition, path: String)(implicit request: RequestHeader, env: Environment): Future[Either[ImageContentPage, PlayResult]] = {
+  def image(edition: Edition, path: String)(implicit request: RequestHeader, context: ApplicationContext): Future[Either[ImageContentPage, PlayResult]] = {
     log.info(s"Fetching image content: $path for edition ${edition.id}")
     val response = contentApiClient.getResponse(contentApiClient.item(path, edition)
       .showFields("all")

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 @import conf.Static
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
@@ -41,7 +41,7 @@ var isRequestForAsset = (function () {
     var assetPathRegex = new RegExp('^@Configuration.assets.path');
     return function (request) {
         var url = new URL(request.url);
-        @if(env.mode == Dev) {
+        @if(context.environment.mode == Dev) {
             return assetPathRegex.test(url.pathname);
         } else {
             return assetPathRegex.test(url.href);

--- a/applications/app/views/accessibleCrossword.scala.html
+++ b/applications/app/views/accessibleCrossword.scala.html
@@ -1,4 +1,4 @@
-@(crosswordPage: crosswords.CrosswordPage, blankSquares: crosswords.AccessibleCrosswordRows)(implicit request: RequestHeader, env: play.api.Environment)
+@(crosswordPage: crosswords.CrosswordPage, blankSquares: crosswords.AccessibleCrosswordRows)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.crosswords._
 

--- a/applications/app/views/all.scala.html
+++ b/applications/app/views/all.scala.html
@@ -3,7 +3,7 @@
 @import services.IndexPage
 @import views.support.PreviousAndNext
 
-@(index: IndexPage, nav: PreviousAndNext)(implicit request: RequestHeader, env: play.api.Environment)
+@(index: IndexPage, nav: PreviousAndNext)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(index.page, projectName = Option("facia")){  }{
 <div class="l-side-margins">

--- a/applications/app/views/contributorsIndexListing.scala.html
+++ b/applications/app/views/contributorsIndexListing.scala.html
@@ -1,4 +1,4 @@
-@(page: model.ContributorsListing, listing: model.TagIndexListings)(implicit requestHeader: RequestHeader, env: play.api.Environment)
+@(page: model.ContributorsListing, listing: model.TagIndexListings)(implicit requestHeader: RequestHeader, context: model.ApplicationContext)
 
 @import fragments.tagIndexListingBody
 

--- a/applications/app/views/crossword.scala.html
+++ b/applications/app/views/crossword.scala.html
@@ -1,4 +1,4 @@
-@(crosswordPage: crosswords.CrosswordPage, svg: Seq[scala.xml.Node])(implicit request: RequestHeader, env: play.api.Environment)
+@(crosswordPage: crosswords.CrosswordPage, svg: Seq[scala.xml.Node])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import play.api.libs.json._
 @import views.html.fragments.crosswords._

--- a/applications/app/views/crosswordSearch.scala.html
+++ b/applications/app/views/crosswordSearch.scala.html
@@ -1,4 +1,4 @@
-@(page: crosswords.CrosswordSearchPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: crosswords.CrosswordSearchPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 @import views.html.fragments.crosswords.crosswordSearchForm

--- a/applications/app/views/crosswordsNoResults.scala.html
+++ b/applications/app/views/crosswordsNoResults.scala.html
@@ -1,4 +1,4 @@
-@(page: crosswords.CrosswordSearchPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: crosswords.CrosswordSearchPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,4 +1,4 @@
-@(page: InteractivePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: InteractivePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.Edition
 @import mvt.WebpackTest
 @import views.support.RenderClasses

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -1,4 +1,4 @@
-@(page: MediaPage, displayCaption: Boolean)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: MediaPage, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}

--- a/applications/app/views/gallery.scala.html
+++ b/applications/app/views/gallery.scala.html
@@ -1,4 +1,4 @@
-@(page: model.GalleryPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
     @if(page.gallery.content.isImmersiveGallery) {

--- a/applications/app/views/imageContent.scala.html
+++ b/applications/app/views/imageContent.scala.html
@@ -1,4 +1,4 @@
-@(page: ImageContentPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: ImageContentPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
     @fragments.imageContentBody(page)

--- a/applications/app/views/index.scala.html
+++ b/applications/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(index: services.IndexPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(index: services.IndexPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(index.page, projectName = Option("facia")){
     @fragments.indexHead(index)

--- a/applications/app/views/interactive.scala.html
+++ b/applications/app/views/interactive.scala.html
@@ -1,6 +1,6 @@
 @import controllers.InteractivePage
 
-@(model: InteractivePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: InteractivePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @main(model){ }{
     @fragments.interactiveBody(model)

--- a/applications/app/views/media.scala.html
+++ b/applications/app/views/media.scala.html
@@ -1,4 +1,4 @@
-@(page: MediaPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: MediaPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
 

--- a/applications/app/views/newspaperPage.scala.html
+++ b/applications/app/views/newspaperPage.scala.html
@@ -1,4 +1,4 @@
-@(paper: controllers.TodayNewspaper)(implicit request: RequestHeader, env: play.api.Environment)
+@(paper: controllers.TodayNewspaper)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(paper.page) { } {
 

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -1,7 +1,7 @@
 package views
 
 import common.Edition
-import model.Interactive
+import model.{ApplicationContext, Interactive}
 import play.api.Environment
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
@@ -9,7 +9,7 @@ import services.IndexPage
 import views.support._
 
 object InteractiveBodyCleaner {
-  def apply(interactive: Interactive)(implicit request: RequestHeader, env: Environment): Html = {
+  def apply(interactive: Interactive)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val html = interactive.fields.body
     val cleaners = List(
       AtomsCleaner(interactive.content.atoms, shouldFence = false)
@@ -20,7 +20,7 @@ object InteractiveBodyCleaner {
 }
 
 object IndexCleaner {
- def apply(page: IndexPage, html: String)(implicit request: RequestHeader, env: Environment) = {
+ def apply(page: IndexPage, html: String)(implicit request: RequestHeader, context: ApplicationContext) = {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html))(
       CommercialComponentHigh(isAdvertisementFeature = false, isNetworkFront = false, hasPageSkin = page.page.metadata.hasPageSkin(edition))

--- a/applications/app/views/preferences/index.scala.html
+++ b/applications/app/views/preferences/index.scala.html
@@ -1,4 +1,4 @@
-@(metaData: model.PreferencesMetaData)(implicit request: RequestHeader, env: play.api.Environment)
+@(metaData: model.PreferencesMetaData)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches._
 @import views.html.fragments.containers.facia_cards.containerScaffold

--- a/applications/app/views/printableCrossword.scala.html
+++ b/applications/app/views/printableCrossword.scala.html
@@ -1,4 +1,4 @@
-@(crosswordPage: crosswords.CrosswordPage, svg: Seq[scala.xml.Node], year: Int)(implicit request: RequestHeader, env: play.api.Environment)
+@(crosswordPage: crosswords.CrosswordPage, svg: Seq[scala.xml.Node], year: Int)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.crosswords.printableCrosswordClue
 

--- a/applications/app/views/quizAnswerPage.scala.html
+++ b/applications/app/views/quizAnswerPage.scala.html
@@ -1,6 +1,6 @@
 @import _root_.model.content._
 
-@(page: QuizAnswersPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: QuizAnswersPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page) { } {
     <div class="l-side-margins">

--- a/applications/app/views/signup/newsletters.scala.html
+++ b/applications/app/views/signup/newsletters.scala.html
@@ -5,7 +5,7 @@
 
 @import common.LinkTo
 
-@(signupPage: Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(signupPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 
 @newsletterSignup(route: String, listId: String, emailName: String) = {

--- a/applications/app/views/subjectsIndexListing.scala.html
+++ b/applications/app/views/subjectsIndexListing.scala.html
@@ -1,4 +1,4 @@
-@(page: model.SubjectsListing, listing: model.TagIndexListings)(implicit requestHeader: RequestHeader, env: play.api.Environment)
+@(page: model.SubjectsListing, listing: model.TagIndexListings)(implicit requestHeader: RequestHeader, context: model.ApplicationContext)
 
 @import fragments.tagIndexListingBody
 

--- a/applications/app/views/sudoku.scala.html
+++ b/applications/app/views/sudoku.scala.html
@@ -1,4 +1,4 @@
-@(sudokuPage: _root_.sudoku.SudokuPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(sudokuPage: _root_.sudoku.SudokuPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 @import play.api.libs.json._

--- a/applications/app/views/survey/formstackSurvey.scala.html
+++ b/applications/app/views/survey/formstackSurvey.scala.html
@@ -1,7 +1,7 @@
 @import model.Page
 @import conf.Configuration.Survey.formStackAccountName
 
-@(formName: String, surveyPage: Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(formName: String, surveyPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
     @surveyMain(surveyPage){
         <div class="l-side-margins">

--- a/applications/app/views/survey/quickSurvey.scala.html
+++ b/applications/app/views/survey/quickSurvey.scala.html
@@ -1,6 +1,6 @@
 @import model.Page
 
-@(surveyPage: Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(surveyPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @surveyMain(surveyPage) {
     <div class="illustration-container">

--- a/applications/app/views/survey/surveyMain.scala.html
+++ b/applications/app/views/survey/surveyMain.scala.html
@@ -2,7 +2,7 @@
 @import model.Page
 @import templates.inlineJS.blocking.js.enableStylesheets
 
-@(surveyPage: Page)(body: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(surveyPage: Page)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html id="js-context" class="js-off is-not-modern id--signed-out" data-page-path="@request.path">

--- a/applications/app/views/survey/thankyou.scala.html
+++ b/applications/app/views/survey/thankyou.scala.html
@@ -1,6 +1,6 @@
 @import model.Page
 
-@(surveyPage: Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(surveyPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @surveyMain(surveyPage){
         <div class="l-side-margins">

--- a/applications/app/views/tagIndexPage.scala.html
+++ b/applications/app/views/tagIndexPage.scala.html
@@ -1,4 +1,4 @@
-@(metaData: model.MetaData, page: model.TagIndexPage, subTitle: String)(implicit request: RequestHeader, env: play.api.Environment)
+@(metaData: model.MetaData, page: model.TagIndexPage, subTitle: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import fragments.tagIndexBody
 

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -3,7 +3,7 @@
 @import templates.inlineJS.blocking.js.curlConfig
 @import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
 
-@(page: EmbedPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: EmbedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-video-embed-html ">

--- a/applications/test/AllIndexControllerTest.scala
+++ b/applications/test/AllIndexControllerTest.scala
@@ -13,7 +13,7 @@ import play.api.test.Helpers._
   with BeforeAndAfterAll
   with WithTestWsClient
   with WithTestContentApiClient
-  with WithTestEnvironment {
+  with WithTestContext {
 
   private val PermanentRedirect = 301
   private val TemporaryRedirect = 302

--- a/applications/test/CrosswordDataTest.scala
+++ b/applications/test/CrosswordDataTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.time.{Millis, Span}
   with ScalaFutures
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   "CrosswordData" - {

--- a/applications/test/CrosswordPageMetaDataTest.scala
+++ b/applications/test/CrosswordPageMetaDataTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val crosswordUrl = "crosswords/cryptic/26697"

--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient{
 
   val galleryUrl = "news/gallery/2012/may/02/picture-desk-live-kabul-burma"

--- a/applications/test/ImageContentControllerTest.scala
+++ b/applications/test/ImageContentControllerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val cartoonUrl = "commentisfree/cartoon/2013/jul/15/iain-duncan-smith-benefits-cap"

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{DoNotDiscover, BeforeAndAfterAll, Matchers, FlatSpec}
   with BeforeAndAfterAll
   with ConfiguredTestSuite
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val section = "books"

--- a/applications/test/IndexMetaDataTest.scala
+++ b/applications/test/IndexMetaDataTest.scala
@@ -14,7 +14,7 @@ import play.api.test.Helpers._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val articleUrl = "money/pensions"

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConversions._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient
   with PrivateMethodTester {
 

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -11,7 +11,7 @@ import scala.util.matching.Regex
   with Matchers
   with ConfiguredTestSuite
   with BeforeAndAfterAll with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val videoUrl = "uk/video/2012/jun/26/queen-enniskillen-northern-ireland-video"

--- a/applications/test/NewspaperControllerTest.scala
+++ b/applications/test/NewspaperControllerTest.scala
@@ -3,7 +3,7 @@ package services
 import controllers.NewspaperController
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
-import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTestEnvironment, WithTestWsClient}
+import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTestContext, WithTestWsClient}
 
 @DoNotDiscover class NewspaperControllerTest
   extends FlatSpec
@@ -11,7 +11,7 @@ import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTes
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val newspaperController = new NewspaperController(testContentApiClient)

--- a/applications/test/common/CombinerControllerTest.scala
+++ b/applications/test/common/CombinerControllerTest.scala
@@ -4,7 +4,7 @@ import contentapi.SectionsLookUp
 import controllers.IndexController
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
-import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTestEnvironment, WithTestWsClient}
+import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTestContext, WithTestWsClient}
 
 @DoNotDiscover class CombinerControllerTest
   extends FlatSpec
@@ -12,7 +12,7 @@ import test.{ConfiguredTestSuite, TestRequest, WithTestContentApiClient, WithTes
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   lazy val sectionsLookUp = new SectionsLookUp(testContentApiClient)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -31,7 +31,6 @@ case class MinutePage(article: Article, related: RelatedContent) extends PageWit
 
 class ArticleController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
-  import context._
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -10,8 +10,6 @@ import model.Cached.WithoutRevalidationResult
 import model._
 import model.liveblog.BodyBlock
 import org.joda.time.DateTime
-import org.scala_tools.time.Imports._
-import play.api.Environment
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Json, _}
 import play.api.mvc._
@@ -31,7 +29,9 @@ case class ArticlePage(article: Article, related: RelatedContent) extends PageWi
 case class LiveBlogPage(article: Article, currentPage: LiveBlogCurrentPage, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-class ArticleController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class ArticleController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+
+  import context._
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
@@ -184,7 +184,7 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit env: Enviro
 
   // range: None means the url didn't include /live/, Some(...) means it did.  Canonical just means no url parameter
   // if we switch to using blocks instead of body for articles, then it no longer needs to be Optional
-  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader, env: Environment): Future[Result] = {
+  def mapModel(path: String, range: Option[BlockRange] = None)(render: PageWithStoryPackage => Result)(implicit request: RequestHeader): Future[Result] = {
     lookup(path, range) map responseToModelOrResult(range) recover convertApiExceptions map {
       case Left(model) => render(model)
       case Right(other) => RenderOtherStatus(other)

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -2,12 +2,12 @@ package controllers
 
 import com.softwaremill.macwire._
 import contentapi.ContentApiClient
-import play.api.Environment
+import model.ApplicationContext
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
 trait ArticleControllers {
   def contentApiClient: ContentApiClient
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val bookAgent: NewspaperBookTagAgent = wire[NewspaperBookTagAgent]
   lazy val bookSectionAgent: NewspaperBookSectionTagAgent = wire[NewspaperBookSectionTagAgent]
   lazy val publicationController = wire[PublicationController]

--- a/article/app/controllers/PublicationController.scala
+++ b/article/app/controllers/PublicationController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import common.{ExecutionContexts, Logging}
 import implicits.{Dates, ItemResponses}
+import model.ApplicationContext
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Environment
@@ -14,11 +15,13 @@ class PublicationController(
   bookAgent: NewspaperBookTagAgent,
   bookSectionAgent: NewspaperBookSectionTagAgent,
   articleController: ArticleController
-  )(implicit env: Environment) extends Controller
+  )(implicit context: ApplicationContext) extends Controller
   with ExecutionContexts
   with ItemResponses
   with Dates
   with Logging {
+
+  import context._
 
   private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
 

--- a/article/app/controllers/PublicationController.scala
+++ b/article/app/controllers/PublicationController.scala
@@ -21,7 +21,6 @@ class PublicationController(
   with Dates
   with Logging {
 
-  import context._
 
   private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
 

--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -1,4 +1,4 @@
-@(model: ArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @main(model){
 }{

--- a/article/app/views/articleAMP.scala.html
+++ b/article/app/views/articleAMP.scala.html
@@ -1,4 +1,4 @@
-@(model: ArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @mainAMP(model, model.related, model.article.content){
     @fragments.articleBody(model, amp = true)

--- a/article/app/views/articleExplore.scala.html
+++ b/article/app/views/articleExplore.scala.html
@@ -1,4 +1,4 @@
-@(model: ArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @main(model){
 }{

--- a/article/app/views/articleImmersive.scala.html
+++ b/article/app/views/articleImmersive.scala.html
@@ -1,4 +1,4 @@
-@(model: ArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @main(model){
 }{

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,5 +1,5 @@
 @import model.ArticleSchemas
-@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.LinkTo
 @import views.BodyCleaner

--- a/article/app/views/fragments/articleBodyExplore.scala.html
+++ b/article/app/views/fragments/articleBodyExplore.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.RenderClasses
 
-@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @defining(model.article) { article =>
     <div class="l-side-margins @if(article.content.elements.hasMainVideo){explore--video}">

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -1,4 +1,4 @@
-@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.LinkTo
 @import views.BodyCleaner

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -1,5 +1,5 @@
 @import views.MainMediaWidths
-@(article: model.Article, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(article: model.Article, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import model.EndSlateComponents
 @import model.{VideoPlayer}

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -1,4 +1,4 @@
-@(model: MinutePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: MinutePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.LinkTo
 @import views.BodyCleaner

--- a/article/app/views/liveBlog.scala.html
+++ b/article/app/views/liveBlog.scala.html
@@ -1,5 +1,4 @@
-
-@(model: LiveBlogPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.LinkTo
 

--- a/article/app/views/liveBlogAMP.scala.html
+++ b/article/app/views/liveBlogAMP.scala.html
@@ -1,4 +1,4 @@
-@(model: LiveBlogPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @mainAMP(model, model.related, model.article.content){
     @views.html.liveblog.liveBlogBody(model, amp = true)

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -3,7 +3,7 @@
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
 
-@(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -2,7 +2,7 @@
 @import model.Badges.badgeFor
 @import _root_.liveblog.Canonical
 
-@(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.{Edition, LinkTo}
 @import conf.switches.Switches._

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -1,4 +1,4 @@
-@(model: LiveBlogPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.Edition
 

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -1,6 +1,6 @@
 @import model.Article
 
-@(model: LiveBlogPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.Edition
 @import views.support.{AmpAd, AmpAdDataSlot}

--- a/article/app/views/minute.scala.html
+++ b/article/app/views/minute.scala.html
@@ -1,4 +1,4 @@
-@(model: MinutePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: MinutePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @main(model){
 }{

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -3,7 +3,7 @@ package views
 import common.Edition
 import layout.ContentWidths
 import layout.ContentWidths.{Inline, LiveBlogMedia, MainMedia, Showcase}
-import model.Article
+import model.{ApplicationContext, Article}
 import play.api.Environment
 import play.api.mvc.RequestHeader
 import views.support._
@@ -24,7 +24,7 @@ object MainMediaWidths {
 }
 
 object MainCleaner {
- def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, env: Environment) = {
+ def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext) = {
       implicit val edition = Edition(request)
       withJsoup(BulletCleaner(html))(
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
@@ -36,7 +36,7 @@ object MainCleaner {
 }
 
 object BodyCleaner {
-  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, env: Environment) = {
+  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext) = {
     implicit val edition = Edition(request)
 
     val shouldShowAds = !article.content.shouldHideAdverts && article.metadata.sectionId != "childrens-books-site"

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConversions._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -16,7 +16,7 @@ import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
   with MockitoSugar
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   private val PermanentRedirect = 301

--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -7,6 +7,7 @@ import commercial.model.merchandise.events.{LiveEventAgent, MasterclassAgent}
 import commercial.model.merchandise.jobs.JobsAgent
 import commercial.model.merchandise.travel.TravelOffersAgent
 import contentapi.ContentApiClient
+import model.ApplicationContext
 import play.api.Environment
 
 trait CommercialControllers {
@@ -18,7 +19,7 @@ trait CommercialControllers {
   def masterclassAgent: MasterclassAgent
   def travelOffersAgent: TravelOffersAgent
   def jobsAgent: JobsAgent
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val bookOffersController = wire[BookOffersController]
   lazy val contentApiOffersController = wire[ContentApiOffersController]
   lazy val creativeTestPage = wire[CreativeTestPage]

--- a/commercial/app/controllers/CreativeTestPage.scala
+++ b/commercial/app/controllers/CreativeTestPage.scala
@@ -33,7 +33,6 @@ case class TestPage(specifiedKeywords : List[String] = Nil) extends model.Standa
 }
 
 class CreativeTestPage (implicit context: ApplicationContext) extends Controller {
-  import context._
   def allComponents(keyword : List[String]) = Action{ implicit request =>
     if(Configuration.environment.stage.toLowerCase == "dev" || Configuration.environment.stage.toLowerCase == "code") {
       Ok(views.html.debugger.allcreatives(TestPage(keyword)))

--- a/commercial/app/controllers/CreativeTestPage.scala
+++ b/commercial/app/controllers/CreativeTestPage.scala
@@ -1,8 +1,7 @@
 package commercial.controllers
 
 import conf.Configuration
-import model.{GuardianContentTypes, MetaData, SectionSummary}
-import play.api.Environment
+import model.{ApplicationContext, GuardianContentTypes, MetaData, SectionSummary}
 import play.api.libs.json.{JsString, JsValue}
 import play.api.mvc._
 
@@ -33,7 +32,8 @@ case class TestPage(specifiedKeywords : List[String] = Nil) extends model.Standa
   val navSection: String = "Commercial"
 }
 
-class CreativeTestPage (implicit env: Environment) extends Controller {
+class CreativeTestPage (implicit context: ApplicationContext) extends Controller {
+  import context._
   def allComponents(keyword : List[String]) = Action{ implicit request =>
     if(Configuration.environment.stage.toLowerCase == "dev" || Configuration.environment.stage.toLowerCase == "code") {
       Ok(views.html.debugger.allcreatives(TestPage(keyword)))

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -6,8 +6,7 @@ import common.commercial.hosted._
 import common.{Edition, ExecutionContexts, JsonComponent, JsonNotFound, Logging}
 import contentapi.ContentApiClient
 import model.Cached.RevalidatableResult
-import model.{Cached, NoCache}
-import play.api.Environment
+import model.{ApplicationContext, Cached, NoCache}
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc._
 import play.twirl.api.Html
@@ -16,8 +15,9 @@ import views.html.hosted._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-class HostedContentController(contentApiClient: ContentApiClient)(implicit env: Environment)
+class HostedContentController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with Logging with implicits.Requests {
+  import context._
 
   private def cacheDuration: Int = 60
 

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -17,7 +17,6 @@ import scala.util.control.NonFatal
 
 class HostedContentController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with Logging with implicits.Requests {
-  import context._
 
   private def cacheDuration: Int = 60
 

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import play.api.libs.json.{JsObject, Json}
 

--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.hosted.HostedArticlePage
-@(page: HostedArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.hosted.HostedAmp.ampify
 @import common.commercial.hosted.hardcoded.Support.makeshiftPage
 @import views.html.hosted._

--- a/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedGallery.scala.html
@@ -3,7 +3,7 @@
 @import model.ImageAsset
 @import com.gu.contentapi.client.model.v1.Asset
 @import com.gu.contentapi.client.model.v1.AssetType
-@(page: HostedGalleryPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedGalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
 @import conf.Configuration
 @import views.support.FBPixel

--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -3,7 +3,7 @@
 @import views.support.FBPixel
 @import conf.Configuration.environment
 @import conf.Configuration.site.host
-@(page: HostedVideoPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedVideoPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!doctype html>
 <html AMP>

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.hosted.HostedArticlePage
-@(page: HostedArticlePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.commercial.hosted.hardcoded.Support.makeshiftPage
 @import views.html.hosted._
 @import model.hosted.HostedArticleQuotes.prepareQuotes

--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -1,5 +1,5 @@
 @import common.commercial.hosted.HostedGalleryPage
-@(page: HostedGalleryPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedGalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
 
 @main(page, Some("commercial"))  { }  {

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -1,9 +1,9 @@
 @import common.commercial.hosted.HostedVideoPage
 @import common.commercial.hosted.hardcoded.Support.makeshiftPage
-@import conf.Configuration.environment
+@import conf.Configuration.{environment => ConfigEnvironment}
 @import conf.Configuration.site.host
 @import views.html.hosted._
-@(page: HostedVideoPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: HostedVideoPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, Some("commercial")) { } {
     <!--[if (gt IE 9)|(IEMobile)]><!-->
@@ -60,7 +60,7 @@
                         data-media-id="@{page.video.mediaId}"
                         data-duration="@{page.video.duration}"
                         class="js-hosted-youtube-video hosted__youtube-video"
-                        src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(environment.isProd && !environment.isPreview) "&origin=https://www.theguardian.com" else if(host != "") s"&origin=$host" else ""}"
+                        src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(ConfigEnvironment.isProd && !ConfigEnvironment.isPreview) "&origin=https://www.theguardian.com" else if(host != "") s"&origin=$host" else ""}"
                         frameborder="0"
                         allowfullscreen=""></iframe>
                         @guardianHostedControlButtons(page)

--- a/commercial/test/test/CommercialAmpValidityTest.scala
+++ b/commercial/test/test/CommercialAmpValidityTest.scala
@@ -7,7 +7,7 @@ import play.api.test.Helpers._
 import play.api.test._
 
 @DoNotDiscover class CommercialAmpValidityTest extends AmpValidityTest
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   override protected def getContentString[T](path: String)(block: (String) => T): T = {

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -1,8 +1,7 @@
 package app
 
-import akka.actor.ActorSystem
 import common._
-import model.ApplicationIdentity
+import model.{ApplicationContext, ApplicationIdentity}
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.HttpFilters
@@ -60,6 +59,7 @@ trait FrontendComponents
 
   // here are the attributes you must provide for your app to start
   def appIdentity: ApplicationIdentity
+  implicit def appContext = new ApplicationContext(environment)
   def lifecycleComponents: List[LifecycleComponent]
   def router: Router
 }

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -97,9 +97,9 @@ object JsMinifier {
 object InlineJs {
   private val memoizedMap: TrieMap[String, String] = TrieMap()
 
-  def withFileNameHint(codeToCompile: String, fileName: String)(implicit env: Environment): Html = {
+  def withFileNameHint(codeToCompile: String, fileName: String)(implicit context: model.ApplicationContext): Html = {
     if (codeToCompile.trim.nonEmpty) {
-      if (env.mode == Dev) {
+      if (context.environment.mode == Dev) {
         Html(optimizeJs(codeToCompile, fileName))
       } else {
         val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
@@ -118,6 +118,6 @@ object InlineJs {
     }
   }
 
-  def apply(codeToCompile: String, fileName: String = "input.js")(implicit env: Environment): Html = withFileNameHint(codeToCompile, fileName)
-  def apply(codeToCompile: Javascript, fileName: String)(implicit env: Environment): Html = this(codeToCompile.body, fileName)
+  def apply(codeToCompile: String, fileName: String = "input.js")(implicit context: model.ApplicationContext): Html = withFileNameHint(codeToCompile, fileName)
+  def apply(codeToCompile: Javascript, fileName: String)(implicit context: model.ApplicationContext): Html = this(codeToCompile.body, fileName)
 }

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -7,9 +7,9 @@ import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
 import model.Cached.RevalidatableResult
-import model.{Cached, NoCache}
+import model.{ApplicationContext, Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
-import play.api.{Environment, Logger}
+import play.api.Logger
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
@@ -19,14 +19,16 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     error.message == "The requested resource has expired for commercial reason."
   }
 
-  def convertApiExceptions[T](implicit request: RequestHeader, env: Environment,
+  def convertApiExceptions[T](implicit request: RequestHeader,
+                              context: ApplicationContext,
                               log: Logger): PartialFunction[Throwable, Either[T, Result]] = {
 
     convertApiExceptionsWithoutEither.andThen(Right(_))
   }
 
-  def convertApiExceptionsWithoutEither[T](implicit request: RequestHeader, env: Environment,
-                              log: Logger): PartialFunction[Throwable, Result] = {
+  def convertApiExceptionsWithoutEither[T](implicit request: RequestHeader,
+                                           context: ApplicationContext,
+                                           log: Logger): PartialFunction[Throwable, Result] = {
     case e: CircuitBreakerOpenException =>
       log.error(s"Got a circuit breaker open error while calling content api")
       NoCache(ServiceUnavailable)

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -15,7 +15,6 @@ import play.api.mvc.{Action, Controller, Result}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import play.api.Environment
 
 object emailLandingPage extends StandalonePage {
   private val id = "email-landing-page"
@@ -113,7 +112,8 @@ class EmailFormService(wsClient: WSClient) {
   }
 }
 
-class EmailSignupController(wsClient: WSClient)(implicit env: Environment) extends Controller with ExecutionContexts with Logging {
+class EmailSignupController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
+  import context._
   val emailFormService = new EmailFormService(wsClient)
   val emailForm: Form[EmailForm] = Form(
     mapping(

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -113,8 +113,7 @@ class EmailFormService(wsClient: WSClient) {
 }
 
 class EmailSignupController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with ExecutionContexts with Logging {
-  import context._
-  val emailFormService = new EmailFormService(wsClient)
+    val emailFormService = new EmailFormService(wsClient)
   val emailForm: Form[EmailForm] = Form(
     mapping(
       "email" -> nonEmptyText.verifying(emailAddress),

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -14,8 +14,7 @@ import scala.concurrent.Future.successful
 trait IndexControllerCommon extends Controller with Index with RendersItemResponse with Logging with Paging with ExecutionContexts {
   private val TagPattern = """^([\w\d-]+)/([\w\d-]+)$""".r
 
-  val context: ApplicationContext
-  import context._
+  implicit val context: ApplicationContext
 
   // Needed as aliases for reverse routing
   def renderCombinerRss(leftSide: String, rightSide: String) = renderCombiner(leftSide, rightSide)

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -4,7 +4,6 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import common._
 import model.Cached.WithoutRevalidationResult
 import model._
-import play.api.Environment
 import play.api.mvc._
 import services.{Index, IndexPage}
 import views.support.RenderOtherStatus
@@ -15,7 +14,8 @@ import scala.concurrent.Future.successful
 trait IndexControllerCommon extends Controller with Index with RendersItemResponse with Logging with Paging with ExecutionContexts {
   private val TagPattern = """^([\w\d-]+)/([\w\d-]+)$""".r
 
-  implicit def env: Environment
+  val context: ApplicationContext
+  import context._
 
   // Needed as aliases for reverse routing
   def renderCombinerRss(leftSide: String, rightSide: String) = renderCombiner(leftSide, rightSide)

--- a/common/app/model/ApplicationContext.scala
+++ b/common/app/model/ApplicationContext.scala
@@ -1,0 +1,7 @@
+package model
+
+import play.api.Environment
+
+class ApplicationContext(env: Environment) {
+  implicit val environment = env
+}

--- a/common/app/model/ApplicationContext.scala
+++ b/common/app/model/ApplicationContext.scala
@@ -2,6 +2,4 @@ package model
 
 import play.api.Environment
 
-class ApplicationContext(env: Environment) {
-  implicit val environment = env
-}
+case class ApplicationContext(environment: Environment)

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -14,8 +14,7 @@ import scala.concurrent.Future
 
 trait Index extends ConciergeRepository with Collections {
 
-  val context: ApplicationContext
-  import context._
+  implicit val context: ApplicationContext
 
   val contentApiClient: ContentApiClient
   val sectionsLookUp: SectionsLookUp

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -8,14 +8,14 @@ import implicits.Collections
 import model._
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
-import play.api.Environment
 import play.api.mvc.{RequestHeader, Result => PlayResult}
 
 import scala.concurrent.Future
 
 trait Index extends ConciergeRepository with Collections {
 
-  implicit def env: Environment
+  val context: ApplicationContext
+  import context._
 
   val contentApiClient: ContentApiClient
   val sectionsLookUp: SectionsLookUp

--- a/common/app/templates/inlineJS/blocking/loadFonts.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadFonts.scala.js
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 
 @import play.api.Mode.Dev
 
@@ -37,7 +37,7 @@ do you have fonts in localStorage?
                 }
             }
         } catch (e) {
-            @if(env.mode == Dev){throw(e)}
+            @if(context.environment.mode == Dev){throw(e)}
         }
         return hinting;
     })();
@@ -66,7 +66,7 @@ do you have fonts in localStorage?
                                     return true;
                                 }
                             } catch (e) {
-                                @if(env.mode == Dev){throw(e)}
+                                @if(context.environment.mode == Dev){throw(e)}
                             }
                         }
 
@@ -160,7 +160,7 @@ do you have fonts in localStorage?
                 return true;
             }
         } catch (e) {
-            @if(env.mode == Dev){throw(e)}
+            @if(context.environment.mode == Dev){throw(e)}
         }
         return false;
     }
@@ -181,7 +181,7 @@ do you have fonts in localStorage?
                 thisScript.parentNode.insertBefore(fonts, thisScript);
             });
         } catch (e) {
-            @if(env.mode == Dev){throw(e)}
+            @if(context.environment.mode == Dev){throw(e)}
         }
     }
 
@@ -243,7 +243,7 @@ do you have fonts in localStorage?
                         }
                     }
                 } catch (e) {
-                    @if(env.mode == Dev){throw(e)}
+                    @if(context.environment.mode == Dev){throw(e)}
                 }
                 // Didn't find any non-black pixels or something went wrong (for example,
                 // non-blink Opera cannot use the canvas fillText() method) so we assume
@@ -255,7 +255,7 @@ do you have fonts in localStorage?
                 return true;
             }
         } catch (e) {
-            @if(env.mode == Dev){throw(e)}
+            @if(context.environment.mode == Dev){throw(e)}
         }
     }
 

--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -1,4 +1,4 @@
-@(item: model.MetaData)(implicit request: RequestHeader, env: play.api.Environment)
+@(item: model.MetaData)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import play.api.Mode.Dev
 
@@ -59,7 +59,7 @@
     window.shouldEnhance = mustNotEnhance() ? false : mustEnhance() ? true : couldEnhance() && weWantToEnhance();
 
     // just so we can tell…
-    @if(env.mode == Dev) {
+    @if(context.environment.mode == Dev) {
         window.console && window.console.info(`THIS IS ${window.shouldEnhance ? 'ENHANCED' : 'STANDARD ONLY'}`);
     }
 })(window);

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 
 @import play.api.Mode.Dev
 
@@ -51,5 +51,5 @@ try {
         });
     })(document, window);
 } catch (e) {
-    @if(env.mode == Dev) {throw (e)}
+    @if(context.environment.mode == Dev) {throw (e)}
 }

--- a/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/getUserData.scala.js
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 
 @import play.api.Mode.Dev
 
@@ -42,5 +42,5 @@ try {
         }
     })(guardian.isEnhanced && 'atob' in window, document, window);
 } catch (e) {
-    @if(env.mode == Dev) {throw (e)}
+    @if(context.environment.mode == Dev) {throw (e)}
 }

--- a/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
@@ -1,4 +1,4 @@
-@()(implicit env: play.api.Environment)
+@()(implicit context: model.ApplicationContext)
 
 @import play.api.Mode.Dev
 
@@ -37,6 +37,6 @@ try {
         }
     })('classList' in document.documentElement, document, window);
 } catch (e) {
-    @if(env.mode == Dev) {throw (e)}
+    @if(context.environment.mode == Dev) {throw (e)}
 }
 

--- a/common/app/views/commercialExpired.scala.html
+++ b/common/app/views/commercialExpired.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, env: play.api.Environment)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(model.CommercialExpiryPage(id = request.path)) { } {
     <div class="l-side-margins">

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -1,4 +1,4 @@
-@(metaData: model.Page)(body: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(metaData: model.Page)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches._
 @import common.InlineJs
@@ -7,7 +7,7 @@
 
 <!doctype html>
 <head>
-    @if(env.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
+    @if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
         <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head.email.css")" />
     } else {
         <style class="js-loggable">

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, emailType: String, listId: Int)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, emailType: String, listId: Int)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page){
     @fragments.email.signup.emailSignUp(emailType, listId, "Sign up to our daily email")

--- a/common/app/views/emailLanding.scala.html
+++ b/common/app/views/emailLanding.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
     @fragments.emailLandingBody()

--- a/common/app/views/emailSubscriptionResult.scala.html
+++ b/common/app/views/emailSubscriptionResult.scala.html
@@ -1,5 +1,5 @@
 @import model.SubscriptionResult
-@(page: model.Page, result: SubscriptionResult)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, result: SubscriptionResult)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page){
     @fragments.email.signup.subscriptionResult(result)

--- a/common/app/views/expired.scala.html
+++ b/common/app/views/expired.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
 <div class="l-side-margins">

--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -1,9 +1,9 @@
-@(path: String)(implicit env: play.api.Environment)
+@(path: String)(implicit context: model.ApplicationContext)
 @import conf.Configuration
 @import play.api.Mode.Dev
 
 @* must be served by localhost, not thegulocal *@
-<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" @if(env.mode != Dev) { credentials="include" } class="onward-list">
+<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" @if(context.environment.mode != Dev) { credentials="include" } class="onward-list">
     <template type="amp-mustache">
         {{#showContent}}
             <div class="fc-container__inner">

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, mainPicture: String, ctaImage: Option[String], brandColour: String)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, mainPicture: String, ctaImage: Option[String], brandColour: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.Edition
 @import common.commercial.PaidContent
@@ -289,6 +289,6 @@
  * Please note that the tests will NOT pass validation with this line.
  * It won't affect prod but please comment out this line when running tests in DEV
  *@
-@if(env.mode == Dev) {
+@if(context.environment.mode == Dev) {
     <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
 }

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request:RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request:RequestHeader, context: model.ApplicationContext)
 @import conf.Configuration
 @import conf.Static
 @import views.support.FBPixel

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.GoogleAnalyticsAccount
 @import play.api.Mode.Dev
@@ -53,8 +53,8 @@
     ***************************************************************************************@
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest)) {
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
-            'sampleRate': @{ if (env.mode == Dev) 100 else tracker.samplePercentage },
-            'siteSpeedSampleRate': @{ if (env.mode == Dev) 100 else tracker.siteSpeedSamplePercentage }
+            'sampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.samplePercentage },
+            'siteSpeedSampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.siteSpeedSamplePercentage }
         });
     }
 

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,4 +1,4 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean)(implicit request: RequestHeader, env: play.api.Environment)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz}
 

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -2,7 +2,7 @@
 @import model.content.InteractiveAtom
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 
-@(interactive: InteractiveAtom, shouldFence: Boolean)(implicit env: play.api.Environment)
+@(interactive: InteractiveAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
 
 @iframeBody = {
     <!DOCTYPE html>

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,4 +1,4 @@
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, env: play.api.Environment)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
     media match {

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -3,7 +3,7 @@
 @import conf.Configuration
 @import templates.inlineJS.blocking.js.curlConfig
 
-@(page: MediaAtomEmbedPage, displayCaption: Boolean)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: MediaAtomEmbedPage, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-video-embed-html">

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.Page.getContent
 @import play.api.Mode.Dev
 
@@ -21,7 +21,7 @@ http://developers.theguardian.com/join-the-team.html
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
 @fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
 
-@if(!(env.mode == Dev)) {
+@if(!(context.environment.mode == Dev)) {
     <link rel="prefetch" href="@Static("javascripts/app.js")">
 }
 

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -8,7 +8,7 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.ImmersiveMainCleaner
 
-@(page: ContentPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: ContentPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @defining((
     page.item.tags.isTheMinuteArticle,

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -5,7 +5,7 @@
 @import templates.inlineJS.blocking.js.{applyRenderConditions, config, curlConfig, enableStylesheets, loadFonts, shouldEnhance}
 @import templates.inlineJS.blocking.polyfills.js.{classlist, details, matches, raf, setTimeout}
 
-@(page: model.Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!--[if lt IE 9]>
     <script src="@Static("javascripts/es5-html5.js")"></script>

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -5,7 +5,7 @@
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._
 
-@(page: Page)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @**
  * Use this fragment to add JavaScript that can improve the perceived rendering speed

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -1,11 +1,9 @@
-@(page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.{AnalyticsHost, _}
 @import conf.{Configuration, _}
 @import model.meta.LinkedData
 @import model.Page
-@import play.api.Play
-@import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
 @import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 @import play.api.Mode.Dev
@@ -59,7 +57,7 @@
 
 @* Additional meta data that does not impact rendering speed (and can live at the end of the <head>) *@
 
-@if(env.mode == Dev){
+@if(context.environment.mode == Dev){
     <link rel="shortcut icon" type="image/png" href="@Static("images/favicons/32x32-dev.ico")" />
 } else {
     <link rel="shortcut icon" type="image/png" href="@Static("images/favicons/32x32.ico")" />
@@ -158,7 +156,7 @@
     see: http://people.apache.org/~pmuellr/weinre/docs/latest/
 
 *@
-@if(env.mode == Dev) {
+@if(context.environment.mode == Dev) {
     @Configuration.javascript.pageData.get("guardian.page.iphoneDebugger").map{ scriptUrl => <script src="@scriptUrl"></script> }
 }
 

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -1,4 +1,4 @@
-@(projectName: Option[String], isCrossword: Boolean = false)(implicit request: RequestHeader, env: play.api.Environment)
+@(projectName: Option[String], isCrossword: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
@@ -51,7 +51,7 @@
   - Include IE Mobile [|(IEMobile)]
 *@
 <!--[if (gt IE 9)|(IEMobile)]><!-->
-@if(env.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
+@if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
     <link rel="stylesheet" id="head-css" data-reload="head@projectName.map("." + _).getOrElse(".content")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(".content") + ".css")" />
 } else {
     <style class="js-loggable">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,5 +1,4 @@
-@(page: model.Page, projectName: Option[String] = None)(head: Html)(body: Html)(implicit request: RequestHeader, env: play.api.Environment)
-
+@(page: model.Page, projectName: Option[String] = None)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, Navigation, commercial}
 @import conf.switches.Switches.{BreakingNewsSwitch}
 @import model.Page.getContent
@@ -115,7 +114,7 @@
 
         @fragments.analytics.base(page)
     </body>
-        @if(env.mode == Dev) {
+        @if(context.environment.mode == Dev) {
             <script>
                 setTimeout(function() {
                     window.callPhantom('takeShot');

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, related: model.RelatedContent, content: model.Content)(body: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, related: model.RelatedContent, content: model.Content)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.{CanonicalLink, LinkTo}
 @import conf.Configuration

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -13,7 +13,6 @@ import model.content.{Atom, Atoms}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
-import play.api.Environment
 
 import scala.collection.JavaConversions._
 
@@ -601,7 +600,7 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false)(implicit val request: RequestHeader, env: Environment) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }

--- a/common/app/views/support/ImmersiveMainCleaner.scala
+++ b/common/app/views/support/ImmersiveMainCleaner.scala
@@ -1,12 +1,12 @@
 package views.support
 
 import common.Edition
-import model.Article
+import model.{ApplicationContext, Article}
 import play.api.Environment
 import play.api.mvc.RequestHeader
 
 object ImmersiveMainCleaner {
-  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, env: Environment) = {
+  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext) = {
     implicit val edition = Edition(request)
     withJsoup(BulletCleaner(html))(
       AtomsCleaner(article.content.atoms, shouldFence = true, amp)

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -16,8 +16,6 @@ import play.api.libs.json.Json._
 import play.api.libs.json.Writes
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
-import play.api.Environment
-
 import scala.collection.JavaConversions._
 
 /**
@@ -183,7 +181,7 @@ object RenderOtherStatus {
     ))
   }
 
-  def apply(result: Result)(implicit request: RequestHeader, env: Environment) = result.header.status match {
+  def apply(result: Result)(implicit request: RequestHeader, context: ApplicationContext) = result.header.status match {
     case 404 => NoCache(NotFound)
     case 410 if request.isJson => Cached(60)(JsonComponent(gonePage, "status" -> "GONE"))
     case 410 => Cached(60)(WithoutRevalidationResult(Ok(views.html.expired(gonePage))))

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -116,10 +116,8 @@ object TestRequest {
   }
 }
 
-trait WithTestEnvironment {
-  val testEnvironment: Environment = Environment.simple()
-  implicit val env = testEnvironment
-  implicit val context = new ApplicationContext(testEnvironment)
+trait WithTestContext {
+  implicit val testContext = new ApplicationContext(Environment.simple())
 }
 
 trait WithTestWsClient {

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,10 +1,12 @@
 package test
 
 import java.io.File
+
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, Page, WebClient, WebResponse}
 import common.{ExecutionContexts, Lazy}
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
+import model.ApplicationContext
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play._
@@ -13,6 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.libs.ws.ning.{NingWSClient, NingWSClientConfig}
 import play.api.test._
 import recorder.ContentApiHttpRecorder
+
 import scala.util.{Failure, Success, Try}
 
 //TODO: to delete once ContentApiClient global object is not used anymore
@@ -116,6 +119,7 @@ object TestRequest {
 trait WithTestEnvironment {
   val testEnvironment: Environment = Environment.simple()
   implicit val env = testEnvironment
+  implicit val context = new ApplicationContext(testEnvironment)
 }
 
 trait WithTestWsClient {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -5,13 +5,13 @@ import model.content.{Atoms, MediaAsset, MediaAtom}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.{FlatSpec, Matchers}
-import test.{TestRequest, WithTestEnvironment}
+import test.{TestRequest, WithTestContext}
 import views.support.AtomsCleaner
 import conf.switches.Switches
 
 class AtomCleanerTest extends FlatSpec
   with Matchers
-  with WithTestEnvironment
+  with WithTestContext
   with FakeRequests {
   val youTubeAtom = Some(Atoms(quizzes = Nil,
     media = Seq(MediaAtom(id = "887fb7b4-b31d-4a38-9d1f-26df5878cf9c",
@@ -35,7 +35,7 @@ class AtomCleanerTest extends FlatSpec
 
 
  private def clean(document: Document, atom:Option[Atoms], amp: Boolean): Document = {
-    val cleaner = AtomsCleaner(youTubeAtom, amp = amp)(TestRequest(), env)
+    val cleaner = AtomsCleaner(youTubeAtom, amp = amp)(TestRequest(), testContext)
     cleaner.clean(document)
     document
   }

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -48,7 +48,6 @@ trait Controllers
   with FrontendComponents
   with CricketControllers {
   self: BuiltInComponents =>
-  implicit def appContext: ApplicationContext
   lazy val accessTokenGenerator = wire[AccessTokenGenerator]
   lazy val apiSandbox = wire[ApiSandbox]
   lazy val assets = wire[Assets]

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -18,7 +18,7 @@ import dfp.DfpDataCacheLifecycle
 import feed._
 import football.controllers._
 import http.{CorsHttpErrorHandler, DevBuildParametersHttpRequestHandler, DevFilters}
-import model.{AdminLifecycle, ApplicationIdentity}
+import model.{AdminLifecycle, ApplicationContext, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
 import play.api._
@@ -48,6 +48,7 @@ trait Controllers
   with FrontendComponents
   with CricketControllers {
   self: BuiltInComponents =>
+  implicit def appContext: ApplicationContext
   lazy val accessTokenGenerator = wire[AccessTokenGenerator]
   lazy val apiSandbox = wire[ApiSandbox]
   lazy val assets = wire[Assets]

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -13,12 +13,11 @@ import play.api.data.validation._
 import play.api.mvc.{Action, RequestHeader, Result}
 import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
 import conf.switches.Switches.LongCacheCommentsSwitch
-import play.api.Environment
-
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionApiLike)(implicit env: Environment) extends DiscussionController with ExecutionContexts {
+class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionApiLike)(implicit context: ApplicationContext) extends DiscussionController with ExecutionContexts {
+  import context._
 
   val userForm = Form(
     Forms.mapping(

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -17,7 +17,6 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionApiLike)(implicit context: ApplicationContext) extends DiscussionController with ExecutionContexts {
-  import context._
 
   val userForm = Form(
     Forms.mapping(

--- a/discussion/app/controllers/DiscussionControllers.scala
+++ b/discussion/app/controllers/DiscussionControllers.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.softwaremill.macwire._
 import discussion.api.DiscussionApi
+import model.ApplicationContext
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import play.filters.csrf.CSRFComponents
@@ -9,7 +10,7 @@ import play.filters.csrf.CSRFComponents
 trait DiscussionControllers extends CSRFComponents {
   def wsClient: WSClient
   def discussionApi: DiscussionApi
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val commentCountController = wire[CommentCountController]
   lazy val commentsController = wire[CommentsController]
   lazy val ctaController = wire[CtaController]

--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -1,7 +1,7 @@
 @import common.LinkTo
 @import discussion.CommentPage
 
-@(page: CommentPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: CommentPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @main(page){
 } {
 <div class="content content--comments">

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -2,7 +2,7 @@
 @import views.html.fragments.reportCommentForm
 
 
-@(commentId: Int, page: SimplePage, userForm: Form[discussion.model.DiscussionAbuseReport], errorMessage: Option[String] = None)(implicit request: RequestHeader, env: play.api.Environment)
+@(commentId: Int, page: SimplePage, userForm: Form[discussion.model.DiscussionAbuseReport], errorMessage: Option[String] = None)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @main(page) { } {
 
 

--- a/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
+++ b/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
@@ -1,6 +1,6 @@
 @import _root_.model.SimplePage
 @import conf.Configuration
-@(webUrl: String, page: SimplePage)(implicit request: RequestHeader, env: play.api.Environment)
+@(webUrl: String, page: SimplePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @main(page) { } {
 
 

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -10,7 +10,7 @@ import play.filters.csrf.CSRFConfig
   with Matchers
   with ConfiguredTestSuite
   with BeforeAndAfterAll
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestWsClient {
 
   "Discussion" should "return 200" in {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -23,7 +23,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
   val frontJsonFapi: FrontJsonFapi
 
-  implicit def env: Environment
+  val context: ApplicationContext
+  import context._
 
   private def getEditionFromString(edition: String) = {
     val editionToFilterBy = edition match {
@@ -248,5 +249,5 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 }
 
-class FaciaControllerImpl(val frontJsonFapi: FrontJsonFapiLive)(implicit val env: Environment) extends FaciaController
+class FaciaControllerImpl(val frontJsonFapi: FrontJsonFapiLive)(implicit val context: ApplicationContext) extends FaciaController
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -23,8 +23,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
   val frontJsonFapi: FrontJsonFapi
 
-  val context: ApplicationContext
-  import context._
+  implicit val context: ApplicationContext
 
   private def getEditionFromString(edition: String) = {
     val editionToFilterBy = edition match {

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -2,11 +2,12 @@ package controllers
 
 import com.softwaremill.macwire._
 import controllers.front.FrontJsonFapiLive
+import model.ApplicationContext
 import play.api.Environment
 
 trait FaciaControllers {
   def frontJsonFapiLive: FrontJsonFapiLive
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val dedupedController = wire[DedupedController]
   lazy val faciaController = wire[FaciaControllerImpl]
 }

--- a/facia/app/views/front.scala.html
+++ b/facia/app/views/front.scala.html
@@ -1,4 +1,4 @@
-@(page: model.PressedPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.PressedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, projectName = Option("facia")){
     @fragments.frontHead(page)

--- a/facia/app/views/package.scala
+++ b/facia/app/views/package.scala
@@ -1,14 +1,14 @@
 package views
 
 import common.Edition
-import model.PressedPage
+import model.{ApplicationContext, PressedPage}
 import play.api.Environment
 import play.api.mvc.RequestHeader
-import views.support.{CommercialComponentHigh, BulletCleaner}
+import views.support.{BulletCleaner, CommercialComponentHigh}
 import views.support.`package`.withJsoup
 
 object FrontsCleaner {
- def apply(page: PressedPage, html: String)(implicit request: RequestHeader, env: Environment) = {
+ def apply(page: PressedPage, html: String)(implicit request: RequestHeader, context: ApplicationContext) = {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html))(
       CommercialComponentHigh(page.frontProperties.isAdvertisementFeature, page.isNetworkFront, page.metadata.hasPageSkin(edition))

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -18,7 +18,7 @@ import controllers.FaciaControllerImpl
   with BeforeAndAfterAll
   with FakeRequests
   with BeforeAndAfterEach
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestWsClient {
 
   val faciaController = new FaciaControllerImpl(new TestFrontJsonFapi(wsClient))

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -7,13 +7,13 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.libs.json._
 import play.api.test.Helpers._
 import services.ConfigAgent
-import test.{ConfiguredTestSuite, TestFrontJsonFapi, TestRequest, WithTestEnvironment, WithTestWsClient}
+import test.{ConfiguredTestSuite, TestFrontJsonFapi, TestRequest, WithTestContext, WithTestWsClient}
 
 @DoNotDiscover class FaciaMetaDataTest extends FlatSpec
   with Matchers
   with ConfiguredTestSuite
   with BeforeAndAfterAll
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestWsClient {
 
   override def beforeAll() {

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.ExecutionContexts
-import model.{IdentityPage, NoCache}
+import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.mvc._
 import play.api.data.{Form, Forms}
 import play.api.data.Forms._
@@ -15,16 +15,16 @@ import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 
 import scala.concurrent.Future
 import idapiclient.requests.PasswordUpdate
-import play.api.Environment
 
 class ChangePasswordController( api: IdApiClient,
                                 authenticatedActions: AuthenticatedActions,
                                 authenticationService: AuthenticationService,
                                 idRequestParser: IdRequestParser,
                                 idUrlBuilder: IdentityUrlBuilder,
-                                val messagesApi: MessagesApi)(implicit env: Environment)
+                                val messagesApi: MessagesApi)(implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms with I18nSupport{
 
+  import context._
   import authenticatedActions.authAction
 
   val page = IdentityPage("/password/change", "Change Password")

--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -24,8 +24,7 @@ class ChangePasswordController( api: IdApiClient,
                                 val messagesApi: MessagesApi)(implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms with I18nSupport{
 
-  import context._
-  import authenticatedActions.authAction
+    import authenticatedActions.authAction
 
   val page = IdentityPage("/password/change", "Change Password")
 

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -30,7 +30,6 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
                             implicit val profileFormsMapping: ProfileFormsMapping)
                            (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
-  import context._
 
   import authenticatedActions._
 

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -28,8 +28,9 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
                             idRequestParser: IdRequestParser,
                             val messagesApi: MessagesApi,
                             implicit val profileFormsMapping: ProfileFormsMapping)
-                           (implicit env: Environment)
+                           (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
+  import context._
 
   import authenticatedActions._
 

--- a/identity/app/controllers/EmailController.scala
+++ b/identity/app/controllers/EmailController.scala
@@ -26,8 +26,7 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
                       val messagesApi: MessagesApi)
                      (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
-  import context._
-  import EmailPrefsData._
+    import EmailPrefsData._
   import authenticatedActions.authAction
 
   val page = IdentityPage("/email-prefs", "Email preferences")

--- a/identity/app/controllers/EmailController.scala
+++ b/identity/app/controllers/EmailController.scala
@@ -9,11 +9,10 @@ import utils.SafeLogging
 import play.api.mvc._
 
 import scala.concurrent.Future
-import model.{EmailSubscriptions, IdentityPage}
+import model.{ApplicationContext, EmailSubscriptions, IdentityPage}
 import play.api.data._
 import client.Error
 import com.gu.identity.model.{EmailList, Subscriber}
-import play.api.Environment
 import play.filters.csrf._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json._
@@ -25,8 +24,9 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
                       idUrlBuilder: IdentityUrlBuilder,
                       authenticatedActions: AuthenticatedActions,
                       val messagesApi: MessagesApi)
-                     (implicit env: Environment)
+                     (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
+  import context._
   import EmailPrefsData._
   import authenticatedActions.authAction
 

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -5,9 +5,8 @@ import idapiclient.IdApiClient
 import services.{AuthenticationService, IdRequestParser, IdentityUrlBuilder, ReturnUrlVerifier}
 import common.ExecutionContexts
 import utils.SafeLogging
-import model.IdentityPage
+import model.{ApplicationContext, IdentityPage}
 import actions.AuthenticatedActions
-import play.api.Environment
 
 class EmailVerificationController(api: IdApiClient,
                                   authenticatedActions: AuthenticatedActions,
@@ -15,8 +14,9 @@ class EmailVerificationController(api: IdApiClient,
                                   idRequestParser: IdRequestParser,
                                   idUrlBuilder: IdentityUrlBuilder,
                                   returnUrlVerifier: ReturnUrlVerifier)
-                                 (implicit env: Environment)
+                                 (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
+  import context._
   import ValidationState._
   import authenticatedActions.authActionWithUser
 

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -16,8 +16,7 @@ class EmailVerificationController(api: IdApiClient,
                                   returnUrlVerifier: ReturnUrlVerifier)
                                  (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
-  import context._
-  import ValidationState._
+    import ValidationState._
   import authenticatedActions.authActionWithUser
 
   val page = IdentityPage("/verify-email", "Verify Email")

--- a/identity/app/controllers/FormstackController.scala
+++ b/identity/app/controllers/FormstackController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.AuthenticatedActions
 import play.api.mvc._
-import model.IdentityPage
+import model.{ApplicationContext, IdentityPage}
 import common.ExecutionContexts
 import services.{IdRequestParser, IdentityUrlBuilder, ReturnUrlVerifier}
 import utils.SafeLogging
@@ -10,15 +10,15 @@ import utils.SafeLogging
 import scala.concurrent.Future
 import formstack.{FormstackApi, FormstackForm}
 import conf.switches.Switches
-import play.api.Environment
 
 class FormstackController(returnUrlVerifier: ReturnUrlVerifier,
                           idRequestParser: IdRequestParser,
                           idUrlBuilder: IdentityUrlBuilder,
                           authenticatedActions: AuthenticatedActions,
                           formStackApi: FormstackApi)
-                         (implicit env: Environment)
+                         (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
+  import context._
 
   import authenticatedActions.authAction
 

--- a/identity/app/controllers/FormstackController.scala
+++ b/identity/app/controllers/FormstackController.scala
@@ -18,7 +18,6 @@ class FormstackController(returnUrlVerifier: ReturnUrlVerifier,
                           formStackApi: FormstackApi)
                          (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
-  import context._
 
   import authenticatedActions.authAction
 

--- a/identity/app/controllers/IdentityControllers.scala
+++ b/identity/app/controllers/IdentityControllers.scala
@@ -5,6 +5,7 @@ import com.softwaremill.macwire._
 import form.FormComponents
 import formstack.FormStackComponents
 import idapiclient.IdApiComponents
+import model.ApplicationContext
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import services.IdentityServices
@@ -14,7 +15,7 @@ trait IdentityControllers extends IdApiComponents
   with FormStackComponents
   with FormComponents {
   def wsClient: WSClient
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
 
   lazy val authenticatedActions = wire[AuthenticatedActions]
   lazy val changePasswordController = wire[ChangePasswordController]

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -21,7 +21,6 @@ class PublicProfileController(idUrlBuilder: IdentityUrlBuilder,
   with ExecutionContexts
   with SafeLogging{
 
-  import context._
 
   def page(url: String, username: String) = IdentityPage(url,  s"$username's public profile")
 

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -5,7 +5,7 @@ import play.api.mvc._
 import common.ExecutionContexts
 import services.{IdRequestParser, IdentityUrlBuilder}
 import utils.SafeLogging
-import model.{Cached, IdentityPage}
+import model.{ApplicationContext, Cached, IdentityPage}
 import idapiclient.IdApiClient
 
 import scala.concurrent.Future
@@ -16,10 +16,12 @@ import play.api.Environment
 class PublicProfileController(idUrlBuilder: IdentityUrlBuilder,
                               identityApiClient: IdApiClient,
                               idRequestParser: IdRequestParser)
-                             (implicit env: Environment)
+                             (implicit context: ApplicationContext)
   extends Controller
   with ExecutionContexts
   with SafeLogging{
+
+  import context._
 
   def page(url: String, username: String) = IdentityPage(url,  s"$username's public profile")
 

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -5,8 +5,7 @@ import common.ExecutionContexts
 import form.Mappings
 import idapiclient.{EmailPassword, IdApiClient, ScGuU}
 import implicits.Forms
-import model.{IdentityPage, NoCache}
-import play.api.Environment
+import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.data._
 import play.api.data.validation.Constraints
 import play.api.i18n.{Messages, MessagesApi}
@@ -24,8 +23,9 @@ class ReauthenticationController(returnUrlVerifier: ReturnUrlVerifier,
                                  authenticatedActions: AuthenticatedActions,
                                  signInService : PlaySigninService,
                                  val messagesApi: MessagesApi)
-                                (implicit env: Environment)
+                                (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
+  import context._
 
   val page = IdentityPage("/reauthenticate", "Re-authenticate")
 

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -25,7 +25,6 @@ class ReauthenticationController(returnUrlVerifier: ReturnUrlVerifier,
                                  val messagesApi: MessagesApi)
                                 (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
-  import context._
 
   val page = IdentityPage("/reauthenticate", "Re-authenticate")
 

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -22,7 +22,6 @@ class RegistrationController(returnUrlVerifier : ReturnUrlVerifier,
                              val messagesApi: MessagesApi)
                             (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
-  import context._
 
   val page = IdentityPage("/register", "Register")
 

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -5,15 +5,13 @@ import common.ExecutionContexts
 import com.gu.identity.model.User
 import utils.{SafeLogging, ThirdPartyConditions}
 import idapiclient.{EmailPassword, IdApiClient}
-import model.{IdentityPage, NoCache}
+import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import play.api.data._
-
 import scala.concurrent.Future
 import services._
 import form.Mappings
-import play.api.Environment
 
 class RegistrationController(returnUrlVerifier : ReturnUrlVerifier,
                              userCreationService : UserCreationService,
@@ -22,8 +20,9 @@ class RegistrationController(returnUrlVerifier : ReturnUrlVerifier,
                              idUrlBuilder : IdentityUrlBuilder,
                              signinService : PlaySigninService,
                              val messagesApi: MessagesApi)
-                            (implicit env: Environment)
+                            (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
+  import context._
 
   val page = IdentityPage("/register", "Register")
 

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -22,7 +22,6 @@ class ResetPasswordController(api : IdApiClient,
                               val messagesApi: MessagesApi)
                              (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
-  import context._
 
   val page = IdentityPage("/reset-password", "Reset Password")
 

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -1,18 +1,18 @@
 package controllers
 
 import common.ExecutionContexts
-import model.{NoCache, IdentityPage}
-import play.api.data.{Forms, Form}
+import model.{ApplicationContext, IdentityPage, NoCache}
+import play.api.data.{Form, Forms}
 import play.api.mvc._
 import idapiclient.IdApiClient
-import services.{AuthenticationService, IdentityUrlBuilder, IdRequestParser}
-import play.api.i18n.{MessagesApi, Messages}
+import services.{AuthenticationService, IdRequestParser, IdentityUrlBuilder}
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.data.validation._
 import play.api.data.Forms._
 import play.api.data.format.Formats._
 import form.Mappings
-import play.api.Environment
 import utils.SafeLogging
+
 import scala.concurrent.Future
 
 class ResetPasswordController(api : IdApiClient,
@@ -20,8 +20,9 @@ class ResetPasswordController(api : IdApiClient,
                               idUrlBuilder: IdentityUrlBuilder,
                               authenticationService: AuthenticationService,
                               val messagesApi: MessagesApi)
-                             (implicit env: Environment)
+                             (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with implicits.Forms {
+  import context._
 
   val page = IdentityPage("/reset-password", "Reset Password")
 

--- a/identity/app/controllers/SaveContentController.scala
+++ b/identity/app/controllers/SaveContentController.scala
@@ -29,8 +29,9 @@ class SaveContentController(api: IdApiClient,
                             savedArticleService: PlaySavedArticlesService,
                             idUrlBuilder: IdentityUrlBuilder,
                             pageDataBuilder: SaveForLaterDataBuilder)
-                           (implicit env: Environment)
+                           (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
+  import context._
 
   import SavedArticleData._
 

--- a/identity/app/controllers/SaveContentController.scala
+++ b/identity/app/controllers/SaveContentController.scala
@@ -31,7 +31,6 @@ class SaveContentController(api: IdApiClient,
                             pageDataBuilder: SaveForLaterDataBuilder)
                            (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging {
-  import context._
 
   import SavedArticleData._
 

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -23,7 +23,6 @@ class SigninController(returnUrlVerifier: ReturnUrlVerifier,
                        val messagesApi: MessagesApi)
                       (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
-  import context._
 
   val page = IdentityPage("/signin", "Sign in")
 

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -5,7 +5,7 @@ import implicits.Forms
 import play.api.mvc._
 import play.api.data._
 import play.api.data.validation.Constraints
-import model.{IdentityPage, NoCache}
+import model.{ApplicationContext, IdentityPage, NoCache}
 import common.ExecutionContexts
 import services.{IdRequestParser, IdentityUrlBuilder, PlaySigninService, ReturnUrlVerifier}
 import idapiclient.IdApiClient
@@ -13,10 +13,7 @@ import play.api.i18n.{Messages, MessagesApi}
 import idapiclient.EmailPassword
 import utils.SafeLogging
 import form.Mappings
-import play.api.Environment
-
 import scala.concurrent.Future
-
 
 class SigninController(returnUrlVerifier: ReturnUrlVerifier,
                        api: IdApiClient,
@@ -24,8 +21,9 @@ class SigninController(returnUrlVerifier: ReturnUrlVerifier,
                        idUrlBuilder: IdentityUrlBuilder,
                        signInService : PlaySigninService,
                        val messagesApi: MessagesApi)
-                      (implicit env: Environment)
+                      (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings with Forms {
+  import context._
 
   val page = IdentityPage("/signin", "Sign in")
 

--- a/identity/app/controllers/ThirdPartyConditionsController.scala
+++ b/identity/app/controllers/ThirdPartyConditionsController.scala
@@ -7,8 +7,7 @@ import utils.ThirdPartyConditions
 import ThirdPartyConditions._
 import form.Mappings
 import idapiclient.IdApiClient
-import model.{IdentityPage, NoCache}
-import play.api.Environment
+import model.{ApplicationContext, IdentityPage, NoCache}
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import play.filters.csrf.CSRFAddToken
@@ -24,8 +23,9 @@ class ThirdPartyConditionsController(returnUrlVerifier: ReturnUrlVerifier,
                                      idUrlBuilder: IdentityUrlBuilder,
                                      authenticatedActions: AuthenticatedActions,
                                      val messagesApi: MessagesApi)
-                                    (implicit env: Environment)
+                                    (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings {
+  import context._
 
   import authenticatedActions.{agreeAction, authAction}
 

--- a/identity/app/controllers/ThirdPartyConditionsController.scala
+++ b/identity/app/controllers/ThirdPartyConditionsController.scala
@@ -25,7 +25,6 @@ class ThirdPartyConditionsController(returnUrlVerifier: ReturnUrlVerifier,
                                      val messagesApi: MessagesApi)
                                     (implicit context: ApplicationContext)
   extends Controller with ExecutionContexts with SafeLogging with Mappings {
-  import context._
 
   import authenticatedActions.{agreeAction, authAction}
 

--- a/identity/app/views/agree.scala.html
+++ b/identity/app/views/agree.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, groupCode: String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, groupCode: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.thirdPartyLandingPage
 @import views.html.fragments.thirdPartyConditions

--- a/identity/app/views/emailVerified.scala.html
+++ b/identity/app/views/emailVerified.scala.html
@@ -1,4 +1,4 @@
-@(state: controllers.ValidationState, page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl : String)(implicit request: RequestHeader, env: play.api.Environment)
+@(state: controllers.ValidationState, page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl : String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import controllers.ValidationState._
 @import views.html.fragments.registrationFooter

--- a/identity/app/views/formstack/formstackComplete.scala.html
+++ b/identity/app/views/formstack/formstackComplete.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches._
 
 <!DOCTYPE html>

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html class="js-off is-not-modern id--signed-out" lang="en-GB">

--- a/identity/app/views/formstack/formstackFormNotFound.scala.html
+++ b/identity/app/views/formstack/formstackFormNotFound.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches._
 
 <!DOCTYPE html>

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -3,7 +3,7 @@ idRequest: services.IdentityRequest,
 idUrlBuilder: services.IdentityUrlBuilder,
 passwordForm: Form[controllers.PasswordFormData],
 passwordExists: Boolean
-)(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField

--- a/identity/app/views/password/emailSent.scala.html
+++ b/identity/app/views/password/emailSent.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.registrationFooter
 

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -3,7 +3,7 @@
 @import services.{IdentityRequest, IdentityUrlBuilder}
 @import views.html.fragments.registrationFooter
 
-@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, projectName = Option("identity")){
 }{

--- a/identity/app/views/password/requestPasswordReset.scala.html
+++ b/identity/app/views/password/requestPasswordReset.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, emailForm: Form[(String)], errors: List[client.Error])(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, emailForm: Form[(String)], errors: List[client.Error])(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String)], token : String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, resetPasswordForm: Form[(String, String, String)], token : String)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField

--- a/identity/app/views/password/resetPasswordRequestNewToken.scala.html
+++ b/identity/app/views/password/resetPasswordRequestNewToken.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, requestNewTokenForm: Form[(String)])(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, requestNewTokenForm: Form[(String)])(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -6,7 +6,7 @@
 
 @import common.LinkTo
 
-@(page: model.Page, emailPrefsForm: Form[EmailPrefsData], formActionUrl: String, emailSubscriptions: EmailSubscriptions)(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, emailPrefsForm: Form[EmailPrefsData], formActionUrl: String, emailSubscriptions: EmailSubscriptions)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @emailListCategoryList(theme: String, subscriptions: List[EmailSubscription], isActive: Boolean) = {
     @fragments.dropdown(theme, isActive = isActive) {

--- a/identity/app/views/profile/savedForLater.scala.html
+++ b/identity/app/views/profile/savedForLater.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, savedArticleForm: Form[SavedArticleData], pageData: model.SaveForLaterPageData)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, savedArticleForm: Form[SavedArticleData], pageData: model.SaveForLaterPageData)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.SimplePagePaths
 @import controllers.SaveForLaterCleaner

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -4,7 +4,7 @@
         forms: controllers.ProfileForms,
         idRequest: services.IdentityRequest,
         idUrlBuilder: services.IdentityUrlBuilder
-)(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import views.html.fragments.form.{inputField, textareaField}
 @import views.html.fragments.registrationFooter

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -3,7 +3,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     user: com.gu.identity.model.User,
     activityType: String
-)(implicit request: RequestHeader, env: play.api.Environment)
+)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.fragments.registrationFooter
 
 @main(page, projectName = Option("identity")){

--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, reauthenticationForm: Form[String], loginHint: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, reauthenticationForm: Form[String], loginHint: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, registrationForm: Form[(String, String, String, String, String, Boolean, Boolean)], registrationErrorOpt: Option[String], groupCode: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, registrationForm: Form[(String, String, String, String, String, Boolean, Boolean)], registrationErrorOpt: Option[String], groupCode: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.{inputField, checkbox}

--- a/identity/app/views/registrationConfirmation.scala.html
+++ b/identity/app/views/registrationConfirmation.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, returnUrl : String)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, returnUrl : String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.registrationFooter
 

--- a/identity/app/views/signin.scala.html
+++ b/identity/app/views/signin.scala.html
@@ -1,5 +1,4 @@
-@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, signinForm: Form[(String, String, Boolean)], groupCode: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, env: play.api.Environment)
-
+@(page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder, signinForm: Form[(String, String, Boolean)], groupCode: Option[String])(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 @import form.IdFormHelpers._
 @import views.html.fragments.form.{inputField, checkbox}
 @import views.html.fragments.socialSignin

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -1,4 +1,4 @@
-@(user: com.gu.identity.model.User, page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, env: play.api.Environment)
+@(user: com.gu.identity.model.User, page: model.Page, idRequest: services.IdentityRequest, idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.html.fragments.registrationFooter
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
   with ShouldMatchers
   with MockitoSugar
   with OptionValues
-  with WithTestEnvironment
+  with WithTestContext
   with ConfiguredServer {
 
   trait EditProfileFixture {

--- a/identity/test/controllers/EmailControllerTest.scala
+++ b/identity/test/controllers/EmailControllerTest.scala
@@ -25,7 +25,7 @@ import actions.AuthenticatedActions
 @DoNotDiscover class EmailControllerTest extends WordSpec
   with ShouldMatchers
   with MockitoSugar
-  with WithTestEnvironment
+  with WithTestContext
   with ConfiguredTestSuite {
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.{ShouldMatchers, path}
 import services._
 import idapiclient.IdApiClient
 import org.scalatest.mock.MockitoSugar
-import test.{Fake, TestRequest, WithTestEnvironment}
+import test.{Fake, TestRequest, WithTestContext}
 import play.api.mvc.{Request, RequestHeader}
 
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ import actions.AuthenticatedActions
 
 class EmailVerificationControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar {
   val api = mock[IdApiClient]
   val idRequestParser = mock[IdRequestParser]

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -15,14 +15,14 @@ import org.scalatest.{ShouldMatchers, path}
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import services.{IdentityRequest, _}
-import test.{Fake, TestRequest, WithTestEnvironment}
+import test.{Fake, TestRequest, WithTestContext}
 
 import scala.concurrent.Future
 
 
 class FormstackControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar {
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val requestParser = mock[IdRequestParser]

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -10,7 +10,7 @@ import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import com.gu.identity.model.{PublicFields, User, UserDates}
 import services.IdentityRequest
-import test.{Fake, TestRequest, WithTestEnvironment}
+import test.{Fake, TestRequest, WithTestContext}
 import org.joda.time.DateTime
 
 import scala.concurrent.Future
@@ -19,7 +19,7 @@ import client.Auth
 
 class PublicProfileControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar {
   val idUrlBuilder = mock[IdentityUrlBuilder]
   val api = mock[IdApiClient]

--- a/identity/test/controllers/RegistrationControllerTest.scala
+++ b/identity/test/controllers/RegistrationControllerTest.scala
@@ -3,7 +3,7 @@ package controllers
 import org.scalatest.path
 import org.scalatest.{Matchers => ShouldMatchers}
 import org.scalatest.mock.MockitoSugar
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test.{Fake, I18NTestComponents, TestRequest, WithTestContext}
 import idapiclient.{EmailPassword, IdApiClient, TrackingData}
 import services._
 import play.api.test.Helpers._
@@ -21,7 +21,7 @@ import conf.IdentityConfiguration
 
 class RegistrationControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar  {
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]

--- a/identity/test/controllers/ResetPasswordControllerTest.scala
+++ b/identity/test/controllers/ResetPasswordControllerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.mock.MockitoSugar
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import idapiclient.{IdApiClient, TrackingData}
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test.{Fake, I18NTestComponents, TestRequest, WithTestContext}
 import play.api.test._
 import play.api.test.Helpers._
 import client.Error
@@ -18,7 +18,7 @@ import services.{AuthenticationService, IdRequestParser, IdentityRequest, Identi
 
 class ResetPasswordControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar {
 
   val api = mock[IdApiClient]

--- a/identity/test/controllers/SigninControllerTest.scala
+++ b/identity/test/controllers/SigninControllerTest.scala
@@ -8,7 +8,7 @@ import org.mockito.Matchers._
 import services._
 import idapiclient.IdApiClient
 import play.api.test._
-import test.{Fake, I18NTestComponents, TestRequest, WithTestEnvironment}
+import test.{Fake, I18NTestComponents, TestRequest, WithTestContext}
 
 import scala.concurrent.Future
 import client.Auth
@@ -26,7 +26,7 @@ import play.api.mvc.RequestHeader
 
 class SigninControllerTest extends path.FreeSpec
   with ShouldMatchers
-  with WithTestEnvironment
+  with WithTestContext
   with MockitoSugar {
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val requestParser = mock[IdRequestParser]

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -592,7 +592,7 @@ class IdApiTest extends path.FreeSpec with ShouldMatchers with MockitoSugar {
   "synchronous version" - {
     val syncApi = new SynchronousIdApi(apiRoot, http, jsonParser, clientAuth)
 
-    "should use current thread context" in {
+    "should use current thread testContext" in {
       syncApi.executionContext should equal(ExecutionContexts.currentThreadContext)
     }
   }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -5,7 +5,6 @@ import contentapi.ContentApiClient
 import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.libs.json._
 import play.api.mvc.{Action, Controller, RequestHeader}
 import views.support.FaciaToMicroFormat2Helpers._
@@ -16,7 +15,8 @@ class MostPopularController(contentApiClient: ContentApiClient,
                             geoMostPopularAgent: GeoMostPopularAgent,
                             dayMostPopularAgent: DayMostPopularAgent,
                             mostPopularAgent: MostPopularAgent)
-                           (implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+                           (implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
   val page = SimplePage(MetaData.make(
     "most-read",
     Some(SectionSummary.fromId("most-read")),

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -16,8 +16,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
                             dayMostPopularAgent: DayMostPopularAgent,
                             mostPopularAgent: MostPopularAgent)
                            (implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
-  val page = SimplePage(MetaData.make(
+    val page = SimplePage(MetaData.make(
     "most-read",
     Some(SectionSummary.fromId("most-read")),
     "Most read"

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -5,12 +5,12 @@ import feed.MostViewedGalleryAgent
 import layout.{CollectionEssentials, FaciaContainer}
 import model._
 import model.pressed.CollectionConfig
-import play.api.Environment
 import play.api.mvc.{Action, Controller, RequestHeader}
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
-class MostViewedGalleryController(mostViewedGalleryAgent: MostViewedGalleryAgent)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class MostViewedGalleryController(mostViewedGalleryAgent: MostViewedGalleryAgent)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   private val page = SimplePage(MetaData.make(
     "more galleries",

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -10,7 +10,6 @@ import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
 class MostViewedGalleryController(mostViewedGalleryAgent: MostViewedGalleryAgent)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   private val page = SimplePage(MetaData.make(
     "more galleries",

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -5,13 +5,14 @@ import weather.controllers.{LocationsController, WeatherController}
 import business.StocksData
 import contentapi.ContentApiClient
 import feed._
+import model.ApplicationContext
 import play.api.Environment
 import play.api.libs.ws.WSClient
 import weather.WeatherApi
 
 trait OnwardControllers {
 
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   def wsClient: WSClient
   def contentApiClient: ContentApiClient
   def stocksData: StocksData

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -14,7 +14,6 @@ import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
 import scala.concurrent.duration._
 
 class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent)(implicit context: ApplicationContext) extends Controller with Related with Containers with Logging with ExecutionContexts {
-  import context._
 
   private val page = SimplePage(MetaData.make(
     "related-content",

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -6,7 +6,6 @@ import contentapi.ContentApiClient
 import feed.MostReadAgent
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.libs.json._
 import play.api.mvc.{Action, Controller, RequestHeader}
 import services._
@@ -14,7 +13,8 @@ import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
 
 import scala.concurrent.duration._
 
-class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent)(implicit env: Environment) extends Controller with Related with Containers with Logging with ExecutionContexts {
+class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent)(implicit context: ApplicationContext) extends Controller with Related with Containers with Logging with ExecutionContexts {
+  import context._
 
   private val page = SimplePage(MetaData.make(
     "related-content",

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -10,7 +10,6 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import play.twirl.api.HtmlFormat
 
 class RichLinkController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Paging with Logging with ExecutionContexts with Requests   {
-  import context._
 
   def renderHtml(path: String) = render(path)
 
@@ -37,7 +36,7 @@ class RichLinkController(contentApiClient: ContentApiClient)(implicit context: A
   private def renderContent(content: ContentType)(implicit request: RequestHeader) = {
     def contentResponse: HtmlFormat.Appendable = views.html.fragments.richLinkBody(content)(request)
 
-    if (!request.isJson) NoCache(Ok(views.html.richLink(content)(request, context.environment)))
+    if (!request.isJson) NoCache(Ok(views.html.richLink(content)(request, context)))
     else Cached(900) {
       JsonComponent(contentResponse)
     }

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -3,15 +3,14 @@ package controllers
 import play.api.mvc.{Action, Controller, RequestHeader}
 import common.{Edition, ExecutionContexts, JsonComponent, Logging}
 import implicits.Requests
-import model.{Cached, Content, ContentType, NoCache}
-
+import model.{ApplicationContext, Cached, Content, ContentType, NoCache}
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.ItemResponse
-import play.api.Environment
 import play.twirl.api.HtmlFormat
 
-class RichLinkController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Paging with Logging with ExecutionContexts with Requests   {
+class RichLinkController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Paging with Logging with ExecutionContexts with Requests   {
+  import context._
 
   def renderHtml(path: String) = render(path)
 
@@ -38,7 +37,7 @@ class RichLinkController(contentApiClient: ContentApiClient)(implicit env: Envir
   private def renderContent(content: ContentType)(implicit request: RequestHeader) = {
     def contentResponse: HtmlFormat.Appendable = views.html.fragments.richLinkBody(content)(request)
 
-    if (!request.isJson) NoCache(Ok(views.html.richLink(content)(request, env)))
+    if (!request.isJson) NoCache(Ok(views.html.richLink(content)(request, context.environment)))
     else Cached(900) {
       JsonComponent(contentResponse)
     }

--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -6,7 +6,6 @@ import model.{ApplicationContext, Cached, MetaData, SectionSummary}
 import play.api.mvc.{Action, Controller}
 
 class TechFeedbackController (implicit context: ApplicationContext) extends Controller with Logging {
-  import context._
 
   def techFeedback(path: String) = Action { implicit request =>
     val page = model.SimplePage(MetaData.make(

--- a/onward/app/controllers/TechFeedbackController.scala
+++ b/onward/app/controllers/TechFeedbackController.scala
@@ -2,11 +2,11 @@ package controllers
 
 import common._
 import model.Cached.RevalidatableResult
-import model.{Cached, MetaData, SectionSummary}
-import play.api.Environment
+import model.{ApplicationContext, Cached, MetaData, SectionSummary}
 import play.api.mvc.{Action, Controller}
 
-class TechFeedbackController (implicit env: Environment) extends Controller with Logging {
+class TechFeedbackController (implicit context: ApplicationContext) extends Controller with Logging {
+  import context._
 
   def techFeedback(path: String) = Action { implicit request =>
     val page = model.SimplePage(MetaData.make(

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -12,7 +12,6 @@ import play.twirl.api.Html
 import scala.concurrent.Future
 
 class TopStoriesController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with Paging with ExecutionContexts {
-  import context._
 
   def renderTopStoriesHtml = renderTopStories()
   def renderTopStories() = Action.async { implicit request =>

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -6,13 +6,13 @@ import contentapi.ContentApiClient
 import model.Cached.RevalidatableResult
 import model._
 import model.pressed.PressedContent
-import play.api.Environment
 import play.api.mvc.{Action, Controller, RequestHeader}
 import play.twirl.api.Html
 
 import scala.concurrent.Future
 
-class TopStoriesController(contentApiClient: ContentApiClient)(implicit env: Environment) extends Controller with Logging with Paging with ExecutionContexts {
+class TopStoriesController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with Paging with ExecutionContexts {
+  import context._
 
   def renderTopStoriesHtml = renderTopStories()
   def renderTopStories() = Action.async { implicit request =>
@@ -48,7 +48,7 @@ class TopStoriesController(contentApiClient: ContentApiClient)(implicit env: Env
       }
   }
 
-  private def renderTopStoriesPage(trails: Seq[PressedContent])(implicit request: RequestHeader, env: Environment) = {
+  private def renderTopStoriesPage(trails: Seq[PressedContent])(implicit request: RequestHeader) = {
     val page = SimplePage( MetaData.make(
       "top-stories",
       Some(SectionSummary.fromId("top-stories")),

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, path: String)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, path: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 

--- a/onward/app/views/mostPopular.scala.html
+++ b/onward/app/views/mostPopular.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, popular: Seq[model.MostPopular])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, popular: Seq[model.MostPopular])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.`package`._
 

--- a/onward/app/views/mostViewedGalleries.scala.html
+++ b/onward/app/views/mostViewedGalleries.scala.html
@@ -1,6 +1,6 @@
 @import model.Page
 
-@(page: Page, container: Html)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page, container: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, Some("facia")){
 }{

--- a/onward/app/views/relatedContent.scala.html
+++ b/onward/app/views/relatedContent.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){ }{
     <main itemprop="mainContentOfPage" role="main" class="monocolumn-wrapper content">

--- a/onward/app/views/richLink.scala.html
+++ b/onward/app/views/richLink.scala.html
@@ -1,4 +1,4 @@
-@(content: model.ContentType)(implicit request: RequestHeader, env: play.api.Environment)
+@(content: model.ContentType)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches._
 @import conf.Static
 @import conf.Configuration
@@ -9,7 +9,7 @@
         <link rel="stylesheet" type="text/css" href="@Static("stylesheets/webfonts-hinting-off-kerning-on.css")" />
 
 
-        @if(env.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
+        @if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
             <link rel="stylesheet" data-reload="head.rich-links" type="text/css" href="@Static("stylesheets/head.rich-links.css")" />
         } else {
             <style>

--- a/onward/app/views/topStories.scala.html
+++ b/onward/app/views/topStories.scala.html
@@ -1,6 +1,6 @@
 @import model.Page
 
-@(page: Page, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page){
 }{

--- a/onward/test/ContentCardControllerTest.scala
+++ b/onward/test/ContentCardControllerTest.scala
@@ -11,7 +11,7 @@ import play.api.test.Helpers._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val article = "/world/2014/nov/18/hereford-hospital-patient-tested-for-ebola"

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -13,7 +13,7 @@ import services.OphanApi
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   val tag = "technology"

--- a/onward/test/RelatedControllerTest.scala
+++ b/onward/test/RelatedControllerTest.scala
@@ -15,7 +15,7 @@ import services.OphanApi
   with BeforeAndAfterAll
   with WithTestWsClient
   with WithTestContentApiClient
-  with WithTestEnvironment {
+  with WithTestContext {
 
   val article = "uk/2012/aug/07/woman-torture-burglary-waterboard-surrey"
   val badArticle = "i/am/not/here"

--- a/onward/test/TopStoriesControllerTest.scala
+++ b/onward/test/TopStoriesControllerTest.scala
@@ -12,6 +12,7 @@ import play.api.Environment
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
+  with WithTestEnvironment
   with WithTestContentApiClient {
 
   lazy val topStoriesController = new TopStoriesController(testContentApiClient)

--- a/onward/test/TopStoriesControllerTest.scala
+++ b/onward/test/TopStoriesControllerTest.scala
@@ -12,7 +12,7 @@ import play.api.Environment
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestContentApiClient {
 
   lazy val topStoriesController = new TopStoriesController(testContentApiClient)

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -3,7 +3,7 @@ package controllers.preview
 import contentapi.{ContentApiClient, SectionsLookUp}
 import controllers.{FaciaController, IndexController}
 import controllers.front.FrontJsonFapi
-import play.api.Environment
+import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import services.ConfigAgent
 
@@ -11,7 +11,7 @@ class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
   val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
 }
 
-class FaciaDraftController(val frontJsonFapi: FrontJsonFapi, contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit val env: Environment) extends FaciaController {
+class FaciaDraftController(val frontJsonFapi: FrontJsonFapi, contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit val context: ApplicationContext) extends FaciaController {
 
   private val indexController = new IndexController(contentApiClient, sectionsLookUp)
 

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -7,7 +7,7 @@ import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import contentapi._
 import controllers.{HealthCheck, RssController}
 import dev.DevParametersHttpRequestHandler
-import model.ApplicationIdentity
+import model.{ApplicationContext, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpRequestHandler

--- a/rss/app/controllers/RssController.scala
+++ b/rss/app/controllers/RssController.scala
@@ -4,12 +4,10 @@ import common._
 import contentapi.{ContentApiClient, SectionsLookUp}
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.mvc.{RequestHeader, Result}
 import services.IndexPage
 
-class RssController(val contentApiClient: ContentApiClient, val sectionsLookUp: SectionsLookUp, playEnv: Environment) extends IndexControllerCommon {
-  override val env: Environment = playEnv
+class RssController(val contentApiClient: ContentApiClient, val sectionsLookUp: SectionsLookUp)(implicit val context: ApplicationContext) extends IndexControllerCommon {
   override protected def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader): Result = Cached(model.page) {
     val body = TrailsToRss(model.page.metadata, model.trails.map(_.trail))
     RevalidatableResult(Ok(body).as("text/xml; charset=utf-8"), body)

--- a/sport/app/cricket/controllers/CricketControllers.scala
+++ b/sport/app/cricket/controllers/CricketControllers.scala
@@ -2,10 +2,11 @@ package cricket.controllers
 
 import com.softwaremill.macwire._
 import jobs.CricketStatsJob
+import model.ApplicationContext
 import play.api.Environment
 
 trait CricketControllers {
   def cricketStatsJob: CricketStatsJob
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val cricketMatchController = wire[CricketMatchController]
 }

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -17,7 +17,6 @@ case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam)
 }
 
 class CricketMatchController(cricketStatsJob: CricketStatsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def renderMatchIdJson(date: String, teamId: String) = renderMatchId(date, teamId)
 

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -7,7 +7,6 @@ import cricketPa.{CricketTeam, CricketTeams}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
-import play.api.Environment
 import play.api.mvc.{Action, Controller}
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
@@ -17,7 +16,8 @@ case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam)
     webTitle = s"${theMatch.competitionName}, ${theMatch.venueName}")
 }
 
-class CricketMatchController(cricketStatsJob: CricketStatsJob)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class CricketMatchController(cricketStatsJob: CricketStatsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def renderMatchIdJson(date: String, teamId: String) = renderMatchId(date, teamId)
 

--- a/sport/app/cricket/views/cricketMatch.scala.html
+++ b/sport/app/cricket/views/cricketMatch.scala.html
@@ -1,7 +1,7 @@
 @import common.LinkTo
 @import cricket.controllers.CricketMatchPage
 
-@(page: CricketMatchPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: CricketMatchPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, "football"){ } {
     <div class="l-side-margins">

--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -7,7 +7,6 @@ import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 
 class CompetitionListController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
-  import context._
 
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions")
 

--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -3,11 +3,11 @@ package football.controllers
 import common._
 import conf.switches.Switches
 import feed.CompetitionsService
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.{Action, Controller}
 
-
-class CompetitionListController(val competitionsService: CompetitionsService)(implicit env: Environment) extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
+class CompetitionListController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
+  import context._
 
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions")
 

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -11,7 +11,6 @@ import play.api.mvc.{Action, AnyContent}
 
 
 class FixturesController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionFixtureFilters {
-  import context._
 
   private def fixtures(date: LocalDate) = FixturesList(date, competitionsService.competitions)
   private val page = new FootballPage("football/fixtures", "football", "All fixtures")

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -10,7 +10,8 @@ import play.api.Environment
 import play.api.mvc.{Action, AnyContent}
 
 
-class FixturesController(val competitionsService: CompetitionsService)(implicit env: Environment) extends MatchListController with CompetitionFixtureFilters {
+class FixturesController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionFixtureFilters {
+  import context._
 
   private def fixtures(date: LocalDate) = FixturesList(date, competitionsService.competitions)
   private val page = new FootballPage("football/fixtures", "football", "All fixtures")

--- a/sport/app/football/controllers/FootballControllers.scala
+++ b/sport/app/football/controllers/FootballControllers.scala
@@ -4,13 +4,14 @@ import com.softwaremill.macwire._
 import conf.FootballClient
 import contentapi.ContentApiClient
 import feed.CompetitionsService
+import model.ApplicationContext
 import play.api.Environment
 
 trait FootballControllers {
   def competitionsService: CompetitionsService
   def footballClient: FootballClient
   def contentApiClient: ContentApiClient
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val fixturesController = wire[FixturesController]
   lazy val resultsController = wire[ResultsController]
   lazy val matchDayController = wire[MatchDayController]

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -6,7 +6,6 @@ import feed.CompetitionsService
 import play.api.mvc.{Action, Controller}
 import model._
 import model.Page
-import play.api.Environment
 
 case class TablesPage(
     page: Page,
@@ -17,7 +16,8 @@ case class TablesPage(
   lazy val singleCompetition = tables.size == 1
 }
 
-class LeagueTableController(val competitionsService: CompetitionsService)(implicit env: Environment) extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
+class LeagueTableController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
+  import context._
 
     val tableOrder = Seq(
         "Premier League",

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -17,7 +17,6 @@ case class TablesPage(
 }
 
 class LeagueTableController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
-  import context._
 
     val tableOrder = Seq(
         "Premier League",

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -46,7 +46,8 @@ case class MatchPage(theMatch: FootballMatch, lineUp: LineUp) extends Standalone
   )
 }
 
-class MatchController(competitionsService: CompetitionsService)(implicit env: Environment) extends Controller with Football with Requests with Logging with ExecutionContexts {
+class MatchController(competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Football with Requests with Logging with ExecutionContexts {
+  import context._
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMMdd")
 

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -47,7 +47,6 @@ case class MatchPage(theMatch: FootballMatch, lineUp: LineUp) extends Standalone
 }
 
 class MatchController(competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Football with Requests with Logging with ExecutionContexts {
-  import context._
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMMdd")
 

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -9,7 +9,8 @@ import common.{Edition, JsonComponent}
 import play.api.Environment
 
 
-class MatchDayController(val competitionsService: CompetitionsService)(implicit env: Environment) extends MatchListController with CompetitionLiveFilters {
+class MatchDayController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionLiveFilters {
+  import context._
 
   def liveMatchesJson() = liveMatches()
   def liveMatches(): Action[AnyContent] =

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -10,7 +10,6 @@ import play.api.Environment
 
 
 class MatchDayController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionLiveFilters {
-  import context._
 
   def liveMatchesJson() = liveMatches()
   def liveMatches(): Action[AnyContent] =

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -4,14 +4,13 @@ import feed.Competitions
 import model.Cached.RevalidatableResult
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.LocalDate
-import model.{Cached, Competition, Page, TeamMap}
+import model.{ApplicationContext, Cached, Competition, Page, TeamMap}
 import football.model.MatchesList
 import play.api.mvc.{Controller, RequestHeader}
 import common.{Edition, JsonComponent}
 import play.twirl.api.Html
 import implicits.Requests
 import pa.FootballTeam
-import play.api.Environment
 
 trait MatchListController extends Controller with Requests {
   val competitionsService: Competitions
@@ -19,7 +18,7 @@ trait MatchListController extends Controller with Requests {
   protected def createDate(year: String, month: String, day: String): LocalDate =
     datePattern.parseDateTime(s"$year$month$day").toLocalDate
 
-  protected def renderMatchList(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, env: Environment) = {
+  protected def renderMatchList(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if (request.isJson)
         JsonComponent(
@@ -32,7 +31,7 @@ trait MatchListController extends Controller with Requests {
     }
   }
 
-  protected def renderMoreMatches(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, env: Environment) = {
+  protected def renderMoreMatches(page: Page, matchesList: MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, context: ApplicationContext) = {
     Cached(10) {
       if(request.isJson)
         JsonComponent(

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -11,7 +11,6 @@ import model.Competition
 import play.api.Environment
 
 class ResultsController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionResultFilters {
-  import context._
 
   private def competitionOrTeam(tag: String): Option[Either[Competition, FootballTeam]] = {
     lookupCompetition(tag).map(Left(_))

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -10,7 +10,8 @@ import pa.FootballTeam
 import model.Competition
 import play.api.Environment
 
-class ResultsController(val competitionsService: CompetitionsService)(implicit env: Environment) extends MatchListController with CompetitionResultFilters {
+class ResultsController(val competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends MatchListController with CompetitionResultFilters {
+  import context._
 
   private def competitionOrTeam(tag: String): Option[Either[Competition, FootballTeam]] = {
     lookupCompetition(tag).map(Left(_))

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -4,12 +4,11 @@ import feed.CompetitionsService
 import model.Cached.RevalidatableResult
 import play.api.mvc.{Action, Controller}
 import common.{ExecutionContexts, Logging}
-import model.Cached
+import model.{ApplicationContext, Cached}
 import football.model.CompetitionStage
-import play.api.Environment
 
-
-class WallchartController(competitionsService: CompetitionsService)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class WallchartController(competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def renderWallchartEmbed(competitionTag: String) = renderWallchart(competitionTag, true)
   def renderWallchart(competitionTag: String, embed: Boolean = false) = Action { implicit request =>

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -8,7 +8,6 @@ import model.{ApplicationContext, Cached}
 import football.model.CompetitionStage
 
 class WallchartController(competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def renderWallchartEmbed(competitionTag: String) = renderWallchart(competitionTag, true)
   def renderWallchart(competitionTag: String, embed: Boolean = false) = Action { implicit request =>

--- a/sport/app/football/views/competitions.scala.html
+++ b/sport/app/football/views/competitions.scala.html
@@ -1,7 +1,7 @@
 @import football.controllers.CompetitionFilter
 @import model.Page
 
-@(competitions: Map[String, Seq[CompetitionFilter]], page: Page, competitionList: List[String])(implicit request: RequestHeader, env: play.api.Environment)
+@(competitions: Map[String, Seq[CompetitionFilter]], page: Page, competitionList: List[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, "football"){
 }{

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, matchesList: football.model.MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, matchesList: football.model.MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches
 @import football.model._

--- a/sport/app/football/views/matchStats/matchStatsPage.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsPage.scala.html
@@ -4,7 +4,7 @@
 @import views.FootballHelpers._
 
 
-@(page: MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @team(players: Seq[LineUpPlayer]) = {
     <ul class="team-list u-unstyled">

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -1,7 +1,7 @@
 @import football.controllers.TablesPage
 @import views.support.`package`.Seq2zipWithRowInfo
 
-@(page: TablesPage)(implicit request: RequestHeader, env: play.api.Environment)
+@(page: TablesPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page.page, "football"){
 }{

--- a/sport/app/football/views/teamlist.scala.html
+++ b/sport/app/football/views/teamlist.scala.html
@@ -1,4 +1,4 @@
-@(pageModel: TablesPage, comps: Seq[model.Competition])(implicit request: RequestHeader, env: play.api.Environment)
+@(pageModel: TablesPage, comps: Seq[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(pageModel.page, "football"){
 }{

--- a/sport/app/football/views/wallchart/embed.scala.html
+++ b/sport/app/football/views/wallchart/embed.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: model.Page, competition: model.Competition, competitionStages: List[_root_.football.model.CompetitionStageLike])(implicit request: RequestHeader, context: model.ApplicationContext)
 <!DOCTYPE html>
 <html class="js-off is-not-modern id--signed-out" lang="en-GB">
     <head>

--- a/sport/app/football/views/wallchart/page.scala.html
+++ b/sport/app/football/views/wallchart/page.scala.html
@@ -1,7 +1,7 @@
 @import _root_.football.model.CompetitionStageLike
 @import model.{Competition, Page}
 
-@(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, "football"){
 }{

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -2,8 +2,7 @@ package rugby.controllers
 
 import common._
 import model.Cached.RevalidatableResult
-import model.{Cached, MetaData, SectionSummary, StandalonePage}
-import play.api.Environment
+import model.{ApplicationContext, Cached, MetaData, SectionSummary, StandalonePage}
 import play.api.mvc.{Action, Controller}
 import play.twirl.api.Html
 import rugby.jobs.RugbyStatsJob
@@ -16,7 +15,8 @@ case class MatchPage(liveScore: Match) extends StandalonePage {
     webTitle = s"${liveScore.homeTeam.name} v ${liveScore.awayTeam.name}")
 }
 
-class MatchesController(rugbyStatsJob: RugbyStatsJob)(implicit env: Environment) extends Controller with Logging with ExecutionContexts {
+class MatchesController(rugbyStatsJob: RugbyStatsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
+  import context._
 
   def scoreJson(year: String, month: String, day: String, homeTeamId: String, awayTeamId: String) = score(year, month, day, homeTeamId, awayTeamId)
 

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -16,7 +16,6 @@ case class MatchPage(liveScore: Match) extends StandalonePage {
 }
 
 class MatchesController(rugbyStatsJob: RugbyStatsJob)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
-  import context._
 
   def scoreJson(year: String, month: String, day: String, homeTeamId: String, awayTeamId: String) = score(year, month, day, homeTeamId, awayTeamId)
 

--- a/sport/app/rugby/controllers/RugbyControllers.scala
+++ b/sport/app/rugby/controllers/RugbyControllers.scala
@@ -2,11 +2,12 @@
 package rugby.controllers
 
 import com.softwaremill.macwire._
+import model.ApplicationContext
 import play.api.Environment
 import rugby.jobs.RugbyStatsJob
 
 trait RugbyControllers {
   def rugbyStatsJob: RugbyStatsJob
-  implicit def environment: Environment
+  implicit def appContext: ApplicationContext
   lazy val matchesController = wire[MatchesController]
 }

--- a/sport/app/rugby/views/matchSummary.scala.html
+++ b/sport/app/rugby/views/matchSummary.scala.html
@@ -1,7 +1,7 @@
 @import model.Page
 @import rugby.model.{Match, ScoreEvent}
 
-@(page: Page, theMatch: Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader, env: play.api.Environment)
+@(page: Page, theMatch: Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @main(page, "football") { } {
     <div class="l-side-margins">

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -13,7 +13,7 @@ import org.scalatest._
   with FootballTestData
   with WithTestFootballClient
   with BeforeAndAfterAll
-  with WithTestEnvironment
+  with WithTestContext
   with WithTestWsClient {
 
   feature("League Tables") {

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-    with WithTestEnvironment
+    with WithTestContext
     with WithTestWsClient {
 
   val url = "/football/competitionsService"

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest._
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-    with WithTestEnvironment
+    with WithTestContext
     with WithTestWsClient {
 
   val fixturesUrl = "/football/fixtures"

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-    with WithTestEnvironment
+    with WithTestContext
     with WithTestWsClient {
 
   val leagueTableController = new LeagueTableController(testCompetitionsService)

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   with BeforeAndAfterAll
   with WithTestWsClient
   with WithTestFootballClient
-  with WithTestEnvironment
+  with WithTestContext
   with FootballTestData {
 
   val matchController = new MatchController(testCompetitionsService)

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.JsValue
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.{FootballTestData, WithTestEnvironment, WithTestFootballClient, WithTestWsClient}
+import test.{FootballTestData, WithTestContext, WithTestFootballClient, WithTestWsClient}
 
 import scala.concurrent.Future
 
@@ -16,7 +16,7 @@ import scala.concurrent.Future
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll
-    with WithTestEnvironment
+    with WithTestContext
     with WithTestWsClient {
 
   val resultsController = new ResultsController(testCompetitionsService)

--- a/standalone/app/controllers/FaciaDraftController.scala
+++ b/standalone/app/controllers/FaciaDraftController.scala
@@ -3,13 +3,13 @@ package controllers
 import com.gu.contentapi.client.model.v1.ItemResponse
 import contentapi.{ContentApiClient, SectionsLookUp}
 import controllers.front.FrontJsonFapiDraft
-import play.api.Environment
+import model.ApplicationContext
 import play.api.mvc.{RequestHeader, Result}
 import services.ConfigAgent
 
 import scala.concurrent.Future
 
-class FaciaDraftController(val frontJsonFapi: FrontJsonFapiDraft, contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit val env: Environment) extends FaciaController with RendersItemResponse {
+class FaciaDraftController(val frontJsonFapi: FrontJsonFapiDraft, contentApiClient: ContentApiClient, sectionsLookUp: SectionsLookUp)(implicit val context: ApplicationContext) extends FaciaController with RendersItemResponse {
 
   private val indexController = new IndexController(contentApiClient, sectionsLookUp)
 


### PR DESCRIPTION
## What does this change?
In preparation of more DI into controllers and html/js templates, we are
now injecting an ApplicationContext instance which now contains a
reference to the Environment. In future PRs  we will add the
ApplicationIdentity into this ApplicationContext which would
allow us to make it available to controllers and templates without
having to modify every files in the project

## What is the value of this and can you measure success?
=> Play 2.5

## Does this affect other platforms - Amp, Apps, etc?
No


<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
