### PR TITLE
Fix: crosswords clues after first direction are truncated

### DIFF
--- a/applications/test/CrosswordDataTest.scala
+++ b/applications/test/CrosswordDataTest.scala
@@ -49,6 +49,9 @@ import org.scalatest.time.{Millis, Span}
       Entry.formatHumanNumber("1,28") should be (Some("1, 28"))
       Entry.formatHumanNumber("10,15,20down") should be (Some("10, 15, 20 down"))
       Entry.formatHumanNumber("2,3,4,5across") should be (Some("2, 3, 4, 5 across"))
+      Entry.formatHumanNumber("2,24across,16") should be (Some("2, 24 across, 16"))
+      Entry.formatHumanNumber("3,down,10,12") should be (None) // Missing number in second clue
+      Entry.formatHumanNumber("this,is,not,well,formed,clues") should be (None)
     }
 
     "fromCrossword should populate solutionAvailable field always and dateSolutionAvailable field if it exists" in {


### PR DESCRIPTION
## What does this change?
Fix bug where clues after the first direction would be truncated.
ex: `1,2,3down,4` should become `1, 2, 3 down, 4` but was in fact `1, 2, 3 down` :(

## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
