### PR TITLE
New header supporter trapezoid... that's right TRAPEZOID

### DIFF
--- a/common/app/layout/Breakpoint.scala
+++ b/common/app/layout/Breakpoint.scala
@@ -11,6 +11,10 @@ case object Mobile extends Breakpoint {
   val minWidth = None
 }
 
+case object MobileMedium extends Breakpoint {
+  val minWidth = Some(375)
+}
+
 case object MobileLandscape extends Breakpoint {
   val minWidth = Some(480)
 }

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,6 +1,6 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
-@import common.{LinkTo, NewNavigation}
+@import common.{LinkTo, NewNavigation, Edition}
 
 <header class="new-header" role="banner">
     @defining(
@@ -12,7 +12,17 @@
                 @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
             </a>
 
-            @fragments.nav.editionPicker()
+            @defining(
+                Edition(request).id.toLowerCase()
+            ) { editionId =>
+                <a class="header__supporter-cta"
+                    data-link-name="nav2 : supporter-cta"
+                    data-edition=@{editionId}
+                    href="@{Configuration.id.membershipUrl}/${editionId}/supporter?INTCMP=mem_${editionId}_web_newheader_trapezoid">
+
+                    Become a <span>Supporter</span>
+                </a>
+            }
 
             <nav class="new-header__nav" data-component="nav2">
                 @NewNavigation.PrimaryLinks.map { link =>

--- a/static/src/javascripts-legacy/projects/common/utils/detect.js
+++ b/static/src/javascripts-legacy/projects/common/utils/detect.js
@@ -33,6 +33,11 @@ define([
                 width: 0
             },
             {
+                name: 'mobileMedium',
+                isTweakpoint: true,
+                width: 375
+            },
+            {
                 name: 'mobileLandscape',
                 isTweakpoint: true,
                 width: 480

--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -15,6 +15,7 @@
 @include grid-system;
 @import 'amp/_header';
 @import 'amp/_footer';
+@import 'module/nav/_supporter-trapezoid';
 
 @import 'amp/_rich-link';
 @import 'amp/_content';

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -48,6 +48,7 @@ $left-column-wide: gs-span(3);
 
 $mq-breakpoints: (
     mobile:          gs-span(4)  + $gs-gutter,   // 320px
+    mobileMedium:    gs-span(5)  - $gs-gutter/4, // 375px
     mobileLandscape: gs-span(6)  + $gs-gutter,   // 480px
     phablet:         gs-span(8)  + $gs-gutter*2, // 660px
     tablet:          gs-span(9)  + $gs-gutter*2, // 740px

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -30,13 +30,13 @@ $veggie-burger-medium: 52px;
     height: auto;
 
     // Aspect ratio: 16:3
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         width: 170px;
         // height: auto doesn't work in Safari
         height: calc(3 / 16 * 170px);
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
         width: 225px;
         height: calc(3 / 16 * 225px);
     }
@@ -65,7 +65,7 @@ $veggie-burger-medium: 52px;
         font-size: 5.1vw;
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
         line-height: $gs-baseline * 3;
     }
 
@@ -89,7 +89,7 @@ $veggie-burger-medium: 52px;
     cursor: pointer;
     bottom: -$gs-baseline / 2;
 
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         //Smaller menu button
         height: $veggie-burger-small;
         min-width: $veggie-burger-small;
@@ -97,7 +97,7 @@ $veggie-burger-medium: 52px;
         right: $gutter-small;
     }
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         height: $veggie-burger-medium;
         width: $veggie-burger-medium;
         //Align with the 'i' in 'theguardian'
@@ -180,7 +180,7 @@ $veggie-burger-medium: 52px;
     overflow: auto;
     font-size: 20px;
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         //Larger font/icon size for larger devices
         font-size: 22px;
     }
@@ -200,11 +200,11 @@ $veggie-burger-medium: 52px;
     flex-wrap: wrap;
     overflow: hidden;
 
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         padding-top: $gs-baseline / 3;
     }
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         padding-top: $gs-baseline;
     }
 }

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -18,51 +18,6 @@ $veggie-burger-medium: 52px;
     max-width: 600px;
 }
 
