### PR TITLE
Add scala linter to project

### DIFF
--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -9,7 +9,7 @@ object DataMapper {
 
   def toGuAdUnit(dfpAdUnit: AdUnit): GuAdUnit = {
     val ancestors = toSeq(dfpAdUnit.getParentPath)
-    val ancestorNames = if (ancestors.isEmpty) Nil else ancestors.map(_.getName).tail
+    val ancestorNames = if (ancestors.isEmpty) Nil else ancestors.tail.map(_.getName)
     GuAdUnit(dfpAdUnit.getId, ancestorNames :+ dfpAdUnit.getName, dfpAdUnit.getStatus.getValue)
   }
 

--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -84,10 +84,9 @@ class R2PagePressJob(wsClient: WSClient, redirects: RedirectService) extends Exe
   private def parseAndClean(originalDocSource: String, convertToHttps: Boolean): Future[String] = {
     val cleaners = Seq(new PollsHtmlCleaner(wsClient), InteractiveHtmlCleaner, NextGenInteractiveHtmlCleaner, SimpleHtmlCleaner)
     val archiveDocument = Jsoup.parse(originalDocSource)
-    val doc: Document = cleaners.filter(_.canClean(archiveDocument))
-      .map(_.clean(archiveDocument, convertToHttps))
-      .headOption
-      .getOrElse(archiveDocument)
+    val doc: Document = cleaners.find(_.canClean(archiveDocument))
+                        .map(_.clean(archiveDocument, convertToHttps))
+                        .getOrElse(archiveDocument)
     Future.successful(doc.toString)
   }
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -57,7 +57,7 @@ object QueryDefaults extends implicits.Collections {
                 .map(date => date.toJodaDateTime)
                 .map(_ >= leadContentCutOff.toDateTimeAtStartOfDay)
                 .exists(identity)
-            }).map(Content(_)).take(1)
+            }).take(1).map(Content(_))
           else
             Nil
 

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -321,8 +321,8 @@ object Front extends implicits.Collections {
           faciaContentList.map(Story.fromFaciaContent)
         ) map { containerDefinition =>
           (seen ++ faciaContentList
-            .map(_.header.url)
-            .take(itemsVisible(containerDefinition)), faciaContentList, (Nil, Nil))
+            .take(itemsVisible(containerDefinition))
+            .map(_.header.url), faciaContentList, (Nil, Nil))
         } getOrElse {
           (seen, faciaContentList, (Nil, Nil))
         }

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -25,7 +25,7 @@
                     "contributorIds": "@{content.tags.contributors.map(_.id).mkString(",")}",
                     "keywordIds": "@{content.tags.keywords.map(_.id).mkString(",")}",
                     "toneIds": "@{content.tags.tones.map(_.id).mkString(",")}",
-                    "seriesId": "@{content.tags.series.map(_.id).headOption.getOrElse("")}",
+                    "seriesId": "@{content.tags.series.headOption.map(_.id).getOrElse("")}",
                     "isHostedFlag": "@{content.metadata.isHosted.toString}",
                     "fullRequestUrl": "@{request.domain}@{request.uri}",
                     "userAgent": "@{request.headers.get("user-agent").getOrElse("")}"

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -83,7 +83,7 @@ class MediaInSectionController(contentApiClient: ContentApiClient)(implicit cont
         1,
         Fixed(FixedContainers.fixedMediumFastXI),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(trails.map(_.faciaContent) take 7, Nil, displayName, None, None, None),
+        CollectionEssentials(trails.take(7).map(_.faciaContent), Nil, displayName, None, None, None),
         componentId
       ).withTimeStamps,
       FrontProperties.empty

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -110,7 +110,7 @@ class MostPopularController(contentApiClient: ContentApiClient,
       .showMostViewed(true)
     ).map{response =>
       val heading = response.section.map(s => "in " + s.webTitle.toLowerCase).getOrElse("across the guardian")
-          val popular = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
+          val popular = response.mostViewed.getOrElse(Nil) take 10 map { RelatedContentItem(_) }
           if (popular.isEmpty) None else Some(MostPopular(heading, path, popular.map(_.faciaContent)))
     }
   }

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -44,7 +44,7 @@ class MostViewedAudioController(mostViewedAudioAgent: MostViewedAudioAgent)(impl
         1,
         Fixed(FixedContainers.fixedSmallSlowIV),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(audios.map(_.faciaContent) take 4, Nil, displayName, None, None, None)
+        CollectionEssentials(audios.take(4).map(_.faciaContent), Nil, displayName, None, None, None)
       ).withTimeStamps,
       FrontProperties.empty
     )

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -22,7 +22,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient) extends Logging with 
   def refresh(edition: Edition) = contentApiClient.getResponse(contentApiClient.item("/", edition)
       .showMostViewed(true)
     ).map { response =>
-      val mostViewed = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
+      val mostViewed = response.mostViewed.getOrElse(Nil) take 10 map { RelatedContentItem(_) }
       agent.alter{ old =>
         old + (edition.id -> mostViewed)
       }
@@ -151,7 +151,7 @@ class MostPopularExpandableAgent(contentApiClient: ContentApiClient) extends Log
         .showMostViewed(true)
         .showFields("headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl,body")
       ).foreach { response =>
-        val mostViewed = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
+        val mostViewed = response.mostViewed.getOrElse(Nil) take 10 map { RelatedContentItem(_) }
         agent.send{ old =>
           old + (edition.id -> mostViewed)
         }

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -17,11 +17,22 @@ trait Prototypes {
   val version = "1-SNAPSHOT"
 
   val frontendCompilationSettings = Seq(
+    addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17"),
     organization := "com.gu",
     maxErrors := 20,
     javacOptions := Seq("-g","-encoding", "utf8"),
-    scalacOptions := Seq("-unchecked", "-deprecation", "-target:jvm-1.8",
-      "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
+    scalacOptions := Seq(
+      "-unchecked",
+      "-deprecation",
+      "-target:jvm-1.8",
+      "-Xcheckinit",
+      "-encoding",
+      "utf8",
+      "-feature",
+      "-Yinline-warnings",
+      "-Xfatal-warnings",
+      "-P:linter:enable-only:FuncFirstThenMap"
+    ),
     doc in Compile := target.map(_ / "none").value,
     incOptions := incOptions.value.withNameHashing(true),
     scalaVersion := "2.11.8",


### PR DESCRIPTION
Just applying rules that are uncontroversially good practice, rather than stylistic or of questionable value.

First one is FuncFirstThenMap, which seems like a sensible rule to me.
Example output:
```
[error] frontend/onward/app/feed/MostPopularAgent.scala:25: [FuncFirstThenMap] Use method take first, then map.
[error]       val mostViewed = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
[error]                                                                                         ^
[error] frontend/onward/app/feed/MostPopularAgent.scala:154: [FuncFirstThenMap] Use method take first, then map.
[error]         val mostViewed = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
[error]                                                                                           ^
[error] two errors found
[error] frontend/admin/app/dfp/DataMapper.scala:12: [FuncFirstThenMap] Use method tail first, then map.
[error]     val ancestorNames = if (ancestors.isEmpty) Nil else ancestors.map(_.getName).tail
[error]                                                                                  ^
[error] frontend/admin/app/jobs/R2PagePressJob.scala:89: [FuncFirstThenMap] Use method headOption first, then map.
[error]       .headOption
[error]        ^
```

I suppose there's a question about whether these should be considered errors or warnings.
Currently they appear as errors because we consider all warnings to be errors.

/cc @guardian/dotcom-platform 