### PR TITLE
Measure more about the module loaders

### DIFF
--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -20,11 +20,17 @@ Only if we detect we should run enhance.
 define([
     'Promise',
     'domReady',
-    'common/utils/raven'
+    'common/utils/raven',
+    'common/utils/user-timing',
+    'common/utils/robust',
+    'common/modules/analytics/google'
 ], function (
     Promise,
     domReady,
-    raven
+    raven,
+    userTiming,
+    robust,
+    ga
 ) {
     // curl’s promise API is broken, so we must cast it to a real Promise
     // https://github.com/cujojs/curl/issues/293
@@ -39,7 +45,13 @@ define([
 
     var bootStandard = function () {
         return promiseRequire(['bootstraps/standard/main'])
-            .then(function (boot) { boot(); });
+            .then(function (boot) {
+                userTiming.mark('standard boot');
+                robust.catchErrorsAndLog('ga-user-timing-standard-boot', function () {
+                    ga.trackPerformance('Javascript Load', 'standardBoot', 'Standard boot time');
+                });
+                boot();
+            });
     };
 
     var bootCommercial = function () {
@@ -57,10 +69,18 @@ define([
             });
         }
 
+        userTiming.mark('commerical request');
+        robust.catchErrorsAndLog('ga-user-timing-commercial-request', function () {
+            ga.trackPerformance('Javascript Load', 'commericalRequest', 'Commerical request time');
+        });
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
                     function (commercial) {
+                        userTiming.mark('commerical boot');
+                        robust.catchErrorsAndLog('ga-user-timing-commercial-boot', function () {
+                            ga.trackPerformance('Javascript Load', 'commericalBoot', 'Commerical boot time');
+                        });
                         commercial.init();
                     }
                 )
@@ -69,8 +89,16 @@ define([
 
     var bootEnhanced = function () {
         if (guardian.isEnhanced) {
+            userTiming.mark('enhanced request');
+            robust.catchErrorsAndLog('ga-user-timing-enhanced-request', function () {
+                ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
+            });
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
+                    userTiming.mark('enhanced boot');
+                    robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', function () {
+                        ga.trackPerformance('Javascript Load', 'enhancedBoot', 'Enhanced boot time');
+                    });
                     boot();
                 });
         }

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -69,18 +69,18 @@ define([
             });
         }
 
-        userTiming.mark('commerical request');
+        userTiming.mark('commercial request');
         robust.catchErrorsAndLog('ga-user-timing-commercial-request', function () {
-            ga.trackPerformance('Javascript Load', 'commericalRequest', 'Commerical request time');
+            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
         });
 
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
                     function (commercial) {
-                        userTiming.mark('commerical boot');
+                        userTiming.mark('commercial boot');
                         robust.catchErrorsAndLog('ga-user-timing-commercial-boot', function () {
-                            ga.trackPerformance('Javascript Load', 'commericalBoot', 'Commerical boot time');
+                            ga.trackPerformance('Javascript Load', 'commercialBoot', 'commercial boot time');
                         });
                         commercial.init();
                     }

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -73,6 +73,7 @@ define([
         robust.catchErrorsAndLog('ga-user-timing-commercial-request', function () {
             ga.trackPerformance('Javascript Load', 'commericalRequest', 'Commerical request time');
         });
+
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
@@ -93,6 +94,7 @@ define([
             robust.catchErrorsAndLog('ga-user-timing-enhanced-request', function () {
                 ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
             });
+
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
                     userTiming.mark('enhanced boot');

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -2,6 +2,9 @@ import domready from 'domready';
 import raven from 'common/utils/raven';
 import bootStandard from 'bootstraps/standard/main';
 import config from 'common/utils/config';
+import userTiming from 'common/utils/user-timing';
+import robust from 'common/utils/robust';
+import ga from 'common/modules/analytics/google';
 
 // let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -11,6 +14,10 @@ __webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
 domready(() => {
     // 1. boot standard, always
+    userTiming.mark('standard boot');
+    robust.catchErrorsAndLog('ga-user-timing-standard-boot', () => {
+        ga.trackPerformance('Javascript Load', 'standardBoot', 'Standard boot time');
+    });
     bootStandard();
 
     // 2. once standard is done, next is commercial
@@ -25,15 +32,33 @@ domready(() => {
             });
         }
 
+        userTiming.mark('commerical request');
+        robust.catchErrorsAndLog('ga-user-timing-commercial-request', () => {
+            ga.trackPerformance('Javascript Load', 'commericalRequest', 'Commerical request time');
+        });
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
+                userTiming.mark('commerical boot');
+                robust.catchErrorsAndLog('ga-user-timing-commercial-boot', () => {
+                    ga.trackPerformance('Javascript Load', 'commericalBoot', 'Commerical boot time');
+                });
                 commercial.init();
 
                 // 3. finally, try enhanced
                 // this is defined here so that webpack's code-splitting algo
                 // excludes all the modules bundled in the commerical chunk from this one
                 if (window.guardian.isEnhanced) {
-                    require(['bootstraps/enhanced/main'], bootEnhanced => bootEnhanced());
+                    userTiming.mark('enhanced request');
+                    robust.catchErrorsAndLog('ga-user-timing-enhanced-request', () => {
+                        ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
+                    });
+                    require(['bootstraps/enhanced/main'], (bootEnhanced) => {
+                        userTiming.mark('enhanced boot');
+                        robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', () => {
+                            ga.trackPerformance('Javascript Load', 'enhancedBoot', 'Enhanced boot time');
+                        });
+                        bootEnhanced();
+                    });
                 }
             })
         );

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -32,21 +32,21 @@ domready(() => {
             });
         }
 
-        userTiming.mark('commerical request');
+        userTiming.mark('commercial request');
         robust.catchErrorsAndLog('ga-user-timing-commercial-request', () => {
-            ga.trackPerformance('Javascript Load', 'commericalRequest', 'Commerical request time');
+            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
         });
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
-                userTiming.mark('commerical boot');
+                userTiming.mark('commercial boot');
                 robust.catchErrorsAndLog('ga-user-timing-commercial-boot', () => {
-                    ga.trackPerformance('Javascript Load', 'commericalBoot', 'Commerical boot time');
+                    ga.trackPerformance('Javascript Load', 'commercialBoot', 'commercial boot time');
                 });
                 commercial.init();
 
                 // 3. finally, try enhanced
                 // this is defined here so that webpack's code-splitting algo
-                // excludes all the modules bundled in the commerical chunk from this one
+                // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
                     userTiming.mark('enhanced request');
                     robust.catchErrorsAndLog('ga-user-timing-enhanced-request', () => {


### PR DESCRIPTION
## What does this change?

adds the following events to ga, for both webpack and require builds

- standardBoot
- commericalRequest
- commericalBoot
- enhancedRequest
- enhancedBoot

## What is the value of this and can you measure success?

it should allow to determine whether differences in the eval times between the bundlers, which we're currently marking, correspond to the ways in the which they work, or the actual speed in which js arrives/runs etc.

## Does this affect other platforms - Amp, Apps, etc?

no

cc @SiAdcock 