### PR TITLE
Use LinkTo for redirecting to https

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -148,12 +148,12 @@ class ArchiveController(redirects: RedirectService) extends Controller with Logg
     }
   }
 
-  private def lookupPath(path: String) = destinationFor(path).map{ _.flatMap(processLookupDestination(path).lift) }
+  private def lookupPath(path: String)(implicit request: RequestHeader) = destinationFor(path).map{ _.flatMap(processLookupDestination(path).lift) }
 
-  def processLookupDestination(path: String) : PartialFunction[Destination, CacheableResult] = {
+  def processLookupDestination(path: String)(implicit request: RequestHeader) : PartialFunction[Destination, CacheableResult] = {
       case PermanentRedirect(_, location) if !linksToItself(path, location) =>
         val locationWithCampaign = retainShortUrlCampaign(path, location)
-        WithoutRevalidationResult(Redirect(locationWithCampaign, redirectHttpStatus))
+        WithoutRevalidationResult(Redirect(LinkTo(locationWithCampaign), redirectHttpStatus))
       case ArchiveRedirect(_, archivePath) =>
         // http://wiki.nginx.org/X-accel
         WithoutRevalidationResult(Ok.withHeaders("X-Accel-Redirect" -> s"/s3-archive/$archivePath"))

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -214,7 +214,7 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
     // The archive x-accel goes to s3. So it is irrelevant whether the original path looks like the s3 archive path.
     val path = "http://www.theguardian.com/redirect/path-to-content"
     val databaseSaysArchive = ArchiveRedirect("any", path)
-    val result = archiveController.processLookupDestination(path).lift(databaseSaysArchive)
+    val result = archiveController.processLookupDestination(path)(TestRequest()).lift(databaseSaysArchive)
     result.map(_.toString).getOrElse("") should include (s"""X-Accel-Redirect -> /s3-archive/$path""")
   }
 


### PR DESCRIPTION
## What does this change?
Makes sure that even redirects explicitly to `http://www.theguardian.com/...` are sent to `https` instead.  Links anywhere else should be unaffected.

## What is the value of this and can you measure success?
Less redirects for users as they will go straight to `https`.
