### PR TITLE
Set up the Ask4 Epic deployment test and the Ask4 "earning" strategy deployment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -69,4 +69,24 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 2, 6),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-ask-four-stagger",
+    "Test to see if imposing a minimum-time-between-impressions for the epic has a positive effect on conversion",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 2, 24),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-ask-four-earning",
+    "This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 5, 1),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/acquisitions-view-log.js
@@ -27,12 +27,10 @@ define([
         var now = new Date().getTime();
 
         return viewLog.filter(function (view) {
-            return (test ? view.testId === test.id : true) && view.date > (now - ms) ;
+            return (test ? view.testId === test.id : true) && view.date > (now - ms);
         }).length;
     }
-
-
-
+    
     return {
         logView: logView,
         viewsInPreviousDays: viewsInPreviousDays

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/acquisitions-view-log.js
@@ -1,0 +1,40 @@
+define([
+    'common/utils/storage'
+], function (storage) {
+
+    var viewKey = 'gu.contributions.views';
+    var viewLog = storage.local.get(viewKey) || [];
+
+
+    var maxLogEntries = 50;
+
+    /**
+     * Log that the user has seen an Epic test so we can limit how many times they see it.
+     * The number of entries is limited to the number in maxLogEntries.
+     *
+     * @param testId
+     */
+    function logView(testId) {
+        viewLog.push({
+            date: new Date().getTime(),
+            testId: testId
+        });
+        storage.local.set(viewKey, viewLog.slice(-maxLogEntries));
+    }
+
+    function viewsInPreviousDays(days, test) {
+        var ms = days * 1000 * 60 * 60 * 24;
+        var now = new Date().getTime();
+
+        return viewLog.filter(function (view) {
+            return (test ? view.testId === test.id : true) && view.date > (now - ms) ;
+        }).length;
+    }
+
+
+
+    return {
+        logView: logView,
+        viewsInPreviousDays: viewsInPreviousDays
+    }
+});

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -52,9 +52,6 @@ define([
         }
     }
 
-
-
-
     function ContributionsABTest(options) {
         this.id = options.id;
         this.start = options.start;

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -3,18 +3,20 @@ define([
     'common/modules/commercial/acquisitions-view-log',
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
-    'common/modules/experiments/tests/contributions-ask4-stagger'
+    'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
+    'common/modules/experiments/tests/contributions-epic-ask-four-earning'
 ], function (
     segmentUtil,
     viewLog,
     brexit,
     alwaysAsk,
-    ask4Stagger
+    askFourStagger,
+    askFourEarning
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [ask4Stagger, alwaysAsk, brexit];
+    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger];
 
     return {
         getTest: function() {
@@ -22,11 +24,11 @@ define([
                 var t = new test();
                 var forced = window.location.hash.indexOf('ab-' + t.id) > -1;
                 var variant = segmentUtil.variantFor(t);
-                var acceptableViewCount =
-                    variant? viewLog.viewsInPreviousDays(variant.maxViews.days, t) <= variant.maxViews.count && viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews, t) === 0 : false;
+                var acceptableViewCount = variant ? viewLog.viewsInPreviousDays(variant.maxViews.days, t) < variant.maxViews.count : false;
+                var acceptableTimeBetweenViews = variant ? viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews, t) === 0 : false;
 
 
-                return forced || (t.canRun() && segmentUtil.isInTest(t) && acceptableViewCount);
+                return forced || (t.canRun() && segmentUtil.isInTest(t) && acceptableViewCount && acceptableTimeBetweenViews);
             });
 
             return eligibleTests[0] && new eligibleTests[0]();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -1,24 +1,32 @@
 define([
     'common/modules/experiments/segment-util',
+    'common/modules/commercial/acquisitions-view-log',
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
+    'common/modules/experiments/tests/contributions-ask4-stagger'
 ], function (
     segmentUtil,
+    viewLog,
     brexit,
-    alwaysAsk
+    alwaysAsk,
+    ask4Stagger
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, brexit];
+    var tests = [ask4Stagger, alwaysAsk, brexit];
 
     return {
         getTest: function() {
             var eligibleTests = tests.filter(function (test) {
                 var t = new test();
                 var forced = window.location.hash.indexOf('ab-' + t.id) > -1;
+                var variant = segmentUtil.variantFor(t);
+                var acceptableViewCount =
+                    variant? viewLog.viewsInPreviousDays(variant.maxViews.days, t) <= variant.maxViews.count && viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews, t) === 0 : false;
 
-                return forced || (t.canRun() && segmentUtil.isInTest(t));
+
+                return forced || (t.canRun() && segmentUtil.isInTest(t) && acceptableViewCount);
             });
 
             return eligibleTests[0] && new eligibleTests[0]();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/segment-util.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/segment-util.js
@@ -34,10 +34,21 @@ define([
             return NOT_IN_TEST;
         }
     }
+    
+     function variantFor(test) {
+         var variantId = variantIdFor(test);
+         
+         return test.variants.filter(function(variant) { 
+             return variant.id === variantId;
+         })[0];
+     }
+    
 
     return {
         variantIdFor: memoize(variantIdFor, getId),
-
+        
+        variantFor: variantFor, 
+        
         isInTest: function(test) {
             return variantIdFor(test) !== NOT_IN_TEST;
         }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-ask4-stagger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-ask4-stagger.js
@@ -1,0 +1,78 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+    function getTemplate(contributionUrl, membershipUrl) {
+        return template(contributionsEpicEqualButtons, {
+            linkUrl1: membershipUrl,
+            linkUrl2: contributionUrl,
+            title: 'Since you’re here…',
+            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+            p3: '',
+            cta1: 'Become a Supporter',
+            cta2: 'Make a contribution'
+        });
+    }
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicAsk4Stagger',
+        campaignId: 'kr1_epic_ask4',
+
+        start: '2017-01-06',
+        expiry: '2017-03-01',
+
+        author: 'Alex Dufournet',
+        description: 'Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'The conversion rate is equal or above what we have observed on other campaigns',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+
+            {
+                id: 'stagger_one_day',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 1
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+
+            {
+                id: 'stagger_one_week',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 7
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -22,20 +22,20 @@ define([
     }
 
     return contributionsUtilities.makeABTest({
-        id: 'ContributionsEpicAsk4Stagger',
-        campaignId: 'kr1_epic_ask4',
+        id: 'ContributionsEpicAskFourEarning',
+        campaignId: 'kr1_epic_ask_four_earning',
 
-        start: '2017-01-06',
-        expiry: '2017-03-01',
+        start: '2017-01-24',
+        expiry: '2017-05-01',
 
-        author: 'Alex Dufournet',
-        description: 'Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles',
+        author: 'Jonathan Rankin',
+        description: 'This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days',
         successMeasure: 'Conversion rate',
-        idealOutcome: 'The conversion rate is equal or above what we have observed on other campaigns',
+        idealOutcome: 'Acquires many Supporters',
 
         audienceCriteria: 'All',
-        audience: 1,
-        audienceOffset: 0,
+        audience: 0.88,
+        audienceOffset: 0.12,
 
         variants: [
             {
@@ -44,30 +44,6 @@ define([
                     days: 30,
                     count: 4,
                     minDaysBetweenViews: 0
-                },
-                template: getTemplate,
-                insertBeforeSelector: '.submeta',
-                successOnView: true
-            },
-
-            {
-                id: 'stagger_one_day',
-                maxViews: {
-                    days: 30,
-                    count: 4,
-                    minDaysBetweenViews: 1
-                },
-                template: getTemplate,
-                insertBeforeSelector: '.submeta',
-                successOnView: true
-            },
-
-            {
-                id: 'stagger_one_week',
-                maxViews: {
-                    days: 30,
-                    count: 4,
-                    minDaysBetweenViews: 7
                 },
                 template: getTemplate,
                 insertBeforeSelector: '.submeta',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
@@ -1,0 +1,78 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+    function getTemplate(contributionUrl, membershipUrl) {
+        return template(contributionsEpicEqualButtons, {
+            linkUrl1: membershipUrl,
+            linkUrl2: contributionUrl,
+            title: 'Since you’re here…',
+            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+            p3: '',
+            cta1: 'Become a Supporter',
+            cta2: 'Make a contribution'
+        });
+    }
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicAskFourStagger',
+        campaignId: 'kr1_epic_ask_four_stagger',
+
+        start: '2017-01-24',
+        expiry: '2017-02-24',
+
+        author: 'Jonathan Rankin',
+        description: 'Test to see if imposing a minimum-time-between-impressions for the epic has a positive effect on conversion',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'We convert more supporters by spacing out Epic impressions',
+
+        audienceCriteria: 'All',
+        audience: 0.12,
+        audienceOffset: 0,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+
+            {
+                id: 'stagger_one_day',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 1
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+
+            {
+                id: 'stagger_three_days',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 3
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -21,8 +21,8 @@ define([
         idealOutcome: 'The conversion rate is equal or above what we have observed on other campaigns',
 
         audienceCriteria: 'All',
-        audience: 1,
-        audienceOffset: 0,
+        audience: 0.88,
+        audienceOffset: 0.12,
         useTargetingTool: true,
 
         variants: [


### PR DESCRIPTION
## What does this change?

In this PR, we split the audience into "earning" and "learning". 

The earning segment, as 88% of the audience, will deploy the epic to everyone on all articles, with a limit of 4 impressions per month. Any additional tests added to this segment will act as a boost, so if a user uses up their impressions with the Ask4 strategy, they could see the epic again if, for example, there was a separate test running on the same segment which instructed that the epic be shown on all articles with a certain tag.

The learning segment aims to learn whether staggering out these 4 asks over the month has more of an effect than showing them in a greedy, as soon as possible way, like the current Ask4 strategy does (which is running in the earning segment). 


In order to facilitate this test, we have added the ability to add a minimum time in between impressions at the variant level for Epic tests. 

## What is the value of this and can you measure success?

If we learn that staggering the asks is more effective, we will have a strategy that converts more people. 

## Does this affect other platforms - Amp, Apps, etc?
No


## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
