### PR TITLE
Remove unused guardian.secure in configurations

### DIFF
--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -46,6 +46,5 @@ play {
 }
 
 guardian: {
-  projectName: admin,
-  secure: true
+  projectName: admin
 }

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -57,6 +57,5 @@ play {
 }
 
 guardian: {
-  projectName: identity,
-  secure: true
+  projectName: identity
 }


### PR DESCRIPTION
## What does this change?
Remove unused guardian.secure parameter in admin and identity configurations

## What is the value of this and can you measure success?
Cleanup 🔪 


<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

