### PR TITLE
Fix the fetching of commercial feeds (again)

### DIFF
--- a/commercial/app/model/feeds/FeedFetcher.scala
+++ b/commercial/app/model/feeds/FeedFetcher.scala
@@ -21,17 +21,9 @@ trait FeedFetcher {
   def fetch()(implicit executionContext: ExecutionContext): Future[FetchResponse]
   def fetch(feedMetaData: FeedMetaData)(implicit executionContext: ExecutionContext): Future[FetchResponse] = {
 
-    def body(response: WSResponse): String = {
-      if (feedMetaData.responseEncoding == ResponseEncoding.default) {
-        response.body
-      } else {
-        response.underlying[Response].getResponseBody(feedMetaData.responseEncoding)
-      }
-    }
+    def body(response: WSResponse): String = response.bodyAsBytes.decodeString(feedMetaData.responseEncoding)
 
-    def contentType(response: WSResponse): String = {
-      response.underlying[Response].getContentType
-    }
+    def contentType(response: WSResponse): String = response.header("Content-Type") getOrElse "application/octet-stream"
 
     val start = currentTimeMillis()
 

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -118,7 +118,8 @@ class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends Loggi
           feedName = "Book Lookup",
           url = s"${props.urlPrefix}/$isbn",
           timeout = 3.seconds,
-          switch = BookLookupSwitch)
+          switch = BookLookupSwitch,
+          responseEncoding = "utf-8")
 
         log.info(s"Looking up book with ISBN $isbn ...")
 


### PR DESCRIPTION
## Background
Commercial feeds are currently [failing to be fetched](https://kibana.gu-web.net/goto/e9c9aa9a48b47e67efc7c5d9a517ff5c) with the following error:

`org.asynchttpclient.netty.NettyResponse cannot be cast to com.ning.http.client.Response`

This error arose during the migration to Play 2.5 but ultimately is a consequence of us casting the `WsResponse` to its underlying response, which is dumb, and we don't need to do this.

## What's changed?
This PR replaces the current casting method by simply getting the response body as an `akka.util.ByteString`, which we can use to simply decode the body using the encoding specified for each feed.

## What is the value of this and can you measure success?
People can get current merchandise in their components.

## Does this affect other platforms - Amp, Apps, etc?
No.