### PR TITLE
Never use links as kickers in email

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -7,15 +7,16 @@
 
 @import views.support.EmailHelpers._
 @import views.support.TrailCssClasses.toneClass
-@import views.html.fragments.items.elements.facia_cards.kicker
 @import model.pressed.Feature
 @import implicits.Requests.RichRequestHeader
+@import implicits.ItemKickerImplicits._
+
 
 @headline(pressedContent: PressedContent) = {
     <h3 class="headline">
         @defining(FaciaCardHeader.fromTrail(pressedContent, None)) { header =>
-            @kicker(header, Seq())
-            @if(header.kicker.isDefined) {
+            @header.kicker.map { kicker =>
+                <span class="fc-item__kicker">@Html(kicker.kickerHtml)</span>
                 <span class="kicker-separator">/</span>
             }
 


### PR DESCRIPTION
The [kicker template I was previously using for kickers in email](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/items/elements/facia_cards/kicker.scala.html) will render tag & section kickers as links. Since we're already inside an `<a></a>` element at this point, this spectacularly breaks the HTML rendering.

So now I just explicitly output a `<span></span>`.  This will allow Editorial to use tag & section kickers for convenience if they want to, rendering them as text inside the whole-card link to the article just as it would for a custom kicker.

### broken (see bottom item):
![picture 353](https://cloud.githubusercontent.com/assets/5122968/21141388/c5e54afe-c134-11e6-98d4-9a0780bf0ee6.png)

### fixed:

![picture 354](https://cloud.githubusercontent.com/assets/5122968/21141509/7913738a-c135-11e6-8c84-aa92fc891902.png)


@lmath @guardian/dotcom-platform 

