### PR TITLE
Visible email footers for outlook.com and office 365

### DIFF
--- a/common/app/views/fragments/email/stylesheets/footer.scala.html
+++ b/common/app/views/fragments/email/stylesheets/footer.scala.html
@@ -4,7 +4,10 @@
 
 <style>
     .footer {
-        background: #484848 url(@footerG) no-repeat bottom right;
+        background-color: #484848;
+        background-image:url(@footerG);
+        background-repeat: no-repeat;
+        background-position: bottom right;
         padding: 25px 0;
         display: block;
         margin-top: 36px;


### PR DESCRIPTION
<!-- **************************************************************** -->
<!-- IMPORTANT -->
<!-- Continuous Deployment is enabled for this repository -->
<!-- Merging into master = deploying to PROD -->
<!-- Use Riff-Raff to deploy/test a PR on CODE before merging -->
<!-- **************************************************************** -->

## What does this change?
Setting background-image and background-color individually in the css for email footers because just background-color being observed is better than neither. 

## What is the value of this and can you measure success?
Users of outlook.com and outlook 365 should be able to see the manage your emails, unsubscribe, and trouble viewing? links.

## Does this affect other platforms - Amp, Apps, etc?
No. 

## Screenshots
This is how the footer looks in e.g. Yahoo Mail:
![image](https://cloud.githubusercontent.com/assets/3072877/22148505/5e786c62-df06-11e6-8fc7-60f3f7bf095f.png)

The footer in outlook.com and office 365 before this change appeared transparent:
![image](https://cloud.githubusercontent.com/assets/3072877/22148463/1f1a603e-df06-11e6-8043-3918f694c698.png)

This change should help to ensure that if the background image fails, the background colour still appears and you can see the links:
![image](https://cloud.githubusercontent.com/assets/3072877/22148673/67116c74-df07-11e6-8e41-86ab8840780f.png)

## Tested in CODE?
No; not required.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@joelochlann @davidfurey 
