### PR TITLE
Refactor Australian campaign

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -7,7 +7,7 @@ define([
     'common/utils/element-inview',
     'common/utils/fastdom-promise',
     'common/utils/mediator',
-    'common/utils/storage',
+    'common/utils/storage'
 ], function (commercialFeatures,
              targetingTool,
              $,
@@ -20,9 +20,6 @@ define([
 
     var membershipURL = 'https://membership.theguardian.com/supporter';
     var contributionsURL = 'https://contribute.theguardian.com';
-
-    var membershipCampaignPrefix = 'gdnwb_copts_mem';
-    var contributionsCampaignPrefix = 'co_global';
 
     var viewKey = 'gu.contributions.views';
     var viewLog = storage.local.get(viewKey) || [];
@@ -91,6 +88,8 @@ define([
         this.successMeasure = options.successMeasure;
         this.audienceCriteria = options.audienceCriteria;
         this.dataLinkNames = options.dataLinkNames || '';
+        this.membershipCampaignPrefix = options.membershipCampaignPrefix || 'gdnwb_copts_mem';
+        this.contributionsCampaignPrefix = options.contributionsCampaignPrefix || 'co_global';
 
         this.insertEvent = this.makeEvent('insert');
         this.viewEvent = this.makeEvent('view');
@@ -131,8 +130,8 @@ define([
         this.campaignId = test.campaignId;
         this.id = options.id;
 
-        this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, contributionsCampaignPrefix);
-        this.membershipURL = options.membershipURL || this.makeURL(membershipURL, membershipCampaignPrefix);
+        this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, test.contributionsCampaignPrefix);
+        this.membershipURL = options.membershipURL || this.makeURL(membershipURL, test.membershipCampaignPrefix);
 
         this.test = function () {
             var component = $.create(options.template(this.contributeURL, this.membershipURL));

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-on-the-moon.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-on-the-moon.js
@@ -1,229 +1,123 @@
 define([
-    'bean',
-    'qwery',
-    'common/utils/$',
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/geolocation',
     'common/utils/template',
-    'common/views/svg',
-    'common/utils/fastdom-promise',
-    'common/utils/mediator',
     'text!common/views/contributions-epic-image.html',
     'text!common/views/contributions-epic-equal-buttons.html',
-    'common/utils/robust',
-    'inlineSvg!svgs/icon/arrow-right',
-    'common/utils/config',
-    'common/utils/cookies',
-    'common/utils/ajax',
-    'common/modules/commercial/commercial-features',
-    'common/utils/element-inview',
-    'lodash/arrays/intersection',
-    'common/utils/storage',
-], function (bean,
-             qwery,
-             $,
-             template,
-             svg,
-             fastdom,
-             mediator,
-             contributionsEpicImage,
-             contributionsEpicEqualButtons,
-             robust,
-             arrowRight,
-             config,
-             cookies,
-             ajax,
-             commercialFeatures,
-             ElementInview,
-             intersection,
-             store
+    'common/utils/config'
+], function (
+    contributionsUtilities,
+    geolocation,
+    template,
+    contributionsEpicImage,
+    contributionsEpicEqualButtons,
+    config
 ) {
 
-    // We want to ensure the test always runs as this enables an easy data lake query to see whether a reader is in the
-    // test segment: check whether the ab_tests field contains a test with name ContributionsEpicAlwaysAskStrategy.
-    // This means having showForSensitive equal to true, and the canRun() function always returning true.
-    // The logic for whether the test-variant is displayed, is handled in the canBeDisplayed() function.
-    return function () {
-        this.id = 'ContributionsEpicOnTheMoon';
-        this.start = '2016-12-13';
-        this.expiry = '2017-01-12';
-        this.author = 'Alex Dufournet';
-        this.description = 'Test with Epic variant containing a message from First Dog on the Moon';
-        this.showForSensitive = true;
-        this.audience = 0.1;
-        this.audienceOffset = 0;
-        this.successMeasure = 'We are able to measure the positive and negative effects of this strategy.';
-        this.audienceCriteria = 'All';
-        this.dataLinkNames = '';
-        this.idealOutcome = 'There are no negative effects and this is the optimum strategy!';
-        this.canRun = function () {
+    function testAustralia(render) {
+        geolocation.get().then(function(geo) {
+            if (geo === 'AU') render();
+        });
+    }
 
-            var participations = store.local.get('gu.ab.participations') || {};
-            var isInAlwaysAsk = 'ContributionsEpicAlwaysAskStrategy' in participations
-                && participations['ContributionsEpicAlwaysAskStrategy'].variant !== 'notintest';
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicOnTheMoon',
+        campaignId: 'epic_end_of_year_2016',
+        start: '2016-12-13',
+        expiry: '2017-01-12',
 
-            var excludedKeywordIds = ['society/guardian-and-observer-charity-appeal-2016'];
+        author: 'Alex Dufournet',
+        description: 'Test with Epic variant containing a message from First Dog on the Moon',
+        successMeasure: 'Conversion rate (contributions / impressions)',
+        idealOutcome: 'There are no negative effects and this is the optimum strategy!',
 
-            var tagsMatch = function () {
-                var pageKeywords = config.page.keywordIds;
-                if (typeof(pageKeywords) !== 'undefined') {
-                    var keywordList = pageKeywords.split(',');
-                    return intersection(excludedKeywordIds, keywordList).length == 0;
-                } else {
-                    return false;
-                }
-            };
-            var userHasNeverContributed = !cookies.get('gu.contributions.contrib-timestamp');
-            var worksWellWithPageTemplate = (config.page.contentType === 'Article') && !config.page.isMinuteArticle; // may render badly on other types
-            var isSensitive = config.page.isSensitive === true;
-            return userHasNeverContributed
-                && commercialFeatures.canReasonablyAskForMoney
-                && worksWellWithPageTemplate
-                && tagsMatch()
-                && !isSensitive
-                && !isInAlwaysAsk;
-        };
+        audienceCriteria: 'AUS readers',
+        audience: 1,
+        audienceOffset: 0,
+        useTargetingTool: true,
 
-        var makeEvent = (function(name) {
-            return this.id + ':' + name;
-        }).bind(this);
+        membershipCampaignPrefix: 'gdnwb_copts_mem',
+        contributionsCampaignPrefix: 'co_au',
 
-        function makeUrl(urlPrefix, intcmp) {
-            return urlPrefix + 'INTCMP=' + intcmp;
-        }
 
-        var contributeUrlSuffix = 'co_au_epic_end_of_year_2016';
-        var membershipUrlSuffix = 'gdnwb_copts_mem_epic_end_of_year_2016';
+        /**
+         * In addition to the typical contributions criteria (in contributions-utilities) we need to exclude anyone
+         * in the "always ask" strategy test
+         */
+        canRun: function () {
+            return !contributionsUtilities.inAlwaysAskTest()
+        },
 
-        var epicViewedEvent = makeEvent('view');
-        var epicInsertedEvent = makeEvent('insert');
-
-        var membershipUrl = 'https://membership.theguardian.com/supporter?';
-        var contributeUrl = 'https://contribute.theguardian.com/?';
-
-        var cta = {
-            cta1: 'Become a Supporter',
-            cta2: 'Make a contribution',
-            url1: makeUrl(membershipUrl, membershipUrlSuffix),
-            url2:  makeUrl(contributeUrl, contributeUrlSuffix),
-            hidden: ''
-        };
-
-        var componentWriter = function (component) {
-            ajax({
-                url: config.page.ajaxUrl + '/geolocation',
-                method: 'GET',
-                contentType: 'application/json',
-                crossOrigin: true
-            }).then(function (resp) {
-                if(resp.country === 'AU') {
-                    fastdom.write(function () {
-                        var submetaElement = $('.submeta');
-                        if (submetaElement.length > 0) {
-                            component.insertBefore(submetaElement);
-                            $('.contributions__epic').each(function (element) {
-                                // top offset of 18 ensures view only counts when half of element is on screen
-                                var elementInview = ElementInview(element, window, {top: 18});
-                                elementInview.on('firstview', function () {
-                                    mediator.emit(epicViewedEvent, component);
-                                });
-                            });
-                            mediator.emit(epicInsertedEvent, component);
-                        }
-                    });
-                }
-            });
-        };
-
-        function registerInsertionListener(track) {
-            mediator.on(epicInsertedEvent, track);
-        }
-
-        function registerViewListener(complete) {
-            mediator.on(epicViewedEvent, complete);
-        }
-
-        this.variants = [
+        variants: [
             {
                 id: 'control',
 
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: cta.url1 + '_control',
-                        linkUrl2: cta.url2 + '_control',
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
                         title: 'Since you\'re here…',
                         p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.',
-                        p3: '',
-                        cta1: cta.cta1,
-                        cta2: cta.cta2,
-                        hidden: cta.hidden
-                    }));
-                    componentWriter(component);
+                        cta1: 'Become a supporter',
+                        cta2: 'Make a contribution'
+                    });
                 },
-                impression: registerInsertionListener,
-                success: registerViewListener
+
+                insertBeforeSelector: '.submeta',
+
+                test: testAustralia,
+
+                impressionOnInsert: true,
+                successOnView: true
             },
             {
                 id: 'firstDog',
 
-                test: function () {
-                    var component = $.create(template(contributionsEpicImage, {
-                        linkUrl1: cta.url1 + '_firstDog',
-                        linkUrl2: cta.url2 + '_firstDog',
-                        cta1: cta.cta1,
-                        cta2: cta.cta2,
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicImage, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
                         defaultImgSrc: config.images.contributions['ab-first-dog-mb'],
                         alt: 'First Dog on the Moon supports the guardian',
                         sources: [
                             {src: config.images.contributions['ab-first-dog-dt'], media:'(min-width:580px)'},
                             {src: config.images.contributions['ab-first-dog-mb'], media:'(max-width:580px)'}
                         ],
-                        hidden: cta.hidden
-                    }));
-                    componentWriter(component);
+                        cta1: 'Become a supporter',
+                        cta2: 'Make a contribution'
+                    });
                 },
-                impression: registerInsertionListener,
-                success: registerViewListener
+
+                insertBeforeSelector: '.submeta',
+
+                test: testAustralia,
+
+                impressionOnInsert: true,
+                successOnView: true
             },
             {
                 id: 'australiaNewsroom',
 
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: cta.url1 + '_australiaNewsroom',
-                        linkUrl2: cta.url2 + '_australiaNewsroom',
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
                         title: 'Since you’re here…',
                         p1: '…we have a favour to ask. Guardian Australia launched three years ago and although many people read it, few pay for it. We fund our content through advertising, but revenues across the media are falling fast. So we need your help. Our independent, investigative reporting takes a lot of time, money and hard work to produce.',
                         p2: 'Any money raised from readers goes directly to fund Guardian Australia\'s journalism, so if everyone who reads it – who believes in it – helps to support it, our future would be more secure.',
-                        p3: '',
-                        cta1: cta.cta1,
-                        cta2: cta.cta2,
-                        hidden: cta.hidden
-                    }));
-                    componentWriter(component);
+                        cta1: 'Become a supporter',
+                        cta2: 'Make a contribution'
+                    });
                 },
