### PR TITLE
New header menu signed in spacing bug

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -567,6 +567,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 .navigation-group__item--user-account {
     .user-account__signed-in {
         display: none;
+
+        .main-navigation__item__button {
+            padding-bottom: $gs-baseline / 1.5;
+        }
     }
 
     &.user-signed-in {
@@ -580,14 +584,19 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     }
 }
 
-.navigation-group__item--edition-picker .main-navigation__item__button {
-    padding-bottom: $gs-baseline / 1.5;
-}
-
 .personalisation__links {
     margin-left: 0;
-    margin-bottom: -$gs-baseline;
     background-color: darken($news-main-2, 10%);
+}
+
+.navigation-group__item--edition-picker {
+    .main-navigation__item__button {
+        padding-bottom: $gs-baseline / 1.5;
+    }
+
+    .personalisation__links {
+        margin-bottom: -$gs-baseline;
+    }
 }
 
 .personalisation__link {


### PR DESCRIPTION
Signed in state of new menu had a couple of bugs due to two consecutive expandatrons. 

Spacing issues:
<img width="312" alt="screen shot 2017-01-25 at 16 40 15" src="https://cloud.githubusercontent.com/assets/14570016/22299742/292f620c-e31d-11e6-945b-64d81d544b8d.png">

And negative margin causing background overlap:
<img width="312" alt="screen shot 2017-01-25 at 16 40 20" src="https://cloud.githubusercontent.com/assets/14570016/22299778/4b0632ac-e31d-11e6-80ab-f7f8479e69ac.png">

Fixed:
<img width="313" alt="screen shot 2017-01-25 at 16 39 21" src="https://cloud.githubusercontent.com/assets/14570016/22299739/29269d70-e31d-11e6-81d1-ff8ddba7ffb1.png">
<img width="311" alt="screen shot 2017-01-25 at 16 39 30" src="https://cloud.githubusercontent.com/assets/14570016/22299740/29289fb2-e31d-11e6-9ecc-d7d143585f2a.png">
