### PR TITLE
temporarily disable discussion in WP build

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
@@ -36,7 +36,11 @@ define([
             });
         }
 
-        return require('discussion-frontend-preact', function (frontend) {
+        // #wp-rjs
+        // this should be a bundler-agnostic require, but waiting for
+        // discussion to update the module to make it wp-compatible.
+        // killing this in WP for now
+        return window.require('discussion-frontend-preact', function (frontend) {
             // - Inject the net module to work around the lack of a global fetch
             //   It can be removed once all browsers have window.fetch
             // - Well, it turns out that fetchJson uses reqwest which sends X-Requested-With


### PR DESCRIPTION
## What does this change?

temporarily switch off comments in webpack build

## What is the value of this and can you measure success?

enables us to get the wp build into prod while waiting for https://github.com/guardian/discussion-frontend/pull/21 to be merged and a new version released.

## Does this affect other platforms - Amp, Apps, etc?

no
