### PR TITLE
Configure screenshots task for CI/PR Build use

### DIFF
--- a/tools/__tasks__/screenshot/config.js
+++ b/tools/__tasks__/screenshot/config.js
@@ -5,14 +5,14 @@ const domain = {
     prod: 'theguardian.com',
     code: 'm.code.dev-theguardian.com',
     dev: 'localhost',
-    ci: 'localhost'
+    ci: 'localhost',
 }[environment];
 
 const port = {
     prod: '80',
     code: '80',
     dev: '9000',
-    ci: '9000'
+    ci: '9000',
 }[environment];
 
 const host = `http://${domain}:${port}/`;
@@ -22,21 +22,21 @@ const paths = {
     prod: [
         'uk',
         'us',
-        'au'
+        'au',
     ],
     code: [
         'uk',
         'us',
-        'au'
+        'au',
     ],
     dev: [
         'uk',
         'us',
-        'au'
+        'au',
     ],
     ci: [
-        'books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism'
-    ]
+        'books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism',
+    ],
 }[environment];
 
 module.exports = {

--- a/tools/__tasks__/screenshot/config.js
+++ b/tools/__tasks__/screenshot/config.js
@@ -1,26 +1,43 @@
 // TODO: Vary on environment
-const environment = 'dev'; // Hardcode this for the moment until we're running anywhere but local
+const environment = 'ci'; // Hardcode this for the moment until we're running anywhere but local
 
 const domain = {
     prod: 'theguardian.com',
     code: 'm.code.dev-theguardian.com',
     dev: 'localhost',
+    ci: 'localhost'
 }[environment];
 
 const port = {
     prod: '80',
     code: '80',
     dev: '9000',
+    ci: '9000'
 }[environment];
 
 const host = `http://${domain}:${port}/`;
 
 // TODO: Add lots more useful paths - interactives, liveblogs, immersives etc
-const paths = [
-    'uk',
-    'us',
-    'au',
-];
+const paths = {
+    prod: [
+        'uk',
+        'us',
+        'au'
+    ],
+    code: [
+        'uk',
+        'us',
+        'au'
+    ],
+    dev: [
+        'uk',
+        'us',
+        'au'
+    ],
+    ci: [
+        'books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism'
+    ]
+}[environment];
 
 module.exports = {
     environment,


### PR DESCRIPTION
## What does this change?

Adds configuration for the screenshots task to only take an article screenshot for now. 

## What is the value of this and can you measure success?

This is needed to get the pr builds proof of concept working. We'll get pr builds to use 'dev' instead of 'ci' in the near future after we get this validated.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
