### PR TITLE
playable youtube media atoms on fronts

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -24,13 +24,14 @@ object FaciaContentFrontendHelpers {
       imageOverride.orElse(defaultTrailPicture)
     }
 
-    def mainVideoAtom: Option[MediaAtom] =
+    def mainYouTubeMediaAtom: Option[MediaAtom] =
       for {
        main <- faciaContent.properties.maybeContent.map(_.fields.main)
        atoms <-  faciaContent.properties.maybeContent.flatMap(_.atoms)
        document <- Some(Jsoup.parse(main))
-       atomContainer <- Some(document.getElementsByClass("element-atom").first())
+       atomContainer <- Option(document.getElementsByClass("element-atom").first())
        bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
+       youTubeIframe <- Option(bodyElement.select("iframe[src^=https://www.youtube.com]").first())
        atomId <- Some(bodyElement.attr("data-atom-id"))
        mainMediaAtom <- atoms.media.find(_.id == atomId)
      } yield mainMediaAtom

--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -24,6 +24,8 @@ object FaciaContentFrontendHelpers {
       imageOverride.orElse(defaultTrailPicture)
     }
 
+
+    //TODO: Use the blocks field of CAPI to derive this in a more structured way
     def mainYouTubeMediaAtom: Option[MediaAtom] =
       for {
        main <- faciaContent.properties.maybeContent.map(_.fields.main)

--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -4,8 +4,10 @@ import common.Edition
 import common.commercial.PaidContent
 import implicits.Dates._
 import model._
+import model.content.MediaAtom
 import model.pressed._
 import org.joda.time.DateTime
+import org.jsoup.Jsoup
 import org.scala_tools.time.Imports._
 
 import scala.util.Try
@@ -21,6 +23,18 @@ object FaciaContentFrontendHelpers {
       val defaultTrailPicture = faciaContent.properties.maybeContent.flatMap(_.trail.trailPicture)
       imageOverride.orElse(defaultTrailPicture)
     }
+
+    def mainVideoAtom: Option[MediaAtom] =
+      for {
+       main <- faciaContent.properties.maybeContent.map(_.fields.main)
+       atoms <-  faciaContent.properties.maybeContent.flatMap(_.atoms)
+       document <- Some(Jsoup.parse(main))
+       atomContainer <- Some(document.getElementsByClass("element-atom").first())
+       bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
+       atomId <- Some(bodyElement.attr("data-atom-id"))
+       mainMediaAtom <- atoms.media.find(_.id == atomId)
+     } yield mainMediaAtom
+
 
     def mainVideo: Option[VideoElement] = {
       val elements: Seq[Element] = faciaContent.properties.maybeContent.map(_.elements.elements).getOrElse(Nil)

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -277,6 +277,7 @@ case class ContentCard(
 
   def hasImage = displayElement match {
     case Some(InlineVideo(_, _, _, Some(_))) => true
+    case Some(InlineYouTubeMediaAtom(_)) => true
     case Some(InlineImage(_)) => true
     case Some(InlineSlideshow(_)) => true
     case Some(CrosswordSvg(_)) => true
@@ -304,6 +305,7 @@ case class ContentCard(
 
   val hasVideoMainMedia = displayElement match {
     case Some(a: InlineVideo) if !isMediaLink => true
+    case Some(a: InlineYouTubeMediaAtom) if !isMediaLink => true
     case _ => false
   }
 }

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -6,6 +6,7 @@ import implicits.FaciaContentFrontendHelpers._
 import layout.ItemClasses
 import model.pressed.PressedContent
 import com.gu.contentapi.client.model.{v1 => contentapi}
+import model.content.MediaAtom
 
 object FaciaDisplayElement {
   def fromFaciaContentAndCardType(faciaContent: PressedContent, itemClasses: ItemClasses): Option[FaciaDisplayElement] = {
@@ -21,8 +22,8 @@ object FaciaDisplayElement {
         faciaContent.properties.maybeContentId map CrosswordSvg
       case _ if faciaContent.properties.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
-      case _ if faciaContent.mainVideoAtom.isDefined =>
-        println("IN MAIN VIDEO ATOM"); None
+      case _ if faciaContent.properties.showMainVideo && faciaContent.mainVideoAtom.isDefined  =>
+        Some(InlineYouTubeMediaAtom(faciaContent.mainVideoAtom.get))
       case _ => InlineImage.fromFaciaContent(faciaContent)
     }
   }
@@ -62,6 +63,8 @@ case class InlineVideo(
   endSlatePath: String,
   fallBack: Option[InlineImage]
 ) extends FaciaDisplayElement
+
+case class InlineYouTubeMediaAtom(youTubeAtom: MediaAtom) extends FaciaDisplayElement
 
 object InlineImage {
   def fromFaciaContent(faciaContent: PressedContent): Option[InlineImage] =

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -21,6 +21,8 @@ object FaciaDisplayElement {
         faciaContent.properties.maybeContentId map CrosswordSvg
       case _ if faciaContent.properties.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
+      case _ if faciaContent.mainVideoAtom.isDefined =>
+        println("IN MAIN VIDEO ATOM"); None
       case _ => InlineImage.fromFaciaContent(faciaContent)
     }
   }

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -22,8 +22,8 @@ object FaciaDisplayElement {
         faciaContent.properties.maybeContentId map CrosswordSvg
       case _ if faciaContent.properties.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
-      case _ if faciaContent.properties.showMainVideo && faciaContent.mainVideoAtom.isDefined  =>
-        Some(InlineYouTubeMediaAtom(faciaContent.mainVideoAtom.get))
+      case _ if faciaContent.properties.showMainVideo && faciaContent.mainYouTubeMediaAtom.isDefined  =>
+        Some(InlineYouTubeMediaAtom(faciaContent.mainYouTubeMediaAtom.get))
       case _ => InlineImage.fromFaciaContent(faciaContent)
     }
   }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -28,6 +28,7 @@ sealed trait ContentType {
   final def tags: Tags = content.tags
   final def elements: Elements = content.elements
   final def fields: Fields = content.fields
+  final def atoms: Option[Atoms] = content.atoms
   final def trail: Trail = content.trail
   final def metadata: MetaData = content.metadata
   final def commercial: Commercial = content.commercial

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -89,7 +89,11 @@ data-test-id="facia-card"
             }
 
             case Some(media@InlineYouTubeMediaAtom(_)) => {
-                @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false)
+                <div class="fc-item__media-wrapper">
+                    <div class="fc-item__video-container">
+                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false)
+                    </div>
+                </div>
             }
 
             case Some(InlineVideo(_, _, _, Some(fallbackImage))) => {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -1,10 +1,11 @@
 @(item: layout.ContentCard, containerIndex: Int, index: Int, visibilityDataAttribute: String, isFirstContainer: Boolean, isList: Boolean)(implicit request: RequestHeader)
 
 @import layout.{FaciaWidths, FrontendLatestSnap}
-@import model.{CrosswordSvg, InlineImage, InlineSlideshow, InlineVideo, VideoPlayer}
+@import model.{CrosswordSvg, InlineImage, InlineSlideshow, InlineVideo, InlineYouTubeMediaAtom, VideoPlayer}
 @import views.html.fragments.items.elements.facia_cards._
 @import views.html.fragments.items.elements.starRating
 @import views.html.fragments.items.facia_cards.meta
+@import views.html.fragments.atoms.youtube
 @import views.html.fragments.media.video
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 
@@ -76,13 +77,19 @@ data-test-id="facia-card"
                 }
             }
 
-            case Some(svg@CrosswordSvg(_)) => {
+
+
+           case Some(svg@CrosswordSvg(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
                         <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img" alt=""
                         role="presentation" data-crossword-id="@svg.persistenceId" ></object>
                     </div>
                 </div>
+            }
+
+            case Some(media@InlineYouTubeMediaAtom(_)) => {
+                @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false)
             }
 
             case Some(InlineVideo(_, _, _, Some(fallbackImage))) => {

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -98,7 +98,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
     adjustSearchQuery: AdjustSearchQuery = identity,
     adjustSnapItemQuery: AdjustItemQuery = identity): Response[List[PressedContent]]
 
-  val showFields = "body,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalPageCode"
+  val showFields = "body,trailText,headline,shortUrl,liveBloggingNow,thumbnail,commentable,commentCloseDate,shouldHideAdverts,lastModified,byline,standfirst,starRating,showInRelatedContent,internalPageCode,main"
   val searchApiQuery: AdjustSearchQuery = (searchQuery: SearchQuery) =>
     searchQuery
       .showSection(true)
@@ -106,6 +106,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
       .showElements("all")
       .showTags("all")
       .showReferences(QueryDefaults.references)
+      .showAtoms("media")
 
   val itemApiQuery: AdjustItemQuery = (itemQuery: ItemQuery) =>
     itemQuery
@@ -114,6 +115,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
       .showElements("all")
       .showTags("all")
       .showReferences(QueryDefaults.references)
+      .showAtoms("media")
 
   def generateCollectionJsonFromFapiClient(collectionId: String): Response[PressedCollection] =
     for {
@@ -274,6 +276,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
       // It is safe to do so because the trail picture is held in trailPicture in the Trail class.
       val slimElements = Elements.apply(content.elements.mainVideo.toList)
       val slimFields = content.fields.copy(body = HTML.takeFirstNElements(content.fields.body, 2), blocks = None)
+      val slimAtoms = content.atoms
 
       // Clear the config fields, because they are not used by facia. That is, the config of
       // an individual card is not used to render a facia front page.
@@ -282,7 +285,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
         opengraphPropertiesOverrides = Map(),
         twitterPropertiesOverrides = Map())
 
-      val slimContent = content.content.copy(metadata = slimMetadata, elements = slimElements, fields = slimFields)
+      val slimContent = content.content.copy(metadata = slimMetadata, elements = slimElements, fields = slimFields, atoms = slimAtoms)
 
       content match {
         case article: Article => article.copy(content = slimContent)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,6 @@ object Dependencies {
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
   val faciaVersion = "2.0.8"
-
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"
   val apacheCommonsMath3 = "org.apache.commons" % "commons-math3" % "3.2"

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -16,6 +16,7 @@
 @import 'module/_submeta';
 @import 'layout/_footer';
 @import 'module/content/_media-player';
+@import 'module/atoms/_youtube';
 @import 'module/commercial/_commercial';
 @import 'module/crosswords/_main';
 @import 'module/email/_main';

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -426,3 +426,16 @@ $video-width-desktop: 700px;
     bottom: 2px;
     color: $neutral-3;
 }
+
+.fc-item__video-container {
+    .youtube-media-atom {
+        z-index: 1;
+    }
+
+    .youtube-media-atom__iframe:not(.youtube__video-ready) {
+        ~ .youtube-media-atom__overlay {
+            visibility: hidden;
+            opacity: 0;       
+        }
+    }
+}

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -434,8 +434,7 @@ $video-width-desktop: 700px;
 
     .youtube-media-atom__iframe:not(.youtube__video-ready) {
         ~ .youtube-media-atom__overlay {
-            visibility: hidden;
-            opacity: 0;       
+            visibility: hidden;      
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -206,6 +206,19 @@ $fc-item-gutter: $gs-gutter / 4;
         .u-faux-block-link__cta {
             text-decoration: none;
         }
+
+        .fc-item__video-container {
+            .youtube-media-atom__overlay::before {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                bottom: 0;
+                right: 0;
+                background-color: #000000;
+                opacity: .1;
+            }
+        }
     }
 
     // This is a temp fix until we completely remove tone-colour from fc-item

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -197,27 +197,14 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     .u-faux-block-link--hover {
+        .youtube-media-atom,
         .fc-item__image-container {
             background-color: #000000;
-
             opacity: .9;
         }
 
         .u-faux-block-link__cta {
             text-decoration: none;
-        }
-
-        .fc-item__video-container {
-            .youtube-media-atom__overlay::before {
-                content: '';
-                position: absolute;
-                top: 0;
-                left: 0;
-                bottom: 0;
-                right: 0;
-                background-color: #000000;
-                opacity: .1;
-            }
         }
     }
 


### PR DESCRIPTION
<!-- ************************** IMPORTANT ************************* -->
<!-- ** Continuous Deployment is enabled for this repository     ** -->
<!-- ** Merging into master = deploying to PROD                  ** -->
<!-- **                                                          ** -->
<!-- ** Use Riff-Raff to deploy/test a PR on CODE before merging ** -->
<!-- ************************************************************** -->

## What does this change?
Adds support for playable youtube media atoms on fronts, when the *show video* option has been selected in facia-tool.

## What is the value of this and can you measure success?
Required for YouTube PFP trial feature parity.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-01-09 at 17 19 33](https://cloud.githubusercontent.com/assets/1764158/21775896/de70b67e-d68f-11e6-9a69-ef2ddd2eb62a.png)


<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
