### PR TITLE
Update GU_ID_CSRF Play cookies to be HttpOnly

### DIFF
--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -49,6 +49,7 @@ play {
     csrf {
       cookie.name=GU_ID_CSRF
       cookie.secure=true
+      cookie.httpOnly=true
       sign.tokens=true
     }
   }


### PR DESCRIPTION
This option is set to false in the default config.  Setting to HttpOnly to prevent JS sniffing.  