### PR TITLE
Structured data - Recipes - add image and improved formatting

### DIFF
--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -1,18 +1,20 @@
 @(recipe: model.content.RecipeAtom)(implicit request: RequestHeader)
 @import play.api.libs.json.Json
+@import views.support.{ImgSrc, GoogleStructuredData}
 
 <script type="application/ld+json">
      {
       "@@context": "http://schema.org/",
       "@@type": "Recipe",
       "name": "@recipe.data.title",
-      @for(category <- recipe.data.tags.category) {"recipeCategory": "@category",} 
-      @* TODO image and autor "image": "@http://i.guimcode.co.uk/img/media/82fbac20615e571c3783602c570cb12ffee5f000/0_2071_4912_2948/master/4912.jpg?w=300&h=300&q=55&auto=format&usm=12&fit=crop",
-      "author": {
-      "@@type": "Person",
-      "name": "scoopnana"
-     }, *@
-     @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@published",}
+      @for(category <- recipe.data.tags.category) {"recipeCategory": "@category",}
+      @recipe.data.images.headOption.map {img => "image": "@imgValue(img)",}
+      @recipe.data.credits.headOption.map { name => "author": {
+          "@@type": "Person",
+          "name": "@name"
+        },
+      } 
+      @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@published",}
      
      @* 
      TODO - We do not have this description and rating in the model yet  
@@ -41,10 +43,14 @@
      },
      *@
      "recipeIngredient": @Html(Json.stringify(Json.toJson(ingredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients))))),
-     "recipeInstructions": 
-        "@recipe.data.steps.zipWithIndex.map { case(step,index) => \n@index. @step }.mkString"
+     "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"$index. $step" })))
     }
 </script>
+
+@imgValue(image: com.gu.contentatom.thrift.Image) = @{
+    val media =  model.content.MediaAtom.imageMediaMake(image, "")
+    ImgSrc.findNearestSrc(media, GoogleStructuredData).getOrElse("")
+}
 
 @formatDuration(mins: Short) = @{s"PT${mins}M"}
 
@@ -56,20 +62,43 @@
     }
 }
 
+
 @*
   TODO - ingredient unit could be improved 1/8 instead of 0.125 for instance depending on the unit 
 *@
 @ingredientValues(ingredients: Seq[com.gu.contentatom.thrift.atom.recipe.Ingredient]) = @{
     ingredients.map { ingredient => 
         val q = if (ingredient.quantity.isDefined) {
-            ingredient.quantity.get    
+            formatQuantity(ingredient.quantity.get)    
         } else if (ingredient.quantityRange.isDefined) {
-            s"${ingredient.quantityRange.get.from}-${ingredient.quantityRange.get.to}"
+            val range = ingredient.quantityRange.get
+            s"${formatQuantity(range.from)}-${formatQuantity(range.to)}"
         } else {
             ""
         }
-        s""" ${q} ${ingredient.unit.getOrElse("")} ${ingredient.item}"""
+        s"""${q} ${formatUnit(ingredient.unit.getOrElse(""))} ${ingredient.item}"""
     }
 }
 
+@formatUnit(unit: String) = @{
+        unit match {
+            case "dsp" => "dessert spoon"
+            case "tsp" => "teaspoon"
+            case "tbsp" => "tablespoon" 
+            case _ => unit
+        }
+}
 
+@formatQuantity(q: Double) = @{
+    if(q == q.toInt) {
+        q.toInt
+    } else {
+        q match {
+            case 0.75 => "3/4"
+            case 0.5 => "1/2"
+            case 0.25 => "1/4"
+            case 0.125 => "1/8"
+            case _ => q 
+        }
+    }
+}

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -19,7 +19,7 @@ sealed trait ElementProfile {
   def compression: Int
   def isPng: Boolean
   def autoFormat: Boolean
-
+  
   def elementFor(image: ImageMedia): Option[ImageAsset] = {
     val sortedCrops = image.imageCrops.sortBy(-_.width)
     width.flatMap{ desiredWidth =>
@@ -100,6 +100,8 @@ object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
+
+object GoogleStructuredData extends Profile(width = Some(300), height = Some(300)) // 1:1
 
 abstract class ShareImage(shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
   override val heightParam = "h=630"


### PR DESCRIPTION

## What does this change?

Following [initial work on structured data ](https://github.com/guardian/frontend/pull/15556):

* Add correctly the image using our image service
* Return instructions as a `List` instead of `String`
* Improved formatting of ingredients by rendering better `Double` instance

## What is the value of this and can you measure success?

See previous changes.

## Does this affect other platforms - Amp, Apps, etc?

AMP is concerned as well.

## Screenshots
Soon 😄 

