### PR TITLE
Removing the eu referendum badge

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -38,16 +38,9 @@ case class SpecialBadge(salt: String, hashedTag: String) extends BaseBadge {
 
 object Badges {
 
-  private val euSvg = Static("images/badges/eu-ref.svg")
-
   val usElection = Badge("us-news/us-elections-2016", Static("images/badges/us-election.png"), Some("us-election"))
   val ausElection = Badge("australia-news/australian-election-2016", Static("images/badges/aus-election.png"), Some("aus-election"))
   val voicesOfAmerica = Badge("us-news/series/voices-of-america", Static("images/badges/voices-of-america.svg"), Some("voices-of-america"))
-
-  val euElection = Badge("politics/eu-referendum", euSvg)
-  val euRealityCheck = Badge("politics/series/eu-referendum-reality-check", euSvg)
-  val euBriefing = Badge("politics/series/eu-referendum-morning-briefing", euSvg)
-  val euSparrow = Badge("politics/series/eu-referendum-live-with-andrew-sparrow", euSvg)
 
   val rio2016 = Badge("sport/rio-2016", Static("images/badges/rio-2016.svg"))
 
@@ -55,7 +48,7 @@ object Badges {
 
   val globalWarning = Badge("environment/series/global-warning", Static("images/badges/global-warning.png"), Some("global-warning"))
 
-  val allBadges = Seq(usElection, ausElection, voicesOfAmerica, nauru, rio2016, euElection, euRealityCheck, euBriefing, euSparrow, globalWarning)
+  val allBadges = Seq(usElection, ausElection, voicesOfAmerica, nauru, rio2016, globalWarning)
 
   def badgeFor(c: ContentType) = {
     badgeForTags(c.tags.tags.map(_.id))

--- a/static/public/images/badges/eu-ref.svg
+++ b/static/public/images/badges/eu-ref.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="306" height="172" viewBox="0 0 306 172"><path fill="#FF0" d="M306 50h-67V5l-86 81 86 81v-45h67z"/><path fill="#00C0F2" d="M153 86L67 5v45H0v72h67v45z"/><g><g fill="none" stroke="#333" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10"><path d="M234 167L72 5M72 167L234 5"/></g></g></svg>


### PR DESCRIPTION
## What does this change?
Removes the EU referendum badge. [Trello card here](https://trello.com/c/VXDrUrLa/194-remove-the-eu-referendum-badge-from-the-brexit-eu-referendum-tag)

cc @desbo and @superfrank because you guys originally put it in I believe. Let me know if I missed anything!

## What is the value of this and can you measure success?
Less code!

## Does this affect other platforms - Amp, Apps, etc?
Yes, this removes it from AMP too

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/22149654/e6c36666-df0c-11e6-8868-f2afa77095be.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/22149646/de5a49b8-df0c-11e6-96aa-90afbbaf0227.png)

## Tested in CODE?
Nope
