### PR TITLE
Stateless config part 3

### DIFF
--- a/admin-jobs/app/AppLoader.scala
+++ b/admin-jobs/app/AppLoader.scala
@@ -44,7 +44,7 @@ trait AppComponents extends FrontendComponents with AdminJobsControllers with Ad
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-admin-jobs")
+  lazy val appIdentity = ApplicationIdentity("admin-jobs")
 
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -67,7 +67,7 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-admin")
+  lazy val appIdentity = ApplicationIdentity("admin")
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[AdminHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonGzipFilter].filters ++ wire[AdminFilters].filters

--- a/admin/app/conf/AdminFilters.scala
+++ b/admin/app/conf/AdminFilters.scala
@@ -2,6 +2,7 @@ package conf
 
 import com.gu.googleauth.FilterExemption
 import googleAuth.GoogleAuthFilters
+import model.ApplicationContext
 import play.api.Environment
 import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
@@ -17,13 +18,11 @@ object FilterExemptions {
   )
 }
 
-class AdminFilters(
-                         environment: Environment
-                       ) extends HttpFilters {
+class AdminFilters(environment: Environment, context: ApplicationContext) extends HttpFilters {
 
   val adminAuthFilter = new GoogleAuthFilters.AuthFilterWithExemptions(
     FilterExemptions.loginExemption,
     FilterExemptions.exemptions)(environment)
 
-  val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common
+  val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common(context: ApplicationContext)
 }

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -60,7 +60,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-applications")
+  lazy val appIdentity = ApplicationIdentity("applications")
 
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -10,7 +10,6 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support.RenderOtherStatus
 import conf.Configuration.interactive.cdnPath
-import conf.Configuration.environment.isPreview
 import scala.concurrent.duration._
 import scala.concurrent.Future
 
@@ -40,7 +39,7 @@ class InteractiveController(contentApiClient: ContentApiClient, wsClient: WSClie
   }
 
   private def getWebWorkerPath(path: String, file: String, timestamp: Option[String]): String = {
-    val stage = if (isPreview) "preview" else "live"
+    val stage = if (context.isPreview) "preview" else "live"
     val deployPath = timestamp.map(ts => s"$path/$ts").getOrElse(path)
 
     s"$cdnPath/service-workers/$stage/$deployPath/$file"

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -37,7 +37,7 @@ trait AppComponents extends FrontendComponents {
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-archive")
+  lazy val appIdentity = ApplicationIdentity("archive")
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -48,7 +48,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-article")
+  lazy val appIdentity = ApplicationIdentity("article")
 
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpLatencyTimingMetric,

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -101,7 +101,7 @@ import scala.collection.JavaConversions._
   it should "know which backend served the request" in {
     val result = route(app, TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")).head
     status(result) should be (200)
-    header("X-Gu-Backend-App", result).head should be ("test-project")
+    header("X-Gu-Backend-App", result).head should be ("article")
   }
 
   it should "infer a Surrogate-Key based on the path" in {

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -67,7 +67,7 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-commercial")
+  lazy val appIdentity = ApplicationIdentity("commercial")
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -60,7 +60,7 @@
                         data-media-id="@{page.video.mediaId}"
                         data-duration="@{page.video.duration}"
                         class="js-hosted-youtube-video hosted__youtube-video"
-                        src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(ConfigEnvironment.isProd && !ConfigEnvironment.isPreview) "&origin=https://www.theguardian.com" else if(host != "") s"&origin=$host" else ""}"
+                        src="https://www.youtube.com/embed/@youtubeId?modestbranding=1&showinfo=0&rel=0&enablejsapi=1@{if(ConfigEnvironment.isProd && !context.isPreview) "&origin=https://www.theguardian.com" else if(host != "") s"&origin=$host" else ""}"
                         frameborder="0"
                         allowfullscreen=""></iframe>
                         @guardianHostedControlButtons(page)

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -59,7 +59,7 @@ trait FrontendComponents
 
   // here are the attributes you must provide for your app to start
   def appIdentity: ApplicationIdentity
-  implicit def appContext = new ApplicationContext(environment)
+  implicit def appContext = ApplicationContext(environment, appIdentity)
   def lifecycleComponents: List[LifecycleComponent]
   def router: Router
 }

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -53,15 +53,15 @@ object css {
 
   private val memoizedCss: ConcurrentMap[String, Try[String]] = TrieMap()
 
-  def head(projectOverride: Option[String])(implicit context: ApplicationContext) = inline(cssHead(projectOverride.getOrElse(Configuration.environment.projectName)))
+  def head(projectOverride: Option[String])(implicit context: ApplicationContext) = inline(cssHead(projectOverride.getOrElse(context.applicationIdentity.name)))
   def inlineStoryPackage(implicit context: ApplicationContext) = inline("story-package")
   def inlineExplore(implicit context: ApplicationContext) = inline("article-explore")
   def amp(implicit context: ApplicationContext) = inline("head.amp")
   def hostedAmp(implicit context: ApplicationContext) = inline("head.hosted-amp")
 
-  def projectCss(projectOverride: Option[String]) = project(projectOverride.getOrElse(Configuration.environment.projectName))
-  def headOldIE(projectOverride: Option[String]) = cssOldIE(projectOverride.getOrElse(Configuration.environment.projectName))
-  def headIE9(projectOverride: Option[String]) = cssIE9(projectOverride.getOrElse(Configuration.environment.projectName))
+  def projectCss(projectOverride: Option[String])(implicit context: ApplicationContext) = project(projectOverride.getOrElse(context.applicationIdentity.name))
+  def headOldIE(projectOverride: Option[String])(implicit context: ApplicationContext) = cssOldIE(projectOverride.getOrElse(context.applicationIdentity.name))
+  def headIE9(projectOverride: Option[String])(implicit context: ApplicationContext) = cssIE9(projectOverride.getOrElse(context.applicationIdentity.name))
 
 
   private def inline(module: String)(implicit context: ApplicationContext): String = {

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -25,7 +25,7 @@ object JsonComponent extends Results with implicits.Requests {
     resultFor(request, json)
   }
 
-  def apply(page: Page, html: Html)(implicit request: RequestHeader): RevalidatableResult = {
+  def apply(page: Page, html: Html)(implicit request: RequestHeader, context: ApplicationContext): RevalidatableResult = {
     val json = jsonFor(page, "html" -> html)
     resultFor(request, json)
   }
@@ -35,12 +35,12 @@ object JsonComponent extends Results with implicits.Requests {
     resultFor(request, json)
   }
 
-  def apply(page: Page, items: (String, Any)*)(implicit request: RequestHeader): RevalidatableResult = {
+  def apply(page: Page, items: (String, Any)*)(implicit request: RequestHeader, context: ApplicationContext): RevalidatableResult = {
     val json = jsonFor(page, items: _*)
     resultFor(request, json)
   }
 
-  private def jsonFor(page: Page, items: (String, Any)*)(implicit request: RequestHeader): String = {
+  private def jsonFor(page: Page, items: (String, Any)*)(implicit request: RequestHeader, context: ApplicationContext): String = {
     jsonFor(("config" -> Json.parse(templates.js.javaScriptConfig(page).body)) +: items: _*)
   }
 

--- a/common/app/common/PagePaths.scala
+++ b/common/app/common/PagePaths.scala
@@ -1,10 +1,11 @@
 package common
 
+import model.ApplicationContext
 import play.api.mvc.RequestHeader
 import services.ConfigAgent
 
 object PagePaths {
-  def fromId(id: String)(implicit request: RequestHeader) = {
+  def fromId(id: String)(implicit request: RequestHeader, context: ApplicationContext) = {
     if (ConfigAgent.shouldServeFront(id) || ConfigAgent.shouldServeEditionalisedFront(Edition(request), id)) {
       AllPagePaths(s"/$id")
     } else {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -124,7 +124,6 @@ object GuardianConfiguration extends Logging {
 
 class GuardianConfiguration extends Logging {
   import GuardianConfiguration._
-  import play.api.Play.current
 
   case class OAuthCredentials(oauthClientId: String, oauthSecret: String, oauthCallback: String)
   case class OAuthCredentialsWithMultipleCallbacks(oauthClientId: String, oauthSecret: String, authorizedOauthCallbacks: List[String])

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -149,7 +149,7 @@ class GuardianConfiguration extends Logging {
     import InstallVars._
 
     lazy val stage = InstallationVars.stage
-    lazy val projectName = Play.application.configuration.getString("guardian.projectName").getOrElse("frontend")
+    lazy val app = InstallationVars.app
 
     lazy val isProd = stage.equalsIgnoreCase("prod")
     lazy val isCode = stage.equalsIgnoreCase("code")

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -154,8 +154,6 @@ class GuardianConfiguration extends Logging {
     lazy val isProd = stage.equalsIgnoreCase("prod")
     lazy val isCode = stage.equalsIgnoreCase("code")
     lazy val isNonProd = List("dev", "code", "gudev").contains(stage.toLowerCase)
-
-    lazy val isPreview = projectName == "preview"
   }
 
   object switches {

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -71,7 +71,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
         RevalidatableResult.Ok(htmlResponse())
     }
 
-  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, page: model.Page, switches: Seq[Switch])(implicit request: RequestHeader) =
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, page: model.Page, switches: Seq[Switch])(implicit request: RequestHeader, context: ApplicationContext) =
     Cached(page) {
       if (request.isJson)
         JsonComponent(page, jsonResponse())
@@ -81,7 +81,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
         RevalidatableResult.Ok(htmlResponse())
     }
 
-  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, cacheTime: Integer)(implicit request: RequestHeader) =
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, cacheTime: Integer)(implicit request: RequestHeader, context: ApplicationContext) =
     Cached(cacheTime) {
       if (request.isJson)
         JsonComponent(jsonResponse())
@@ -91,8 +91,8 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
         RevalidatableResult.Ok(htmlResponse())
     }
 
-  def renderFormat(html: () => Html, cacheTime: Integer)(implicit request: RequestHeader): Result = {
-    renderFormat(html, html, cacheTime)(request)
+  def renderFormat(html: () => Html, cacheTime: Integer)(implicit request: RequestHeader, context: ApplicationContext): Result = {
+    renderFormat(html, html, cacheTime)
   }
 }
 

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -71,7 +71,7 @@ private object RequestDebugInfo {
 
   private lazy val host: String = Try(InetAddress.getLocalHost.getCanonicalHostName).getOrElse("unable-to-determine-host")
   private lazy val stage: String = Configuration.environment.stage
-  private lazy val project: String = Configuration.environment.projectName
+  private lazy val project: String = Configuration.environment.app
 
   lazy val debugParams = Seq(
     s"ngw-host=${encode(host, "UTF-8")}",

--- a/common/app/layout/FaciaContainerHeader.scala
+++ b/common/app/layout/FaciaContainerHeader.scala
@@ -1,7 +1,7 @@
 package layout
 
 import common.Pagination
-import model.{Page, Section, Tag}
+import model.{ApplicationContext, Page, Section, Tag}
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
 import services.ConfigAgent
@@ -29,7 +29,7 @@ case class FaciaHeaderImage(
 }
 
 object FaciaContainerHeader {
-  def fromSection(sectionPage: Section, dateHeadline: DateHeadline): FaciaContainerHeader = MetaDataHeader(
+  def fromSection(sectionPage: Section, dateHeadline: DateHeadline)(implicit context: ApplicationContext): FaciaContainerHeader = MetaDataHeader(
     sectionPage.metadata.webTitle,
     None,
     sectionPage.metadata.description,
@@ -37,7 +37,7 @@ object FaciaContainerHeader {
     frontHref(sectionPage.metadata.id, sectionPage.metadata.pagination)
   )
 
-  def fromPage(page: Page, dateHeadline: DateHeadline): FaciaContainerHeader = {
+  def fromPage(page: Page, dateHeadline: DateHeadline)(implicit context: ApplicationContext): FaciaContainerHeader = {
     MetaDataHeader(
       page.metadata.webTitle,
       None,
@@ -47,7 +47,7 @@ object FaciaContainerHeader {
     )
   }
 
-  def fromTagPage(tagPage: Tag, dateHeadline: DateHeadline): FaciaContainerHeader = {
+  def fromTagPage(tagPage: Tag, dateHeadline: DateHeadline)(implicit context: ApplicationContext): FaciaContainerHeader = {
     if (tagPage.isFootballTeam) {
       MetaDataHeader(
         tagPage.metadata.webTitle,
@@ -76,7 +76,7 @@ object FaciaContainerHeader {
   }
 
   /** Want to show a link to the front if it exists, or to the first page of the tag page if we're not on that page */
-  private def frontHref(id: String, pagination: Option[Pagination]) =
+  private def frontHref(id: String, pagination: Option[Pagination])(implicit context: ApplicationContext) =
     if (ConfigAgent.shouldServeFront(id) || pagination.exists(_.currentPage > 1)) {
       Some(s"/$id")
     } else {

--- a/common/app/model/ApplicationContext.scala
+++ b/common/app/model/ApplicationContext.scala
@@ -2,4 +2,6 @@ package model
 
 import play.api.Environment
 
-case class ApplicationContext(environment: Environment)
+case class ApplicationContext(environment: Environment, applicationIdentity: ApplicationIdentity) {
+  val isPreview = applicationIdentity.name == "preview"
+}

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -9,7 +9,7 @@ import common._
 import conf.Configuration
 import fronts.FrontsApi
 import model.pressed.CollectionConfig
-import model.{FrontProperties, SeoDataJson}
+import model.{ApplicationContext, FrontProperties, SeoDataJson}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
 import conf.switches.Switches
@@ -135,10 +135,10 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   def isFrontHidden(id: String): Boolean =
     configAgent.get().exists(_.fronts.get(id).flatMap(_.isHidden).exists(identity))
 
-  def shouldServeFront(id: String, isEmailRequest: Boolean = false) = getPathIds.contains(id) &&
-    (Configuration.environment.isPreview || (Switches.DisplayHiddenFrontsAsEmails.isSwitchedOn && isEmailRequest) || !isFrontHidden(id))
+  def shouldServeFront(id: String, isEmailRequest: Boolean = false)(implicit context: ApplicationContext) = getPathIds.contains(id) &&
+    (context.isPreview || (Switches.DisplayHiddenFrontsAsEmails.isSwitchedOn && isEmailRequest) || !isFrontHidden(id))
 
-  def shouldServeEditionalisedFront(edition: Edition, id: String) = {
+  def shouldServeEditionalisedFront(edition: Edition, id: String)(implicit context: ApplicationContext) = {
     shouldServeFront(s"${edition.id.toLowerCase}/$id")
   }
 

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -59,7 +59,7 @@ object IndexPage {
     case _ => None
   }
 
-  def makeFront(indexPage: IndexPage, edition: Edition): Front = {
+  def makeFront(indexPage: IndexPage, edition: Edition)(implicit context: ApplicationContext): Front = {
     val isCartoonPage = indexPage.isTagWithId("type/cartoon")
     val isReviewPage = indexPage.isTagWithId("tone/reviews")
 

--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, StringEncodings}
 @import conf.Static
 @import play.api.libs.json.Json

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -36,7 +36,7 @@
             "trackers": {
                 "editorialTest": "@{GoogleAnalyticsAccount.editorialTest.trackerName}",
                 "editorialProd": "@{GoogleAnalyticsAccount.editorialProd.trackerName}",
-                "editorial": "@{GoogleAnalyticsAccount.editorialTracker.trackerName}"
+                "editorial": "@{GoogleAnalyticsAccount.editorialTracker(context).trackerName}"
             }
         }
     }

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -1,4 +1,4 @@
-@(item: model.Page)(implicit request: RequestHeader)
+@(item: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, StringEncodings}
 @import conf.Static
 @import play.api.libs.json.Json

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,4 +1,4 @@
-@(content: model.Content)(implicit request: RequestHeader)
+@(content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.GoogleAnalyticsAccount
 
@@ -10,7 +10,7 @@
                 "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}"
               },
               "vars": {
-                "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
+                "account": "@{GoogleAnalyticsAccount.editorialTracker(context).trackingId}"
               },
               "triggers": {
                 "trackPageview": {

--- a/common/app/views/fragments/amp/hostedGoogleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/hostedGoogleAnalytics.scala.html
@@ -1,4 +1,4 @@
-@(hostedPage: common.commercial.hosted.HostedPage)(implicit request: RequestHeader)
+@(hostedPage: common.commercial.hosted.HostedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.AmpLinkTo
 @import views.support.GoogleAnalyticsAccount
 
@@ -10,7 +10,7 @@
                 "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}"
               },
               "vars": {
-                "account": "@{GoogleAnalyticsAccount.editorialTracker.trackingId}"
+                "account": "@{GoogleAnalyticsAccount.editorialTracker(context).trackingId}"
               },
               "triggers": {
                 "trackPageview": {

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -96,7 +96,7 @@
         }
     }
 
-    @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>
+    @defining(GoogleAnalyticsAccount.editorialTracker(context).trackerName) { trackerName =>
 
         ga('@{trackerName}.send', 'pageview', {
             hitCallback: function() {

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import conf.Configuration.environment
+import model.{ApplicationContext, ApplicationIdentity}
 
 object GoogleAnalyticsAccount {
 
@@ -20,8 +21,8 @@ object GoogleAnalyticsAccount {
   */
   val editorialTest = Tracker("UA-33592456-1", "guardianTestPropertyTracker", 5)
 
-  private val useProdTracker = environment.isProd && !environment.isPreview
+  private def useProdTracker(context: ApplicationContext) = environment.isProd && !context.isPreview
 
-  val editorialTracker: Tracker = if (useProdTracker) editorialProd else editorialTest
+  def editorialTracker(context: ApplicationContext): Tracker = if (useProdTracker(context)) editorialProd else editorialTest
 
 }

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -10,9 +10,9 @@ import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
 
-  def get(page: Page)(implicit request: RequestHeader): JsValue = Json.toJson(getMap(page))
+  def get(page: Page)(implicit request: RequestHeader, context: ApplicationContext): JsValue = Json.toJson(getMap(page))
 
-  def getMap(page: Page)(implicit request: RequestHeader): Map[String,JsValue] = {
+  def getMap(page: Page)(implicit request: RequestHeader, context: ApplicationContext): Map[String,JsValue] = {
     val edition = Edition(request)
     val metaData = page.metadata
     val content: Option[Content] = Page.getContent(page).map(_.content)
@@ -61,7 +61,7 @@ object JavaScriptPage {
       ("idUrl", JsString(Configuration.id.url)),
       ("beaconUrl", JsString(Configuration.debug.beaconUrl)),
       ("assetsPath", JsString(Configuration.assets.path)),
-      ("isPreview", JsBoolean(environment.isPreview)),
+      ("isPreview", JsBoolean(context.isPreview)),
       ("allowUserGeneratedContent", JsBoolean(allowUserGeneratedContent)),
       ("requiresMembershipAccess", JsBoolean(requiresMembershipAccess)),
       ("membershipAccess", JsString(membershipAccess)),

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -6,7 +6,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, Page, WebClient, WebResponse}
 import common.{ExecutionContexts, Lazy}
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
-import model.ApplicationContext
+import model.{ApplicationContext, ApplicationIdentity}
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play._
@@ -117,7 +117,7 @@ object TestRequest {
 }
 
 trait WithTestContext {
-  implicit val testContext = new ApplicationContext(Environment.simple())
+  implicit val testContext = ApplicationContext(Environment.simple(), ApplicationIdentity("tests"))
 }
 
 trait WithTestWsClient {

--- a/dev-build/app/http/DevFilters.scala
+++ b/dev-build/app/http/DevFilters.scala
@@ -3,8 +3,9 @@ package http
 import common.ExecutionContexts
 import conf.Filters
 import implicits.Requests
+import model.ApplicationContext
 import play.api.http.HttpFilters
-import play.api.mvc.{RequestHeader, EssentialAction, EssentialFilter}
+import play.api.mvc.{EssentialAction, EssentialFilter, RequestHeader}
 
 
 // obviously this is only for devbuild and should never end up in one of our
@@ -49,6 +50,6 @@ class DevJsonExtensionFilter extends EssentialFilter with ExecutionContexts with
   }
 }
 
-class DevFilters extends HttpFilters {
-  override def filters: Seq[EssentialFilter] = new DevJsonExtensionFilter :: new DevCacheWarningFilter :: Filters.common
+class DevFilters(context: ApplicationContext) extends HttpFilters {
+  override def filters: Seq[EssentialFilter] = new DevJsonExtensionFilter :: new DevCacheWarningFilter :: Filters.common(context)
 }

--- a/diagnostics/app/AppLoader.scala
+++ b/diagnostics/app/AppLoader.scala
@@ -38,6 +38,6 @@ trait AppLifecycleComponents {
 
 trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
   lazy val router: Router = wire[Routes]
-  lazy val appIdentity = ApplicationIdentity("frontend-diagnostics")
+  lazy val appIdentity = ApplicationIdentity("diagnostics")
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonGzipFilter].filters
 }

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -41,7 +41,7 @@ trait AppComponents extends FrontendComponents with DiscussionControllers with D
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-discussion")
+  lazy val appIdentity = ApplicationIdentity("discussion")
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -43,7 +43,7 @@ trait AppComponents extends FrontendComponents {
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-facia-press")
+  lazy val appIdentity = ApplicationIdentity("facia-press")
 
   override lazy val appMetrics = ApplicationMetrics(
     FaciaPressMetrics.FrontPressCronSuccess,

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -49,7 +49,7 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-facia")
+  lazy val appIdentity = ApplicationIdentity("facia")
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -45,7 +45,7 @@ trait AppComponents extends FrontendComponents with Controllers with AppLifecycl
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-identity")
+  lazy val appIdentity = ApplicationIdentity("identity")
   override lazy val httpFilters: Seq[EssentialFilter] = wire[IdentityFilters].filters
   override lazy val httpErrorHandler: HttpErrorHandler = wire[IdentityHttpErrorHandler]
 }

--- a/identity/app/conf/IdentityFilters.scala
+++ b/identity/app/conf/IdentityFilters.scala
@@ -1,9 +1,10 @@
 package conf
 
 import filters.{HeaderLoggingFilter, StrictTransportSecurityHeaderFilter}
+import model.ApplicationContext
 import play.api.http.HttpFilters
 
-class IdentityFilters extends HttpFilters {
+class IdentityFilters(context: ApplicationContext) extends HttpFilters {
 
-  val filters = new HeaderLoggingFilter :: new StrictTransportSecurityHeaderFilter :: conf.Filters.common
+  val filters = new HeaderLoggingFilter :: new StrictTransportSecurityHeaderFilter :: conf.Filters.common(context)
 }

--- a/identity/app/views/formstack/formstackComplete.scala.html
+++ b/identity/app/views/formstack/formstackComplete.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches._
 
 <!DOCTYPE html>
@@ -8,7 +8,7 @@
     <title>@Html(page.metadata.webTitle)</title>
 
     @* get the stylesheets downloading ASAP *@
-    @fragments.stylesheets(projectName)
+    @fragments.stylesheets(Some(context.applicationIdentity.name))
 
     @* start trying to use the stylesheets *@
     @if(AsyncCss.isSwitchedOn) {

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, formstackForm: _root_.formstack.FormstackForm)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html class="js-off is-not-modern id--signed-out" lang="en-GB">
@@ -7,7 +7,7 @@
     <title>@Html(page.metadata.webTitle)</title>
 
     @* get the stylesheets downloading ASAP *@
-    @fragments.stylesheets(projectName)
+    @fragments.stylesheets(Some(context.applicationIdentity.name))
 
     @* inline JS - blocking *@
     @fragments.inlineJSBlocking(page)

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, formstackForm: _root_.formstack.FormstackForm, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader)
+@(page: model.Page, formstackForm: _root_.formstack.FormstackForm)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
 <html lang="en-GB">

--- a/identity/app/views/formstack/formstackFormNotFound.scala.html
+++ b/identity/app/views/formstack/formstackFormNotFound.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, projectName: Option[String] = Some(conf.Configuration.environment.projectName))(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches._
 
 <!DOCTYPE html>
@@ -8,7 +8,7 @@
     <title>@Html(page.metadata.webTitle)</title>
 
     @* get the stylesheets downloading ASAP *@
-    @fragments.stylesheets(projectName)
+    @fragments.stylesheets(Some(context.applicationIdentity.name))
 
     @* start trying to use the stylesheets *@
     @if(AsyncCss.isSwitchedOn) {

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -62,7 +62,7 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-onward")
+  lazy val appIdentity = ApplicationIdentity("onward")
 
   val applicationMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -10,7 +10,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 
 import scala.concurrent.Future
 
-class VideoEndSlateController(contentApiClient: ContentApiClient) extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class VideoEndSlateController(contentApiClient: ContentApiClient)(implicit context: ApplicationContext) extends Controller with Logging with Paging with ExecutionContexts with Requests {
 
   def renderSection(sectionId: String) = Action.async { implicit request =>
     val response = lookupSection(Edition(request), sectionId) map { seriesItems =>

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -46,7 +46,7 @@ trait AppComponents extends FrontendComponents {
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-rss")
+  lazy val appIdentity = ApplicationIdentity("rss")
 
   override lazy val appMetrics = ApplicationMetrics(
     ContentApiMetrics.HttpTimeoutCountMetric,

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -71,7 +71,7 @@ trait AppComponents extends FrontendComponents
 
   lazy val router: Router = wire[Routes]
 
-  lazy val appIdentity = ApplicationIdentity("frontend-sport")
+  lazy val appIdentity = ApplicationIdentity("sport")
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]

--- a/standalone/app/conf/StandaloneFilters.scala
+++ b/standalone/app/conf/StandaloneFilters.scala
@@ -3,6 +3,7 @@ package conf
 import com.gu.googleauth.FilterExemption
 import common.ExecutionContexts
 import googleAuth.GoogleAuthFilters
+import model.ApplicationContext
 import play.api.Environment
 import play.api.http.HttpFilters
 import play.api.mvc.{Filter, RequestHeader, Result}
@@ -30,12 +31,13 @@ object FilterExemptions {
 }
 
 class StandaloneFilters(
-    environment: Environment
+    environment: Environment,
+    context: ApplicationContext
 ) extends HttpFilters {
 
   val previewAuthFilter = new GoogleAuthFilters.AuthFilterWithExemptions(
     FilterExemptions.loginExemption,
     FilterExemptions.exemptions)(environment)
 
-  val filters = previewAuthFilter :: new NoCacheFilter() :: Filters.common
+  val filters = previewAuthFilter :: new NoCacheFilter() :: Filters.common(context)
 }

--- a/standalone/app/controllers/OAuthLoginStandaloneController.scala
+++ b/standalone/app/controllers/OAuthLoginStandaloneController.scala
@@ -4,11 +4,11 @@ import com.gu.googleauth.{GoogleAuthConfig, UserIdentity}
 import googleAuth.OAuthLoginController
 import play.api.mvc.{Action, AnyContent, Request}
 import conf.Configuration
-import conf.Configuration.environment.projectName
+import model.ApplicationContext
 
-class OAuthLoginStandaloneController extends OAuthLoginController {
+class OAuthLoginStandaloneController(implicit context: ApplicationContext) extends OAuthLoginController {
   override def login = Action { request =>
-    Ok(views.html.standalone_auth(projectName, "Dev", UserIdentity.fromRequest(request)))
+    Ok(views.html.standalone_auth(context.applicationIdentity.name, "Dev", UserIdentity.fromRequest(request)))
   }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = Configuration.standalone.oauthCredentials.map { cred =>
     GoogleAuthConfig(


### PR DESCRIPTION
## What does this change?
Making GuardianConfiguration not depend on Play environment or config
Until now it was relying on Play.current which is being deprecated in Play 2.5

Reviewing commit by commit would make more sense

## What is the value of this and can you measure success?
=> Play 2.5

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
