### PR TITLE
New header menu colour change

### DIFF
--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -3,7 +3,7 @@
 @import common.{Edition, LinkTo}
 @import views.support.RenderClasses
 
-<li class="navigation-group__item">
+<li class="navigation-group__item navigation-group__item--edition-picker">
     <details>
         <summary class="main-navigation__item__button"
         data-link-name="nav2 : edition picker">

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -74,7 +74,7 @@
             </ul>
         }
 
-        <ul class="navigation-group navigation-group--grey secondary-navigation">
+        <ul class="navigation-group navigation-group--contrast secondary-navigation">
 
             @defining(Edition(request)) { edition =>
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -113,31 +113,12 @@ $gutter-large: 55px;
     cursor: pointer;
     bottom: -$gs-baseline / 2;
 
-    &--open {
-        z-index: 1071;
-        box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
-
-        &:before {
-            // Extended hit area for veggie burger close state, for fat fingers
-            content: '';
-            position: absolute;
-        }
-    }
-
     @include mq($until: mobileMedium) {
         //Smaller menu button
         height: $veggie-burger-small;
         min-width: $veggie-burger-small;
         //Align with the 'i' in 'theguardian'
         right: $gutter-small;
-
-        &--open:before {
-            height: $veggie-burger-small * 2;
-            width: $veggie-burger-small;
-            top: -$veggie-burger-small / 2;
-            right: $veggie-burger-small / 2;
-            border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
-        }
     }
 
     @include mq(mobileMedium) {
@@ -145,19 +126,38 @@ $gutter-large: 55px;
         width: $veggie-burger-medium;
         //Align with the 'i' in 'theguardian'
         right: $gutter-medium;
+    }
 
-        &--open:before {
+    @include mq(mobileLandscape) {
+        //Align with the 'i' in 'theguardian'
+        right: $gutter-large;
+    }
+}
+
+.new-header__nav__menu-button--open {
+    z-index: 1071;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
+
+    &:before {
+        // Extended hit area for veggie burger close state, for fat fingers
+        content: '';
+        position: absolute;
+
+        @include mq($until: mobileMedium) {
+            height: $veggie-burger-small * 2;
+            width: $veggie-burger-small;
+            top: -$veggie-burger-small / 2;
+            right: $veggie-burger-small / 2;
+            border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
+        }
+
+        @include mq(mobileMedium) {
             height: $veggie-burger-medium * 2;
             width: $veggie-burger-medium;
             top: -$veggie-burger-medium / 2;
             right: $veggie-burger-medium / 2;
             border-radius: ($veggie-burger-medium * 2) 0 0 ($veggie-burger-medium * 2);
         }
-    }
-
-    @include mq(mobileLandscape) {
-        //Align with the 'i' in 'theguardian'
-        right: $gutter-large;
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -115,6 +115,7 @@ $gutter-large: 55px;
 
     &--open {
         z-index: 1071;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
 
         &:before {
             // Extended hit area for veggie burger close state, for fat fingers
@@ -463,15 +464,16 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     }
 }
 
-.navigation-group--grey {
-    background-color: $neutral-1;
+.navigation-group--contrast {
+    color: $guardian-brand-dark;
+    background-color: $news-main-2;
 
     .main-menu__icon__svg {
-        fill: $neutral-2;
+        fill: $guardian-brand;
     }
 
     .personalisation__icon:before {
-        border-color: $neutral-2;
+        border-color: $guardian-brand;
     }
 }
 
@@ -483,10 +485,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
     a {
         display: block;
-        padding-top: $gs-baseline / 2;
+        padding-top: $gs-baseline / 1.5;
         padding-left: $navigation-horizontal-padding;
         padding-right: $gs-gutter;
-        padding-bottom: $gs-baseline;
+        padding-bottom: $gs-baseline / 1.5;
         // Override a from user agent stylesheet
         color: inherit;
 
@@ -578,18 +580,40 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     }
 }
 
+.navigation-group__item--edition-picker .main-navigation__item__button {
+    padding-bottom: $gs-baseline / 1.5;
+}
+
 .personalisation__links {
     margin-left: 0;
     margin-bottom: -$gs-baseline;
-    background-color: rgba(0, 0, 0, .15);
+    background-color: darken($news-main-2, 10%);
 }
 
 .personalisation__link {
-    color: $neutral-3;
+    color: $guardian-brand-dark;
 }
 
 .personalisation__link--active {
-    color: #ffffff;
+    color: $guardian-brand-dark;
+    position: relative;
+    font-weight: bold;
+
+    // Tick icon
+    &:before {
+            content: '';
+            position: absolute;
+            top: 8px;
+            left: 26px;
+            width: $gs-gutter / 4;
+            height: $gs-baseline;
+            border-width: 2px;
+            border-style: solid;
+            border-color: currentColor;
+            border-top: 0;
+            border-left: 0;
+            transform: rotate(45deg);
+        }
 }
 
 .no-text-transform {


### PR DESCRIPTION
## I'm Blue da ba dee da ba daa
Colour of the account area has been changed to news-main-2. Also the spacing has been tweaked slightly to add a little more breathing space between words and the top of their containers. 

<img width="320" alt="screen shot 2017-01-24 at 16 51 49" src="https://cloud.githubusercontent.com/assets/14570016/22257296/88f7995c-e255-11e6-87fc-8d1c4d2f2f1c.png">

## Tick
The edition switcher has been given a clear active state through the use of a TICK and BOLD TEXT.

<img width="320" alt="screen shot 2017-01-24 at 16 52 14" src="https://cloud.githubusercontent.com/assets/14570016/22257298/88fd4370-e255-11e6-895a-def7bb692283.png">

## Outline
Now the account area is the same colour as the hamburglar, I needed to add a slight outline to the opened state of the menu button to prevent it bleeding into the background colour.

<img width="107" alt="screen shot 2017-01-24 at 16 52 25" src="https://cloud.githubusercontent.com/assets/14570016/22257297/88fa177c-e255-11e6-9304-8f76929ddb65.png">

FAO the usual suspects:
@NataliaLKB @stephanfowler 