### PR TITLE
Restart Weback test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -57,7 +57,7 @@ object WebpackTest extends TestDefinition(
   sellByDate = new LocalDate(2017, 1, 9)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-webpack").contains("webpack")
+    request.headers.get("X-GU-ab-webpack-bundle").contains("webpack")
   }
 }
 
@@ -68,7 +68,7 @@ object WebpackControl extends TestDefinition(
   sellByDate = new LocalDate(2017, 1, 9)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-webpack").contains("control")
+    request.headers.get("X-GU-ab-webpack-bundle").contains("control")
   }
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -51,7 +51,7 @@ object CommercialClientLoggingVariant extends TestDefinition(
 }
 
 object WebpackTest extends TestDefinition(
-  name = "ab-webpack",
+  name = "ab-webpack-bundle",
   description = "for users in this test, website will serve standard JavaScript that has been bundled by Webpack",
   owners = Seq(Owner.withGithub("siadcock")),
   sellByDate = new LocalDate(2017, 1, 9)
@@ -62,7 +62,7 @@ object WebpackTest extends TestDefinition(
 }
 
 object WebpackControl extends TestDefinition(
-  name = "ab-webpack-control",
+  name = "ab-webpack-bundle-control",
   description = "control for Webpack test",
   owners = Seq(Owner.withGithub("siadcock")),
   sellByDate = new LocalDate(2017, 1, 9)

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -81,7 +81,7 @@ define([
          *  Interactives are content, we want them booting as soon (and as stable) as possible.
          */
 
-        if (!config.tests.abWebpack && /Article|LiveBlog/.test(config.page.contentType)) {
+        if (!config.tests.abWebpackBundle && /Article|LiveBlog/.test(config.page.contentType)) {
             qwery('figure.interactive').forEach(function (el) {
                 var mainJS = el.getAttribute('data-interactive');
                 if (!mainJS) {


### PR DESCRIPTION
## What does this change?

Our Webpack test may not be entirely reliable, as the variant bucketing was implemented a day before the control bucketing. I'd like to restart the test with clean headers and a clean test name, to ensure the test is fair.

## What is the value of this and can you measure success?

More scientific test FTW

## Does this affect other platforms - Amp, Apps, etc?

Oh no

## Related

guardian/fastly-edge-cache#728

@guardian/dotcom-platform 