### PR TITLE
Trigger a re-display of the engagement banner

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -38,7 +38,7 @@ define([
 
         // change messageCode to force redisplay of the message to users who already closed it.
         // messageCode is also consumed by .../test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
-        var messageCode = 'engagement-banner-2016-11-10';
+        var messageCode = 'engagement-banner-2017-01-11';
 
         var baseParams = {
             minArticles: 10,


### PR DESCRIPTION
## What does this change?

Triggers a 're-display' of the engagement banner. People who have formerly closed the engagement banner will now see it again. They can, of course, chose to close it once again, hiding it until the next time we change the re-display code.

## What is the value of this and can you measure success?

https://trello.com/c/lonwAy32/255-engagement-banner-redisplay

Now that https://github.com/guardian/frontend/pull/15536 has gone out, ending the current batch of engagement banner A/B tests, and choosing the most successful variants, Jesse would like us to do a re-display so we can send a lot of traffic to them.

cc @JustinPinner 