### PR TITLE
us spelling of favour (favor)

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-all-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-us-eoy-all-control.js
@@ -48,7 +48,7 @@ define([
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
                         title: 'Since you’re here…',
-                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p1: '…we have a small favor to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it our future would be much more secure.',
                         cta1: 'Become a supporter',
                         cta2: 'Make a contribution'


### PR DESCRIPTION
## What does this change?

For the US epic, uses the American spelling for favour (favor).

## What is the value of this and can you measure success?

Improves the locality of the Guardian, although it's (probably) hard to measure the impact of this.

## Does this affect other platforms - Amp, Apps, etc?

No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
