### PR TITLE
extend expired switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -494,7 +494,7 @@ trait FeatureSwitches {
     "Adds a placeholder attribute to interactives on amp so that they are allowed to display in the top part of the page",
     owners = Seq(Owner.withGithub("michaelwmcnamara")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 20),
+    sellByDate = new LocalDate(2017, 2, 20),
     exposeClientSide = true
   )
 
@@ -516,7 +516,7 @@ trait FeatureSwitches {
     "Sends a healthcheck metric for every page",
     owners = Seq(Owner.withGithub("michaelwmcnamara")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 20),
+    sellByDate = new LocalDate(2017, 3, 20),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
extend expiry for:
amp-interactive-placeholder-attribute
stress-test-tailor-healthcheck

There will be a pull request to remove amp-interactive-placeholder-attribute shortly, but this is to unblock things in the meantime.

the stress-test-tailor-healthcheck has external stakeholders. I will check with them and confirm its ok to remove in a future pull request.

@guardian/dotcom-platform 