### PR TITLE
autoplay youtube media atoms (under certain conditions)

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -79,30 +79,20 @@ define([
 
     function shouldAutoplay(){
 
-        function isMobile() {
+        function isAutoplayBlockingPlatform() {
             return detect.isIOS() || detect.isAndroid();
         }
 
         function isInternalReferrer() {
-            /**
-             * Polyfill for String.startsWith
-             * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
-             */
-            if (!String.prototype.startsWith) {
-                String.prototype.startsWith = function(searchString, position){
-                    position = position || 0;
-                    return this.substr(position, searchString.length) === searchString;
-                };
-            }
 
             if(config.page.isDev) {
-                return document.referrer.startsWith(window.location.origin);
+                return document.referrer.indexOf(window.location.origin) === 0;
             }
             else {
-                return document.referrer.startsWith(config.page.host);
+                return document.referrer.indexOf(config.page.host) === 0;
             }
         }
-        return config.page.contentType === 'Video' && isInternalReferrer() && !isMobile();
+        return config.page.contentType === 'Video' && isInternalReferrer() && !isAutoplayBlockingPlatform();
     }
 
     function onPlayerReady(atomId, overlay, event) {

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -3,13 +3,15 @@ define([
     'common/modules/atoms/youtube-player',
     'common/modules/atoms/youtube-tracking',
     'common/utils/$',
-    'common/utils/config'
+    'common/utils/config',
+    'common/utils/detect'
 ], function (
     fastdom,
     youtubePlayer,
     tracking,
     $,
-    config
+    config,
+    detect
 ) {
 
     var players = {};
@@ -78,13 +80,21 @@ define([
     function shouldAutoplay(){
 
         function isMobile() {
-            const isIOS = () => /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
-            const isAndroid = () => /Android/i.test(navigator.userAgent);
-
-            return isIOS() || isAndroid();
+            return detect.isIOS() || detect.isAndroid();
         }
 
         function isInternalReferrer() {
+            /**
+             * Polyfill for String.startsWith
+             * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+             */
+            if (!String.prototype.startsWith) {
+                String.prototype.startsWith = function(searchString, position){
+                    position = position || 0;
+                    return this.substr(position, searchString.length) === searchString;
+                };
+            }
+
             if(config.page.isDev) {
                 return document.referrer.startsWith(window.location.origin);
             }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -92,14 +92,14 @@ define([
                 return document.referrer.startsWith(config.page.host);
             }
         }
-        return config.page.contentType == 'Video' && isInternalReferrer() && !isMobile();
+        return config.page.contentType === 'Video' && isInternalReferrer() && !isMobile();
     }
 
     function onPlayerReady(atomId, overlay, event) {
         if(shouldAutoplay()) {
             event.target.playVideo();
         }
-        
+
         players[atomId] = {
             player: event.target,
             pendingTrackingCalls: [25, 50, 75]

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -2,12 +2,14 @@ define([
     'fastdom',
     'common/modules/atoms/youtube-player',
     'common/modules/atoms/youtube-tracking',
-    'common/utils/$'
+    'common/utils/$',
+    'common/utils/config'
 ], function (
     fastdom,
     youtubePlayer,
     tracking,
-    $
+    $,
+    config
 ) {
 
     var players = {};
@@ -41,7 +43,7 @@ define([
     }
 
     function setProgressTracker(atomId)  {
-        players[atomId].progressTracker = setInterval(recordPlayerProgress.bind(null, atomId), 1000); 
+        players[atomId].progressTracker = setInterval(recordPlayerProgress.bind(null, atomId), 1000);
     }
 
     function killProgressTracker(atomId) {
@@ -71,7 +73,33 @@ define([
         }
     }
 
+
+
+    function shouldAutoplay(){
+
+        function isMobile() {
+            const isIOS = () => /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
+            const isAndroid = () => /Android/i.test(navigator.userAgent);
+
+            return isIOS() || isAndroid();
+        }
+
+        function isInternalReferrer() {
+            if(config.page.isDev) {
+                return document.referrer.startsWith(window.location.origin);
+            }
+            else {
+                return document.referrer.startsWith(config.page.host);
+            }
+        }
+        return config.page.contentType == 'Video' && isInternalReferrer() && !isMobile();
+    }
+
     function onPlayerReady(atomId, overlay, event) {
+        if(shouldAutoplay()) {
+            event.target.playVideo();
+        }
+        
         players[atomId] = {
             player: event.target,
             pendingTrackingCalls: [25, 50, 75]
@@ -94,7 +122,7 @@ define([
             times.push(formatTime(minutes));
         } else {
             times.push(minutes);
-        }    
+        }
         times.push(formatTime(seconds));
 
         return times.join(':');


### PR DESCRIPTION
<!-- ************************** IMPORTANT ************************* -->
<!-- ** Continuous Deployment is enabled for this repository     ** -->
<!-- ** Merging into master = deploying to PROD                  ** -->
<!-- **                                                          ** -->
<!-- ** Use Riff-Raff to deploy/test a PR on CODE before merging ** -->
<!-- ************************************************************** -->

## What does this change?

Autoplays youtube media atom if user:
* Is on a Video page
* Has an internal referrer 
* Not on Android or iOS *(as these OS's block autoplay)*

CC @guardian/accessibility we might want to turn this off if a user has disabled flashing elements?

## What is the value of this and can you measure success?

Required for YouTube PFP trial feature parity

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![autoplay](https://cloud.githubusercontent.com/assets/1764158/21847141/29f28556-d7f2-11e6-9a3e-454e0f7ce492.gif)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