-                impression: registerInsertionListener,
-                success: registerViewListener
-            },
-            {
-                id: 'endOfYearAustralia',
 
-                test: function () {
-                    var component = $.create(template(contributionsEpicEqualButtons, {
-                        linkUrl1: cta.url1 + '_endOfYearAustralia',
-                        linkUrl2: cta.url2 + '_endOfYearAustralia',
-                        title: 'In 2017…',
-                        p1: '…the pursuit of truth will matter more than ever. At a time when lies can be read as widely as facts, Guardian Australia holds an important place in the media landscape. But we need your help. Independent investigative journalism dedicated to holding the powerful to account​ and ensuring diverse, local voices are heard​ takes time and money. Next year we will shine a light on critical issues such as politics, climate, detention, minority voices and inequality.',
-                        p2: 'If everyone who reads Guardian Australia – who believes in it – helps to support it, our ability to tell these stories will be more secure.',
-                        p3: '',
-                        cta1: cta.cta1,
-                        cta2: cta.cta2,
-                        hidden: cta.hidden
-                    }));
-                    componentWriter(component);
-                },
-                impression: registerInsertionListener,
-                success: registerViewListener
+                insertBeforeSelector: '.submeta',
+
+                test: testAustralia,
+
+                impressionOnInsert: true,
+                successOnView: true
             }
