### PR TITLE
Configure Nginx to use http 1.1 when it proxies requests

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -4,6 +4,7 @@ upstream frontend {
 }
 
 server {
+    proxy_http_version 1.1; # this is essential for chunked responses to work
     server_name m.thegulocal.com;
 
     location / {

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -14,6 +14,7 @@ server {
 }
 
 server {
+    proxy_http_version 1.1; # this is essential for chunked responses to work
     listen 443;
     server_name m.thegulocal.com;
 


### PR DESCRIPTION
Configures Nginx to use http 1.1 when proxying requests. 

Otherwise when accessing frontend via  m.thegulocal.com chunked requests will not work (return 505 responses) and css and js doesn't get served correctly. 

More info [here](https://medium.com/@yatskevich/chunked-responses-with-nginx-and-play-framework-3ffada39ea0c#.w5ptvl9v8)

<!-- **************************************************************** -->
<!-- IMPORTANT -->
<!-- Continuous Deployment is enabled for this repository -->
<!-- Merging into master = deploying to PROD -->
<!-- Use Riff-Raff to deploy/test a PR on CODE before merging -->
<!-- **************************************************************** -->

## What does this change?
Does what it says on the tin.

## What is the value of this and can you measure success?
Enables local development using Nginx

## Does this affect other platforms - Amp, Apps, etc?
No 

## Screenshots
Before:
![screen shot 2017-01-17 at 11 50 19](https://cloud.githubusercontent.com/assets/181371/22019511/cc3c366e-dcab-11e6-8639-11e83dd5eaf9.png)

After:
![screen shot 2017-01-17 at 11 53 54](https://cloud.githubusercontent.com/assets/181371/22019524/d816c382-dcab-11e6-8207-1c720df0aaec.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
