### PR TITLE
Link 'Trouble viewing' to email version of email fronts

### DIFF
--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -5,7 +5,7 @@
 @import common.{CanonicalLink, LinkTo}
 
 @fullRow(Seq("email__links")) {
-    <a class="email__link" href="https://profile.theguardian.com/email-prefs">Manage your emails</a> | <a class="email__link" href="%%unsub_center_url%%">Unsubscribe</a> | <a class="email__link" href="@LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))">Trouble viewing?</a>
+    <a class="email__link" href="https://profile.theguardian.com/email-prefs">Manage your emails</a> | <a class="email__link" href="%%unsub_center_url%%">Unsubscribe</a> | <a class="email__link" href="@linkToWebVersion(page)">Trouble viewing?</a>
 }
 
 @fullRow(Seq("disclaimer")) {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -1,8 +1,10 @@
 package views.support
 
+import common.{CanonicalLink, LinkTo}
 import conf.Static
 import layout.ContentCard
 import model._
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
 object EmailHelpers {
@@ -63,6 +65,17 @@ object EmailHelpers {
 
   def imgFromCard(card: ContentCard) = imageUrlFromCard(card).map { url =>
     imgForFront(url, Some(card.header.headline))
+  }
+
+  def linkToWebVersion(page: Page)(implicit request: RequestHeader) = {
+    // Email fronts aren't visible as normal web fronts (since they don't always look very good),
+    // so link to email-friendly version that was used to produce the email
+    // But email articles actually look nicer on web than in email.
+    if (page.metadata.isFront) {
+      request.uri
+    } else {
+      LinkTo(page.metadata.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, page.metadata.webUrl)))
+    }
   }
 
   object Images {


### PR DESCRIPTION
The "Trouble viewing" link at the bottom of the email has always been broken for front-generated emails since it tries to link to the web front (based on the behaviour of article-generated emails which link to the normal article rather than the email-friendly one). Email fronts are only visible in email format.

This fixes the problem by using the request URI as the link href for front emails. Since we have a few different email formats & alternative ways of requesting them in play at the moment (`?format=email`, `?format=email-connected`, `/email`) this will ensure it always links to the right one. In the near future when we consolidate to a single way of requesting email format, this will still work without modification.

@davidfurey @lmath 
