### PR TITLE
Related content name change

### DIFF
--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -15,10 +15,12 @@ import scala.concurrent.duration._
 
 class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgent: MostReadAgent)(implicit context: ApplicationContext) extends Controller with Related with Containers with Logging with ExecutionContexts {
 
+  private val RelatedLabel : String = "Related stories"
+
   private val page = SimplePage(MetaData.make(
     "related-content",
     Some(SectionSummary.fromId("related-content")),
-    "Related stories")
+    RelatedLabel)
   )
 
   def renderHtml(path: String) = render(path)
@@ -29,8 +31,8 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
 
     related(edition, path, excludeTags) map {
       case related if related.items.isEmpty => Cached(60)(JsonNotFound())
-      case related if isMf2 => renderRelatedMf2(related.items.sortBy(-_.content.trail.webPublicationDate.getMillis), "related stories")
-      case trails => renderRelated(trails.items.sortBy(-_.content.trail.webPublicationDate.getMillis), containerTitle = "related stories")
+      case related if isMf2 => renderRelatedMf2(related.items.sortBy(-_.content.trail.webPublicationDate.getMillis), RelatedLabel.toLowerCase())
+      case trails => renderRelated(trails.items.sortBy(-_.content.trail.webPublicationDate.getMillis), containerTitle = RelatedLabel.toLowerCase())
     }
   }
 
@@ -54,7 +56,7 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
     JsonComponent(
       "items" -> JsArray(Seq(
         Json.obj(
-          "displayName" -> "related stories",
+          "displayName" -> RelatedLabel.toLowerCase(),
           "showContent" -> relatedTrails.nonEmpty,
           "content" -> relatedTrails.map( collection => isCuratedContent(collection.faciaContent))
         )

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -18,7 +18,7 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
   private val page = SimplePage(MetaData.make(
     "related-content",
     Some(SectionSummary.fromId("related-content")),
-    "Related content")
+    "Related stories")
   )
 
   def renderHtml(path: String) = render(path)
@@ -29,8 +29,8 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
 
     related(edition, path, excludeTags) map {
       case related if related.items.isEmpty => Cached(60)(JsonNotFound())
-      case related if isMf2 => renderRelatedMf2(related.items.sortBy(-_.content.trail.webPublicationDate.getMillis), "related content")
-      case trails => renderRelated(trails.items.sortBy(-_.content.trail.webPublicationDate.getMillis), containerTitle = "related content")
+      case related if isMf2 => renderRelatedMf2(related.items.sortBy(-_.content.trail.webPublicationDate.getMillis), "related stories")
+      case trails => renderRelated(trails.items.sortBy(-_.content.trail.webPublicationDate.getMillis), containerTitle = "related stories")
     }
   }
 
@@ -54,7 +54,7 @@ class RelatedController(val contentApiClient: ContentApiClient, val mostReadAgen
     JsonComponent(
       "items" -> JsArray(Seq(
         Json.obj(
-          "displayName" -> "related content",
+          "displayName" -> "related stories",
           "showContent" -> relatedTrails.nonEmpty,
           "content" -> relatedTrails.map( collection => isCuratedContent(collection.faciaContent))
         )


### PR DESCRIPTION
## What does this change?

Change references to "Related content" to "Related stories"

## What is the value of this and can you measure success?

This is the preferred terminology

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 27](https://cloud.githubusercontent.com/assets/1590704/21982396/0755edda-dbe4-11e6-818f-2ee8b228d509.png)

## Tested in CODE?

No