### PR TITLE
AMP alignment

### DIFF
--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -232,7 +232,11 @@
 }
 
 .media-primary {
-    margin: 0 $gs-gutter * -.5;
+    margin: 0 (-$gs-gutter / 2);
+
+    @include mq(mobileLandscape) {
+        margin: 0 (-$gs-gutter);
+    }
 }
 
 // TODO: on amp, shouldn't have this. Or, use amp-lightbox

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -73,7 +73,6 @@ $veggie-burger-medium: 52px;
     // Removes extra spacing
     display: block;
     height: auto;
-    padding-right: $gs-gutter / 2;
 
     // Aspect ratio: 16:3
     @include mq($until: $mobile-medium) {
@@ -91,8 +90,7 @@ $veggie-burger-medium: 52px;
         width: 260px;
         // height: auto doesn't work in Safari
         height: calc(3 / 16 * 260px);
-        padding: ($gs-baseline / 2) ($gs-gutter / 2) 0;
-        margin-right: $gs-gutter / 2;
+        padding-top: $gs-baseline / 2;
     }
 }
 
@@ -119,7 +117,7 @@ $veggie-burger-medium: 52px;
     @include mq(mobileLandscape) {
         font-size: 24px;
         line-height: $gs-baseline * 3.5;
-        margin-left: $gs-gutter / 2;
+        margin-left: 0;
     }
 }
 
@@ -200,7 +198,7 @@ $veggie-burger-medium: 52px;
     }
 
     &:first-child {
-        padding-left: $gs-gutter / 2;
+        padding-left: 0;
     }
 
     &:before {


### PR DESCRIPTION
In a post-refactor world, there were a few wobbly alignments. 

Before:
<img width="332" alt="screen shot 2017-01-10 at 11 48 13" src="https://cloud.githubusercontent.com/assets/14570016/21805227/0739c71c-d72b-11e6-97b2-552a7d3320a9.png">

After:
<img width="333" alt="screen shot 2017-01-10 at 11 47 53" src="https://cloud.githubusercontent.com/assets/14570016/21805228/08a70da8-d72b-11e6-8cad-5a958366bb1f.png">


@NataliaLKB have a 🐑 