### PR TITLE
youtube iframe api ready fix (Redux)

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -424,6 +424,16 @@ object Article {
     // `headOption` as the video could be main media or a regular embed, so just get the first video
     val videoDuration = content.elements.videos.headOption.map { v => JsNumber(v.videos.duration) }.getOrElse(JsNull)
 
+    def hasYouTubeAtom: Boolean = {
+      val hasYouTubeAtom: Option[Boolean] = for {
+        atoms <- content.atoms
+        firstMediaAtom <- atoms.media.headOption
+        firstAsset <- firstMediaAtom.assets.headOption
+      } yield firstAsset.platform == "Youtube"
+      
+      hasYouTubeAtom.getOrElse(false)
+    }
+
     val javascriptConfig: Map[String, JsValue] = Map(
       ("isLiveBlog", JsBoolean(content.tags.isLiveBlog)),
       ("inBodyInternalLinkCount", JsNumber(content.linkCounts.internal)),
@@ -432,6 +442,7 @@ object Article {
       ("hasInlineMerchandise", JsBoolean(commercial.hasInlineMerchandise)),
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
+      ("hasYouTubeMediaAtom", JsBoolean(hasYouTubeAtom)),
       ("isImmersive", JsBoolean(content.isImmersive)),
       ("isHosted", JsBoolean(false)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),

--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
@@ -383,6 +383,7 @@ define([
         var shouldPreroll = commercialFeatures.videoPreRolls &&
             !config.page.hasMultipleVideosInPage &&
             !config.page.hasYouTubeMediaAtom &&
+            !config.page.isFront &&
             !config.page.isAdvertisementFeature &&
             !config.page.sponsorshipType;
 

--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
@@ -382,6 +382,7 @@ define([
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
             !config.page.hasMultipleVideosInPage &&
+            !config.page.hasYouTubeMediaAtom &&
             !config.page.isAdvertisementFeature &&
             !config.page.sponsorshipType;
 


### PR DESCRIPTION
## What does this change?

Fixes a bug we were seeing where youtube atoms were not being enhanced on pages where another non-youtube video existed which had pre-roll adverts enabled. Now we don't allow pre-roll ads if the page's content contains a youtube atom.

Note, we now explicitly prevent pre-roll on Fronts in the JS and don't instantiate the IMA JS whereas previously pre-roll was blocked on the DFP side.

## What is the value of this and can you measure success?

Consistent loading of enhanced youtube atoms.
Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Tested in CODE?

No