### PR TITLE
Update config to v18

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 17
+    val s3ConfigVersion = 18
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/docs/03-dev-howtos/13-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/13-Update-configuration-in-s3.md
@@ -12,27 +12,27 @@ To add or update a configuration item you need to:
 aws s3 ls --profile=frontend s3://aws-frontend-store/config/
 ```
 
-look for the most recent version ( the `v17` part ):
+look for the most recent version ( the `v18` part ):
 
 ```
-2016-08-30 21:52:58      31386 eu-west-1-frontend.v17.conf
+2016-08-30 21:52:58      31386 eu-west-1-frontend.v18.conf
 ```
 
-- Create a new copy of the s3 and bump the version number (change `v17` to `v18` ).
+- Create a new copy of the s3 and bump the version number (change `v18` to `v19` ).
 
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v17.conf s3://aws-frontend-store/config/eu-west-1-frontend.v18.conf
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v18.conf s3://aws-frontend-store/config/eu-west-1-frontend.v19.conf
 ```
 
 -  Download the new file locally:
 ```
-aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v18.conf .
+aws s3 cp --profile=frontend s3://aws-frontend-store/config/eu-west-1-frontend.v19.conf .
 ```
 
 - Make your changes ....
 -- Test them locally by uploading these to s3
 ```
-aws s3 cp --profile=frontend eu-west-1-frontend.v18.conf s3://aws-frontend-store/config/eu-west-1-frontend.v18.conf
+aws s3 cp --profile=frontend eu-west-1-frontend.v19.conf s3://aws-frontend-store/config/eu-west-1-frontend.v19.conf
 ```
 and bump the version number `var s3ConfigVersion` in [/common/app/common/configuration.scala](https://github.com/guardian/frontend/blob/master/common/app/common/configuration.scala) to match the version of the config file you created.
 
@@ -40,7 +40,7 @@ and bump the version number `var s3ConfigVersion` in [/common/app/common/configu
 
 - Delete the local copy once you have finished
 ```
-rm eu-west-1-frontend.v18.conf
+rm eu-west-1-frontend.v19.conf
 ```
 
 - Once your pull request is merged, everything is done!


### PR DESCRIPTION
## What does this change?

There is a domain convention across the department that if preview is found at preview.gutools.co.uk then a code version should be found at preview.code.dev-gutools.co.uk.

Updating preview CODE callback from `https://preview-code.gu-web.net/callback` to `https://preview.code.dev-gutools.co.uk/oauth2callback`