### PR TITLE
Remove old information about cricket PA API usage

### DIFF
--- a/admin/app/views/cricketTroubleshooter.scala.html
+++ b/admin/app/views/cricketTroubleshooter.scala.html
@@ -9,7 +9,7 @@
 
     <h1>Cricket Troubleshooter</h1>
 
-    <p>This page helps the user access the raw PA (Press Association) feeds to check if a cricket problem is external or internal. <strong>Currently, the Guardian dotcom website only uses PA to populate England matches.</strong></p>
+    <p>This page helps the user access the raw PA (Press Association) feeds to check if a cricket problem is external or internal.</p>
 
     <p>The current API host is <i>@pa.cricketHost</i> and the API key is <i>@pa.cricketApiKey</i>.</p>
 


### PR DESCRIPTION
## What does this change?
Removes out-of-date information from the cricket troubleshooter, as requested by CP.

## What is the value of this and can you measure success?
Less misleading docs.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
