### PR TITLE
New header variant six. Secondary Nav only on fronts

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -39,7 +39,7 @@
                 @fragments.guBand()
             }
 
-            @if(!mvt.ABNewNavVariantFour.isParticipating) {
+            @if(!mvt.ABNewNavVariantSix.isParticipating) {
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
                 @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
@@ -70,7 +70,7 @@
                             @fragments.mainMedia(article, amp)
                         }
 
-                        @if(mvt.ABNewNavVariantFour.isParticipating) {
+                        @if(mvt.ABNewNavVariantSix.isParticipating) {
                             <div class="mobile-only">
                                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
                             </div>

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -17,14 +17,14 @@ import conf.switches.Switches.ServerSideTests
 // }
 
 
-object ABNewNavVariantFour extends TestDefinition(
-  name = "ab-new-nav-variant-four",
-  description = "users in this test will see the new header fourth variant",
+object ABNewNavVariantSix extends TestDefinition(
+  name = "ab-new-nav-variant-six",
+  description = "users in this test will see the new header sixth variant",
   owners = Seq(Owner.withGithub("natalialkb")),
   sellByDate = new LocalDate(2017, 2, 8)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variantfour")
+    request.headers.get("X-GU-ab-new-header").contains("variantsix")
   }
 }
 
@@ -85,7 +85,7 @@ trait ServerSideABTests {
 
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
-    ABNewNavVariantFour,
+    ABNewNavVariantSix,
     ABNewNavControl,
     CommercialClientLoggingVariant,
     WebpackTest,

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariantFour.isParticipating) {hide-on-mobile}">
+                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariantSix.isParticipating) {hide-on-mobile}">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,11 +4,11 @@
 @import conf.Configuration
 @import conf.switches.Switches._
 
-@if(mvt.ABNewNavVariantFour.isParticipating) {
+@if(mvt.ABNewNavVariantSix.isParticipating) {
     @fragments.newHeader(page)
 }
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantFour.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantSix.isParticipating) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -107,7 +107,7 @@
 @caption(picture: model.ImageMedia, imageOption: Option[ImageAsset], isMain: Boolean) = {
     @imageOption.map { img =>
         @if(img.showCaption) {
-            @if(isMain && mvt.ABNewNavVariantFour.isParticipating) {
+            @if(isMain && mvt.ABNewNavVariantSix.isParticipating) {
 
                 <input type="checkbox" id="show-caption" class="mobile-only u-h">
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,7 +1,6 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
-@import common.{LinkTo, NewNavigation, NavLink, Edition}
-@import views.support.RenderClasses
+@import common.{LinkTo, NewNavigation, Edition}
 
 <header class="new-header" role="banner">
     @defining(
@@ -17,7 +16,7 @@
 
             <nav class="new-header__nav" data-component="nav2">
                 @NewNavigation.PrimaryLinks.map { link =>
-                    <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
+                    <a class="new-header__nav__link @if(link.title == currentTopLevelSection && page.metadata.isFront) {section-indicator}"
                         href="@LinkTo(link.url)"
                         data-link-name="nav2 : primary : @link.title">
                         @link.title
@@ -36,10 +35,11 @@
             </nav>
         </div>
 
-        <div class="tertiary-container">
+        @if(page.metadata.isFront) {
+
+            <div class="tertiary-container">
             <ul class="tertiary-navigation">
 
-                @if(page.metadata.isFront) {
                     @defining(
                         if(page.metadata.sectionId.isEmpty || page.metadata.isFront) page.metadata.id else page.metadata.sectionId
                     ) { id =>
@@ -53,16 +53,17 @@
                             </li>
                         }
                     }
-                }
-                @sections.map { link =>
-                    <li class="tertiary-navigation__item @if((link.uniqueSection == page.metadata.sectionId) && !page.metadata.isFront){tertiary-navigation__item--current-section}">
-                        <a class="tertiary-navigation__link" href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @link.title">
-                        @Html(link.title)
-                        </a>
-                    </li>
-                }
-            </ul>
-        </div>
+                    @sections.map { link =>
+                        <li class="tertiary-navigation__item @if((link.uniqueSection == page.metadata.sectionId) && !page.metadata.isFront){tertiary-navigation__item--current-section}">
+                            <a class="tertiary-navigation__link" href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @link.title">
+                                @Html(link.title)
+                            </a>
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
+
     }
 
 </header>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -39,7 +39,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
-            ("has-new-header", mvt.ABNewNavVariantFour.isParticipating),
+            ("has-new-header", mvt.ABNewNavVariantSix.isParticipating),
             ("is-immersive", getContent(page).exists(_.content.isImmersive)),
             ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">


### PR DESCRIPTION
## What does this change?

Good news: variant four was successful (the data showed it performed well)

Bad news: It looks too heavy and is too big on mobile.

Conclusion:
Lets only have the secondary nav (the grey part) on fronts, where they are needed more.

<img src="https://cloud.githubusercontent.com/assets/8774970/21766236/1937194a-d665-11e6-97f4-f457bff67659.png" width="400px">

Corresponding Fastly change here: https://github.com/guardian/fastly-edge-cache/pull/734

## What is the value of this and can you measure success?
In the end this redesign was successful, but we still are tweaking to make sure we are happy to put it out to everyone. Keep your eye out for more tweaks ahead.

## Does this affect other platforms - Amp, Apps, etc?
Nope


@guardian/dotcom-platform 
