### PR TITLE
Removed unnecessary css from header test

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -879,27 +879,6 @@ $caption-button-size: 32px;
             background-color: $multimedia-support-5;
         }
 
-        .content__meta-container {
-            display: flex;
-            flex-wrap: wrap;
-            border-bottom: 0;
-
-            .meta__extras,
-            .content__dateline {
-                flex: 1 0 auto;
-                width: 100%;
-            }
-        }
-
-        .meta__extras {
-            border-bottom: 1px dotted $neutral-4;
-            order: -1;
-
-            .meta__social {
-                border-top: 0;
-            }
-        }
-
         // Padding above headline in galleries, because kicker is hidden
         .tonal--tone-media .content__headline--gallery {
             padding-top: $gs-baseline / 2;


### PR DESCRIPTION
A cheeky few lines of CSS remained from PBM (Pre better meta). I've chucked them in the bin alongside the turkey carcass and the wrapping paper*

That was happening. It doesn't now. 
![screen shot 2016-12-30 at 11 43 05](https://cloud.githubusercontent.com/assets/14570016/21564524/749c052a-ce86-11e6-818b-9768b469c2d2.png)

@NataliaLKB Hello 👋 

* Sorry I should have recycled