### PR TITLE
Disable the high merch component on hosted pages

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
@@ -34,6 +34,8 @@ define([
 
         var isArticle = config.page.contentType === 'Article';
 
+        var isInteractive = config.page.contentType === 'Interactive';
+
         var isGallery = config.page.contentType == 'Gallery';
 
         var isLiveBlog = config.page.isLiveBlog;
@@ -104,6 +106,7 @@ define([
             this.dfpAdvertising &&
             !isMinuteArticle &&
             !isHosted &&
+            !isInteractive &&
             !config.page.isFront &&
             switches.commercial;
 

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
@@ -103,6 +103,7 @@ define([
         this.highMerch =
             this.dfpAdvertising &&
             !isMinuteArticle &&
+            !isHosted &&
             !config.page.isFront &&
             switches.commercial;
 


### PR DESCRIPTION
The "Hosted by" pages do not have merchandising components. This is currently preventing videos from playing.