### PR TITLE
Speedup Hosted video

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
@@ -34,7 +34,7 @@ define([
     var player;
 
     function isDesktop() {
-        return contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint());
+        return detect.isBreakpoint({ min: 'desktop' });
     }
 
     function initLoadingSpinner(player) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
@@ -14,7 +14,6 @@ define([
     'common/modules/video/events',
     'common/modules/video/videojs-options',
     'common/modules/media/videojs-plugins/fullscreener',
-    'lodash/collections/contains',
     'text!common/views/ui/loading.html'
 ], function (
     Promise,
@@ -28,7 +27,6 @@ define([
     events,
     videojsOptions,
     fullscreener,
-    contains,
     loadingTmpl
 ) {
     var player;


### PR DESCRIPTION
We still have some work left before blocking `enhanced` until the commercial modules have run, namely the hosted by modules.

In this change, I'm just not blocking the commercial setup on any of the `require` calls necessary to load the video plugin, so that the `commercial.init` promise resolves early. This will take these operations out of the commercial load time (the `baseline` measurements), yet they still will be taken into account in the module breakdown.