### PR TITLE
Remove `insertRequire` from bundle config

### DIFF
--- a/tools/__tasks__/compile/javascript/rjs--webpack.js
+++ b/tools/__tasks__/compile/javascript/rjs--webpack.js
@@ -5,7 +5,6 @@ const { target } = require('../../config').paths;
 const bundles = [{
     name: 'boot-rjs',
     out: `${target}/javascripts/boot-rjs.js`,
-    insertRequire: ['boot-rjs'],
     exclude: [
         'text',
         'inlineSvg',

--- a/tools/__tasks__/compile/javascript/rjs.js
+++ b/tools/__tasks__/compile/javascript/rjs.js
@@ -6,7 +6,6 @@ const bundles = [{
     name: 'boot',
     out: `${target}/javascripts/boot.js`,
     include: 'bootstraps/standard/main',
-    insertRequire: ['boot'],
     exclude: [
         'text',
         'inlineSvg',


### PR DESCRIPTION
## What does this change?

Removes extraneous `insertRequire` properties from the r.js bundle config. These are not necessary as curl.js [infers the execution order](https://github.com/cujojs/curl/wiki/Module-Lifecycle) of our modules by walking the dependency tree. We don't need to specify the application's entry point.

## What is the value of this and can you measure success?

This code is redundant and potentially confusing. Removing it makes our code cleaner.

## Does this affect other platforms - Amp, Apps, etc?

Nope
