### PR TITLE
Extend switch for testing two email designs

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -516,7 +516,7 @@ trait FeatureSwitches {
     "Allows alternate email styling when passing ?format=email-connected, for testing two email design variants",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 10),
+    sellByDate = new LocalDate(2017, 1, 24),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Test continues... extending the switch from #15156

@guardian/dotcom-platform 