### PR TITLE
Extend expired comment cache switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -52,7 +52,7 @@ trait PerformanceSwitches {
     "If this switch is on then closed comment threads will get a longer cache time",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 1, 10),
+    sellByDate = new LocalDate(2017, 1, 16),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Extending switch while we work out whether it just needs removing.

@SiAdcock 