-.header__supporter-cta {
-    // Some very specific values in here, as it's all got to line up with the x-height of the logo
-    position: absolute;
-    left: ($gs-gutter / 4) - 1px;
-    padding: 10px 23px 12px 12px;
-    font-size: 13px;
-    line-height: .95;
-    color: $guardian-brand-dark;
-    overflow: hidden;
-
-    & > span {
-        display: block;
-    }
-
-    &:before {
-        content: '';
-        position: absolute;
-        top: -$gs-baseline / 2;
-        left: 1px;
-        right: 0;
-        border-top: $gs-baseline * 4 solid $news-main-2;
-        border-left: $gs-gutter / 4 solid transparent;
-        border-right: $gs-gutter solid transparent;
-        transform: rotate(-3deg);
-        z-index: -1;
-    }
-
-    @include mq($until: mobile) {
-        display: none;
-    }
-
-    @include mq($from: $mobile-medium) {
-        padding-top: 14px;
-        font-size: 14px;
-
-        &:before {
-            border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
-        }
-    }
-
-    @include mq($from: mobileLandscape) {
-        left: $gs-gutter/2;
-    }
-}
-
 .header__logo-wrapper {
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline / 2;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -5,8 +5,6 @@ $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
 
-$mobile-medium: 375px; // Breakpoint for our most common device sizes
-
 @mixin trailing-slash {
     position: absolute;
     pointer-events: none;
@@ -55,13 +53,13 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     padding-right: $gs-gutter / 2;
 
     // Aspect ratio: 16:3
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         width: 170px;
         // height: auto doesn't work in Safari
         height: calc(3 / 16 * 170px);
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
         width: 225px;
         height: calc(3 / 16 * 225px);
     }
@@ -91,7 +89,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         font-size: 5.1vw;
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
         line-height: $gs-baseline * 3;
     }
 
@@ -125,7 +123,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         }
     }
 
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         //Smaller menu button
         height: $veggie-burger-small;
         min-width: $veggie-burger-small;
@@ -141,7 +139,7 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
         }
     }
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         height: $veggie-burger-medium;
         width: $veggie-burger-medium;
         //Align with the 'i' in 'theguardian'
@@ -235,120 +233,6 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     padding-right: .8em;
 }
 
-/*****************
- * Edition Picker
- *****************/
-
-.edition-picker {
-    @include fs-textSans(3);
-    position: absolute;
-    left: 0;
-    color: $news-support-1;
-    // Override from fs-textSans mixin
-    line-height: 1;
-    padding-top: $gs-baseline / 2;
-    padding-left: $gs-gutter / 2;
-    width: gs-span(2);
-    z-index: $zindex-sticky;
-
-    @include mq($until: mobile) {
-        display: none;
-    }
-
-    // Smaller size compensates for how big the word "Australia" is
-    @include mq($until: $mobile-medium) {
-        font-size: 13px;
-    }
-
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter / 2;
-    }
-}
-
-.inline-world__svg {
-    fill: $news-support-1;
-    vertical-align: middle;
-    min-width: 14px;
-    min-height: 14px;
-    margin-right: 1px;
-    margin-top: -$gs-baseline / 4;
-}
-
-.edition-picker__dropdown {
-    display: none;
-    position: absolute;
-    top: 40px;
-    left: $gs-gutter / 2;
-    // overriding default styling
-    width: gs-span(2);
-    margin: 0;
-    list-style: none;
-    padding: 0;
-
-    @include mq(mobileLandscape) {
-        left: $gs-gutter;
-    }
-
-    &:before {
-        content: '';
-        position: absolute;
-        left: 15px;
-        top: -10px;
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 0 $gs-gutter / 2 $gs-gutter / 2;
-        border-color: transparent transparent $guardian-brand-dark;
-    }
-}
-
-.edition-picker__dropdown-item-link {
-    color: #ffffff;
-    display: block;
-    padding-top: $gs-baseline;
-    padding-bottom: $gs-baseline;
-    padding-left: $gs-gutter;
-
-    &:hover {
-        text-decoration: none;
-        background-color: darken($guardian-brand-dark, 3%);
-    }
-}
-
-.edition-picker__current-edition {
-    width: gs-span(2);
-    padding-top: $gs-baseline / 2;
-    padding-bottom: $gs-baseline / 2;
-    display: block;
-    outline: none;
-    cursor: pointer;
-
-    &:hover {
-        color: #ffffff;
-
-        .inline-world__svg {
-            fill: #ffffff;
-        }
-    }
-}
-
-.edition-picker__button {
-    display: none;
-
-    &:checked,
-    &[aria-expanded='true'] {
-        & ~ .edition-picker__dropdown {
-            display: block;
-            background-color: $guardian-brand-dark;
-            box-shadow: 0 0 $gs-baseline * 2.5 0 rgba(0, 0, 0, .2);
-        }
-
-        & ~ .edition-picker__current-edition {
-            z-index: 3;
-        }
-    }
-}
-
 /****************
  * Menu Styling
  ****************/
