### PR TITLE
Structured Data - Recipe - Use master asset for resizing or fallback to default

### DIFF
--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -49,7 +49,7 @@
 
 @imgValue(image: com.gu.contentatom.thrift.Image) = @{
     val media =  model.content.MediaAtom.imageMediaMake(image, "")
-    ImgSrc.findNearestSrc(media, GoogleStructuredData).getOrElse("")
+    ImgSrc.findLargestSrc(media, GoogleStructuredData).getOrElse("")
 }
 
 @formatDuration(mins: Short) = @{s"PT${mins}M"}

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -200,7 +200,7 @@ object ImgSrc extends Logging with implicits.Strings {
     }
   }
 
-  private def findLargestSrc(ImageElement: ImageMedia, profile: Profile): Option[String] = {
+  def findLargestSrc(ImageElement: ImageMedia, profile: Profile): Option[String] = {
     profile.largestFor(ImageElement).flatMap(_.url).map{ largestImage =>
       ImgSrc(largestImage, profile)
     }


### PR DESCRIPTION
## What does this change?

Usage of the largest asset for resizing following @paperboyo recommendation.
Benefits are:
- Better image quality (we resize from a non-previously resized image)
- Better caching
