### PR TITLE
Load video player after main media

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -60,80 +60,79 @@ define([
     function init(moduleName) {
         performanceLogging.moduleStart(moduleName);
 
-        require([
-            'bootstraps/enhanced/media/main',
-            'bootstraps/enhanced/media/video-player'
-        ], function (_, videojs) {
-            var $videoEl = $('.vjs-hosted__video');
-            var $inlineVideoEl = $('video');
-            var $youtubeIframe = $('.js-hosted-youtube-video');
+        require(['bootstraps/enhanced/media/main'], function() {
+            require(['bootstraps/enhanced/media/video-player'], function (_, videojs) {
+                var $videoEl = $('.vjs-hosted__video');
+                var $inlineVideoEl = $('video');
+                var $youtubeIframe = $('.js-hosted-youtube-video');
 
-            if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
-                if ($inlineVideoEl.length === 0) {
-                    // halt execution
-                    return;
-                } else {
-                    $videoEl = $inlineVideoEl;
-                }
-            }
-
-            $videoEl.each(function(el){
-                var mediaId = $videoEl.attr('data-media-id');
-                player = videojs(el, videojsOptions());
-                player.guMediaType = 'video';
-                videojs.plugin('fullscreener', fullscreener);
-
-                events.addContentEvents(player, mediaId, player.guMediaType);
-                events.bindGoogleAnalyticsEvents(player, window.location.pathname);
-
-                player.ready(function () {
-                    var vol;
-                    var player = this;
-                    initLoadingSpinner(player);
-                    upgradeVideoPlayerAccessibility(player);
-
-                    // unglitching the volume on first load
-                    vol = player.volume();
-                    if (vol) {
-                        player.volume(0);
-                        player.volume(vol);
+                if ($youtubeIframe.length === 0 && $videoEl.length === 0) {
+                    if ($inlineVideoEl.length === 0) {
+                        // halt execution
+                        return;
+                    } else {
+                        $videoEl = $inlineVideoEl;
                     }
+                }
 
-                    player.fullscreener();
+                $videoEl.each(function(el){
+                    var mediaId = $videoEl.attr('data-media-id');
+                    player = videojs(el, videojsOptions());
+                    player.guMediaType = 'video';
+                    videojs.plugin('fullscreener', fullscreener);
 
-                    deferToAnalytics(function () {
-                        events.initOphanTracking(player, mediaId);
-                        events.bindGlobalEvents(player);
-                        events.bindContentEvents(player);
-                    });
+                    events.addContentEvents(player, mediaId, player.guMediaType);
+                    events.bindGoogleAnalyticsEvents(player, window.location.pathname);
 
-                    player.on('error', function () {
-                        var err = player.error();
-                        if (err && 'message' in err && 'code' in err) {
-                            reportError(new Error(err.message), {
-                                feature: 'hosted-player',
-                                vjsCode: err.code
-                            }, false);
+                    player.ready(function () {
+                        var vol;
+                        var player = this;
+                        initLoadingSpinner(player);
+                        upgradeVideoPlayerAccessibility(player);
+
+                        // unglitching the volume on first load
+                        vol = player.volume();
+                        if (vol) {
+                            player.volume(0);
+                            player.volume(vol);
                         }
+
+                        player.fullscreener();
+
+                        deferToAnalytics(function () {
+                            events.initOphanTracking(player, mediaId);
+                            events.bindGlobalEvents(player);
+                            events.bindContentEvents(player);
+                        });
+
+                        player.on('error', function () {
+                            var err = player.error();
+                            if (err && 'message' in err && 'code' in err) {
+                                reportError(new Error(err.message), {
+                                    feature: 'hosted-player',
+                                    vjsCode: err.code
+                                }, false);
+                            }
+                        });
                     });
+
+                    if (nextVideoAutoplay.canAutoplay()) {
+                        //on desktop show the next video link 10 second before the end of the currently watching video
+                        if (isDesktop()) {
+                            nextVideoAutoplay.addCancelListener();
+                            player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
+                        } else {
+                            player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
+                        }
+                    }
                 });
 
-                if (nextVideoAutoplay.canAutoplay()) {
-                    //on desktop show the next video link 10 second before the end of the currently watching video
-                    if (isDesktop()) {
-                        nextVideoAutoplay.addCancelListener();
-                        player && player.one('timeupdate', nextVideoAutoplay.triggerAutoplay.bind(this, player.currentTime.bind(player), parseInt($videoEl.data('duration'), 10)));
-                    } else {
-                        player && player.one('ended', nextVideoAutoplay.triggerEndSlate);
-                    }
-                }
-            });
+                $youtubeIframe.each(function(el){
+                    hostedYoutube.init(el);
+                });
 
-            $youtubeIframe.each(function(el){
-                hostedYoutube.init(el);
+                performanceLogging.moduleEnd(moduleName);
             });
-
-            performanceLogging.moduleEnd(moduleName);
         });
 
         return Promise.resolve();


### PR DESCRIPTION
This delineation matters because of some naming kung-fu happening behind the scenes.

This is a fix for this [PR](https://github.com/guardian/frontend/pull/15390).