### PR TITLE
Hosted AMP css fix

### DIFF
--- a/common/app/views/fragments/amp/customStyles.scala.html
+++ b/common/app/views/fragments/amp/customStyles.scala.html
@@ -32,5 +32,9 @@
  * It won't affect prod but please comment out this line when running tests in DEV
  *@
 @if(context.environment.mode == Dev) {
-    <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+    @if(page.metadata.isHosted) {
+        <link rel="stylesheet" id="head-css" data-reload="head.hosted-amp" type="text/css" href="@Static("stylesheets/head.hosted-amp.css")" />
+    } else {
+        <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+    }
 }

--- a/common/app/views/fragments/amp/customStyles.scala.html
+++ b/common/app/views/fragments/amp/customStyles.scala.html
@@ -35,6 +35,10 @@
     @if(page.metadata.isHosted) {
         <link rel="stylesheet" id="head-css" data-reload="head.hosted-amp" type="text/css" href="@Static("stylesheets/head.hosted-amp.css")" />
     } else {
-        <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+        @if(page.metadata.contentType == "LiveBlog"){
+            <link rel="stylesheet" id="head-css" data-reload="head.amp-liveblog" type="text/css" href="@Static("stylesheets/head.amp-liveblog.css")" />
+        } else {
+            <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+        }
     }
 }


### PR DESCRIPTION
## What does this change?
The wrong head CSS file was being included when working locally on Hosted AMP and liveblog AMP pages. This means styling issues that were in production were not replicable locally.

## What is the value of this and can you measure success?
These pages now have the same styles on production as on localhost.

## Does this affect other platforms - Amp, Apps, etc?
Just AMP.

CC @NataliaLKB 