### PR TITLE
Use ISO 8601 format in AB test start & expiry, for consistent date parsing across browsers

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -435,6 +435,7 @@ define([
         getTestVariantId: getTestVariantId,
         setTestVariant: setTestVariant,
         getVariant: getVariant,
+        TESTS: TESTS,
 
         /**
          * check if a test can be run (i.e. is not expired and switched on)

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -81,7 +81,7 @@ define([
     };
 
     return [
-        new EditionTest('UK', 'MembershipEngagementBannerUkTest13', '2016-12-22', '2017-1-5', 'gdnwb_copts_mem_banner_uk_banner__')
+        new EditionTest('UK', 'MembershipEngagementBannerUkTest13', '2016-12-22', '2017-01-05', 'gdnwb_copts_mem_banner_uk_banner__')
             .addMembershipVariant('control', {})
             .addMembershipVariant('3_rotating', {messageText: [
                 'We all want to make the world a fairer place. We believe journalism can help – but producing it is expensive. That’s why we need Supporters.',
@@ -89,13 +89,13 @@ define([
                 'Not got round to supporting us yet? If everyone chipped in, our future would be more secure.'
             ]})
             .addMembershipVariant('coffee_95p', {messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for 95p a week.'}),
-        new EditionTest('AU', 'AuMembEngagementMsgCopyTest8', '2016-11-24', '2017-1-5', 'gdnwb_copts_mem_banner_aubanner__')
+        new EditionTest('AU', 'AuMembEngagementMsgCopyTest8', '2016-11-24', '2017-01-05', 'gdnwb_copts_mem_banner_aubanner__')
             .addMembershipVariant('control', {})
             .addMembershipVariant('fearless_10', {messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $10 a month'})
             .addMembershipVariant('stories_that_matter', {messageText: 'We need your help to tell the stories that matter. Support Guardian Australia now'})
             .addMembershipVariant('power_to_account', {messageText: 'We need your help to hold power to account. Become a Guardian Australia supporter'})
             .addMembershipVariant('independent_journalism', {messageText: 'Support quality, independent journalism in Australia by becoming a supporter'})
-        ,new EditionTest('INT', 'MembershipEngagementInternationalExperimentTest12', '2016-12-13', '2017-1-6', 'gdnwb_copts_mem_banner_int_banner__')
+        ,new EditionTest('INT', 'MembershipEngagementInternationalExperimentTest12', '2016-12-13', '2017-01-06', 'gdnwb_copts_mem_banner_int_banner__')
             .addMembershipVariant('control', {})
             .addMembershipVariant('1st_article', {minArticles: 1})
             .addMembershipVariant('3rd_article', {minArticles: 3})

--- a/static/test/javascripts/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab.spec.js
@@ -56,6 +56,17 @@ define([
 
         });
 
+        describe('Start and Expiry dates', function () {
+
+            it('should use Start and Expiry dates in exact ISO 8601 format for consistent parsing across browsers', function () {
+                ab.TESTS.forEach(function(test) {
+                    expect(test.start).toMatch('\\d{4}-\\d{2}-\\d{2}');
+                    expect(test.expiry).toMatch('\\d{4}-\\d{2}-\\d{2}');
+                });
+            });
+
+        });
+
         describe('User segmentation', function () {
 
             it('should not run if switch is off', function () {


### PR DESCRIPTION
## What does this change?

This change adds a test to verify that all start and expiry dates for AB tests conform to strict ISO 8601 date format, ie `yyyy-mm-dd`. It also fixes the engagement banner AB tests which weren't doing this!

## What is the value of this and can you measure success?

We had a bug where AB tests which were _supposed_ to be expired :dagger: :skull:   were **still** being exposed to users, multiple days after expiration - this was happening for literally 50% of our audience.

On checking Google Analytics, all these users were using mobile Safari as their web browser. It turns out Safari does not parse `'2017-1-5'` as a valid date - while other browsers like Chrome do.

You can test the behaviour of your browser here https://jsfiddle.net/165zkx8o/1/

The date-parsing behaviour of browsers is extremely inconsistent, but [all browsers we care about will correctly parse ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Browser_compatibility) if we use the strict format.

![image](https://cloud.githubusercontent.com/assets/52038/21847525/39968104-d7f4-11e6-86e9-ccf8fd959cd2.png)
![image](https://cloud.githubusercontent.com/assets/52038/21847534/4237feaa-d7f4-11e6-93a2-b7bf67a19271.png)


## Does this affect other platforms - Amp, Apps, etc?

Any platform that uses the client-side A/B testing framework.


cc @SiAdcock @rupertbates @JustinPinner @rich-nguyen 