### PR TITLE
Editorial Tone clashes with special report

### DIFF
--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -19,7 +19,8 @@
     }
 
     &,
-    .fc-sublink__title {
+    .fc-sublink__title,
+    .fc-sublink__kicker {
         color: #ffffff;
     }
 


### PR DESCRIPTION
This was happening. 

![screen_shot_2016-11-16_at_5 13 14_pm](https://cloud.githubusercontent.com/assets/14570016/21900055/4fc862a2-d8ea-11e6-8713-b013036c5d5e.png)

Now it isn't. 

@gtrufitt can you check if I've done this the right way please? 🌴 
