### PR TITLE
Sticky: account for resized top banner

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
@@ -26,7 +26,7 @@ define([
 
     Sticky.prototype.init = function init() {
         fastdom.read(function () {
-            this.absolutePos = window.pageYOffset + this.element.getBoundingClientRect().top;
+            this.offsetFromParent = this.element.getBoundingClientRect().top - this.element.parentNode.getBoundingClientRect().top;
         }, this);
         mediator.on('window:throttledScroll', this.updatePosition.bind(this));
         // kick off an initial position update
@@ -40,7 +40,7 @@ define([
         var css, message, stick;
 
         // have we scrolled past the element
-        if (window.pageYOffset < this.absolutePos) {
+        if (0 < parentRect.top + this.offsetFromParent) {
             stick = false;
             css = { top: null };
             message = 'unfixed';


### PR DESCRIPTION
Because the top banner may get resized after we compute the absolute position of the element, it may happen that the sticky snaps into place too early, which creates a jarring effect. Solution: because the parent element will never stick, we use it as a proxy to account for any top banner resize ... and then all we need is the offset of the element from the top of its parent container.