### PR TITLE
resolve promise immediately if window.YT.Player already exists

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-player.js
@@ -11,7 +11,11 @@ define([
 ) {
     var scriptSrc = 'https://www.youtube.com/iframe_api';
     var promise = new Promise(function(resolve) {
-        window.onYouTubeIframeAPIReady = resolve;
+        if (window.YT && window.YT.Player) {
+            resolve();
+        } else {
+            window.onYouTubeIframeAPIReady = resolve;
+        }
     });
 
     function loadYoutubeJs() {

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -38,7 +38,7 @@ define([
         tracking.track('play', atomId);
 
         if (player.endSlate &&
-            !player.overlay.querySelector('.end-slate-container')) {
+            !player.overlay.parentNode.querySelector('.end-slate-container')) {
             player.endSlate.fetch(player.overlay.parentNode, 'html');
         }
     }


### PR DESCRIPTION
## What does this change?

Guards against potential race condition where window.YT.Player is defined before we define our Promise that waits for window.YT.Player to be defined before resolving. 

## What is the value of this and can you measure success?

Reduces possibility of youtube atoms failing to initialise.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

@gidsg 