### PR TITLE
Capture Webpack variant experience value in Google Analytics

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -2,7 +2,7 @@
 @import play.api.Mode.Dev
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.{Commercial, GoogleAnalyticsAccount}
-@import mvt.WebpackTest
+@import mvt.{WebpackTest,WebpackControl}
 
 <script id='google_analytics'>
 
@@ -37,7 +37,15 @@
 
     // Please email Dotcom Platform before changing this value
     function getExperienceValue() {
-        return @if(WebpackTest.isParticipating) {'webpack'} else {'curl'};
+        @if(WebpackTest.isParticipating) {
+            return 'webpack';
+        } else {
+            @if(WebpackControl.isParticipating) {
+                return 'webpack-control';
+            } else {
+                return 'curl';
+            }
+        }
     }
 
     var identityId = null;


### PR DESCRIPTION
## What does this change?

Captures an experience value in Google Analytics for users participating in the Webpack test variant and the Webpack test control.  

## What is the value of this and can you measure success?

Allows us to distinguish between users receiving the Webpack variant and those in the control group, allowing us to fairly compare performance metrics. The performance delta captured here will feed into the results of the Webpack test.

## Does this affect other platforms - Amp, Apps, etc?

No

c/c @sndrs 