### PR TITLE
Overridden news tone on review tone

### DIFF
--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -60,6 +60,10 @@
     .fc-item__meta {
         color: $neutral-4;
     }
+
+    .tone-news--sublink .fc-sublink__kicker {
+        color: #ffffff;
+    }
 }
 
 .tone-review--sublink {


### PR DESCRIPTION
A @ScottPainterGNM spot:

![screen shot 2017-01-16 at 11 42 51](https://cloud.githubusercontent.com/assets/14570016/21981764/ed4839c8-dbe0-11e6-8f5f-c4ae3725a74a.png)

Ahh, that's easier on the eyes.
<img width="231" alt="screen shot 2017-01-16 at 11 48 41" src="https://cloud.githubusercontent.com/assets/14570016/21981932/c0f57862-dbe1-11e6-93fb-9b82918bfe89.png">

CC @stephanfowler, this ensures I get a treat next Friday.