### PR TITLE
look up platform in atoms block

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -33,9 +33,8 @@ object FaciaContentFrontendHelpers {
        document <- Some(Jsoup.parse(main))
        atomContainer <- Option(document.getElementsByClass("element-atom").first())
        bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
-       youTubeIframe <- Option(bodyElement.select("iframe[src^=https://www.youtube.com]").first())
        atomId <- Some(bodyElement.attr("data-atom-id"))
-       mainMediaAtom <- atoms.media.find(_.id == atomId)
+       mainMediaAtom <- atoms.media.find(ma => ma.id == atomId && ma.assets.exists(_.platform == "Youtube"))
      } yield mainMediaAtom
 
 


### PR DESCRIPTION
## What does this change?
Small refactor to look up platform of main media atom from atoms CAPI response.

## What is the value of this and can you measure success?
Less Jsoup 

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
