### PR TITLE
only show youtube atom duration if not on front

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -3,7 +3,7 @@
 @import views.support.{RenderClasses, Video700}
 @import views.html.fragments.atoms.mediaAtomCaption
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, showDuration: Boolean = true)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
@@ -24,12 +24,14 @@
             @media.posterImage.map { image =>
                 <div class="youtube-media-atom__overlay vjs-big-play-button" style="background-image: url(@Video700.bestFor(image))">
                     <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
-                    <div class="youtube-media-atom__bottom-bar">
-                        <div class="youtube-media-atom__bottom-bar__icon">
+                    @if(showDuration) {
+                        <div class="youtube-media-atom__bottom-bar">
+                            <div class="youtube-media-atom__bottom-bar__icon">
                             @fragments.inlineSvg("video-icon", "icon")
+                            </div>
+                            <div class="youtube-media-atom__bottom-bar__duration"></div>
                         </div>
-                        <div class="youtube-media-atom__bottom-bar__duration"></div>
-                    </div>
+                    }
                 </div>
             }
     </div>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -3,7 +3,7 @@
 @import views.support.{RenderClasses, Video700}
 @import views.html.fragments.atoms.mediaAtomCaption
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, showDuration: Boolean = true)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         "u-responsive-ratio" -> true,
@@ -24,7 +24,7 @@
             @media.posterImage.map { image =>
                 <div class="youtube-media-atom__overlay vjs-big-play-button" style="background-image: url(@Video700.bestFor(image))">
                     <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
-                    @if(showDuration) {
+                    @if(displayDuration) {
                         <div class="youtube-media-atom__bottom-bar">
                             <div class="youtube-media-atom__bottom-bar__icon">
                             @fragments.inlineSvg("video-icon", "icon")

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -91,7 +91,7 @@ data-test-id="facia-card"
             case Some(media@InlineYouTubeMediaAtom(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false)
+                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, showDuration = false)
                     </div>
                 </div>
             }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -91,7 +91,7 @@ data-test-id="facia-card"
             case Some(media@InlineYouTubeMediaAtom(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, showDuration = false)
+                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false)
                     </div>
                 </div>
             }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -115,9 +115,9 @@ define([
         };
 
         if (overlay) {
-            var formattedDuration = getFormattedDuration(players[atomId].player.getDuration());
-            
-            setDuration(formattedDuration, overlay);
+            if (!config.page.isFront) {
+                showDuration(atomId, overlay);
+            }    
             
             players[atomId].overlay = overlay;
 
@@ -148,10 +148,11 @@ define([
         return ('0' + time).slice(-2);
     }
 
-    function setDuration(formattedDuration, overlay) {
+    function showDuration(atomId, overlay) {
         var durationElem = overlay.querySelector('.youtube-media-atom__bottom-bar__duration');
 
-        durationElem.innerText = formattedDuration;
+        durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
+        durationElem.parentNode.classList.add('youtube-media-atom__bottom-bar-enabled');
     }
 
     function getEndSlate(overlay) {

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -115,10 +115,8 @@ define([
         };
 
         if (overlay) {
-            if (!config.page.isFront) {
-                showDuration(atomId, overlay);
-            }    
-            
+            showDuration(atomId, overlay);
+
             players[atomId].overlay = overlay;
 
             if (!!config.page.section && detect.isBreakpoint({ min: 'desktop' })) {
@@ -151,8 +149,9 @@ define([
     function showDuration(atomId, overlay) {
         var durationElem = overlay.querySelector('.youtube-media-atom__bottom-bar__duration');
 
-        durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
-        durationElem.parentNode.classList.add('youtube-media-atom__bottom-bar-enabled');
+        if (durationElem) {
+            durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
+        }
     }
 
     function getEndSlate(overlay) {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -95,6 +95,10 @@
         height: 34px;
         z-index: 2;
 
+        &:not(.youtube-media-atom__bottom-bar-enabled) {
+            @include hide;
+        }
+
         &::before,
         &::after {
             position: absolute;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -95,10 +95,6 @@
         height: 34px;
         z-index: 2;
 
-        &:not(.youtube-media-atom__bottom-bar-enabled) {
-            @include hide;
-        }
-
         &::before,
         &::after {
             position: absolute;


### PR DESCRIPTION
## What does this change?

On fronts we don't want to show the bottom bar with the icon/duration

## What is the value of this and can you measure success?

N/A

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before...

![picture 29](https://cloud.githubusercontent.com/assets/1590704/22146138/8ee600ae-defb-11e6-8fa4-4caea33f9e2b.png)

and after...

![picture 28](https://cloud.githubusercontent.com/assets/1590704/22146149/960beb50-defb-11e6-9e9e-41aa34834eb3.png)

## Tested in CODE?

No

@gidsg @duarte 
