### PR TITLE
Speedup commercial boot

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -72,7 +72,7 @@ define([
     ];
 
     var secondaryModules = [
-        ['cm-fill-advert-slots', fillAdvertSlots.init],
+        ['cm-fill-advert-slots', fillAdvertSlots.init, fillAdvertSlots.customTiming],
         ['cm-paidforBand', paidforBand.init],
         ['cm-paidContainers', paidContainers.init],
         ['cm-ready', function () {

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -9,28 +9,31 @@ define([
     'commercial/modules/dfp/queue-advert',
     'commercial/modules/dfp/display-lazy-ads',
     'commercial/modules/dfp/display-ads',
-    'commercial/modules/dfp/refresh-on-resize'
-], function (Promise, qwery, sha1, identity, commercialFeatures, dfpEnv, Advert, queueAdvert, displayLazyAds, displayAds, refreshOnResize) {
+    'commercial/modules/dfp/refresh-on-resize',
+    'commercial/modules/dfp/performance-logging'
+], function (Promise, qwery, sha1, identity, commercialFeatures, dfpEnv, Advert, queueAdvert, displayLazyAds, displayAds, refreshOnResize, performanceLogging) {
 
-    function init() {
+    function init(moduleName) {
         if (commercialFeatures.dfpAdvertising) {
-            return fillAdvertSlots();
+            fillAdvertSlots(moduleName);
         }
         return Promise.resolve();
     }
 
-    function fillAdvertSlots() {
+    function fillAdvertSlots(moduleName) {
+        window.googletag.cmd.push(
+            createAdverts,
+            queueAdverts,
+            setPublisherProvidedId,
+            dfpEnv.shouldLazyLoad() ? displayLazyAds : displayAds,
+            // anything we want to happen after displaying ads
+            refreshOnResize,
+            moduleEnd
+        );
 
-        return new Promise(function(resolve) {
-            window.googletag.cmd.push(
-                createAdverts,
-                queueAdverts,
-                setPublisherProvidedId,
-                dfpEnv.shouldLazyLoad() ? displayLazyAds : displayAds,
-                // anything we want to happen after displaying ads
-                refreshOnResize,
-                resolve);
-        });
+        function moduleEnd() {
+            performanceLogging.moduleEnd(moduleName);
+        }
     }
 
     function createAdverts() {
@@ -56,6 +59,7 @@ define([
     }
 
     return {
-        init: init
+        init: init,
+        customTiming: true
     };
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -21,6 +21,8 @@ define([
     }
 
     function fillAdvertSlots(moduleName) {
+        performanceLogging.moduleStart(moduleName);
+
         window.googletag.cmd.push(
             createAdverts,
             queueAdverts,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -54,26 +54,24 @@ define([
             // Use Custom Timing to time the googletag code without the sonobi pre-loading.
             performanceLogging.moduleStart(moduleName);
 
-            return new Promise(function(resolve) {
+            var promise = Promise.resolve(require(['js!googletag.js']));
 
-                if (dfpEnv.sonobiEnabled) {
-                    // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
-                    require(['js!googletag.js']);
-                    performanceLogging.addTag('sonobi');
-                } else {
-                    require(['js!googletag.js']);
-                    performanceLogging.addTag('waterfall');
-                }
+            if (dfpEnv.sonobiEnabled) {
+                // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
+                performanceLogging.addTag('sonobi');
+            } else {
+                performanceLogging.addTag('waterfall');
+            }
 
-                window.googletag.cmd.push = raven.wrap({deep: true}, window.googletag.cmd.push);
+            window.googletag.cmd.push = raven.wrap({deep: true}, window.googletag.cmd.push);
 
-                window.googletag.cmd.push(
-                    setListeners,
-                    setPageTargeting,
-                    moduleEnd,
-                    resolve
-                );
-            });
+            window.googletag.cmd.push(
+                setListeners,
+                setPageTargeting,
+                moduleEnd
+            );
+
+            return promise;
         }
 
         if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -50,9 +50,6 @@ define([
             // Use Custom Timing to time the googletag code without the sonobi pre-loading.
             performanceLogging.moduleStart(moduleName);
 
-            // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
-            var promise = Promise.resolve(require(['js!googletag.js']));
-
             performanceLogging.addTag(dfpEnv.sonobiEnabled ? 'sonobi' : 'waterfall');
 
             window.googletag.cmd.push(
@@ -61,7 +58,8 @@ define([
                 moduleEnd
             );
 
-            return promise;
+            // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
+            return Promise.resolve(require(['js!googletag.js']));
         }
 
         if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -42,10 +42,6 @@ define([
 
     function init(moduleName) {
 
-        function removeAdSlots() {
-            bonzo(qwery(dfpEnv.adSlotSelector)).remove();
-        }
-
         function moduleEnd() {
             performanceLogging.moduleEnd(moduleName);
         }
@@ -69,15 +65,14 @@ define([
         }
 
         if (commercialFeatures.dfpAdvertising) {
-            return prepareSonobiTag.init().then(setupAdvertising).catch(function(){
-                // A promise error here, from a failed module load,
-                // could be a network problem or an intercepted request.
-                // Abandon the init sequence.
-                return fastdom.write(removeAdSlots);
-            });
+            return prepareSonobiTag.init().then(setupAdvertising)
+            // A promise error here, from a failed module load,
+            // could be a network problem or an intercepted request.
+            // Abandon the init sequence.
+            .catch(removeAdSlots);
         }
 
-        return fastdom.write(removeAdSlots);
+        return removeAdSlots();
     }
 
     function setListeners() {
@@ -93,6 +88,12 @@ define([
         var targeting = buildPageTargeting();
         Object.keys(targeting).forEach(function (key) {
             pubads.setTargeting(key, targeting[key]);
+        });
+    }
+
+    function removeAdSlots() {
+        return fastdom.write(function () {
+            bonzo(qwery(dfpEnv.adSlotSelector)).remove();
         });
     }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -59,8 +59,6 @@ define([
 
             performanceLogging.addTag(dfpEnv.sonobiEnabled ? 'sonobi' : 'waterfall');
 
-            window.googletag.cmd.push = raven.wrap({deep: true}, window.googletag.cmd.push);
-
             window.googletag.cmd.push(
                 setListeners,
                 setPageTargeting,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -54,14 +54,10 @@ define([
             // Use Custom Timing to time the googletag code without the sonobi pre-loading.
             performanceLogging.moduleStart(moduleName);
 
+            // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
             var promise = Promise.resolve(require(['js!googletag.js']));
 
-            if (dfpEnv.sonobiEnabled) {
-                // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
-                performanceLogging.addTag('sonobi');
-            } else {
-                performanceLogging.addTag('waterfall');
-            }
+            performanceLogging.addTag(dfpEnv.sonobiEnabled ? 'sonobi' : 'waterfall');
 
             window.googletag.cmd.push = raven.wrap({deep: true}, window.googletag.cmd.push);
 

--- a/static/src/javascripts/projects/commercial/modules/paidfor-band.js
+++ b/static/src/javascripts/projects/commercial/modules/paidfor-band.js
@@ -1,9 +1,8 @@
 define([
-    'fastdom',
     'Promise',
     'common/utils/config',
     'common/modules/ui/sticky'
-], function (fastdom, Promise, config, Sticky) {
+], function (Promise, config, Sticky) {
     function init() {
         if (config.page.hasSuperStickyBanner) {
             return Promise.resolve(false);


### PR DESCRIPTION
Ok there are two things going on here:

1- `prepare-googletag` and `fill-advert-slots` won't slow down the startup process anymore.
2- in both module, we want to know how much time it takes DFP to empty the command queue, but we don't want this process to block the other modules.

As long as (1) every interaction with DFP is done by means of the command queue (which it is) and (2) DFP processes the command queue deterministically (which it does), all we need to care about in the startup process is that the command queue has been correctly initialized.

Paradoxically, this change will not improve the total running time of each of these modules, but we should see a significant drop in the running time of primary and secondary module batches.