### PR TITLE
Conditionally prefetch app-webpack

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,6 +1,7 @@
 @(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.Page.getContent
 @import play.api.Mode.Dev
+@import mvt.WebpackTest
 
 <meta charset="utf-8" />
 <!--
@@ -22,7 +23,11 @@ http://developers.theguardian.com/join-the-team.html
 @fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
 
 @if(!(context.environment.mode == Dev)) {
-    <link rel="prefetch" href="@Static("javascripts/app.js")">
+    @if(WebpackTest.isParticipating) {
+        <link rel="prefetch" href="@Static("javascripts/app-webpack.js")">
+    } else {
+        <link rel="prefetch" href="@Static("javascripts/app.js")">
+    }
 }
 
 @*


### PR DESCRIPTION
## What does this change?

If the user is participating in the Webpack test, this change ensures the app with the Webpack-bundled standard code (`app-webpack.js`) is [prefetched and cached ready for the user's next page visit](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ). 

## What is the value of this and can you measure success?

It is unclear whether this is absolutely necessary as `app-webpack.js` should be downloaded and cached on every page (including the page doing the prefetching?). 

However, it is definitely not correct for the page to be prefetching `app.js` (which contains r.js-bundled standard code) when the user is participating in the Webpack test, since it will not be executed for this user.

The prefetching implementation originated in [this PR](https://github.com/guardian/frontend/pull/11258)

## Does this affect other platforms - Amp, Apps, etc?

Nein

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
