### PR TITLE
Add contributions utilities module and use it in 3 tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -101,7 +101,7 @@ trait ABTestSwitches {
     "Run the control variant for 87.5% of the US audience",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 1),
+    sellByDate = new LocalDate(2017, 1, 3),
     exposeClientSide = true
   )
 
@@ -111,7 +111,7 @@ trait ABTestSwitches {
     "Run the end of year variant for 12.5% of the US audience",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 1),
+    sellByDate = new LocalDate(2016, 12, 31),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -77,11 +77,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-us-pre-end-of-year-two",
-    "Test which Epic variant to use in the US end of year campaign",
+    "ab-contributions-epic-always-ask-strategy",
+    "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 19),
+    sellByDate = new LocalDate(2017, 1, 6),
     exposeClientSide = true
   )
 
@@ -97,11 +97,21 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-always-ask-strategy",
-    "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
+    "ab-contributions-epic-us-eoy-control",
+    "Run the control variant for 87.5% of the US audience",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 6),
+    sellByDate = new LocalDate(2017, 1, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-us-eoy-end-of-year",
+    "Run the end of year variant for 12.5% of the US audience",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 1, 1),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -111,7 +111,7 @@ trait ABTestSwitches {
     "Run the end of year variant for 12.5% of the US audience",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 31),
+    sellByDate = new LocalDate(2017, 1, 3),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -155,15 +155,15 @@ define([
             });
         };
 
