### PR TITLE
End current engagement banner tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -73,14 +73,15 @@ define([
             },
             AU: {
                 membership: {
-                    messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia Member for just $100 a year.',
+                    messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $10 a month.',
                     campaignCode: "mem_au_banner"
                 }
             },
             INT: {
                 membership: {
                     messageText: 'The Guardian’s voice is needed now more than ever. Support our journalism for just $69/€49 per year.',
-                    campaignCode: "mem_int_banner"
+                    campaignCode: "mem_int_banner",
+                    minArticles: 3
                 }
             }
         };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -81,25 +81,5 @@ define([
     };
 
     return [
-        new EditionTest('UK', 'MembershipEngagementBannerUkTest13', '2016-12-22', '2017-01-05', 'gdnwb_copts_mem_banner_uk_banner__')
-            .addMembershipVariant('control', {})
-            .addMembershipVariant('3_rotating', {messageText: [
-                'We all want to make the world a fairer place. We believe journalism can help – but producing it is expensive. That’s why we need Supporters.',
-                'Become a Supporter and appreciate every article, knowing you’ve helped bring it to the page. Be part of the Guardian.',
-                'Not got round to supporting us yet? If everyone chipped in, our future would be more secure.'
-            ]})
-            .addMembershipVariant('coffee_95p', {messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for 95p a week.'}),
-        new EditionTest('AU', 'AuMembEngagementMsgCopyTest8', '2016-11-24', '2017-01-05', 'gdnwb_copts_mem_banner_aubanner__')
-            .addMembershipVariant('control', {})
-            .addMembershipVariant('fearless_10', {messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $10 a month'})
-            .addMembershipVariant('stories_that_matter', {messageText: 'We need your help to tell the stories that matter. Support Guardian Australia now'})
-            .addMembershipVariant('power_to_account', {messageText: 'We need your help to hold power to account. Become a Guardian Australia supporter'})
-            .addMembershipVariant('independent_journalism', {messageText: 'Support quality, independent journalism in Australia by becoming a supporter'})
-        ,new EditionTest('INT', 'MembershipEngagementInternationalExperimentTest12', '2016-12-13', '2017-01-06', 'gdnwb_copts_mem_banner_int_banner__')
-            .addMembershipVariant('control', {})
-            .addMembershipVariant('1st_article', {minArticles: 1})
-            .addMembershipVariant('3rd_article', {minArticles: 3})
-            .addMembershipVariant('5th_article', {minArticles: 5})
-            .addMembershipVariant('7th_article', {minArticles: 7})
     ];
 });


### PR DESCRIPTION
## What does this change?

Ending current engagement banner tests, using the preferred variants as the new defaults.

* https://trello.com/c/R6RNJXQy/257-engagement-banner-test-13-uk-end-test-and-revert-to-control-message
* https://trello.com/c/nLAs3Qup/258-engagement-banner-test-8-aus-end-test-and-make-fearless-10-the-new-control
* https://trello.com/c/ZRJZCTaY/259-engagement-banner-test-12-row-end-test-and-make-3rd-article-the-new-control

cc @JustinPinner 