### PR TITLE
prevent the epic being shown on immersive articles

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -115,11 +115,18 @@ define([
             var inCompatibleLocation = options.locations ? options.locations.some(function (geo) {
                 return geo === storedGeolocation;
             }) : true;
+            var isImmersive = config.page.isImmersive === true;
 
             if (options.overrideCanRun) return tagsMatch && options.canRun();
 
-            return enoughTimeSinceLastContribution && acceptableViewCount && tagsMatch &&
-                testCanRun && worksWellWithPageTemplate && commercialFeatures.canReasonablyAskForMoney && inCompatibleLocation;
+            return enoughTimeSinceLastContribution &&
+                acceptableViewCount &&
+                tagsMatch &&
+                testCanRun &&
+                worksWellWithPageTemplate &&
+                commercialFeatures.canReasonablyAskForMoney &&
+                inCompatibleLocation &&
+                !isImmersive;
         }).bind(this);
 
         this.variants = options.variants.map(function (variant) {


### PR DESCRIPTION
## What does this change?

Prevents the epic being shown on immersive articles (provided the epic is being implemented using the functions in `contributions-utilities.js`).

## What is the value of this and can you measure success?

Intermediate solution to prevent clashes on the website (see screenshots). 

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![image](https://cloud.githubusercontent.com/assets/4085817/21568135/e5db9534-cea9-11e6-8dc5-410fdd2fcc84.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
