### PR TITLE
Don't use the circle byline image on interactives

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -110,7 +110,7 @@ final case class Content(
   lazy val hasTonalHeaderIllustration: Boolean = tags.isLetters
 
   lazy val showCircularBylinePicAtSide: Boolean =
-    cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1
+    cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1 && !tags.isInteractive
 
   lazy val signedArticleImage: String = {
     ImgSrc(rawOpenGraphImage, EmailImage)


### PR DESCRIPTION
## What does this change?

Removes the circular byline image from interactive articles.

## What is the value of this and can you measure success?

Fixes [Trello bug](https://trello.com/c/fWMsZAxq/173-byline-field-broken-in-feature-tone-interactives) reported by @fcage 

## Screenshots

### Before
![screen shot 2017-01-23 at 11 48 12](https://cloud.githubusercontent.com/assets/638051/22203188/ada1d490-e163-11e6-96df-99d3a9409b8c.jpg)

### After
![screen shot 2017-01-23 at 11 48 35](https://cloud.githubusercontent.com/assets/638051/22203187/ada1a9d4-e163-11e6-8663-02527b512c15.jpg)

## Tested in CODE?
No