### PR TITLE
Change the message on the International membership engagement banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -60,7 +60,7 @@ define([
             },
             INT: {
                 campaign: 'mem_int_banner',
-                messageText: 'The Guardian’s voice is needed now more than ever. Support our journalism for just $69/€49 per year.',
+                messageText: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for $7 / €5 a month.',
                 buttonCaption: 'Become a Supporter'
             }
         };


### PR DESCRIPTION
## What does this change?
Updates the message on the International version of the membership engagement banner

## What is the value of this and can you measure success?
This is the message that has consistently performed best in other regions so we want to roll it out to international users as well.

## Does this affect other platforms - Amp, Apps, etc?
Web only
