### PR TITLE
Remove css report routes in dev-build

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -19,8 +19,6 @@ GET            /assets/*path                                                    
 
 # Diagnostics
 GET            /count/$prefix<.+>.gif                                                                                            controllers.DiagnosticsController.analytics(prefix)
-POST           /css                                                                                                              controllers.DiagnosticsController.css
-OPTIONS        /css                                                                                                              controllers.DiagnosticsController.cssOptions
 POST           /csp-report                                                                                                       controllers.DiagnosticsController.csp
 OPTIONS        /csp-report                                                                                                       controllers.DiagnosticsController.cspOptions
 POST           /commercial-report                                                                                                controllers.DiagnosticsController.commercialReport
@@ -235,11 +233,6 @@ GET            /press/r2                                                        
 POST           /press/r2                                                                                                         controllers.admin.R2PressController.press()
 GET            /press/r2/batchupload                                                                                             controllers.admin.R2PressController.pressForm()
 POST           /press/r2/batchupload                                                                                             controllers.admin.R2PressController.batchUpload()
-
-# css reports
-GET            /css-reports                                                                                                      controllers.admin.CssReportController.entry
-GET            /css-reports.json                                                                                                 controllers.admin.CssReportController.index
-GET            /css-reports/:date.json                                                                                           controllers.admin.CssReportController.report(date: org.joda.time.LocalDate)
 
 
 # Football admin


### PR DESCRIPTION
Forgot to removes the routes in dev-build in previous PR https://github.com/guardian/frontend/pull/15395 :roll_eyes: 

## What is the value of this and can you measure success?
Fixing dev-build

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
