### PR TITLE
Use same campaignId for both EOY tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -15,7 +15,7 @@ define([
 ) {
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicUsEoyControl',
-        campaignId: 'epic_us_eoy_control',
+        campaignId: 'epic_us_eoy',
 
         start: '2016-12-13',
         expiry: '2017-01-03',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -13,7 +13,7 @@ define([
              contributionsEpicEqualButtons) {
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicUsEoyEndOfYear',
-        campaignId: 'epic_us_eoy_end_of_year',
+        campaignId: 'epic_us_eoy',
 
         start: '2016-12-13',
         expiry: '2016-12-31',


### PR DESCRIPTION
These two files actually represent one test, split this way so we can have different audience sizes. Using the same campaign ID means we can manage the tags from one place in the targeting tool.

@alexduf  