### PR TITLE
add switch to use amp-youtube instead of amp-iframe

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -519,4 +519,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 1, 20),
     exposeClientSide = true
   )
+
+  //Owner Gideon Goldberg
+  val UseAmpYouTubeTagForMediaAtoms = Switch(
+    SwitchGroup.Feature,
+    "use-amp-youtube-tag-for-media-atoms",
+    "Use amp-youtube tag to render YouTube media atoms on AMP pages",
+    owners = Seq(Owner.withGithub("michaelwmcnamara")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 1, 20),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -527,7 +527,7 @@ trait FeatureSwitches {
     "Use amp-youtube tag to render YouTube media atoms on AMP pages",
     owners = Seq(Owner.withGithub("michaelwmcnamara")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 20),
+    sellByDate = new LocalDate(2017, 2, 2),
     exposeClientSide = true
   )
 }

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,15 +1,28 @@
-@(media: model.content.MediaAtom)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom,  displayCaption: Boolean)(implicit request: RequestHeader)
 @import conf.Configuration
 @import views.support.Video700
+@import conf.switches.Switches.UseAmpYouTubeTagForMediaAtoms
+@import views.html.fragments.atoms.simpleCaption
 
-<amp-iframe
-sandbox="allow-scripts allow-same-origin allow-popups"
-layout="responsive"
-width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
-@media.posterImage.map { posterImage =>
-    <amp-img layout="fill" src="@Video700.bestFor(posterImage)" placeholder></amp-img>
+@if(UseAmpYouTubeTagForMediaAtoms.isSwitchedOn){
+    <amp-youtube
+    data-videoid="@media.assets.head.id"
+    layout="responsive"
+    width="16" height="9" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
+    </amp-youtube>
+} else {
+    <amp-iframe
+    sandbox="allow-scripts allow-same-origin allow-popups"
+    layout="responsive"
+    width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
+    @media.posterImage.map { posterImage =>
+        <amp-img layout="fill" src="@Video700.bestFor(posterImage)" placeholder></amp-img>
+    }
+    </amp-iframe>
 }
-</amp-iframe>
+@if(displayCaption) {
+    @simpleCaption(media.title)
+}
 
 
 

--- a/common/app/views/fragments/atoms/genericMedia.scala.html
+++ b/common/app/views/fragments/atoms/genericMedia.scala.html
@@ -1,21 +1,22 @@
 @import views.support.RenderClasses
+@import views.html.fragments.atoms.simpleCaption
 
-@(media: model.content.MediaAtom, displayCaption: Boolean)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, amp: Boolean)(implicit request: RequestHeader)
 
-    <div class="@RenderClasses(Map(
+    @if(!amp) {
+        <div class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
         "u-responsive-ratio--hd" -> true
     ))">
+        }
+    @Html(media.defaultHtml)
 
-        @Html(media.defaultHtml)
-
+    @if(!amp){
     </div>
+    }
 
-@if(displayCaption) {
-    <figcaption class="caption caption--main" itemprop="description">
-        @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
-        @media.title
-    </figcaption>
-}
+    @if(displayCaption) {
+        @simpleCaption(media.title)
+    }
 
 

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -7,8 +7,8 @@
                 doCaption = displayCaption,
                 // image_figureClasses needs to be defined to avoid extra indent on AMP (see imageFigure fragment)
                 image_figureClasses = Some(media.posterImage.get.largestImage.get, ""))
-            case youtube if media.assets.headOption.filter(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage)
-            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption)
+            case youtube if media.assets.headOption.filter(_.platform == "Youtube") => if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage)
+            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }
 

--- a/common/app/views/fragments/atoms/simpleCaption.scala.html
+++ b/common/app/views/fragments/atoms/simpleCaption.scala.html
@@ -1,0 +1,5 @@
+@(captionText: String)(implicit request: RequestHeader)
+<figcaption class="caption caption--main" itemprop="description">
+    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
+    @captionText
+</figcaption>


### PR DESCRIPTION
<!-- **************************************************************** -->
<!-- IMPORTANT -->
<!-- Continuous Deployment is enabled for this repository -->
<!-- Merging into master = deploying to PROD -->
<!-- Use Riff-Raff to deploy/test a PR on CODE before merging -->
<!-- **************************************************************** -->

## What does this change?
Adds switch which uses [amp-youtube](https://www.ampproject.org/docs/reference/components/amp-youtube) instead of [amp-iframe](https://www.ampproject.org/docs/reference/components/amp-iframe) for YouTube Media Atoms on AMP.

Also, some refactoring including adding the caption on AMP and moving caption template to its own fragment.

## What is the value of this and can you measure success?
This enables us to test the whitelisting of ads on AMP using `amp-youtube`

## Does this affect other platforms - Amp, Apps, etc?
AMP only

## Screenshots
<img width="579" alt="screen shot 2017-01-17 at 16 31 52" src="https://cloud.githubusercontent.com/assets/1764158/22030352/4940cd2c-dcd5-11e6-8a0d-82a4753250d2.png">




## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
