### PR TITLE
Media briefing banner for front

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -110,10 +110,15 @@ case object OlympicsDailyBriefing extends ArticleEmailMetadata {
   def test(c: ContentPage) = c.item.tags.series.exists(_.id == "sport/series/olympics-2016-daily-briefing")
 }
 
-case object MediaBriefing extends ArticleEmailMetadata {
+case object HandwrittenMediaBriefing extends ArticleEmailMetadata {
   val name = "Media Briefing"
   override val banner = Some("media-briefing.png")
   def test(c: ContentPage) = c.item.tags.series.exists(_.id == "media/series/mediaguardian-briefing")
+}
+
+case object CuratedMediaBriefing extends FrontEmailMetadata {
+  val name = "Media Briefing"
+  override val banner = Some("media-briefing.png")
 }
 
 case object VaginaDispatches extends ArticleEmailMetadata {
@@ -133,6 +138,7 @@ case object TheFlyer extends FrontEmailMetadata {
   override val banner = Some("the-flyer.png")
   override val toneColour = Some("#ffbdc6")
 }
+
 
 object EmailAddons {
   private val defaultAddress = "Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396"
@@ -154,11 +160,12 @@ object EmailAddons {
     EuReferendum,
     LabNotes,
     OlympicsDailyBriefing,
-    MediaBriefing,
+    HandwrittenMediaBriefing,
     VaginaDispatches,
     KeepItInTheGround)
   private val frontEmails = Seq(
-    TheFlyer
+    TheFlyer,
+    CuratedMediaBriefing
   )
 
   implicit class EmailContentType(p: Page) {

--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -1,3 +1,7 @@
+@(page: model.Page)
+
+@import model.EmailAddons.EmailContentType
+
 <style>
     body, .body {
         background: #f6f6f6;
@@ -117,7 +121,7 @@
 
 
     .tone-external .facia-card {
-        border-top: 1px solid #fdadba;
+        border-top: 1px solid @page.toneColour;
     }
     .tone-external .facia-card__text {
         background-color: #ffffff;

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -39,7 +39,7 @@
 
             @* This is a temporary override to test two alternative email designs 29/11/2016 *@
             @if(request.isEmailConnectedStyle) {
-                @fragments.email.stylesheets.connectedStyleOverride()
+                @fragments.email.stylesheets.connectedStyleOverride(page)
             }
         } else {
             @fragments.email.stylesheets.articleFonts()


### PR DESCRIPTION
We're moving the Media Briefing email, previously "handwritten" and thus generated from an article, to a curated email generated from a front. For this front email to have the right banner we need to add an object extending `FrontEmailMetadata`, to allow it to match up the correct banner based on the page title (article emails match by tag but this obviously isn't appropriate for fronts).

I also added in a bit of styling I'd forgotten from #15322 - the top border on external links will now be the email tone colour on the "connected" style, as it already is on the "card" style.

## before
![picture 372](https://cloud.githubusercontent.com/assets/5122968/21361524/4cdb763a-c6dc-11e6-8597-dfb5a71d64e8.png)

## after
![picture 373](https://cloud.githubusercontent.com/assets/5122968/21361529/5222726a-c6dc-11e6-8460-2ee19620300a.png)
