### PR TITLE
Fix confirmation message for logged in users on Newsletters page

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -38,11 +38,7 @@ define([
           $('.' + classes.textInput, form).removeClass('is-hidden').focus();
           $('.' + classes.signupButton, form).addClass(classes.styleSignup);
           $('.' + classes.previewButton, meta).addClass('is-hidden');
-          buttonEl.setAttribute('type', 'submit');
-          bean.on(buttonEl, 'click', function (event) {
-              event.preventDefault();
-              subscribeToEmail(buttonEl);
-          });
+          subscribeToEmail(buttonEl);
       });
     }
 
@@ -90,8 +86,7 @@ define([
     }
 
     function subscribeToEmail(buttonEl) {
-      bean.on(buttonEl, 'click', function (event) {
-          event.preventDefault();
+      bean.on(buttonEl, 'click', function () {
           var form = buttonEl.form;
           if (validate(form)) {
               submitForm(form, buttonEl);

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -46,7 +46,7 @@ define([
       });
     }
 
-    function updateFormForLoggedIn(emailAddress, el) {
+    function updatePageForLoggedIn(emailAddress, el) {
         fastdom.write(function () {
             hideInputAndShowPreview(el);
             $('.' + classes.textInput, el).val(emailAddress);
@@ -90,10 +90,13 @@ define([
     }
 
     function subscribeToEmail(buttonEl) {
-        var form = buttonEl.form;
-        if (validate(form)) {
-            submitForm(form, buttonEl);
-        }
+      bean.on(buttonEl, 'click', function (event) {
+          event.preventDefault();
+          var form = buttonEl.form;
+          if (validate(form)) {
+              submitForm(form, buttonEl);
+          }
+      });
     }
 
     function showSecondStageSignup(buttonEl) {
@@ -110,7 +113,7 @@ define([
         // email address is not stored in the cookie, gotta go to the Api
         Id.getUserFromApi(function (userFromId) {
           if (userFromId && userFromId.primaryEmailAddress) {
-            updateFormForLoggedIn(userFromId.primaryEmailAddress);
+            updatePageForLoggedIn(userFromId.primaryEmailAddress);
             $.forEachElement('.' + classes.signupButton, subscribeToEmail);
           }
         });


### PR DESCRIPTION
## What does this change?

Fix for this page: https://www.theguardian.com/email-newsletters

Signed in users are not getting the confirmation/success message upon form submission. This fixes the `subscribeToEmail` function so that the success message appears for both anon and signed in users.

#### Bonus: 
`updateFormForLoggedIn` did much more than update the form; it has therefore been renamed `updatePageForLoggedIn` 

Removing the `setAttribute` and subsequent `preventDefault`; the button does not need to be a `submit` type when we are just going to prevent the `submit` anyway...

🎄 🎅🏼 ☃️

## What is the value of this and can you measure success?

- Better UX
- Tells users that their action worked, rather than just leaving them guessing

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

After fix:

<img width="1128" alt="picture 419" src="https://cloud.githubusercontent.com/assets/8607683/21453832/25f5a60e-c90b-11e6-81ba-6e3a4c74b6e9.png">
