### PR TITLE
Filter invalid line items report

### DIFF
--- a/admin/app/dfp/AdvertiserAgent.scala
+++ b/admin/app/dfp/AdvertiserAgent.scala
@@ -1,0 +1,20 @@
+package dfp
+
+import common.AkkaAgent
+import common.dfp.GuAdvertiser
+
+import scala.concurrent.Future
+
+object AdvertiserAgent {
+
+  private lazy val cache = AkkaAgent(Seq.empty[GuAdvertiser])
+
+  def refresh(): Future[Seq[GuAdvertiser]] = {
+    cache alterOff { oldData =>
+      val freshData = DfpApi.getAllAdvertisers
+      if (freshData.nonEmpty) freshData else oldData
+    }
+  }
+
+  def get: Seq[GuAdvertiser] = cache.get()
+}

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -168,4 +168,19 @@ object DataMapper {
       previewUrl = Some(dfpCreative.getPreviewUrl)
     )
   }
+
+  def toGuOrder(dfpOrder: Order): GuOrder = {
+    GuOrder(
+      id = dfpOrder.getId,
+      name = dfpOrder.getName,
+      advertiserId = dfpOrder.getAdvertiserId
+    )
+  }
+  def toGuAdvertiser(dfpCompany: Company): GuAdvertiser = {
+
+    GuAdvertiser(
+      id = dfpCompany.getId,
+      name = dfpCompany.getName
+    )
+  }
 }

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -102,6 +102,7 @@ object DataMapper {
 
   def toGuLineItem(session: SessionWrapper)(dfpLineItem: LineItem) = GuLineItem(
     id = dfpLineItem.getId,
+    orderId = dfpLineItem.getOrderId,
     name = dfpLineItem.getName,
     startTime = toJodaTime(dfpLineItem.getStartDateTime),
     endTime = {

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -3,8 +3,8 @@ package dfp
 import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder
 import com.google.api.ads.dfp.axis.v201608._
 import common.Logging
-import common.dfp.{GuAdUnit, GuCreative, GuCreativeTemplate, GuLineItem}
-import dfp.DataMapper.{toGuAdUnit, toGuCreativeTemplate, toGuLineItem, toGuTemplateCreative}
+import common.dfp._
+import dfp.DataMapper.{toGuAdUnit, toGuCreativeTemplate, toGuLineItem, toGuTemplateCreative, toGuAdvertiser, toGuOrder}
 import org.joda.time.DateTime
 
 object DfpApi extends Logging {
@@ -27,6 +27,25 @@ object DfpApi extends Logging {
     DfpLineItems(
       validItems = validatedLineItems.getOrElse(true, Nil),
       invalidItems = validatedLineItems.getOrElse(false, Nil))
+  }
+
+  def getAllOrders: Seq[GuOrder] = {
+    val stmtBuilder = new StatementBuilder()
+
+    withDfpSession( session => {
+      session.orders(stmtBuilder).map(toGuOrder)
+    })
+  }
+
+  def getAllAdvertisers: Seq[GuAdvertiser] = {
+    val stmtBuilder = new StatementBuilder()
+                      .where("type = :type")
+                      .withBindVariableValue("type", CompanyType.ADVERTISER.toString)
+                      .orderBy("id ASC")
+
+    withDfpSession( session => {
+      session.companies(stmtBuilder).map(toGuAdvertiser)
+    })
   }
 
   def readCurrentLineItems: DfpLineItems = {

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -96,6 +96,14 @@ class DfpDataCacheLifecycle(
       val name: String = "DFP-Template-Creatives-Cache"
       val interval: Int = 2
       def run() = DfpTemplateCreativeCacheJob.run()
+    },
+
+    new Job[Unit] {
+      val name = "DFP-Order-Advertiser-Update"
+      val interval: Int = 300
+      def run() = {
+        Future.sequence(Seq(AdvertiserAgent.refresh(), OrderAgent.refresh())).map(_ => ())
+      }
     }
 
   )
@@ -113,6 +121,8 @@ class DfpDataCacheLifecycle(
       CreativeTemplateAgent.refresh()
       DfpTemplateCreativeCacheJob.run()
       CustomTargetingKeyValueJob.run()
+      AdvertiserAgent.refresh()
+      OrderAgent.refresh()
     }
   }
 }

--- a/admin/app/dfp/OrderAgent.scala
+++ b/admin/app/dfp/OrderAgent.scala
@@ -1,0 +1,20 @@
+package dfp
+
+import common.AkkaAgent
+import common.dfp.GuOrder
+
+import scala.concurrent.Future
+
+object OrderAgent {
+
+  private lazy val cache = AkkaAgent(Seq.empty[GuOrder])
+
+  def refresh(): Future[Seq[GuOrder]] = {
+    cache alterOff { oldData =>
+      val freshData = DfpApi.getAllOrders
+      if (freshData.nonEmpty) freshData else oldData
+    }
+  }
+
+  def get: Seq[GuOrder] = cache.get()
+}

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -27,4 +27,8 @@ private[dfp] class ServicesWrapper(session: DfpSession) {
   lazy val creativeService = dfpServices.get(session, classOf[CreativeServiceInterface])
 
   lazy val networkService = dfpServices.get(session, classOf[NetworkServiceInterface])
+
+  lazy val orderService = dfpServices.get(session, classOf[OrderServiceInterface])
+
+  lazy val companyService = dfpServices.get(session, classOf[CompanyServiceInterface])
 }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -25,6 +25,24 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
     }
   }
 