@@ -389,11 +273,11 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     will-change: transform;
     transition: transform .2s cubic-bezier(.23, 1, .32, 1);
 
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         padding-top: $gs-baseline / 3;
     }
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         //Larger font/icon size for larger devices
         font-size: 22px;
         padding-top: $gs-baseline;
@@ -413,11 +297,11 @@ $mobile-medium: 375px; // Breakpoint for our most common device sizes
     transform: translateX(-110%);
     transition: transform .4s cubic-bezier(.23, 1, .32, 1);
 
-    @include mq($until: $mobile-medium) {
+    @include mq($until: mobileMedium) {
         margin-right: $gutter-small + ($veggie-burger-small / 2);
     }
 
-    @include mq($from: $mobile-medium, $until: mobileLandscape) {
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
         margin-right: $gutter-medium + ($veggie-burger-medium / 2);
     }
 
@@ -945,7 +829,7 @@ $caption-button-size: 32px;
     line-height: 30px;
     padding-right: $gs-gutter / 2;
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         line-height: 40px;
     }
 }
@@ -961,7 +845,7 @@ $caption-button-size: 32px;
     height: $veggie-burger-small;
     min-width: $veggie-burger-small;
 
-    @include mq($mobile-medium) {
+    @include mq(mobileMedium) {
         height: $veggie-burger-medium;
         width: $veggie-burger-medium;
     }
@@ -974,9 +858,11 @@ $caption-button-size: 32px;
         left: 0;
         margin: auto;
 
-        @include mq($mobile-medium) {
+        @include mq(mobileMedium) {
             width: 30px;
             height: 24px;
         }
     }
 }
+
+@import '../module/nav/_supporter-trapezoid';

--- a/static/src/stylesheets/module/nav/_supporter-trapezoid.scss
+++ b/static/src/stylesheets/module/nav/_supporter-trapezoid.scss
@@ -1,0 +1,53 @@
+.header__supporter-cta {
+    // Some very specific values in here, as it's all got to line up with the x-height of the logo
+    position: absolute;
+    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;
+    font-weight: 500;
+    left: ($gs-gutter / 4) - 1px;
+    padding: 10px 23px 12px 12px;
+    font-size: 13px;
+    line-height: .95;
+    color: $guardian-brand-dark;
+    overflow: hidden;
+    z-index: 3;
+
+    & > span {
+        display: block;
+    }
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+        color: $guardian-brand-dark;
+    }
+
+    &:before {
+        content: '';
+        position: absolute;
+        top: -$gs-baseline / 2;
+        left: 1px;
+        right: 0;
+        border-top: $gs-baseline * 4 solid $news-main-2;
+        border-left: $gs-gutter / 4 solid transparent;
+        border-right: $gs-gutter solid transparent;
+        transform: rotate(-3deg);
+        z-index: -1;
+    }
+
+    @include mq($until: mobile) {
+        display: none;
+    }
+
+    @include mq($from: mobileMedium) {
+        padding-top: 14px;
+        font-size: 14px;
+
+        &:before {
+            border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
+        }
+    }
+
+    @include mq($from: mobileLandscape) {
+        left: $gs-gutter/2;
+    }
+}


### PR DESCRIPTION
Some trapezoid action in that new header.

Bonus addition of much lauded 'mobileMedium' breakpoint. @NataliaLKB will be creating a PR for edition switcher within the menu.

<img width="483" alt="screen shot 2017-01-20 at 11 40 48" src="https://cloud.githubusercontent.com/assets/14570016/22148347/74fbb35a-df05-11e6-83b8-df870ec9c8ce.png">
