### PR TITLE
Don't use display: block links in email HTML

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -8,7 +8,7 @@
 @defining(page.article) { article =>
     @fullRow {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
-            @img(src = page.banner, alt = page.email.map(_.name))
+            @imgForArticle(src = page.banner, alt = page.email.map(_.name))
         </a>
     }
 
@@ -85,10 +85,10 @@
                             @fullRow {
                                 @if(article.isLiveBlog && block.url.isDefined) {
                                     <a href="@block.url.getOrElse("#")">
-                                        @img(src = imageUrl, alt = data.get("alt"))
+                                        @imgForArticle(src = imageUrl, alt = data.get("alt"))
                                     </a>
                                 } else {
-                                    @img(src = imageUrl, alt = data.get("alt"))
+                                    @imgForArticle(src = imageUrl, alt = data.get("alt"))
                                 }
                             }
 
@@ -114,10 +114,10 @@
                         @EmailVideoImage.bestFor(media).map { imageUrl =>
                             @fullRow {
                                 @data.get("url").fold {
-                                    @img(src = imageUrl, alt = data.get("alt"))
+                                    @imgForArticle(src = imageUrl, alt = data.get("alt"))
                                 }{ linkUrl =>
                                     <a href="@linkUrl">
-                                        @img(src = imageUrl, alt = data.get("alt"))
+                                        @imgForArticle(src = imageUrl, alt = data.get("alt"))
                                     </a>
                                 }
                             }

--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -18,6 +18,8 @@
 
     .tone-news .facia-card {
         border-top: 1px solid #4bc6df;
+    }
+    .tone-news .facia-card__text {
         background-color: #ffffff;
     }
     .tone-news .headline {
@@ -36,9 +38,10 @@
 
     .tone-feature .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-feature .facia-card__text {
         background-color: #ffffff;
     }
-
     .tone-feature .headline {
         color: #333333;
     }
@@ -55,6 +58,8 @@
 
     .tone-media .facia-card {
         border-top: 1px solid #ff9b0b;
+    }
+    .tone-media .facia-card__text {
         background-color: #ffffff;
     }
     .tone-media .headline {
@@ -73,6 +78,8 @@
 
     .tone-review .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-review .facia-card__text {
         background-color: #ffffff;
     }
     .tone-review .headline {
@@ -91,6 +98,8 @@
 
     .tone-editorial .facia-card {
         border-top: 1px solid #aad8f1;
+    }
+    .tone-editorial .facia-card__text {
         background-color: #ffffff;
     }
     .tone-editorial .headline {
@@ -109,6 +118,8 @@
 
     .tone-external .facia-card {
         border-top: 1px solid #fdadba;
+    }
+    .tone-external .facia-card__text {
         background-color: #ffffff;
     }
     .tone-external .headline {
@@ -127,6 +138,8 @@
 
     .tone-live .facia-card {
         border-top: 1px solid #fdadba;
+    }
+    .tone-live .facia-card__text {
         background-color: #ffffff;
     }
     .tone-live .headline {
@@ -145,6 +158,8 @@
 
     .tone-analysis .facia-card {
         border-top: 1px solid #4bc6df;
+    }
+    .tone-analysis .facia-card__text {
         background-color: #ffffff;
     }
     .tone-analysis .headline {
@@ -163,6 +178,8 @@
 
     .tone-special-report .facia-card {
         border-top: 1px solid #fce800;
+    }
+    .tone-special-report .facia-card__text {
         background-color: #ffffff;
     }
     .tone-special-report .headline {
@@ -181,6 +198,8 @@
 
     .tone-comment .facia-card {
         border-top: 1px solid #e6711b;
+    }
+    .tone-comment .facia-card__text {
         background-color: #ffffff;
     }
     .tone-comment .headline {
@@ -199,6 +218,8 @@
 
     .tone-dead .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-dead .facia-card__text {
         background-color: #ffffff;
     }
     .tone-dead .headline {

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -7,26 +7,6 @@
         background: #ffffff;
     }
 
-    h1, h2, h3, h5, h6, p, blockquote {
-        font-family: "Guardian Egyptian Web Headline", Georgia, serif;
-    }
-
-    h2 {
-        font-family: "Guardian Egyptian Web Header", "Guardian Egyptian Web Headline", Georgia, serif;
-        font-size: 26px;
-        margin-bottom: 12px;
-        margin-top: 26px;
-    }
-
-    h4 {
-        font-family: Georgia, serif;
-    }
-
-    p {
-        font-size: 14px;
-        line-height: 18px;
-    }
-
     .full-width {
         width: 100%;
     }
@@ -42,12 +22,18 @@
     }
 
     .introduction {
-        font-family: "Helvetica", "Arial", sans-serif;
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 18px;
         background: #f6f6f6;
         padding: 6px 10px 36px 10px;
     }
 
     .container-title {
+        font-family: "Guardian Egyptian Web Header", "Guardian Egyptian Web Headline", Georgia, serif;
+        font-size: 26px;
+        margin-bottom: 12px;
+        margin-top: 26px;
         color: #333333;
         padding-top: 4px;
     }
@@ -55,27 +41,28 @@
         border-top: 3px solid @page.toneColour;
     }
 
-    .facia-card {
-        display: block;
+    .facia-link {
         text-decoration: none;
-        padding-bottom: 26px;
+    }
+    .facia-card__text {
+        padding: 0 10px 26px 10px !important;
+    }
+
+    .headline, .trail-text {
+        margin-top: 6px;
     }
 
     .headline {
+        font-family: "Guardian Egyptian Web Headline", Georgia, serif;
         font-size: 16px;
         line-height: 20px;
-        margin: 0;
         color: inherit;
     }
 
     .trail-text {
-      font-size: 14px;
-      line-height: 18px;
-    }
-
-    .facia-card .headline,
-    .facia-card .trail-text {
-        padding: 6px 10px 0px 10px;
+        font-family: Georgia, serif;
+        font-size: 14px;
+        line-height: 18px;
     }
 
     .facia-card--large .headline {

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -5,6 +5,8 @@
 <style>
     .tone-news .facia-card {
         border-top: 1px solid #4bc6df;
+    }
+    .tone-news .facia-card__text {
         background-color: #f6f6f6;
     }
     .tone-news .headline {
@@ -23,9 +25,10 @@
 
     .tone-feature .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-feature .facia-card__text {
         background-color: #951c55;
     }
-
     .tone-feature .headline {
         color: #fff;
     }
@@ -42,6 +45,8 @@
 
     .tone-media .facia-card {
         border-top: 1px solid #ffbb00;
+    }
+    .tone-media .facia-card__text {
         background-color: #333;
     }
     .tone-media .headline {
@@ -60,6 +65,8 @@
 
     .tone-review .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-review .facia-card__text {
         background-color: #7d7569;
     }
     .tone-review .headline {
@@ -78,6 +85,8 @@
 
     .tone-editorial .facia-card {
         border-top: 1px solid #aad8f1;
+    }
+    .tone-editorial .facia-card__text {
         background-color: #005689;
     }
     .tone-editorial .headline {
@@ -99,6 +108,8 @@
     }
     .tone-external .facia-card {
         border-top: 1px solid @page.toneColour;
+    }
+    .tone-external .facia-card__text {
         background-color: #f6f6f6;
     }
     .tone-external .headline {
@@ -121,6 +132,8 @@
 
     .tone-live .facia-card {
         border-top: 1px solid #fdadba;
+    }
+    .tone-live .facia-card__text {
         background-color: #b51800;
     }
     .tone-live .headline {
@@ -139,6 +152,8 @@
 
     .tone-analysis .facia-card {
         border-top: 1px solid #4bc6df;
+    }
+    .tone-analysis .facia-card__text {
         background-color: #f6f6f6;
     }
     .tone-analysis .headline {
@@ -157,6 +172,8 @@
 
     .tone-special-report .facia-card {
         border-top: 1px solid #fce800;
+    }
+    .tone-special-report .facia-card__text {
         background-color: #63717a;
     }
     .tone-special-report .headline {
@@ -175,6 +192,8 @@
 
     .tone-comment .facia-card {
         border-top: 1px solid #e6711b;
+    }
+    .tone-comment .facia-card__text {
         background-color: #e3e3de;
     }
     .tone-comment .headline {
@@ -193,6 +212,8 @@
 
     .tone-dead .facia-card {
         border-top: 1px solid pink;
+    }
+    .tone-dead .facia-card__text {
         background-color: #f6f6f6;
     }
     .tone-dead .headline {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,13 +53,13 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
   }
 
-  def imgForArticle(src: String, alt: Option[String] = None) = Html {
-    s"""<img width="${EmailImage.knownWidth}" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
+  private def img(src: String, width: Int, alt: Option[String] = None) = Html {
+    s"""<img width="$width" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
   }
 
-  def imgForFront(src: String, alt: Option[String] = None) = Html {
-    s"""<img width="${FrontEmailImage.knownWidth}" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
-  }
+  def imgForArticle(src: String, alt: Option[String] = None) = img(src, EmailImage.knownWidth, alt)
+
+  def imgForFront(src: String, alt: Option[String] = None) = img(src, FrontEmailImage.knownWidth, alt)
 
   def imgFromPressedContent(pressedContent: PressedContent) = imageUrlFromPressedContent(pressedContent).map { url =>
     imgForFront(src = url, alt = Some(pressedContent.header.headline))

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,12 +53,16 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
   }
 
-  def img(src: String, alt: Option[String] = None) = Html {
-    s"""<img width="580" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
+  def imgForArticle(src: String, alt: Option[String] = None) = Html {
+    s"""<img width="${EmailImage.knownWidth}" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
+  }
+
+  def imgForFront(src: String, alt: Option[String] = None) = Html {
+    s"""<img width="${FrontEmailImage.knownWidth}" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
   }
 
   def imgFromPressedContent(pressedContent: PressedContent) = imageUrlFromPressedContent(pressedContent).map { url =>
-    img(src = url, alt = Some(pressedContent.header.headline))
+    imgForFront(src = url, alt = Some(pressedContent.header.headline))
   }
 
   object Images {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -129,6 +129,7 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {
   override val qualityparam = "q=40"
+  val knownWidth = 580
 }
 
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
@@ -146,6 +147,7 @@ object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
 
 object FrontEmailImage extends Profile(width = Some(500), autoFormat = false) {
   override val qualityparam = "q=40"
+  val knownWidth = 500
 }
 
 // The imager/images.js base image.

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -129,7 +129,7 @@ object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.i
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {
   override val qualityparam = "q=40"
-  val knownWidth = 580
+  val knownWidth = width.get
 }
 
 object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
@@ -147,7 +147,7 @@ object EmailVideoImage extends Profile(width = Some(580), autoFormat = false) {
 
 object FrontEmailImage extends Profile(width = Some(500), autoFormat = false) {
   override val qualityparam = "q=40"
-  val knownWidth = 500
+  val knownWidth = width.get
 }
 
 // The imager/images.js base image.

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -73,7 +73,7 @@
 }
 
 @fullRow {
-    @img(src = page.banner, alt = page.email.map(_.name))
+    @imgForFront(src = page.banner, alt = page.email.map(_.name))
 }
 
 @page.frontProperties.onPageDescription.map { description =>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -38,24 +38,30 @@
 }
 
 @faciaCardLarge(pressedContent: PressedContent) = {
-    @paddedRow(Seq(toneClass(pressedContent))) {
-        @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-            <a @Html(href) class="facia-card facia-card--large">
-                @imgFromPressedContent(pressedContent)
-                @headline(pressedContent)
-                @pressedContent.card.trailText.map { trailText =>
-                    <h4 class="trail-text">@trailText</h4>
-                }
+    @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
+        @paddedRow(Seq(toneClass(pressedContent))) {
+            <a @Html(href) class="facia-link">
+                <div class="facia-card facia-card--large">
+                    @imgFromPressedContent(pressedContent)
+                    @fullRow(Seq("facia-card__text")) {
+                        @headline(pressedContent)
+                        @pressedContent.card.trailText.map { trailText =>
+                            <h4 class="trail-text">@trailText</h4>
+                        }
+                    }
+                </div>
             </a>
         }
     }
 }
 
 @faciaCardSmall(pressedContent: PressedContent) = {
-    @paddedRow(Seq(toneClass(pressedContent))) {
-        @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-            <a @Html(href) class="facia-card">
-                @headline(pressedContent)
+    @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
+        @paddedRow(Seq(toneClass(pressedContent))) {
+            <a @Html(href) class="facia-link">
+                @fullRow(Seq("facia-card", "facia-card__text")) {
+                    @headline(pressedContent)
+                }
             </a>
         }
     }


### PR DESCRIPTION
Some email clients (all Windows versions of Outlook, and Gmail on Android) had a problem with the way I was putting `display: block` on the `<a></a>` element and using it for background colour and padding (my thought was that if I could get away with it, I would save quite a bit of markup and reduce the payload).

Since I can't get away with it, I've introduced a bit more `@fullRow` table cruft and ended up with:
- `@fullRow` with `.facia-card__text` wraps the headline & standfirst, providing background colour & internal padding
- `<div class="facia-card">` wraps the image and the `.facia-card__text`, providing top border
- `<a class="facia-link>` wraps the facia-card div, providing links
- `@paddedRow` wraps the lot and provides margins between cards

I also added in some logic to set the `width` attribute on the img elements to the width of the container. I didn't think this affected anything but it does - in Outlook, of course. So this fixed some knock-on problems from my changes.

And I moved some styles out of generic `h1`, `p` etc into classes which describe the role of that element - while refactoring, having the styles tied to specific tags was a nightmare (see also: BEM).

## Outlook 2007 before
![picture 370](https://cloud.githubusercontent.com/assets/5122968/21230421/d3dc44ce-c2dc-11e6-9e3e-25a7794bfb31.png)

## Outlook 2007 after
![picture 368](https://cloud.githubusercontent.com/assets/5122968/21230434/dc206ca0-c2dc-11e6-92a8-34114dc27b31.png)

## Android Gmail before
![picture 371](https://cloud.githubusercontent.com/assets/5122968/21230440/e2f81a1e-c2dc-11e6-98d4-c063b6af98f2.png)


## Android Gmail after
![picture 369](https://cloud.githubusercontent.com/assets/5122968/21230441/e7ef9ce0-c2dc-11e6-9dfe-6d7330d89dd4.png)


@guardian/dotcom-platform @lmath 