+  def orders(stmtBuilder: StatementBuilder): Seq[Order] = {
+    logAroundRead("orders", stmtBuilder) {
+      read(stmtBuilder) { statement =>
+        val page = services.orderService.getOrdersByStatement(statement)
+        (page.getResults, page.getTotalResultSetSize)
+      }
+    }
+  }
+
+  def companies(stmtBuilder: StatementBuilder): Seq[Company] = {
+    logAroundRead("companies", stmtBuilder) {
+      read(stmtBuilder) { statement =>
+        val page = services.companyService.getCompaniesByStatement(statement)
+        (page.getResults, page.getTotalResultSetSize)
+      }
+    }
+  }
+
   def customFields(stmtBuilder: StatementBuilder): Seq[CustomField] = {
     logAroundRead("custom fields", stmtBuilder) {
       read(stmtBuilder) { statement =>

--- a/admin/app/views/commercial/invalidLineItems.scala.html
+++ b/admin/app/views/commercial/invalidLineItems.scala.html
@@ -26,7 +26,7 @@
 
     <h2>Invalid Page Skin Sponsorships</h2>
 
-    @if(invalidPageskins.isEmpty) {<p>None</p>} else {
+    @if(invalidPageskins.isEmpty) {<em>None</em>} else {
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>
@@ -47,7 +47,7 @@
 
     <h2>Invalid High-Merchandising Line Items</h2>
 
-    @if(invalidHighMerchandising.isEmpty) {<p>None</p>} else {
+    @if(invalidHighMerchandising.isEmpty) {<em>None</em>} else {
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>
@@ -68,7 +68,7 @@
 
     <h2>Invalid Top-Above-Nav Line Items</h2>
 
-    @if(invalidTopAbove.isEmpty) {<p>None</p>} else {
+    @if(invalidTopAbove.isEmpty) {<em>None</em>} else {
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>
@@ -94,7 +94,7 @@
     They are likely to be line items targeting other platforms, but it is possible for unidentified anomalies to appear here too.
     </p>
 
-    @if(unknownInvalidLineItems.isEmpty) {<p>None</p>} else {
+    @if(unknownInvalidLineItems.isEmpty) {<em>None</em>} else {
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>
@@ -119,7 +119,7 @@
     These line items are used by the Sonobi SSP to pass winning bids through DFP. They can be ignored.
     </p>
 
-    @if(sonobiItems.isEmpty) {<p>None</p>} else {
+    @if(sonobiItems.isEmpty) {<em>None</em>} else {
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>

--- a/admin/app/views/commercial/invalidLineItems.scala.html
+++ b/admin/app/views/commercial/invalidLineItems.scala.html
@@ -5,6 +5,7 @@
 @(invalidPageskins: Seq[PageSkinSponsorship],
   invalidTopAbove: Seq[GuLineItem],
   invalidHighMerchandising: Seq[HighMerchandisingLineItem],
+  sonobiItems: Seq[GuLineItem],
   unknownInvalidLineItems: Seq[GuLineItem])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @admin_main("Line Item Problems", isAuthed = true, hasCharts = false) {
@@ -89,7 +90,7 @@
     <h2>Unidentified Line Items</h2>
 
     <p>
-    The remaining invalid line items do not target <em>theguardian.com</em> ad units exclusively, and don't clearly target Frontend.
+    These invalid line items do not target <em>theguardian.com</em> ad units exclusively, and don't clearly target Frontend.
     They are likely to be line items targeting other platforms, but it is possible for unidentified anomalies to appear here too.
     </p>
 
@@ -103,6 +104,31 @@
             </thead>
             <tbody>
                 @for(lineItem <- unknownInvalidLineItems) {
+                    <tr>
+                        <td>@{lineItem.name}</td>
+                        <td><a target="_blank" href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+
+    <h2>Sonobi Line Items</h2>
+
+    <p>
+    These line items are used by the Sonobi SSP to pass winning bids through DFP. They can be ignored.
+    </p>
+
+    @if(sonobiItems.isEmpty) {<p>None</p>} else {
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <th class="col-md-4">Line Item Name</th>
+                    <th class="col-md-4">DFP link</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(lineItem <- sonobiItems) {
                     <tr>
                         <td>@{lineItem.name}</td>
                         <td><a target="_blank" href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -17,6 +17,7 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
 
     GuLineItem(
       id = 0L,
+      orderId = 0L,
       name = "test line item",
       startTime = DateTime.now.withTimeAtStartOfDay,
       endTime = None,

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -18,6 +18,7 @@ class DfpDataCacheJobTest
   private def lineItem(id: Long, name: String, completed: Boolean = false): GuLineItem = {
     GuLineItem(
       id,
+      0L,
       name,
       startTime = DateTime.now.withTimeAtStartOfDay,
       endTime = None,

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -388,7 +388,7 @@ class GuardianConfiguration extends Logging {
     lazy val dfpInlineMerchandisingTagsDataKey = s"$dfpRoot/inline-merchandising-tags-v3.json"
     lazy val dfpHighMerchandisingTagsDataKey = s"$dfpRoot/high-merchandising-tags.json"
     lazy val dfpPageSkinnedAdUnitsKey = s"$dfpRoot/pageskinned-adunits-v6.json"
-    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v5.json"
+    lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v6.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
     lazy val dfpMobileAppsAdUnitListKey = s"$dfpRoot/mobile-active-ad-units.csv"
     lazy val dfpFacebookIaAdUnitListKey = s"$dfpRoot/facebookia-active-ad-units.csv"

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -141,6 +141,7 @@ object GuTargeting {
 }
 
 case class GuLineItem(id: Long,
+                      orderId: Long,
                       name: String,
                       startTime: DateTime,
                       endTime: Option[DateTime],
@@ -208,6 +209,7 @@ object GuLineItem {
     def writes(lineItem: GuLineItem): JsValue = {
       Json.obj(
         "id" -> lineItem.id,
+        "orderId" -> lineItem.orderId,
         "name" -> lineItem.name,
         "startTime" -> timeFormatter.print(lineItem.startTime),
         "endTime" -> lineItem.endTime.map(timeFormatter.print(_)),
@@ -224,17 +226,18 @@ object GuLineItem {
 
   implicit val lineItemReads: Reads[GuLineItem] = (
     (JsPath \ "id").read[Long] and
-      (JsPath \ "name").read[String] and
-      (JsPath \ "startTime").read[String].map(timeFormatter.parseDateTime) and
-      (JsPath \ "endTime").readNullable[String].map(_.map(timeFormatter.parseDateTime)) and
-      (JsPath \ "isPageSkin").read[Boolean] and
-      (JsPath \ "sponsor").readNullable[String] and
-      (JsPath \ "status").read[String] and
-      (JsPath \ "costType").read[String] and
-      (JsPath \ "creativePlaceholders").read[Seq[GuCreativePlaceholder]] and
-      (JsPath \ "targeting").read[GuTargeting] and
-      (JsPath \ "lastModified").read[String].map(timeFormatter.parseDateTime)
-    )(GuLineItem.apply _)
+    (JsPath \ "orderId").read[Long] and
+    (JsPath \ "name").read[String] and
+    (JsPath \ "startTime").read[String].map(timeFormatter.parseDateTime) and
+    (JsPath \ "endTime").readNullable[String].map(_.map(timeFormatter.parseDateTime)) and
+    (JsPath \ "isPageSkin").read[Boolean] and
+    (JsPath \ "sponsor").readNullable[String] and
+    (JsPath \ "status").read[String] and
+    (JsPath \ "costType").read[String] and
+    (JsPath \ "creativePlaceholders").read[Seq[GuCreativePlaceholder]] and
+    (JsPath \ "targeting").read[GuTargeting] and
+    (JsPath \ "lastModified").read[String].map(timeFormatter.parseDateTime)
+  )(GuLineItem.apply _)
 
   def asMap(lineItems: Seq[GuLineItem]) = lineItems.map(item => item.id -> item).toMap
 }

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -321,6 +321,17 @@ object GuCreativeTemplate extends implicits.Collections {
   implicit val guCreativeTemplateFormats: Format[GuCreativeTemplate] = Json.format[GuCreativeTemplate]
 }
 
+case class GuAdvertiser(
+  id: Long,
+  name: String
+)
+
+case class GuOrder(
+  id: Long,
+  name: String,
+  advertiserId: Long
+)
+
 case class LineItemReport(
   timestamp: String,
   lineItems: Seq[GuLineItem],

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -34,7 +34,8 @@ class GuLineItemTest extends FlatSpec with Matchers {
     targeting: GuTargeting = defaultTargeting
   ): GuLineItem = {
     GuLineItem(
-      id = 0,
+      id = 0L,
+      orderId = 0L,
       name = "name",
       startTime = now,
       endTime,


### PR DESCRIPTION
The invalid line items report would be clearer if:

- line items which exclusive target other gu sites using 'nearly' top level ad units, like `jobs.theguardian.com` and `apps`, were understood and grouped.

- automated line items from sonobi were grouped, leaving true unknowns left in the list.

I'd like to do both, but this change sorts out the first, and it should be quite easy to update the `groupBy` in future to understand `jobs.thguardian.com`. @ScottPainterGNM 

![screen shot 2017-01-05 at 10 59 35](https://cloud.githubusercontent.com/assets/4549425/21678300/1506c91a-d336-11e6-91a6-dde04fd5a922.png)

