### PR TITLE
AMP menu alignment

### DIFF
--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -221,9 +221,9 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .main-navigation__item__button {
     position: relative;
-    padding-top: $gs-baseline / 2;
+    padding-top: $gs-baseline / 4;
     padding-left: $navigation-horizontal-padding;
-    padding-bottom: $gs-baseline + ($gs-baseline / 3);
+    padding-bottom: $gs-baseline;
     cursor: pointer;
     font-size: 1em;
     font-weight: normal;
@@ -313,10 +313,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
     a {
         display: block;
-        padding-top: $gs-baseline / 2;
+        padding-top: $gs-baseline / 1.5;
         padding-left: $navigation-horizontal-padding;
         padding-right: $gs-gutter;
-        padding-bottom: $gs-baseline;
+        padding-bottom: $gs-baseline / 1.5;
         // Override a from user agent stylesheet
         color: inherit;
     }
@@ -324,4 +324,5 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .secondary-navigation {
     font-size: .9em;
+    margin: 0;
 }


### PR DESCRIPTION
Just a humble little PR to sort out some weird spacing in the AMP menu

Before:
<img width="317" alt="screen shot 2017-01-25 at 10 30 01" src="https://cloud.githubusercontent.com/assets/14570016/22287768/f66c3830-e2eb-11e6-9694-aa57a5feb7ea.png">

After:
<img width="320" alt="screen shot 2017-01-25 at 10 29 28" src="https://cloud.githubusercontent.com/assets/14570016/22287769/f66e6d12-e2eb-11e6-8aba-1916211a68b5.png">
