### PR TITLE
Fix Raven for Webpack

### DIFF
--- a/static/src/javascripts/components/raven-js/raven.js
+++ b/static/src/javascripts/components/raven-js/raven.js
@@ -1835,4 +1835,4 @@ if (typeof define === 'function' && define.amd) {
     define('raven', [], function() { return Raven; });
 }
 
-})(this);
+})(window);

--- a/static/src/javascripts/projects/common/utils/raven.js
+++ b/static/src/javascripts/projects/common/utils/raven.js
@@ -11,6 +11,10 @@ define([
 
     var app = guardian.app = guardian.app || {};
 
+    if (app.raven) {
+        return app.raven;
+    }
+
     var adblockBeingUsed = false;
     detect.adblockInUse.then(function(adblockInUse){
         adblockBeingUsed = adblockInUse;


### PR DESCRIPTION
## What does this change?

Raven 1.1.6 is wrapped in an immediately-invoked function that passes `this` as a parameter. Under normal circumstances, `this` would be the `window` object. However, when the Raven module is bundled by Webpack, it is wrapped in another function, that is called with an [empty object as its context](https://github.com/jhnns/webpack/blob/master/lib/MainTemplate.js#L98). I don't quite understand [why Webpack does this](https://github.com/webpack/webpack/pull/102), but it's been working that way for 3 years.

Anyway, because the context is an empty object instead of `window`, Raven's test to ensure [JSON is supported in the browser](https://github.com/guardian/frontend/blob/master/static/src/javascripts/components/raven-js/raven.js#L1094) fails, so the Raven install fails.

To fix this, I'm explicitly passing the `window` object in to the immediately-invoked function. It is not an ideal fix as it involves updating vendor code. Ideally, we'd upgrade our ancient version of Raven, but when we attempted this previously, it caused [an issue in Windows phones](https://github.com/guardian/frontend/pull/15190), generating millions of Sentry reports per day.

## What is the value of this and can you measure success?

Raven will work in Webpack bundles, so errors will be reported correctly.

## Does this affect other platforms - Amp, Apps, etc?

No
