### PR TITLE
Encode crop param for share images

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -104,7 +104,7 @@ object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 1
 abstract class ShareImage(shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
   override val heightParam = "h=630"
   override val fitParam = "fit=crop"
-  val cropParam = "crop=faces,entropy"  
+  val cropParam = "crop=faces%2Centropy"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=bottom%2Cleft"
   val blendImageParam: String


### PR DESCRIPTION
## What does this change?
Encodes the comma in the `crop` imgix parameter for share images.  I noticed that we are seeing requests from facebook, outbrain (and other) crawlers that have encoded this comma automatically - which results in the associated signature being invalid.  I have confirmed the signature they use is valid for the URL with the comma un-encoded.

## What is the value of this and can you measure success?
Allows signing to work correctly for requests from external services that encode parameter values (e.g. facebook).

@guardian/dotcom-platform @paperboyo 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->