### PR TITLE
Structured data - Recipes - add description, dates and total time 

### DIFF
--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -18,10 +18,12 @@
       @recipe.atom.contentChangeDetails.created.map { created => "dateCreated": "@{new DateTime(created.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
+
+      "description": "a tasteful @{recipe.data.tags.category.headOption.getOrElse("recipe")} with @{recipe.data.ingredientsLists.flatMap(_.ingredients).headOption.map(_.item).getOrElse("secrets ingredients! You need to know about them")}",
      
      @* 
      TODO - We do not have this description and rating in the model yet  
-     "description": "Mango, strawberries, and sweetened dried cranberries are a vibrant addition to mixed greens tossed with an oil and balsamic vinegar dressing.",
+     
      "aggregateRating": {
        "@@type": "AggregateRating",
        "ratingValue": "5",

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -2,7 +2,6 @@
 @import play.api.libs.json.Json
 @import views.support.{ImgSrc, GoogleStructuredData}
 @import org.joda.time.DateTime
-@import cats.implicits._
 
 <script type="application/ld+json">
      {
@@ -33,7 +32,7 @@
      *@
       @recipe.data.time.preparation.map {minutes => "prepTime": "PT@{minutes}M",}
       @recipe.data.time.cooking.map {minutes => "cookTime": "PT@{minutes}M",}
-      @recipe.data.time.preparation.combine(recipe.data.time.cooking).map { minutes => "totalTime": "PT@{minutes}M",}
+      @totalTime(recipe).map { minutes => "totalTime": "PT@{minutes}M",}
       @recipe.data.serves.map { serves => "recipeYield": "@yieldValue(serves)",}
      @*
      TODO - We do not have nutrition in the model yet  
@@ -48,6 +47,10 @@
      "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"$index. $step" })))
     }
 </script>
+
+@totalTime(recipe: model.content.RecipeAtom) = @{
+    (recipe.data.time.preparation ++ recipe.data.time.cooking).map(_.toInt).reduceOption(_ + _)
+}
 
 @imgValue(image: com.gu.contentatom.thrift.Image) = @{
     val media =  model.content.MediaAtom.imageMediaMake(image, "")

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -2,6 +2,7 @@
 @import play.api.libs.json.Json
 @import views.support.{ImgSrc, GoogleStructuredData}
 @import org.joda.time.DateTime
+@import cats.implicits._
 
 <script type="application/ld+json">
      {
@@ -30,14 +31,10 @@
        "reviewCount": "52"
      },
      *@
-
-     @recipe.data.time.preparation.map {minutes => "prepTime": "@formatDuration(minutes)",}
-     @recipe.data.time.cooking.map {minutes => "cookTime": "@formatDuration(minutes)",}
-     
-     @* TODO - @recipe.data.time.total.map {minutes => "totalTime": "@formatDuration(minutes)",}  *@
-
-     @recipe.data.serves.map { serves => "recipeYield": "@yieldValue(serves)",}
-
+      @recipe.data.time.preparation.map {minutes => "prepTime": "PT@{minutes}M",}
+      @recipe.data.time.cooking.map {minutes => "cookTime": "PT@{minutes}M",}
+      @recipe.data.time.preparation.combine(recipe.data.time.cooking).map { minutes => "totalTime": "PT@{minutes}M",}
+      @recipe.data.serves.map { serves => "recipeYield": "@yieldValue(serves)",}
      @*
      TODO - We do not have nutrition in the model yet  
      "nutrition": {
@@ -56,8 +53,6 @@
     val media =  model.content.MediaAtom.imageMediaMake(image, "")
     ImgSrc.findLargestSrc(media, GoogleStructuredData).getOrElse("")
 }
-
-@formatDuration(mins: Short) = @{s"PT${mins}M"}
 
 @yieldValue(serves: com.gu.contentatom.thrift.atom.recipe.Serves) = @{
     serves.`type` match {

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -62,20 +62,15 @@
     }
 }
 
-
 @*
   TODO - ingredient unit could be improved 1/8 instead of 0.125 for instance depending on the unit 
 *@
 @ingredientValues(ingredients: Seq[com.gu.contentatom.thrift.atom.recipe.Ingredient]) = @{
-    ingredients.map { ingredient => 
-        val q = if (ingredient.quantity.isDefined) {
-            formatQuantity(ingredient.quantity.get)    
-        } else if (ingredient.quantityRange.isDefined) {
-            val range = ingredient.quantityRange.get
-            s"${formatQuantity(range.from)}-${formatQuantity(range.to)}"
-        } else {
-            ""
-        }
+    ingredients.map { ingredient =>
+        val q = ingredient.quantity
+          .map(formatQuantity)
+          .orElse(ingredient.quantityRange.map(range => s"${formatQuantity(range.from)}-${formatQuantity(range.to)}" ))
+          .getOrElse("")
         s"""${q} ${formatUnit(ingredient.unit.getOrElse(""))} ${ingredient.item}"""
     }
 }
@@ -90,15 +85,12 @@
 }
 
 @formatQuantity(q: Double) = @{
-    if(q == q.toInt) {
-        q.toInt
-    } else {
-        q match {
-            case 0.75 => "3/4"
-            case 0.5 => "1/2"
-            case 0.25 => "1/4"
-            case 0.125 => "1/8"
-            case _ => q 
-        }
+    q match {
+        case qty if qty == qty.toInt => qty.toInt 
+        case 0.75 => "3/4"
+        case 0.5 => "1/2"
+        case 0.25 => "1/4"
+        case 0.125 => "1/8"
+        case _ => q 
     }
 }

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -65,9 +65,6 @@
     }
 }
 
-@*
-  TODO - ingredient unit could be improved 1/8 instead of 0.125 for instance depending on the unit 
-*@
 @ingredientValues(ingredients: Seq[com.gu.contentatom.thrift.atom.recipe.Ingredient]) = @{
     ingredients.map { ingredient =>
         val q = ingredient.quantity

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -1,6 +1,7 @@
 @(recipe: model.content.RecipeAtom)(implicit request: RequestHeader)
 @import play.api.libs.json.Json
 @import views.support.{ImgSrc, GoogleStructuredData}
+@import org.joda.time.DateTime
 
 <script type="application/ld+json">
      {
@@ -13,8 +14,10 @@
           "@@type": "Person",
           "name": "@name"
         },
-      } 
-      @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@published",}
+      }
+      @recipe.atom.contentChangeDetails.created.map { created => "dateCreated": "@{new DateTime(created.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
+      @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
+      @recipe.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
      
      @* 
      TODO - We do not have this description and rating in the model yet  

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -83,11 +83,11 @@
 
 @formatQuantity(q: Double) = @{
     q match {
-        case qty if qty == qty.toInt => qty.toInt 
+        case qty if qty == qty.toInt => qty.toInt.toString
         case 0.75 => "3/4"
         case 0.5 => "1/2"
         case 0.25 => "1/4"
         case 0.125 => "1/8"
-        case _ => q 
+        case _ => q.toString
     }
 }

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -20,7 +20,7 @@
       @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
 
-      "description": "a tasteful @{recipe.data.tags.category.headOption.getOrElse("recipe")} with @{recipe.data.ingredientsLists.flatMap(_.ingredients).headOption.map(_.item).getOrElse("secrets ingredients! You need to know about them")}",
+      "description": "a tasty @{recipe.data.tags.category.headOption.getOrElse("recipe")} with @{recipe.data.ingredientsLists.flatMap(_.ingredients).headOption.map(_.item).getOrElse("secrets ingredients! You need to know about them")}",
      
      @* 
      TODO - We do not have this description and rating in the model yet  


### PR DESCRIPTION
## What does this change?

Following [initial work on structured data ](https://github.com/guardian/frontend/pull/15556):

* Improve a bit existing code following @TBonnin feedback
* Add `description` field with a fallback until we have `description` field on the model
* Add `totalTime` field
* Fomat correctly time according to google specification

## What is the value of this and can you measure success?

See previous changes.

## Does this affect other platforms - Amp, Apps, etc?

AMP is concerned as well.
