### PR TITLE
Updating config, which contains updated DFP API credentials.

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 19
+    val s3ConfigVersion = 20
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
## What does this change?
I've updated the config number to v20 - this config file has updated DFP credentials in it, which have recently expired.

## What is the value of this and can you measure success?
We can use the DFP API again, which is kind of important for, you know, commercial things.

/@guardian/commercial-dev 