### PR TITLE
Extend EditorialEmailVariants test to January

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     "Assign users to variants of our editorial emails",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 21),
+    sellByDate = new LocalDate(2017, 1, 18),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -16,7 +16,7 @@ define([
     return function () {
         this.id = 'EditorialEmailVariants';
         this.start = '2016-12-01';
-        this.expiry = '2017-01-01';
+        this.expiry = '2017-01-18';
         this.author = 'Kate Whalen';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB function in ExactTarget re-randomises all recipients on each send, and we need users to receive their variant for several weeks. This test will ensure users are added to the corresponding email list (listId) in ExactTarget';
         this.audience = 1;


### PR DESCRIPTION
## What does this change?

Extends the EditorialEmailVariants test

## What is the value of this and can you measure success?

We're not finished testing this feature

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
