### PR TITLE
Avoid exceptions when the commercial switch is disabled

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -1,7 +1,6 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import conf.switches.SwitchGroup.CommercialLabs
 import org.joda.time.LocalDate
 
 trait CommercialSwitches {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -649,12 +649,14 @@ case class CommercialComponentHigh(isAdvertisementFeature: Boolean, isNetworkFro
 
       val adSlotHtml = views.html.fragments.commercial.commercialComponentHigh(isAdvertisementFeature, hasPageSkin)
 
-      val adSlot: Element = Jsoup.parseBodyFragment(adSlotHtml.toString).body().child(0)
+      val adSlot: Option[Element] = Jsoup.parseBodyFragment(adSlotHtml.toString).body().children().toList.headOption
 
-      containers.lift(containerIndex).map { case ((container, index)) => {
-          container.after(adSlot)
-          adSlot.wrap(s"""<div class="fc-container fc-container--commercial"></div>""")
-        }
+      for {
+        (container, index) <- containers.lift(containerIndex)
+        slot <- adSlot
+      } {
+          container.after(slot)
+          slot.wrap(s"""<div class="fc-container fc-container--commercial"></div>""")
       }
 
     }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -656,7 +656,7 @@ case class CommercialComponentHigh(isAdvertisementFeature: Boolean, isNetworkFro
         slot <- adSlot
       } {
           container.after(slot)
-          slot.wrap(s"""<div class="fc-container fc-container--commercial"></div>""")
+          slot.wrap("""<div class="fc-container fc-container--commercial"></div>""")
       }
 
     }


### PR DESCRIPTION
Make sure the cleaner code doesn't throw an exception in the unlikely event that this switch is off.

## Tested in CODE?
Yes (but missed an error in facia).