### PR TITLE
fix caption padding on YouTube Media Atoms

### DIFF
--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 @import views.support.Video700
 @import conf.switches.Switches.UseAmpYouTubeTagForMediaAtoms
-@import views.html.fragments.atoms.simpleCaption
+@import views.html.fragments.atoms.mediaAtomCaption
 
 @if(UseAmpYouTubeTagForMediaAtoms.isSwitchedOn){
     <amp-youtube
@@ -21,7 +21,7 @@
     </amp-iframe>
 }
 @if(displayCaption) {
-    @simpleCaption(media.title)
+    @mediaAtomCaption(media.title)
 }
 
 

--- a/common/app/views/fragments/atoms/genericMedia.scala.html
+++ b/common/app/views/fragments/atoms/genericMedia.scala.html
@@ -1,5 +1,5 @@
 @import views.support.RenderClasses
-@import views.html.fragments.atoms.simpleCaption
+@import views.html.fragments.atoms.mediaAtomCaption
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, amp: Boolean)(implicit request: RequestHeader)
 
@@ -16,7 +16,7 @@
     }
 
     @if(displayCaption) {
-        @simpleCaption(media.title)
+        @mediaAtomCaption(media.title)
     }
 
 

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -1,5 +1,5 @@
 @(captionText: String)(implicit request: RequestHeader)
-<figcaption class="caption caption--img" itemprop="description">
+<figcaption class="caption caption--img caption--media-atom" itemprop="description">
     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
     @captionText
 </figcaption>

--- a/common/app/views/fragments/atoms/simpleCaption.scala.html
+++ b/common/app/views/fragments/atoms/simpleCaption.scala.html
@@ -1,5 +1,5 @@
 @(captionText: String)(implicit request: RequestHeader)
-<figcaption class="caption caption--main" itemprop="description">
+<figcaption class="caption caption--img" itemprop="description">
     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
     @captionText
 </figcaption>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -33,10 +33,8 @@
             }
     </div>
 
-
-@if(displayCaption) {
-    @simpleCaption(media.title)
-}
-
+    @if(displayCaption) {
+        @simpleCaption(media.title)
+    }
 }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -34,10 +34,9 @@
     </div>
 
 
-    @if(displayCaption) {
-        <figcaption class="caption caption--main" itemprop="description">
-        @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
-        @media.title</figcaption>
-    }
+@if(displayCaption) {
+    @simpleCaption(media.title)
+}
+
 }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,6 +1,7 @@
 @import conf.Configuration.site.host
 @import conf.Configuration.Media
 @import views.support.{RenderClasses, Video700}
+@import views.html.fragments.atoms.mediaAtomCaption
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean)(implicit request: RequestHeader)
 
@@ -34,7 +35,7 @@
     </div>
 
     @if(displayCaption) {
-        @simpleCaption(media.title)
+        @mediaAtomCaption(media.title)
     }
 }
 

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -109,6 +109,11 @@ figure.element-video {
     }
 }
 
+.youtube-media-atom ~ figcaption {
+    padding-top: ($gs-baseline/3)*2;
+    padding-bottom: ($gs-baseline/3)*2;
+}
+
 figure.element.element--showcase {
     @include mq(leftCol) {
         figcaption {

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -109,7 +109,7 @@ figure.element-video {
     }
 }
 
-.youtube-media-atom ~ figcaption {
+figcaption.caption--media-atom {
     padding-top: ($gs-baseline/3)*2;
     padding-bottom: ($gs-baseline/3)*2;
 }


### PR DESCRIPTION
## What does this change?
Fix excessive caption padding on YouTube Media Atoms


## What is the value of this and can you measure success?
Aesthetic beauty has immeasurable value

## Does this affect other platforms - Amp, Apps, etc?
This makes the padding too small on AMP.  However, @zeftilldeath says its better to make a subsequent fix for AMP. CC @NataliaLKB 
AMP
![screen shot 2017-01-18 at 15 32 10](https://cloud.githubusercontent.com/assets/1764158/22070612/9358c242-dd94-11e6-99a7-bd35d3ebcfeb.png)


## Screenshots
.COM BEFORE
![screen shot 2017-01-18 at 15 33 23](https://cloud.githubusercontent.com/assets/1764158/22070496/2634a46a-dd94-11e6-8898-44b1274d1e0e.png)
.COM AFTER
![screen shot 2017-01-18 at 15 35 06](https://cloud.githubusercontent.com/assets/1764158/22070584/78e8009e-dd94-11e6-9e7d-1085aeaa2e4f.png)

The examples is taken from this page: http://www.theguardian.com/science/grrlscientist/2012/aug/07/3

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
