### PR TITLE
Disable 300ms delay on taps

### DIFF
--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -97,3 +97,12 @@ ol,
 ul {
     list-style-position: inside;
 }
+
+/* disable 300ms delay for 'clicks' on mobile */
+/* see: https://webkit.org/blog/5610/more-responsive-tapping-on-ios/ */
+a,
+button,
+input[type="button"],
+input[type="submit"] {
+    touch-action: manipulation;
+}


### PR DESCRIPTION
The difference is dramatic on iOS Safari.

cc @guardian/dotcom-platform 