### PR TITLE
Ensuring people can opt in to variant six new header

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -29,16 +29,12 @@ class OptInController extends Controller {
 
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
-      case "headerthree" => headerThree.opt(choice)
-      case "headerfour" => headerFour.opt(choice)
-      case "headerfive" => headerFive.opt(choice)
+      case "headersix" => headerSix.opt(choice)
       case "webpack" => webpack.opt(choice)
       case _ => NotFound
     }))
   }
 
-  val headerThree = OptInFeature("new_header_three_opt_in")
-  val headerFour = OptInFeature("new_header_four_opt_in")
-  val headerFive = OptInFeature("new_header_five_opt_in")
+  val headerSix = OptInFeature("new_header_six_opt_in")
   val webpack = OptInFeature("webpack_opt_in")
 }


### PR DESCRIPTION
## What does this change?
Follow on from #15501. People should be able to opt in to the new header!

Fastly change here: https://github.com/guardian/fastly-edge-cache/pull/735

@stephanfowler @zeftilldeath 

## What is the value of this and can you measure success?
Makes it easier to test, and easier to show people in the building what we are working on.

## Does this affect other platforms - Amp, Apps, etc?
No
