### PR TITLE
Improve hosted by modules init time

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -88,7 +88,7 @@ define([
     if (config.page.isHosted) {
         secondaryModules.unshift(
             ['cm-hostedAbout', hostedAbout.init],
-            ['cm-hostedVideo', hostedVideo.init],
+            ['cm-hostedVideo', hostedVideo.init, hostedVideo.customTiming],
             ['cm-hostedGallery', hostedGallery.init],
             ['cm-hostedOnward', hostedOnward.init],
             ['cm-hostedOJCarousel', hostedOJCarousel.init]);

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -90,7 +90,7 @@ define([
             ['cm-hostedAbout', hostedAbout.init],
             ['cm-hostedVideo', hostedVideo.init, hostedVideo.customTiming],
             ['cm-hostedGallery', hostedGallery.init, hostedGallery.customTiming],
-            ['cm-hostedOnward', hostedOnward.init],
+            ['cm-hostedOnward', hostedOnward.init, hostedOnward.customTiming],
             ['cm-hostedOJCarousel', hostedOJCarousel.init]);
     }
 

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -89,7 +89,7 @@ define([
         secondaryModules.unshift(
             ['cm-hostedAbout', hostedAbout.init],
             ['cm-hostedVideo', hostedVideo.init, hostedVideo.customTiming],
-            ['cm-hostedGallery', hostedGallery.init],
+            ['cm-hostedGallery', hostedGallery.init, hostedGallery.customTiming],
             ['cm-hostedOnward', hostedOnward.init],
             ['cm-hostedOJCarousel', hostedOJCarousel.init]);
     }

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.js
@@ -10,27 +10,23 @@ define([
     SurveySimple
 ) {
     function init() {
-
-        return new Promise(function(resolve) {
-
-            var survey = new SurveySimple({
-                id: 'hosted-about',
-                header: 'Advertiser content',
-                paragraph1: 'Advertiser content is used to describe advertisement features that are paid for, produced and controlled by the advertiser rather than the publisher​.',
-                paragraph2: 'They​ are subject to regulation by the Advertising Standards Authority in the UK, the Federal Trade Commission in the US and the Advertising Standards Bureau in Australia.',
-                paragraph3: 'This content is produced by the advertiser and does not involve Guardian News and Media staff.',
-                showCloseBtn: true
-            });
-
-            survey.attach();
-
-            bean.on(document, 'click', $('.js-hosted-about'), function (e) {
-                e.preventDefault();
-                $('.js-survey-overlay').removeClass('u-h');
-            });
-
-            resolve();
+        var survey = new SurveySimple({
+            id: 'hosted-about',
+            header: 'Advertiser content',
+            paragraph1: 'Advertiser content is used to describe advertisement features that are paid for, produced and controlled by the advertiser rather than the publisher​.',
+            paragraph2: 'They​ are subject to regulation by the Advertising Standards Authority in the UK, the Federal Trade Commission in the US and the Advertising Standards Bureau in Australia.',
+            paragraph3: 'This content is produced by the advertiser and does not involve Guardian News and Media staff.',
+            showCloseBtn: true
         });
+
+        survey.attach();
+
+        bean.on(document, 'click', $('.js-hosted-about'), function (e) {
+            e.preventDefault();
+            $('.js-survey-overlay').removeClass('u-h');
+        });
+
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,4 +1,5 @@
 define([
+    'Promise',
     'bean',
     'lodash/functions/debounce',
     'bonzo',
@@ -17,7 +18,8 @@ define([
     'common/utils/chain',
     'common/utils/load-css-promise',
     'commercial/modules/dfp/performance-logging'
-], function (bean,
+], function (Promise,
+             bean,
              debounce,
              bonzo,
              fastdom,

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -15,7 +15,8 @@ define([
     'lodash/collections/forEach',
     'common/modules/analytics/interaction-tracking',
     'common/utils/chain',
-    'common/utils/load-css-promise'
+    'common/utils/load-css-promise',
+    'commercial/modules/dfp/performance-logging'
 ], function (bean,
              debounce,
              bonzo,
@@ -32,7 +33,8 @@ define([
              forEach,
              interactionTracking,
              chain,
-             loadCssPromise) {
+             loadCssPromise,
+             performanceLogging) {
 
 
     function HostedGallery() {
@@ -446,8 +448,11 @@ define([
         }
     };
 
-    function init() {
-        return loadCssPromise.then(function () {
+    function init(moduleName) {
+        performanceLogging.moduleStart(moduleName);
+
+        loadCssPromise
+        .then(function () {
             var gallery,
                 match,
                 galleryHash = window.location.hash,
@@ -463,7 +468,12 @@ define([
                     gallery.loadAtIndex(parseInt(res[1], 10));
                 }
             }
+        })
+        .then(function () {
+            performanceLogging.moduleEnd(moduleName);
         });
+
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -10,11 +10,8 @@ define([
     'common/utils/detect',
     'common/utils/fsm',
     'common/utils/mediator',
-    'lodash/collections/map',
     'lodash/functions/throttle',
-    'lodash/collections/forEach',
     'common/modules/analytics/interaction-tracking',
-    'common/utils/chain',
     'common/utils/load-css-promise',
     'commercial/modules/dfp/performance-logging'
 ], function (Promise,
@@ -28,11 +25,8 @@ define([
              detect,
              FiniteStateMachine,
              mediator,
-             map,
              throttle,
-             forEach,
              interactionTracking,
-             chain,
              loadCssPromise,
              performanceLogging) {
 
@@ -172,19 +166,18 @@ define([
 
     HostedGallery.prototype.loadSurroundingImages = function (index, count) {
         var $img, that = this;
-        chain([0, 1, 2]).and(
-            map,
-            function (i) {
-                return index + i === 0 ? count - 1 : (index - 1 + i) % count;
-            }
-        ).and(forEach, function (i) {
+        [0, 1, 2]
+        .map(function (i) {
+            return index + i === 0 ? count - 1 : (index - 1 + i) % count;
+        })
+        .forEach(function (i) {
             $img = $('img', this.$images[i]);
             if (!$img[0].complete) {
                 bean.one($img[0], 'load', setSize.bind(this, $img, i));
             } else {
                 setSize($img, i);
             }
-        }.bind(this));
+        }, this);
 
         function setSize($image, index) {
             if (!that.imageRatios[index]) {

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,7 +1,6 @@
 define([
     'Promise',
     'bean',
-    'lodash/functions/debounce',
     'bonzo',
     'fastdom',
     'common/utils/$',
@@ -20,7 +19,6 @@ define([
     'commercial/modules/dfp/performance-logging'
 ], function (Promise,
              bean,
-             debounce,
              bonzo,
              fastdom,
              $,

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -65,10 +65,8 @@ define([
     };
 
     function init() {
-        return new Promise(function(resolve) {
-            new HostedCarousel().bindButtons();
-            resolve();
-        });
+        new HostedCarousel().bindButtons();
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -15,12 +15,12 @@ define([
         var placeholders = document.getElementsByClassName('js-onward-placeholder');
 
         if (placeholders.length) {
-            return fetchJson(config.page.ajaxUrl + '/'
+            fetchJson(config.page.ajaxUrl + '/'
                 + config.page.pageId + '/'
                 + config.page.contentType.toLowerCase() + '/'
                 + 'onward.json', {mode: 'cors'})
                 .then(function (json) {
-                    return fastdom.write(function () {
+                    fastdom.write(function () {
                         var i;
                         for (i = 0; i < placeholders.length; i++) {
                             placeholders[i].innerHTML = json.html;

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -12,7 +12,7 @@ define([
 
     function loadOnwardComponent() {
 
-        var placeholders = document.querySelectorAll('.js-onward-placeholder');
+        var placeholders = document.getElementsByClassName('js-onward-placeholder');
 
         if (placeholders.length) {
             return fetchJson(config.page.ajaxUrl + '/'

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -3,14 +3,17 @@ define([
     'common/utils/fetch-json',
     'common/utils/fastdom-promise',
     'commercial/modules/hosted/onward-journey-carousel',
+    'commercial/modules/dfp/performance-logging',
     'Promise'
-], function (config, fetchJson, fastdom, HostedCarousel, Promise) {
+], function (config, fetchJson, fastdom, HostedCarousel, performanceLogging, Promise) {
 
     return {
-        init: loadOnwardComponent
+        init: loadOnwardComponent,
+        customTiming: true
     };
 
-    function loadOnwardComponent() {
+    function loadOnwardComponent(moduleName) {
+        performanceLogging.moduleStart(moduleName);
 
         var placeholders = document.getElementsByClassName('js-onward-placeholder');
 
@@ -20,13 +23,16 @@ define([
                 + config.page.contentType.toLowerCase() + '/'
                 + 'onward.json', {mode: 'cors'})
                 .then(function (json) {
-                    fastdom.write(function () {
+                    return fastdom.write(function () {
                         var i;
                         for (i = 0; i < placeholders.length; i++) {
                             placeholders[i].innerHTML = json.html;
                         }
                         new HostedCarousel.init();
                     });
+                })
+                .then(function () {
+                    performanceLogging.moduleEnd(moduleName);
                 });
         }
         return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -56,82 +56,80 @@ define([
     }
 
     function init() {
-        return new Promise(function (resolve) {
-            require(['bootstraps/enhanced/media/main'], function () {
-                require(['bootstraps/enhanced/media/video-player'], function (videojs) {
-                    var $videoEl = $('.vjs-hosted__video');
-                    var $inlineVideoEl = $('video');
-                    var $youtubeIframe = $('.js-hosted-youtube-video');
+        require(['bootstraps/enhanced/media/main'], function () {
+            require(['bootstraps/enhanced/media/video-player'], function (videojs) {
+                var $videoEl = $('.vjs-hosted__video');
+                var $inlineVideoEl = $('video');
+                var $youtubeIframe = $('.js-hosted-youtube-video');
 
-                    if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
-                        if ($inlineVideoEl.length === 0) {
-                            // halt execution
-                            return resolve();
-                        } else {
-                            $videoEl = $inlineVideoEl;
-                        }
+                if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
+                    if ($inlineVideoEl.length === 0) {
+                        // halt execution
+                        return resolve();
+                    } else {
+                        $videoEl = $inlineVideoEl;
                     }
+                }
 
-                    $videoEl.each(function(el){
-                        var mediaId = $videoEl.attr('data-media-id');
-                        player = videojs(el, videojsOptions());
-                        player.guMediaType = 'video';
-                        videojs.plugin('fullscreener', fullscreener);
+                $videoEl.each(function(el){
+                    var mediaId = $videoEl.attr('data-media-id');
+                    player = videojs(el, videojsOptions());
+                    player.guMediaType = 'video';
+                    videojs.plugin('fullscreener', fullscreener);
 
-                        events.addContentEvents(player, mediaId, player.guMediaType);
-                        events.bindGoogleAnalyticsEvents(player, window.location.pathname);
+                    events.addContentEvents(player, mediaId, player.guMediaType);
+                    events.bindGoogleAnalyticsEvents(player, window.location.pathname);
 
-                        player.ready(function () {
-                            var vol;
-                            var player = this;
-                            initLoadingSpinner(player);
-                            upgradeVideoPlayerAccessibility(player);
+                    player.ready(function () {
+                        var vol;
+                        var player = this;
+                        initLoadingSpinner(player);
+                        upgradeVideoPlayerAccessibility(player);
 
-                            // unglitching the volume on first load
-                            vol = player.volume();
-                            if (vol) {
-                                player.volume(0);
-                                player.volume(vol);
-                            }
+                        // unglitching the volume on first load
+                        vol = player.volume();
+                        if (vol) {
+                            player.volume(0);
+                            player.volume(vol);
+                        }
 
-                            player.fullscreener();
+                        player.fullscreener();
 
-                            deferToAnalytics(function () {
-                                events.initOphanTracking(player, mediaId);
-                                events.bindGlobalEvents(player);
-                                events.bindContentEvents(player);
-                            });
-
-                            player.on('error', function () {
-                                var err = player.error();
-                                if (err && 'message' in err && 'code' in err) {
-                                    reportError(new Error(err.message), {
-                                        feature: 'hosted-player',
-                                        vjsCode: err.code
-                                    }, false);
-                                }
-                            });
+                        deferToAnalytics(function () {
+                            events.initOphanTracking(player, mediaId);
+                            events.bindGlobalEvents(player);
+                            events.bindContentEvents(player);
                         });
 
-                        if (nextVideoAutoplay.canAutoplay()) {
-                            //on desktop show the next video link 10 second before the end of the currently watching video
-                            if (isDesktop()) {
-                                nextVideoAutoplay.addCancelListener();
-                                player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
-                            } else {
-                                player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
+                        player.on('error', function () {
+                            var err = player.error();
+                            if (err && 'message' in err && 'code' in err) {
+                                reportError(new Error(err.message), {
+                                    feature: 'hosted-player',
+                                    vjsCode: err.code
+                                }, false);
                             }
+                        });
+                    });
+
+                    if (nextVideoAutoplay.canAutoplay()) {
+                        //on desktop show the next video link 10 second before the end of the currently watching video
+                        if (isDesktop()) {
+                            nextVideoAutoplay.addCancelListener();
+                            player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
+                        } else {
+                            player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
                         }
-                    });
+                    }
+                });
 
-                    $youtubeIframe.each(function(el){
-                        hostedYoutube.init(el);
-                    });
-
-                    resolve();
+                $youtubeIframe.each(function(el){
+                    hostedYoutube.init(el);
                 });
             });
         });
+
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -6,6 +6,7 @@ define([
     'Promise',
     'commercial/modules/hosted/youtube',
     'commercial/modules/hosted/next-video-autoplay',
+    'commercial/modules/dfp/performance-logging',
     'common/utils/$',
     'common/utils/defer-to-analytics',
     'common/utils/detect',
@@ -19,6 +20,7 @@ define([
     Promise,
     hostedYoutube,
     nextVideoAutoplay,
+    performanceLogging,
     $,
     deferToAnalytics,
     detect,
@@ -55,84 +57,90 @@ define([
         $('.vjs-fullscreen-control', player.el()).attr('aria-label', 'video fullscreen');
     }
 
-    function init() {
-        require(['bootstraps/enhanced/media/main'], function () {
-            require(['bootstraps/enhanced/media/video-player'], function (videojs) {
-                var $videoEl = $('.vjs-hosted__video');
-                var $inlineVideoEl = $('video');
-                var $youtubeIframe = $('.js-hosted-youtube-video');
+    function init(moduleName) {
+        performanceLogging.moduleStart(moduleName);
 
-                if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
-                    if ($inlineVideoEl.length === 0) {
-                        // halt execution
-                        return resolve();
-                    } else {
-                        $videoEl = $inlineVideoEl;
-                    }
+        require([
+            'bootstraps/enhanced/media/main',
+            'bootstraps/enhanced/media/video-player'
+        ], function (_, videojs) {
+            var $videoEl = $('.vjs-hosted__video');
+            var $inlineVideoEl = $('video');
+            var $youtubeIframe = $('.js-hosted-youtube-video');
+
+            if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
+                if ($inlineVideoEl.length === 0) {
+                    // halt execution
+                    return;
+                } else {
+                    $videoEl = $inlineVideoEl;
                 }
+            }
 
-                $videoEl.each(function(el){
-                    var mediaId = $videoEl.attr('data-media-id');
-                    player = videojs(el, videojsOptions());
-                    player.guMediaType = 'video';
-                    videojs.plugin('fullscreener', fullscreener);
+            $videoEl.each(function(el){
+                var mediaId = $videoEl.attr('data-media-id');
+                player = videojs(el, videojsOptions());
+                player.guMediaType = 'video';
+                videojs.plugin('fullscreener', fullscreener);
 
-                    events.addContentEvents(player, mediaId, player.guMediaType);
-                    events.bindGoogleAnalyticsEvents(player, window.location.pathname);
+                events.addContentEvents(player, mediaId, player.guMediaType);
+                events.bindGoogleAnalyticsEvents(player, window.location.pathname);
 
-                    player.ready(function () {
-                        var vol;
-                        var player = this;
-                        initLoadingSpinner(player);
-                        upgradeVideoPlayerAccessibility(player);
+                player.ready(function () {
+                    var vol;
+                    var player = this;
+                    initLoadingSpinner(player);
+                    upgradeVideoPlayerAccessibility(player);
 
-                        // unglitching the volume on first load
-                        vol = player.volume();
-                        if (vol) {
-                            player.volume(0);
-                            player.volume(vol);
-                        }
+                    // unglitching the volume on first load
+                    vol = player.volume();
+                    if (vol) {
+                        player.volume(0);
+                        player.volume(vol);
+                    }
 
-                        player.fullscreener();
+                    player.fullscreener();
 
-                        deferToAnalytics(function () {
-                            events.initOphanTracking(player, mediaId);
-                            events.bindGlobalEvents(player);
-                            events.bindContentEvents(player);
-                        });
-
-                        player.on('error', function () {
-                            var err = player.error();
-                            if (err && 'message' in err && 'code' in err) {
-                                reportError(new Error(err.message), {
-                                    feature: 'hosted-player',
-                                    vjsCode: err.code
-                                }, false);
-                            }
-                        });
+                    deferToAnalytics(function () {
+                        events.initOphanTracking(player, mediaId);
+                        events.bindGlobalEvents(player);
+                        events.bindContentEvents(player);
                     });
 
-                    if (nextVideoAutoplay.canAutoplay()) {
-                        //on desktop show the next video link 10 second before the end of the currently watching video
-                        if (isDesktop()) {
-                            nextVideoAutoplay.addCancelListener();
-                            player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
-                        } else {
-                            player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
+                    player.on('error', function () {
+                        var err = player.error();
+                        if (err && 'message' in err && 'code' in err) {
+                            reportError(new Error(err.message), {
+                                feature: 'hosted-player',
+                                vjsCode: err.code
+                            }, false);
                         }
-                    }
+                    });
                 });
 
-                $youtubeIframe.each(function(el){
-                    hostedYoutube.init(el);
-                });
+                if (nextVideoAutoplay.canAutoplay()) {
+                    //on desktop show the next video link 10 second before the end of the currently watching video
+                    if (isDesktop()) {
+                        nextVideoAutoplay.addCancelListener();
+                        player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
+                    } else {
+                        player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
+                    }
+                }
             });
+
+            $youtubeIframe.each(function(el){
+                hostedYoutube.init(el);
+            });
+
+            performanceLogging.moduleEnd(moduleName);
         });
 
         return Promise.resolve();
     }
 
     return {
-        init: init
+        init: init,
+        customTiming: true
     };
 });


### PR DESCRIPTION
A few small changes to the delineation of the "Hosted by" modules initialisation.

We are in a situation where `enhanced` starts loading before all our commercial modules have had the chance to set everything up. That is because the boot script [does not wait](https://github.com/guardian/frontend/blob/master/static/src/javascripts/boot.js#L64) for commercial code to get through.

We could change that now, but there are still modules that take too long to initialise. In this PR, I address the "Hosted by" modules, so that their `init` function exists asap, without losing the ability to measure the actual running time of the whole module.

cc @lps88 