### PR TITLE
Change healthcheck endpoint for preview

### DIFF
--- a/preview/app/controllers/HealthCheck.scala
+++ b/preview/app/controllers/HealthCheck.scala
@@ -4,5 +4,5 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
 class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
+  NeverExpiresSingleHealthCheck("/lifeandstyle/2015/aug/30/espigoladors-barcelona-catalan-food-funny-shaped-vegetables-people-need")
 )(wsClient)


### PR DESCRIPTION
## What does this change?
New healthcheck endpoint exists in both PROD and CODE preview CAPI

## What is the value of this and can you measure success?
Preview can run in CODE environemnt (ie: when accessing CODE preview CAPI)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
