### PR TITLE
Hash webpack by dir, not filename

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -24,7 +24,7 @@ http://developers.theguardian.com/join-the-team.html
 
 @if(!(context.environment.mode == Dev)) {
     @if(WebpackTest.isParticipating) {
-        <link rel="prefetch" href="@Static("javascripts/boot-webpack.js")">
+        <link rel="prefetch" href="@Static("javascripts/app-webpack.js")">
     } else {
         <link rel="prefetch" href="@Static("javascripts/app.js")">
     }

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -70,7 +70,7 @@
             var script = document.createElement('script');
             var ref = document.getElementsByTagName('script')[0];
             @if(WebpackTest.isParticipating) {
-                script.src = '@Static("javascripts/boot-webpack.js")';
+                script.src = '@Static("javascripts/app-webpack.js")';
             } else {
                 script.src = '@Static("javascripts/app.js")';
             }

--- a/tools/__tasks__/compile/hash/index.js
+++ b/tools/__tasks__/compile/hash/index.js
@@ -48,14 +48,16 @@ module.exports = {
                     Object.keys(assetMap).map(asset =>
                         cpFile(path.resolve(target, asset), path.resolve(hash, assetMap[asset]))
                     )
-                ).then(() => { // add an unhashed keys for any webpack boot files for use in play templates
+                ).then(() => { // add unhashed keys for any webpack boot files for use in play templates
                     const webpackBootfiles = Object.keys(assetMap).filter(key =>
                         webpackRegex.test(key) && !webpackChunkRegex.test(key) && !sourcemapRegex.test(key)
                     );
 
-                    return webpackBootfiles.reduce((map, webpackBootfile) => Object.assign({}, assetMap, {
-                        [webpackBootfile.replace(/(javascripts\/)(.+\/)/, '$1')]: assetMap[webpackBootfile],
-                    }), {});
+                    return Object.assign({}, assetMap, webpackBootfiles.reduce((map, webpackBootfile) =>
+                        Object.assign(map, {
+                            [webpackBootfile.replace(/(javascripts\/)(.+\/)/, '$1')]: assetMap[webpackBootfile],
+                        }
+                    ), {}));
                 }).then(normalisedAssetMap => // save the asset map
                     mkdirpp(path.resolve(hash, 'assets')).then(() =>
                         writeFile(path.resolve(hash, 'assets', 'assets.map'), JSON.stringify(normalisedAssetMap, null, 4))

--- a/tools/__tasks__/compile/hash/index.js
+++ b/tools/__tasks__/compile/hash/index.js
@@ -32,6 +32,7 @@ module.exports = {
                         // webpack bundles come pre-hashed, so we won't hash them, just add them
                         if (webpackRegex.test(assetPath)) {
                             const sourcemap = hasSourceMap ? { [`${assetPath}.map`]: `${assetPath}.map` } : {};
+
                             return Object.assign(map, { [assetPath]: assetPath }, sourcemap);
                         }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,12 +4,15 @@ const path = require('path');
 const webpack = require('webpack');
 const Visualizer = require('webpack-visualizer-plugin');
 
+const outputName = 'app-webpack';
+
 module.exports = {
     devtool: 'source-map',
     entry: path.join(__dirname, 'static', 'src', 'javascripts', 'boot-webpack.js'),
     output: {
         path: path.join(__dirname, 'static', 'target', 'javascripts'),
-        filename: 'boot-webpack.[chunkhash].js',
+        filename: `[chunkhash]/${outputName}.js`,
+        chunkFilename: `[chunkhash]/${outputName}.chunk-[id].js`,
     },
     resolve: {
         modules: [


### PR DESCRIPTION
## What does this change?

updates webpack hashing to use dirs, like all other assets

## What is the value of this and can you measure success?

makes the browser console much easier to read

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

![screen shot 2017-01-20 at 17 49 46](https://cloud.githubusercontent.com/assets/867233/22159451/db999f54-df38-11e6-82f0-e3161f4bbee0.png)

