### PR TITLE
Update hosted content explainer

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -67,9 +67,7 @@
 
                                 </div>
                                 <div class="hosted__standfirst content__hosted-body">
-                                    <div class="hosted__terms">​​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
-                                        <button on="tap:hosted-about-lightbox" class="hosted__terms-link hosted-tone">commercial content explainer</button>.
-                                    </div>
+                                    @hostedExplainer(onAmp = true)
                                 </div>
                             </div>
                             @hostedOnwardAmp(s"${page.url}/article/onward.json")

--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -77,9 +77,7 @@
                 </div>
                 <div class="hosted__standfirst content__hosted-body">
                     <p class="hosted__text">@Html(page.standfirst)</p>
-                    <div class="hosted__terms">​​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
-                        <button on="tap:hosted-about-lightbox" class="hosted__terms-link hosted-tone">commercial content explainer</button>.
-                    </div>
+                    @hostedExplainer(onAmp = true)
                 </div>
             </div>
             <header class="host__header hosted__social content__hosted-body">

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -102,11 +102,7 @@
                                 case _ => { @Html(prepareQuotes(page.body)) }
                             }
                             <div class="hosted__standfirst">
-                                <div class="hosted__terms">​Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
-                                    <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
-                                        <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about hosted-tone" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
-                                    </div>
-                                </div>
+                                @hostedExplainer()
                             </div>
                         </div>
                         <div class="hosted__onward-journey">

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -117,11 +117,7 @@
                 </div>
                 <div class="hosted__standfirst">
                     <p class="hosted__text">@Html(page.standfirst)</p>
-                    <div class="hosted__terms">Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
-                        <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
-                            <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about" data-link-name="terms-and-conditions-text-link">commercial content explainer.</button>
-                        </div>
-                    </div>
+                    @hostedExplainer()
                 </div>
             </div>
 

--- a/commercial/app/views/hosted/hostedExplainer.scala.html
+++ b/commercial/app/views/hosted/hostedExplainer.scala.html
@@ -3,7 +3,7 @@
 @buttonText() = {commercial content explainer.}
 
 <div class="hosted__terms">
-    Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
+    This content is paid for and supplied by the advertiser. Find out more with our
     @if(onAmp) {
         <button on="tap:hosted-about-lightbox" class="hosted__terms-link hosted-tone">@buttonText()</button>
     } else {

--- a/commercial/app/views/hosted/hostedExplainer.scala.html
+++ b/commercial/app/views/hosted/hostedExplainer.scala.html
@@ -1,0 +1,15 @@
+@(onAmp: Boolean = false)
+
+@buttonText() = {commercial content explainer.}
+
+<div class="hosted__terms">
+    Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our
+    @if(onAmp) {
+        <button on="tap:hosted-about-lightbox" class="hosted__terms-link hosted-tone">@buttonText()</button>
+    } else {
+        <div class="paidfor-label paidfor-meta__more has-popup hosted__link">
+            <button class="u-button-reset paidfor-label__btn hosted__label-btn--small popup__toggle hosted__label-btn js-hosted-about hosted-tone"
+            data-link-name="terms-and-conditions-text-link">@buttonText()</button>
+        </div>
+    }
+</div>


### PR DESCRIPTION
Research shows that the explanation of hosted content is unclear.  
So [this](https://github.com/guardian/frontend/commit/5955b2199d816b093d913ffcdcb83d8460169b78) tweak to the wording suggested by Labs team is an attempt to make it clearer. 

/cc @guardian/commercial-dev 