### PR TITLE
Only serve email fronts if ?format=email

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -1,6 +1,6 @@
 package jobs
 
-import com.gu.facia.api.models.{CommercialPriority, EditorialPriority, TrainingPriority}
+import com.gu.facia.api.models.{CommercialPriority, EditorialPriority, EmailPriority, TrainingPriority}
 import common.{AkkaAsync, ExecutionContexts, Logging}
 import conf.Configuration
 import services.{ConfigAgent, FrontPressNotification}
@@ -29,6 +29,7 @@ object RefreshFrontsJob extends Logging with ExecutionContexts {
         case Some(EditorialPriority) => StandardFrequency
         case Some(CommercialPriority) => LowFrequency
         case Some(TrainingPriority) => LowFrequency
+        case Some(EmailPriority) => LowFrequency
         case None => LowFrequency
       }
   }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -499,17 +499,6 @@ trait FeatureSwitches {
   )
 
   // Owner: Joseph Smith
-  val DisplayHiddenFrontsAsEmails = Switch(
-    SwitchGroup.Feature,
-    "display-hidden-fronts-as-emails",
-    "Allows hidden fronts to be rendered as email-friendly HTML by passing ?format=email",
-    owners = Seq(Owner.withGithub("joelochlann")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 10),
-    exposeClientSide = true
-  )
-
-  // Owner: Joseph Smith
   val RenderEmailConnectedStyle = Switch(
     SwitchGroup.Feature,
     "render-email-connected-style",

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -113,6 +113,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
         _.priority match {
           case Some("commercial") => CommercialPriority
           case Some("training") => TrainingPriority
+          case Some("email") => EmailPriority
           case _ => EditorialPriority
         }
       }

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -136,6 +136,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   def isEmailFront(id: String): Boolean =
     getFrontPriorityFromConfig(id).contains(EmailPriority)
 
+  // email fronts are only served if the email-friendly format has been specified in the request
   def shouldServeFront(id: String, isEmailRequest: Boolean = false)(implicit context: ApplicationContext) = getPathIds.contains(id) &&
     (context.isPreview || !isFrontHidden(id)) && (isEmailRequest || !isEmailFront(id))
 

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -2,9 +2,8 @@ package services
 
 import akka.util.Timeout
 import app.LifecycleComponent
-import com.gu.facia.api.models._
+import com.gu.facia.api.models.{Front, _}
 import com.gu.facia.client.ApiClient
-import com.gu.facia.api.models.Front
 import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common._
 import conf.Configuration
@@ -13,11 +12,9 @@ import model.pressed.CollectionConfig
 import model.{ApplicationContext, FrontProperties, SeoDataJson}
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.Json
-import play.api.mvc._
-import conf.switches.Switches
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 case class CollectionConfigWithId(id: String, config: CollectionConfig)

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -1,0 +1,127 @@
+package services
+
+import com.gu.facia.client.models.{Branded, CollectionConfigJson, ConfigJson, FrontJson}
+import model.{ApplicationContext, ApplicationIdentity}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.Environment
+import test.WithTestContext
+
+class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
+
+  val fronts = ConfigJson(
+    Map(
+      "email-front" -> FrontJson(
+        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        navSection = None,
+        webTitle = None,
+        title = None,
+        description = None,
+        onPageDescription = None,
+        imageUrl = None,
+        imageWidth = None,
+        imageHeight = None,
+        isImageDisplayed = None,
+        priority = Some("email"),
+        isHidden = None,
+        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        group = Some("US professional")
+      ),
+      "hidden-email-front" -> FrontJson(
+        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        navSection = None,
+        webTitle = None,
+        title = None,
+        description = None,
+        onPageDescription = None,
+        imageUrl = None,
+        imageWidth = None,
+        imageHeight = None,
+        isImageDisplayed = None,
+        priority = Some("email"),
+        isHidden = Some(true),
+        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        group = Some("US professional")
+      ),
+      "editorial-front" -> FrontJson(
+        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        navSection = None,
+        webTitle = None,
+        title = None,
+        description = None,
+        onPageDescription = None,
+        imageUrl = None,
+        imageWidth = None,
+        imageHeight = None,
+        isImageDisplayed = None,
+        priority = Some("editorial"),
+        isHidden = None,
+        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        group = Some("US professional")
+      ),
+      "hidden-editorial-front" -> FrontJson(
+        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        navSection = None,
+        webTitle = None,
+        title = None,
+        description = None,
+        onPageDescription = None,
+        imageUrl = None,
+        imageWidth = None,
+        imageHeight = None,
+        isImageDisplayed = None,
+        priority = Some("editorial"),
+        isHidden = Some(true),
+        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
+        group = Some("US professional")
+      )
+    ),
+    Map(
+      "e59785e9-ba82-48d8-b79a-0a80b2f9f808" -> CollectionConfigJson(
+        displayName = Some("sc johnson partner zone"),
+        backfill = None,
+        metadata = Some(List(Branded)),
+        `type` = Some("fixed/large/slow-XIV"),
+        href = None,
+        description = None,
+        groups = None,
+        uneditable = None,
+        showTags = None,
+        showSections = None,
+        hideKickers = None,
+        showDateHeader = None,
+        showLatestUpdate = None,
+        excludeFromRss = None,
+        showTimestamps = None,
+        hideShowMore = None
+      )
+    )
+  )
+
+  ConfigAgent.refreshWith(fronts)
+
+  "shouldServeFront" should "not serve the front if the front is not in the config JSON" in {
+    ConfigAgent.shouldServeFront("nonexistent-front") should be(false)
+  }
+
+  it should "not serve a hidden editorial front" in {
+    ConfigAgent.shouldServeFront("hidden-editorial-front") should be(false)
+  }
+
+  it should "serve a hidden front in preview mode" in {
+    val previewContext = ApplicationContext(Environment.simple(), ApplicationIdentity("preview"))
+    ConfigAgent.shouldServeFront("editorial-front")(previewContext) should be(true)
+  }
+
+  it should "not serve an email front requested as a normal front" in {
+    ConfigAgent.shouldServeFront("email-front") should be(false)
+  }
+
+  it should "serve an email front requested as an email front" in {
+    ConfigAgent.shouldServeFront("email-front", isEmailRequest = true) should be(true)
+  }
+
+  it should "not serve a hidden email front requested as an email front" in {
+    ConfigAgent.shouldServeFront("hidden-email-front", isEmailRequest = true) should be(false)
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
-  val faciaVersion = "2.0.6"
+  val faciaVersion = "2.0.8"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"


### PR DESCRIPTION
Since we now have the notion of email fronts in the [facia tool](https://github.com/guardian/facia-tool/pull/220) and [facia client](https://github.com/guardian/facia-scala-client/pull/180), we can handle them differently in frontend. Because they're not designed for normal viewing on the web, they should only be visible in email-friendly format, i.e. if `format=email` is passed as a parameter. If it's not an email request, email fronts are not served.

This means I was able to get rid of the hack from #15224 and associated switch. So as regards being hidden or not, email fronts behave as other fronts (if they're hidden, they're not visible on the live site in any format).

@guardian/dotcom-platform 

and particularly @TBonnin who had some comments on #15224 - you suggested writing some tests for `shouldServeFront` to document the hacky logic. Do you still feel that's necessary now that the behaviour is saner? If so, advice on the best approach to make this testable would be appreciated, since the `ConfigAgent` is a scheduled Akka agent and it also has a static dependency on a real S3 client

