### PR TITLE
New footer to match the new header!

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -8,7 +8,7 @@
 @import conf.switches.Switches._
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
-    <div class="l-footer__primary">
+    <div class="l-footer__primary @if(mvt.ABNewNavVariantSix.isParticipating) {hide-on-mobile}">
         <div id="footer-nav" class="gs-container">
             <div class="brand-bar modern-visible u-cf">
                 <a href="@LinkTo {/}" data-link-name="site logo" class="guardian-logo-footer hide-on-mobile">
@@ -25,7 +25,7 @@
             </div>
 
             @if(showNav) {
-                <div class="l-footer__navigation-wrapper u-cf @if(mvt.ABNewNavVariantSix.isParticipating) {hide-on-mobile}">
+                <div class="l-footer__navigation-wrapper u-cf">
                     @fragments.nav.navigationFooter(page)
                 </div>
             }
@@ -33,6 +33,23 @@
             @Page.getContentPage(page).map(fragments.breadcrumb(_))
         </div>
     </div>
+
+    @if(mvt.ABNewNavVariantSix.isParticipating) {
+        <div class="mobile-only footer__primary">
+            @* TODO: styling footer *@
+            <a data-link-name="back to top" href="#top">
+                <div class="footer__back-to-top__container">
+                    <div class="footer__back-to-top">
+                        <span class="back-to-top__text">back to top</span>
+                        @fragments.inlineSvg("arrow-up", "icon", List("back-to-top__icon"))
+                    </div>
+                </div>
+            </a>
+
+
+            @fragments.nav.subSectionNav(page)
+        </div>
+    }
 
     <div class="l-footer__secondary js-footer__secondary @if(EmailInlineInFooterSwitch.isSwitchedOff) {l-footer__secondary--no-email} gs-container" role="contentinfo">
         <div class="colophon u-cf">

--- a/common/app/views/fragments/nav/subSectionNav.scala.html
+++ b/common/app/views/fragments/nav/subSectionNav.scala.html
@@ -1,0 +1,12 @@
+@(page: model.Page)(implicit request: RequestHeader)
+
+@import common.{NewNavigation, Edition, LinkTo}
+
+<div class="tertiary-navigation">
+    @NewNavigation.SubSectionLinks.getSubSectionNavLinks(page.metadata.sectionId, Edition(request), page.metadata.isFront).map { link =>
+        <a class="tertiary-navigation__link @if((link.uniqueSection == page.metadata.sectionId) && !page.metadata.isFront){tertiary-navigation__link--current-section}"
+            href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
+                @link.title
+        </a>
+    }
+</div>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,6 +1,6 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
-@import common.{LinkTo, NewNavigation, Edition}
+@import common.{LinkTo, NewNavigation}
 
 <header class="new-header" role="banner">
     @defining(
@@ -35,12 +35,6 @@
             </nav>
         </div>
 
-        <div class="tertiary-navigation">
-            @NewNavigation.SubSectionLinks.getSubSectionNavLinks(page.metadata.sectionId, Edition(request), page.metadata.isFront).map { link =>
-                <a class="tertiary-navigation__link @if((link.uniqueSection == page.metadata.sectionId) && !page.metadata.isFront){tertiary-navigation__link--current-section}" href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
-                    @link.title
-                </a>
-            }
-        </div>
+        @fragments.nav.subSectionNav(page)
     }
 </header>

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -740,6 +740,8 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     border-bottom: $gs-baseline / 3 solid #747a81;
     max-height: $gs-baseline * 3.4;
     overflow: hidden;
+    z-index: 1;
+    position: relative;
 
     @include mq($from: mobile, $until: mobileLandscape) {
         max-height: $gs-baseline * 3.5;
@@ -898,6 +900,77 @@ $caption-button-size: 32px;
                 border-left: $gs-baseline / 2 solid transparent;
                 border-right: $gs-baseline / 2 solid transparent;
             }
+        }
+    }
+}
+
+/****************
+ * FOOTER
+ ****************/
+
+.l-footer {
+    // these two lines are needed so that the footer sits over the nav
+    position: absolute;
+    z-index: 9999;
+    width: 100%;
+}
+.footer__back-to-top__container {
+    @include content-gutter();
+    background-color: $guardian-brand;
+}
+
+.footer__back-to-top {
+    @include fs-textSans(4);
+    position: relative;
+    text-align: right;
+
+    @include mq($from: mobile, $until: mobileLandscape) {
+        font-size: 14px;
+        font-size: 4.6vw;
+    }
+
+    @include mq(mobileLandscape) {
+        font-size: 20px;
+    }
+}
+
+.back-to-top__text {
+    display: inline-block;
+    color: white;
+    padding: 4px;
+
+    @include mq($mobile-medium) {
+        padding: 9px;
+    }
+}
+
+.back-to-top__icon {
+    position: relative;
+    float: right;
+    margin-top: -($gs-baseline / 2);
+    margin-bottom: -$gs-baseline;
+    border-radius: 100%;
+    background-color: $news-main-2;
+    cursor: pointer;
+    height: $veggie-burger-small;
+    min-width: $veggie-burger-small;
+
+    @include mq($mobile-medium) {
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+    }
+
+    svg {
+        position: absolute;
+        top: -($gs-baseline / 2);
+        bottom: 0;
+        right: 0;
+        left: 0;
+        margin: auto;
+
+        @include mq($mobile-medium) {
+            width: 30px;
+            height: 24px;
         }
     }
 }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -917,6 +917,11 @@ $caption-button-size: 32px;
 .footer__back-to-top__container {
     @include content-gutter();
     background-color: $guardian-brand;
+
+    a:hover > &,
+    a:focus > & {
+        background-color: $guardian-brand-dark;
+    }
 }
 
 .footer__back-to-top {
@@ -937,10 +942,11 @@ $caption-button-size: 32px;
 .back-to-top__text {
     display: inline-block;
     color: white;
-    padding: 4px;
+    line-height: 30px;
+    padding-right: $gs-gutter / 2;
 
     @include mq($mobile-medium) {
-        padding: 9px;
+        line-height: 40px;
     }
 }
 
@@ -948,7 +954,7 @@ $caption-button-size: 32px;
     position: relative;
     float: right;
     margin-top: -($gs-baseline / 2);
-    margin-bottom: -$gs-baseline;
+    margin-bottom: -($gs-baseline / 2);
     border-radius: 100%;
     background-color: $news-main-2;
     cursor: pointer;


### PR DESCRIPTION
## What does this change?
@zeftilldeath came up with a lovely design to improve our footer, and keep it consistent with the new header. 

Based on the data we looked at, we have kept the back to top button because users do use it. We have not added a menu to the bottom though, as not enough people found that useful. 

## What is the value of this and can you measure success?
Looks nicer, and more consistent with the new header

## Does this affect other platforms - Amp, Apps, etc?
Nope! 
...@zeftilldeath should we do the AMP footer??

## Screenshots
<img src="https://cloud.githubusercontent.com/assets/8774970/22106458/beda916e-de40-11e6-8a0a-d4458ff9555e.png" width="300px"/>

## Tested in CODE?
Nope, but these changes shouldn't need to be