### PR TITLE
New header on AMP

### DIFF
--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -1,10 +1,11 @@
 @()(implicit request: RequestHeader)
 
+@import conf.Configuration
 @import common.{LinkTo, NewNavigation}
 
 <header class="header" role="banner">
     <div class="header__inner gs-container">
-        <a class="header__supporter-cta" href="https://membership.theguardian.com/supporter?INTCMP=AMP_HEADER_GU_SUPPORTER">
+        <a class="header__supporter-cta" href="@Configuration.id.membershipUrl/supporter?INTCMP=AMP_HEADER_GU_SUPPORTER">
             Become a <span>Supporter</span>
         </a>
 

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -4,6 +4,10 @@
 
 <header class="header" role="banner">
     <div class="header__inner gs-container">
+        <a class="header__supporter-cta" href="https://membership.theguardian.com/supporter?INTCMP=AMP_HEADER_GU_SUPPORTER">
+            Become a <span>Supporter</span>
+        </a>
+
         <a href="@LinkTo{/}" class="header__logo-wrapper" tabindex="0">
             <h1 class="u-h">The Guardian</h1>
             @fragments.inlineSvg("guardian-logo-160", "logo", List("header__logo"))

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -1,24 +1,26 @@
-@import conf.Configuration
+@()(implicit request: RequestHeader)
 
-<header class="main-header">
-    <a href="@Configuration.site.host/" class="logo-wrapper" name="top">
-    @fragments.inlineSvg("guardian-logo-160", "logo")
-    </a>
-    <div class="main-navigation variant-kicker">
-        <div class="main-navigation_link">
-            <a href="@Configuration.site.host/">news</a>
-        </div>
-        <div class="main-navigation_link">
-            <a href="@Configuration.site.host/commentisfree">opinion</a>
-        </div>
-        <div class="main-navigation_link">
-            <a href="@Configuration.site.host/sport">sport</a>
-        </div>
-        <div class="main-navigation_link">
-            <a href="@Configuration.site.host/culture">arts</a>
-        </div>
-        <div class="main-navigation_link">
-            <a href="@Configuration.site.host/lifeandstyle">life</a>
-        </div>
+@import common.{LinkTo, NewNavigation}
+
+<header class="header" role="banner">
+    <div class="header__inner gs-container">
+        <a href="@LinkTo{/}" class="header__logo-wrapper" tabindex="0">
+            <h1 class="u-h">The Guardian</h1>
+            @fragments.inlineSvg("guardian-logo-160", "logo", List("header__logo"))
+        </a>
+
+        <nav class="header__nav">
+            @NewNavigation.PrimaryLinks.map { link =>
+                <a class="header__nav__link"
+                    href="@LinkTo(link.url)">
+                        @link.title
+                </a>
+            }
+            <a class="header__nav__menu-button"
+                href="@LinkTo{/}">
+                    @fragments.inlineSvg("home", "icon", List("centered-icon"))
+                    <span class="u-h">Home</span>
+            </a>
+        </nav>
     </div>
 </header>

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -63,7 +63,8 @@
 .guardian-egyptian-loaded .signposting__item a,
 .guardian-egyptian-loaded .from-content-api h2,
 .guardian-egyptian-loaded .from-content-api .block-elements h2,
