### PR TITLE
DEVINFRA test configuration to allow local overrides

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -77,7 +77,7 @@ object GuardianConfiguration extends Logging {
 
     // test mode is self contained and won't need to use anything secret
     lazy val test = ClassPathConfigurationSource("env/DEVINFRA.properties")
-    lazy val testConfig = new CM(List(test), PlayDefaultLogger).load.resolve
+    lazy val testConfig = new CM(List(userPrivate, test), PlayDefaultLogger).load.resolve
 
     val appConfig =
       if (stage == "DEVINFRA") testConfig


### PR DESCRIPTION
## What does this change?

@TBonnin @jfsoul 

Ok,

So the preferred way of mocking out CAPI (and other services) we talked about last week is to run a little app that pretends to be CAPI as a separate process, and just configure the frontend to use http://localhost:NNNN as the capi endpoint.

There are two ways the frontend can get config currently:

1. Use DEVINFRA.properties directly if we are in stage=DEVINFRA mode, or
2. Grab the config off of S3 + apply local overrides (This will fail if S3 isn't accessible)

I still prefer not to need to screw around with S3 if possible since I'm trying to be location agnostic. So that gives me three options to achieve this:

1. Create a whole new install vars stage like PRBUILDS that loads config *only* from ~/.gu/, and use *that* instead of DEVINFRA.
2. Modify DEVINFRA.properties file in this repo to point to my preferred endpoints (I don't like because it creates an invisible dependency between my mock services and this properties file)
3. Modify config loaded from DEVINFRA.properties to be overrideable with the normal ~/.gu/frontend.conf file and I can put my capi endpoints as an override.

I've implemented number 3 under this PR since it's the smallest possible change I can make. I'm happy with going with one of the other two options if it's preferred.

## What is the value of this and can you measure success?

Success will give frontend a way to override service locations at runtime in the absence of s3.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
