### PR TITLE
Stubbed capi at runtime

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -8,7 +8,7 @@ import targeting.TargetingLifecycle
 import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, CommonFilters}
-import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
+import contentapi.{CapiHttpClient, ContentApiClient, HttpClient, MockHttpClient}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import model.ApplicationIdentity
@@ -20,6 +20,7 @@ import play.api.routing.Router
 import play.api._
 import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi}
 import router.Routes
+import conf.Configuration
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -27,7 +28,9 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait AppComponents extends FrontendComponents with ArticleControllers {
 
-  lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
+  lazy val _isDevInfra = Configuration.environment.stage.equalsIgnoreCase("DEVINFRA")
+  lazy val capiHttpClient: HttpClient = if (_isDevInfra) wire[MockHttpClient] else wire[CapiHttpClient]
+
   lazy val contentApiClient = wire[ContentApiClient]
   lazy val ophanApi = wire[OphanApi]
 

--- a/common/app/contentapi/MockHttpClient.scala
+++ b/common/app/contentapi/MockHttpClient.scala
@@ -1,0 +1,56 @@
+package contentapi
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+
+import org.apache.commons.codec.digest.DigestUtils
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MockHttpClient extends HttpClient {
+
+  lazy val baseDir = new File(System.getProperty("user.dir"), "data/database")
+
+  def getFile(baseDir: File, name: String): Option[File] = {
+
+    val file = new File(baseDir, name)
+
+    if (file.exists()) {
+      Some(file)
+    } else {
+      None
+    }
+
+  }
+
+  def name(url: String, headers: Map[String, String]): (String, String) = {
+
+    def headersFormat(headers: Map[String, String]): String = {
+      headers.toList.sortBy(_._1).map{ case (key, value) => key + value }.mkString
+    }
+
+    val uri = URI.create(url)
+    val key = uri.getPath + uri.getQuery + headersFormat(headers)
+
+    (DigestUtils.sha256Hex(key), key)
+
+  }
+
+  override def GET(url: String, headers: Iterable[(String, String)]): Future[Response] = {
+
+    val contentFromFile = (file: File) => Files.readAllBytes(
+      java.nio.file.Paths.get(file.getPath)
+    )
+
+    val response = getFile(baseDir, "93ae7c215a04fa59f720faaffb9d91f61f50c1cbe416905964b782c5eef0a27f") match {
+      case Some(file) => Response(contentFromFile(file), 200, "OK")
+      case None => throw new Exception("No data found")
+    }
+
+    Future(response)
+
+  }
+
+}


### PR DESCRIPTION
## What does this change?

This introduces a quick mock CAPI service which is injected in by the **article** AppLoader when the install_vars stage is set to DEVINFRA - causing all capi queries to be retrieved from the local data directory instead of going out to the real CAPI service.

This duplicates some functionality of the original http recorder thing - I'm leaving refactoring out that duplication for a different PR.

@TBonnin @jfsoul couple of questions I have about this change:

1. Is it valid for me to have this logic conditional on DEVINFRA? I'm not sure if we use that stage mode for anything in particular that I might be breaking - I'm only using DEVINFRA because the original httpRecorder in the test directory has some conditionals around that too.

2. I noticed in DEVINFRA.properties file that the image assets are coming from i.gucode.co.uk - which doesn't resolve so the images are always broken. Can I set this to something else or is there a reason it needs to be i.gucode.co.uk?

## What is the value of this and can you measure success?

* Easier for non-guardian contributors to be able to run the app outside of our infra.
* Makes the frontend app easier to run on build/ci systems since you don't have to deal with configuration.
* Provides a way to ensure data doesn't change between regression test runs such as on the screenshot functionality we're trying to implement

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
