### PR TITLE
Use partially applied function to avoid repeating params

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -8,7 +8,7 @@
 @defining(page.article) { article =>
     @fullRow {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
-            @imgForArticle(src = page.banner, alt = page.email.map(_.name))
+            @imgForArticle(page.banner, page.email.map(_.name))
         </a>
     }
 
@@ -85,10 +85,10 @@
                             @fullRow {
                                 @if(article.isLiveBlog && block.url.isDefined) {
                                     <a href="@block.url.getOrElse("#")">
-                                        @imgForArticle(src = imageUrl, alt = data.get("alt"))
+                                        @imgForArticle(imageUrl, data.get("alt"))
                                     </a>
                                 } else {
-                                    @imgForArticle(src = imageUrl, alt = data.get("alt"))
+                                    @imgForArticle(imageUrl, data.get("alt"))
                                 }
                             }
 
@@ -114,10 +114,10 @@
                         @EmailVideoImage.bestFor(media).map { imageUrl =>
                             @fullRow {
                                 @data.get("url").fold {
-                                    @imgForArticle(src = imageUrl, alt = data.get("alt"))
+                                    @imgForArticle(imageUrl, data.get("alt"))
                                 }{ linkUrl =>
                                     <a href="@linkUrl">
-                                        @imgForArticle(src = imageUrl, alt = data.get("alt"))
+                                        @imgForArticle(imageUrl, data.get("alt"))
                                     </a>
                                 }
                             }

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -53,16 +53,16 @@ object EmailHelpers {
     s"""<img src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
   }
 
-  private def img(src: String, width: Int, alt: Option[String] = None) = Html {
+  private def img(width: Int)(src: String, alt: Option[String] = None) = Html {
     s"""<img width="$width" class="full-width" src="$src" ${alt.map(alt => s"""alt="$alt"""").getOrElse("")}>"""
   }
 
-  def imgForArticle(src: String, alt: Option[String] = None) = img(src, EmailImage.knownWidth, alt)
+  def imgForArticle = img(EmailImage.knownWidth) _
 
-  def imgForFront(src: String, alt: Option[String] = None) = img(src, FrontEmailImage.knownWidth, alt)
+  def imgForFront = img(FrontEmailImage.knownWidth) _
 
   def imgFromPressedContent(pressedContent: PressedContent) = imageUrlFromPressedContent(pressedContent).map { url =>
-    imgForFront(src = url, alt = Some(pressedContent.header.headline))
+    imgForFront(url, Some(pressedContent.header.headline))
   }
 
   object Images {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -79,7 +79,7 @@
 }
 
 @fullRow {
-    @imgForFront(src = page.banner, alt = page.email.map(_.name))
+    @imgForFront(page.banner, page.email.map(_.name))
 }
 
 @page.frontProperties.onPageDescription.map { description =>


### PR DESCRIPTION
@jfsoul made an interesting point in #15355 about using a higher-order function to avoid some repetition. I slightly misinterpreted him, and while I did manage to avoid repeating the function body, I had to repeat function parameters (and default values) which were simply being passed through to the function which did the main work.

Using a partially applied function (as @jfsoul was suggesting) solves this. It has the interesting effect of breaking the use of named parameters, presumably because named parameters only work for methods, and for partial application Scala converts methods to functions (thanks @davidfurey for that insight) 