### PR TITLE
The ultimate Sonobi/Googletag load speedup

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
@@ -68,11 +68,12 @@ define([
         }
 
         if (commercialFeatures.dfpAdvertising) {
-            return setupAdvertising()
+            setupAdvertising()
             // A promise error here, from a failed module load,
             // could be a network problem or an intercepted request.
             // Abandon the init sequence.
             .catch(removeAdSlots);
+            return Promise.resolve();
         }
 
         return removeAdSlots();

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -15,7 +15,7 @@ define([
     function setupSonobi() {
         // Setting the async property to false will _still_ load the script in
         // a non-blocking fashion but will ensure it is executed before googletag
-        return loadScript(config.libs.sonobi, { async: false }).then(catchPolyfillErrors);
+        loadScript(config.libs.sonobi, { async: false }).then(catchPolyfillErrors);
     }
 
     // Wrap the native implementation of getOwnPropertyNames in a try-catch. If any polyfill attempts
@@ -41,7 +41,11 @@ define([
     }
 
     function init() {
-        return dfpEnv.sonobiEnabled && commercialFeatures.dfpAdvertising ? setupSonobi() : Promise.resolve();
+        if (dfpEnv.sonobiEnabled && commercialFeatures.dfpAdvertising) {
+            setupSonobi();
+        }
+
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/onward.js
@@ -1,14 +1,18 @@
 define([
     'common/utils/config',
+    'common/utils/mediator',
     'common/utils/fetch-json',
     'common/utils/fastdom-promise',
     'commercial/modules/hosted/onward-journey-carousel',
     'commercial/modules/dfp/performance-logging',
     'Promise'
-], function (config, fetchJson, fastdom, HostedCarousel, performanceLogging, Promise) {
+], function (config, mediator, fetchJson, fastdom, HostedCarousel, performanceLogging, Promise) {
 
     return {
         init: loadOnwardComponent,
+        whenRendered: new Promise(function (resolve) {
+            mediator.on('hosted:onward:done', resolve);
+        }),
         customTiming: true
     };
 
@@ -32,6 +36,7 @@ define([
                 })
                 .then(function () {
                     HostedCarousel.init();
+                    mediator.emit('hosted:onward:done');
                 })
                 .then(function () {
                     performanceLogging.moduleEnd(moduleName);

--- a/static/test/javascripts/spec/commercial/hosted/onward.spec.js
+++ b/static/test/javascripts/spec/commercial/hosted/onward.spec.js
@@ -53,6 +53,9 @@ define([
         it('should make an ajax call and insert html', function (done) {
             hostedOnward.init()
                 .then(function () {
+                    return hostedOnward.whenRendered;
+                })
+                .then(function () {
                     expect(mock).toHaveBeenCalledWith('some.url/pageId/gallery/onward.json', {mode: 'cors'});
                     expect($('.js-onward-placeholder .next-page', $fixturesContainer).length).toBeGreaterThan(0);
                 })


### PR DESCRIPTION
Given that we know:

- network calls will happen
- if they succeed, sonobi will be executed before googletag
- every interaction with them is done via the googletag command queue

... then we don't need our commercial bootstrap to block on network calls.

- [ ] needs to fix failing tests