### PR TITLE
Add poster only template for media atoms

### DIFF
--- a/common/app/views/fragments/atoms/ampMediaPosterOnly.scala.html
+++ b/common/app/views/fragments/atoms/ampMediaPosterOnly.scala.html
@@ -1,0 +1,12 @@
+@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+<amp-img
+src="@media.posterUrl.get"
+alt="@media.title"
+width="16"
+height="9"
+layout="responsive">
+</amp-img>
+<figcaption class="caption caption--img" itemprop="description">
+@fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+@media.title
+</figcaption>

--- a/common/app/views/fragments/atoms/genericMedia.scala.html
+++ b/common/app/views/fragments/atoms/genericMedia.scala.html
@@ -1,14 +1,21 @@
 @import views.support.RenderClasses
 
-@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean)(implicit request: RequestHeader)
 
-<div class="@RenderClasses(Map(
-    "u-responsive-ratio" -> true,
-    "u-responsive-ratio--hd" -> true
-))">
+    <div class="@RenderClasses(Map(
+        "u-responsive-ratio" -> true,
+        "u-responsive-ratio--hd" -> true
+    ))">
 
-@Html(media.defaultHtml)
+        @Html(media.defaultHtml)
 
-</div>
+    </div>
+
+@if(displayCaption) {
+    <figcaption class="caption caption--main" itemprop="description">
+        @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+        @media.title
+    </figcaption>
+}
 
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,7 +1,6 @@
 @(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
-    println(media)
     media match {
             case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -2,7 +2,7 @@
 
 @{
     media match {
-            case youtube if media.assets.head.platform == "Youtube" => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
+            case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -3,8 +3,9 @@
 @{
     media match {
             case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media) else views.html.fragments.atoms.mediaPosterOnly(media)
-            case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
-            case _ => views.html.fragments.atoms.genericMedia(media)
+            case youtube if media.assets.headOption.filter(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
+            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption)
+            case _ =>
         }
 
 }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,7 +1,9 @@
 @(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
+    println(media)
     media match {
+            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -2,7 +2,7 @@
 
 @{
     media match {
-            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media)
+            case posterOnly if media.posterUrl.isDefined && media.assets.isEmpty => if(amp) views.html.fragments.atoms.ampMediaPosterOnly(media) else views.html.fragments.atoms.mediaPosterOnly(media)
             case youtube if media.assets.headOption.map(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption)
             case _ => views.html.fragments.atoms.genericMedia(media)
         }

--- a/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
+++ b/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
@@ -1,0 +1,19 @@
+@(media: model.content.MediaAtom)
+<figure
+itemprop="associatedMedia image"
+itemscope
+itemtype="http://schema.org/ImageObject"
+data-component="image" xmlns="http://www.w3.org/1999/html"
+class="element element-image">
+    <div class="u-responsive-ratio">
+        <picture>
+            <img itemprop="contentUrl"
+            alt="@media.title"
+            src="@media.posterUrl.get">
+        </picture>
+    </div>
+    <figcaption class="caption caption--img" itemprop="description">
+    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon")) @media.title
+    </figcaption>
+</figure>
+

--- a/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
+++ b/common/app/views/fragments/atoms/mediaPosterOnly.scala.html
@@ -6,11 +6,9 @@ itemtype="http://schema.org/ImageObject"
 data-component="image" xmlns="http://www.w3.org/1999/html"
 class="element element-image">
     <div class="u-responsive-ratio">
-        <picture>
-            <img itemprop="contentUrl"
+            <img
             alt="@media.title"
             src="@media.posterUrl.get">
-        </picture>
     </div>
     <figcaption class="caption caption--img" itemprop="description">
     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon")) @media.title

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -30,7 +30,9 @@
 
 
     @if(displayCaption) {
-        <figcaption class="caption caption--main" itemprop="description">@media.title</figcaption>
+        <figcaption class="caption caption--main" itemprop="description">
+        @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+        @media.title</figcaption>
     }
 }
 


### PR DESCRIPTION
## What does this change?
Adds a template for case where media atom has `posterUrl` but no assets. This is because editorial may wish to preview or publish an media atom before assets are available.

## What is the value of this and can you measure success?
Fix previous exception when a media atom with no assets was embedded. Support poster only case. Adds caption icon across media atom cases.

## Does this affect other platforms - Amp, Apps, etc?
Adds AMP template for poster only

## Screenshots
.com

![screen shot 2016-12-15 at 10 36 38](https://cloud.githubusercontent.com/assets/1764158/21220789/78a7da7a-c2b2-11e6-9127-cb58b1389adc.png)

AMP

![screen shot 2016-12-15 at 10 36 23](https://cloud.githubusercontent.com/assets/1764158/21220790/78a83d4e-c2b2-11e6-854a-068c9a00e761.png)


<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
