### PR TITLE
set showinfo=1 on youtube atom embed.

### DIFF
--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -8,7 +8,7 @@
     <amp-youtube
     data-videoid="@media.assets.head.id"
     layout="responsive"
-    width="16" height="9" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="0">
+    width="16" height="9" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="1">
     </amp-youtube>
 } else {
     <amp-iframe

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -2,6 +2,7 @@
 @import conf.Configuration.Media
 @import views.support.{RenderClasses, Video700}
 @import views.html.fragments.atoms.mediaAtomCaption
+@import com.netaporter.uri.dsl._
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean)(implicit request: RequestHeader)
 
@@ -14,12 +15,21 @@
         data-end-slate="@endSlate"
         }
     >
-
-        @defining(if(embedPage) "&origin=" + Media.externalEmbedHost else if(!host.isEmpty) "&origin=" + host else "") { origin =>
-            <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"
-            src="https://www.youtube.com/embed/@media.assets.head.id?modestbranding=1&enablejsapi=1&rel=0&showinfo=0@origin" frameborder="0"
-            allowfullscreen="">
-            </iframe>
+            @defining(s"https://www.youtube.com/embed${
+                media.assets.head.id
+                    .addParams(List(
+                    "modestbranding" -> 1,
+                    "enablejsapi" -> 1,
+                    "rel" -> 0,
+                    "showinfo" -> 1,
+                    "origin" -> (if(embedPage) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                )).toString
+            }") { embedUri: String  =>
+                <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"
+                src="@embedUri" frameborder="0"
+                allowfullscreen="">
+                </iframe>
+            }
 
             @media.posterImage.map { image =>
                 <div class="youtube-media-atom__overlay vjs-big-play-button" style="background-image: url(@Video700.bestFor(image))">
@@ -37,5 +47,4 @@
     @if(displayCaption) {
         @mediaAtomCaption(media.title)
     }
-}
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val scalajTime = "org.scalaj" % "scalaj-time_2.10.2" % "0.7"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % Test
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
-  val scalaUri = "com.netaporter" % "scala-uri_2.11" % "0.4.11"
+  val scalaUri = "com.netaporter" % "scala-uri" % "0.4.16"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion
   val shadeMemcached = "com.bionicspirit" %% "shade" % "1.6.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % slf4jVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val scalajTime = "org.scalaj" % "scalaj-time_2.10.2" % "0.7"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % Test
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
-  val scalaUri = "com.netaporter" % "scala-uri" % "0.4.16"
+  val scalaUri = "com.netaporter" % "scala-uri_2.11" % "0.4.16"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion
   val shadeMemcached = "com.bionicspirit" %% "shade" % "1.6.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % slf4jVersion

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -51,7 +51,8 @@ object Frontend extends Build with Prototypes {
       logback,
       kinesisLogbackAppender,
       targetingClient,
-      scanamo
+      scanamo,
+      scalaUri
     )
   ).settings(
       mappings in TestAssets ~= filterAssets
@@ -94,9 +95,6 @@ object Frontend extends Build with Prototypes {
   )
 
   val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common).settings(
-    libraryDependencies ++= Seq(
-      scalaUri
-    ),
     TwirlKeys.templateImports ++= Seq("discussion._", "discussion.model._")
   )
 


### PR DESCRIPTION
<!-- **************************************************************** -->
<!-- IMPORTANT -->
<!-- Continuous Deployment is enabled for this repository -->
<!-- Merging into master = deploying to PROD -->
<!-- Use Riff-Raff to deploy/test a PR on CODE before merging -->
<!-- **************************************************************** -->

## What does this change?
set [showinfo=1](https://developers.google.com/youtube/player_parameters#showinfo) on youtube atom embed

Refactor YouTube URI generation to use netaporter URI

## What is the value of this and can you measure success?
Removes large YouTube watermark on unenhanced YouTube atoms. Adds title overlay. This change was requested by editorial as part of the YouTube PFP trial.

## Does this affect other platforms - Amp, Apps, etc?
Same parameter change is made on `amp-youtube`
## Screenshots
BEFORE
![screen shot 2017-01-19 at 11 45 43](https://cloud.githubusercontent.com/assets/1764158/22106377/5e7f4c9c-de40-11e6-96fe-3f234af2cd0d.png)
AFTER
![screen shot 2017-01-19 at 12 10 37](https://cloud.githubusercontent.com/assets/1764158/22106390/6a5c4678-de40-11e6-85b6-9c8c24d8111f.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
