### PR TITLE
Content Card should use headline rather than webTitle

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -338,7 +338,7 @@ object ContentCard {
         isGallery = false,
         isAudio = false,
         kicker = None,
-        headline = apiContent.webTitle,
+        headline = apiContent.fields.flatMap(_.headline).getOrElse(apiContent.webTitle),
         url = EditionalisedLink(apiContent.webUrl)
       )
 


### PR DESCRIPTION
## What does this change?

Changes the source of the headline for individual content cards to be consistent with normal fronts.

## What is the value of this and can you measure success?

Recommendations with have the correct headline

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Unstyled (sorry)

Before:

![screen shot 2017-01-17 at 10 41 53](https://cloud.githubusercontent.com/assets/2619836/22017285/a0696688-dca1-11e6-8dcf-925c991f2f38.png)

After:

![screen shot 2017-01-17 at 10 42 02](https://cloud.githubusercontent.com/assets/2619836/22017286/a069bee4-dca1-11e6-9959-64a4fdacbb09.png)


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
