### PR TITLE
Style external links

### DIFF
--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -16,7 +16,7 @@
         background: #fee9ed;
     }
 
-    .tone-news {
+    .tone-news .facia-card {
         border-top: 1px solid #4bc6df;
         background-color: #ffffff;
     }
@@ -34,7 +34,7 @@
     }
 
 
-    .tone-feature {
+    .tone-feature .facia-card {
         border-top: 1px solid pink;
         background-color: #ffffff;
     }
@@ -53,7 +53,7 @@
     }
 
 
-    .tone-media {
+    .tone-media .facia-card {
         border-top: 1px solid #ff9b0b;
         background-color: #ffffff;
     }
@@ -71,7 +71,7 @@
     }
 
 
-    .tone-review {
+    .tone-review .facia-card {
         border-top: 1px solid pink;
         background-color: #ffffff;
     }
@@ -89,7 +89,7 @@
     }
 
 
-    .tone-editorial {
+    .tone-editorial .facia-card {
         border-top: 1px solid #aad8f1;
         background-color: #ffffff;
     }
@@ -107,7 +107,7 @@
     }
 
 
-    .tone-external {
+    .tone-external .facia-card {
         border-top: 1px solid #fdadba;
         background-color: #ffffff;
     }
@@ -125,7 +125,7 @@
     }
 
 
-    .tone-live {
+    .tone-live .facia-card {
         border-top: 1px solid #fdadba;
         background-color: #ffffff;
     }
@@ -143,7 +143,7 @@
     }
 
 
-    .tone-analysis {
+    .tone-analysis .facia-card {
         border-top: 1px solid #4bc6df;
         background-color: #ffffff;
     }
@@ -161,7 +161,7 @@
     }
 
 
-    .tone-special-report {
+    .tone-special-report .facia-card {
         border-top: 1px solid #fce800;
         background-color: #ffffff;
     }
@@ -179,7 +179,7 @@
     }
 
 
-    .tone-comment {
+    .tone-comment .facia-card {
         border-top: 1px solid #e6711b;
         background-color: #ffffff;
     }
@@ -197,7 +197,7 @@
     }
 
 
