### PR TITLE
Move CommercialClientSideLogging job to admin app

### DIFF
--- a/admin-jobs/app/AppLoader.scala
+++ b/admin-jobs/app/AppLoader.scala
@@ -14,7 +14,6 @@ import play.api.ApplicationLoader.Context
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import services.ConfigAgentLifecycle
-import jobs.CommercialClientSideLoggingLifecycle
 import play.api.http.HttpRequestHandler
 import play.api.{BuiltInComponentsFromContext, Environment}
 import router.Routes
@@ -39,8 +38,7 @@ trait AppComponents extends FrontendComponents with AdminJobsControllers with Ad
     wire[ConfigAgentLifecycle],
     wire[CloudWatchMetricsLifecycle],
     wire[SwitchboardLifecycle],
-    wire[CachedHealthCheckLifeCycle],
-    wire[CommercialClientSideLoggingLifecycle]
+    wire[CachedHealthCheckLifeCycle]
   )
 
   lazy val router: Router = wire[Routes]

--- a/admin-jobs/conf/logback.xml
+++ b/admin-jobs/conf/logback.xml
@@ -15,23 +15,6 @@
         </encoder>
     </appender>
 
-    <appender name="COMMERCIAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/frontend-commercial-client-side.log</file>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/frontend-commercial-client-side-archive/%d{yyyy-MM-dd--HH-mm}.log</fileNamePattern>
-            <maxHistory>40</maxHistory>
-        </rollingPolicy>
-
-        <encoder>
-            <pattern>%msg%n%nopex</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="jobs.CommercialClientSideLogging" level="INFO" additivity="false">
-        <appender-ref ref="COMMERCIAL"/>
-    </logger>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
     </root>

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -62,7 +62,8 @@ trait AppComponents extends FrontendComponents with AdminControllers with AdminS
     wire[SurgingContentAgentLifecycle],
     wire[DfpAgentLifecycle],
     wire[DfpDataCacheLifecycle],
-    wire[CachedHealthCheckLifeCycle]
+    wire[CachedHealthCheckLifeCycle],
+    wire[CommercialClientSideLoggingLifecycle]
   )
 
   lazy val router: Router = wire[Routes]

--- a/admin/app/jobs/CommercialClientSideLogging.scala
+++ b/admin/app/jobs/CommercialClientSideLogging.scala
@@ -7,12 +7,13 @@ import common._
 import common.commercial.ClientSideLogging
 import org.apache.commons.io.FileUtils
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import org.joda.time.{Seconds, Duration, DateTime}
+import org.joda.time.{DateTime, Duration, Seconds}
 import org.slf4j.LoggerFactory
 import play.api.inject.ApplicationLifecycle
 import services.S3
-import scala.concurrent.{Future, ExecutionContext}
+
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 object CommercialClientSideLogging extends Logging {
 

--- a/admin/conf/logback.xml
+++ b/admin/conf/logback.xml
@@ -18,6 +18,26 @@
     <!-- DFP API logging -->
     <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="WARN"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
+    <!-- END -->
+
+    <!-- Commercial client side logging -->
+    <appender name="COMMERCIAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-commercial-client-side.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-commercial-client-side-archive/%d{yyyy-MM-dd--HH-mm}.log</fileNamePattern>
+            <maxHistory>40</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%msg%n%nopex</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="jobs.CommercialClientSideLogging" level="INFO" additivity="false">
+        <appender-ref ref="COMMERCIAL"/>
+    </logger>
+    <!-- END -->
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>


### PR DESCRIPTION
We created admin-jobs one year ago with the goal to move all jobs from
admin into admin-jobs.
A year later we failed at doing so, only one job has been created in
admin-jobs (CommercialClientSideLogging) and none has been moved.
Since moving jobs out of admin is NOT a priority at all at the moment, I
think it makes sense to keep things simple with all the jobs in admin.
We can revisit how we manage jobs in frontend later (ie: use lambda
maybe for example)

## What is the value of this and can you measure success?
Keep things simple and eventually remove admin-jobs which is barely doing anything at the moment

## Tested in CODE?
No
