### PR TITLE
Fix check to detect user in Always Ask test

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -176,7 +176,9 @@ define([
 
         inAlwaysAskTest: function () {
             var participations = storage.local.get('gu.ab.participations') || {};
-            return ('ContributionsEpicAlwaysAskStrategy' in participations);
+            var test = participations['ContributionsEpicAlwaysAskStrategy'];
+
+            return test && test.variant !== 'notintest';
         }
     };
 });


### PR DESCRIPTION
## What does this change?
Fixes a bug in detecting a user's allocation to one of the contributions tests.

## What is the value of this and can you measure success?
Other tests were relying on this check to run, so they will run now.
