### PR TITLE
Extend uk membership engagement test switch again

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 12, 22), // Thursday 22nd December
+    sellByDate = new LocalDate(2017, 1, 5), // Thursday 22nd December
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Test alternate short messages on membership engagement banner",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 5), // Thursday 22nd December
+    sellByDate = new LocalDate(2017, 1, 5), // Thursday 5th January
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
@rtyley has some changes coming through very soon that will remove this test and switch. But if the switch expires before that's out, builds will break - so I extended it by another couple of weeks.

## What is the value of this and can you measure success?
Don't break builds with expired switches.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
N/A

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
