### PR TITLE
Extend Webpack test by a month

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -54,7 +54,7 @@ object WebpackTest extends TestDefinition(
   name = "ab-webpack-bundle",
   description = "for users in this test, website will serve standard JavaScript that has been bundled by Webpack",
   owners = Seq(Owner.withGithub("siadcock")),
-  sellByDate = new LocalDate(2017, 1, 9)
+  sellByDate = new LocalDate(2017, 2, 13)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-webpack-bundle").contains("webpack")
@@ -65,7 +65,7 @@ object WebpackControl extends TestDefinition(
   name = "ab-webpack-bundle-control",
   description = "control for Webpack test",
   owners = Seq(Owner.withGithub("siadcock")),
-  sellByDate = new LocalDate(2017, 1, 9)
+  sellByDate = new LocalDate(2017, 2, 13)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-webpack-bundle").contains("control")


### PR DESCRIPTION
## What does this change?

Extends the Webpack test by one month as the migration continues

## What is the value of this and can you measure success?

There is an outstanding issue with Webpack-bundled code, with page views reporting slightly lower than those in the control. We need more time to look into this, and also continue to migrate the entire application over to Webpack.

## Does this affect other platforms - Amp, Apps, etc?

Noo

@guardian/dotcom-platform 