### PR TITLE
Activate recommended for you test for 1% of users

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -37,12 +37,14 @@ define([
 ) {
     return function () {
         this.id = 'RecommendedForYouRecommendations';
-        this.start = '2016-08-02';
+        this.start = '2017-01-17';
         this.expiry = '2017-02-21';
-        this.author = 'Joseph Smith';
-        this.description = 'Add a personalised container to fronts';
-        this.audience = 0;
-        this.audienceOffset = 0;
+        this.author = 'David Furey';
+        this.description = 'Add an extra container above Opinion on the home front with recommended content based on ' +
+            'each users history.  Users in the test group are prompted to opt-in.  Recommendations are only fetched' +
+            'if the user opts-in.';
+        this.audience = 0.01;
+        this.audienceOffset = 0.2;
         this.successMeasure = 'Visit frequency';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';


### PR DESCRIPTION
## What does this change?

A/B test adding a new container to the home front containing recommended content based on visitors browsing history

## What is the value of this and can you measure success?

Demand test showed that users wanted this feature. Showing people content that is picked specifically for them might increase visit frequency.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![image](https://cloud.githubusercontent.com/assets/3072877/21603790/904d0a76-d197-11e6-96cd-344c3d806b74.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
