### PR TITLE
Build standalone bootstraps/enhaced/youtube.js bundle - used in youtu…

### DIFF
--- a/tools/__tasks__/compile/javascript/rjs--webpack.js
+++ b/tools/__tasks__/compile/javascript/rjs--webpack.js
@@ -169,7 +169,6 @@ const bundles = [{
     exclude: [
         'boot-rjs',
         'bootstraps/commercial',
-        'bootstraps/enhanced/main',
         'text',
         'inlineSvg',
     ],

--- a/tools/__tasks__/compile/javascript/rjs.js
+++ b/tools/__tasks__/compile/javascript/rjs.js
@@ -186,7 +186,6 @@ const bundles = [{
         'boot',
         'bootstraps/standard/main',
         'bootstraps/commercial',
-        'bootstraps/enhanced/main',
         'text',
         'inlineSvg',
     ],


### PR DESCRIPTION
## What does this change?

- Fix issue with embedded youtube atoms (views/fragments/atoms/mediaEmbed.scala.html) where common/modules/atom/youtube.js is unavailable (403s when required by bootstraps/enhanced/youtube).

- bootstraps/enhanced/youtube.js is required in 2 locations bootstraps/enhanced/main.js and views/fragments/atoms/mediaEmbed.scala.html. Because it's used by main when the youtube.js asset is built it doesn't create a standalone bundle that can be used by mediaEmbed.scala.html.

## What is the value of this and can you measure success?

Embedded youtube atoms can be enhanced

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Request for comment

@sndrs @SiAdcock 