### PR TITLE
Add check for ga on window and store values for later send

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -42,7 +42,8 @@
                 "editorialTest": "@{GoogleAnalyticsAccount.editorialTest.trackerName}",
                 "editorialProd": "@{GoogleAnalyticsAccount.editorialProd.trackerName}",
                 "editorial": "@{GoogleAnalyticsAccount.editorialTracker(context).trackerName}"
-            }
+            },
+            "timingEvents": []
         },
         "libs": {
             "foresee": "vendor/foresee/20150703/foresee-trigger.js",

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -138,8 +138,10 @@
 
     }
 
-})();
+    // Mediator will be intialised if we need to use this, otherwise just use GA straight away
+    guardian.app && guardian.app.mediator && guardian.app.mediator.emit('modules:ga:ready');
 
+})();
 </script>
 
 @*

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -1,7 +1,9 @@
 define([
-    'common/utils/config'
+    'common/utils/config',
+    'common/utils/mediator'
 ], function (
-    config
+    config,
+    mediator
 ) {
     var ga = window.ga;
     var trackerName = config.googleAnalytics.trackers.editorial;
@@ -48,6 +50,15 @@ define([
         });
     }
 
+    function mapEvents() {
+        config.googleAnalytics.timingEvents.map(sendPerformanceEvent);
+        mediator.off('modules:ga:ready', mapEvents);
+    }
+
+    function sendPerformanceEvent(event) {
+        window.ga(send, 'timing', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel);
+    }
+
     // Track important user timing metrics so that we can be notified and measure over time in GA
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/user-timings
     // Tracks into Behaviour > Site Speed > User Timings in GA
@@ -56,7 +67,28 @@ define([
         if (window.performance) {
             // Value must be an integer - grabs the number of milliseconds since page load
             var timeSincePageLoad = Math.round(window.performance.now());
-            ga(send, 'timing', timingCategory, timingVar, timeSincePageLoad, timingLabel);
+
+            if (window.ga) {
+                sendPerformanceEvent({
+                    timingCategory: timingCategory,
+                    timingVar: timingVar,
+                    timeSincePageLoad: timeSincePageLoad,
+                    timingLabel: timingLabel
+                });
+            } else {
+                if (!config.googleAnalytics.timingEvents) {
+                    config.googleAnalytics.timingEvents = [];
+                }
+
+                mediator.on('modules:ga:ready', mapEvents);
+
+                config.googleAnalytics.timingEvents.push({
+                    timingCategory: timingCategory,
+                    timingVar: timingVar,
+                    timeSincePageLoad: timeSincePageLoad,
+                    timingLabel: timingLabel
+                })
+            }
         }
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -76,9 +76,6 @@ define([
                     timingLabel: timingLabel
                 });
             } else {
-                if (!config.googleAnalytics.timingEvents) {
-                    config.googleAnalytics.timingEvents = [];
-                }
 
                 mediator.on('modules:ga:ready', mapEvents);
 

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -67,24 +67,18 @@ define([
         if (window.performance) {
             // Value must be an integer - grabs the number of milliseconds since page load
             var timeSincePageLoad = Math.round(window.performance.now());
+            var eventObj = {
+                timingCategory: timingCategory,
+                timingVar: timingVar,
+                timeSincePageLoad: timeSincePageLoad,
+                timingLabel: timingLabel
+            };
 
             if (window.ga) {
-                sendPerformanceEvent({
-                    timingCategory: timingCategory,
-                    timingVar: timingVar,
-                    timeSincePageLoad: timeSincePageLoad,
-                    timingLabel: timingLabel
-                });
+                sendPerformanceEvent(eventObj);
             } else {
-
                 mediator.on('modules:ga:ready', mapEvents);
-
-                config.googleAnalytics.timingEvents.push({
-                    timingCategory: timingCategory,
-                    timingVar: timingVar,
-                    timeSincePageLoad: timeSincePageLoad,
-                    timingLabel: timingLabel
-                })
+                config.googleAnalytics.timingEvents.push(eventObj)
             }
         }
     }


### PR DESCRIPTION
## What does this change?
There was a race condition if GA loaded after standard was parsed, we're seeing errors in sentry because of this.

## What is the value of this and can you measure success?
Should have more accurate reporting...

## Does this affect other platforms - Amp, Apps, etc?
No


## Tested in CODE?
No
