### PR TITLE
Extend the Nielsen test into next week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -56,7 +56,7 @@ trait ABTestSwitches {
     "Test new params for Neilsen => Zero participation, will send them the opt-in link",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 1, 23),
+    sellByDate = new LocalDate(2017, 1, 31),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/neilsen-check.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/neilsen-check.js
@@ -4,7 +4,7 @@ define([
     return function () {
         this.id = 'NeilsenCheck';
         this.start = '2017-01-19';
-        this.expiry = '2017-01-23';
+        this.expiry = '2017-01-31';
         this.author = 'Kate Whalen';
         this.description = 'Letting Neilsen opt in to get the updated script';
         this.audience = 0;


### PR DESCRIPTION
## What does this change?

Waiting for update so extending this switch into next week

Follow up to #15633

## What is the value of this and can you measure success?

- Build doesn't break tomorrow
- Enable testing of IMR update

## Does this affect other platforms - Amp, Apps, etc?

Nope

