### PR TITLE
New contributions / membership campaign on brexit

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -42,6 +42,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-brexit",
+    "Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles",
+    owners = Seq(Owner.withGithub("alexduf")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 3, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-contributions-epic-always-ask-strategy",
     "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
     owners = Seq(Owner.withGithub("Mullefa")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -9,10 +9,15 @@ define([
         name: 'ContributionsEpicAlwaysAskStrategy',
         variants: ['alwaysAsk']
     };
+    var ContributionsEpicBrexit = {
+        name: 'ContributionsEpicBrexit',
+        variants: ['control']
+    };
 
     function userIsInAClashingAbTest() {
         var clashingTests = [
-            ContributionsEpicAlwaysAskStrategy
+            ContributionsEpicAlwaysAskStrategy,
+            ContributionsEpicBrexit
         ];
         return _testABClash(ab.isInVariant, clashingTests);
     }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,6 +10,7 @@ define([
     'common/modules/experiments/tests/editorial-email-variants',
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/membership-engagement-banner-tests',
+    'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy'
 ], function (reportError,
              config,
@@ -22,11 +23,13 @@ define([
              EditorialEmailVariants,
              RecommendedForYou,
              MembershipEngagementBannerTests,
+             ContributionsEpicBrexit,
              ContributionsEpicAlwaysAskStrategy
     ) {
     var TESTS = [
         new EditorialEmailVariants(),
         new RecommendedForYou(),
+        new ContributionsEpicBrexit,
         new ContributionsEpicAlwaysAskStrategy
     ].concat(MembershipEngagementBannerTests);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -1,0 +1,56 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicBrexit',
+        campaignId: 'epic_brexit_2017_01',
+
+        start: '2017-01-06',
+        expiry: '2017-03-01',
+
+        author: 'Alex Dufournet',
+        description: 'Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'The conversion rate is equal or above what we have observed on other campaigns',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+        useTargetingTool: true,
+
+        overrideCanRun: true,
+        canRun: function () {
+            return !contributionsUtilities.inAlwaysAskTest()
+        },
+
+        variants: [
+            {
+                id: 'control',
+
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+
+                insertBeforeSelector: '.submeta',
+
+                successOnView: true
+            }
+        ]
+    });
+});


### PR DESCRIPTION
## What does this change?
Adds a new contribution / membership campaign running against brexit content

## What is the value of this and can you measure success?
💰 and measuring the conversion rate

## Does this affect other platforms - Amp, Apps, etc?
no
@guardian/contributions @guardian/guardian-frontend 