### PR TITLE
Smaller icons for smaller headlines in emails even in Outlook

### DIFF
--- a/common/app/views/support/EmailHelpers.scala
+++ b/common/app/views/support/EmailHelpers.scala
@@ -66,8 +66,9 @@ object EmailHelpers {
     case p: PressedPage => p.frontProperties.onPageDescription
   }
 
-  def icon(name: String) = Html {
-    s"""<img src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
+  def icon(name: String, largeHeadline: Boolean = false) = Html {
+    val height = if(largeHeadline) 18 else 12
+    s"""<img height="$height" src="${Static(s"images/email/icons/$name.png")}" class="icon icon-$name">"""
   }
 
   private def img(width: Int)(src: String, alt: Option[String] = None) = Html {

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -10,7 +10,7 @@
 @import views.support.TrailCssClasses.toneClassFromStyle
 
 
-@headline(card: ContentCard) = {
+@headline(card: ContentCard, largeHeadline: Boolean = false) = {
     <a @Html(card.header.url.hrefWithRel) class="facia-link">
         <h3 class="headline">
             @card.header.kicker.map { kicker =>
@@ -19,15 +19,15 @@
             }
 
             @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
-                @if(card.header.isGallery) { @icon("gallery" + suffix) }
-                @if(card.header.isAudio) { @icon("podcast" + suffix) }
-                @if(card.header.isVideo) { @icon("video" + suffix) }
+                @if(card.header.isGallery) { @icon("gallery" + suffix, largeHeadline) }
+                @if(card.header.isAudio) { @icon("podcast" + suffix, largeHeadline) }
+                @if(card.header.isVideo) { @icon("video" + suffix, largeHeadline) }
             }
 
             @if(card.header.quoted) {
                 @card.cardStyle match {
-                    case Feature => { @icon("quote-feature") }
-                    case _ => { @icon("quote") }
+                    case Feature => { @icon("quote-feature", largeHeadline) }
+                    case _ => { @icon("quote", largeHeadline) }
                 }
             }
             @RemoveOuterParaHtml(card.header.headline)
@@ -46,9 +46,9 @@
     }
 }
 
-@headlineAndTrailWithCutout(card: ContentCard) = {
+@headlineAndTrailWithCutout(card: ContentCard, withImage: Boolean) = {
     @fullRow(Seq("facia-card__text")) {
-        @headline(card)
+        @headline(card, withImage)
     }
     @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
         @trailText(card)
@@ -60,7 +60,7 @@
         <div class="facia-card @if(withImage){facia-card--large}">
             @if(withImage) { @imgFromCard(card) }
             @if(card.header.quoted) {
-                @headlineAndTrailWithCutout(card)
+                @headlineAndTrailWithCutout(card, withImage)
             } else {
                 @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
                     @headline(card)

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -10,7 +10,7 @@
 @import views.support.TrailCssClasses.toneClassFromStyle
 
 
-@headline(card: ContentCard, largeHeadline: Boolean = false) = {
+@headline(card: ContentCard, isLarge: Boolean = false) = {
     <a @Html(card.header.url.hrefWithRel) class="facia-link">
         <h3 class="headline">
             @card.header.kicker.map { kicker =>
@@ -19,15 +19,15 @@
             }
 
             @defining(if(request.isEmailConnectedStyle) "-connected" else "") { suffix =>
-                @if(card.header.isGallery) { @icon("gallery" + suffix, largeHeadline) }
-                @if(card.header.isAudio) { @icon("podcast" + suffix, largeHeadline) }
-                @if(card.header.isVideo) { @icon("video" + suffix, largeHeadline) }
+                @if(card.header.isGallery) { @icon("gallery" + suffix, isLarge) }
+                @if(card.header.isAudio) { @icon("podcast" + suffix, isLarge) }
+                @if(card.header.isVideo) { @icon("video" + suffix, isLarge) }
             }
 
             @if(card.header.quoted) {
                 @card.cardStyle match {
-                    case Feature => { @icon("quote-feature", largeHeadline) }
-                    case _ => { @icon("quote", largeHeadline) }
+                    case Feature => { @icon("quote-feature", isLarge) }
+                    case _ => { @icon("quote", isLarge) }
                 }
             }
             @RemoveOuterParaHtml(card.header.headline)
@@ -48,7 +48,7 @@
 
 @headlineAndTrailWithCutout(card: ContentCard, withImage: Boolean) = {
     @fullRow(Seq("facia-card__text")) {
-        @headline(card, withImage)
+        @headline(card, isLarge = withImage)
     }
     @fullRow(Seq("facia-card__text", "facia-card__text--last")) {
         @trailText(card)


### PR DESCRIPTION
## What does this change?
In emails, when headlines have icons (e.g. the quote marks for opinion headlines), then the size of the icon should be consistent with the size of the headline. This is the case for most clients. This change should ensure this is also true for Outlook on Windows. 

This involved setting height on icon img elements. This will be ignored by most clients but will be useful for Outlook.

## What is the value of this and can you measure success?
Emails read on Outlook on Windows will be rendered more consistently with how they appear on other clients. 

## Does this affect other platforms - Amp, Apps, etc?
Nope.

## Screenshots
This is how the icons appear on other clients e.g. here iPhone 6:
![image](https://cloud.githubusercontent.com/assets/3072877/22299372/b32fc3ea-e31b-11e6-8aec-a3ac67e08f51.png)

This is how this email would look on Outlook on Windows before the change:
![image](https://cloud.githubusercontent.com/assets/3072877/22299515/47c2996a-e31c-11e6-889a-5ea2086f5dbe.png)

After the change:
![image](https://cloud.githubusercontent.com/assets/3072877/22299296/73c75d8a-e31b-11e6-8713-3eb5c8f20c50.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
