### PR TITLE
Fix: Preview internal healthcheck url should not required authentication

### DIFF
--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -2,29 +2,20 @@ package http
 
 import akka.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
-import com.gu.googleauth.FilterExemption
+import googleAuth.FilterExemptions
 import model.ApplicationContext
 import play.api.http.HttpFilters
 import play.api.libs.crypto.CryptoConfig
 import play.api.mvc.EssentialFilter
 
-object FilterExemptions {
-
-  lazy val loginExemption: FilterExemption = FilterExemption("/login")
-  lazy val exemptions: Seq[FilterExemption] = List(
-    FilterExemption("/oauth2callback"),
-    FilterExemption("/assets"),
-    FilterExemption("/_healthcheck"),
-    FilterExemption("/deploys"), // This endpoint is not authenticated so it can be accessed by Prout to determine which builds have been deployed
-    FilterExemption("/deploys-notify") // This endpoint is authenticated via api-key (to be accessible to riffraff hook for instance)
-  )
-}
-
 class AdminFilters(cryptoConfig: CryptoConfig)(implicit mat: Materializer, context: ApplicationContext) extends HttpFilters {
 
+  val filterExemptions = new FilterExemptions(
+    "/deploys" //not authenticated so it can be accessed by Prout to determine which builds have been deployed
+  )
   val adminAuthFilter = new AuthFilterWithExemptions(
-    FilterExemptions.loginExemption,
-    FilterExemptions.exemptions)(mat, context, cryptoConfig)
+    filterExemptions.loginExemption,
+    filterExemptions.exemptions)(mat, context, cryptoConfig)
 
   val filters: List[EssentialFilter] = adminAuthFilter :: Filters.common
 }

--- a/common/app/googleAuth/FilterExemptions.scala
+++ b/common/app/googleAuth/FilterExemptions.scala
@@ -1,17 +1,15 @@
-package http
+package googleAuth
 
 import com.gu.googleauth.FilterExemption
 
-object FilterExemptions {
+case class FilterExemptions(additionalUrls: String*) {
 
   lazy val loginExemption: FilterExemption = FilterExemption("/login")
   lazy val exemptions: Seq[FilterExemption] = List(
+    // Default
     FilterExemption("/oauth2callback"),
     FilterExemption("/assets"),
     FilterExemption("/favicon.ico"),
-    FilterExemption("/_healthcheck"),
-    FilterExemption("/2015-06-24-manifest.json"),
-    // the healthcheck url
-    FilterExemption("/world/2012/sep/11/barcelona-march-catalan-independence")
-  )
+    FilterExemption("/_healthcheck")
+  ) ++ additionalUrls.map { url => FilterExemption(url)}
 }


### PR DESCRIPTION
Fix: Preview internal healthcheck url should not required authentication
Url of healthcheck has been changed but the authentication exemption has not been modified at the same time. Therefore the internal healthcheck request will hit this endpoint and because it is not exempt will redirect to `/login`

This patch is making the dependency between preview healthcheck and preview authentication exemption explicit.
I also took advantage of it to do some refactoring, replacing the 2 very similar FilterExemptions objects in `admin` and `preview` by a single class that can accept additional urls to exempt 

## What is the value of this and can you measure success?
Real healthcheck endpoint is tested, not `/login`

## Tested in CODE?
Yes
