### PR TITLE
Improve fill adverts perf measurements

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -21,9 +21,9 @@ define([
     }
 
     function fillAdvertSlots(moduleName) {
-        performanceLogging.moduleStart(moduleName);
 
         window.googletag.cmd.push(
+            moduleStart,
             createAdverts,
             queueAdverts,
             setPublisherProvidedId,
@@ -32,6 +32,10 @@ define([
             refreshOnResize,
             moduleEnd
         );
+
+        function moduleStart() {
+            performanceLogging.moduleStart(moduleName);
+        }
 
         function moduleEnd() {
             performanceLogging.moduleEnd(moduleName);

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -17,12 +17,7 @@ define([
         if (commercialFeatures.dfpAdvertising) {
             fillAdvertSlots(moduleName);
         }
-        // Return a promise that resolves after the async work is done.
-        return new Promise(function(resolve){
-            window.googletag.cmd.push(
-                resolve
-            );
-        });
+        return Promise.resolve();
     }
 
     function fillAdvertSlots(moduleName) {


### PR DESCRIPTION
Same thing as #15601 where we only measure the time to empty the queue related to fill advert slots.