### PR TITLE
Extend RecommendedForYou and scale the images

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -36,7 +36,7 @@ define([
     return function () {
         this.id = 'RecommendedForYouRecommendations';
         this.start = '2016-08-02';
-        this.expiry = '2016-12-23';
+        this.expiry = '2017-01-18';
         this.author = 'Joseph Smith';
         this.description = 'Add a personalised container to fronts';
         this.audience = 0;

--- a/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
+++ b/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
@@ -26,7 +26,7 @@
                     <li class="fc-slice__item l-row__item l-row__item--span-1 u-faux-block-link">
                         <div class="fc-item fc-item--has-image fc-item--has-sublinks-1 js-fc-item tone-news--item fc-item--list-media-mobile fc-item--standard-tablet fc-item--rfy js-snappable">
                             <div class="fc-item__container">
-                                <div class="fc-item__media-wrapper"><% if (item.imageUrl) { %><img src="<%= item.imageUrl %>" /><% } else { %><%= guardianLogo %><% } %></div>
+                                <div class="fc-item__media-wrapper"><% if (item.imageUrl) { %><img class="rfy__image" src="<%= item.imageUrl %>" /><% } else { %><%= guardianLogo %><% } %></div>
                                 <div class="fc-item__content">
                                     <div class="fc-item__header">
                                         <h2 class="fc-item__title"><a href="/<%= item.id %>" class="fc-item__link" data-link-name="article">

--- a/static/src/stylesheets/module/experiments/_recommended-for-you.scss
+++ b/static/src/stylesheets/module/experiments/_recommended-for-you.scss
@@ -29,8 +29,6 @@
 }
 
 .rfy__image {
-  object-fit:none;
-  object-position:center;
   width:100%;
 }
 

--- a/static/src/stylesheets/module/experiments/_recommended-for-you.scss
+++ b/static/src/stylesheets/module/experiments/_recommended-for-you.scss
@@ -6,7 +6,7 @@
     @include mq(tablet) {
         margin: 10px 0;
     }
-    
+
     background-color: $neutral-3;
 
     line-height: 14px;
@@ -26,6 +26,12 @@
     &:nth-child(4) {
         width: 41%;
     }
+}
+
+.rfy__image {
+  object-fit:none;
+  object-position:center;
+  width:100%;
 }
 
 .rfy-profile-icon {


### PR DESCRIPTION
## What does this change?

- Extends the JavaScript expiry date of the test
- Makes the images of the recommendations facia-cards fit correctly on smaller displays

## What is the value of this and can you measure success?

- Less red on the switches dashboard
- Recommendations facia-cards have an image overflow issue at narrow (tablet/mobile) resolutions

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

##### Before:

<img width="666" alt="picture 420" src="https://cloud.githubusercontent.com/assets/8607683/21542236/5cc5a492-cdb4-11e6-9d5c-5fe8007ef801.png">

##### After:

<img width="661" alt="picture 425" src="https://cloud.githubusercontent.com/assets/8607683/21542534/4f4b7ff6-cdb6-11e6-9e14-3fb1db3f407b.png">

---------
@lmath 