### PR TITLE
Opinion styling for email

### DIFF
--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -12,6 +12,10 @@
         background: #f6f6f6;
     }
 
+    @*
+     * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
+     * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
+     *@
     .panel {
         padding: 0 !important;
     }
@@ -251,7 +255,10 @@
     }
 
     /*  Media Queries */
-
+    @*
+     * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
+     * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
+     *@
     @@media only screen and (max-width: 600px) {
         table[class="body"] .container {
             width: 100% !important;

--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -29,7 +29,8 @@
     .tone-news .headline {
         color: #333333;
     }
-    .tone-news .fc-item__kicker {
+    .tone-news .fc-item__kicker,
+    .tone-news .byline {
         color: #005689;
     }
     .tone-news .kicker-separator {
@@ -49,7 +50,8 @@
     .tone-feature .headline {
         color: #333333;
     }
-    .tone-feature .fc-item__kicker {
+    .tone-feature .fc-item__kicker,
+    .tone-feature .byline {
         color: #951c55;
     }
     .tone-feature .kicker-separator {
@@ -69,7 +71,8 @@
     .tone-media .headline {
         color: #333333;
     }
-    .tone-media .fc-item__kicker {
+    .tone-media .fc-item__kicker,
+    .tone-media .byline {
         color: #ff9b0b;
     }
     .tone-media .kicker-separator {
@@ -89,7 +92,8 @@
     .tone-review .headline {
         color: #333333;
     }
-    .tone-review .fc-item__kicker {
+    .tone-review .fc-item__kicker,
+    .tone-review .byline {
         color: #ff9b0b;
     }
     .tone-review .kicker-separator {
@@ -109,7 +113,8 @@
     .tone-editorial .headline {
         color: #333333;
     }
-    .tone-editorial .fc-item__kicker {
+    .tone-editorial .fc-item__kicker,
+    .tone-editorial .byline {
         color: #aad8f1;
     }
     .tone-editorial .kicker-separator {
@@ -129,7 +134,8 @@
     .tone-external .headline {
         color: #333333;
     }
-    .tone-external .fc-item__kicker {
+    .tone-external .fc-item__kicker,
+    .tone-external .byline {
         color: #333333;
     }
     .tone-external .kicker-separator {
@@ -149,7 +155,8 @@
     .tone-live .headline {
         color: #333333;
     }
-    .tone-live .fc-item__kicker {
+    .tone-live .fc-item__kicker,
+    .tone-live .byline {
         color: #fdadba;
     }
     .tone-live .kicker-separator {
@@ -169,7 +176,8 @@
     .tone-analysis .headline {
         color: #333333;
     }
-    .tone-analysis .fc-item__kicker {
+    .tone-analysis .fc-item__kicker,
+    .tone-analysis .byline {
         color: #767676;
     }
     .tone-analysis .kicker-separator {
@@ -189,7 +197,8 @@
     .tone-special-report .headline {
         color: #333333;
     }
-    .tone-special-report .fc-item__kicker {
+    .tone-special-report .fc-item__kicker,
+    .tone-special-report .byline {
         color: #fce800;
     }
     .tone-special-report .kicker-separator {
@@ -209,7 +218,8 @@
     .tone-comment .headline {
         color: #333333;
     }
-    .tone-comment .fc-item__kicker {
+    .tone-comment .fc-item__kicker,
+    .tone-comment .byline {
         color: #e6711b;
     }
     .tone-comment .kicker-separator {
@@ -229,7 +239,8 @@
     .tone-dead .headline {
         color: #333333;
     }
-    .tone-dead .fc-item__kicker {
+    .tone-dead .fc-item__kicker,
+    .tone-dead .byline {
         color: #cc2b12;
     }
     .tone-dead .kicker-separator {

--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -115,7 +115,7 @@
     }
     .tone-editorial .fc-item__kicker,
     .tone-editorial .byline {
-        color: #aad8f1;
+        color: #005689;
     }
     .tone-editorial .kicker-separator {
         color: #d6d6d6;

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -52,7 +52,7 @@
         margin-top: 6px;
     }
 
-    .headline {
+    .headline, .byline {
         font-family: "Guardian Egyptian Web Headline", Georgia, serif;
         font-size: 16px;
         line-height: 20px;

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -65,7 +65,8 @@
         line-height: 18px;
     }
 
-    .facia-card--large .headline {
+    .facia-card--large .headline,
+    .facia-card--large .byline {
         font-size: 22px;
         line-height: 26px;
         color: inherit;

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -45,7 +45,10 @@
         text-decoration: none;
     }
     .facia-card__text {
-        padding: 0 10px 26px 10px !important;
+        padding: 0 10px 0px 10px !important;
+    }
+    .facia-card__text--last {
+        padding-bottom: 26px !important;
     }
 
     .headline, .trail-text {
@@ -69,7 +72,6 @@
     .facia-card--large .byline {
         font-size: 22px;
         line-height: 26px;
-        color: inherit;
     }
 
     .kicker-separator {

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -51,11 +51,13 @@
         padding-bottom: 26px !important;
     }
 
-    .headline, .trail-text {
+    .headline,
+    .trail-text {
         margin-top: 6px;
     }
 
-    .headline, .byline {
+    .headline,
+    .byline {
         font-family: "Guardian Egyptian Web Headline", Georgia, serif;
         font-size: 16px;
         line-height: 20px;

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -17,6 +17,10 @@
     }
 
     .panel {
+        @*
+         * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
+         * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
+         *@
         padding: 0 0 10px 0 !important;
         border: none;
     }

--- a/common/app/views/fragments/email/stylesheets/ink.scala.html
+++ b/common/app/views/fragments/email/stylesheets/ink.scala.html
@@ -5,6 +5,14 @@
 * Ink v1.0.5 - Copyright 2013 ZURB Inc        *
 **********************************************/
 
+@*
+ * Lots of these base styles need !important because for Gmail we have to inline styles, since Gmail strips
+ * out <style> tags. But some styles (e.g. :hover) can't be inlined, and for clients which leave those styles intact,
+ * !important is the only way to override an inlined style with a non-inlined style.
+ * Gmail is apparently rolling out updates that will make style inlining unnecessary, which will hopefully
+ * allow us to remove !important from this stylesheet and all email-related ones.
+ *@
+
 /* Client-specific Styles and Reset */
 
 #outlook a {

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -49,6 +49,10 @@
         color: #005689;
     }
 
+    @*
+     * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
+     * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
+     *@
     a:visited, a:active,
     h2 a:visited, h2 a:active {
         color: #005689 !important;

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -12,7 +12,8 @@
     .tone-news .headline {
         color: #333333;
     }
-    .tone-news .fc-item__kicker {
+    .tone-news .fc-item__kicker,
+    .tone-news .byline, {
         color: #005689;
     }
     .tone-news .kicker-separator {
@@ -32,7 +33,8 @@
     .tone-feature .headline {
         color: #fff;
     }
-    .tone-feature .fc-item__kicker {
+    .tone-feature .fc-item__kicker,
+    .tone-feature .byline, {
         color: #fdadba;
     }
     .tone-feature .kicker-separator {
@@ -52,7 +54,8 @@
     .tone-media .headline {
         color: #fff;
     }
-    .tone-media .fc-item__kicker {
+    .tone-media .fc-item__kicker,
+    .tone-media .byline, {
         color: #ffbb00;
     }
     .tone-media .kicker-separator {
@@ -72,7 +75,8 @@
     .tone-review .headline {
         color: #fff;
     }
-    .tone-review .fc-item__kicker {
+    .tone-review .fc-item__kicker,
+    .tone-review .byline, {
         color: #ffce4b;
     }
     .tone-review .kicker-separator {
@@ -92,7 +96,8 @@
     .tone-editorial .headline {
         color: #fff;
     }
-    .tone-editorial .fc-item__kicker {
+    .tone-editorial .fc-item__kicker,
+    .tone-editorial .byline, {
         color: #aad8f1;
     }
     .tone-editorial .kicker-separator {
@@ -118,7 +123,8 @@
         font-weight: normal;
         font-size: 16px;
     }
-    .tone-external .fc-item__kicker {
+    .tone-external .fc-item__kicker,
+    .tone-external .byline, {
         color: #333333;
         font-weight: bold;
     }
@@ -139,7 +145,8 @@
     .tone-live .headline {
         color: #fff;
     }
-    .tone-live .fc-item__kicker {
+    .tone-live .fc-item__kicker,
+    .tone-live .byline, {
         color: #fdadba;
     }
     .tone-live .kicker-separator {
@@ -159,7 +166,8 @@
     .tone-analysis .headline {
         color: #005689;
     }
-    .tone-analysis .fc-item__kicker {
+    .tone-analysis .fc-item__kicker,
+    .tone-analysis .byline, {
         color: #767676;
     }
     .tone-analysis .kicker-separator {
@@ -179,7 +187,8 @@
     .tone-special-report .headline {
         color: #fff;
     }
-    .tone-special-report .fc-item__kicker {
+    .tone-special-report .fc-item__kicker,
+    .tone-special-report .byline, {
         color: #fce800;
     }
     .tone-special-report .kicker-separator {
@@ -199,7 +208,8 @@
     .tone-comment .headline {
         color: #333333;
     }
-    .tone-comment .fc-item__kicker {
+    .tone-comment .fc-item__kicker,
+    .tone-comment .byline, {
         color: #e6711b;
     }
     .tone-comment .kicker-separator {
@@ -219,7 +229,8 @@
     .tone-dead .headline {
         color: #333333;
     }
-    .tone-dead .fc-item__kicker {
+    .tone-dead .fc-item__kicker,
+    .tone-dead .byline, {
         color: #cc2b12;
     }
     .tone-dead .kicker-separator {

--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -117,6 +117,10 @@
     .tone-external .facia-card__text {
         background-color: #f6f6f6;
     }
+    @*
+     * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
+     * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
+     *@
     .tone-external .headline {
         color: #333333;
         font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -3,7 +3,6 @@ package views.support
 import conf.Static
 import layout.ContentCard
 import model._
-import model.pressed.PressedContent
 import play.twirl.api.Html
 
 object EmailHelpers {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import conf.Static
+import layout.ContentCard
 import model._
 import model.pressed.PressedContent
 import play.twirl.api.Html
@@ -32,9 +33,9 @@ object EmailHelpers {
   def paddedRow(inner: Html): Html = row(columns(12, Seq("panel"))(inner))
   def paddedRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(columns(12, classes ++ Seq("panel"))(inner))
 
-  def imageUrlFromPressedContent(pressedContent: PressedContent): Option[String] = {
+  def imageUrlFromCard(contentCard: ContentCard): Option[String] = {
     for {
-      InlineImage(imageMedia) <- InlineImage.fromFaciaContent(pressedContent)
+      InlineImage(imageMedia) <- contentCard.displayElement
       url <- FrontEmailImage.bestFor(imageMedia)
     } yield url
   }
@@ -61,8 +62,8 @@ object EmailHelpers {
 
   def imgForFront = img(FrontEmailImage.knownWidth) _
 
-  def imgFromPressedContent(pressedContent: PressedContent) = imageUrlFromPressedContent(pressedContent).map { url =>
-    imgForFront(url, Some(pressedContent.header.headline))
+  def imgFromCard(card: ContentCard) = imageUrlFromCard(card).map { url =>
+    imgForFront(url, Some(card.header.headline))
   }
 
   object Images {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -46,7 +46,7 @@
         @card.header.headline
     </h3>
     @if(card.header.quoted) {
-        @card.bylineText.map { byline => <h3 class="byline">@byline</h3> }
+        @card.bylineText.map { byline => <h4 class="byline">@byline</h4> }
     }
 }
 
@@ -105,7 +105,7 @@
     }
 
     @collection.curatedPlusBackfillDeduplicated.zipWithIndex.map { case (pressedContent, cardIndex) =>
-        @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = true)) { card =>
+        @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) { card =>
             @if(cardIndex == 0) {
                 @firstCard(card)
             } else {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -18,25 +18,15 @@
         }
 
         @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
-            @if(card.header.isGallery) {
-                @icon("gallery" + suffix)
-            }
-            @if(card.header.isAudio) {
-                @icon("podcast" + suffix)
-            }
-            @if(card.header.isVideo) {
-                @icon("video" + suffix)
-            }
+            @if(card.header.isGallery) { @icon("gallery" + suffix) }
+            @if(card.header.isAudio) { @icon("podcast" + suffix) }
+            @if(card.header.isVideo) { @icon("video" + suffix) }
         }
 
         @if(card.header.quoted) {
             @card.cardStyle match {
-                case Feature => {
-                    @icon("quote-feature")
-                }
-                case _ => {
-                    @icon("quote")
-                }
+                case Feature => { @icon("quote-feature") }
+                case _ => { @icon("quote") }
             }
         }
         @RemoveOuterParaHtml(card.header.headline)

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -1,18 +1,13 @@
-@import layout.{FaciaCard, FaciaCardHeader}
-@import model.pressed.PressedContent
-@import layout.EditionalisedLink
-@import model.EmailAddons.EmailContentType
-
-@import layout.ItemClasses
-@import layout.ContentCard
-@import views.support.RemoveOuterParaHtml
 @(page: model.PressedPage)(implicit request: RequestHeader)
 
-@import views.support.EmailHelpers._
-@import views.support.TrailCssClasses.toneClassFromStyle
-@import model.pressed.{Feature, ExternalLink}
-@import implicits.Requests.RichRequestHeader
 @import implicits.ItemKickerImplicits._
+@import implicits.Requests.RichRequestHeader
+@import layout.{ContentCard, FaciaCard, ItemClasses}
+@import model.EmailAddons.EmailContentType
+@import model.pressed.{ExternalLink, Feature}
+@import views.support.EmailHelpers._
+@import views.support.RemoveOuterParaHtml
+@import views.support.TrailCssClasses.toneClassFromStyle
 
 
 @headline(card: ContentCard) = {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -5,6 +5,7 @@
 
 @import layout.ItemClasses
 @import layout.ContentCard
+@import views.support.RemoveOuterParaHtml
 @(page: model.PressedPage)(implicit request: RequestHeader)
 
 @import views.support.EmailHelpers._
@@ -43,7 +44,7 @@
                 }
             }
         }
-        @card.header.headline
+        @RemoveOuterParaHtml(card.header.headline)
     </h3>
     @if(card.header.quoted) {
         @card.bylineText.map { byline => <h4 class="byline">@byline</h4> }
@@ -58,7 +59,7 @@
                 @fullRow(Seq("facia-card__text")) {
                     @headline(card)
                     @card.trailText.map { trailText =>
-                        <h4 class="trail-text">@trailText</h4>
+                        <h4 class="trail-text">@Html(trailText)</h4>
                     }
                 }
             </div>

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -51,15 +51,30 @@
     }
 }
 
-@faciaCardLarge(card: ContentCard) = {
+@headlineAndTrailWithCutout(card: ContentCard) = {
+    @fullRow(Seq("facia-card__text")) {
+        @headline(card)
+    }
+    @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
+        @card.trailText.map { trailText =>
+            <h4 class="trail-text">@Html(trailText)</h4>
+        }
+    }
+}
+
+@faciaCardLarge(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
         <a @Html(card.header.url.hrefWithRel) class="facia-link">
-            <div class="facia-card facia-card--large">
-                @imgFromCard(card)
-                @fullRow(Seq("facia-card__text")) {
-                    @headline(card)
-                    @card.trailText.map { trailText =>
-                        <h4 class="trail-text">@Html(trailText)</h4>
+            <div class="facia-card @if(withImage){facia-card--large}">
+                @if(withImage) { @imgFromCard(card) }
+                @if(card.header.quoted) {
+                    @headlineAndTrailWithCutout(card)
+                } else {
+                    @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
+                        @headline(card)
+                        @card.trailText.map { trailText =>
+                            <h4 class="trail-text">@Html(trailText)</h4>
+                        }
                     }
                 }
             </div>
@@ -70,7 +85,7 @@
 @faciaCardSmall(card: ContentCard) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
         <a @Html(card.header.url.hrefWithRel) class="facia-link">
-            @fullRow(Seq("facia-card", "facia-card__text")) {
+            @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
                 @headline(card)
             }
         </a>
@@ -78,14 +93,22 @@
 }
 
 @firstCard(card: ContentCard) = {
+    @* if fast layout: small card, with image *@
+    @* if medium or slow layout: large card, with image *@
     @card.cardStyle match {
         case ExternalLink => { @faciaCardSmall(card) }
-        case _ => { @faciaCardLarge(card) }
+        case _ => { @faciaCardLarge(card, withImage = true) }
     }
 }
 
-@otherCard(card: ContentCard) = {
-    @faciaCardSmall(card)
+@otherCard(card: ContentCard, isSlowLayout: Boolean) = {
+    @* if fast or medium layout: small card, no image *@
+    @* if slow layout: large card, no image *@
+    @if(isSlowLayout) {
+        @faciaCardLarge(card, withImage = false)
+    } else {
+        @faciaCardSmall(card)
+    }
 }
 
 @fullRow {
@@ -110,7 +133,7 @@
             @if(cardIndex == 0) {
                 @firstCard(card)
             } else {
-                @otherCard(card)
+                @otherCard(card, isSlowLayout = collection.collectionType == "slow")
             }
         }
     }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -3,79 +3,88 @@
 @import layout.EditionalisedLink
 @import model.EmailAddons.EmailContentType
 
+@import layout.ItemClasses
+@import layout.ContentCard
 @(page: model.PressedPage)(implicit request: RequestHeader)
 
 @import views.support.EmailHelpers._
-@import views.support.TrailCssClasses.toneClass
+@import views.support.TrailCssClasses.toneClassFromStyle
 @import model.pressed.{Feature, ExternalLink}
 @import implicits.Requests.RichRequestHeader
 @import implicits.ItemKickerImplicits._
 
 
-@headline(pressedContent: PressedContent) = {
+@headline(card: ContentCard) = {
     <h3 class="headline">
-        @defining(FaciaCardHeader.fromTrail(pressedContent, None)) { header =>
-            @header.kicker.map { kicker =>
-                <span class="fc-item__kicker">@Html(kicker.kickerHtml)</span>
-                <span class="kicker-separator">/</span>
-            }
+        @card.header.kicker.map { kicker =>
+            <span class="fc-item__kicker">@Html(kicker.kickerHtml)</span>
+            <span class="kicker-separator">/</span>
+        }
 
-            @defining(if (request.isEmailConnectedStyle) "-connected" else "") { suffix =>
-                @if(header.isGallery) { @icon("gallery" + suffix) }
-                @if(header.isAudio) { @icon("podcast" + suffix) }
-                @if(header.isVideo) { @icon("video" + suffix) }
+        @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
+            @if(card.header.isGallery) {
+                @icon("gallery" + suffix)
             }
+            @if(card.header.isAudio) {
+                @icon("podcast" + suffix)
+            }
+            @if(card.header.isVideo) {
+                @icon("video" + suffix)
+            }
+        }
 
-            @if(header.quoted) {
-                @pressedContent.card.cardStyle match {
-                    case Feature => { @icon("quote-feature") }
-                    case _ => { @icon("quote") }
+        @if(card.header.quoted) {
+            @card.cardStyle match {
+                case Feature => {
+                    @icon("quote-feature")
+                }
+                case _ => {
+                    @icon("quote")
                 }
             }
         }
-        @pressedContent.header.headline
+        @card.header.headline
     </h3>
+    @if(card.header.quoted) {
+        @card.bylineText.map { byline => <h3 class="byline">@byline</h3> }
+    }
 }
 
-@faciaCardLarge(pressedContent: PressedContent) = {
-    @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-        @paddedRow(Seq(toneClass(pressedContent))) {
-            <a @Html(href) class="facia-link">
-                <div class="facia-card facia-card--large">
-                    @imgFromPressedContent(pressedContent)
-                    @fullRow(Seq("facia-card__text")) {
-                        @headline(pressedContent)
-                        @pressedContent.card.trailText.map { trailText =>
-                            <h4 class="trail-text">@trailText</h4>
-                        }
+@faciaCardLarge(card: ContentCard) = {
+    @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
+        <a @Html(card.header.url.hrefWithRel) class="facia-link">
+            <div class="facia-card facia-card--large">
+                @imgFromCard(card)
+                @fullRow(Seq("facia-card__text")) {
+                    @headline(card)
+                    @card.trailText.map { trailText =>
+                        <h4 class="trail-text">@trailText</h4>
                     }
-                </div>
-            </a>
-        }
-    }
-}
-
-@faciaCardSmall(pressedContent: PressedContent) = {
-    @defining(EditionalisedLink.fromFaciaContent(pressedContent).hrefWithRel) { href =>
-        @paddedRow(Seq(toneClass(pressedContent))) {
-            <a @Html(href) class="facia-link">
-                @fullRow(Seq("facia-card", "facia-card__text")) {
-                    @headline(pressedContent)
                 }
-            </a>
-        }
+            </div>
+        </a>
     }
 }
 
-@firstCard(pressedContent: PressedContent) = {
-    @pressedContent.card.cardStyle match {
-        case ExternalLink => { @faciaCardSmall(pressedContent) }
-        case _ => { @faciaCardLarge(pressedContent) }
+@faciaCardSmall(card: ContentCard) = {
+    @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
+        <a @Html(card.header.url.hrefWithRel) class="facia-link">
+            @fullRow(Seq("facia-card", "facia-card__text")) {
+                @headline(card)
+            }
+        </a>
     }
 }
 
-@card(pressedContent: PressedContent) = {
-    @faciaCardSmall(pressedContent)
+@firstCard(card: ContentCard) = {
+    @card.cardStyle match {
+        case ExternalLink => { @faciaCardSmall(card) }
+        case _ => { @faciaCardLarge(card) }
+    }
+}
+
+@otherCard(card: ContentCard) = {
+    @faciaCardSmall(card)
 }
 
 @fullRow {
@@ -96,10 +105,12 @@
     }
 
     @collection.curatedPlusBackfillDeduplicated.zipWithIndex.map { case (pressedContent, cardIndex) =>
-        @if(cardIndex == 0) {
-            @firstCard(pressedContent)
-        } else {
-            @card(pressedContent)
+        @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = true)) { card =>
+            @if(cardIndex == 0) {
+                @firstCard(card)
+            } else {
+                @otherCard(card)
+            }
         }
     }
 }


### PR DESCRIPTION
Some styling & extra logic necessary to render our Opinion email. Specifically:

- Bylines are pulled in and displayed below the headline for opinion-tone articles
- Render the trail text as HTML since sometimes this has markup in it
- Show trail text on all cards for the "slow" layout. (We have three layout types for email fronts: **slow**, **medium** and **fast**. So far we've only needed medium)

## before
![picture 375](https://cloud.githubusercontent.com/assets/5122968/21928042/7e86384e-d980-11e6-8570-388d3932276c.png)
![picture 376](https://cloud.githubusercontent.com/assets/5122968/21928043/7e884616-d980-11e6-98ac-6cf644978749.png)

## after
![picture 377](https://cloud.githubusercontent.com/assets/5122968/21928058/a2207f1c-d980-11e6-9369-e7d7eb47010a.png)
![picture 378](https://cloud.githubusercontent.com/assets/5122968/21928059/a220e498-d980-11e6-91fd-dd1dbc2ab0fe.png)

@guardian/dotcom-platform 