### PR TITLE
Improve label for GA click events on hosted campaign logos

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -34,7 +34,7 @@
 
         <div class="main-body">
             <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge content__hosted-body">
-                <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+                <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
                     <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"></amp-img>
                 </a>
             </div></div></div>

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -69,7 +69,7 @@
     </style>
     <!--<![endif]-->
     <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
-        <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+        <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
             <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
         </a>
     </div></div></div>

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -5,7 +5,7 @@
     <div class="hosted__headerwrap js-hosted-headerwrap">
         <div class="hostedbadge hosted-tone-bg content__hosted-body">
             <p class="hostedbadge__info">Advertiser content</p>
-            <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+            <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
             @if(isAMP) {
                 <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"></amp-img>
             } else {
@@ -53,7 +53,7 @@
             </div>
         }
         <div class="hosted-header__spacer"></div>
-        <a href="http://www.theguardian.com" data-link-name="guardian-logo-top-right" class="hosted__glogo">
+        <a href="http://www.theguardian.com" data-link-name="@page.campaign.logo.trackingCode" class="hosted__glogo">
             <p class="hosted__glogotext">Hosted by</p>
             @fragments.inlineSvg("guardian-logo-320", "logo", List("hosted__guardian-logo"))
         </a>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -90,7 +90,7 @@
                             <h1 class="hosted__heading">@{page.video.title}</h1>
                         </div>
                         <div class="hostedbadge">
-                            <a href="@page.cta.url" data-link-name="hosted-logo-top-left" target="_blank">
+                            <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
                                 <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
                             </a>
                         </div>

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -2,12 +2,13 @@ package common.commercial.hosted
 
 import java.net.URLEncoder
 
-import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.model.v1.ContentType.{Article, Gallery, Video}
+import com.gu.contentapi.client.model.v1.{Content, SponsorshipLogoDimensions}
 import common.Logging
-import common.commercial.Logo
+import common.commercial.Dimensions
 import conf.Configuration.site
 import model.StandalonePage
+import play.api.libs.json.Json
 
 trait HostedPage extends StandalonePage {
   def id: String
@@ -56,7 +57,7 @@ case class HostedCampaign(
   id: String,
   name: String,
   owner: String,
-  logo: Logo,
+  logo: HostedLogo,
   fontColour: Colour
 )
 
@@ -69,13 +70,27 @@ object HostedCampaign {
       sponsorships <- hostedTag.activeSponsorships
       sponsorship <- sponsorships.headOption
     } yield {
+      val id = section.id.stripPrefix("advertiser-content/")
       HostedCampaign(
-        id = section.id.stripPrefix("advertiser-content/"),
+        id,
         name = section.webTitle,
         owner = sponsorship.sponsorName,
-        logo = Logo.make(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions),
+        logo = HostedLogo.make(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions, id),
         fontColour = Colour(hostedTag.paidContentCampaignColour getOrElse "")
       )
     }
   }
+}
+
+case class HostedLogo(url: String, dimensions: Option[Dimensions], trackingCode: String)
+
+object HostedLogo {
+
+  implicit val jsonFormat = Json.format[HostedLogo]
+
+  def make(url: String, dimensions: Option[SponsorshipLogoDimensions], campaignId: String) = HostedLogo(
+    url,
+    dimensions map (d => Dimensions(d.width, d.height)),
+    trackingCode = s"$campaignId logo"
+  )
 }

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -1,7 +1,7 @@
 package common.commercial.hosted.hardcoded
 
+import common.commercial.Dimensions
 import common.commercial.hosted._
-import common.commercial.{Dimensions, Logo}
 import conf.switches.Switches
 
 object ChesterZooHostedPages {
@@ -10,9 +10,10 @@ object ChesterZooHostedPages {
     id = "chester-zoo-act-for-wildlife",
     name = "What we fight for",
     owner = "Chester Zoo",
-    logo = Logo(
+    logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png",
-      Some(Dimensions(width = 280, height = 261))
+      Some(Dimensions(width = 280, height = 261)),
+      trackingCode = ""
     ),
     fontColour = Colour("#E31B22")
   )

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -1,6 +1,6 @@
 package common.commercial.hosted.hardcoded
 
-import common.commercial.{Dimensions, Logo}
+import common.commercial.Dimensions
 import common.commercial.hosted._
 
 object Formula1HostedPages {
@@ -9,9 +9,10 @@ object Formula1HostedPages {
     id = "singapore-grand-prix",
     name = "Singapore Grand Prix",
     owner = "First Stop Singapore",
-    logo = Logo(
+    logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg",
-      Some(Dimensions(width = 500, height = 500))
+      Some(Dimensions(width = 500, height = 500)),
+      trackingCode = ""
     ),
     fontColour = Colour("#063666")
   )

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -1,6 +1,6 @@
 package common.commercial.hosted.hardcoded
 
-import common.commercial.{Dimensions, Logo}
+import common.commercial.Dimensions
 import common.commercial.hosted._
 import conf.Static
 
@@ -16,9 +16,10 @@ object LeffeHostedPages {
     id = "leffe-rediscover-time",
     name = "Leffe - Rediscover Time",
     owner = "Leffe",
-    logo = Logo(
+    logo = HostedLogo(
       Static("images/commercial/leffe.jpg"),
-      Some(Dimensions(width = 132, height = 132))
+      Some(Dimensions(width = 132, height = 132)),
+      trackingCode = ""
     ),
     fontColour = Colour("#dec190")
   )

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -1,6 +1,6 @@
 package common.commercial.hosted.hardcoded
 
-import common.commercial.{Dimensions, Logo}
+import common.commercial.Dimensions
 import common.commercial.hosted._
 import conf.Static
 
@@ -14,9 +14,10 @@ object RenaultHostedPages {
     id = "renault-car-of-the-future",
     name = "Discover your Renault Zoe",
     owner = "Renault",
-    logo = Logo(
+    logo = HostedLogo(
       Static("images/commercial/logo_renault.jpg"),
-      Some(Dimensions(width = 132, height = 132))
+      Some(Dimensions(width = 132, height = 132)),
+      trackingCode = ""
     ),
     fontColour = Colour("#ffc421")
   )

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -1,7 +1,7 @@
 package common.commercial.hosted.hardcoded
 
+import common.commercial.Dimensions
 import common.commercial.hosted._
-import common.commercial.{Dimensions, Logo}
 
 object VisitBritainHostedPages {
 
@@ -13,9 +13,10 @@ object VisitBritainHostedPages {
     id = "visit-britain",
     name = "#OMGB. Home of Amazing Moments. Great Britain & Northern Ireland",
     owner = "OMGB",
-    logo = Logo(
+    logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
-      Some(Dimensions(width = 1378, height = 957))
+      Some(Dimensions(width = 1378, height = 957)),
+      trackingCode = ""
     ),
     fontColour = Colour("#E41F13")
   )


### PR DESCRIPTION
It now references the campaign of the logo, to make reporting easier.

Eg. 
![image](https://cloud.githubusercontent.com/assets/1722550/21312365/76d0af7c-c5e3-11e6-9537-b7648bb16a0f.png)

I've left the hardcoded campaigns without a tracking code because they're going soon and no-one's counting their logo clicks.

/cc @guardian/labs-beta 
