### PR TITLE
Update config (preview-code changes)

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 13
+    val s3ConfigVersion = 14
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/docs/03-dev-howtos/13-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/13-Update-configuration-in-s3.md
@@ -12,27 +12,27 @@ To add or update a configuration item you need to:
 aws s3 ls --profile=frontend s3://aws-frontend-store/config/
 ```
 
-look for the most recent version ( the `v9` part ):
+look for the most recent version ( the `v14` part ):
 
 ```
-2016-08-30 21:52:58      31386 eu-west-1-frontend.v9.conf
+2016-08-30 21:52:58      31386 eu-west-1-frontend.v14.conf
 ```
 
-- Create a new copy of the s3 and bump the version number (change `v9` to `v10` ).
+- Create a new copy of the s3 and bump the version number (change `v14` to `v15` ).
 
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v9.conf s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v14.conf s3://aws-frontend-store/config/eu-west-1-frontend.v15.conf
 ```
 
 -  Download the new file locally:
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf .
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v15.conf .
 ```
 
 - Make your changes ....
 -- Test them locally by uploading these to s3
 ```
-aws s3 cp --profile=frontend eu-west-1-frontend.v10.conf s3://aws-frontend-store/config/eu-west-1-frontend.v10.conf
+aws s3 cp --profile=frontend eu-west-1-frontend.v15.conf s3://aws-frontend-store/config/eu-west-1-frontend.v15.conf
 ```
 and bump the version number `var s3ConfigVersion` in [/common/app/common/configuration.scala](https://github.com/guardian/frontend/blob/master/common/app/common/configuration.scala) to match the version of the config file you created.
 
@@ -40,7 +40,7 @@ and bump the version number `var s3ConfigVersion` in [/common/app/common/configu
 
 - Delete the local copy once you have finished
 ```
-rm eu-west-1-frontend.v10.conf
+rm eu-west-1-frontend.v15.conf
 ```
 
 - Once your pull request is merged, everything is done!


### PR DESCRIPTION
## What does this change?
Currently there is `preview` (talking to `CAPI-preview`) and training-preview (talking to `CAPI-preview-CODE`)
The idea is to simplify things by replacing `training-preview` by `preview-CODE`

This is the first PR that's updating the config so `preview-CODE` is accessing the correct `CAPI` + google auth setup

## What is the value of this and can you measure success?
Less app, less confusion about what `training-preview` is

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
