### PR TITLE
Extending comment switch and assigning to nic long

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -50,9 +50,9 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "long-cache-comments-switch",
     "If this switch is on then closed comment threads will get a longer cache time",
-    owners = Seq(Owner.withGithub("dominickendrick")),
+    owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2016, 12, 14),
+    sellByDate = new LocalDate(2017, 1, 10),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extends comment switch and assigning to nic long

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/dotcom-platform @nicl 

