### PR TITLE
Add form tones for the listID of the new Opinion email

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -37,6 +37,7 @@ object ListIds {
   val guardianTodayAu = 1506
 
   val theBestOfOpinion = 2313
+  val newBestOfOpinion = 3811
   val theFiver = 218
   val mediaBriefing = 217
   val greenLight = 28

--- a/common/app/model/EmailSubscriptions.scala
+++ b/common/app/model/EmailSubscriptions.scala
@@ -357,7 +357,7 @@ object EmailSubscriptions {
       description = "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
       frequency = "Weekday afternoons",
       listId = "2313",
-      subscribedTo = subscribedListIds.exists{ x => x == "2313" },
+      subscribedTo = subscribedListIds.exists{ x => x == "2313" || x == "3811" },
       subheading = Some("UK"),
       tone = Some("comment"),
       signupPage = Some("/commentisfree/2014/jan/29/comment-is-free-daily-roundup")

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -11,6 +11,7 @@
 
 @listIdTones = @{ Map[Int, String] (
     theBestOfOpinion -> "comment",
+    newBestOfOpinion -> "comment",
     bestOfOpinionAUS -> "comment",
     bestOfOpinionUS -> "comment",
     theFiver -> "feature",

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -154,11 +154,13 @@ define([
             } else {
                 buttonString += 'addEmailSubscriptions[]=' + encodeURIComponent(value) + '&';
             }
-            // hacks to deal with the various AB tests running on email listIDs
+            // hacks to deal with the various email variants and AB tests running on email listIDs
             // delete me after 2017-02-01!
             if (config.switches.abEditorialEmailVariants && value === 'unsubscribe-2211') {
                 buttonString += 'removeEmailSubscriptions[]=3806&';
                 buttonString += 'removeEmailSubscriptions[]=3807&';
+            } else if (value === 'unsubscribe-2313') {
+                buttonString += 'removeEmailSubscriptions[]=3811&';
             }
             // end of hacks
         }


### PR DESCRIPTION
The email sign up forms include the Guardian Today footer, and the iframe embeds used by editorial in articles. They are also used in the email sign up interactive atoms, examples [here](https://www.theguardian.com/info/ng-interactive/2016/dec/07/sign-up-for-the-flyer) and [here](https://www.theguardian.com/info/ng-interactive/2016/dec/05/sign-up-for-weekend-reading).

They live in routes like this: `www.theguardian.com/email/form/<type>/<listID>`

## What does this change?

The default colour is brand blue. This PR adds a rule to make the new version of the Opinion email  (listID 3811) have the matching comment tone applied to it's forms

(Tones are only applied when the type is **article** or **plaintone**)



###### Before

<img width="624" alt="picture 447" src="https://cloud.githubusercontent.com/assets/8607683/21685677/5c7d739c-d35a-11e6-81bc-8f683511048a.png">

<img width="440" alt="picture 446" src="https://cloud.githubusercontent.com/assets/8607683/21685689/664a2154-d35a-11e6-805b-d01b473b56d2.png">


###### After

<img width="865" alt="picture 444" src="https://cloud.githubusercontent.com/assets/8607683/21682743/163bebd6-d34e-11e6-9a06-577a59e920ad.png">

<img width="421" alt="picture 445" src="https://cloud.githubusercontent.com/assets/8607683/21685478/aac1b4d8-d359-11e6-8e39-01f3851e17d3.png">


## What is the value of this and can you measure success?

This form will be used in a [new interactive](https://github.com/guardian/interactive-email-signups/tree/master/interactive-opinion)

## Does this affect other platforms - Amp, Apps, etc?

No... but it will be used as an embed in Composer content

