### PR TITLE
Email fronts always get served as email

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -134,8 +134,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
     getFrontPriorityFromConfig(id).contains(EmailPriority)
 
   // email fronts are only served if the email-friendly format has been specified in the request
-  def shouldServeFront(id: String, isEmailRequest: Boolean = false)(implicit context: ApplicationContext) = getPathIds.contains(id) &&
-    (context.isPreview || !isFrontHidden(id)) && (isEmailRequest || !isEmailFront(id))
+  def shouldServeFront(id: String)(implicit context: ApplicationContext) =
+    getPathIds.contains(id) && (context.isPreview || !isFrontHidden(id))
 
   def shouldServeEditionalisedFront(edition: Edition, id: String)(implicit context: ApplicationContext) = {
     shouldServeFront(s"${edition.id.toLowerCase}/$id")

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -10,38 +10,6 @@ class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
 
   val fronts = ConfigJson(
     Map(
-      "email-front" -> FrontJson(
-        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
-        navSection = None,
-        webTitle = None,
-        title = None,
-        description = None,
-        onPageDescription = None,
-        imageUrl = None,
-        imageWidth = None,
-        imageHeight = None,
-        isImageDisplayed = None,
-        priority = Some("email"),
-        isHidden = None,
-        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
-        group = Some("US professional")
-      ),
-      "hidden-email-front" -> FrontJson(
-        collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
-        navSection = None,
-        webTitle = None,
-        title = None,
-        description = None,
-        onPageDescription = None,
-        imageUrl = None,
-        imageWidth = None,
-        imageHeight = None,
-        isImageDisplayed = None,
-        priority = Some("email"),
-        isHidden = Some(true),
-        canonical = Some("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
-        group = Some("US professional")
-      ),
       "editorial-front" -> FrontJson(
         collections = List("e59785e9-ba82-48d8-b79a-0a80b2f9f808"),
         navSection = None,
@@ -111,17 +79,4 @@ class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
     val previewContext = ApplicationContext(Environment.simple(), ApplicationIdentity("preview"))
     ConfigAgent.shouldServeFront("editorial-front")(previewContext) should be(true)
   }
-
-  it should "not serve an email front requested as a normal front" in {
-    ConfigAgent.shouldServeFront("email-front") should be(false)
-  }
-
-  it should "serve an email front requested as an email front" in {
-    ConfigAgent.shouldServeFront("email-front", isEmailRequest = true) should be(true)
-  }
-
-  it should "not serve a hidden email front requested as an email front" in {
-    ConfigAgent.shouldServeFront("hidden-email-front", isEmailRequest = true) should be(false)
-  }
-
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -84,7 +84,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     log.info(s"Serving Path: $path")
     if (shouldEditionRedirect(path))
       redirectTo(Editionalise(path, Edition(request)))
-    else if (!ConfigAgent.shouldServeFront(path, request.isEmail) || request.getQueryString("page").isDefined)
+    else if (!ConfigAgent.shouldServeFront(path) || request.getQueryString("page").isDefined)
       applicationsRedirect(path)
     else
       renderFrontPressResult(path)
@@ -118,7 +118,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           }
           else if (request.isJson)
             Cached(CacheTime.Facia)(JsonFront(faciaPage))
-          else if (request.isEmail) {
+          else if (request.isEmail || ConfigAgent.isEmailFront(path)) {
             Cached(CacheTime.Facia) {
               RevalidatableResult.Ok(InlineStyles(views.html.frontEmail(faciaPage)))
             }


### PR DESCRIPTION
Initially as a solution to the problem detailed in #15587 (but actually with a few other benefits too), I've decided to tweak the functionality of email fronts to be this:

- Email fronts always render in email format. No `?format=email` etc needed
- Non-email fronts **can** be rendered as email with `?format=email` (there may not be a use case for this yet but seems reasonable to leave this possibility open)

This has these advantages:
- The broken "Troubling Viewing" link (see #15587) would work without this extra logic, for future **and** existing emails
- The [slightly convoluted logic](https://github.com/guardian/frontend/pull/15516/files) around whether fronts can be rendered would be simplified. In fact, it wouldn't care about email fronts at all. The only logic is: render as an email if the request is an email request or the front is an email front
- Preview in the fronts tool would work without any extra logic

@davidfurey @lmath 