-        this.registerListener('impression', 'impressionOnInsert', this.insertEvent, options);
-        this.registerListener('success', 'successOnView', this.viewEvent, options);
+        this.registerListener('impression', 'impressionOnInsert', test.insertEvent, options);
+        this.registerListener('success', 'successOnView', test.viewEvent, options);
     }
 
     ContributionsABTestVariant.prototype.registerListener = function (type, defaultFlag, event, options) {
         if (options[type]) this[type] = options[type];
         else if (options[defaultFlag]) {
             this[type] = (function (track) {
-                return mediator.on(this[event], track);
+                return mediator.on(event, track);
             }).bind(this);
         }
     };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -58,7 +58,7 @@ define([
 
         return viewLog.filter(function (view) {
             return view.date > (now - maxDays);
-        }).length < maxViews.count;
+        }).length <= maxViews.count;
     }
 
     function daysSince(date) {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -1,0 +1,183 @@
+define([
+    'common/modules/commercial/commercial-features',
+    'common/modules/commercial/targeting-tool',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/element-inview',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'common/utils/storage',
+], function (commercialFeatures,
+             targetingTool,
+             $,
+             config,
+             cookies,
+             ElementInView,
+             fastdom,
+             mediator,
+             storage) {
+
+    var membershipURL = 'https://membership.theguardian.com/supporter';
+    var contributionsURL = 'https://contribute.theguardian.com';
+
+    var membershipCampaignPrefix = 'gdnwb_copts_mem';
+    var contributionsCampaignPrefix = 'co_global';
+
+    function lastContributionDate() {
+        return cookies.get('gu.contributions.contrib-timestamp');
+    }
+
+    function userHasContributed() {
+        return !!lastContributionDate();
+    }
+
+    var viewKey = 'gu.contributions.views';
+    var viewLog = storage.local.get(viewKey) || [];
+
+    /**
+     * How many times the user can see the Epic, e.g. 6 times within 7 days.
+     * @type {{days: number, count: number}}
+     */
+    var maxViews = {
+        days: 7,
+        count: 6
+    };
+
+    /**
+     * The maxViews.days duration in milliseconds.
+     * @type {number}
+     */
+    var window = maxViews.days * 1000 * 60 * 60 * 24;
+
+    /**
+     * Log that the user has seen an Epic test so we can limit how many times they see it.
+     * We only store events that fall within the range specified in `maxViews.days`.
+     *
+     * @param testId
+     */
+    function logView(testId) {
+        viewLog.push({
+            date: new Date().getTime(),
+            testId: testId
+        });
+
+        storage.local.set(viewKey, viewLog);
+    }
+
+    function isViewable() {
+        var now = new Date().getTime();
+
+        return viewLog.filter(function (view) {
+            return view.date > (now - window);
+        }).length < maxViews.count;
+    }
+
+    function ContributionsABTest(options) {
+        this.id = options.id;
+        this.start = options.start;
+        this.expiry = options.expiry;
+        this.author = options.author;
+        this.idealOutcome = options.idealOutcome;
+        this.campaignId = options.campaignId;
+        this.description = options.description;
+        this.showForSensitive = options.showForSensitive || false;
+        this.showOnCharity = options.showOnCharity || false;
+        this.audience = options.audience;
+        this.audienceOffset = options.audienceOffset;
+        this.successMeasure = options.successMeasure;
+        this.audienceCriteria = options.audienceCriteria;
+        this.dataLinkNames = options.dataLinkNames || '';
+
+        this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, contributionsCampaignPrefix);
+        this.membershipURL = options.membershipURL || this.makeURL(membershipURL, membershipCampaignPrefix);
+
+        this.insertEvent = this.makeEvent('insert');
+        this.viewEvent = this.makeEvent('view');
+
+        /**
+         * Provides a default `canRun` function with typical rules for Contributions messages. If your test provides
+         * its own `canRun` option, it will be included in the check.
+         *
+         * You can alternatively use the `overrideCanRun` option, which, if true, will only use the `canRun`
+         * option provided and ignore the rules here.
+         *
+         * @type {Function}
+         */
+        this.canRun = options.overrideCanRun ? options.canRun : (function () {
+            var tagsMatch = options.useTargetingTool ? targetingTool.isAbTestTargeted(this) : true;
+            var extendedCanRun = (typeof options.canRun === 'function') ? options.canRun() : true;
+            var userHasNeverContributed = !userHasContributed();
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle;
+
+            return tagsMatch && extendedCanRun && userHasNeverContributed &&
+                commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+        }).bind(this);
+
+        this.variants = options.variants.map(function (variant) {
+            return new ContributionsABTestVariant(variant, this);
+        }.bind(this));
+    }
+
+    ContributionsABTest.prototype.makeEvent = function (event) {
+        return this.id + ':' + event;
+    };
+
+    ContributionsABTest.prototype.makeURL = function (base, campaignCodePrefix) {
+        return base + '?' + campaignCodePrefix + '_' + this.campaignId;
+    };
+
+    function ContributionsABTestVariant(options, test) {
+        this.id = options.id;
+        this.test = function () {
+            var component = $.create(options.template(test.contributeURL, test.membershipURL));
+
+            return options.test(function () {
+                return fastdom.write(function () {
+                    var sibling = $(options.insertBeforeSelector);
+
+                    if (sibling.length > 0) {
+                        component.insertBefore(sibling);
+                        mediator.emit(test.insertEvent, component);
+
+                        component.each(function (element) {
+                            // top offset of 18 ensures view only counts when half of element is on screen
+                            var elementInView = ElementInView(element, window, { top: 18 });
+
+                            elementInView.on('firstview', function () {
+                                logView(test.id);
+                                mediator.emit(test.viewEvent);
+                            });
+                        });
+                    }
+                });
+            });
+        };
+
+        this.registerListener('impression', 'impressionOnInsert', this.insertEvent, options);
+        this.registerListener('success', 'successOnView', this.viewEvent, options);
+    }
+
+    ContributionsABTestVariant.prototype.registerListener = function (type, defaultFlag, event, options) {
+        if (options[type]) this[type] = options[type];
+        else if (options[defaultFlag]) {
+            this[type] = (function (track) {
+                return mediator.on(this[event], track);
+            }).bind(this);
+        }
+    };
+
+    return {
+        makeABTest: function (test) {
+            // this is so it can be instantiated with `new` later
+            return function () {
+                return new ContributionsABTest(test);
+            };
+        },
+
+        inAlwaysAskTest: function () {
+            var participations = storage.local.get('gu.ab.participations') || {};
+            return ('ContributionsEpicAlwaysAskStrategy' in participations);
+        }
+    };
+});

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -83,7 +83,6 @@ define([
         this.campaignId = options.campaignId;
         this.description = options.description;
         this.showForSensitive = options.showForSensitive || false;
-        this.showOnCharity = options.showOnCharity || false;
         this.audience = options.audience;
         this.audienceOffset = options.audienceOffset;
         this.successMeasure = options.successMeasure;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -40,7 +40,6 @@ define([
 
     /**
      * Log that the user has seen an Epic test so we can limit how many times they see it.
-     * We only store events that fall within the range specified in `maxViews.days`.
      *
      * @param testId
      */

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -53,11 +53,11 @@ define([
     }
 
     function canShow() {
-        var window = maxViews.days * 1000 * 60 * 60 * 24;
+        var maxDays = maxViews.days * 1000 * 60 * 60 * 24;
         var now = new Date().getTime();
 
         return viewLog.filter(function (view) {
-            return view.date > (now - window);
+            return view.date > (now - maxDays);
         }).length < maxViews.count;
     }
 
@@ -68,7 +68,7 @@ define([
             var ms = Date.parse(date);
 
             if (isNaN(ms)) return Infinity;
-            else return (new Date() - ms) / oneDay;
+            return (new Date() - ms) / oneDay;
         } catch(e) {
             return Infinity;
         }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -24,16 +24,10 @@ define([
     var membershipCampaignPrefix = 'gdnwb_copts_mem';
     var contributionsCampaignPrefix = 'co_global';
 
-    function lastContributionDate() {
-        return cookies.get('gu.contributions.contrib-timestamp');
-    }
-
-    function userHasContributed() {
-        return !!lastContributionDate();
-    }
-
     var viewKey = 'gu.contributions.views';
     var viewLog = storage.local.get(viewKey) || [];
+
+    var lastContributionDate = cookies.get('gu.contributions.contrib-timestamp');
 
     /**
      * How many times the user can see the Epic, e.g. 6 times within 7 days.
@@ -43,12 +37,6 @@ define([
         days: 7,
         count: 6
     };
-
-    /**
-     * The maxViews.days duration in milliseconds.
-     * @type {number}
-     */
-    var window = maxViews.days * 1000 * 60 * 60 * 24;
 
     /**
      * Log that the user has seen an Epic test so we can limit how many times they see it.
@@ -65,12 +53,26 @@ define([
         storage.local.set(viewKey, viewLog);
     }
 
-    function isViewable() {
+    function canShow() {
+        var window = maxViews.days * 1000 * 60 * 60 * 24;
         var now = new Date().getTime();
 
         return viewLog.filter(function (view) {
             return view.date > (now - window);
         }).length < maxViews.count;
+    }
+
+    function daysSince(date) {
+        var oneDay = 24 * 60 * 60 * 1000;
+
+        try {
+            var ms = Date.parse(date);
+
+            if (isNaN(ms)) return Infinity;
+            else return (new Date() - ms) / oneDay;
+        } catch(e) {
+            return Infinity;
+        }
     }
 
     function ContributionsABTest(options) {
@@ -105,13 +107,12 @@ define([
          * @type {Function}
          */
         this.canRun = options.overrideCanRun ? options.canRun : (function () {
+            var testCanRun = (typeof options.canRun === 'function') ? options.canRun() : true;
+            var okToAsk = daysSince(lastContributionDate) >= 90 && canShow();
             var tagsMatch = options.useTargetingTool ? targetingTool.isAbTestTargeted(this) : true;
-            var extendedCanRun = (typeof options.canRun === 'function') ? options.canRun() : true;
-            var userHasNeverContributed = !userHasContributed();
             var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle;
 
-            return tagsMatch && extendedCanRun && userHasNeverContributed &&
-                commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+            return okToAsk && tagsMatch && testCanRun && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
         }).bind(this);
 
         this.variants = options.variants.map(function (variant) {

--- a/static/src/javascripts/projects/common/modules/commercial/targeting-tool.js
+++ b/static/src/javascripts/projects/common/modules/commercial/targeting-tool.js
@@ -30,7 +30,7 @@ define([
      * @return {Boolean}
      */
     function isAbTestTargeted(test) {
-        return campaignsFor(test.id).length > 0;
+        return campaignsFor(test.campaignId).length > 0;
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -6,7 +6,6 @@ define([
     ab
 ) {
 
-
     var ContributionsEpicUsaCtaThreeWay = {
         name: 'ContributionsEpicUsaCtaThreeWay',
         variants: ['mixed', 'just-contribute', 'just-supporter']
@@ -22,11 +21,6 @@ define([
         variants: ['mixed']
     };
 
-    var ContributionsEpicUsPreEndOfYearTwo = {
-        name: 'ContributionsEpicUsPreEndOfYearTwo',
-        variants: ['control', 'endOfYear']
-    };
-
     var ContributionsEpicAlwaysAskStrategy = {
         name: 'ContributionsEpicAlwaysAskStrategy',
         variants: ['control', 'alwaysAsk']
@@ -37,14 +31,25 @@ define([
         variants: ['control', 'showMeTheMoon', 'australiaNewsroom', 'endOfYearAustralia']
     };
 
+    var ContributionsEpicUsEoyControl = {
+        name: 'ContributionsEpicUsEoyControl',
+        variants: ['control']
+    };
+
+    var ContributionsEpicUsEoyEndOfYear = {
+        name: 'ContributionsEpicUsEoyEndOfYear',
+        variants: ['endOfYear']
+    };
+
     function userIsInAClashingAbTest() {
         var clashingTests = [
             ContributionsEpicUsaCtaThreeWay,
             ContributionsEpicObserverAnniversary,
             ContributionsEpicBrexitSupreme,
-            ContributionsEpicUsPreEndOfYearTwo,
+            ContributionsEpicOnTheMoon,
             ContributionsEpicAlwaysAskStrategy,
-            ContributionsEpicOnTheMoon
+            ContributionsEpicUsEoyControl,
+            ContributionsEpicUsEoyEndOfYear
         ];
         return _testABClash(ab.isInVariant, clashingTests);
     }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,13 +11,14 @@ define([
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/membership-engagement-international-experiment',
     'common/modules/experiments/tests/contributions-epic-brexit-supreme',
-    'common/modules/experiments/tests/contributions-epic-us-pre-end-of-year-two',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-on-the-moon',
     'common/modules/experiments/tests/uk-membership-engagement-message-test-10',
     'common/modules/experiments/tests/au-membership-engagement-message-test-8',
     'common/modules/experiments/tests/its-raining-inline-ads',
-    'common/modules/experiments/tests/video-headline'
+    'common/modules/experiments/tests/video-headline',
+    'common/modules/experiments/tests/contributions-epic-us-eoy-control',
+    'common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year'
 ], function (reportError,
              config,
              cookies,
@@ -30,26 +31,28 @@ define([
              RecommendedForYou,
              MembershipEngagementInternationalExperimentTest12,
              ContributionsEpicBrexitSupreme,
-             ContributionsEpicUsPreEndOfYearTwo,
              ContributionsEpicAlwaysAskStrategy,
              ContributionsEpicOnTheMoon,
              UkMembershipEngagementMessageTest10,
              AuMembershipEngagementMessageTest8,
              ItsRainingInlineAds,
-             VideoHeadline
+             VideoHeadline,
+             ContributionsEpicUsEoyControl,
+             ContributionsEpicUsEoyEndOfYear
     ) {
     var TESTS = [
         new EditorialEmailVariants(),
         new RecommendedForYou(),
         new MembershipEngagementInternationalExperimentTest12(),
         new ContributionsEpicBrexitSupreme(),
-        new ContributionsEpicUsPreEndOfYearTwo(),
         new ContributionsEpicAlwaysAskStrategy(),
         new ContributionsEpicOnTheMoon(),
         new UkMembershipEngagementMessageTest10(),
         new AuMembershipEngagementMessageTest8(),
         new ItsRainingInlineAds(),
-        new VideoHeadline()
+        new VideoHeadline(),
+        new ContributionsEpicUsEoyControl(),
+        new ContributionsEpicUsEoyEndOfYear()
     ];
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -63,7 +63,7 @@ define([
 
     function isParticipating(test) {
         var participations = getParticipations();
-        return participations[test.id];
+        return test.id in participations;
     }
 
     function addParticipation(test, variantId) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -13,7 +13,8 @@ define([
     'common/utils/cookies',
     'common/utils/ajax',
     'common/modules/commercial/commercial-features',
-    'common/utils/element-inview'
+    'common/utils/element-inview',
+    'lodash/arrays/intersection'
 
 ], function (bean,
              qwery,
@@ -29,7 +30,8 @@ define([
              cookies,
              ajax,
              commercialFeatures,
-             ElementInview) {
+             ElementInview,
+             intersection) {
 
     // We want to ensure the test always runs as this enables an easy data lake query to see whether a reader is in the
     // test segment: check whether the ab_tests field contains a test with name ContributionsEpicAlwaysAskStrategy.
@@ -108,13 +110,29 @@ define([
         };
 
         var canBeDisplayed = function() {
+
+            var isCharityAskPage = function() {
+                var charityKeywordIds = [
+                    // TODO
+                ];
+                var pageKeywordIdsString = config.page.keywordIds;
+                if (typeof (pageKeywordIdsString) !== 'undefined') {
+                    var pageKeywordIds = pageKeywordIdsString.split(',');
+                    return intersection(charityKeywordIds, pageKeywordIds).length > 0;
+                } else {
+                    return false;
+                }
+            };
+
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
             var isSensitive = config.page.isSensitive === true;
+
             return userHasNeverContributed &&
                 commercialFeatures.canReasonablyAskForMoney &&
                 worksWellWithPageTemplate &&
-                !isSensitive;
+                !isSensitive &&
+                !isCharityAskPage();
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -1,172 +1,85 @@
 define([
-    'bean',
-    'qwery',
-    'common/utils/$',
-    'common/utils/template',
-    'common/views/svg',
-    'common/utils/fastdom-promise',
-    'common/utils/mediator',
-    'text!common/views/contributions-epic-equal-buttons.html',
-    'common/utils/robust',
-    'inlineSvg!svgs/icon/arrow-right',
+    'common/modules/commercial/commercial-features',
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/ajax',
     'common/utils/config',
     'common/utils/cookies',
-    'common/utils/ajax',
-    'common/modules/commercial/commercial-features',
-    'common/utils/element-inview',
-    'lodash/arrays/intersection'
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html',
+], function (
+            commercialFeatures,
+            contributionsUtilities,
+            ajax,
+            config,
+            cookies,
+            store,
+            template,
+            contributionsEpicEqualButtons) {
 
-], function (bean,
-             qwery,
-             $,
-             template,
-             svg,
-             fastdom,
-             mediator,
-             contributionsEpicEqualButtons,
-             robust,
-             arrowRight,
-             config,
-             cookies,
-             ajax,
-             commercialFeatures,
-             ElementInview,
-             intersection) {
+    function canBeDisplayed() {
+        var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+        var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+        var isSensitive = config.page.isSensitive === true;
 
-    // We want to ensure the test always runs as this enables an easy data lake query to see whether a reader is in the
-    // test segment: check whether the ab_tests field contains a test with name ContributionsEpicAlwaysAskStrategy.
-    // This means having showForSensitive equal to true, and the canRun() function always returning true.
-    // The logic for whether the test-variant is displayed, is handled in the canBeDisplayed() function.
-    return function () {
-        this.id = 'ContributionsEpicAlwaysAskStrategy';
-        this.start = '2016-12-06';
-        this.expiry = '2017-01-06';
-        this.author = 'Guy Dawson';
-        this.description = 'Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period.';
-        this.showForSensitive = true;
-        this.audience = 0.02;
-        this.audienceOffset = 0.88;
-        this.successMeasure = 'We are able to measure the positive and negative effects of this strategy.';
-        this.audienceCriteria = 'All';
-        this.dataLinkNames = '';
-        this.idealOutcome = 'There are no negative effects and this is the optimum strategy!';
-        this.canRun = function () {
+        return userHasNeverContributed &&
+            commercialFeatures.canReasonablyAskForMoney &&
+            worksWellWithPageTemplate && !isSensitive;
+    }
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicAlwaysAskStrategy',
+        campaignId: 'epic_always_ask_strategy',
+
+        start: '2016-12-06',
+        expiry: '2017-01-06',
+
+        author: 'Guy Dawson',
+        description: 'Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period.',
+        successMeasure: 'We are able to measure the positive and negative effects of this strategy.',
+        idealOutcome: 'There are no negative effects and this is the optimum strategy!',
+
+        audienceCriteria: 'All',
+        audience: 0.02,
+        audienceOffset: 0.88,
+        showForSensitive: true,
+        useTargetingTool: true,
+
+        overrideCanRun: true,
+        canRun: function () {
             return true;
-        };
+        },
 
-        var makeEvent = (function(name) {
-            return this.id + ':' + name;
-        }).bind(this);
-
-        function makeUrl(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        }
-
-        var contributeUrlPrefix = 'co_global_epic_always_ask_strategy';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_always_ask_strategy';
-
-        var epicViewedEvent = makeEvent('view');
-
-        var membershipUrl = 'https://membership.theguardian.com/supporter?';
-        var contributeUrl = 'https://contribute.theguardian.com/?';
-
-        var messages  = {
-            alwaysAsk: {
-                title: 'Since you’re here …',
-                p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
-            }
-        };
-
-        var cta = {
-            equal: {
-                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
-                p3: '',
-                cta1: 'Become a Supporter',
-                cta2: 'Make a contribution',
-                url1: makeUrl(membershipUrl, membershipUrlPrefix),
-                url2:  makeUrl(contributeUrl, contributeUrlPrefix),
-                hidden: ''
-            }
-        };
-
-        var componentWriter = function (component) {
-            fastdom.write(function () {
-                var submetaElement = $('.submeta');
-                if (submetaElement.length > 0) {
-                    component.insertBefore(submetaElement);
-                    $('.contributions__epic').each(function (element) {
-                        // top offset of 18 ensures view only counts when half of element is on screen
-                        var elementInview = ElementInview(element, window, {top: 18});
-                        elementInview.on('firstview', function () {
-                            mediator.emit(epicViewedEvent);
-                        });
-                    });
-                }
-            });
-        };
-
-        var registerViewListener = function (complete) {
-            mediator.on(epicViewedEvent, complete);
-        };
-
-        var canBeDisplayed = function() {
-
-            var isCharityAskPage = function() {
-                var charityKeywordIds = [
-                    // TODO
-                ];
-                var pageKeywordIdsString = config.page.keywordIds;
-                if (typeof (pageKeywordIdsString) !== 'undefined') {
-                    var pageKeywordIds = pageKeywordIdsString.split(',');
-                    return intersection(charityKeywordIds, pageKeywordIds).length > 0;
-                } else {
-                    return false;
-                }
-            };
-
-            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
-            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
-            var isSensitive = config.page.isSensitive === true;
-
-            return userHasNeverContributed &&
-                commercialFeatures.canReasonablyAskForMoney &&
-                worksWellWithPageTemplate &&
-                !isSensitive &&
-                !isCharityAskPage();
-        };
-
-        this.variants = [
+        variants: [
             {
                 id: 'control',
-
-                test: function() {},
-
-                success: registerViewListener
+                test: function() {}
             },
+
             {
                 id: 'alwaysAsk',
 
-                test: function () {
-                    if (canBeDisplayed()) {
-                        var ctaType = cta.equal;
-                        var message = messages.alwaysAsk;
-                        var component = $.create(template(contributionsEpicEqualButtons, {
-                            linkUrl1: ctaType.url1 + '_always_ask',
-                            linkUrl2: ctaType.url2 + '_always_ask',
-                            title: message.title,
-                            p1: message.p1,
-                            p2: ctaType.p2,
-                            p3: ctaType.p3,
-                            cta1: ctaType.cta1,
-                            cta2: ctaType.cta2,
-                            hidden: ctaType.hidden
-                        }));
-                        componentWriter(component);
-                    }
+                template: function (membershipUrl, contributionUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl + '_always_ask',
+                        linkUrl2: contributionUrl + '_always_ask',
+                        title: 'Since you’re here…',
+                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
                 },
 
-                success: registerViewListener
+                insertBeforeSelector: '.submeta',
+
+                test: function (render) {
+                    if (canBeDisplayed()) render();
+                },
+
+                successOnView: true
             }
-        ];
-    };
+        ]
+    });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -13,7 +13,9 @@ define([
     'common/utils/cookies',
     'common/utils/ajax',
     'common/modules/commercial/commercial-features',
-    'common/utils/element-inview'
+    'common/utils/element-inview',
+    'common/modules/experiments/ab',
+    'lodash/arrays/intersection'
 
 ], function (bean,
              qwery,
@@ -29,12 +31,14 @@ define([
              cookies,
              ajax,
              commercialFeatures,
-             ElementInview) {
+             ElementInview,
+             ab,
+             intersection) {
 
     return function () {
         this.id = 'ContributionsEpicUsEoyControl';
         this.start = '2016-12-13';
-        this.expiry = '2017-01-01';
+        this.expiry = '2017-01-03';
         this.author = 'Guy Dawson';
         this.description = 'Run the control variant for 87.5% of the US audience';
         this.showForSensitive = false;
@@ -45,9 +49,33 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'A conversion rate of 0.1%';
         this.canRun = function () {
+
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
-            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
-            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+
+            // may render badly on other types
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle;
+
+            // prevent multiple epics from being shown
+            var userInAlwaysAskStrategy = ab.isParticipating({id: 'ContributionsEpicAlwaysAskStrategy'});
+
+            var isCharityAskPage = function() {
+                var charityKeywordIds = [
+                    // TODO
+                ];
+                var pageKeywordIdsString = config.page.keywordIds;
+                if (typeof (pageKeywordIdsString) !== 'undefined') {
+                    var pageKeywordIds = pageKeywordIdsString.split(',');
+                    return intersection(charityKeywordIds, pageKeywordIds).length > 0;
+                } else {
+                    return false;
+                }
+            };
+
+            return userHasNeverContributed &&
+                commercialFeatures.canReasonablyAskForMoney &&
+                worksWellWithPageTemplate &&
+                !userInAlwaysAskStrategy &&
+                !isCharityAskPage();
         };
 
         var makeEvent = (function(name) {
@@ -93,7 +121,7 @@ define([
                 contentType: 'application/json',
                 crossOrigin: true
             }).then(function (resp) {
-                if ('country' in resp && resp.country === 'US'){
+                //if ('country' in resp && resp.country === 'US'){
                     fastdom.write(function () {
                         var submetaElement = $('.submeta');
                         if (submetaElement.length > 0) {
@@ -109,7 +137,7 @@ define([
                             });
                         }
                     });
-                }
+                //}
             });
         };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -13,13 +13,6 @@ define([
     template,
     contributionsEpicEqualButtons
 ) {
-    // I had to copy this and the function below over from ab.js to avoid a circular dependency.
-    var participationsKey = 'gu.ab.participations';
-
-    function getParticipations() {
-        return store.local.get(participationsKey) || {};
-    }
-
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicUsEoyControl',
         campaignId: 'epic_us_eoy_control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -32,18 +32,18 @@ define([
              ElementInview) {
 
     return function () {
-        this.id = 'ContributionsEpicUsPreEndOfYearTwo';
-        this.start = '2016-12-12';
-        this.expiry = '2016-12-19';
+        this.id = 'ContributionsEpicUsEoyControl';
+        this.start = '2016-12-13';
+        this.expiry = '2017-01-01';
         this.author = 'Guy Dawson';
-        this.description = 'Test which Epic variant to use in the US end of year campaign';
+        this.description = 'Run the control variant for 87.5% of the US audience';
         this.showForSensitive = false;
-        this.audience = 0.1;
-        this.audienceOffset = 0.9;
+        this.audience = 0.875;
+        this.audienceOffset = 0;
         this.successMeasure = 'Conversion rate (contributions / impressions)';
-        this.audienceCriteria = 'All';
+        this.audienceCriteria = 'US members';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We are able to determine which Epic variant to use in the US end of year campaign';
+        this.idealOutcome = 'A conversion rate of 0.1%';
         this.canRun = function () {
             var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
             var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
@@ -58,8 +58,8 @@ define([
             return urlPrefix + 'INTCMP=' + intcmp;
         }
 
-        var contributeUrlPrefix = 'co_global_epic_us_pre_end_of_year';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_us_pre_end_of_year';
+        var contributeUrlPrefix = 'co_global_epic_us_eoy_control';
+        var membershipUrlPrefix = 'gdnwb_copts_epic_us_eoy_control';
 
         var epicInsertedEvent = makeEvent('insert');
         var epicViewedEvent = makeEvent('view');
@@ -72,11 +72,6 @@ define([
                 title: 'Since you’re here…',
                 p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.'
-            },
-            endOfYear: {
-                title: 'As 2016 comes to a close…',
-                p1: '…we would like to ask for your support. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why now is the right time to ask. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure.'
             }
         };
 
@@ -89,7 +84,6 @@ define([
                 url2:  makeUrl(contributeUrl, contributeUrlPrefix),
                 hidden: ''
             }
-
         };
 
         var componentWriter = function (component) {
@@ -135,32 +129,8 @@ define([
                     var ctaType = cta.equal;
                     var message = messages.control;
                     var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + '_control',
-                        linkUrl2: ctaType.url2 + '_control',
-                        title: message.title,
-                        p1: message.p1,
-                        p2: message.p2,
-                        p3: ctaType.p3,
-                        cta1: ctaType.cta1,
-                        cta2: ctaType.cta2,
-                        hidden: ctaType.hidden
-                    }));
-                    componentWriter(component);
-                },
-
-                impression: registerInsertionListener,
-
-                success: registerViewListener
-            },
-            {
-                id: 'endOfYear',
-
-                test: function () {
-                    var ctaType = cta.equal;
-                    var message = messages.endOfYear;
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1 + '_end_of_year',
-                        linkUrl2: ctaType.url2 + '_end_of_year',
+                        linkUrl1: ctaType.url1,
+                        linkUrl2: ctaType.url2,
                         title: message.title,
                         p1: message.p1,
                         p2: message.p2,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -1,179 +1,77 @@
 define([
-    'bean',
-    'qwery',
-    'common/utils/$',
-    'common/utils/template',
-    'common/views/svg',
-    'common/utils/fastdom-promise',
-    'common/utils/mediator',
-    'text!common/views/contributions-epic-equal-buttons.html',
-    'common/utils/robust',
-    'inlineSvg!svgs/icon/arrow-right',
-    'common/utils/config',
-    'common/utils/cookies',
+    'common/modules/commercial/contributions-utilities',
     'common/utils/ajax',
-    'common/modules/commercial/commercial-features',
-    'common/utils/element-inview',
-    'common/modules/experiments/ab',
-    'lodash/arrays/intersection'
+    'common/utils/geolocation',
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html',
+], function (
+    contributionsUtilities,
+    ajax,
+    geolocation,
+    store,
+    template,
+    contributionsEpicEqualButtons
+) {
+    // I had to copy this and the function below over from ab.js to avoid a circular dependency.
+    var participationsKey = 'gu.ab.participations';
 
-], function (bean,
-             qwery,
-             $,
-             template,
-             svg,
-             fastdom,
-             mediator,
-             contributionsEpicEqualButtons,
-             robust,
-             arrowRight,
-             config,
-             cookies,
-             ajax,
-             commercialFeatures,
-             ElementInview,
-             ab,
-             intersection) {
+    function getParticipations() {
+        return store.local.get(participationsKey) || {};
+    }
 
-    return function () {
-        this.id = 'ContributionsEpicUsEoyControl';
-        this.start = '2016-12-13';
-        this.expiry = '2017-01-03';
-        this.author = 'Guy Dawson';
-        this.description = 'Run the control variant for 87.5% of the US audience';
-        this.showForSensitive = false;
-        this.audience = 0.875;
-        this.audienceOffset = 0;
-        this.successMeasure = 'Conversion rate (contributions / impressions)';
-        this.audienceCriteria = 'US members';
-        this.dataLinkNames = '';
-        this.idealOutcome = 'A conversion rate of 0.1%';
-        this.canRun = function () {
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicUsEoyControl',
+        campaignId: 'epic_us_eoy_control',
 
-            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+        start: '2016-12-13',
+        expiry: '2017-01-03',
 
-            // may render badly on other types
-            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle;
+        author: 'Sam Desborough',
+        description: 'Run the control variant for 87.5% of the US audience',
+        successMeasure: 'Conversion rate (contributions / impressions)',
+        idealOutcome: 'A conversion rate of 0.1%',
 
-            // prevent multiple epics from being shown
-            var userInAlwaysAskStrategy = ab.isParticipating({id: 'ContributionsEpicAlwaysAskStrategy'});
+        audienceCriteria: 'US members',
+        audience: 0.875,
+        audienceOffset: 0,
+        useTargetingTool: true,
 
-            var isCharityAskPage = function() {
-                var charityKeywordIds = [
-                    // TODO
-                ];
-                var pageKeywordIdsString = config.page.keywordIds;
-                if (typeof (pageKeywordIdsString) !== 'undefined') {
-                    var pageKeywordIds = pageKeywordIdsString.split(',');
-                    return intersection(charityKeywordIds, pageKeywordIds).length > 0;
-                } else {
-                    return false;
-                }
-            };
+        /**
+         * In addition to the typical contributions criteria (in contributions-utilities) we need to exclude anyone
+         * in the "always ask" strategy test
+         */
+        canRun: function () {
+            return !contributionsUtilities.inAlwaysAskTest();
+        },
 
-            return userHasNeverContributed &&
-                commercialFeatures.canReasonablyAskForMoney &&
-                worksWellWithPageTemplate &&
-                !userInAlwaysAskStrategy &&
-                !isCharityAskPage();
-        };
-
-        var makeEvent = (function(name) {
-            return this.id + ':' + name;
-        }).bind(this);
-
-        function makeUrl(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        }
-
-        var contributeUrlPrefix = 'co_global_epic_us_eoy_control';
-        var membershipUrlPrefix = 'gdnwb_copts_epic_us_eoy_control';
-
-        var epicInsertedEvent = makeEvent('insert');
-        var epicViewedEvent = makeEvent('view');
-
-        var membershipUrl = 'https://membership.theguardian.com/supporter?';
-        var contributeUrl = 'https://contribute.theguardian.com/?';
-
-        var messages  = {
-            control: {
-                title: 'Since you’re here…',
-                p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.'
-            }
-        };
-
-        var cta = {
-            equal: {
-                p3: '',
-                cta1: 'Become a Supporter',
-                cta2: 'Make a contribution',
-                url1: makeUrl(membershipUrl, membershipUrlPrefix),
-                url2:  makeUrl(contributeUrl, contributeUrlPrefix),
-                hidden: ''
-            }
-        };
-
-        var componentWriter = function (component) {
-            ajax({
-                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
-                method: 'GET',
-                contentType: 'application/json',
-                crossOrigin: true
-            }).then(function (resp) {
-                //if ('country' in resp && resp.country === 'US'){
-                    fastdom.write(function () {
-                        var submetaElement = $('.submeta');
-                        if (submetaElement.length > 0) {
-                            component.insertBefore(submetaElement);
-                            mediator.emit(epicInsertedEvent, component);
-                            $('.contributions__epic').each(function (element) {
-                                // top offset of 18 ensures view only counts when half of element is on screen
-                                var elementInView = ElementInview(element, window, {top: 18});
-                                elementInView.on('firstview', function () {
-                                    mediator.emit(epicViewedEvent);
-                                });
-
-                            });
-                        }
-                    });
-                //}
-            });
-        };
-
-        function registerInsertionListener(track) {
-            mediator.on(epicInsertedEvent, track);
-        }
-
-        function registerViewListener(complete) {
-            mediator.on(epicViewedEvent, complete);
-        }
-
-        this.variants = [
+        variants: [
             {
                 id: 'control',
 
-                test: function () {
-                    var ctaType = cta.equal;
-                    var message = messages.control;
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1,
-                        linkUrl2: ctaType.url2,
-                        title: message.title,
-                        p1: message.p1,
-                        p2: message.p2,
-                        p3: ctaType.p3,
-                        cta1: ctaType.cta1,
-                        cta2: ctaType.cta2,
-                        hidden: ctaType.hidden
-                    }));
-                    componentWriter(component);
+                template: function (membershipUrl, contributionUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.',
+                        cta1: 'Become a supporter',
+                        cta2: 'Make a contribution',
+                    });
                 },
 
-                impression: registerInsertionListener,
+                insertBeforeSelector: '.submeta',
 
-                success: registerViewListener
+                test: function (render) {
+                    geolocation.get().then(function(geo) {
+                        if (geo === 'US') render();
+                    });
+                },
+
+                impressionOnInsert: true,
+                successOnView: true
             }
-        ];
-    };
+        ]
+    });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -1,0 +1,151 @@
+define([
+    'bean',
+    'qwery',
+    'common/utils/$',
+    'common/utils/template',
+    'common/views/svg',
+    'common/utils/fastdom-promise',
+    'common/utils/mediator',
+    'text!common/views/contributions-epic-equal-buttons.html',
+    'common/utils/robust',
+    'inlineSvg!svgs/icon/arrow-right',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/ajax',
+    'common/modules/commercial/commercial-features',
+    'common/utils/element-inview'
+
+], function (bean,
+             qwery,
+             $,
+             template,
+             svg,
+             fastdom,
+             mediator,
+             contributionsEpicEqualButtons,
+             robust,
+             arrowRight,
+             config,
+             cookies,
+             ajax,
+             commercialFeatures,
+             ElementInview) {
+
+    return function () {
+        this.id = 'ContributionsEpicUsEoyEndOfYear';
+        this.start = '2016-12-13';
+        this.expiry = '2017-01-01';
+        this.author = 'Guy Dawson';
+        this.description = 'Run the end of year variant for 12.5% of the US audience';
+        this.showForSensitive = false;
+        this.audience = 0.125;
+        this.audienceOffset = 0.875;
+        this.successMeasure = 'Conversion rate (contributions / impressions)';
+        this.audienceCriteria = 'All';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'A conversion rate of 0.1%';
+        this.canRun = function () {
+            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
+            return userHasNeverContributed && commercialFeatures.canReasonablyAskForMoney && worksWellWithPageTemplate;
+        };
+
+        var makeEvent = (function(name) {
+            return this.id + ':' + name;
+        }).bind(this);
+
+        function makeUrl(urlPrefix, intcmp) {
+            return urlPrefix + 'INTCMP=' + intcmp;
+        }
+
+        var contributeUrlPrefix = 'co_global_epic_us_eoy_end_of_year';
+        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_us_eoy_end_of_year';
+
+        var epicInsertedEvent = makeEvent('insert');
+        var epicViewedEvent = makeEvent('view');
+
+        var membershipUrl = 'https://membership.theguardian.com/supporter?';
+        var contributeUrl = 'https://contribute.theguardian.com/?';
+
+        var messages  = {
+            endOfYear: {
+                title: 'As 2016 comes to a close…',
+                p1: '…we would like to ask for your support. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why now is the right time to ask. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure.'
+            }
+        };
+
+        var cta = {
+            equal: {
+                p3: '',
+                cta1: 'Become a Supporter',
+                cta2: 'Make a contribution',
+                url1: makeUrl(membershipUrl, membershipUrlPrefix),
+                url2:  makeUrl(contributeUrl, contributeUrlPrefix),
+                hidden: ''
+            }
+        };
+
+        var componentWriter = function (component) {
+            ajax({
+                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
+                method: 'GET',
+                contentType: 'application/json',
+                crossOrigin: true
+            }).then(function (resp) {
+                if ('country' in resp && resp.country === 'US'){
+                    fastdom.write(function () {
+                        var submetaElement = $('.submeta');
+                        if (submetaElement.length > 0) {
+                            component.insertBefore(submetaElement);
+                            mediator.emit(epicInsertedEvent, component);
+                            $('.contributions__epic').each(function (element) {
+                                // top offset of 18 ensures view only counts when half of element is on screen
+                                var elementInView = ElementInview(element, window, {top: 18});
+                                elementInView.on('firstview', function () {
+                                    mediator.emit(epicViewedEvent);
+                                });
+
+                            });
+                        }
+                    });
+                }
+            });
+        };
+
+        function registerInsertionListener(track) {
+            mediator.on(epicInsertedEvent, track);
+        }
+
+        function registerViewListener(complete) {
+            mediator.on(epicViewedEvent, complete);
+        }
+
+        this.variants = [
+            {
+                id: 'endOfYear',
+
+                test: function () {
+                    var ctaType = cta.equal;
+                    var message = messages.endOfYear;
+                    var component = $.create(template(contributionsEpicEqualButtons, {
+                        linkUrl1: ctaType.url1,
+                        linkUrl2: ctaType.url2,
+                        title: message.title,
+                        p1: message.p1,
+                        p2: message.p2,
+                        p3: ctaType.p3,
+                        cta1: ctaType.cta1,
+                        cta2: ctaType.cta2,
+                        hidden: ctaType.hidden
+                    }));
+                    componentWriter(component);
+                },
+
+                impression: registerInsertionListener,
+
+                success: registerViewListener
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -28,8 +28,6 @@ define([
         audienceOffset: 0.875,
         useTargetingTool: true,
 
-        overrideCanRun: true,
-
         /**
          * In addition to the typical contributions criteria (in contributions-utilities) we need to exclude anyone
          * in the "always ask" strategy test

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -1,177 +1,71 @@
 define([
-    'bean',
-    'qwery',
-    'common/utils/$',
-    'common/utils/template',
-    'common/views/svg',
-    'common/utils/fastdom-promise',
-    'common/utils/mediator',
-    'text!common/views/contributions-epic-equal-buttons.html',
-    'common/utils/robust',
-    'inlineSvg!svgs/icon/arrow-right',
-    'common/utils/config',
-    'common/utils/cookies',
+    'common/modules/commercial/contributions-utilities',
     'common/utils/ajax',
-    'common/modules/commercial/commercial-features',
-    'common/utils/element-inview',
-    'common/modules/experiments/ab',
-    'lodash/arrays/intersection'
-], function (bean,
-             qwery,
-             $,
-             template,
-             svg,
-             fastdom,
-             mediator,
-             contributionsEpicEqualButtons,
-             robust,
-             arrowRight,
-             config,
-             cookies,
+    'common/utils/geolocation',
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html',
+], function (contributionsUtilities,
              ajax,
-             commercialFeatures,
-             ElementInview,
-             ab,
-             intersection) {
+             geolocation,
+             store,
+             template,
+             contributionsEpicEqualButtons) {
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicUsEoyEndOfYear',
+        campaignId: 'epic_us_eoy_end_of_year',
 
-    return function () {
-        this.id = 'ContributionsEpicUsEoyEndOfYear';
-        this.start = '2016-12-13';
-        this.expiry = '2016-12-31';
-        this.author = 'Guy Dawson';
-        this.description = 'Run the end of year variant for 12.5% of the US audience';
-        this.showForSensitive = false;
-        this.audience = 0.125;
-        this.audienceOffset = 0.875;
-        this.successMeasure = 'Conversion rate (contributions / impressions)';
-        this.audienceCriteria = 'All';
-        this.dataLinkNames = '';
-        this.idealOutcome = 'A conversion rate of 0.1%';
-        this.canRun = function () {
-            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
+        start: '2016-12-13',
+        expiry: '2016-12-31',
 
-            // may render badly on other types
-            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle;
+        author: 'Sam Desborough',
+        description: 'Run the end of year variant for 12.5% of the US audience',
+        successMeasure: 'Conversion rate (contributions / impressions)',
+        idealOutcome: 'A conversion rate of 0.1%',
 
-            // prevent multiple epics from being shown
-            var userInAlwaysAskStrategy = ab.isParticipating({id: 'ContributionsEpicAlwaysAskStrategy'});
+        audienceCriteria: 'US members',
+        audience: 0.125,
+        audienceOffset: 0.875,
+        useTargetingTool: true,
 
-            var isCharityAskPage = function() {
-                var charityKeywordIds = [
-                    // TODO
-                ];
-                var pageKeywordIdsString = config.page.keywordIds;
-                if (typeof (pageKeywordIdsString) !== 'undefined') {
-                    var pageKeywordIds = pageKeywordIdsString.split(',');
-                    return intersection(charityKeywordIds, pageKeywordIds).length > 0;
-                } else {
-                    return false;
-                }
-            };
+        overrideCanRun: true,
 
-            return userHasNeverContributed &&
-                commercialFeatures.canReasonablyAskForMoney &&
-                worksWellWithPageTemplate &&
-                !userInAlwaysAskStrategy &&
-                !isCharityAskPage();
-        };
+        /**
+         * In addition to the typical contributions criteria (in contributions-utilities) we need to exclude anyone
+         * in the "always ask" strategy test
+         */
+        canRun: function () {
+            return !contributionsUtilities.inAlwaysAskTest();
+        },
 
-        var makeEvent = (function(name) {
-            return this.id + ':' + name;
-        }).bind(this);
-
-        function makeUrl(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        }
-
-        var contributeUrlPrefix = 'co_global_epic_us_eoy_end_of_year';
-        var membershipUrlPrefix = 'gdnwb_copts_mem_epic_us_eoy_end_of_year';
-
-        var epicInsertedEvent = makeEvent('insert');
-        var epicViewedEvent = makeEvent('view');
-
-        var membershipUrl = 'https://membership.theguardian.com/supporter?';
-        var contributeUrl = 'https://contribute.theguardian.com/?';
-
-        var messages  = {
-            endOfYear: {
-                title: 'As 2016 comes to a close…',
-                p1: '…we would like to ask for your support. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why now is the right time to ask. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure.'
-            }
-        };
-
-        var cta = {
-            equal: {
-                p3: '',
-                cta1: 'Become a Supporter',
-                cta2: 'Make a contribution',
-                url1: makeUrl(membershipUrl, membershipUrlPrefix),
-                url2:  makeUrl(contributeUrl, contributeUrlPrefix),
-                hidden: ''
-            }
-        };
-
-        var componentWriter = function (component) {
-            ajax({
-                url: 'https://api.nextgen.guardianapps.co.uk/geolocation',
-                method: 'GET',
-                contentType: 'application/json',
-                crossOrigin: true
-            }).then(function (resp) {
-                if ('country' in resp && resp.country === 'US'){
-                    fastdom.write(function () {
-                        var submetaElement = $('.submeta');
-                        if (submetaElement.length > 0) {
-                            component.insertBefore(submetaElement);
-                            mediator.emit(epicInsertedEvent, component);
-                            $('.contributions__epic').each(function (element) {
-                                // top offset of 18 ensures view only counts when half of element is on screen
-                                var elementInView = ElementInview(element, window, {top: 18});
-                                elementInView.on('firstview', function () {
-                                    mediator.emit(epicViewedEvent);
-                                });
-
-                            });
-                        }
-                    });
-                }
-            });
-        };
-
-        function registerInsertionListener(track) {
-            mediator.on(epicInsertedEvent, track);
-        }
-
-        function registerViewListener(complete) {
-            mediator.on(epicViewedEvent, complete);
-        }
-
-        this.variants = [
+        variants: [
             {
-                id: 'endOfYear',
+                id: 'control',
 
-                test: function () {
-                    var ctaType = cta.equal;
-                    var message = messages.endOfYear;
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: ctaType.url1,
-                        linkUrl2: ctaType.url2,
-                        title: message.title,
-                        p1: message.p1,
-                        p2: message.p2,
-                        p3: ctaType.p3,
-                        cta1: ctaType.cta1,
-                        cta2: ctaType.cta2,
-                        hidden: ctaType.hidden
-                    }));
-                    componentWriter(component);
+                template: function (membershipUrl, contributionUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'As 2016 comes to a close…',
+                        p1: '…we would like to ask for your support. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why now is the right time to ask. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting – who believes in it – helps to support it, our future would be more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
                 },
 
-                impression: registerInsertionListener,
+                insertBeforeSelector: '.submeta',
 
-                success: registerViewListener
+                test: function (render) {
+                    geolocation.get().then(function (geo) {
+                        if (geo === 'US') render();
+                    });
+                },
+
+                impressionOnInsert: true,
+                successOnView: true
             }
-        ];
-    };
+        ]
+    });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -38,7 +38,7 @@ define([
 
         variants: [
             {
-                id: 'control',
+                id: 'endOfYear',
 
                 template: function (membershipUrl, contributionUrl) {
                     return template(contributionsEpicEqualButtons, {

--- a/static/src/javascripts/projects/common/utils/geolocation.js
+++ b/static/src/javascripts/projects/common/utils/geolocation.js
@@ -1,0 +1,29 @@
+define([
+    'common/utils/fetch-json',
+], function (
+    fetch
+) {
+    var location;
+
+    return {
+        get: function() {
+            return new Promise(function(resolve, reject) {
+                if (location) return resolve(location);
+                else {
+                    fetch('https://api.nextgen.guardianapps.co.uk/geolocation', {
+                        method: 'GET',
+                        contentType: 'application/json',
+                        crossOrigin: true
+                    }).then(function (response) {
+                        if (response.country) {
+                            location = response.country;
+                            resolve(response.country);
+                        } else {
+                            reject('No country in geolocation response', response);
+                        }
+                    }).catch(reject);
+                }
+            });
+        }
+    };
+});

--- a/static/src/javascripts/projects/common/utils/geolocation.js
+++ b/static/src/javascripts/projects/common/utils/geolocation.js
@@ -1,6 +1,8 @@
 define([
+    'Promise',
     'common/utils/fetch-json',
 ], function (
+    Promise,
     fetch
 ) {
     var location;

--- a/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
@@ -12,7 +12,7 @@
             </a>
         </div>
 
-        <div class="contributions__<%=hidden%>">
+        <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member" href="<%=linkUrl2%>" target="_blank">
                 <%=cta2%>
             </a>


### PR DESCRIPTION
## What does this change?
Adds a module that abstracts most of the common code in contributions A/B tests. I've created 2 new tests that make use of this module, and updated the `always-ask` test to use it as well.

The module also adds some functionality to limit how many times we show the Epic (6 times a week) and wires up the targeting tool to the tests, so we can control the tags without raising other PRs.

I've also included a small `geolocation` module that saves some more duplicate code and caches the result to save on network requests.

## What is the value of this and can you measure success?
There's a lot less code in contributions A/B tests, meaning future tests will be easier to write, and their PRs significantly easier to review. In this case a test was about 40% of its former size (180 down to 70 lines).

## Does this affect other platforms - Amp, Apps, etc?
Nope