### PR TITLE
Fix instant ad loaded twice

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
@@ -13,7 +13,7 @@ define([
             dfpEnv.lazyLoadEnabled = true;
             if (dfpEnv.lazyLoadObserve) {
                 observer = new IntersectionObserver(lazyLoad, { rootMargin: '200px 0%' });
-                dfpEnv.adverts.forEach(function (advert) {
+                dfpEnv.advertsToLoad.forEach(function (advert) {
                     observer.observe(advert.node);
                 });
             } else {


### PR DESCRIPTION
I just introduced a bug by taking adverts from the wrong array in the bootstrapping of the lazy loading process. As a result, ads that are "instantly loaded" (like the pageskin, the high-merch) are loaded twice.
