### PR TITLE
Removing the warning about Continuous deployment in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,3 @@
-<!-- **************************************************************** -->
-<!-- IMPORTANT -->
-<!-- Continuous Deployment is enabled for this repository -->
-<!-- Merging into master = deploying to PROD -->
-<!-- Use Riff-Raff to deploy/test a PR on CODE before merging -->
-<!-- **************************************************************** -->
-
 ## What does this change?
 
 ## What is the value of this and can you measure success?


### PR DESCRIPTION
## What does this change?
Removing the warning about Continuous deployment in PR template
The warning has been in place for around 10 days and I feel like most of the people contributing to frontend are now aware

## Tested in CODE?
No

cc @guardian/dotcom-platform 
