### PR TITLE
Add test for opinion emails

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -32,6 +32,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-opinion-email-variants",
+    "Assign users to variants of opinion emails",
+    owners = Seq(Owner.withGithub("davidfurey")),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 2, 8),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-recommended-for-you-recommendations",
     "Test personalised container on fronts",
     owners = Seq(Owner.withGithub("davidfurey")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -35,7 +35,7 @@ trait ABTestSwitches {
     "ab-opinion-email-variants",
     "Assign users to variants of opinion emails",
     owners = Seq(Owner.withGithub("davidfurey")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2017, 2, 8),
     exposeClientSide = true
   )

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -36,8 +36,9 @@ object ListIds {
   val guardianTodayUs = 1493
   val guardianTodayAu = 1506
 
-  val theBestOfOpinion = 3811
+  val theBestOfOpinion = 2313
   val newBestOfOpinion = 3811
+  val controlBestOfOpinion = 3814
   val theFiver = 218
   val mediaBriefing = 217
   val greenLight = 28

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -36,7 +36,7 @@ object ListIds {
   val guardianTodayUs = 1493
   val guardianTodayAu = 1506
 
-  val theBestOfOpinion = 2313
+  val theBestOfOpinion = 3811
   val newBestOfOpinion = 3811
   val theFiver = 218
   val mediaBriefing = 217

--- a/common/app/model/EmailSubscriptions.scala
+++ b/common/app/model/EmailSubscriptions.scala
@@ -1,5 +1,7 @@
 package model
 
+import controllers.ListIds
+
 case class EmailSubscriptions(subscriptions: List[EmailSubscription])
 case class EmailSubscription(
   name: String,
@@ -356,6 +358,12 @@ object EmailSubscriptions {
     )
   )
 
+  private val isOpinionVariant = List(
+    ListIds.newBestOfOpinion,
+    ListIds.controlBestOfOpinion,
+    ListIds.theBestOfOpinion
+  ).map(_.toString).contains[String](_)
+
   def commentEmails(subscribedListIds: Iterable[String] = None) = List(
     EmailSubscription(
       name = "Best of Guardian Opinion",
@@ -363,8 +371,8 @@ object EmailSubscriptions {
       teaser = "Get up to speed on the most interesting and provoking issues and join the debate every afternoon",
       description = "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
       frequency = "Weekday afternoons",
-      listId = "3811",
-      subscribedTo = subscribedListIds.exists{ x => x == "2313" || x == "3811" || x == "3814"},
+      listId = ListIds.newBestOfOpinion.toString,
+      subscribedTo = subscribedListIds.exists(isOpinionVariant),
       subheading = Some("UK"),
       tone = Some("comment"),
       signupPage = Some("/commentisfree/2014/jan/29/comment-is-free-daily-roundup")

--- a/common/app/model/EmailSubscriptions.scala
+++ b/common/app/model/EmailSubscriptions.scala
@@ -363,8 +363,8 @@ object EmailSubscriptions {
       teaser = "Get up to speed on the most interesting and provoking issues and join the debate every afternoon",
       description = "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every afternoon.",
       frequency = "Weekday afternoons",
-      listId = "2313",
-      subscribedTo = subscribedListIds.exists{ x => x == "2313" || x == "3811" },
+      listId = "3811",
+      subscribedTo = subscribedListIds.exists{ x => x == "2313" || x == "3811" || x == "3814"},
       subheading = Some("UK"),
       tone = Some("comment"),
       signupPage = Some("/commentisfree/2014/jan/29/comment-is-free-daily-roundup")

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -12,6 +12,7 @@
 @listIdTones = @{ Map[Int, String] (
     theBestOfOpinion -> "comment",
     newBestOfOpinion -> "comment",
+    controlBestOfOpinion -> "comment",
     bestOfOpinionAUS -> "comment",
     bestOfOpinionUS -> "comment",
     theFiver -> "feature",

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -8,6 +8,7 @@ define([
     'lodash/functions/memoize',
     'lodash/utilities/noop',
     'common/modules/experiments/tests/editorial-email-variants',
+    'common/modules/experiments/tests/opinion-email-variants',
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/membership-engagement-banner-tests',
     'common/modules/experiments/tests/contributions-epic-brexit',
@@ -21,6 +22,7 @@ define([
              memoize,
              noop,
              EditorialEmailVariants,
+             OpinionEmailVariants,
              RecommendedForYou,
              MembershipEngagementBannerTests,
              ContributionsEpicBrexit,
@@ -28,6 +30,7 @@ define([
     ) {
     var TESTS = [
         new EditorialEmailVariants(),
+        new OpinionEmailVariants(),
         new RecommendedForYou(),
         new ContributionsEpicBrexit,
         new ContributionsEpicAlwaysAskStrategy

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -29,7 +29,7 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = '90% of users in new format list, 10% in the other list';
 
-        var OPINION_URL = 'info/ng-interactive/2017/jan/12/sign-up-for-opinion'; // TODO: check this url
+        var OPINION_URL = 'info/ng-interactive/2017/jan/12/sign-up-for-the-guardian-opinion-email';
 
         this.canRun = function () {
             return (config.page.contentId === OPINION_URL ||

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -1,0 +1,77 @@
+define([
+    'bean',
+    'fastdom',
+    'qwery',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/fastdom-promise'
+], function (
+    bean,
+    fastdom,
+    qwery,
+    $,
+    config,
+    fastdomPromise
+) {
+    return function () {
+        this.id = 'OpinionEmailVariants';
+        this.start = '2017-01-12';
+        this.expiry = '2017-02-08';
+        this.author = 'David Furey';
+        this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB ' +
+            'function in ExactTarget re-randomises all recipients on each send, and we need users to receive their ' +
+            'variant for several weeks. This test will ensure users are added to the corresponding email list ' +
+            '(listId) in ExactTarget';
+        this.audience = 0.2;
+        this.audienceOffset = 0;
+        this.successMeasure = 'We can trial two different email formats to fairly compare their CTO rates';
+        this.audienceCriteria = 'All users who visit the email sign up page';
+        this.dataLinkNames = '';
+        this.idealOutcome = '90% of users in new format list, 10% in the other list';
+
+        var OPINION_URL = 'info/ng-interactive/2017/jan/12/sign-up-for-opinion'; // TODO: check this url
+
+        this.canRun = function () {
+            return (config.page.contentId === OPINION_URL ||
+            config.page.pageId === '/email-newsletters');
+        };
+
+        function enhanceWebView(emailListID) {
+            var emailForm = $('.js-email-sub__iframe')[0];
+            emailForm.setAttribute('src', 'https://www.theguardian.com/email/form/plaintone/' + emailListID);
+        }
+
+        // Runs the test on https://www.theguardian.com/email-newsletters
+        function updateNewslettersPage(emailListID) {
+            return fastdomPromise.write(function () {
+                var input = $('input[value="3811"]')[0];
+                var button = $('button[value="3811"]')[0];
+                input.setAttribute('value', emailListID);
+                button.setAttribute('value', emailListID);
+            });
+        }
+
+        function runTheTest(emailListID) {
+            if (config.page.contentId === OPINION_URL) {
+                enhanceWebView(emailListID);
+            } else {
+                updateNewslettersPage(emailListID);
+            }
+        }
+
+        this.variants = [
+            {
+                id: 'Opinion-Connected',
+                test: function () {
+                    runTheTest(3811);
+                }
+            },
+            {
+                id: 'Opinion-Legacy',
+                test: function () {
+                    runTheTest(3814);
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -61,13 +61,13 @@ define([
 
         this.variants = [
             {
-                id: 'Opinion-Connected',
+                id: 'Opinion-UK-Connected',
                 test: function () {
                     runTheTest(3811);
                 }
             },
             {
-                id: 'Opinion-Legacy',
+                id: 'Opinion-UK-Legacy',
                 test: function () {
                     runTheTest(3814);
                 }

--- a/static/src/javascripts-legacy/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/email-preferences.js
@@ -159,8 +159,12 @@ define([
             if (config.switches.abEditorialEmailVariants && value === 'unsubscribe-2211') {
                 buttonString += 'removeEmailSubscriptions[]=3806&';
                 buttonString += 'removeEmailSubscriptions[]=3807&';
-            } else if (value === 'unsubscribe-2313') {
-                buttonString += 'removeEmailSubscriptions[]=3811&';
+            } else if (value === 'unsubscribe-2313') { // legacy opinion listId
+                buttonString += 'removeEmailSubscriptions[]=3811&'; // new opinion listId
+                buttonString += 'removeEmailSubscriptions[]=3814&'; // control group listId
+            } else if (value === 'unsubscribe-3811') { // new opinion listId
+                buttonString += 'removeEmailSubscriptions[]=2313&'; // legacy opinion listId
+                buttonString += 'removeEmailSubscriptions[]=3814&'; // control group listId
             }
             // end of hacks
         }


### PR DESCRIPTION
## What does this change?

A/B test for opinion email

- The new version (listId=3811) is now the default
- 10% of users will be added to another new list (listId=3814) which will be sent the old email.  This is so that we can compare fresh users to the old and new versions

## What is the value of this and can you measure success?

Allows us to test a new version of an editorial email.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
