### PR TITLE
remove placeholder switch - make placeholder attribute permanent

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -487,17 +487,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  //Owner Michael McNamara
-  val AmpInteractivePlaceHolderAttribute = Switch(
-    SwitchGroup.Feature,
-    "amp-interactive-placeholder-attribute",
-    "Adds a placeholder attribute to interactives on amp so that they are allowed to display in the top part of the page",
-    owners = Seq(Owner.withGithub("michaelwmcnamara")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 20),
-    exposeClientSide = true
-  )
-
   // Owner: Joseph Smith
   val RenderEmailConnectedStyle = Switch(
     SwitchGroup.Feature,

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -5,7 +5,6 @@ import java.net.URLDecoder
 import model.{Elements, Article, VideoAsset}
 import org.jsoup.nodes.{Document, Element}
 import views.support.{AmpSrcCleaner, HtmlCleaner}
-import conf.switches.Switches.AmpInteractivePlaceHolderAttribute
 
 import scala.annotation.switch
 import scala.collection.JavaConversions._
@@ -201,9 +200,7 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
           overflowElem.addClass("cta cta--medium cta--show-more cta--show-more__unindent")
           overflowElem.text("See the full visual")
           overflowElem.attr("overflow", "")
-          if (AmpInteractivePlaceHolderAttribute.isSwitchedOn) {
-            overflowElem.attr("placeholder", "")
-          }
+          overflowElem.attr("placeholder", "")
           link.remove()
           iframe.appendChild(overflowElem)
           interactive.appendChild(iframe)


### PR DESCRIPTION
## What does this change?
We were trialling the use of a placeholder attr in amp interactive embeds.
This allows the interactive to be put in the main media.
The trial was successful, so removing the switch and making this change permanent.

## What is the value of this and can you measure success?
This allows interactive atoms to be embedded in main media without breaking amp-validation

## Does this affect other platforms - Amp, Apps, etc?
Exclusively for Amp. No other impact.

## Tested in CODE?
Nope

Amp pages validate successfully (manual checks and tested using make validate-amp).
Amp Embed Cleaner tests all pass too.
cc @guardian/dotcom-platform 