### PR TITLE
Update canRun check of AB test, and make it more resilient

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -27,7 +27,7 @@ define([
         this.idealOutcome = 'Similar quantity of users in each list in ExactTarget';
 
         this.canRun = function () {
-            return (config.page.webTitle.toLowerCase() === 'sign up for the flyer');
+          return (config.page.contentId === 'info/ng-interactive/2016/dec/07/sign-up-for-the-flyer');
         };
 
         function updateExampleUrl(exampleUrl) {


### PR DESCRIPTION
## What does this change?

Previous `canRun` check was relying on the headline entered in Composer - when the headline was changed it stopped the test running.

The new check is based on the page URL, which is much less likely to change.

## What is the value of this and can you measure success?

Fixes a test and makes it harder to break in the future.

## Does this affect other platforms - Amp, Apps, etc?

Nope
