### PR TITLE
Make AB test work with Newsletters page, fix linter warning

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -55,18 +55,22 @@ define([
           });
         }
 
+        function runTheTest(emailListID, exampleUrl) {
+          if (config.page.contentId === FLYERURL) {
+            enhanceWebView(emailListID);
+          } else {
+            updateNewslettersPage(emailListID);
+          }
+          updateExampleUrl(exampleUrl);
+        }
+
         this.variants = [
             {
                 id: 'The-Flyer-Cards',
                 test: function () {
                     var emailListID = 3806;
                     var exampleUrl = 'https://www.theguardian.com/email/the-flyer?format=email';
-                    if (config.page.contentId === FLYERURL) {
-                      enhanceWebView(emailListID);
-                    } else {
-                      updateNewslettersPage(emailListID);
-                    }
-                    updateExampleUrl(exampleUrl);
+                    runTheTest(emailListID, exampleUrl);
                 }
             },
             {
@@ -74,12 +78,7 @@ define([
                 test: function () {
                     var emailListID = 3807;
                     var exampleUrl = 'https://www.theguardian.com/email/the-flyer?format=email-connected';
-                    if (config.page.contentId === FLYERURL) {
-                      enhanceWebView(emailListID);
-                    } else {
-                      updateNewslettersPage(emailListID);
-                    }
-                    updateExampleUrl(exampleUrl);
+                    runTheTest(emailListID, exampleUrl);
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -26,8 +26,11 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Similar quantity of users in each list in ExactTarget';
 
+        var FLYERURL = 'info/ng-interactive/2016/dec/07/sign-up-for-the-flyer';
+
         this.canRun = function () {
-          return (config.page.contentId === 'info/ng-interactive/2016/dec/07/sign-up-for-the-flyer');
+          return (config.page.contentId === FLYERURL ||
+            config.page.pageId === '/email-newsletters');
         };
 
         function updateExampleUrl(exampleUrl) {
@@ -42,13 +45,27 @@ define([
           emailForm.setAttribute('src', 'https://www.theguardian.com/email/form/plaintone/' + emailListID);
         }
 
+        // Runs the test on https://www.theguardian.com/email-newsletters
+        function updateNewslettersPage(emailListID) {
+          return fastdomPromise.write(function () {
+            var flyerInput = $('input[value="2211"]')[0];
+            var flyerButton = $('button[value="2211"]')[0];
+            flyerInput.setAttribute('value', emailListID);
+            flyerButton.setAttribute('value', emailListID);
+          });
+        }
+
         this.variants = [
             {
                 id: 'The-Flyer-Cards',
                 test: function () {
                     var emailListID = 3806;
                     var exampleUrl = 'https://www.theguardian.com/email/the-flyer?format=email';
-                    enhanceWebView(emailListID);
+                    if (config.page.contentId === FLYERURL) {
+                      enhanceWebView(emailListID);
+                    } else {
+                      updateNewslettersPage(emailListID);
+                    }
                     updateExampleUrl(exampleUrl);
                 }
             },
@@ -57,7 +74,11 @@ define([
                 test: function () {
                     var emailListID = 3807;
                     var exampleUrl = 'https://www.theguardian.com/email/the-flyer?format=email-connected';
-                    enhanceWebView(emailListID);
+                    if (config.page.contentId === FLYERURL) {
+                      enhanceWebView(emailListID);
+                    } else {
+                      updateNewslettersPage(emailListID);
+                    }
                     updateExampleUrl(exampleUrl);
                 }
             }

--- a/static/src/stylesheets/module/experiments/_recommended-for-you.scss
+++ b/static/src/stylesheets/module/experiments/_recommended-for-you.scss
@@ -29,7 +29,7 @@
 }
 
 .rfy__image {
-  width:100%;
+    width: 100%;
 }
 
 .rfy-profile-icon {


### PR DESCRIPTION
## What does this change?

- Updates https://www.theguardian.com/email-newsletters so that subscriptions through this page lead to one of the new variants of the Flyer email

- Fixes a css formatting issue

## What is the value of this and can you measure success?

- Gives users a new, shiny email
- Makes the liner happy

## Does this affect other platforms - Amp, Apps, etc?

Nope

