### PR TITLE
Enable users to update username on first comment

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -27,7 +27,9 @@
 
         <div class="d-comment-box__onboarding-username">
             <p>Please choose your username under which you would like all your comments to show up:</p>
-            <input type="text" class="d-comment-box__onboarding-username-input" placeholder="Username: 6-20 characters, letters & numbers only, no spaces" value=""/>
+            <label class="d-comment-box__onboarding-username-label" for="usernameInput">Username: </label>
+            <span>Must have 6-20 characters, letters & numbers only, no spaces.</span>
+            <input type="text" id="usernameInput" class="d-comment-box__onboarding-username-input" placeholder="" value=""/>
             <p class="d-comment-box__onboarding-username-error-message is-hidden"></p>
         </div>
 

--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -24,6 +24,13 @@
     <div class="d-comment-box__onboarding">
         <h3>Welcome <span class="d-comment-box__onboarding-author"></span>, you’re about to make your first comment!</h3>
         <p>Before you post, we’d like to thank you for joining the debate - we’re glad you’ve chosen to participate and we value your opinions and experiences.</p>
+
+        <div class="d-comment-box__onboarding-username">
+            <p>Please choose your username under which you would like all your comments to show up:</p>
+            <input type="text" class="d-comment-box__onboarding-username-input" placeholder="Username: 6-20 characters, letters & numbers only, no spaces" value=""/>
+            <p class="d-comment-box__onboarding-username-error-message is-hidden"></p>
+        </div>
+
         <p>Please keep your posts respectful and abide by the <a target="_blank" href="/community-standards">community guidelines</a> - and if you spot a comment you think doesn’t adhere to the guidelines, please use the ‘Report’ link next to it to let us know.</p>
         <p>Please preview your comment below and click ‘post’ when you’re happy with it.</p>
         <div class="d-comment-box__onboarding-preview-body"></div>

--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -28,7 +28,7 @@
         <div class="d-comment-box__onboarding-username">
             <p>Please choose your username under which you would like all your comments to show up:</p>
             <label class="d-comment-box__onboarding-username-label" for="usernameInput">Username: </label>
-            <span>Must have 6-20 characters, letters & numbers only, no spaces.</span>
+            <span>Must be 6-20 characters, letters and/or numbers only, no spaces.</span>
             <input type="text" id="usernameInput" class="d-comment-box__onboarding-username-input" placeholder="" value=""/>
             <p class="d-comment-box__onboarding-username-error-message is-hidden"></p>
         </div>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -259,7 +259,8 @@ CommentBox.prototype.postComment = function() {
             .then(self.postCommentSuccess.bind(self, comment), self.fail.bind(self));
     };
 
