### PR TITLE
Only update example url on interactive page

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -58,10 +58,10 @@ define([
         function runTheTest(emailListID, exampleUrl) {
           if (config.page.contentId === FLYERURL) {
             enhanceWebView(emailListID);
+            updateExampleUrl(exampleUrl);
           } else {
             updateNewslettersPage(emailListID);
           }
-          updateExampleUrl(exampleUrl);
         }
 
         this.variants = [


### PR DESCRIPTION
## What does this change?

Stops trying to update an non-existant example url

## What is the value of this and can you measure success?

Fixes an exception which was being thrown

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
