### PR TITLE
Make sure captions show on showcase videos

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -39,7 +39,9 @@ $ima-controls-height: 70px;
 .element-video {
     position: relative;
     // Force this container to wrap around the floated rich link
-    overflow: hidden;
+    &:not(.element--showcase) {
+        overflow: hidden;
+    }
 }
 
 .gu-video-embed-html {


### PR DESCRIPTION
## What does this change?

Adds an exception to overflow styles for showcase videos to make sure they show the caption. The `overflow: hidden` is there because without it, videos wrap below supporting rich-links but a showcase video is never required to *not* wrap below as it is full width.

## What is the value of this and can you measure success?

Show captions for showcase videos.

## Screenshots

### Before

![screen shot 2017-01-09 at 17 02 27](https://cloud.githubusercontent.com/assets/638051/21775421/ea95f038-d68d-11e6-87ac-409bee434230.jpg)

### After

![screen shot 2017-01-09 at 17 01 25](https://cloud.githubusercontent.com/assets/638051/21775424/ef4a8a30-d68d-11e6-9552-a37b15655299.jpg)
