### PR TITLE
Fix images as links for minute email

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -83,7 +83,7 @@
                     case ImageBlockElement(media, data, showCredit) => {
                         @EmailImage.bestFor(media).map { imageUrl =>
                             @fullRow {
-                                @if(article.isLiveBlog && block.url.isDefined) {
+                                @if(article.isTheMinute && block.url.isDefined) {
                                     <a href="@block.url.getOrElse("#")">
                                         @imgForArticle(imageUrl, data.get("alt"))
                                     </a>


### PR DESCRIPTION
In #14826 I made it so images in the [Weekend Reading email](https://www.theguardian.com/membership/live/2017/jan/14/weekend-reading-curry-houses-avoiding-divorce-and-weetabix-benedict?format=email) and other emails generated from The Minute-style articles were links. I noticed these links haven't been working for a while and it seems that the articles in question are not live blogs as defined by `.isLiveBlog`, i.e. they don't have [this minutebyminute tone tag](https://github.com/guardian/frontend/blob/master/common/app/model/meta.scala#L626)

Not sure what changed or what the relationship is between live blogs & minute articles now (I thought minute articles were a subset of live blog articles) but anyway, checking for `.isTheMinute` works for the articles I care about.

@katebee 