### PR TITLE
Remove Play.current in assets css object

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -6,7 +6,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.{GalleryCaptionCleaner, RenderClasses}
 
-@(page: GalleryPage)(implicit request: RequestHeader)
+@(page: GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <div class="l-side-margins l-side-margins--media l-side-margins--gallery">
 

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,4 +1,4 @@
-@(page: ImageContentPage)(implicit request: RequestHeader)
+@(page: ImageContentPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import layout.ContentWidths.ImageContentMedia
 @import views.support.Commercial._
 @import views.support.RenderClasses

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -1,4 +1,4 @@
-@(index: services.IndexPage)(implicit request: RequestHeader)
+@(index: services.IndexPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.commercial.PaidContent
 @import common.{Edition, PagePaths}
 @import model.FrontProperties

--- a/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
+++ b/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
@@ -5,7 +5,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import views.support.{ImgSrc, RenderClasses}
 
-@(page: GalleryPage)(implicit request: RequestHeader)
+@(page: GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <div class="l-side-margins l-side-margins--media">
 

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -2,6 +2,7 @@ package common.Assets
 
 import common.{Logging, RelativePathEscaper}
 import conf.Configuration
+import model.ApplicationContext
 import org.apache.commons.io.IOUtils
 import play.api.libs.json._
 import play.api.{Mode, Play}
@@ -52,20 +53,20 @@ object css {
 
   private val memoizedCss: ConcurrentMap[String, Try[String]] = TrieMap()
 
-  def head(projectOverride: Option[String]) = inline(cssHead(projectOverride.getOrElse(Configuration.environment.projectName)))
-  def inlineStoryPackage = inline("story-package")
-  def inlineExplore = inline("article-explore")
-  def amp = inline("head.amp")
-  def hostedAmp = inline("head.hosted-amp")
+  def head(projectOverride: Option[String])(implicit context: ApplicationContext) = inline(cssHead(projectOverride.getOrElse(Configuration.environment.projectName)))
+  def inlineStoryPackage(implicit context: ApplicationContext) = inline("story-package")
+  def inlineExplore(implicit context: ApplicationContext) = inline("article-explore")
+  def amp(implicit context: ApplicationContext) = inline("head.amp")
+  def hostedAmp(implicit context: ApplicationContext) = inline("head.hosted-amp")
 
   def projectCss(projectOverride: Option[String]) = project(projectOverride.getOrElse(Configuration.environment.projectName))
   def headOldIE(projectOverride: Option[String]) = cssOldIE(projectOverride.getOrElse(Configuration.environment.projectName))
   def headIE9(projectOverride: Option[String]) = cssIE9(projectOverride.getOrElse(Configuration.environment.projectName))
 
 
-  private def inline(module: String): String = {
+  private def inline(module: String)(implicit context: ApplicationContext): String = {
     val resourceName = s"assets/inline-stylesheets/$module.css"
-    Get(if (Play.current.mode == Mode.Dev) {
+    Get(if (context.environment.mode == Mode.Dev) {
       LoadFromClasspath(resourceName)
     } else {
       memoizedCss.getOrElseUpdate(resourceName, LoadFromClasspath(resourceName))

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -12,7 +12,7 @@
   isPaidFront: Boolean = false,
   maybeContainerModel: Option[ContainerModel] = None,
   showFrontBranding: Boolean = false
-  )(implicit request: RequestHeader)
+  )(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,7 +1,7 @@
 @(content: model.ContentType,
   related: model.RelatedContent,
   cssClass: String = "",
-  isPaidContent: Boolean)(implicit request: RequestHeader)
+  isPaidContent: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.Edition
 @import views.support.ContentFooterContainersLayout
 

--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -3,7 +3,7 @@
 @import model.ContentPage
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
-@(page: ContentPage)(implicit request: RequestHeader)
+@(page: ContentPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @defining((
     page.item.elements.hasMainEmbed,

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -1,6 +1,6 @@
 @(content: model.ContentType,
   related: model.RelatedContent,
-  isPaidContent: Boolean)(implicit request: RequestHeader)
+  isPaidContent: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import layout.FaciaContainer
 @import views.html.fragments.containers
@@ -8,7 +8,7 @@
 @container(title: String, dataId: String, href: Option[String]) = {
     @containers.facia_cards.container(
         FaciaContainer.forStoryPackage(dataId, related.faciaItems, title, href)
-    )(request)
+    )
 }
 
 @defining(Seq("related") ++ (if(isPaidContent) Seq("paid-content--advertisement-feature") else Nil)) { classes =>

--- a/facia/app/views/fragments/brandedFrontBody.scala.html
+++ b/facia/app/views/fragments/brandedFrontBody.scala.html
@@ -1,4 +1,4 @@
-@(faciaPage: model.PressedPage)(implicit request: RequestHeader)
+@(faciaPage: model.PressedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.Edition
 @import common.commercial.{ContainerModel, PaidContent, Sponsored}
 @import views.support.RenderClasses

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,7 +1,7 @@
 @import common.Edition
 @import common.commercial.{ContainerModel, PaidContent, Sponsored}
 @import views.support.RenderClasses
-@(faciaPage: model.PressedPage)(implicit request: RequestHeader)
+@(faciaPage: model.PressedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @defining((faciaPage.branding(Edition(request)).exists(_.sponsorshipType == Sponsored),
            faciaPage.branding(Edition(request)).exists(_.sponsorshipType == PaidContent))) { case (isSponsored, isAdFeature) =>

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -14,7 +14,7 @@ import slices.{Fixed, FixedContainers}
 
 import scala.concurrent.Future
 
-class MediaInSectionController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class MediaInSectionController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with Paging with ExecutionContexts with Requests {
   // These exist to work around the absence of default values in Play routing.
   def renderSectionMediaWithSeries(mediaType: String, sectionId: String, seriesId: String) =
     renderMedia(mediaType, sectionId, Some(seriesId))
@@ -87,7 +87,7 @@ class MediaInSectionController(contentApiClient: ContentApiClient) extends Contr
         componentId
       ).withTimeStamps,
       FrontProperties.empty
-    )(request)
+    )
     renderFormat(response, response, 900)
   }
 }

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -4,12 +4,12 @@ import common._
 import feed.MostViewedAudioAgent
 import layout.{CollectionEssentials, FaciaContainer}
 import model.pressed.CollectionConfig
-import model.{RelatedContentItem, Cached, FrontProperties}
+import model.{ApplicationContext, Cached, FrontProperties, RelatedContentItem}
 import play.api.mvc.{Action, Controller, RequestHeader}
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
-class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent) extends Controller with Logging with ExecutionContexts {
+class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
   def renderMostViewed() = Action { implicit request =>
     getMostViewedAudio match {
       case Nil => Cached(60) { JsonNotFound() }
@@ -47,7 +47,7 @@ class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent) exte
         CollectionEssentials(audios.map(_.faciaContent) take 4, Nil, displayName, None, None, None)
       ).withTimeStamps,
       FrontProperties.empty
-    )(request)
+    )
 
     JsonComponent(html)
   }

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -51,7 +51,7 @@ class MostViewedGalleryController(mostViewedGalleryAgent: MostViewedGalleryAgent
         CollectionEssentials(galleries.map(_.faciaContent), Nil, Some("more galleries"), None, None, None)
       ).withTimeStamps,
       FrontProperties.empty
-    )(request)
+    )
 
     val htmlResponse = () => views.html.mostViewedGalleries(page, html)
     val jsonResponse = () => html

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -5,7 +5,7 @@ import common.{Edition, ExecutionContexts, JsonNotFound}
 import contentapi.ContentApiClient
 import feed.MostPopularSocialAutoRefresh
 import layout.{CollectionEssentials, FaciaContainer}
-import model.{Cached, FrontProperties}
+import model.{ApplicationContext, Cached, FrontProperties}
 import model.pressed.CollectionConfig
 import play.api.mvc.{Action, Controller}
 import services.{CollectionConfigWithId, FaciaContentConvert}
@@ -13,7 +13,7 @@ import slices.Fixed
 
 import scala.concurrent.Future.{successful => unit}
 
-class MostViewedSocialController(contentApiClient: ContentApiClient, mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh) extends Controller with ExecutionContexts {
+class MostViewedSocialController(contentApiClient: ContentApiClient, mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh)(implicit context: ApplicationContext) extends Controller with ExecutionContexts {
   def renderMostViewed(socialContext: String) = Action.async { implicit request =>
     val mostPopularSocial = mostPopularSocialAutoRefresh.get
 
@@ -58,7 +58,7 @@ class MostViewedSocialController(contentApiClient: ContentApiClient, mostPopular
               componentId
             ).withTimeStamps,
             properties
-          )(request)
+          )
 
           renderFormat(facebookResponse, facebookResponse, 900)
         }

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -8,7 +8,7 @@ import model._
 import play.api.mvc.{Action, Controller, RequestHeader}
 import services._
 
-class PopularInTag(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent) extends Controller with Related with Containers with Logging with ExecutionContexts {
+class PopularInTag(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent)(implicit context: ApplicationContext) extends Controller with Related with Containers with Logging with ExecutionContexts {
   def render(tag: String) = Action.async { implicit request =>
     val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
@@ -22,7 +22,7 @@ class PopularInTag(val contentApiClient: ContentApiClient, val mostReadAgent: Mo
     val html = views.html.fragments.containers.facia_cards.container(
       onwardContainer("related content", trails.faciaItems take 8),
       FrontProperties.empty
-    )(request)
+    )
 
     JsonComponent(html)
   }

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -41,7 +41,7 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
       val html = views.html.fragments.containers.facia_cards.container(
         onwardContainer(containerTitle, relatedTrails.map(_.faciaContent)),
         FrontProperties.empty
-      )(request)
+      )
       JsonComponent(html)
     } else {
       RevalidatableResult.Ok(views.html.relatedContent(page, relatedTrails.map(_.faciaContent)))

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -26,7 +26,7 @@ case class Series(id: String, tag: Tag, trails: RelatedContent) {
  }
 }
 
-class SeriesController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class SeriesController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with Paging with ExecutionContexts with Requests {
   def renderSeriesStories(seriesId: String) = Action.async { implicit request =>
     lookup(Edition(request), seriesId) map { series =>
       series.map(renderSeriesTrails).getOrElse(NotFound)
@@ -105,7 +105,7 @@ class SeriesController(contentApiClient: ContentApiClient) extends Controller wi
       ).withTimeStamps
        .copy(customHeader = header),
       properties
-    )(request)
+    )
 
     renderFormat(response, response, 900)
   }

--- a/onward/test/SeriesControllerTest.scala
+++ b/onward/test/SeriesControllerTest.scala
@@ -10,7 +10,8 @@ import play.api.test.Helpers._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestContentApiClient {
+  with WithTestContentApiClient
+  with WithTestContext {
 
   var series = "news/series/pass-notes"
   lazy val seriesController = new SeriesController(testContentApiClient)

--- a/onward/test/VideoInSectionTest.scala
+++ b/onward/test/VideoInSectionTest.scala
@@ -10,7 +10,8 @@ import play.api.test.Helpers._
   with ConfiguredTestSuite
   with BeforeAndAfterAll
   with WithTestWsClient
-  with WithTestContentApiClient {
+  with WithTestContentApiClient
+  with WithTestContext {
 
   lazy val mediaInSectionController = new MediaInSectionController(testContentApiClient)
 

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -41,7 +41,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
   lazy val competitionAndGroupFinder = new CompetitionAndGroupFinder(competitions)
   lazy val teamNameBuilder = new TeamNameBuilder(competitions)
 
-  def makeContainer(tagId: String)(implicit request: RequestHeader) = {
+  def makeContainer(tagId: String)(implicit request: RequestHeader, context: ApplicationContext) = {
 
     (for {
       teamId <- TeamMap.findTeamIdByUrlName(tagId)

--- a/sport/app/football/controllers/FixturesAndResultsContainerController.scala
+++ b/sport/app/football/controllers/FixturesAndResultsContainerController.scala
@@ -3,12 +3,12 @@ package football.controllers
 import common.JsonComponent
 import feed.CompetitionsService
 import football.containers.FixturesAndResults
-import model.Cached
+import model.{ApplicationContext, Cached}
 import play.api.mvc.{Action, Controller}
 import play.twirl.api.Html
 import views.html.fragments.containers.facia_cards.{container => containerHtml}
 
-class FixturesAndResultsContainerController(competitionsService: CompetitionsService) extends Controller {
+class FixturesAndResultsContainerController(competitionsService: CompetitionsService)(implicit context: ApplicationContext) extends Controller {
 
   val fixturesAndResults = new FixturesAndResults(competitionsService)
 

--- a/sport/app/football/views/fragments/componentStyles.scala.html
+++ b/sport/app/football/views/fragments/componentStyles.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader)
+@()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <style>
     @Html(common.Assets.css.head("footballSnaps"))

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -1,7 +1,7 @@
 @import football.model.MatchesList
 @import views.support.`package`.Seq2zipWithRowInfo
 
-@(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader)
+@(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <div data-component="football-matches-embed" class="c-football-matches">
 

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -1,6 +1,6 @@
 @import model.{Competition, Group}
 
-@(competition: Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader)
+@(competition: Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @if(!multiGroup) {
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">


### PR DESCRIPTION
## What does this change?
Remove Play.current (deprecated in Play 2.5) in assets css object

## What is the value of this and can you measure success?
-> Play 2.5

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

