### PR TITLE
Do not send random Etag header

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -124,7 +124,7 @@ object Cached extends implicits.Dates {
         (etag, result)
       }
     }.getOrElse(
-      (s""""johnRandom${scala.util.Random.nextInt}${scala.util.Random.nextInt}"""", result) // just to see if they come back in
+      (s""""guRandomEtag${scala.util.Random.nextInt}${scala.util.Random.nextInt}"""", result) // just to see if they come back in
     )
 
     validatedResult.withHeaders(


### PR DESCRIPTION
This patch ensures no Etag header is being sent if not necessary
rather than sending back a random Etag header

<!-- ************************** IMPORTANT ************************* -->
<!-- ** Continuous Deployment is enabled for this repository     ** -->
<!-- ** Merging into master = deploying to PROD                  ** -->
<!-- **                                                          ** -->
<!-- ** Use Riff-Raff to deploy/test a PR on CODE before merging ** -->
<!-- ************************************************************** -->

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
