### PR TITLE
[POC] Deterministic asynchronous task scheduler

### DIFF
--- a/static/src/javascripts/projects/common/utils/schedule.js
+++ b/static/src/javascripts/projects/common/utils/schedule.js
@@ -9,7 +9,7 @@ define(function () {
     function enqueue(tasks, options) {
         options = options || {};
 
-        var taskRunner = options.taskRunner : iife;
+        var taskRunner = options.taskRunner || iife;
         var args = options.args || [];
 
         schedule(run.bind(tasks, taskRunner, args), options.timeout | 0);
@@ -24,12 +24,12 @@ define(function () {
     }
 
     function run(taskRunner, args, deadline) {
-        while((deadline.didTimeout || deadline.timeRemaining() > 0) && tasks.length) {
+        while((deadline.didTimeout || deadline.timeRemaining() > 0) && this.length) {
             var task = this.shift();
             taskRunner(task, args);
         }
 
-        if (tasks.length) {
+        if (this.length) {
             schedule(run.bind(this, taskRunner, args));
         }
     }

--- a/static/src/javascripts/projects/common/utils/schedule.js
+++ b/static/src/javascripts/projects/common/utils/schedule.js
@@ -1,0 +1,40 @@
+define(function () {
+    var mockDeadline = { didTimeout: true };
+
+    return {
+        enqueue: enqueue,
+        schedule: schedule
+    };
+
+    function enqueue(tasks, options) {
+        options = options || {};
+
+        var taskRunner = options.taskRunner : iife;
+        var args = options.args || [];
+
+        schedule(run.bind(tasks, taskRunner, args), options.timeout | 0);
+    }
+
+    function schedule(fn, timeout) {
+        if ('requestIdleCallback' in window) {
+            window.requestIdleCallback(fn, timeout ? { timeout: timeout } : null);
+        } else {
+            fn(mockDeadline);
+        }
+    }
+
+    function run(taskRunner, args, deadline) {
+        while((deadline.didTimeout || deadline.timeRemaining() > 0) && tasks.length) {
+            var task = this.shift();
+            taskRunner(task, args);
+        }
+
+        if (tasks.length) {
+            schedule(run.bind(this, taskRunner, args));
+        }
+    }
+
+    function iife(fn, args) {
+        fn.apply(undefined, args);
+    }
+});


### PR DESCRIPTION
Even though we are all religiously sealing DOM interactions between Fastdom walls, most of the front-end code still looks like this:

![black-friday](https://cloud.githubusercontent.com/assets/629976/21288433/bc086946-c47a-11e6-9b0c-97732c5689d9.gif)

... something the browser is not really fond of. Even though Web Workers have been available for years, they are still not widely used, quite understandably: with no access to DOM-related APIs, there is not much a Web Worker can do, not in the context of a site like ours. For all its attractiveness, I don't think VDOM is a solution, not with [the optimisations that browser makers are now heading towards](https://servo.org/)—ironically, the React Native team found out that the best optimisation they could come up with was ... [direct DOM manipulation](https://speakerdeck.com/vjeux/react-rally-animated-react-performance-toolbox).

That leaves us with a single thread to deal with a plethora of modules that all vie for the same opportunity. To make matters even worse, once a module gets hold of the main thread, it can keep it for as long as it desires.

Of course, we all know that and diligently leverage the opportunity that asynchronous calls give us, by delaying the execution of synchronous code until it becomes necessary. This is queueing theory 101. Still, synchronous code must run at some point, and run it will, and so this solution doesn't solve the main problem at all. If anything, it leaves all the responsibility of running the code to the vagaries of network performance: objectively, the main thread will be held for the same amount of time.

There's now an opportunity to improve that, with `requestIdleCallback` [around](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/requestidlecallback/) [the](https://bugzilla.mozilla.org/show_bug.cgi?id=1198381) [corner](https://webkit.org/status/#feature-requestidlecallback). With this API, modules have now the ability to schedule work deterministically and let the browser decide when it is best to execute it. It even has room for "out-of-band modules" via the `timeout` option.

But first we need to recognize that our modules are mostly made of _discrete_ tasks that may not need to run all at once. The standard [main.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/standard/main.js) is a good example of that.

I think the _command queue_ pattern used by ga.js or googletag.js is a powerful abstraction that could be useful here, so I wrote this small proof-of-concept for us to play with. It is by no means complete, but I thought I'd share before having actually used it with the hope it would spark some interesting discussions.

@gtrufitt @sndrs @SiAdcock @desbo @rich-nguyen 