### PR TITLE
Extending and changing ownership of long cache comments switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -60,9 +60,9 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "long-cache-comments-switch",
     "If this switch is on then closed comment threads will get a longer cache time",
-    owners = Seq(Owner.withGithub("nicl")),
+    owners = Seq(Owner.withGithub("jfsoul")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 1, 16),
+    sellByDate = new LocalDate(2017, 2, 1),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?
Extends and assigns to me the switch for long closed comment thread caching.  I have taken the rash decision of looking at this myself in the next week or so - we should be able to measure the value of it fairly easily and make a decision one way or another.

## What is the value of this and can you measure success?
Tests pass.

## Tested in CODE?
No!
