### PR TITLE
Remove unnecessary TestSettings trait

### DIFF
--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -20,24 +20,6 @@ import recorder.ContentApiHttpRecorder
 
 import scala.util.{Failure, Success, Try}
 
-//TODO: to delete once ContentApiClient global object is not used anymore
-trait TestSettings {
-  val recorder = new ContentApiHttpRecorder {
-    override lazy val baseDir = new File(System.getProperty("user.dir"), "data/database")
-  }
-
-  private def toRecorderHttp(httpClient: HttpClient) = new HttpClient {
-
-    val originalHttp = httpClient
-
-    override def GET(url: String, headers: Iterable[(String, String)]) = {
-      recorder.load(url.replaceAll("api-key=[^&]*", "api-key=none"), headers.toMap) {
-        originalHttp.GET(url, headers)
-      }
-    }
-  }
-}
-
 trait ConfiguredTestSuite extends ConfiguredServer with ConfiguredBrowser with ExecutionContexts {
   this: ConfiguredTestSuite with org.scalatest.Suite =>
 
@@ -84,7 +66,7 @@ trait ConfiguredTestSuite extends ConfiguredServer with ConfiguredBrowser with E
 
 }
 
-trait SingleServerSuite extends OneServerPerSuite with TestSettings with OneBrowserPerSuite with HtmlUnitFactory {
+trait SingleServerSuite extends OneServerPerSuite with OneBrowserPerSuite with HtmlUnitFactory {
   this: SingleServerSuite with org.scalatest.Suite =>
 
   BrowserVersion.setDefault(BrowserVersion.CHROME)

--- a/identity/test/package.scala
+++ b/identity/test/package.scala
@@ -13,7 +13,7 @@ import play.api.test.Helpers._
 /**
  * Executes a block of code in a FakeApplication.
  */
-trait FakeApp extends TestSettings {
+trait FakeApp {
   def app: Application = {
     val environment = Environment(new File("."), this.getClass.getClassLoader, Mode.Test)
     val context = ApplicationLoader.createContext(


### PR DESCRIPTION
## What does this change?
It was a leftover from a time where CapiClient was a global object

## What is the value of this and can you measure success?
🔪 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
