### PR TITLE
Hosted article pages sticky header

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -34,7 +34,12 @@
         </amp-analytics>
 
         <div class="main-body">
-            @guardianHostedHeader(if(page.campaign.fontColour.isDark) "hosted-article-page hosted-page--bright" else "hosted-article-page", page, isAMP = true)
+            <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge content__hosted-body">
+                <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+                    <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"></amp-img>
+                </a>
+            </div></div></div>
+            @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page, isAMP = true)
             <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.campaign.fontColour.isDark) {hosted-page--bright}">
 
                 <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -68,7 +68,12 @@
 
     </style>
     <!--<![endif]-->
-    @guardianHostedHeader(if(page.campaign.fontColour.isDark) "hosted-article-page hosted-page--bright" else "hosted-article-page", page)
+    <div class="hosted__header hosted__header--logo"><div class="hosted__headerwrap"><div class="hostedbadge">
+        <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+            <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
+        </a>
+    </div></div></div>
+    @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page)
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.campaign.fontColour.isDark) {hosted-page--bright}">
 
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -68,7 +68,7 @@
 
     </style>
     <!--<![endif]-->
-    <div class="hosted__header hosted__header--logo"><div class="hosted__headerwrap"><div class="hostedbadge">
+    <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
         <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
             <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
         </a>

--- a/static/src/stylesheets/amp/_hosted-article.scss
+++ b/static/src/stylesheets/amp/_hosted-article.scss
@@ -117,3 +117,15 @@
         height: auto;
     }
 }
+
+
+.hosted__header.hosted__header--sticky {
+    position: fixed;
+    top: 0;
+    max-width: 600px;
+    z-index: $zindex-sticky;
+}
+
+.hosted__header--sticky .hostedbadge__logo {
+    display: none;
+}

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -343,3 +343,15 @@ $dotSize: 8px;
         background: transparent;
     }
 }
+
+.hosted__header.hosted__header--sticky {
+    top: 0;
+    position: fixed;
+    z-index: $zindex-sticky;
+}
+
+.hosted__header--sticky .hostedbadge__logo {
+    @include mq($until: leftCol) {
+        height: 0;
+    }
+}


### PR DESCRIPTION
## What does this change?
Make the header 'sticky' so it's always visible as you scroll through the article.

## What is the value of this and can you measure success?
Our UX lab tests showed that the 'advertiser content' banner is the strongest indicator that this is commercial content, so we want it to be more visible.

A previous survey relating to Hosted articles showed that ~70% of users understand what Hosted pages are. We will do another survey after this change to see if this has improved.

## Does this affect other platforms - Amp, Apps, etc?
Also implemented for AMP Hosted articles.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/21141735/aa5a2334-c136-11e6-88d9-8c24a5fb0b23.png)


CC @guardian/labs-beta 
