### PR TITLE
Improve prepare googletag perf measurements

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
@@ -44,17 +44,21 @@ define([
 
     function init(moduleName) {
 
+        function moduleStart() {
+            // Use Custom Timing to time the googletag code without the sonobi pre-loading.
+            performanceLogging.moduleStart(moduleName);
+        }
+
         function moduleEnd() {
             performanceLogging.moduleEnd(moduleName);
         }
 
         function setupAdvertising() {
-            // Use Custom Timing to time the googletag code without the sonobi pre-loading.
-            performanceLogging.moduleStart(moduleName);
 
             performanceLogging.addTag(dfpEnv.sonobiEnabled ? 'sonobi' : 'waterfall');
 
             window.googletag.cmd.push(
+                moduleStart,
                 setListeners,
                 setPageTargeting,
                 moduleEnd

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
@@ -65,14 +65,7 @@ define([
             );
 
             // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
-            loadScript(config.libs.googletag);
-
-            // Return a promise that resolves after the async work is done.
-            return new Promise(function(resolve){
-                window.googletag.cmd.push(
-                    resolve
-                );
-            });
+            return loadScript(config.libs.googletag);
         }
 
         if (commercialFeatures.dfpAdvertising) {


### PR DESCRIPTION
@rich-nguyen two small things:

1- the `init` promise resolves when the DFP lib has loaded, otherwise it has to wait for the whole command queue (which, when the lib has loaded, may contain many more tasks than the ones in here) to be emptied

2- I took the network call measurement out of the module execution time. I'm not sure you'll agree with this, but it feels like something we aren't able to improve ourselves.