### PR TITLE
Extending new header tests until after the holidays

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -21,7 +21,7 @@ object ABNewNavVariantFour extends TestDefinition(
   name = "ab-new-nav-variant-four",
   description = "users in this test will see the new header fourth variant",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 21) // Wednesday
+  sellByDate = new LocalDate(2017, 1, 5)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variantfour")
@@ -32,7 +32,7 @@ object ABNewNavControl extends TestDefinition(
   name = "ab-new-nav-control",
   description = "control for the new header test",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 12, 21) // Wednesday
+  sellByDate = new LocalDate(2017, 1, 5)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("control")


### PR DESCRIPTION
## What does this change?
Tomorrow the new header test switches will expire. This extends it to the first week of January.

## What is the value of this and can you measure success?
It has been proven successful, but we are being cautious and testing it on slightly larger audiences to try and weed out bugs before rolling it out to everyone. 

## Does this affect other platforms - Amp, Apps, etc?
Nope!

@guardian/dotcom-platform 
