### PR TITLE
Revert "Build standalone bootstraps/enhaced/youtube.js bundle - used in youtu…"

### DIFF
--- a/tools/__tasks__/compile/javascript/rjs--webpack.js
+++ b/tools/__tasks__/compile/javascript/rjs--webpack.js
@@ -169,6 +169,7 @@ const bundles = [{
     exclude: [
         'boot-rjs',
         'bootstraps/commercial',
+        'bootstraps/enhanced/main',
         'text',
         'inlineSvg',
     ],

--- a/tools/__tasks__/compile/javascript/rjs.js
+++ b/tools/__tasks__/compile/javascript/rjs.js
@@ -186,6 +186,7 @@ const bundles = [{
         'boot',
         'bootstraps/standard/main',
         'bootstraps/commercial',
+        'bootstraps/enhanced/main',
         'text',
         'inlineSvg',
     ],


### PR DESCRIPTION
Reverts guardian/frontend#15340

This change produces a duplicate define error when using hashed bundles.