### PR TITLE
Add experience dimension for GA

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -34,6 +34,11 @@
         return (analyticsTitle === 'Network Front') ? getAnalyticsEdition() + ' network front' : analyticsTitle;
     }
 
+    // Please email Dotcom Platform before changing this value
+    function getExperienceValue() {
+        return 'test-experience';
+    }
+
     var identityId = null;
     if (guardian.config.user) {
         identityId = guardian.config.user.id;
@@ -94,6 +99,7 @@
         @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
           ga('@{trackerName}.set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
         }
+        ga('@{trackerName}.set', 'dimension43', getExperienceValue()); @* 'Experience' dimension, for short-lived experiment values. *@
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker(context).trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?

Adds a custom dimension for 'experience' (term defined by data-team). This is a value that can be used for developer experiments and is initially reserved for use by platform for the webpack test.

Initially testing an arbitrary value to test the data is filtering through until webpack vs curl becomes an MVT test again.

## What is the value of this and can you measure success?

It will allows us to get high-level data in GA for user timing metrics, page load time and all the other things that GA gives us. It should not be used for proving statistical significance.

## Does this affect other platforms - Amp, Apps, etc?

Not currently, but could do in the future (technically other platforms using UK editorial property can happily push to this dimension with different data) but initially it should be reserved for the Dotcom Platform team.

## Tested in CODE?

Na.