### PR TITLE
Add webpack/curl to ga experience

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -2,6 +2,7 @@
 @import play.api.Mode.Dev
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.{Commercial, GoogleAnalyticsAccount}
+@import mvt.WebpackTest
 
 <script id='google_analytics'>
 
@@ -36,7 +37,7 @@
 
     // Please email Dotcom Platform before changing this value
     function getExperienceValue() {
-        return 'test-experience';
+        return @if(WebpackTest.isParticipating) {'webpack'} else {'curl'};
     }
 
     var identityId = null;


### PR DESCRIPTION
## What does this change?

Adds webpack experience value to #15624 

## What is the value of this and can you measure success?

we can compare webpack and curl in GA

## Does this affect other platforms - Amp, Apps, etc?

no
