### PR TITLE
Check for seriesName rather than webTitle when determining shouldShowAds

### DIFF
--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -14,7 +14,7 @@ object Commercial {
     case c: model.ContentPage if c.item.content.shouldHideAdverts => false
     case p: model.Page if p.metadata.sectionId == "identity" => false
     case s: model.SimplePage if s.metadata.contentType == "Signup" => false
-    case e: model.ContentPage if e.metadata.webTitle == "Sign up for The Flyer" => false
+    case e: model.ContentPage if e.item.content.seriesName.contains("Newsletter sign-ups") => false
     case p: model.CommercialExpiryPage => false
     case _ => true
   }


### PR DESCRIPTION
## What does this change?

Checking for `webTitle` adds waaaaay too much specificity to the `shouldShowAds` check

We want the same logic to apply to all email sign up pages ([example](https://www.theguardian.com/info/ng-interactive/2016/dec/07/sign-up-for-the-flyer) and [example](https://www.theguardian.com/info/ng-interactive/2016/dec/05/sign-up-for-weekend-reading)) without adding a new case for each.

## What is the value of this and can you measure success?

All subsequent email sign up landing pages behave the same as: https://www.theguardian.com/info/ng-interactive/2016/dec/07/sign-up-for-the-flyer

## Does this affect other platforms - Amp, Apps, etc?

Nope

-----------

@lmath @joelochlann 