### PR TITLE
Sticky "paid for" band not working properly

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/paidfor-band.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/paidfor-band.js
@@ -10,7 +10,7 @@ define([
         }
 
         return new Promise(function (resolve) {
-            var elem = document.querySelector('.facia-page > .paidfor-band, #article > .paidfor-band');
+            var elem = document.querySelector('.paidfor-band');
             if (elem) {
                 new Sticky(elem).init();
             }

--- a/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
@@ -17,6 +17,7 @@ define([
      */
     function Sticky(element, options) {
         this.element  = element;
+        this.sticks   = false;
         this.opts     = defaults(options || {}, {
             top: 0,
             containInParent: true,
@@ -34,23 +35,28 @@ define([
     };
 
     Sticky.prototype.updatePosition = function updatePosition() {
+        var elementRect = this.element.getBoundingClientRect();
         var parentRect = this.element.parentNode.getBoundingClientRect();
-        var elementHeight = this.element.offsetHeight;
-        var css = {}, message, stick;
+        var elementHeight = elementRect.height;
+        var css, message, stick;
 
         // have we scrolled past the element
-        if (parentRect.top < this.opts.top + paidforBandHeight) {
-            // make sure the element stays within its parent
-            var fixedTop = this.opts.containInParent && parentRect.bottom < this.opts.top + elementHeight ?
-                Math.floor(parentRect.bottom - elementHeight - this.opts.top) :
-                this.opts.top;
-            stick = true;
-            css = { top: fixedTop };
-            message = 'fixed';
+        if (this.sticks) {
+            if (window.pageYOffset < this.absolutePos) {
+                stick = false;
+                css = { top: null };
+                message = 'unfixed';
+            }
         } else {
-            stick = false;
-            css = { top: 0 };
-            message = 'unfixed';
+            if (elementRect.top <= this.opts.top) {
+                // make sure the element stays within its parent
+                var fixedTop = this.opts.containInParent && parentRect.bottom < this.opts.top + elementHeight ?
+                    Math.floor(parentRect.bottom - elementHeight - this.opts.top) :
+                    this.opts.top;
+                stick = true;
+                css = { top: fixedTop };
+                message = 'fixed';
+            }
         }
 
         if (this.opts.emitMessage && message && message !== this.lastMessage) {
@@ -60,6 +66,7 @@ define([
 
         if (css) {
             fastdom.write(function () {
+                this.sticks = stick;
                 if (stick) {
                     bonzo(this.element).addClass('is-sticky').css(css);
                 } else {

--- a/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
@@ -12,20 +12,6 @@ define([
     defaults
 ) {
 
-    var paidforBandHeight;
-
-    function initPaidForBand(element) {
-        paidforBandHeight = 0;
-        if (config.page.isAdvertisementFeature) {
-            var paidforBand = document.querySelector('.paidfor-band');
-            if (paidforBand && paidforBand !== element) {
-                fastdom.read(function () {
-                    paidforBandHeight = paidforBand.offsetHeight;
-                });
-            }
-        }
-    }
-
     /**
      * @todo: check if browser natively supports "position: sticky"
      */
@@ -39,9 +25,9 @@ define([
     }
 
     Sticky.prototype.init = function init() {
-        if (paidforBandHeight === undefined) {
-            initPaidForBand(this.element);
-        }
+        fastdom.read(function () {
+            this.absolutePos = window.pageYOffset + this.element.getBoundingClientRect().top;
+        }, this);
         mediator.on('window:throttledScroll', this.updatePosition.bind(this));
         // kick off an initial position update
         fastdom.read(this.updatePosition, this);


### PR DESCRIPTION
There were several issues:

- in this page, the band is outside of the element where we presumed it would be found, and so the sticky script never kicked off

- the sticky script has a bug where it assumes the sticky element is at the top of its parent container, which may not always be the case.