### PR TITLE
Fix hosted logo link

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -35,7 +35,7 @@
         <div class="main-body">
             <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge content__hosted-body">
                 <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-                    <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"></amp-img>
+                    <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
                 </a>
             </div></div></div>
             @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page, isAMP = true)

--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -34,7 +34,7 @@
 
         <div class="main-body">
             <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge content__hosted-body">
-                <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
+                <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
                     <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
                 </a>
             </div></div></div>

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -70,7 +70,7 @@
     <!--<![endif]-->
     <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
         <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-            <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
+            <img class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"/>
         </a>
     </div></div></div>
     @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page)

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -69,7 +69,7 @@
     </style>
     <!--<![endif]-->
     <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
-        <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
+        <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
             <img class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"/>
         </a>
     </div></div></div>

--- a/commercial/app/views/hosted/guardianHostedCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedCta.scala.html
@@ -7,9 +7,9 @@
             <a href="@{cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{cta.trackingCode}" target="_blank">
                 <div class="hostedbadge hostedbadge--pushdown hosted-tone-bg content__hosted-body">
                     @if(isAMP) {
-                        <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}"></amp-img>
+                        <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@{page.campaign.logo.src}" alt="logo @{page.campaign.owner}"></amp-img>
                     } else {
-                        <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
+                        <img class="hostedbadge__logo" src="@{page.campaign.logo.src}" alt="logo @{page.campaign.owner}">
                     }
                 </div>
                 @if(cta.btnText.isEmpty) {

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -7,9 +7,9 @@
             <p class="hostedbadge__info">Advertiser content</p>
             <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
             @if(isAMP) {
-                <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"></amp-img>
+                <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
             } else {
-                <img class="hostedbadge__logo" src="@page.campaign.logo.url" alt="logo @page.campaign.owner"/>
+                <img class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"/>
             }
             </a>
         </div>

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -5,7 +5,7 @@
     <div class="hosted__headerwrap js-hosted-headerwrap">
         <div class="hostedbadge hosted-tone-bg content__hosted-body">
             <p class="hostedbadge__info">Advertiser content</p>
-            <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
+            <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
             @if(isAMP) {
                 <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
             } else {

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -91,7 +91,7 @@
                             <h1 class="hosted__heading">@{page.video.title}</h1>
                         </div>
                         <div class="hostedbadge">
-                            <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
+                            <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
                                 <img class="hostedbadge__logo" src="@{page.campaign.logo.src}" alt="logo @{page.campaign.owner}">
                             </a>
                         </div>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -92,7 +92,7 @@
                         </div>
                         <div class="hostedbadge">
                             <a href="@page.cta.url" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-                                <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
+                                <img class="hostedbadge__logo" src="@{page.campaign.logo.src}" alt="logo @{page.campaign.owner}">
                             </a>
                         </div>
                     </div>

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -78,7 +78,12 @@ object HostedCampaign {
         id,
         name = section.webTitle,
         owner = sponsorship.sponsorName,
-        logo = HostedLogo.make(sponsorship.sponsorLogo, sponsorship.sponsorLogoDimensions, id),
+        logo = HostedLogo.make(
+          src = sponsorship.sponsorLogo,
+          dimensions = sponsorship.sponsorLogoDimensions,
+          link = sponsorship.sponsorLink,
+          campaignId = id
+        ),
         fontColour = Colour(hostedTag.paidContentCampaignColour getOrElse "")
       )
     }
@@ -87,15 +92,21 @@ object HostedCampaign {
   }
 }
 
-case class HostedLogo(url: String, dimensions: Option[Dimensions], trackingCode: String)
+case class HostedLogo(src: String, dimensions: Option[Dimensions], link: String, trackingCode: String)
 
 object HostedLogo {
 
   implicit val jsonFormat = Json.format[HostedLogo]
 
-  def make(url: String, dimensions: Option[SponsorshipLogoDimensions], campaignId: String) = HostedLogo(
-    url,
+  def make(
+    src: String,
+    dimensions: Option[SponsorshipLogoDimensions],
+    link: String,
+    campaignId: String
+  ) = HostedLogo(
+    src,
     dimensions map (d => Dimensions(d.width, d.height)),
+    link,
     trackingCode = s"$campaignId logo"
   )
 }

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -13,6 +13,7 @@ object ChesterZooHostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png",
       Some(Dimensions(width = 280, height = 261)),
+      link = "",
       trackingCode = ""
     ),
     fontColour = Colour("#E31B22")

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -12,6 +12,7 @@ object Formula1HostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg",
       Some(Dimensions(width = 500, height = 500)),
+      link = "",
       trackingCode = ""
     ),
     fontColour = Colour("#063666")

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -19,6 +19,7 @@ object LeffeHostedPages {
     logo = HostedLogo(
       Static("images/commercial/leffe.jpg"),
       Some(Dimensions(width = 132, height = 132)),
+      link = "",
       trackingCode = ""
     ),
     fontColour = Colour("#dec190")

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -17,6 +17,7 @@ object RenaultHostedPages {
     logo = HostedLogo(
       Static("images/commercial/logo_renault.jpg"),
       Some(Dimensions(width = 132, height = 132)),
+      link = "",
       trackingCode = ""
     ),
     fontColour = Colour("#ffc421")

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -16,6 +16,7 @@ object VisitBritainHostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
       Some(Dimensions(width = 1378, height = 957)),
+      link = "",
       trackingCode = ""
     ),
     fontColour = Colour("#E41F13")

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -16,7 +16,7 @@ object VisitBritainHostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
       Some(Dimensions(width = 1378, height = 957)),
-      link = "",
+      link = "http://www.homeofamazing.com/?utm_source=guardianpartnership&utm_medium=hostedgalleries&utm_campaign=display",
       trackingCode = ""
     ),
     fontColour = Colour("#E41F13")


### PR DESCRIPTION
This fixes a bug that has been raised on a new hosted campaign, where the link on hosted logos was wrong because they were always using the CTA link.

Eg. in https://www.theguardian.com/advertiser-content/anchor-award/anchor-reeperbahn-festival-international-music-award
logo link should be http://www.anchor-award.com/home.html
rather than https://youtu.be/Z8I1dKHNnOs

/cc @guardian/labs-beta 