### PR TITLE
Add a switch for panic shedding

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -5,6 +5,16 @@ import org.joda.time.LocalDate
 
 trait PerformanceSwitches {
 
+  val PanicSheddingSwitch = Switch(
+    SwitchGroup.Performance,
+    "panic-shedding",
+    "When this switch is on, the Panic Shedding system is enabled which can filter requests under high latency",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val InlineJSStandardOptimisation = Switch(
     SwitchGroup.Performance,
     "inline-standard-optimisation",


### PR DESCRIPTION
This switch allows us to turn off panic shedding. It may allow us to eliminate remnant problems when the panic shedding system is active when we think it shouldn't be.