### PR TITLE
Lift the first child into an option to prevent 500 if none exist

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -106,7 +106,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
         }
 
         child.wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
-      };
+      }
     }
 
     cleanVideo(document)

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -96,16 +96,17 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
       element.getElementsByClass("gu-video").isEmpty
     }.foreach { element: Element =>
       val canonicalUrl = element.attr("data-canonical-url")
+      element.children().lift(0).map(child => {
+        // As Facebook have declared that you have to use their video JS plugin, which in turn pulls in their whole JS API
+        // We've decided to use the canonical URL, and create the video element here rather that CAPI, as, if it changes
+        // again, we can change it here and it will also fix things retrospectively.
+        if (canonicalUrl.startsWith("https://www.facebook.com")) {
+          val facebookUrl = facebookVideoEmbedUrlFor(element.attr("data-canonical-url"))
+          child.attr("src", facebookUrl)
+        }
 
-      // As Facebook have declared that you have to use their video JS plugin, which in turn pulls in their whole JS API
-      // We've decided to use the canonical URL, and create the video element here rather that CAPI, as, if it changes
-      // again, we can change it here and it will also fix things retrospectively.
-      if (canonicalUrl.startsWith("https://www.facebook.com")) {
-        val facebookUrl = facebookVideoEmbedUrlFor(element.attr("data-canonical-url"))
-        element.child(0).attr("src", facebookUrl)
-      }
-
-      element.child(0).wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
+        child.wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
+      });
     }
 
     cleanVideo(document)

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -96,7 +96,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
       element.getElementsByClass("gu-video").isEmpty
     }.foreach { element: Element =>
       val canonicalUrl = element.attr("data-canonical-url")
-      element.children().lift(0).map(child => {
+      element.children().headOption.foreach { child =>
         // As Facebook have declared that you have to use their video JS plugin, which in turn pulls in their whole JS API
         // We've decided to use the canonical URL, and create the video element here rather that CAPI, as, if it changes
         // again, we can change it here and it will also fix things retrospectively.
@@ -106,7 +106,7 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
         }
 
         child.wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
-      });
+      };
     }
 
     cleanVideo(document)


### PR DESCRIPTION
Easier to see changes with https://github.com/guardian/frontend/pull/15506/files?w=0

## What does this change?

Probably not anything as it's not possible to cause this error anymore in composer *but* fixes it historic screw ups I guess:

"Unlikely there is an existing example of this any more, as we should have fixed the one that was broken. Essentially we need to make the child array access safe in L98-101 of VideoEmbedCleaner - just in case a video is embedded in such a way that there is no child element of an "element-video"."

## What is the value of this and can you measure success?

Bug fix, moves a Trello card to Done.