### PR TITLE
Sticky right-hand slot

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
@@ -19,7 +19,7 @@ define([
     var rightSlot;
 
     function stickyMpu($adSlot) {
-        if ($adSlot.data('name') !== 'right' || stickyElement) {
+        if ($adSlot.data('name') !== 'right') {
             return;
         }
 
@@ -39,7 +39,7 @@ define([
         }).then(function () {
             //if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
             var options = config.page.isAdvertisementFeature ? {top: 43} : {};
-            stickyElement = new Sticky($adSlot[0], options);
+            var stickyElement = new Sticky($adSlot[0], options);
             stickyElement.init();
             mediator.emit('page:commercial:sticky-mpu');
             messenger.register('resize', onResize);

--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
@@ -15,7 +15,7 @@ define([
     messenger,
     Promise
 ) {
-    var stickyElement = null;
+    var noSticky = document.documentElement.classList.contains('has-no-sticky');
     var rightSlot;
 
     function stickyMpu($adSlot) {
@@ -37,13 +37,14 @@ define([
                 $adSlot.parent().css('height', newHeight + 'px');
             });
         }).then(function () {
-            //if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
-            var options = config.page.isAdvertisementFeature ? {top: 43} : {};
-            var stickyElement = new Sticky($adSlot[0], options);
-            stickyElement.init();
+            if (noSticky) {
+                //if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
+                var options = config.page.isAdvertisementFeature ? {top: 43} : {};
+                var stickyElement = new Sticky($adSlot[0], options);
+                stickyElement.init();
+                messenger.register('resize', onResize);
+            }
             mediator.emit('page:commercial:sticky-mpu');
-            messenger.register('resize', onResize);
-            return stickyElement;
         });
     }
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-mpu.js
@@ -16,6 +16,7 @@ define([
     Promise
 ) {
     var noSticky = document.documentElement.classList.contains('has-no-sticky');
+    var stickyElement;
     var rightSlot;
 
     function stickyMpu($adSlot) {
@@ -40,7 +41,7 @@ define([
             if (noSticky) {
                 //if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
                 var options = config.page.isAdvertisementFeature ? {top: 43} : {};
-                var stickyElement = new Sticky($adSlot[0], options);
+                stickyElement = new Sticky($adSlot[0], options);
                 stickyElement.init();
                 messenger.register('resize', onResize);
             }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -20,6 +20,9 @@
 }
 
 .ad-slot--right {
+    position: sticky;
+    top: 0;
+
     &.is-sticky {
         width: 300px;
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -23,6 +23,11 @@
     position: sticky;
     top: 0;
 
+    // Sorry but no other choice :=(
+    .has-sticky .paidfor-band ~ .content__main & {
+        top: 46px;
+    }
+
     &.is-sticky {
         width: 300px;
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -100,7 +100,6 @@
     margin-right: $gs-gutter;
     width: gs-span(4);
     padding-left: $gs-gutter;
-    overflow: hidden;
 
     @include mq($until: desktop) {
         display: none;


### PR DESCRIPTION
... and finally the right-hand slot is made sticky with CSS.

There is one issue in Chrome when the creative is a Sindewinder in the expanded state and the user scrolls up so the creative crosses the viewport. I expect this issue to be fixed by the time the next stable Chrome release ships (which is the one with support for `sticky`), which is around Jan 31st.