### PR TITLE
Add Banner test 13, with message rotation and 95p variants

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -7,6 +7,7 @@ import org.joda.time.LocalDate
 trait ABTestSwitches {
 
   for ((edition, testId) <- Map(
+    Uk -> "ab-membership-engagement-banner-uk-test13",
     International -> "ab-membership-engagement-international-experiment-test12",
     Au -> "ab-au-memb-engagement-msg-copy-test8"
   )) Switch(

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -43,9 +43,7 @@ define([
         var baseParams = {
             minArticles: 10,
             colourStrategy: function() {
-                var colours = ['yellow', 'purple', 'bright-blue', 'dark-blue'];
-                // Rotate through different colours on successive page views
-                return 'membership-prominent ' + colours[storage.local.get('gu.alreadyVisited') % colours.length];
+                return 'membership-prominent ' + selectSequentiallyFrom(['yellow', 'purple', 'bright-blue', 'dark-blue']);
             }
         };
 
@@ -143,9 +141,11 @@ define([
         function showBanner(params) {
             var colourClass = params.colourStrategy();
 
+            var messageText = Array.isArray(params.messageText)?selectSequentiallyFrom(params.messageText):params.messageText;
+
             var renderedBanner = template(messageTemplate, {
                 linkHref: params.linkUrl + '?INTCMP=' + params.campaignCode,
-                messageText: params.messageText,
+                messageText: messageText,
                 buttonCaption: params.buttonCaption,
                 colourClass: colourClass,
                 arrowWhiteRight: svgs('arrowWhiteRight')
@@ -178,6 +178,10 @@ define([
             }
 
             return Promise.resolve();
+        }
+
+        function selectSequentiallyFrom(array) {
+            return array[storage.local.get('gu.alreadyVisited') % array.length];
         }
 
         return {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -81,6 +81,14 @@ define([
     };
 
     return [
+        new EditionTest('UK', 'MembershipEngagementBannerUkTest13', '2016-12-22', '2017-1-5', 'gdnwb_copts_mem_banner_uk_banner__')
+            .addMembershipVariant('control', {})
+            .addMembershipVariant('3_rotating', {messageText: [
+                'We all want to make the world a fairer place. We believe journalism can help – but producing it is expensive. That’s why we need Supporters.',
+                'Become a Supporter and appreciate every article, knowing you’ve helped bring it to the page. Be part of the Guardian.',
+                'Not got round to supporting us yet? If everyone chipped in, our future would be more secure.'
+            ]})
+            .addMembershipVariant('coffee_95p', {messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for 95p a week.'}),
         new EditionTest('AU', 'AuMembEngagementMsgCopyTest8', '2016-11-24', '2017-1-5', 'gdnwb_copts_mem_banner_aubanner__')
             .addMembershipVariant('control', {})
             .addMembershipVariant('fearless_10', {messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $10 a month'})


### PR DESCRIPTION
## What does this change?

This PR introduces a new convention that the `messageText` param can be either a simple string or an array of strings. If the `messageText` param is an array, the messages supplied will be rotated through on successive page views (much like the colours already are).

As well as that, we are testing a variant that is identical to the control, but specifies 95p a week (ie mentioning a smaller weekly figure first, though payment is monthly or annual), which research from other media orgs indicates might be a good way to draw people in.

https://trello.com/c/XNDFl8SZ/215-engagement-banner-test-13-test-3-rotating-messages-vs-1-single-message-95p-price-variant

## Does this affect other platforms - Amp, Apps, etc?

Nope, just web.

## Screenshots

Here's the rotation:

![stuff 4](https://cloud.githubusercontent.com/assets/52038/21432171/2339a9be-c862-11e6-9172-f03bf7e1c57d.gif)

cc @JustinPinner @svillafe 