### PR TITLE
Change screenshots hook to be enabled in ci mode

### DIFF
--- a/tools/__tasks__/screenshot/screenshot.js
+++ b/tools/__tasks__/screenshot/screenshot.js
@@ -19,7 +19,7 @@ const screenshotDefaults = {
         height: 'all',
     },
     timeout: 120000, // We're going to wait two minutes before bailing on the screenshot
-    takeShotOnCallback: environment === 'dev',
+    takeShotOnCallback: environment === 'ci',
 };
 
 // For each path, run a concurrent task that takes a screenshot of each path at each breakpoint


### PR DESCRIPTION
<!-- ************************** IMPORTANT ************************* -->
<!-- ** Continuous Deployment is enabled for this repository     ** -->
<!-- ** Merging into master = deploying to PROD                  ** -->
<!-- **                                                          ** -->
<!-- ** Use Riff-Raff to deploy/test a PR on CODE before merging ** -->
<!-- ************************************************************** -->

## What does this change?

Going to swap the screenshots hook to be on ci instead of dev until I finish off support for fronts.

## What is the value of this and can you measure success?

Makes the screenshots properly load in all the js so they look more like what a user would see.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Yes!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
