### PR TITLE
Outbrain fixes

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -226,7 +226,6 @@ object ContentTypeFormat {
     showByline: Boolean,
     hasStoryPackage: Boolean,
     rawOpenGraphImage: String,
-    showFooterContainers: Boolean,
     atoms: Option[Atoms])
 
   private case class JsonCommercial(
@@ -299,8 +298,7 @@ object ContentTypeFormat {
         jsonContent.wordCount,
         jsonContent.showByline,
         jsonContent.hasStoryPackage,
-        jsonContent.rawOpenGraphImage,
-        jsonContent.showFooterContainers
+        jsonContent.rawOpenGraphImage
        )
       }
     }
@@ -332,7 +330,6 @@ object ContentTypeFormat {
           content.showByline,
           content.hasStoryPackage,
           content.rawOpenGraphImage,
-          content.showFooterContainers,
           content.atoms
         ),
         JsonCommercial.apply(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -65,8 +65,7 @@ final case class Content(
   wordCount: Int,
   showByline: Boolean,
   hasStoryPackage: Boolean,
-  rawOpenGraphImage: String,
-  showFooterContainers: Boolean = false
+  rawOpenGraphImage: String
 ) {
 
   lazy val isBlog: Boolean = tags.blogs.nonEmpty
@@ -484,8 +483,7 @@ object Article {
       trail = trail,
       commercial = commercial,
       metadata = metadata,
-      sharelinks = sharelinks,
-      showFooterContainers = !tags.isLiveBlog && !content.shouldHideAdverts
+      sharelinks = sharelinks
     )
 
     Article(contentOverrides, lightboxProperties)

--- a/common/app/views/fragments/externalContentPlaceholder.scala.html
+++ b/common/app/views/fragments/externalContentPlaceholder.scala.html
@@ -1,3 +1,0 @@
-@()
-	<div class="js-external-content-widget-anchor">
-    </div>

--- a/common/app/views/support/ContentFooterContainersLayout.scala
+++ b/common/app/views/support/ContentFooterContainersLayout.scala
@@ -1,7 +1,6 @@
 package views.support
 
-import conf.switches.Switches.OutbrainSwitch
-import model.{Content}
+import model.Content
 import play.twirl.api.{Html, HtmlFormat}
 
 import scala.collection.immutable.Seq

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -170,11 +170,7 @@ define([
     }
 
     function init() {
-        if (commercialFeatures.outbrain &&
-            !config.page.isFront &&
-            !config.page.isPreview &&
-            identityPolicy()
-        ) {
+        if (commercialFeatures.outbrain && identityPolicy() ) {
             // if there is no merch component, load the outbrain widget right away
             return loadInstantly().then(function(shouldLoadInstantly) {
                 if (shouldLoadInstantly) {

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
@@ -118,6 +118,8 @@ define([
             externalAdvertising &&
             !sensitiveContent &&
             switches.outbrain &&
+            isArticle &&
+            !config.page.isPreview &&
             config.page.showRelatedContent;
 
         this.commentAdverts =

--- a/static/test/javascripts/spec/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/commercial/third-party-tags/outbrain.spec.js
@@ -62,10 +62,7 @@ define([
                 config.switches.emailInArticleOutbrain = false;
                 config.page = {
                     section: 'uk-news',
-                    isFront: false,
-                    isPreview: false,
-                    commentable: true,
-                    edition: 'UK'
+                    commentable: true
                 };
 
                 identity.isUserLoggedIn = function () {
@@ -96,23 +93,6 @@ define([
             it('should start outbrain component', function (done) {
                 sut.init().then(function () {
                     expect(sut.load).toHaveBeenCalled();
-                    done();
-                });
-            });
-
-            it('should not load when sensitive content', function (done) {
-                commercialFeatures.outbrain = false;
-                sut.init().then(function () {
-                    expect(sut.load).not.toHaveBeenCalled();
-                    done();
-                });
-            });
-
-            it('should not load when isPreview', function (done) {
-                config.page.isPreview = true;
-
-                sut.init().then(function () {
-                    expect(sut.load).not.toHaveBeenCalled();
                     done();
                 });
             });


### PR DESCRIPTION
We had an issue with the move to client side in https://github.com/guardian/frontend/pull/15588 . The old placeholder does not appear on every page, so this change explicitly avoids loading Outbrain based on the content type (article only).

A few server-side tidy ups too, with some fields and templates left unused since the move.

## Tested in CODE?
Yes