### PR TITLE
Handle case where media atom has no assets

### DIFF
--- a/common/app/views/fragments/atoms/ampMediaPosterOnly.scala.html
+++ b/common/app/views/fragments/atoms/ampMediaPosterOnly.scala.html
@@ -1,0 +1,12 @@
+@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+<amp-img
+src="@media.posterUrl.get"
+alt="@media.title"
+width="16"
+height="9"
+layout="responsive">
+</amp-img>
+<figcaption class="caption caption--img" itemprop="description">
+@fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+@media.title
+</figcaption>

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,7 +1,6 @@
 @(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
-    println(media)
     media match {
             case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -2,7 +2,7 @@
 
 @{
     media match {
-            case youtube if media.assets.head.platform == "Youtube" => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
+            case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,7 +1,9 @@
 @(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
+    println(media)
     media match {
+            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -2,7 +2,7 @@
 
 @{
     media match {
-            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
+            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media) else views.html.fragments.atoms.mediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }

--- a/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
+++ b/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
@@ -1,0 +1,19 @@
+@(media: model.content.MediaAtom)
+<figure
+itemprop="associatedMedia image"
+itemscope
+itemtype="http://schema.org/ImageObject"
+data-component="image" xmlns="http://www.w3.org/1999/html"
+class="element element-image">
+    <div class="u-responsive-ratio">
+        <picture>
+            <img itemprop="contentUrl"
+            alt="@media.title"
+            src="@media.posterUrl.get">
+        </picture>
+    </div>
+    <figcaption class="caption caption--img" itemprop="description">
+    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon")) @media.title
+    </figcaption>
+</figure>
+

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -30,7 +30,9 @@
 
 
     @if(displayCaption) {
-        <figcaption class="caption caption--main" itemprop="description">@media.title</figcaption>
+        <figcaption class="caption caption--main" itemprop="description">
+        @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+        @media.title</figcaption>
     }
 }
 


### PR DESCRIPTION
## What does this change?
Previously if a media atom was embedded which had no assets it would throw an exception trying to read head of an empty list. Now this is a `headOption` so it will safely fall through this case.

## What is the value of this and can you measure success?
Fix possible exception

## Does this affect other platforms - Amp, Apps, etc?
Fix also applies to amp

## Screenshots
N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

