### PR TITLE
Remove the control variant of the always ask test from the outbrain check

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -7,7 +7,7 @@ define([
 ) {
     var ContributionsEpicAlwaysAskStrategy = {
         name: 'ContributionsEpicAlwaysAskStrategy',
-        variants: ['control', 'alwaysAsk']
+        variants: ['alwaysAsk']
     };
 
     var ContributionsEpicOnTheMoon = {


### PR DESCRIPTION
The control variant of the always ask test does not actually insert the epic, so it doesn't need to be in this check 

## What does this change?

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
