### PR TITLE
Fix CSS typo

### DIFF
--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -13,7 +13,7 @@
         color: #333333;
     }
     .tone-news .fc-item__kicker,
-    .tone-news .byline, {
+    .tone-news .byline {
         color: #005689;
     }
     .tone-news .kicker-separator {
@@ -34,7 +34,7 @@
         color: #fff;
     }
     .tone-feature .fc-item__kicker,
-    .tone-feature .byline, {
+    .tone-feature .byline {
         color: #fdadba;
     }
     .tone-feature .kicker-separator {
@@ -55,7 +55,7 @@
         color: #fff;
     }
     .tone-media .fc-item__kicker,
-    .tone-media .byline, {
+    .tone-media .byline {
         color: #ffbb00;
     }
     .tone-media .kicker-separator {
@@ -76,7 +76,7 @@
         color: #fff;
     }
     .tone-review .fc-item__kicker,
-    .tone-review .byline, {
+    .tone-review .byline {
         color: #ffce4b;
     }
     .tone-review .kicker-separator {
@@ -97,7 +97,7 @@
         color: #fff;
     }
     .tone-editorial .fc-item__kicker,
-    .tone-editorial .byline, {
+    .tone-editorial .byline {
         color: #aad8f1;
     }
     .tone-editorial .kicker-separator {
@@ -128,7 +128,7 @@
         font-size: 16px;
     }
     .tone-external .fc-item__kicker,
-    .tone-external .byline, {
+    .tone-external .byline {
         color: #333333;
         font-weight: bold;
     }
@@ -150,7 +150,7 @@
         color: #fff;
     }
     .tone-live .fc-item__kicker,
-    .tone-live .byline, {
+    .tone-live .byline {
         color: #fdadba;
     }
     .tone-live .kicker-separator {
@@ -171,7 +171,7 @@
         color: #005689;
     }
     .tone-analysis .fc-item__kicker,
-    .tone-analysis .byline, {
+    .tone-analysis .byline {
         color: #767676;
     }
     .tone-analysis .kicker-separator {
@@ -192,7 +192,7 @@
         color: #fff;
     }
     .tone-special-report .fc-item__kicker,
-    .tone-special-report .byline, {
+    .tone-special-report .byline {
         color: #fce800;
     }
     .tone-special-report .kicker-separator {
@@ -213,7 +213,7 @@
         color: #333333;
     }
     .tone-comment .fc-item__kicker,
-    .tone-comment .byline, {
+    .tone-comment .byline {
         color: #e6711b;
     }
     .tone-comment .kicker-separator {
@@ -234,7 +234,7 @@
         color: #333333;
     }
     .tone-dead .fc-item__kicker,
-    .tone-dead .byline, {
+    .tone-dead .byline {
         color: #cc2b12;
     }
     .tone-dead .kicker-separator {


### PR DESCRIPTION
Fixes a mistake in #15555 (which luckily would not have affected any live emails: these tone styles get overriden for "connected-style" emails and the only one being sent out in "card-style" is The Flyer, which goes out on Wednesday afternoon)

@SiAdcock  