-        ];
-    };
+        ]
+    });
 });

--- a/static/src/javascripts/projects/common/utils/geolocation.js
+++ b/static/src/javascripts/projects/common/utils/geolocation.js
@@ -1,9 +1,11 @@
 define([
     'Promise',
     'common/utils/fetch-json',
+    'common/utils/config'
 ], function (
     Promise,
-    fetch
+    fetch,
+    config
 ) {
     var location;
 
@@ -12,7 +14,7 @@ define([
             return new Promise(function(resolve, reject) {
                 if (location) return resolve(location);
                 else {
-                    fetch('https://api.nextgen.guardianapps.co.uk/geolocation', {
+                    fetch(config.page.ajaxUrl + '/geolocation', {
                         method: 'GET',
                         contentType: 'application/json',
                         crossOrigin: true

--- a/static/src/javascripts/projects/common/views/contributions-epic-image.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-image.html
@@ -13,7 +13,7 @@
             </a>
         </div>
 
-        <div class="contributions__<%=hidden%>">
+        <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member" href="<%=linkUrl2%>" target="_blank">
                 <%=cta2%>
             </a>


### PR DESCRIPTION
## What does this change?
Push the Australian campaign 100%, removes one variant, and uses the contribution utilities to reduce boiler plate (and risk of bugs)

## What is the value of this and can you measure success?
Measure the efficiency of each message and start monetising them

## Does this affect other platforms - Amp, Apps, etc?
no
## Screenshots

see 
https://github.com/guardian/frontend/pull/15339