### PR TITLE
Measure site speed at 100% of GA

### DIFF
--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -6,7 +6,7 @@ import model.{ApplicationContext, ApplicationIdentity}
 object GoogleAnalyticsAccount {
 
   // NOTE that the 'samples rates' when set to 0, seem to be 100%
-  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 0.1)
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 100)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")


### PR DESCRIPTION
## What does this change?

bumps site speed GA measuring to 100% 

## What is the value of this and can you measure success?

faster stats for webpack test

## Does this affect other platforms - Amp, Apps, etc?

cost of GA, must be disabled before end of the month