### PR TITLE
Plaintone message should be dark, because background is light

### DIFF
--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -334,6 +334,13 @@
     }
 }
 
+.email-sub--plaintone {
+    .email-sub__message__headline,
+    .email-sub__message__description {
+        color: $neutral-1;
+    }
+}
+
 // POST-ARTICLE
 
 .email-sub__iframe--post-article {


### PR DESCRIPTION
## What does this change?

Changes the colour of email signup success message from light to dark.

## What is the value of this and can you measure success?

Improved usability

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before:
<img width="268" alt="screen shot 2017-01-19 at 16 33 27" src="https://cloud.githubusercontent.com/assets/2619836/22115586/85eb6174-de65-11e6-91e5-eec6d1dabf55.png">

After:
<img width="281" alt="screen shot 2017-01-19 at 16 31 46" src="https://cloud.githubusercontent.com/assets/2619836/22115584/85a51372-de65-11e6-8542-14a4d829fa15.png">


## Tested in CODE?

No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
