### PR TITLE
Add unlimited option to contributions epic rate limits

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -116,6 +116,7 @@ define([
         this.campaignId = test.campaignId;
         this.id = options.id;
         this.maxViews = options.maxViews || maxViews;
+        this.isUnlimited = options.isUnlimited || false;
 
         this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, test.contributionsCampaignPrefix);
         this.membershipURL = options.membershipURL || this.makeURL(membershipURL, test.membershipCampaignPrefix);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -13,11 +13,21 @@ define([
         name: 'ContributionsEpicBrexit',
         variants: ['control']
     };
+    var ContributionsEpicAskFourStagger = {
+        name: 'ContributionsEpicAskFourStagger',
+        variants: ['control', 'stagger_one_day', 'stagger_three_days']
+    };
+    var ContributionsEpicAskFourEarning = {
+        name: 'ContributionsEpicAskFourEarning',
+        variants: ['control']
+    };
 
     function userIsInAClashingAbTest() {
         var clashingTests = [
             ContributionsEpicAlwaysAskStrategy,
-            ContributionsEpicBrexit
+            ContributionsEpicBrexit,
+            ContributionsEpicAskFourStagger,
+            ContributionsEpicAskFourEarning
         ];
         return _testABClash(ab.isInVariant, clashingTests);
     }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -24,11 +24,13 @@ define([
                 var t = new test();
                 var forced = window.location.hash.indexOf('ab-' + t.id) > -1;
                 var variant = segmentUtil.variantFor(t);
-                var acceptableViewCount = variant ? viewLog.viewsInPreviousDays(variant.maxViews.days, t) < variant.maxViews.count : false;
-                var acceptableTimeBetweenViews = variant ? viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews, t) === 0 : false;
 
+                var hasNotReachedRateLimit = variant &&
+                    ((viewLog.viewsInPreviousDays(variant.maxViews.days, t) < variant.maxViews.count &&
+                    viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews, t) === 0) ||
+                    variant.isUnlimited);
 
-                return forced || (t.canRun() && segmentUtil.isInTest(t) && acceptableViewCount && acceptableTimeBetweenViews);
+                return forced || (t.canRun() && segmentUtil.isInTest(t) && hasNotReachedRateLimit);
             });
 
             return eligibleTests[0] && new eligibleTests[0]();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -53,12 +53,13 @@ define([
         variants: [
             {
                 id: 'control',
-                test: function() {}
+                test: function() {},
+                isUnlimited : true
+
             },
 
             {
                 id: 'alwaysAsk',
-
                 template: function (contributionUrl, membershipUrl) {
                     return template(contributionsEpicEqualButtons, {
                         linkUrl1: membershipUrl,
@@ -77,7 +78,7 @@ define([
                 test: function (render) {
                     if (canBeDisplayed()) render();
                 },
-
+                isUnlimited : true,
                 successOnView: true
             }
         ]


### PR DESCRIPTION
## What does this change?

For the always ask test, running on 2% of the population, we need the ability to ignore the default rate limit (in terms of how often a user will see the epic). We accidentally removed the ability to be always on when we introduced a default rate limit. 

This PR adds back that functionality.

## What is the value of this and can you measure success?

Our AlwaysOn test runs correctly

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
