### PR TITLE
Remove rogue <a> wrapping a <table>

### DIFF
--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -73,11 +73,9 @@
 
 @faciaCardSmall(card: ContentCard) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
-        <a @Html(card.header.url.hrefWithRel) class="facia-link">
-            @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
-                @headline(card)
-            }
-        </a>
+        @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
+            @headline(card)
+        }
     }
 }
 


### PR DESCRIPTION
In #15634, I wrapped individual inline elements (images, headlines, standfirsts) with `<a>` tags rather than block-level tables. I accidentally left in place an `<a>` wrapping a table, meaning nested `<a>` tags (since that table contains a headline). Strangely this didn't seem to break Outlook (presumably the block-level `<a>` gets ignored) but I thought it best to remove it anyway!