### PR TITLE
extend always on test by another month

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -46,7 +46,7 @@ trait ABTestSwitches {
     "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 6),
+    sellByDate = new LocalDate(2017, 2, 6),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -32,7 +32,7 @@ define([
         campaignId: 'epic_always_ask_strategy',
 
         start: '2016-12-06',
-        expiry: '2017-01-06',
+        expiry: '2017-02-06',
 
         author: 'Guy Dawson',
         description: 'Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period.',


### PR DESCRIPTION
## What does this change?

Extends the always on test, as we wish to keep the test running for at least another month 

## What is the value of this and can you measure success?



## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
