### PR TITLE
Sharecount improvements

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -45,6 +45,8 @@ GET        /index/contributors/*contributor                                     
 GET        /embed/video/*path                                                   controllers.EmbedController.render(path)
 GET        /embed/atom/media/:id                                                controllers.MediaAtomEmbedController.render(id)
 
+# Share counts
+GET        /sharecount/*path.json                                               controllers.ShareCountController.fetch(path)
 
 # Preferences
 GET        /preferences                                                         controllers.PreferencesController.indexPrefs()
@@ -111,6 +113,3 @@ GET        /$leftSide<[^+]+>+*rightSide                                         
 
 # Google site verification
 GET        /google$account<[\w\d-]*>.html                                       controllers.SiteVerificationController.googleSiteVerify(account)
-
-# Share counts
-GET        /sharecount/*path.json                                               controllers.ShareCountController.fetch(path)

--- a/applications/test/helpers/FacebookGraphApiTestClient.scala
+++ b/applications/test/helpers/FacebookGraphApiTestClient.scala
@@ -7,6 +7,8 @@ import play.api.libs.ws.WSClient
 import recorder.DefaultHttpRecorder
 import services.FacebookGraphApiClient
 
+import scala.concurrent.duration.Duration
+
 
 class FacebookGraphApiTestClient(wsClient: WSClient) extends FacebookGraphApiClient(wsClient) {
 
@@ -14,11 +16,11 @@ class FacebookGraphApiTestClient(wsClient: WSClient) extends FacebookGraphApiCli
     override lazy val baseDir = new File(System.getProperty("user.dir"), "data/facebook-graph-api")
   }
 
-  override def GET(endpoint: Option[String], params: (String, String)*) = {
+  override def GET(endpoint: Option[String], timeout: Duration, params: (String, String)*) = {
     val queryString = params.map({ case (key, value) => key + "=" + URLEncoder.encode(value, "UTF-8")}).mkString("&")
 
     recorder.load(s"${makeUrl(endpoint)}?$queryString", Map.empty) {
-      super.GET(endpoint, params: _*)
+      super.GET(endpoint, timeout, params: _*)
     }
   }
 }

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -22,7 +22,7 @@ object CacheTime {
   object RecentlyUpdated extends CacheTime(60)
   object Facia extends CacheTime(300)
   object ArchiveRedirect extends CacheTime(300)
-  object ShareCount extends CacheTime(300)
+  object ShareCount extends CacheTime(600)
   object NotFound extends CacheTime(10) // This will be overwritten by fastly
 
   def LastDayUpdated = CacheTime(extended(60))


### PR DESCRIPTION
## What does this change?
Includes a few improvements for the new share count endpoint after reviewing performance in `PROD`.  Adds:

- A timeout for calls to the graph API - I looked at the request latency for the last few days and 1 second seems about right
- Doubled cache length to 10 minutes to make sure we don't put too much extra load on `applications`
- Specific logging for failures
- Bumps up the route for `/sharecount` so it doesn't clash with others in `applications`

## What is the value of this and can you measure success?
Fixes sharecounts on content with video/audio in the url and avoids increased latency caused by the graph API

## Does this affect other platforms - Amp, Apps, etc?
No
