### PR TITLE
Fast layout style for email fronts

### DIFF
--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -54,6 +54,13 @@
     .facia-card__text--last {
         padding-bottom: 26px !important;
     }
+    .facia-card__text.sub-columns {
+        padding-left: 10px !important;
+        padding-bottom: 26px !important;
+    }
+    .facia-card__text.sub-columns.last {
+        padding-right: 10px !important;
+    }
 
     .headline,
     .trail-text {

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -55,11 +55,10 @@
         padding-bottom: 26px !important;
     }
     .facia-card__text.sub-columns {
-        padding-left: 10px !important;
-        padding-bottom: 26px !important;
+        padding: 0 10px 26px 10px !important;
     }
     .facia-card__text.sub-columns.last {
-        padding-right: 10px !important;
+        padding: 0 !important;
     }
 
     .headline,

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -7,8 +7,8 @@ import play.twirl.api.Html
 import play.api.mvc._
 
 object EmailHelpers {
-  def columnNumber(n: Int): String = {
-    Seq("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve").lift(n - 1).getOrElse("")
+  def columnWidth(width: Int): String = {
+    Seq("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve").lift(width - 1).getOrElse("")
   }
 
   def row(inner: Html): Html = Html {
@@ -17,9 +17,9 @@ object EmailHelpers {
         </table>"""
   }
 
-  def columns(n: Int, innerClasses: Seq[String] = Seq(), last: Boolean = false, style: Option[String] = None)(inner: Html): Html = Html {
-    s"""<td class="wrapper ${if (last || n == 12) "last" else ""}" ${style.map(css => s"""style="$css"""").getOrElse("")}>
-      <table class="${columnNumber(n)} columns">
+  def column(width: Int, innerClasses: Seq[String] = Seq(), last: Boolean = false, style: Option[String] = None)(inner: Html): Html = Html {
+    s"""<td class="wrapper ${if (last || width == 12) "last" else ""}" ${style.map(css => s"""style="$css"""").getOrElse("")}>
+      <table class="${columnWidth(width)} columns">
         <tr>
           <td ${if (innerClasses.nonEmpty) s"""class="${innerClasses.mkString(" ")}" """ else ""}>$inner</td>
           <td class="expander"></td>
@@ -28,10 +28,26 @@ object EmailHelpers {
     </td>"""
   }
 
-  def fullRow(inner: Html): Html = row(columns(12)(inner))
-  def fullRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(columns(12, classes)(inner))
-  def paddedRow(inner: Html): Html = row(columns(12, Seq("panel"))(inner))
-  def paddedRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(columns(12, classes ++ Seq("panel"))(inner))
+  def columnWithSubColumns(width: Int, innerClasses: Seq[String] = Seq(), last: Boolean = false, style: Option[String] = None)(inner: Html): Html = Html {
+    s"""<td class="wrapper ${if (last || width == 12) "last" else ""}" ${style.map(css => s"""style="$css"""").getOrElse("")}>
+      <table class="${columnWidth(width)} columns">
+        <tr>
+          $inner
+          <td class="expander"></td>
+        </tr>
+      </table>
+    </td>"""
+  }
+
+  def subColumn(width: Int, classes: Seq[String] = Seq(), last: Boolean = false)(inner: Html): Html = Html {
+    s"""<td class="${columnWidth(width)} sub-columns ${if (last || width == 12) "last" else ""} ${classes.mkString(" ")}">$inner</td>"""
+  }
+
+  def fullRow(inner: Html): Html = row(column(12)(inner))
+  def fullRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(column(12, classes)(inner))
+  def fullRowWithSubColumns(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(columnWithSubColumns(12, classes)(inner))
+  def paddedRow(inner: Html): Html = row(column(12, Seq("panel"))(inner))
+  def paddedRow(classes: Seq[String] = Seq.empty)(inner: Html): Html = row(column(12, classes ++ Seq("panel"))(inner))
 
   def imageUrlFromCard(contentCard: ContentCard): Option[String] = {
     for {

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -78,10 +78,13 @@ object EmailHelpers {
 
   def imgForFront = img(FrontEmailImage.knownWidth) _
 
-  def imgFromCard(card: ContentCard)(implicit requestHeader: RequestHeader) = imageUrlFromCard(card).map { url => Html {
-      s"""<a class="facia-link" ${card.header.url.hrefWithRel}>${imgForFront(url, Some(card.header.headline))}</a>"""
+  def imgFromCard(card: ContentCard, colWidth: Int = 12)(implicit requestHeader: RequestHeader) = imageUrlFromCard(card).map { url => Html {
+      val width = ((colWidth.toDouble / 12.toDouble) * FrontEmailImage.knownWidth).toInt
+      s"""<a class="facia-link" ${card.header.url.hrefWithRel}>${img(width)(url, Some(card.header.headline))}</a>"""
     }
   }
+
+
 
   object Images {
     val footerG = Static("images/email/grey-g.png")

--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -78,7 +78,7 @@ object EmailHelpers {
 
   def imgForFront = img(FrontEmailImage.knownWidth) _
 
-  def imgFromCard(card: ContentCard, colWidth: Int = 12)(implicit requestHeader: RequestHeader) = imageUrlFromCard(card).map { url => Html {
+  def imgFromCard(card: ContentCard, colWidth: Int = 12)(implicit requestHeader: RequestHeader): Option[Html] = imageUrlFromCard(card).map { url => Html {
       val width = ((colWidth.toDouble / 12.toDouble) * FrontEmailImage.knownWidth).toInt
       s"""<a class="facia-link" ${card.header.url.hrefWithRel}>${img(width)(url, Some(card.header.headline))}</a>"""
     }

--- a/docs/03-dev-howtos/18-working-with-emails.md
+++ b/docs/03-dev-howtos/18-working-with-emails.md
@@ -89,3 +89,40 @@ function validate(form) {
 - https://davidwalsh.name/html5-email
 
 4) If all else fails, ExactTarget has checks in place for valid emails and also cleans the lists.
+
+## Email rendering
+
+Fronts and articles can be rendered in email-friendly HTML by appending the URL parameter `format=email`. The response from these endpoints can be put into an email body and will render well in a wide variety of email clients.
+ 
+For curating emails, you'll normally want to set up a custom front rather than co-opting an existing front. For
+this purpose, we have a notion of "Email fronts" (in addition to Commercial, Editorial, and Training). These
+are visible in the fronts tool: https://fronts.gutools.co.uk/email
+
+Email fronts will always render in email-friendly format, regardless of the `format` parameter. They also
+have a much smaller set of layout types than web fronts: **fast**, **medium** and **slow**. Here's an example of each along with a table summarising their differences:
+
+### Slow
+![picture 397](https://cloud.githubusercontent.com/assets/5122968/22215773/83d61456-e194-11e6-82bb-792e377f7168.png)
+
+### Medium
+![picture 398](https://cloud.githubusercontent.com/assets/5122968/22215781/89027276-e194-11e6-96f3-c90e5a6f4226.png)
+
+### Fast
+![picture 399](https://cloud.githubusercontent.com/assets/5122968/22215787/90b7230e-e194-11e6-9448-425a1b9d2ded.png)
+
+### Table summarising differences between slow/medium/fast
+
+```
+LAYOUT | CARD   | IMAGE?   | STANDFIRST? | HEADLINE?
+----------------|-----------------------------------
+slow   | 1st    | big      | yes         | big
+       | others | none     | yes         | small
+----------------|-----------------------------------
+medium | 1st    | big      | yes         | big
+       | others | none     | no          | small
+----------------|-----------------------------------
+fast   | 1st    | small    | no          | small
+       | others | none     | no          | small
+```
+
+

--- a/docs/03-dev-howtos/18-working-with-emails.md
+++ b/docs/03-dev-howtos/18-working-with-emails.md
@@ -95,11 +95,26 @@ function validate(form) {
 Fronts and articles can be rendered in email-friendly HTML by appending the URL parameter `format=email`. The response from these endpoints can be put into an email body and will render well in a wide variety of email clients.
  
 For curating emails, you'll normally want to set up a custom front rather than co-opting an existing front. For
-this purpose, we have a notion of "Email fronts" (in addition to Commercial, Editorial, and Training). These
-are visible in the fronts tool: https://fronts.gutools.co.uk/email
+this purpose, we have a notion of "Email fronts" (in addition to Commercial, Editorial, and Training). Content can
+be placed into email fronts in the same way as for web fronts, via the [fronts tool](https://fronts.gutools.co.uk/email). 
 
-Email fronts will always render in email-friendly format, regardless of the `format` parameter. They also
-have a much smaller set of layout types than web fronts: **fast**, **medium** and **slow**. Here's an example of each along with a table summarising their differences:
+As for web fronts, other properties of email fronts can be configured via the [fronts config tool](https://fronts.gutools.co.uk/email/config).
+This includes creating containers and choosing their layout types.
+
+There are some differences between web fronts and email fronts.
+- Email fronts always render in email-friendly format, regardless of the `format` parameter
+- Email fronts have a much smaller set of layout types than web fronts:
+  - **Fast** is for news-like content which is expected to be scanned quickly. Cards are smaller,
+  containing just the headline.
+  - **Slow** is for more long-form/feature/opinion content which might be consumed more slowly. Cards are larger,
+  containing headline and standfirst.
+  - **Medium** is somewhere in between
+
+The use cases given (news-like vs feature-like) are just suggestions. In reality you can use whatever layout looks
+best for your design of email. For instance, longer emails will typically contain more containers with the **fast** layout since
+the email would take too long to scan from top to bottom otherwise.
+
+Here's an example of each layout type along with a table summarising their differences:
 
 ### Slow
 ![picture 397](https://cloud.githubusercontent.com/assets/5122968/22215773/83d61456-e194-11e6-82bb-792e377f7168.png)

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -77,7 +77,7 @@
             @if(withImage) {
                 @fullRowWithSubColumns() {
                     @subColumn(7, Seq("facia-card__text")) { @headline(card)}
-                    @subColumn(5, Seq(), last = true) { @imgFromCard(card) }
+                    @subColumn(5, Seq("facia-card__text"), last = true) { @imgFromCard(card) }
                 }
             } else {
                 @fullRow(Seq("facia-card__text", "facia-card__text--last")) {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -74,7 +74,7 @@
 @faciaCardSmall(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
         @if(withImage) {
-            @fullRowWithSubColumns() {
+            @fullRowWithSubColumns(Seq("facia-card")) {
                 @subColumn(7, Seq("facia-card__text")) { @headline(card)}
                 @subColumn(5, Seq(), last = true) { @imgFromCard(card) }
             }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -73,16 +73,18 @@
 
 @faciaCardSmall(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
-        @if(withImage) {
-            @fullRowWithSubColumns(Seq("facia-card")) {
-                @subColumn(7, Seq("facia-card__text")) { @headline(card)}
-                @subColumn(5, Seq(), last = true) { @imgFromCard(card) }
+        <div class="facia-card">
+            @if(withImage) {
+                @fullRowWithSubColumns() {
+                    @subColumn(7, Seq("facia-card__text")) { @headline(card)}
+                    @subColumn(5, Seq(), last = true) { @imgFromCard(card) }
+                }
+            } else {
+                @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
+                    @headline(card)
+                }
             }
-        } else {
-            @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
-                @headline(card)
-            }
-        }
+        </div>
     }
 }
 

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -71,19 +71,27 @@
     }
 }
 
-@faciaCardSmall(card: ContentCard) = {
+@faciaCardSmall(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
-        @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
-            @headline(card)
+        @if(withImage) {
+            @fullRowWithSubColumns() {
+                @subColumn(7, Seq("facia-card__text")) { @headline(card)}
+                @subColumn(5, Seq(), last = true) { @imgFromCard(card) }
+            }
+        } else {
+            @fullRow(Seq("facia-card", "facia-card__text", "facia-card__text--last")) {
+                @headline(card)
+            }
         }
     }
 }
 
-@firstCard(card: ContentCard) = {
+@firstCard(card: ContentCard, isFastLayout: Boolean) = {
     @* if fast layout: small card, with image *@
     @* if medium or slow layout: large card, with image *@
     @card.cardStyle match {
-        case ExternalLink => { @faciaCardSmall(card) }
+        case ExternalLink => { @faciaCardSmall(card, withImage = false) }
+        case _ if isFastLayout => { @faciaCardSmall(card, withImage = true) }
         case _ => { @faciaCardLarge(card, withImage = true) }
     }
 }
@@ -94,7 +102,7 @@
     @if(isSlowLayout) {
         @faciaCardLarge(card, withImage = false)
     } else {
-        @faciaCardSmall(card)
+        @faciaCardSmall(card, withImage = false)
     }
 }
 
@@ -118,7 +126,7 @@
     @collection.curatedPlusBackfillDeduplicated.take(6).zipWithIndex.map { case (pressedContent, cardIndex) =>
         @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) { card =>
             @if(cardIndex == 0) {
-                @firstCard(card)
+                @firstCard(card, isFastLayout = collection.collectionType == "fast")
             } else {
                 @otherCard(card, isSlowLayout = collection.collectionType == "slow")
             }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -77,7 +77,7 @@
             @if(withImage) {
                 @fullRowWithSubColumns() {
                     @subColumn(7, Seq("facia-card__text")) { @headline(card)}
-                    @subColumn(5, Seq("facia-card__text"), last = true) { @imgFromCard(card) }
+                    @subColumn(5, Seq("facia-card__text"), last = true) { @imgFromCard(card, 5) }
                 }
             } else {
                 @fullRow(Seq("facia-card__text", "facia-card__text--last")) {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -74,7 +74,7 @@
 @faciaCardSmall(card: ContentCard, withImage: Boolean) = {
     @paddedRow(Seq(toneClassFromStyle(card.cardStyle))) {
         <div class="facia-card">
-            @if(withImage) {
+            @if(withImage && imgFromCard(card).isDefined) {
                 @fullRowWithSubColumns() {
                     @subColumn(7, Seq("facia-card__text")) { @headline(card)}
                     @subColumn(5, Seq("facia-card__text"), last = true) { @imgFromCard(card, 5) }


### PR DESCRIPTION
This continues work in #15555 which added the "Slow" layout style for email by adding the "Fast" style. We now have three layouts: **fast**, **medium** and **slow** which you can select in the Fronts config tool. Here's an example of each along with a table summarising their differences:

### Slow
![picture 397](https://cloud.githubusercontent.com/assets/5122968/22215773/83d61456-e194-11e6-82bb-792e377f7168.png)

### Medium
![picture 398](https://cloud.githubusercontent.com/assets/5122968/22215781/89027276-e194-11e6-96f3-c90e5a6f4226.png)

### Fast
![picture 399](https://cloud.githubusercontent.com/assets/5122968/22215787/90b7230e-e194-11e6-9448-425a1b9d2ded.png)

### Table summarising differences between slow/medium/fast

```
LAYOUT | CARD   | IMAGE?   | STANDFIRST? | HEADLINE?
----------------|-----------------------------------
slow   | 1st    | big      | yes         | big
       | others | none     | yes         | small
----------------|-----------------------------------
medium | 1st    | big      | yes         | big
       | others | none     | no          | small
----------------|-----------------------------------
fast   | 1st    | small    | no          | small
       | others | none     | no          | small
```