### PR TITLE
Speedup Hosted onward

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/onward.js
@@ -17,10 +17,8 @@ define([
 
         var placeholders = document.getElementsByClassName('js-onward-placeholder');
 
-        var fetchPromise;
-
         if (placeholders.length) {
-            fetchPromise = fetchJson(config.page.ajaxUrl + '/'
+            fetchJson(config.page.ajaxUrl + '/'
                 + config.page.pageId + '/'
                 + config.page.contentType.toLowerCase() + '/'
                 + 'onward.json', {mode: 'cors'})
@@ -30,15 +28,16 @@ define([
                         for (i = 0; i < placeholders.length; i++) {
                             placeholders[i].innerHTML = json.html;
                         }
-                        new HostedCarousel.init();
                     });
                 })
-        } else {
-            fetchPromise = Promise.resolve();
+                .then(function () {
+                    HostedCarousel.init();
+                })
+                .then(function () {
+                    performanceLogging.moduleEnd(moduleName);
+                })
         }
 
-        return fetchPromise.then(function () {
-            performanceLogging.moduleEnd(moduleName);
-        });
+        return Promise.resolve();
     }
 });


### PR DESCRIPTION
Same as for hosted videos, we don't want to block the commercial bootstrap on a network call. Also moved the carousel init out of the fastdom frame to make room for other modules that need to write to the DOM.