-.guardian-egyptian-loaded .from-content-api p strong {
+.guardian-egyptian-loaded .from-content-api p strong,
+.guardian-egyptian-loaded .header__supporter-cta {
     font-family: "Guardian Egyptian Web", Georgia, serif;
     font-weight: 500;
 }

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -88,7 +88,7 @@ $c-primary-footer-background-side-bar: mix($guardian-brand, #ffffff, 90%);
 .l-footer__misc {
     padding-top: 0.375rem;
     padding-bottom: 1.125rem;
-    border-top: 1px solid #666;
+    border-top: 1px solid $neutral-2;
 }
 
 .breadcrumb {

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -3,7 +3,6 @@ $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
 $veggie-burger-small: 42px;
-$veggie-burger-small: 42px;
 $veggie-burger-medium: 52px;
 
 .header {
@@ -34,12 +33,12 @@ $veggie-burger-medium: 52px;
     &:before {
         content: '';
         position: absolute;
-        top: -$gs-baseline/2;
-        left: -$gs-gutter/2;
+        top: -$gs-baseline / 2;
+        left: -$gs-gutter / 2;
         right: -23px;
-        border-top: $gs-baseline*4 solid $news-main-2;
-    	border-left: $gs-gutter/4 solid transparent;
-    	border-right: $gs-gutter solid transparent;
+        border-top: $gs-baseline * 4 solid $news-main-2;
+        border-left: $gs-gutter / 4 solid transparent;
+        border-right: $gs-gutter solid transparent;
         transform: rotate(-3deg);
         z-index: -1;
     }
@@ -53,7 +52,7 @@ $veggie-burger-medium: 52px;
         font-size: 14px;
 
         &:before {
-            border-top-width: ($gs-baseline*4) + ($gs-baseline/2);
+            border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
         }
     }
 }

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -1,89 +1,174 @@
-.main-header {
-    background: $guardian-brand;
-    position: relative;
-    height: 68px;
+$mobile-medium: 375px; // Breakpoint for our most common device sizes
+$gutter-small: 29px;
+$gutter-medium: 37px;
+$gutter-large: 55px;
+$veggie-burger-small: 42px;
+$veggie-burger-small: 42px;
+$veggie-burger-medium: 52px;
 
-    @include mq($until: 390px) {
-        height: 63px;
+.header {
+    background-color: $guardian-brand;
+}
+
+.header__inner {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.header__logo-wrapper {
+    padding-top: $gs-baseline / 2;
+    padding-bottom: $gs-baseline / 2;
+    margin-left: auto;
+}
+
+.header__logo__svg {
+    // Removes extra spacing
+    display: block;
+    height: auto;
+    padding-right: $gs-gutter / 2;
+
+    // Aspect ratio: 16:3
+    @include mq($until: $mobile-medium) {
+        width: 170px;
+        // height: auto doesn't work in Safari
+        height: calc(3 / 16 * 170px);
     }
 
-    @include mq($until: 360px) {
-        height: 57px;
+    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+        width: 225px;
+        height: calc(3 / 16 * 225px);
     }
 
-    .logo-wrapper {
+    @include mq(mobileLandscape) {
+        width: 260px;
+        // height: auto doesn't work in Safari
+        height: calc(3 / 16 * 260px);
+        padding: ($gs-baseline / 2) ($gs-gutter / 2) 0;
+        margin-right: $gs-gutter / 2;
+    }
+}
+
+.header__nav {
+    font-size: 16px;
+    line-height: $gs-baseline * 2.5;
+    width: 100%;
+    overflow: hidden;
+
+    @include mq($until: mobile) {
+        // Menu squishes gracefully
+        height: $gs-baseline * 2.5;
+        margin-right: $gutter-small + $veggie-burger-small + $gs-gutter / 3;
+    }
+
+    @include mq($from: mobile, $until: mobileLandscape) {
+        font-size: 5.1vw;
+    }
+
+    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+        line-height: $gs-baseline * 3;
+    }
+
+    @include mq(mobileLandscape) {
+        font-size: 24px;
+        line-height: $gs-baseline * 3.5;
+        margin-left: $gs-gutter / 2;
+    }
+}
+
+.header__nav__menu-button {
+    // Override button from user agent stylesheet
+    position: absolute;
+    // Unset button from user agent stylesheet
+    border: 0;
+    outline: none;
+    // Override button from user agent stylesheet
+    border-radius: 100%;
+    z-index: 1049;
+    background-color: $news-main-2;
+    cursor: pointer;
+    bottom: -$gs-baseline / 2;
+
+    @include mq($until: $mobile-medium) {
+        //Smaller menu button
+        height: $veggie-burger-small;
+        min-width: $veggie-burger-small;
+        //Align with the 'i' in 'theguardian'
+        right: $gutter-small;
+    }
+
+    @include mq($mobile-medium) {
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+        //Align with the 'i' in 'theguardian'
+        right: $gutter-medium;
+    }
+
+    @include mq(mobileLandscape) {
+        //Align with the 'i' in 'theguardian'
+        right: $gutter-large;
+    }
+}
+
+.header__nav__menu-button--open {
+    z-index: 1071;
+
+    &:before {
+        // Extended hit area for veggie burger close state, for fat fingers
+        content: '';
         position: absolute;
-        right: $gs-gutter;
-        padding-top: $gs-baseline/3;
-        width: inherit;
-        text-align: right;
+    }
 
-        @include mq($until: mobileLandscape) {
-            right: $gs-gutter/2;
+    @include mq($until: $mobile-medium) {
+        &:before {
+            height: $veggie-burger-small * 2;
+            width: $veggie-burger-small;
+            top: -$veggie-burger-small / 2;
+            right: $veggie-burger-small / 2;
+            border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
         }
+    }
 
-        svg {
-            width: 190px;
-            height: $gs-row-height;
-
-            @include mq($until: 390px) {
-                width: 170px;
-                height: 32px;
-            }
-
-            @include mq($until: 360px) {
-                width: 160px;
-                height: 30px;
-            }
-
-            @include mq($until: 340px) {
-                width: 140px;
-                height: 27px;
-            }
+    @include mq($mobile-medium) {
+        &:before {
+            height: $veggie-burger-medium * 2;
+            width: $veggie-burger-medium;
+            top: -$veggie-burger-medium / 2;
+            right: $veggie-burger-medium / 2;
+            border-radius: ($veggie-burger-medium * 2) 0 0 ($veggie-burger-medium * 2);
         }
     }
 }
 
-.main-navigation {
-    position: absolute;
-    top: $gs-baseline/2;
-    left: $gs-gutter;
-    line-height: 1.1;
+.header__nav__link {
+    // Override a from _lists.scss
+    color: #ffffff;
+    position: relative;
+    padding-left: .3em;
+    padding-right: .35em;
+    float: left;
+    cursor: pointer;
 
-    @include mq($until: mobileLandscape) {
-        left: $gs-gutter/2;
+    &:focus,
+    &:hover {
+        text-decoration: none;
     }
 
-    .main-navigation_link {
-        display: inline;
-        font-size: 22px;
+    &:first-child {
+        padding-left: $gs-gutter / 2;
+    }
 
-        @include mq($until: 390px) {
-            font-size: 20px;
-        }
+    &:before {
+        position: absolute;
+        pointer-events: none;
+        content: '/';
+        //optically aligns slashes
+        left: -.19em;
+        color: $news-main-2;
+    }
 
-        @include mq($until: 360px) {
-            font-size: 18px;
-        }
-
-        a {
-            font-weight: 400;
-            color: $news-support-1;
-            display: inline-block;
-        }
-
-        &::after {
-            content: "/";
-            color: rgba(255,255,255,0.3);
-        }
-
-        &:last-of-type::after {
-            content:none;
-        }
-
-        &:nth-child(2)::after {
-            content: "\A";
-            white-space: pre;
-        }
+    &:first-of-type:before {
+        content: none;
     }
 }

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -15,6 +15,47 @@ $veggie-burger-medium: 52px;
     justify-content: space-between;
     flex-wrap: wrap;
     align-items: flex-start;
+    z-index: 1;
+}
+
+.header__supporter-cta {
+    // Some very specific values in here, as it's all got to line up with the x-height of the logo
+    position: absolute;
+    left: $gs-gutter;
+    padding-top: 10px;
+    font-size: 13px;
+    line-height: .95;
+    color: $guardian-brand-dark;
+
+    & > span {
+        display: block;
+    }
+
+    &:before {
+        content: '';
+        position: absolute;
+        top: -$gs-baseline/2;
+        left: -$gs-gutter/2;
+        right: -23px;
+        border-top: $gs-baseline*4 solid $news-main-2;
+    	border-left: $gs-gutter/4 solid transparent;
+    	border-right: $gs-gutter solid transparent;
+        transform: rotate(-3deg);
+        z-index: -1;
+    }
+
+    @include mq($until: mobile) {
+        display: none;
+    }
+
+    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+        padding-top: 14px;
+        font-size: 14px;
+
+        &:before {
+            border-top-width: ($gs-baseline*4) + ($gs-baseline/2);
+        }
+    }
 }
 
 .header__logo-wrapper {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -66,7 +66,6 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     overflow: hidden;
 
     @include mq($until: mobile) {
-        font-size: 16px;
         // Menu squishes gracefully
         height: $gs-baseline * 2.5;
         margin-right: $gutter-small + $veggie-burger-small + $gs-gutter / 3;
@@ -83,7 +82,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     @include mq(mobileLandscape) {
         font-size: 24px;
         line-height: $gs-baseline * 3.5;
-        margin-left: $gs-gutter/2;
+        margin-left: $gs-gutter / 2;
     }
 }
 
@@ -204,7 +203,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     }
 
     &:first-child {
-        padding-left: $gs-gutter/2;
+        padding-left: $gs-gutter / 2;
     }
 
     &:before {
@@ -237,7 +236,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     color: $news-support-1;
     // Override from fs-textSans mixin
     line-height: 1;
-    padding-top: $gs-baseline/2;
+    padding-top: $gs-baseline / 2;
     padding-left: $gs-gutter / 2;
     width: gs-span(2);
     z-index: $zindex-sticky;
@@ -262,14 +261,14 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     min-width: 14px;
     min-height: 14px;
     margin-right: 1px;
-    margin-top: -$gs-baseline/4;
+    margin-top: -$gs-baseline / 4;
 }
 
 .edition-picker__dropdown {
     display: none;
     position: absolute;
     top: 40px;
-    left: $gs-gutter/2;
+    left: $gs-gutter / 2;
     // overriding default styling
     width: gs-span(2);
     margin: 0;
@@ -308,8 +307,8 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 
 .edition-picker__current-edition {
     width: gs-span(2);
-    padding-top: $gs-baseline/2;
-    padding-bottom: $gs-baseline/2;
+    padding-top: $gs-baseline / 2;
+    padding-bottom: $gs-baseline / 2;
     display: block;
     outline: none;
     cursor: pointer;
@@ -457,7 +456,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
 }
 
 //This variable is only used in open menu styling
-$navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
+$navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .main-navigation__item__button {
     position: relative;
@@ -509,7 +508,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
 
 .main-menu__icon {
     position: absolute;
-    left: $gs-gutter/2;
+    left: $gs-gutter / 2;
     text-align: center;
     width: $navigation-horizontal-padding - $gs-gutter/2;
 
@@ -524,7 +523,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
 .main-navigation__secondary {
     color: #ffffff;
     background-color: #003b5e;
-    padding-bottom: $gs-baseline/2;
+    padding-bottom: $gs-baseline / 2;
 
     .main-menu__icon__svg {
         margin-top: -.24em;
@@ -619,7 +618,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
 // Search bar
 .navigation-group__search-container {
     font-size: .8em;
-    margin: $gs-baseline/2 $gs-gutter*2 $gs-baseline $gs-gutter/2;
+    margin: $gs-baseline / 2 $gs-gutter * 2 $gs-baseline $gs-gutter / 2;
     overflow: hidden;
 }
 
@@ -627,7 +626,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
     border: 0;
     vertical-align: middle;
     background-color: $guardian-brand;
-    padding-left: $navigation-horizontal-padding - $gs-gutter/2;
+    padding-left: $navigation-horizontal-padding - $gs-gutter / 2;
     border-radius: 1000px;
     box-sizing: border-box;
     height: 36px;
@@ -722,23 +721,23 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
 
 .tertiary-container {
     overflow: hidden;
-    border-bottom: $gs-baseline/2 solid #747a81;
+    border-bottom: $gs-baseline / 2 solid #747a81;
 }
 
 .tertiary-navigation {
     margin: 0;
     background-color: #747a81;
-    padding-left: $gs-gutter/2;
-    padding-right: $gs-gutter/2;
+    padding-left: $gs-gutter / 2;
+    padding-right: $gs-gutter / 2;
     list-style: none;
     white-space: nowrap;
     display: flex;
-        padding-top: $gs-baseline/2;
-    max-height: $gs-baseline*3.4;
+    padding-top: $gs-baseline / 2;
+    max-height: $gs-baseline * 3.4;
     flex-wrap: wrap;
 
     @include mq($from: mobile, $until: mobileLandscape) {
-        max-height: $gs-baseline*4;
+        max-height: $gs-baseline * 4;
         max-height: 14.8vw;
     }
 
@@ -780,7 +779,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter/2;
         content: '/';
         color: rgba(255, 255, 255, .3);
         margin-left: -.1em;
-        padding: 0 $gs-gutter/10;
+        padding: 0 $gs-gutter / 10;
     }
 }
 
@@ -801,8 +800,8 @@ $caption-button-size: 32px;
     // TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
     .content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live) {
         @include mq($until: mobileLandscape) {
-            margin-right: -$gs-gutter /2;
-            margin-left: -$gs-gutter /2;
+            margin-right: -$gs-gutter / 2;
+            margin-left: -$gs-gutter / 2;
         }
 
         @include mq($from: mobileLandscape, $until: phablet) {
@@ -821,7 +820,7 @@ $caption-button-size: 32px;
 
     @include mq($until: tablet) {
         .content__headline {
-            padding-top: $gs-baseline/3;
+            padding-top: $gs-baseline / 3;
         }
 
         .inline-expand-image,
@@ -831,7 +830,7 @@ $caption-button-size: 32px;
 
         .reveal-caption {
             position: absolute;
-            right: $gs-gutter/4;
+            right: $gs-gutter / 4;
             width: $caption-button-size;
             height: $caption-button-size;
             z-index: 1;
@@ -851,7 +850,7 @@ $caption-button-size: 32px;
             background: rgba($multimedia-support-5, .8);
             color: #ffffff;
             display: none;
-            padding: $gs-baseline/2 $gs-gutter*2 $gs-baseline $gs-gutter/2;
+            padding: $gs-baseline / 2 $gs-gutter * 2 $gs-baseline $gs-gutter / 2;
             max-width: 100%;
 
             @include mq($from: mobileLandscape) {
@@ -903,7 +902,7 @@ $caption-button-size: 32px;
 
         // Padding above headline in galleries, because kicker is hidden
         .tonal--tone-media .content__headline--gallery {
-            padding-top: $gs-baseline/2;
+            padding-top: $gs-baseline / 2;
         }
 
         .section-indicator:after {
@@ -911,10 +910,10 @@ $caption-button-size: 32px;
             position: absolute;
             left: 50%;
             bottom: 0;
-            margin-left: -$gs-baseline/2;
-            border-bottom: $gs-baseline/2 solid #747a81;
-            border-left: $gs-baseline/2 solid transparent;
-            border-right: $gs-baseline/2 solid transparent;
+            margin-left: -$gs-baseline / 2;
+            border-bottom: $gs-baseline / 2 solid #747a81;
+            border-left: $gs-baseline / 2 solid transparent;
+            border-right: $gs-baseline / 2 solid transparent;
         }
     }
 }

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -195,7 +195,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
 .l-footer__misc {
     padding-top: $gs-baseline * .5;
     padding-bottom: $gs-baseline * 1.5;
-    border-top: 1px solid mix($neutral-4, $c-footer-background, 20%);
+    border-top: 1px solid $neutral-2;
 }
 
 .really-serious-copyright {


### PR DESCRIPTION
## What does this change?
This is the first pull request to put the new header on AMP. In a seperate PR I will try using [amp-side bar](https://ampbyexample.com/components/amp-sidebar/) with amp-list for the menu.  This will change the home button to be the burger just like this design on www.theguardian.com

## What is the value of this and can you measure success?
This design was proved successful on www.theguardian.com. Time to put it out on AMP!

## Does this affect other platforms - Amp, Apps, etc?
This will only affect AMP

## Screenshots

BEFORE:
![image](https://cloud.githubusercontent.com/assets/8774970/21144570/1555e0cc-c143-11e6-9447-4a6f7f9b8c7d.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/8774970/21314521/7887d596-c5ef-11e6-80e9-2877e50dbc37.png)


@guardian/dotcom-platform 