### PR TITLE
AMP cta overflow fix

### DIFF
--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -15,16 +15,18 @@ $veggie-burger-medium: 52px;
     flex-wrap: wrap;
     align-items: flex-start;
     z-index: 1;
+    max-width: 600px;
 }
 
 .header__supporter-cta {
     // Some very specific values in here, as it's all got to line up with the x-height of the logo
     position: absolute;
-    left: $gs-gutter / 2 + $gs-gutter / 4;
-    padding-top: 10px;
+    left: ($gs-gutter / 4) - 1px;
+    padding: 10px 23px 12px 12px;
     font-size: 13px;
     line-height: .95;
     color: $guardian-brand-dark;
+    overflow: hidden;
 
     & > span {
         display: block;
@@ -34,8 +36,8 @@ $veggie-burger-medium: 52px;
         content: '';
         position: absolute;
         top: -$gs-baseline / 2;
-        left: -$gs-gutter / 2;
-        right: -23px;
+        left: 1px;
+        right: 0;
         border-top: $gs-baseline * 4 solid $news-main-2;
         border-left: $gs-gutter / 4 solid transparent;
         border-right: $gs-gutter solid transparent;
@@ -47,7 +49,7 @@ $veggie-burger-medium: 52px;
         display: none;
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: $mobile-medium) {
         padding-top: 14px;
         font-size: 14px;
 
@@ -57,7 +59,7 @@ $veggie-burger-medium: 52px;
     }
 
     @include mq($from: mobileLandscape) {
-        left: $gs-gutter + $gs-gutter / 4
+        left: $gs-gutter/2;
     }
 }
 


### PR DESCRIPTION
## What does this change?
When using AMP you could occasionally see the 'Become a supporter' rotation peaking out above the header. Looks a bit messy and ruins the magic 🎩 🌟 . Couldn't use overflow hidden on the entire header because the veggie burger has to overlap. 

## What is the value of this and can you measure success?
Neatness

## Does this affect other platforms - Amp, Apps, etc?
Yep, only AMP

## Screenshots
Before
![screen shot 2017-01-04 at 11 14 57](https://cloud.githubusercontent.com/assets/14570016/21642088/f389c738-d277-11e6-9e2e-2ea2913e0255.png)

After
![screen shot 2017-01-04 at 12 10 17](https://cloud.githubusercontent.com/assets/14570016/21642090/f779f2d2-d277-11e6-83ab-ed449e3cc331.png)

@NataliaLKB @stephanfowler 🌮 
