### PR TITLE
Remove archive transition route

### DIFF
--- a/archive/app/controllers/HealthCheck.scala
+++ b/archive/app/controllers/HealthCheck.scala
@@ -4,5 +4,5 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
 class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html")
+  NeverExpiresSingleHealthCheck(routes.ArchiveController.lookup("/Adzip/adzip-fb.html").url)
 )(wsClient)

--- a/archive/conf/routes
+++ b/archive/conf/routes
@@ -5,10 +5,6 @@
 
 GET        /_healthcheck                            controllers.HealthCheck.healthCheck()
 
-# Adding this here to support transition while removing www.theguardian.com from the router redirect
-# We want to temporarily support both /404/www.theguardian.com/path AND /404/path in the same way
-GET        /404/www.theguardian.com$path<.*>        controllers.ArchiveController.lookup(path)
-
 # 404
 GET        /404$path</.*>                           controllers.ArchiveController.lookup(path)
 


### PR DESCRIPTION
## What does this change?
Take 2 of removing the old archive route - this time with a working healthcheck...

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

