### PR TITLE
Add date modified back into the dateline

### DIFF
--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -17,14 +17,22 @@
         <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 
-    @if(hasBeenModified && firstPublicationDate.getOrElse("") != webPublicationDate && !isMinute) {
-        @defining(firstPublicationDate.getOrElse(webPublicationDate)) { firstPublicationDate =>
-            <time datetime='@Format(firstPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
-            data-timestamp="@firstPublicationDate.getMillis" class="content__dateline-lm js-lm u-h">
-                First published on @Format(firstPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(firstPublicationDate)</span>
-            </time>
-        }
+    @secondaryDateLine(date: DateTime, label: String, optItemProp: Option[String] = None) = {
+        <time datetime='@Format(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
+        data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
+        @optItemProp.map { itemProp => itemprop="@itemProp" }
+        >
+            @label @Format(date, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(date)</span>
+        </time>
     }
+
+
+    @{if(!isMinute && hasBeenModified) {
+        firstPublicationDate.getOrElse("") != webPublicationDate match {
+            case true => secondaryDateLine(firstPublicationDate.getOrElse(webPublicationDate), "First published on")
+            case _ => secondaryDateLine(lastModified, "Last modified on", Option("dateModified"))
+        }
+    }}
 
     @if(isLiveBlog && !isLive) {
         <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">


### PR DESCRIPTION
## What does this change?

For the situation when 'update to now' hasn't been pressed, we still want 'last modified' to display. On from #15124

## What is the value of this and can you measure success?

Last modified is shown, more metadata.

## Screenshots

![screen shot 2016-12-20 at 15 06 27](https://cloud.githubusercontent.com/assets/638051/21357661/eeb567f4-c6cd-11e6-96e1-cb9e2afabff9.jpg)
![screen shot 2016-12-20 at 15 06 34](https://cloud.githubusercontent.com/assets/638051/21357660/eeb48fdc-c6cd-11e6-99df-978bd17b8dc3.jpg)
