### PR TITLE
Remove fakeOnStart workaround

### DIFF
--- a/admin/app/controllers/DeploysNotifyController.scala
+++ b/admin/app/controllers/DeploysNotifyController.scala
@@ -74,7 +74,7 @@ trait DeploysNotifyController extends Controller with ApiKeyAuthenticationSuppor
 }
 
 class DeploysNotifyControllerImpl(val wsClient: WSClient) extends DeploysNotifyController {
-  override val apiKey = Configuration.DeploysNotify.apiKey.getOrElse(
+  override lazy val apiKey = Configuration.DeploysNotify.apiKey.getOrElse(
     throw new RuntimeException("Deploys-notify API Key not set")
   )
   val httpClient = new HttpClient(wsClient)

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 class MetricsController(wsClient: WSClient)(implicit context: ApplicationContext) extends Controller with Logging with ExecutionContexts {
     // We only do PROD metrics
 
-  val stage = Configuration.environment.stage.toUpperCase
+  lazy val stage = Configuration.environment.stage.toUpperCase
 
   def renderLoadBalancers() = Action.async { implicit request =>
     for {

--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -17,7 +17,7 @@ object AdUnitAgent extends DataAgent[String, GuAdUnit] {
       val dfpAdUnits = session.adUnits(statementBuilder)
 
       val networkRootId = session.getRootAdUnitId
-      val guardianRootName = Configuration.commercial.dfpAdUnitGuRoot
+      lazy val guardianRootName = Configuration.commercial.dfpAdUnitGuRoot
 
       val runOfNetwork = dfpAdUnits.find(_.getId == networkRootId).map( networkAdUnit => {
         val id = networkAdUnit.getId

--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -19,9 +19,9 @@ import services.RedirectService.ArchiveRedirect
 import scala.concurrent.Future
 
 class R2PagePressJob(wsClient: WSClient, redirects: RedirectService) extends ExecutionContexts with Logging {
-  private val waitTimeSeconds = Configuration.r2Press.pressQueueWaitTimeInSeconds
-  private val maxMessages = Configuration.r2Press.pressQueueMaxMessages
-  private val credentials = Configuration.aws.mandatoryCredentials
+  private lazy val waitTimeSeconds = Configuration.r2Press.pressQueueWaitTimeInSeconds
+  private lazy val maxMessages = Configuration.r2Press.pressQueueMaxMessages
+  private lazy val credentials = Configuration.aws.mandatoryCredentials
 
   def run() = {
     if (R2PagePressServiceSwitch.isSwitchedOn) {
@@ -48,7 +48,7 @@ class R2PagePressJob(wsClient: WSClient, redirects: RedirectService) extends Exe
     }
   }
 
-  private val queue: JsonMessageQueue[SNSNotification] = (Configuration.r2Press.sqsQueueUrl map { queueUrl =>
+  private lazy val queue: JsonMessageQueue[SNSNotification] = (Configuration.r2Press.sqsQueueUrl map { queueUrl =>
     JsonMessageQueue[SNSNotification](
       new AmazonSQSAsyncClient(credentials).withRegion(Region.getRegion(Regions.EU_WEST_1)),
       queueUrl
@@ -57,7 +57,7 @@ class R2PagePressJob(wsClient: WSClient, redirects: RedirectService) extends Exe
     throw new RuntimeException("Required property 'r2Press.sqsQueueUrl' not set")
   }
 
-  private val takedownQueue: TextMessageQueue[SNSNotification] = (Configuration.r2Press.sqsTakedownQueueUrl map { queueUrl =>
+  private lazy val takedownQueue: TextMessageQueue[SNSNotification] = (Configuration.r2Press.sqsTakedownQueueUrl map { queueUrl =>
     TextMessageQueue[SNSNotification](
       new AmazonSQSAsyncClient(credentials).withRegion(Region.getRegion(Regions.EU_WEST_1)),
       queueUrl

--- a/admin/app/pagepresser/HtmlCleaner.scala
+++ b/admin/app/pagepresser/HtmlCleaner.scala
@@ -9,7 +9,7 @@ import conf.Configuration
 import scala.collection.JavaConversions._
 
 abstract class HtmlCleaner extends Logging with ExecutionContexts {
-  val fallbackCacheBustId = Configuration.r2Press.fallbackCachebustId
+  lazy val fallbackCacheBustId = Configuration.r2Press.fallbackCachebustId
   lazy val staticRegEx = """//static.guim.co.uk/static/(\w+)/(.+)(\.\w+)$""".r("cacheBustId", "paths", "extension")
   lazy val nonDigitRegEx = """\D+""".r
 

--- a/applications/app/model/notifications/DynamoDbStore.scala
+++ b/applications/app/model/notifications/DynamoDbStore.scala
@@ -14,7 +14,7 @@ import scala.util.{Success, Failure}
 
 
 object DynamoDbStore extends Logging with ExecutionContexts {
-  val tableName = Configuration.Notifications.notificationSubscriptionTable
+  lazy val tableName = Configuration.Notifications.notificationSubscriptionTable
 
   private val client = services.DynamoDB.asyncClient
 

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -17,19 +17,10 @@ trait FrontendApplicationLoader extends ApplicationLoader {
 
   def buildComponents(context: Context): FrontendComponents
 
-  // this is a workaround the lifecycle issue: "There is no started Application"
-  // When starting lifecycles, it's possible the code hit a point where we use Play.current, directly or via WS and akka.system.
-  // If that happen before the application is actually started by Play (see ProdServerStart.scala), we will get an error at runtime
-  // This workaround should be removed when we migrated to Play2.5 or when we got rid of all the deprecated calls to Play.current
-  def fakeOnStart(components: FrontendComponents): Unit = Play.maybeApplication match {
-    case Some(_) => components.startLifecycleComponents()
-    case None => components.akkaAsync.after1s(fakeOnStart(components))
-  }
-
   override def load(context: Context): Application = {
     Logger.configure(context.environment)
     val components = buildComponents(context)
-    fakeOnStart(components)
+    components.startLifecycleComponents()
     components.application
   }
 }

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -174,7 +174,7 @@ class CachedHealthCheckLifeCycle(
   jobs: JobScheduler,
   akkaAsync: AkkaAsync) extends LifecycleComponent {
 
-  private val healthCheckRequestFrequencyInSec = Configuration.healthcheck.updateIntervalInSecs
+  private lazy val healthCheckRequestFrequencyInSec = Configuration.healthcheck.updateIntervalInSecs
 
   override def start() = {
     jobs.deschedule("HealthCheckFetch")

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success}
 case class CollectionConfigWithId(id: String, config: CollectionConfig)
 
 trait ConfigAgentTrait extends ExecutionContexts with Logging {
-  implicit val alterTimeout: Timeout = Configuration.faciatool.configBeforePressTimeout.millis
+  implicit lazy val alterTimeout: Timeout = Configuration.faciatool.configBeforePressTimeout.millis
   private lazy val configAgent = AkkaAgent[Option[Config]](None)
 
   def isLoaded() = configAgent.get().isDefined

--- a/common/app/services/DynamoDB.scala
+++ b/common/app/services/DynamoDB.scala
@@ -8,8 +8,8 @@ import conf.Configuration
 
 
 object DynamoDB {
-  private lazy val credentials = Configuration.aws.mandatoryCredentials
-  private lazy val region = Region.getRegion(Regions.fromName(Configuration.aws.region))
+  private val credentials = Configuration.aws.mandatoryCredentials
+  private val region = Region.getRegion(Regions.fromName(Configuration.aws.region))
 
   lazy val asyncClient = createClient(classOf[AmazonDynamoDBAsyncClient])
   lazy val syncClient = createClient(classOf[AmazonDynamoDBClient])

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -179,8 +179,8 @@ object S3FrontsApi extends S3 {
 
 class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {
   val algorithm: String = "HmacSHA1"
-  val frontendBucket: String = Configuration.aws.bucket
-  val frontendStore: String = Configuration.frontend.store
+  lazy val frontendBucket: String = Configuration.aws.bucket
+  lazy val frontendStore: String = Configuration.frontend.store
 
   def urlGet(id: String): WSRequest = url("GET", id)
 

--- a/discussion/app/controllers/WitnessActivityController.scala
+++ b/discussion/app/controllers/WitnessActivityController.scala
@@ -20,5 +20,5 @@ trait WitnessActivityController extends WitnessApi with Controller with Executio
 }
 
 class WitnessActivityControllerImpl(val wsClient: WSClient) extends WitnessActivityController {
-  protected val witnessApiRoot: String = Configuration.witness.witnessApiRoot
+  protected lazy val witnessApiRoot: String = Configuration.witness.witnessApiRoot
 }

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -208,7 +208,7 @@ class DiscussionApi(val wsClient: WSClient) extends DiscussionApiLike {
     else
       Configuration.discussion.apiRoot.replaceFirst("https://", "http://") // CODE SSL cert is defective and expensive to fix
 
-  override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
+  override protected lazy val clientHeaderValue: String = Configuration.discussion.apiClientHeader
 }
 
 

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorker: ToolPressQueueWorker) extends JsonQueueWorker[SNSNotification] {
-  val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
+  lazy val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
   override val deleteOnFailure: Boolean = true
 
   override val queue: JsonMessageQueue[SNSNotification] = (Configuration.faciatool.frontPressCronQueue map { queueUrl =>

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFrontPress: DraftFapiFrontPress) extends JsonQueueWorker[PressJob] with Logging {
-  override val queue = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
+  override lazy val queue = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials
 
     JsonMessageQueue[PressJob](

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -10,7 +10,7 @@ import services.SecureS3Request
 import scala.concurrent.Future
 
 trait FrontJsonFapi extends Logging with ExecutionContexts {
-  val stage: String = Configuration.facia.stage.toUpperCase
+  lazy val stage: String = Configuration.facia.stage.toUpperCase
   val bucketLocation: String
 
   val wsClient: WSClient


### PR DESCRIPTION
## What does this change?
Remove fakeOnStart workaround which is not useful anymore since we don't reference Play.current global object anymore

## What is the value of this and can you measure success?
=> Play 2.5

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
