### PR TITLE
Dynamic width of programmatics

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -176,7 +176,7 @@ define([
             id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444',
             type: 'resize',
             iframeId: payload.value.id,
-            value: { height: +payload.value.height }
+            value: { height: +payload.value.height, width: +payload.value.width }
         };
     }
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -17,11 +17,11 @@ define([
 
         var styles = {};
 
-        if ('width' in specs) {
+        if (specs.width) {
             styles.width = normalise(specs.width);
         }
 
-        if ('height' in specs) {
+        if (specs.height) {
             styles.height = normalise(specs.height);
         }
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -403,6 +403,12 @@
     padding-left: 0;
     padding-right: 0;
     padding-bottom: 0;
+
+    &.ad-slot--top-banner-ad-desktop {
+        @include mq(wide) {
+            margin-left: 0;
+        }
+    }
 }
 
 .ad-slot--fabric-v1,

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -361,6 +361,7 @@
 .ad-slot--fluid {
     min-height: 250px;
     padding: 0;
+    margin: 0;
 
     &:not(.ad-slot--im) {
         width: auto;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -75,11 +75,6 @@
 .ad-slot--top-banner-ad {
     text-align: center;
 
-    @include mq(wide) {
-        width: gs-span(16) - ($left-column-wide + $gs-gutter);
-        padding-left: $left-column-wide + $gs-gutter;
-    }
-
     .ad-slot__label {
         /* this is the minimum width of possible ads sizes */
         width: 728px;
@@ -114,6 +109,11 @@
 
     @include mq($until: tablet) {
         display: none;
+    }
+
+    @include mq(wide) {
+        padding-left: $left-column-wide + $gs-gutter * 2;
+        margin-left: calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
     }
 
     &.ad-slot--fabric {


### PR DESCRIPTION
## What does this change?

Adds the real width of the ad to the resize message being sent by Rubicon/AppNexus/et al ad networks.

There was a `width` being set on the top ad slot; knowing it would be overwritten by the message above, I used a left margin instead, which basically achieves the same purpose. Then I removed the margin for fluid slots, i.e. native ads and Fabrics.

## What is the value of this and can you measure success?

AppNexus billboards are correctly resized vertically, but not horizontally right now, and so they appear cropped.

## Screenshots

Before:
![promo size_728 width](https://cloud.githubusercontent.com/assets/629976/21615821/133c1bfe-d1d7-11e6-93af-dc0f80372b14.png)

After:
![picture 2](https://cloud.githubusercontent.com/assets/629976/21615916/65faf072-d1d7-11e6-922c-8b1c3e69d96a.jpg)
