### PR TITLE
Prevent MPUs to be cut off in the "most popular" container

### DIFF
--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -9,7 +9,7 @@
 @defining(popular.size > 1){ isTabbed =>
     <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular Test" data-test-id="popular-in">
         @if(isTabbed) {
-            <div class="tabs u-cf">
+            <div class="tabs tabs--mostpop u-cf">
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
                     @popular.zipWithRowInfo.map{ case (section, info) =>
                     <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">

--- a/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/commercial-component.js
@@ -84,26 +84,6 @@ define([
         }
     }
 
-    function adjustMostPopHeight(el) {
-        var adSlotHeight;
-        var $adSlot = $(el);
-        var $mostPopTabs = $('.js-most-popular-footer .tabs__pane');
-        var mostPopTabsHeight;
-
-        if ($adSlot.hasClass('ad-slot--mostpop')) {
-            fastdom.read(function () {
-                adSlotHeight = $adSlot.dim().height;
-                mostPopTabsHeight = $mostPopTabs.dim().height;
-
-                if (adSlotHeight > mostPopTabsHeight) {
-                    fastdom.write(function () {
-                        $mostPopTabs.css('height', adSlotHeight);
-                    });
-                }
-            });
-        }
-    }
-
     function setFluid(el) {
         if (el.classList.contains('ad-slot--container-inline')) {
             el.classList.add('ad-slot--fluid');
@@ -197,7 +177,6 @@ define([
         capiSingle: createToggle,
         paidforCard: function (el) {
             setFluid(el);
-            adjustMostPopHeight(el);
             createToggle(el);
         }
     };

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -157,3 +157,13 @@ category: Common
         display: none;
     }
 }
+
+// Most Popular customisation: change layout to accomodate MPU
+.tabs--mostpop {
+    @include mq(desktop) {
+        .tabs__content {
+            display: table;
+            display: flex;
+        }
+    }
+}

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -222,9 +222,18 @@ Hence why a greater depth of selector specificity is needed.
     }
 
     @include mq(desktop) {
-        position: absolute;
-        top: $gs-baseline;
-        right: -($gs-gutter / 2);
+        width: auto;
+        margin-left: auto;
+
+        .ad-slot {
+            margin: 0;
+        }
+
+        .has-no-flex & {
+            position: absolute;
+            top: $gs-baseline;
+            right: -($gs-gutter / 2);
+        }
     }
 }
 


### PR DESCRIPTION
From time to time, we deliver an ad in the "most popular" that is being cut off because its height is more than what the allocated space allows for. That is because the ad slot is positioned absolutely: dealing with that requires amounts of JS we could really do without.

With this PR, the container adopts a flex layout on desktop, so that the ad slot is taken into account in the computation of the height of the container.

No noticeable impact when tab switching:
![mostpop](https://cloud.githubusercontent.com/assets/629976/21686643/0c178ad8-d35e-11e6-9380-f7bbfca750a4.gif)

... and we can now stop worrying about changes in height:
![mostpop-height](https://cloud.githubusercontent.com/assets/629976/21686664/1bdfb7e2-d35e-11e6-9adc-b1d168ac9090.gif)
