### PR TITLE
Acquisitions A/B test wrapper

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -195,13 +195,6 @@ define([
             return function () {
                 return new ContributionsABTest(test);
             };
-        },
-
-        inAlwaysAskTest: function () {
-            var participations = storage.local.get('gu.ab.participations') || {};
-            var test = participations['ContributionsEpicAlwaysAskStrategy'];
-
-            return test && test.variant !== 'notintest';
         }
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -4,40 +4,37 @@ define([
     'common/utils/cookies',
     'common/utils/mediator',
     'common/utils/storage',
-    'common/modules/analytics/mvt-cookie',
-    'lodash/functions/memoize',
+    'lodash/arrays/compact',
     'lodash/utilities/noop',
+    'common/modules/experiments/segment-util',
     'common/modules/experiments/tests/editorial-email-variants',
     'common/modules/experiments/tests/opinion-email-variants',
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/neilsen-check',
     'common/modules/experiments/tests/membership-engagement-banner-tests',
-    'common/modules/experiments/tests/contributions-epic-brexit',
-    'common/modules/experiments/tests/contributions-epic-always-ask-strategy'
+    'common/modules/experiments/acquisition-test-selector',
 ], function (reportError,
              config,
              cookies,
              mediator,
              store,
-             mvtCookie,
-             memoize,
+             compact,
              noop,
+             segmentUtil,
              EditorialEmailVariants,
              OpinionEmailVariants,
              RecommendedForYou,
              NeilsenCheck,
              MembershipEngagementBannerTests,
-             ContributionsEpicBrexit,
-             ContributionsEpicAlwaysAskStrategy
+             acquisitionTestSelector
     ) {
-    var TESTS = [
+    var TESTS = compact([
         new EditorialEmailVariants(),
         new OpinionEmailVariants(),
         new RecommendedForYou(),
         new NeilsenCheck(),
-        new ContributionsEpicBrexit,
-        new ContributionsEpicAlwaysAskStrategy
-    ].concat(MembershipEngagementBannerTests);
+        acquisitionTestSelector.getTest()
+    ].concat(MembershipEngagementBannerTests));
 
     var participationsKey = 'gu.ab.participations';
 
@@ -169,7 +166,7 @@ define([
                 .forEach(function (test) {
                     var variant = getTestVariantId(test.id);
 
-                    if (variant && variant !== 'notintest') {
+                    if (variant && segmentUtil.isInTest(test)) {
                         log[test.id] = abData(variant, 'false');
                     }
                 });
@@ -223,40 +220,16 @@ define([
             var variant = getVariant(test, variantId);
             if (variant) {
                 variant.test();
-            } else if (variantId === 'notintest' && test.notInTest) {
+            } else if (!segmentUtil.isInTest(test) && test.notInTest) {
                 test.notInTest();
             }
         }
     }
 
-    /**
-     * Determine whether the user is in the test or not and return the associated
-     * variant ID.
-     *
-     * The test population is just a subset of mvt ids. A test population must
-     * begin from a specific value. Overlapping test ranges are permitted.
-     *
-     * @return {String} variant ID
-     */
-    var variantIdFor = memoize(function (test) {
-        var smallestTestId = mvtCookie.getMvtNumValues() * test.audienceOffset;
-        var largestTestId = smallestTestId + mvtCookie.getMvtNumValues() * test.audience;
-        var mvtCookieId = mvtCookie.getMvtValue();
-
-        if (mvtCookieId && mvtCookieId > smallestTestId && mvtCookieId <= largestTestId) {
-            // This mvt test id is in the test range, so allocate it to a test variant.
-            var variantIds = test.variants.map(getId);
-
-            return variantIds[mvtCookieId % variantIds.length];
-        } else {
-            return 'notintest';
-        }
-    }, getId); // use test ids as memo cache keys
-
     function allocateUserToTest(test) {
         // Only allocate the user if the test is valid and they're not already participating.
         if (testCanBeRun(test) && !isParticipating(test)) {
-            addParticipation(test, variantIdFor(test));
+            addParticipation(test, segmentUtil.variantIdFor(test));
         }
     }
 
@@ -270,9 +243,9 @@ define([
      */
     function registerCompleteEvent(complete) {
         return function initListener(test) {
-            var variantId = variantIdFor(test);
+            var variantId = segmentUtil.variantIdFor(test);
 
-            if (variantId !== 'notintest') {
+            if (segmentUtil.isInTest(test)) {
                 var variant = getVariant(test, variantId);
                 var listener = (complete ? variant.success : variant.impression) || noop;
 
@@ -369,8 +342,8 @@ define([
             var test = getTest(testId);
 
             var variant = test && test.variants.filter(function (v) {
-                    return v.id.toLowerCase() === variantId.toLowerCase();
-                })[0];
+                return v.id.toLowerCase() === variantId.toLowerCase();
+            })[0];
 
             var impression = variant && variant.impression || noop;
             var complete = variant && variant.success || noop;
@@ -476,7 +449,7 @@ define([
         // testing
         reset: function () {
             TESTS = [];
-            variantIdFor.cache = {};
+            segmentUtil.variantIdFor.cache = {};
         }
     };
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -1,0 +1,27 @@
+define([
+    'common/modules/experiments/segment-util',
+    'common/modules/experiments/tests/contributions-epic-brexit',
+    'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
+], function (
+    segmentUtil,
+    brexit,
+    alwaysAsk
+) {
+    /**
+     * acquisition tests in priority order (highest to lowest)
+     */
+    var tests = [alwaysAsk, brexit];
+
+    return {
+        getTest: function() {
+            var eligibleTests = tests.filter(function (test) {
+                var t = new test();
+                var forced = new RegExp('^#ab-' + t.id).test(window.location.hash);
+
+                return forced || (t.canRun() && segmentUtil.isInTest(t));
+            });
+
+            return eligibleTests && new eligibleTests[0]();
+        }
+    }
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -16,7 +16,7 @@ define([
         getTest: function() {
             var eligibleTests = tests.filter(function (test) {
                 var t = new test();
-                var forced = new RegExp('^#ab-' + t.id).test(window.location.hash);
+                var forced = window.location.hash.indexOf('ab-' + t.id) > -1;
 
                 return forced || (t.canRun() && segmentUtil.isInTest(t));
             });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -21,7 +21,7 @@ define([
                 return forced || (t.canRun() && segmentUtil.isInTest(t));
             });
 
-            return eligibleTests && new eligibleTests[0]();
+            return eligibleTests[0] && new eligibleTests[0]();
         }
     }
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/segment-util.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/segment-util.js
@@ -1,0 +1,45 @@
+define([
+    'lodash/functions/memoize',
+    'common/modules/analytics/mvt-cookie'
+], function(
+    memoize,
+    mvtCookie
+) {
+    var NOT_IN_TEST = 'notintest';
+
+    function getId(test) {
+        return test.id; // use test ids as memo cache keys
+    }
+
+    /**
+     * Determine whether the user is in the test or not and return the associated
+     * variant ID.
+     *
+     * The test population is just a subset of mvt ids. A test population must
+     * begin from a specific value. Overlapping test ranges are permitted.
+     *
+     * @return {String} variant ID
+     */
+    function variantIdFor(test) {
+        var smallestTestId = mvtCookie.getMvtNumValues() * test.audienceOffset;
+        var largestTestId = smallestTestId + mvtCookie.getMvtNumValues() * test.audience;
+        var mvtCookieId = mvtCookie.getMvtValue();
+
+        if (mvtCookieId && mvtCookieId > smallestTestId && mvtCookieId <= largestTestId) {
+            // This mvt test id is in the test range, so allocate it to a test variant.
+            var variantIds = test.variants.map(getId);
+
+            return variantIds[mvtCookieId % variantIds.length];
+        } else {
+            return NOT_IN_TEST;
+        }
+    }
+
+    return {
+        variantIdFor: memoize(variantIdFor, getId),
+
+        isInTest: function(test) {
+            return variantIdFor(test) !== NOT_IN_TEST;
+        }
+    }
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -25,10 +25,6 @@ define([
         audienceOffset: 0,
         useTargetingTool: true,
 
-        canRun: function () {
-            return !contributionsUtilities.inAlwaysAskTest();
-        },
-
         variants: [
             {
                 id: 'control',


### PR DESCRIPTION
## What does this change?
This tool prevents multiple acquisitions (formerly contributions) tests
clashing with each other by working out which one should be active. It
is not enough for us to rely on audience segments since we might
have multiple tests running against the same segments, but targeted at
different tags via the targeting tool. 

I had to move a small part of `ab.js` (the bit that works out the variant
based on the MVT ID) into its own module to use it here.

## What is the value of this and can you measure success?
No clashing tests

## Does this affect other platforms - Amp, Apps, etc?
No