### PR TITLE
Effect the new business requirements for when Plista should run.

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags.js
@@ -60,9 +60,7 @@ define([
             .then(init);
         }
 
-        var isMobileOrTablet = ['mobile', 'tablet'].indexOf(detect.getBreakpoint(false)) >= 0;
-        var shouldIgnoreSwitch =  isMobileOrTablet || config.page.section === 'world' || config.page.edition.toLowerCase() !== 'au';
-        var shouldServePlista = config.switches.plistaForOutbrainAu && !shouldIgnoreSwitch;
+        var shouldServePlista = config.switches.plistaForOutbrainAu && config.page.edition.toLowerCase() === 'au';
 
         if (shouldServePlista) {
             renderWidget('plista', plista.init);


### PR DESCRIPTION
## What does this change?
Previously the widget provided by third-party content-provider Plista should only be shown when the switchboard switch was toggled AND the user was in the AU, not mobile or tablet and not on world news.

The criteria have now been simplified and if the switch is on and we are in the AU edition, show Plista.