### PR TITLE
Amp sans

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/buttons.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/buttons.scala.html
@@ -18,7 +18,7 @@
     height: 1.875rem;
     padding: 0 0.625rem;
     margin-right: 0.625rem;
-    line-height: 1.75rem;
+    line-height: 30px;
 }
 
 .cta--show-more {

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -73,8 +73,20 @@ b, strong {
     font-weight: 500;
 }
 
-
 .guardian-text-sans-loaded .hosted-page,
-.guardian-text-sans-loaded .hosted__header {
+.guardian-text-sans-loaded .hosted__header,
+.guardian-text-sans-loaded .header__nav__link,
+.guardian-text-sans-loaded .caption,
+.guardian-text-sans-loaded .content__dateline,
+.guardian-text-sans-loaded .ad-slot--paid-for-badge__header,
+.guardian-text-sans-loaded .element-rich-link--not-upgraded a:before,
+.guardian-text-sans-loaded .l-footer__secondary,
+.guardian-text-sans-loaded .contact {
     font-family: "Guardian Text Sans Web", Georgia, serif;
+}
+
+.guardian-text-sans-loaded .cta,
+.guardian-text-sans-loaded .element-interactive a {
+    font-family: "Guardian Text Sans Web", Georgia, serif;
+    font-weight: 500;
 }

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -17,8 +17,8 @@
 
 @@font-face {
     font-family: "Guardian Text Sans Web";
-    src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot");
-    src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot?#iefix") format("embedded-opentype"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff2") format("woff2"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff") format("woff"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.ttf") format("truetype"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Regular.svg#GuardianTextSansWeb-Regular") format("svg");
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot");
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot?#iefix") format("embedded-opentype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff2") format("woff2"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff") format("woff"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.ttf") format("truetype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.svg#GuardianTextSansWeb-Regular") format("svg");
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
@@ -26,9 +26,9 @@
 
 @@font-face {
     font-family: "Guardian Text Sans Web";
-    src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.eot");
-    src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.eot?#iefix") format("embedded-opentype"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.woff2") format("woff2"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.woff") format("woff"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.ttf") format("truetype"), url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.svg#GuardianTextSansWeb-Medium") format("svg");
-    font-weight: 500;
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.eot");
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.eot?#iefix") format("embedded-opentype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.woff2") format("woff2"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.woff") format("woff"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.ttf") format("truetype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.svg#GuardianTextSansWeb-Bold") format("svg");
+    font-weight: 600;
     font-style: normal;
     font-stretch: normal;
 }
@@ -82,11 +82,11 @@ b, strong {
 .guardian-text-sans-loaded .element-rich-link--not-upgraded a:before,
 .guardian-text-sans-loaded .l-footer__secondary,
 .guardian-text-sans-loaded .contact {
-    font-family: "Guardian Text Sans Web", Georgia, serif;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 }
 
 .guardian-text-sans-loaded .cta,
 .guardian-text-sans-loaded .element-interactive a {
-    font-family: "Guardian Text Sans Web", Georgia, serif;
-    font-weight: 500;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-weight: 600;
 }

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -24,15 +24,6 @@
     font-stretch: normal;
 }
 
-@@font-face {
-    font-family: "Guardian Text Sans Web";
-    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.eot");
-    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.eot?#iefix") format("embedded-opentype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.woff2") format("woff2"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.woff") format("woff"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.ttf") format("truetype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Bold.svg#GuardianTextSansWeb-Bold") format("svg");
-    font-weight: 600;
-    font-style: normal;
-    font-stretch: normal;
-}
-
 .guardian-egyptian-loaded .content__headline,
 .guardian-egyptian-loaded .content__labels,
 .guardian-egyptian-loaded .element-pullquote,
@@ -81,12 +72,8 @@ b, strong {
 .guardian-text-sans-loaded .ad-slot--paid-for-badge__header,
 .guardian-text-sans-loaded .element-rich-link--not-upgraded a:before,
 .guardian-text-sans-loaded .l-footer__secondary,
-.guardian-text-sans-loaded .contact {
-    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-}
-
+.guardian-text-sans-loaded .contact,
 .guardian-text-sans-loaded .cta,
 .guardian-text-sans-loaded .element-interactive a {
     font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-    font-weight: 600;
 }

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -116,7 +116,6 @@
         display: inline-block;
         vertical-align: top;
         font-size: 0.75rem;
-        font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     }
 
     .meta__twitter, .meta__email {
@@ -173,7 +172,6 @@
     .caption, .content__dateline, .ad-slot--paid-for-badge__header {
         font-size: 0.75rem;
         line-height: 1rem;
-        font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     }
 
     .content__meta-container {

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -289,6 +289,6 @@
  * Please note that the tests will NOT pass validation with this line.
  * It won't affect prod but please comment out this line when running tests in DEV
  *@
-@if(context.environment.mode == Dev) {
+<!-- @if(context.environment.mode == Dev) {
     <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
-}
+} -->

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -289,6 +289,6 @@
  * Please note that the tests will NOT pass validation with this line.
  * It won't affect prod but please comment out this line when running tests in DEV
  *@
-<!-- @if(context.environment.mode == Dev) {
+@if(context.environment.mode == Dev) {
     <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
-} -->
+}

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -118,6 +118,16 @@
                 on-load-add-class="guardian-egyptian-loaded">
             </amp-font>
 
+            <amp-font
+                layout="nodisplay"
+                font-family="Guardian Text Sans Web"
+                timeout="3000"
+                on-error-remove-class="guardian-text-sans-loading"
+                on-error-add-class="guardian-text-sans-missing"
+                on-load-remove-class="guardian-text-sans-loading"
+                on-load-add-class="guardian-text-sans-loaded">
+            </amp-font>
+
             @fragments.amp.footerAMP(page)
         </div>
     </body>

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -20,7 +20,7 @@ $veggie-burger-medium: 52px;
 .header__supporter-cta {
     // Some very specific values in here, as it's all got to line up with the x-height of the logo
     position: absolute;
-    left: $gs-gutter;
+    left: $gs-gutter / 2 + $gs-gutter / 4;
     padding-top: 10px;
     font-size: 13px;
     line-height: .95;
@@ -54,6 +54,10 @@ $veggie-burger-medium: 52px;
         &:before {
             border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
         }
+    }
+
+    @include mq($from: mobileLandscape) {
+        left: $gs-gutter + $gs-gutter / 4
     }
 }
 


### PR DESCRIPTION
Made use of text sans in amp, particularly for the header. Also I've aligned the Supporter tab with the word news, cos design. 

👋  @NataliaLKB 🎄 

![screen shot 2016-12-20 at 12 05 43](https://cloud.githubusercontent.com/assets/14570016/21349973/be870298-c6ac-11e6-9ec3-e19e0b7fdfc2.png)

![screen shot 2016-12-20 at 12 05 29](https://cloud.githubusercontent.com/assets/14570016/21349974/be9c5b52-c6ac-11e6-9dae-47983c5b6464.png)
