### PR TITLE
Limit items in email containers

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -106,7 +106,7 @@
     }
 }
 
-@page.collections.zipWithIndex.map { case (collection, collectionIndex) =>
+@page.collections.filterNot(_.curatedPlusBackfillDeduplicated.isEmpty).zipWithIndex.map { case (collection, collectionIndex) =>
     @paddedRow {
         <h2 class="container-title @if(collectionIndex > 0) { container-title--not-first }">
             @collection.displayName

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -113,7 +113,7 @@
         </h2>
     }
 
-    @collection.curatedPlusBackfillDeduplicated.zipWithIndex.map { case (pressedContent, cardIndex) =>
+    @collection.curatedPlusBackfillDeduplicated.take(6).zipWithIndex.map { case (pressedContent, cardIndex) =>
         @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) { card =>
             @if(cardIndex == 0) {
                 @firstCard(card)


### PR DESCRIPTION
Two things for email fronts:

- Don't display empty containers
- Max six items per container - more than that simply won't display. This is because we're now using backfill for email fronts (specifically, [The Guardian Today, US Edition](https://www.theguardian.com/email/us/daily?format=email-connected)) and some of the container sizes are unwieldy. We will probably put something more sophisticated in place eventually but it depends on the needs of the desks once they start using backfilled containers in anger (we may add a "backfill max items" field to the fronts tool)

@SiAdcock 