### PR TITLE
Delete EmailSignupController.renderPage and associated routes

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -32,7 +32,6 @@ POST           /notification/store                                              
 POST           /notification/delete                                             controllers.NotificationsController.deleteSubscription()
 
 # Email paths
-GET        /email                                                               controllers.EmailSignupController.renderPage()
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -37,7 +37,6 @@ GET            /crosswords/search                                               
 GET            /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
 # Email paths
-GET            /email                                                                                                            controllers.EmailSignupController.renderPage()
 GET            /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()

--- a/identity/app/controllers/HealthCheck.scala
+++ b/identity/app/controllers/HealthCheck.scala
@@ -4,5 +4,5 @@ import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import play.api.libs.ws.WSClient
 
 class HealthCheck(wsClient: WSClient) extends AllGoodCachedHealthCheck(
-  NeverExpiresSingleHealthCheck(routes.EmailSignupController.renderPage().url)
+  NeverExpiresSingleHealthCheck(routes.EmailSignupController.renderForm("footer", 37).url)
 )(wsClient)

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -45,7 +45,6 @@ POST        /saved-for-later                        controllers.SaveContentContr
 
 
 #Email Footer signup routes
-GET        /email                                                               controllers.EmailSignupController.renderPage()
 GET        /email/form/$emailType<article|footer>/:listId                       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -173,7 +173,6 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|graphic|picture)/.*>.json       
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json                   controllers.InteractiveController.renderInteractiveJson(path)
 
 # Email paths
-GET        /email                                                                              controllers.EmailSignupController.renderPage()
 GET        /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()


### PR DESCRIPTION
## What does this change?

- Removes usages of `EmailSignupController.renderPage()`
- Deletes an unneeded route, and reverts an [odd and lonely page](https://www.theguardian.com/email) to a 404

## What is the value of this and can you measure success?

- The only live usage of the `EmailSignupController.renderPage()` appears to be https://www.theguardian.com/email
- Less routes, email routes still work

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

Turning this page into a 404:

<img width="1136" alt="picture 192" src="https://cloud.githubusercontent.com/assets/8607683/21549974/f052ddfe-cded-11e6-96f0-bcf27ce13444.png">

:fire: :fire: :fire: :fire: :fire: :fire: :fire: :fire: :fire: :fire: :fire: 

## Requests for feedback:

@markjamesbutler: This updates the identity health check to use a different route
@joelochlann: I don't believe this will affect any of the email fronts?
@gtrufitt: I can still subscribe to emails, and I'm leaving the POST path intact
