### PR TITLE
Remove static future

### DIFF
--- a/static-future/README.md
+++ b/static-future/README.md
@@ -1,9 +1,0 @@
-# Future Client-Side Architecture
-
-## Current Status
-
-**ALPHA** - Initial investigation and implementation, do not use in production.
-
-## Client-Side DX JS
-
-https://docs.google.com/a/guardian.co.uk/spreadsheets/d/1uUms84HMp2M1ju4uVUbFRImd8D7fxgpQxCkWmf76av8/edit?usp=sharing

--- a/static-future/package.json
+++ b/static-future/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "static-future",
-  "version": "0.0.1",
-  "description": "Future Client-Side Architecture",
-  "scripts": { },
-  "author": "",
-  "license": "ISC"
-}


### PR DESCRIPTION
Removing static future - my understanding is that we're no longer planning to use this directory?

@guardian/dotcom-platform 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

