### PR TITLE
Make hosted logo tracking consistent

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -34,9 +34,7 @@
 
         <div class="main-body">
             <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
-                <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-                    <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
-                </a>
+                @hostedLogo(page.campaign, onAmp = true)
             </div></div></div>
             @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page, isAMP = true)
             <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.campaign.fontColour.isDark) {hosted-page--bright}">

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -69,9 +69,7 @@
     </style>
     <!--<![endif]-->
     <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
-        <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-            <img class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"/>
-        </a>
+        @hostedLogo(page.campaign)
     </div></div></div>
     @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.campaign.fontColour.isDark) " hosted-page--bright" else ""), page)
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.campaign.fontColour.isDark) {hosted-page--bright}">

--- a/commercial/app/views/hosted/guardianHostedHeader.scala.html
+++ b/commercial/app/views/hosted/guardianHostedHeader.scala.html
@@ -1,17 +1,12 @@
 @import common.commercial.hosted.HostedPage
+@import views.html.hosted.hostedLogo
 @(pageCssClass: String, page: HostedPage, isAMP: Boolean = false)
 
 <div class="hosted__header @pageCssClass">
     <div class="hosted__headerwrap js-hosted-headerwrap">
         <div class="hostedbadge hosted-tone-bg">
             <p class="hostedbadge__info">Advertiser content</p>
-            <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-            @if(isAMP) {
-                <amp-img layout="responsive" width="@{page.campaign.logo.dimensions.map(_.width)}" height="@{page.campaign.logo.dimensions.map(_.height)}" class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"></amp-img>
-            } else {
-                <img class="hostedbadge__logo" src="@page.campaign.logo.src" alt="logo @page.campaign.owner"/>
-            }
-            </a>
+            @hostedLogo(page.campaign, onAmp = isAMP)
         </div>
         @if(isAMP) {
             <div class="hosted__label content__hosted-body">
@@ -53,7 +48,7 @@
             </div>
         }
         <div class="hosted-header__spacer"></div>
-        <a href="http://www.theguardian.com" data-link-name="@page.campaign.logo.trackingCode" class="hosted__glogo">
+        <a href="http://www.theguardian.com" class="hosted__glogo">
             <p class="hosted__glogotext">Hosted by</p>
             @fragments.inlineSvg("guardian-logo-320", "logo", List("hosted__guardian-logo"))
         </a>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -91,9 +91,7 @@
                             <h1 class="hosted__heading">@{page.video.title}</h1>
                         </div>
                         <div class="hostedbadge">
-                            <a href="@page.campaign.logo.link" data-link-name="@page.campaign.logo.trackingCode" target="_blank">
-                                <img class="hostedbadge__logo" src="@{page.campaign.logo.src}" alt="logo @{page.campaign.owner}">
-                            </a>
+                            @hostedLogo(page.campaign)
                         </div>
                     </div>
                     @for(nextPage <- page.nextVideo) {

--- a/commercial/app/views/hosted/hostedLogo.scala.html
+++ b/commercial/app/views/hosted/hostedLogo.scala.html
@@ -1,0 +1,14 @@
+@(campaign: common.commercial.hosted.HostedCampaign, onAmp: Boolean = false)
+
+<a href="@campaign.logo.link" data-sponsor="@campaign.owner.toLowerCase" target="_blank">
+@if(onAmp) {
+    <amp-img layout="responsive"
+             width="@campaign.logo.dimensions.map(_.width)"
+             height="@campaign.logo.dimensions.map(_.height)"
+             class="hostedbadge__logo"
+             src="@campaign.logo.src"
+             alt="@campaign.owner"></amp-img>
+} else {
+    <img class="hostedbadge__logo" src="@campaign.logo.src" alt="@campaign.owner"/>
+}
+</a>

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -92,7 +92,7 @@ object HostedCampaign {
   }
 }
 
-case class HostedLogo(src: String, dimensions: Option[Dimensions], link: String, trackingCode: String)
+case class HostedLogo(src: String, dimensions: Option[Dimensions], link: String)
 
 object HostedLogo {
 
@@ -106,7 +106,6 @@ object HostedLogo {
   ) = HostedLogo(
     src,
     dimensions map (d => Dimensions(d.width, d.height)),
-    link,
-    trackingCode = s"$campaignId logo"
+    link
   )
 }

--- a/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ChesterZooHostedPages.scala
@@ -13,8 +13,7 @@ object ChesterZooHostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/act-for-wildlife/AFW+with+CZ+portrait+with+padding.png",
       Some(Dimensions(width = 280, height = 261)),
-      link = "",
-      trackingCode = ""
+      link = ""
     ),
     fontColour = Colour("#E31B22")
   )

--- a/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/Formula1HostedPages.scala
@@ -12,8 +12,7 @@ object Formula1HostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/formula1-singapore/Logos-SGP-SA-1.jpg",
       Some(Dimensions(width = 500, height = 500)),
-      link = "",
-      trackingCode = ""
+      link = ""
     ),
     fontColour = Colour("#063666")
   )

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -19,8 +19,7 @@ object LeffeHostedPages {
     logo = HostedLogo(
       Static("images/commercial/leffe.jpg"),
       Some(Dimensions(width = 132, height = 132)),
-      link = "",
-      trackingCode = ""
+      link = ""
     ),
     fontColour = Colour("#dec190")
   )

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -17,8 +17,7 @@ object RenaultHostedPages {
     logo = HostedLogo(
       Static("images/commercial/logo_renault.jpg"),
       Some(Dimensions(width = 132, height = 132)),
-      link = "",
-      trackingCode = ""
+      link = ""
     ),
     fontColour = Colour("#ffc421")
   )

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -16,8 +16,7 @@ object VisitBritainHostedPages {
     logo = HostedLogo(
       "https://static.theguardian.com/commercial/hosted/visit-britain/OMGB_LOCK_UP_Hashtag_HOAM_Blue.jpg",
       Some(Dimensions(width = 1378, height = 957)),
-      link = "http://www.homeofamazing.com/?utm_source=guardianpartnership&utm_medium=hostedgalleries&utm_campaign=display",
-      trackingCode = ""
+      link = "http://www.homeofamazing.com/?utm_source=guardianpartnership&utm_medium=hostedgalleries&utm_campaign=display"
     ),
     fontColour = Colour("#E41F13")
   )


### PR DESCRIPTION
This change makes tracking of hosted logo clicks consistent with the tracking of other sponsor logo clicks.  They will be tracked in GA as `click > sponsor logo > <lowercase sponsor name>`

/cc @steppenwells 