-    var updateUsernameSuccess = function () {
+    var updateUsernameSuccess = function (resp) {
+        mediator.emit('user:username:updated', resp.user.publicFields.username);
         self.options.newUsername = false;
         self.getElem('onboarding-username').classList.add('is-hidden');
         postCommentToDAPI();
@@ -551,27 +552,16 @@ CommentBox.prototype.formatComment = function(formatStyle) {
     }
 };
 
-/**
- * The username is used in three places:
- *   1. header menu - read from GU_U cookie
- *   2. discussion header - read from DAPI
- *   3. comment - read from DAPI
- *
- * When the user updates the username the changes are visible only when the page is refreshed. This method
- * temporarily updates HTML client-side so that user has instant feedback before the page is refreshed.
-*/
+
+// When the user updates the username the changes are visible only when the page is refreshed. This method
+// temporarily updates HTML client-side so that user has instant feedback before the page is refreshed.
 CommentBox.prototype.refreshUsernameHtml = function() {
     IdentityApi.reset();
     var displayName = this.getUserData().displayName;
-    var userId = this.getUserData().id;
-
-    var menuHeaderUsername = document.querySelector(".js-profile-info");
-    var discussionHeaderUsername = document.querySelector("._author_tywwu_16");
-    var firstCommentUsername = document.querySelector('[data-comment-author-id=' + '"' + userId + '"]');
-
+    var menuHeaderUsername = $('.js-profile-info')[0];
+    var discussionHeaderUsername = $('._author_tywwu_16')[0];
     menuHeaderUsername && (menuHeaderUsername.innerHTML = displayName);
     discussionHeaderUsername && (discussionHeaderUsername.innerHTML = displayName);
-    firstCommentUsername && (firstCommentUsername.querySelector('[itemprop="givenName"]').textContent = displayName);
 };
 
 return CommentBox;

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -96,6 +96,7 @@ CommentBox.prototype.defaultOptions = {
     maxLength: 5000,
     premod: false,
     newCommenter: false,
+    newUsername: true,
     focus: false,
     state: 'top-level',
     replyTo: null,
@@ -156,8 +157,9 @@ CommentBox.prototype.showOnboarding = function(e) {
 
     // Check if new commenter as they may have already commented on this article
     if (this.hasState('onboarding-visible') || !this.options.newCommenter) {
-        this.options.newCommenter = false;
-        this.removeState('onboarding-visible');
+        if (!this.options.newUsername) {
+            this.removeState('onboarding-visible');
+        }
         this.postComment();
     } else {
         this.getElem('onboarding-author').innerHTML = this.getUserData().displayName;
@@ -234,8 +236,9 @@ CommentBox.prototype.submitPostComment = function(e) {
 };
 
 CommentBox.prototype.invalidEmailError = function () {
-   this.error('EMAIL_NOT_VALIDATED');
-   ValidationEmail.init();
+    this.removeState('onboarding-visible');
+    this.error('EMAIL_NOT_VALIDATED');
+    ValidationEmail.init();
 };
 
 CommentBox.prototype.postComment = function() {
@@ -245,6 +248,32 @@ CommentBox.prototype.postComment = function() {
         };
 
     self.clearErrors();
+
+    var postCommentToDAPI = function () {
+        self.removeState('onboarding-visible');
+        self.options.newUsername = false;
+        comment.body = self.urlify(comment.body);
+        self.setFormState(true);
+        DiscussionApi
+            .postComment(self.getDiscussionId(), comment)
+            .then(self.postCommentSuccess.bind(self, comment), self.fail.bind(self));
+    };
+
+    var updateUsernameSuccess = function () {
+        self.options.newUsername = false;
+        self.getElem('onboarding-username').classList.add('is-hidden');
+        postCommentToDAPI();
+    };
+
+    var updateUsernameFailure = function (errorResponse) {
+        var usernameField = self.getElem('onboarding-username-input');
+        self.options.newUsername = true;
+        self.setState('onboarding-visible');
+        usernameField.classList.add('d-comment-box__onboarding-username-error-border');
+        var errorMessage = self.getElem('onboarding-username-error-message');
+        errorMessage.innerHTML = JSON.parse(errorResponse.responseText).errors[0].description;
+        errorMessage.classList.remove('is-hidden');
+    };
 
     var validEmailCommentSubmission = function () {
         if (comment.body === '') {
@@ -261,11 +290,11 @@ CommentBox.prototype.postComment = function() {
         }
 
         if (self.errors.length === 0) {
-            comment.body = self.urlify(comment.body);
-            self.setFormState(true);
-            DiscussionApi
-                .postComment(self.getDiscussionId(), comment)
-                .then(self.postCommentSuccess.bind(self, comment), self.fail.bind(self));
+            if (self.options.newCommenter && self.options.newUsername) {
+                IdentityApi.updateUsername(self.getElem('onboarding-username-input').value).then(updateUsernameSuccess, updateUsernameFailure);
+            } else {
+                postCommentToDAPI();
+            }
         }
     };
 
@@ -313,6 +342,11 @@ CommentBox.prototype.error = function(type, message) {
  * @param {Object} resp
  */
 CommentBox.prototype.postCommentSuccess = function(comment, resp) {
+    if (this.options.newCommenter) {
+        this.refreshUsernameHtml();
+        this.options.newCommenter = false;
+    }
+
     comment.id = parseInt(resp.message, 10);
     this.getElem('body').value = '';
     this.resetPreviewComment();
@@ -515,6 +549,29 @@ CommentBox.prototype.formatComment = function(formatStyle) {
             formatSelectionLink();
             break;
     }
+};
+
+/**
+ * The username is used in three places:
+ *   1. header menu - read from GU_U cookie
+ *   2. discussion header - read from DAPI
+ *   3. comment - read from DAPI
+ *
+ * When the user updates the username the changes are visible only when the page is refreshed. This method
+ * temporarily updates HTML client-side so that user has instant feedback before the page is refreshed.
+*/
+CommentBox.prototype.refreshUsernameHtml = function() {
+    IdentityApi.reset();
+    var displayName = this.getUserData().displayName;
+    var userId = this.getUserData().id;
+
+    var menuHeaderUsername = document.querySelector(".js-profile-info");
+    var discussionHeaderUsername = document.querySelector("._author_tywwu_16");
+    var firstCommentUsername = document.querySelector('[data-comment-author-id=' + '"' + userId + '"]');
+
+    menuHeaderUsername && (menuHeaderUsername.innerHTML = displayName);
+    discussionHeaderUsername && (discussionHeaderUsername.innerHTML = displayName);
+    firstCommentUsername && (firstCommentUsername.querySelector('[itemprop="givenName"]').textContent = displayName);
 };
 
 return CommentBox;

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -456,6 +456,7 @@ Comments.prototype.reportCommentFailure = function() {
 };
 
 Comments.prototype.addUser = function(user) {
+    var self = this;
     this.user = user;
 
     // Determine user staff status
@@ -475,6 +476,12 @@ Comments.prototype.addUser = function(user) {
             this.on('click', this.getClass('commentPick'), this.handlePickClick);
         }
     }
+
+    mediator.on('user:username:updated', function(newUsername) {
+        if (self.user) {
+            self.user.displayName = newUsername;
+        }
+    });
 };
 
 Comments.prototype.relativeDates = function() {

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -275,5 +275,24 @@ define([
         return request;
     };
 
+    Id.updateUsername = function (username) {
+        var endpoint = '/user/me',
+            data = {'publicFields': {'username': username, 'displayName': username}},
+            request = ajax({
+                url: Id.idApiRoot + endpoint,
+                type: 'json',
+                crossOrigin: true,
+                method: 'POST',
+                contentType: 'application/json; charset=utf-8',
+                data: JSON.stringify(data),
+                withCredentials: true,
+                headers: {
+                    'X-GU-ID-Client-Access-Token':  'Bearer ' + config.page.idApiJsClientToken
+                }
+            });
+
+        return request;
+    };
+
     return Id;
 });

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1530,3 +1530,29 @@ $comment-recommend-button-size: 19px;
     background-color: colour(neutral-3);
     border-color: colour(neutral-3);
 }
+
+.d-comment-box__onboarding-username-input {
+    box-sizing: border-box;
+    display: block;
+    background-color: transparent;
+    border: 1px solid $neutral-4;
+    color: $neutral-1;
+    padding: 7px 15px;
+    border-radius: 18px;
+    margin: 0.2rem 0;
+    width: 70%;
+    margin-bottom: $gs-baseline;
+
+    &:focus {
+        border-color: $neutral-2;
+        outline: none;
+    }
+}
+
+.d-comment-box__onboarding-username-error-border {
+    border-color: $error;
+}
+
+.d-comment-box__onboarding-username-error-message {
+    color: $error;
+}

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1537,11 +1537,11 @@ $comment-recommend-button-size: 19px;
     background-color: transparent;
     border: 1px solid $neutral-4;
     color: $neutral-1;
-    padding: 7px 15px;
+    padding: $gs-baseline/2 $gs-gutter;
     border-radius: 18px;
-    margin: 0.2rem 0;
+    margin: $gs-baseline 0;
+    margin-top: $gs-baseline/2;
     width: 70%;
-    margin-bottom: $gs-baseline;
 
     &:focus {
         border-color: $neutral-2;
@@ -1550,7 +1550,7 @@ $comment-recommend-button-size: 19px;
 }
 
 .d-comment-box__onboarding-username-label {
-    font-size: 14px;
+    @include fs-textSans(3);
     font-weight: bold;
 }
 

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1521,7 +1521,7 @@ $comment-recommend-button-size: 19px;
 }
 
 .d-comment-box__onboarding-preview-body p {
-    background-color: #ffffff;
+    background-color: $neutral-7;
     padding: $gs-baseline $gs-gutter;
     margin-bottom: $gs-baseline;
 }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1549,6 +1549,11 @@ $comment-recommend-button-size: 19px;
     }
 }
 
+.d-comment-box__onboarding-username-label {
+    font-size: 14px;
+    font-weight: bold;
+}
+
 .d-comment-box__onboarding-username-error-border {
     border-color: $error;
 }


### PR DESCRIPTION
## What does this change?

This allow users to set their username the first time they post a comment, that is, during discussion on-boarding process.

## What is the value of this and can you measure success?

Users that register via social sign in (Google, Facebook) have their `displayNames` automatically set to their real names, thus when they comment they are unaware that the comment will be posted under their real name. Currently there is no self-service mechanism to allow users to change their username. For this reason they often contact Userhelp to request account deletion. 

Also, `username/displayName` has been removed from all registration forms to improve conversion, since usernames are used only for commenting, so there is no need to have this extra field during Membership or Subscription registration flows:
* https://github.com/guardian/identity-frontend/pull/187
* https://github.com/guardian/identity-frontend/pull/195

## Does this affect other platforms - Amp, Apps, etc?

https://github.com/guardian/identity/pull/604

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/21546402/6ec1fb56-cdd6-11e6-9b4d-59d6119d2ca5.png)

Error path:

![image](https://cloud.githubusercontent.com/assets/13835317/21546432/9ef26252-cdd6-11e6-8d52-2c2fa5232c9f.png)

@markjamesbutler @thomaska @andrewfindlay



<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
