### PR TITLE
fix GA tracking IDs of YouTube atoms

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-tracking.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-tracking.js
@@ -36,7 +36,7 @@ define([
                 eventAction: eventAction(),
                 eventLabel: videoId,
                 dimension19: videoId,
-                dimension20: 'guardian-youtube'
+                dimension20: 'gu-video-youtube'
             }
         };
 
@@ -48,7 +48,7 @@ define([
                 ophanRecord(mediaEvent);
                 window.ga(gaTracker + '.send', 'event',
                     gaHelper.buildGoogleAnalyticsEvent(mediaEvent, events.metricMap, id,
-                        'gu-video-youtube', eventAction, id));
+                        'gu-video-youtube', eventAction, event.mediaId));
             });
         });
 


### PR DESCRIPTION
## What does this change?
Fix GA tracking IDs of YouTube atoms to be consistent with those sent from other platforms namely:

> - mediaPlayer (custom dimension 20) be: gu-video-youtube
> - mediaId (custom dimension 19) be the media atom id

## What is the value of this and can you measure success?
Enable x-platform tracking of YouTube Media Atoms in Google Analytics

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
<img width="365" alt="screen shot 2017-01-25 at 15 39 48" src="https://cloud.githubusercontent.com/assets/1764158/22297502/6465d6f6-e315-11e6-86dd-33d4660a527b.png">


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