-    .tone-dead {
+    .tone-dead .facia-card {
         border-top: 1px solid pink;
         background-color: #ffffff;
     }

--- a/common/app/views/fragments/email/stylesheets/footer.scala.html
+++ b/common/app/views/fragments/email/stylesheets/footer.scala.html
@@ -6,7 +6,8 @@
     .footer {
         background: #484848 url(@footerG) no-repeat bottom right;
         padding: 25px 0;
-        margin-top: 20px !important;
+        display: block;
+        margin-top: 36px;
     }
 
     .social__links, .email__links, .disclaimer p {

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -103,9 +103,9 @@
     }
     .tone-external .headline {
         color: #333333;
-        font-family: "Helvetica", "Arial", sans-serif !important;
+        font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
         font-weight: normal;
-        font-size: 14px;
+        font-size: 16px;
     }
     .tone-external .fc-item__kicker {
         color: #333333;

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -1,4 +1,6 @@
-@()
+@(page: model.Page)
+
+@import model.EmailAddons.EmailContentType
 
 <style>
     .tone-news .facia-card {
@@ -92,15 +94,22 @@
     }
 
 
+    .tone-external {
+        padding-bottom: 0 !important;
+    }
     .tone-external .facia-card {
-        border-top: 1px solid #4bc6df;
+        border-top: 1px solid @page.toneColour;
         background-color: #f6f6f6;
     }
     .tone-external .headline {
         color: #333333;
+        font-family: "Helvetica", "Arial", sans-serif !important;
+        font-weight: normal;
+        font-size: 14px;
     }
     .tone-external .fc-item__kicker {
-        color: #005689;
+        color: #333333;
+        font-weight: bold;
     }
     .tone-external .kicker-separator {
         color: #d6d6d6;

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -1,7 +1,7 @@
 @()
 
 <style>
-    .tone-news {
+    .tone-news .facia-card {
         border-top: 1px solid #4bc6df;
         background-color: #f6f6f6;
     }
@@ -19,7 +19,7 @@
     }
 
 
-    .tone-feature {
+    .tone-feature .facia-card {
         border-top: 1px solid pink;
         background-color: #951c55;
     }
@@ -38,7 +38,7 @@
     }
 
 
-    .tone-media {
+    .tone-media .facia-card {
         border-top: 1px solid #ffbb00;
         background-color: #333;
     }
@@ -56,7 +56,7 @@
     }
 
 
-    .tone-review {
+    .tone-review .facia-card {
         border-top: 1px solid pink;
         background-color: #7d7569;
     }
@@ -74,7 +74,7 @@
     }
 
 
-    .tone-editorial {
+    .tone-editorial .facia-card {
         border-top: 1px solid #aad8f1;
         background-color: #005689;
     }
@@ -92,7 +92,7 @@
     }
 
 
-    .tone-external {
+    .tone-external .facia-card {
         border-top: 1px solid #4bc6df;
         background-color: #f6f6f6;
     }
@@ -110,7 +110,7 @@
     }
 
 
-    .tone-live {
+    .tone-live .facia-card {
         border-top: 1px solid #fdadba;
         background-color: #b51800;
     }
@@ -128,7 +128,7 @@
     }
 
 
-    .tone-analysis {
+    .tone-analysis .facia-card {
         border-top: 1px solid #4bc6df;
         background-color: #f6f6f6;
     }
@@ -146,7 +146,7 @@
     }
 
 
-    .tone-special-report {
+    .tone-special-report .facia-card {
         border-top: 1px solid #fce800;
         background-color: #63717a;
     }
@@ -164,7 +164,7 @@
     }
 
 
-    .tone-comment {
+    .tone-comment .facia-card {
         border-top: 1px solid #e6711b;
         background-color: #e3e3de;
     }
@@ -182,7 +182,7 @@
     }
 
 
-    .tone-dead {
+    .tone-dead .facia-card {
         border-top: 1px solid pink;
         background-color: #f6f6f6;
     }

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -35,7 +35,7 @@
         @if(page.metadata.isFront) {
             @fragments.email.stylesheets.frontFonts()
             @fragments.email.stylesheets.front(page)
-            @fragments.email.stylesheets.tones()
+            @fragments.email.stylesheets.tones(page)
 
             @* This is a temporary override to test two alternative email designs 29/11/2016 *@
             @if(request.isEmailConnectedStyle) {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -7,7 +7,7 @@
 
 @import views.support.EmailHelpers._
 @import views.support.TrailCssClasses.toneClass
-@import model.pressed.Feature
+@import model.pressed.{Feature, ExternalLink}
 @import implicits.Requests.RichRequestHeader
 @import implicits.ItemKickerImplicits._
 
@@ -38,9 +38,9 @@
 }
 
 @faciaCardLarge(pressedContent: PressedContent) = {
-    @paddedRow {
+    @paddedRow(Seq(toneClass(pressedContent))) {
         @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-            <a @Html(href) class="facia-card facia-card--large @toneClass(pressedContent)">
+            <a @Html(href) class="facia-card facia-card--large">
                 @imgFromPressedContent(pressedContent)
                 @headline(pressedContent)
                 @pressedContent.card.trailText.map { trailText =>
@@ -52,13 +52,24 @@
 }
 
 @faciaCardSmall(pressedContent: PressedContent) = {
-    @paddedRow {
+    @paddedRow(Seq(toneClass(pressedContent))) {
         @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-            <a @Html(href) class="facia-card @toneClass(pressedContent)">
+            <a @Html(href) class="facia-card">
                 @headline(pressedContent)
             </a>
         }
     }
+}
+
+@firstCard(pressedContent: PressedContent) = {
+    @pressedContent.card.cardStyle match {
+        case ExternalLink => { @faciaCardSmall(pressedContent) }
+        case _ => { @faciaCardLarge(pressedContent) }
+    }
+}
+
+@card(pressedContent: PressedContent) = {
+    @faciaCardSmall(pressedContent)
 }
 
 @fullRow {
@@ -80,9 +91,9 @@
 
     @collection.curatedPlusBackfillDeduplicated.zipWithIndex.map { case (pressedContent, cardIndex) =>
         @if(cardIndex == 0) {
-            @faciaCardLarge(pressedContent)
+            @firstCard(pressedContent)
         } else {
-            @faciaCardSmall(pressedContent)
+            @card(pressedContent)
         }
     }
 }


### PR DESCRIPTION
Style external links differently from Guardian links. Specifically:

- no bottom padding
- sans serif font
- border colour based on page tone (e.g. pink for flyer)

Might need some refinement by @superfrank 

## Old (card)
![picture 358](https://cloud.githubusercontent.com/assets/5122968/21142247/22493644-c139-11e6-9b52-a0eb1b454ffd.png)

## New (card)
![picture 355](https://cloud.githubusercontent.com/assets/5122968/21142222/07822258-c139-11e6-9600-f93901f9e11b.png)

## Old (connected)
![picture 359](https://cloud.githubusercontent.com/assets/5122968/21142237/1a6066c8-c139-11e6-800b-f9ef8f319777.png)

## New (connected)
![picture 356](https://cloud.githubusercontent.com/assets/5122968/21142231/1161249a-c139-11e6-8085-da2e7c7cf74b.png)
