### PR TITLE
Only wrap inline elements in <a>, because Outlook

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -4,6 +4,7 @@ import conf.Static
 import layout.ContentCard
 import model._
 import play.twirl.api.Html
+import play.api.mvc._
 
 object EmailHelpers {
   def columnNumber(n: Int): String = {
@@ -61,8 +62,9 @@ object EmailHelpers {
 
   def imgForFront = img(FrontEmailImage.knownWidth) _
 
-  def imgFromCard(card: ContentCard) = imageUrlFromCard(card).map { url =>
-    imgForFront(url, Some(card.header.headline))
+  def imgFromCard(card: ContentCard)(implicit requestHeader: RequestHeader) = imageUrlFromCard(card).map { url => Html {
+      s"""<a class="facia-link" ${card.header.url.hrefWithRel}>${imgForFront(url, Some(card.header.headline))}</a>"""
+    }
   }
 
   object Images {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -11,28 +11,38 @@
 
 
 @headline(card: ContentCard) = {
-    <h3 class="headline">
-        @card.header.kicker.map { kicker =>
-            <span class="fc-item__kicker">@Html(kicker.kickerHtml)</span>
-            <span class="kicker-separator">/</span>
-        }
-
-        @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
-            @if(card.header.isGallery) { @icon("gallery" + suffix) }
-            @if(card.header.isAudio) { @icon("podcast" + suffix) }
-            @if(card.header.isVideo) { @icon("video" + suffix) }
-        }
-
-        @if(card.header.quoted) {
-            @card.cardStyle match {
-                case Feature => { @icon("quote-feature") }
-                case _ => { @icon("quote") }
+    <a @Html(card.header.url.hrefWithRel) class="facia-link">
+        <h3 class="headline">
+            @card.header.kicker.map { kicker =>
+                <span class="fc-item__kicker">@Html(kicker.kickerHtml)</span>
+                <span class="kicker-separator">/</span>
             }
+
+            @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
+                @if(card.header.isGallery) { @icon("gallery" + suffix) }
+                @if(card.header.isAudio) { @icon("podcast" + suffix) }
+                @if(card.header.isVideo) { @icon("video" + suffix) }
+            }
+
+            @if(card.header.quoted) {
+                @card.cardStyle match {
+                    case Feature => { @icon("quote-feature") }
+                    case _ => { @icon("quote") }
+                }
+            }
+            @RemoveOuterParaHtml(card.header.headline)
+        </h3>
+        @if(card.header.quoted) {
+            @card.bylineText.map { byline => <h4 class="byline">@byline</h4> }
         }
-        @RemoveOuterParaHtml(card.header.headline)
-    </h3>
-    @if(card.header.quoted) {
-        @card.bylineText.map { byline => <h4 class="byline">@byline</h4> }
+    </a>
+}
+
+@trailText(card: ContentCard) = {
+    @card.trailText.map { trailText =>
+        <a @Html(card.header.url.hrefWithRel) class="facia-link">
+            <h4 class="trail-text">@Html(trailText)</h4>
+        </a>
     }
 }
 
@@ -41,29 +51,23 @@
         @headline(card)
     }
     @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
-        @card.trailText.map { trailText =>
-            <h4 class="trail-text">@Html(trailText)</h4>
-        }
+        @trailText(card)
     }
 }
 
 @faciaCardLarge(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
-        <a @Html(card.header.url.hrefWithRel) class="facia-link">
-            <div class="facia-card @if(withImage){facia-card--large}">
-                @if(withImage) { @imgFromCard(card) }
-                @if(card.header.quoted) {
-                    @headlineAndTrailWithCutout(card)
-                } else {
-                    @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
-                        @headline(card)
-                        @card.trailText.map { trailText =>
-                            <h4 class="trail-text">@Html(trailText)</h4>
-                        }
-                    }
+        <div class="facia-card @if(withImage){facia-card--large}">
+            @if(withImage) { @imgFromCard(card) }
+            @if(card.header.quoted) {
+                @headlineAndTrailWithCutout(card)
+            } else {
+                @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
+                    @headline(card)
+                    @trailText(card)
                 }
-            </div>
-        </a>
+            }
+        </div>
     }
 }
 


### PR DESCRIPTION
Outlook doesn't like `<a>` elements wrapping block-level elements. This means a lot of links don't work in Outlook. I've rejigged things so links only wrap inline elements. This means there are a few gaps on the cards which aren't clickable, but I think that's acceptable.

@lmath @guardian/dotcom-platform 