### PR TITLE
Fix outbrian reporting bug by include geolocation checks in canRun for contributions AB tests

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -11,7 +11,8 @@ define([
     'common/modules/experiments/ab',
     './common',
     './sport',
-    'common/modules/analytics/google'
+    'common/modules/analytics/google',
+    'common/utils/geolocation'
 ], function (
     fastdom,
     bean,
@@ -25,7 +26,8 @@ define([
     ab,
     common,
     sport,
-    ga
+    ga,
+    geolocation
 ) {
     return function () {
         var bootstrapContext = function (featureName, bootstrap) {
@@ -57,6 +59,9 @@ define([
 
             ab.trackEvent();
         });
+
+        // geolocation
+        robust.catchErrorsAndLog('geolocation', geolocation.init);
 
         // Front
         if (config.page.isFront) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-on-the-moon.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-on-the-moon.js
@@ -14,12 +14,6 @@ define([
     config
 ) {
 
-    function testAustralia(render) {
-        geolocation.get().then(function(geo) {
-            if (geo === 'AU') render();
-        });
-    }
-
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicOnTheMoon',
         campaignId: 'epic_end_of_year_2016',
@@ -31,6 +25,7 @@ define([
         successMeasure: 'Conversion rate (contributions / impressions)',
         idealOutcome: 'There are no negative effects and this is the optimum strategy!',
 
+        locations: ['AU'],
         audienceCriteria: 'AUS readers',
         audience: 1,
         audienceOffset: 0,
@@ -65,9 +60,6 @@ define([
                 },
 
                 insertBeforeSelector: '.submeta',
-
-                test: testAustralia,
-
                 impressionOnInsert: true,
                 successOnView: true
             },
@@ -90,9 +82,6 @@ define([
                 },
 
                 insertBeforeSelector: '.submeta',
-
-                test: testAustralia,
-
                 impressionOnInsert: true,
                 successOnView: true
             },
@@ -112,9 +101,6 @@ define([
                 },
 
                 insertBeforeSelector: '.submeta',
-
-                test: testAustralia,
-
                 impressionOnInsert: true,
                 successOnView: true
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-control.js
@@ -25,6 +25,7 @@ define([
         successMeasure: 'Conversion rate (contributions / impressions)',
         idealOutcome: 'A conversion rate of 0.1%',
 
+        locations: ['US'],
         audienceCriteria: 'US members',
         audience: 0.875,
         audienceOffset: 0,
@@ -55,13 +56,6 @@ define([
                 },
 
                 insertBeforeSelector: '.submeta',
-
-                test: function (render) {
-                    geolocation.get().then(function(geo) {
-                        if (geo === 'US') render();
-                    });
-                },
-
                 impressionOnInsert: true,
                 successOnView: true
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-end-of-year.js
@@ -23,6 +23,7 @@ define([
         successMeasure: 'Conversion rate (contributions / impressions)',
         idealOutcome: 'A conversion rate of 0.1%',
 
+        locations: ['US'],
         audienceCriteria: 'US members',
         audience: 0.125,
         audienceOffset: 0.875,
@@ -54,12 +55,6 @@ define([
                 },
 
                 insertBeforeSelector: '.submeta',
-
-                test: function (render) {
-                    geolocation.get().then(function (geo) {
-                        if (geo === 'US') render();
-                    });
-                },
 
                 impressionOnInsert: true,
                 successOnView: true

--- a/static/src/javascripts/projects/common/utils/geolocation.js
+++ b/static/src/javascripts/projects/common/utils/geolocation.js
@@ -1,33 +1,64 @@
 define([
     'Promise',
     'common/utils/fetch-json',
-    'common/utils/config'
+    'common/utils/config',
+    'common/utils/storage'
 ], function (
     Promise,
     fetch,
-    config
+    config,
+    storage
 ) {
     var location;
+    var storageKey = 'gu.geolocation'
+    var editionToGeolocationMap = {
+        'UK' : 'GB',
+        'US' : 'US',
+        'AU' : 'AU'
+    };
+    var daysBeforeGeolocationRefresh = 10;
+
+    function init() {
+        get().then(function (geolocation) {
+            var currentDate = new Date();
+            storage.local.set(storageKey, geolocation, {
+                expires: currentDate.setDate(currentDate.getDate() + daysBeforeGeolocationRefresh)
+            });
+        });
+    }
+
+    function editionToGeolocation(editionKey) {
+        return editionToGeolocationMap[editionKey] || 'GB';
+    }
+
+    function get() {
+        return new Promise(function (resolve, reject) {
+            if (location) return resolve(location);
+            else {
+                fetch(config.page.ajaxUrl + '/geolocation', {
+                    method: 'GET',
+                    contentType: 'application/json',
+                    crossOrigin: true
+                }).then(function (response) {
+                    if (response.country) {
+                        location = response.country;
+                        resolve(response.country);
+                    } else {
+                        reject('No country in geolocation response', response);
+                    }
+                }).catch(reject);
+            }
+        });
+    }
 
     return {
-        get: function() {
-            return new Promise(function(resolve, reject) {
-                if (location) return resolve(location);
-                else {
-                    fetch(config.page.ajaxUrl + '/geolocation', {
-                        method: 'GET',
-                        contentType: 'application/json',
-                        crossOrigin: true
-                    }).then(function (response) {
-                        if (response.country) {
-                            location = response.country;
-                            resolve(response.country);
-                        } else {
-                            reject('No country in geolocation response', response);
-                        }
-                    }).catch(reject);
-                }
-            });
-        }
+        get: get,
+
+        getSync: function() {
+            var geolocationFromStorage = storage.local.get(storageKey);
+            return geolocationFromStorage ? geolocationFromStorage : editionToGeolocation(config.page.edition)
+        },
+
+        init: init
     };
 });


### PR DESCRIPTION
## What does this change?

There was a problem where we were marking pages as non-outbrain-compliant even when they were indeed compliant. This was because the compliancy relies on the canRun function in the AB tests, but we were checking the geolocation outside of this (due to the fact that it was an asynchronous call). In order to put the geo checking in the canRun, we had to make it synchronous. 

We've added the geolocation ajax call to main.js (enhanced) which, if there is no valid geolocation in the local storage, makes the call and sets the geolocation with a 10 day expiry. When a page loads, it checks local storage for a valid geolocation. If none exists, it uses the edition as a proxy (whilst the call in main.js is updating it with the correct geolocation in the background, ready for the next pageview). 

This PR also removes some more of the rendering boilerplate from the contributions tests by providing a default test function. 

## What is the value of this and can you measure success?

We can accurately report our outbrain usage, meaning we will get paid properly. Also, less boilerplate = easier peer reviewing of future epic tests.

## Does this affect other platforms - Amp, Apps, etc?
no

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
