### PR TITLE
I'm blue da ba dee...

### DIFF
--- a/static/src/javascripts/projects/common/views/experiments/recommended-for-you-opt-in.html
+++ b/static/src/javascripts/projects/common/views/experiments/recommended-for-you-opt-in.html
@@ -3,7 +3,7 @@
         <div class="fc-container__header js-container__header ">
             <div class="fc-container__header__title">
                 <%= profileIcon %>
-                <span class="fc-container__title__text">recommended <span class="rfy-light-blue">for&nbsp;you</span></span>
+                <span class="rfy-light-blue">recommended for you</span>
             </div>
         </div>
 

--- a/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
+++ b/static/src/javascripts/projects/common/views/experiments/recommended-for-you.html
@@ -3,7 +3,7 @@
         <div class="fc-container__header js-container__header ">
             <div class="fc-container__header__title">
                 <%= profileIcon %>
-                <span class="fc-container__title__text">recommended <span class="rfy-light-blue">for&nbsp;you</span></span>
+                <span class="rfy-light-blue">recommended for you</span>
             </div>
         </div>
 

--- a/static/src/stylesheets/module/experiments/_recommended-for-you.scss
+++ b/static/src/stylesheets/module/experiments/_recommended-for-you.scss
@@ -1,5 +1,10 @@
 .rfy-light-blue {
     color: $news-main-2 !important;
+
+    @include mq($from: wide) {
+      display: block;
+      clear: both;
+    }
 }
 
 .rfy-dummy-text {


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/6727874/22257244/5de49a3a-e255-11e6-9744-795902732b09.png)

## What does this change?
The colour of the header/it breaks onto a new line on Desktop
## What is the value of this and can you measure success?
Naa
## Does this affect other platforms - Amp, Apps, etc?
Naa
## Screenshots
![image](https://cloud.githubusercontent.com/assets/6727874/22257188/3168945c-e255-11e6-8e21-f57ce3fd1a53.png)

becomes

![image](https://cloud.githubusercontent.com/assets/6727874/22257169/22e804b2-e255-11e6-8ee1-22442691e30e.png)

## Tested in CODE?
Yeah
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@davidfurey 
