### PR TITLE
Build standalone youtube-embed.js

### DIFF
--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -53,12 +53,12 @@
             @Html(curlConfig().body)
 
             @if(Configuration.assets.useHashedBundles) {
-                window.curl.paths['bootstraps/enhanced/youtube'] = '@Static("javascripts/bootstraps/enhanced/youtube.js")';
+                window.curl.paths['bootstraps/youtube-embed'] = '@Static("javascripts/bootstraps/youtube-embed.js")';
             } else {
-                window.curl.paths['bootstraps/enhanced/youtube'] = '@{Configuration.assets.path}javascripts/bootstraps/enhanced/youtube.js';
+                window.curl.paths['bootstraps/youtube-embed'] = '@{Configuration.assets.path}javascripts/bootstraps/youtube-embed.js';
             }
             @Html(common.Assets.js.curl)
-            require(['bootstraps/enhanced/youtube'], function(bootstrap) {
+            require(['bootstraps/youtube-embed'], function(bootstrap) {
                 bootstrap.init();
             });
         </script>

--- a/static/src/javascripts/bootstraps/youtube-embed.js
+++ b/static/src/javascripts/bootstraps/youtube-embed.js
@@ -1,0 +1,14 @@
+define([
+    'bootstraps/enhanced/youtube'
+], function (
+    youtube
+) {
+
+    function init() {
+        youtube.init();
+    }
+
+    return {
+        init: init
+    };
+});

--- a/tools/__tasks__/compile/javascript/rjs--webpack.js
+++ b/tools/__tasks__/compile/javascript/rjs--webpack.js
@@ -196,6 +196,16 @@ const bundles = [{
     generateSourceMaps: true,
     preserveLicenseComments: false,
 }, {
+    name: 'bootstraps/youtube-embed',
+    out: `${target}/javascripts/bootstraps/youtube-embed-rjs.js`,
+    exclude: [
+        'boot-rjs',
+        'text',
+        'inlineSvg',
+    ],
+    generateSourceMaps: true,
+    preserveLicenseComments: false,
+}, {
     name: 'bootstraps/enhanced/accessibility',
     out: `${target}/javascripts/bootstraps/enhanced/accessibility-rjs.js`,
     exclude: [

--- a/tools/__tasks__/compile/javascript/rjs.js
+++ b/tools/__tasks__/compile/javascript/rjs.js
@@ -214,6 +214,15 @@ const bundles = [{
         generateSourceMaps: true,
         preserveLicenseComments: false,
     }, {
+        name: 'bootstraps/youtube-embed',
+        out: `${target}/javascripts/bootstraps/youtube-embed.js`,
+        exclude: [
+            'text',
+            'inlineSvg',
+        ],
+        generateSourceMaps: true,
+        preserveLicenseComments: false,
+    }, {
         name: 'bootstraps/enhanced/accessibility',
         out: `${target}/javascripts/bootstraps/enhanced/accessibility.js`,
         exclude: [


### PR DESCRIPTION
## What does this change?

- Creates a new standalone bundle youtube-embed.js which is used by mediaEmbed.scala.html (as done for video-embed).

## What is the value of this and can you measure success?

- Embedded youtube atoms can be enhanced

## Does this affect other platforms - Amp, Apps, etc?

- No

## Screenshots

N/A

## Request for comment

@SiAdcock 
