### PR TITLE
Apply profile to media atom posterUrl

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -8,6 +8,7 @@ import com.gu.contentatom.thrift.atom.media.{MediaAtom => AtomApiMediaAtom}
 import org.joda.time.Duration
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import quiz._
+import views.support.{ImgSrc, Item700}
 
 final case class Atoms(
   quizzes: Seq[Quiz],
@@ -115,7 +116,7 @@ object MediaAtom extends common.Logging {
       title = mediaAtom.title,
       duration = mediaAtom.duration,
       source = mediaAtom.source,
-      posterUrl = mediaAtom.posterUrl)
+      posterUrl = mediaAtom.posterUrl.map(ImgSrc(_, Item700)))
 
   def mediaAssetMake(mediaAsset: AtomApiMediaAsset): MediaAsset =
   {


### PR DESCRIPTION
## What does this change?
Applies profile to media atom `posterUrl`, this means it is processed by Imgix instead of using  the original origin in CAPI.

## What is the value of this and can you measure success?
Example image:

Before: https://media.guim.co.uk/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/master/3488.jpg (3.47mb)

After: http://i.guimcode.co.uk/img/media/4d7c1db00237690e268015c5fd09502c66cdfd34/0_64_3488_1962/master/3488.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=54e2e4747a6fe6f04560e910e508e04f (58.04kb)

## Does this affect other platforms - Amp, Apps, etc?
Will be inherited by amp through the embed version

## Screenshots
Looks the same only less pageweight 😉 

CC @michaelmcnamara 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
