### PR TITLE
Extending recommendations a/b test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
     "Test personalised container on fronts",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 10),
+    sellByDate = new LocalDate(2017, 2, 21),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -38,7 +38,7 @@ define([
     return function () {
         this.id = 'RecommendedForYouRecommendations';
         this.start = '2016-08-02';
-        this.expiry = '2017-01-18';
+        this.expiry = '2017-02-21';
         this.author = 'Joseph Smith';
         this.description = 'Add a personalised container to fronts';
         this.audience = 0;


### PR DESCRIPTION
## What does this change?

Extends the recommendations a/b test

## What is the value of this and can you measure success?

We haven't run this test yet, so aren't ready for it to expire.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
