### PR TITLE
Add new size for outstream ads in inline slots

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/ad-sizes.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/ad-sizes.js
@@ -13,6 +13,7 @@ define(function () {
 
         // guardian proprietary ad sizes
         video:                  AdSize(620, 1),
+        video2:                 AdSize(620, 350),
         merchandisingHighAdFeature: AdSize(88, 89),
         merchandisingHigh:      AdSize(88, 87),
         merchandising:          AdSize(88, 88),

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
@@ -10,7 +10,7 @@ define([
     var inlineDefinition = {
         sizeMappings: {
             mobile: compile(adSizes.outOfPage, adSizes.empty, adSizes.mpu, adSizes.fluid),
-            desktop: compile(adSizes.outOfPage, adSizes.empty, adSizes.mpu, adSizes.video, adSizes.fluid)
+            desktop: compile(adSizes.outOfPage, adSizes.empty, adSizes.mpu, adSizes.video, adSizes.video2, adSizes.fluid)
         }
     };
 

--- a/static/test/javascripts/fixtures/commercial/ad-slots/inline1.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/inline1.html
@@ -4,4 +4,4 @@
     data-test-id="ad-slot-inline1"
     data-name="inline1"
     data-mobile="1,1|2,2|300,250|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|fluid"></div>
+    data-desktop="1,1|2,2|300,250|620,1|620,350|fluid"></div>

--- a/static/test/javascripts/fixtures/commercial/ad-slots/inline2.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/inline2.html
@@ -1,7 +1,0 @@
-<div id="dfp-ad--inline2"
-    class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline2"
-    data-link-name="ad slot inline2"
-    data-test-id="ad-slot-inline2"
-    data-name="inline2"
-    data-mobile="1,1|2,2|300,250|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|fluid"></div>

--- a/static/test/javascripts/fixtures/commercial/ad-slots/inline3.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/inline3.html
@@ -1,7 +1,0 @@
-<div id="dfp-ad--inline3"
-    class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline3"
-    data-link-name="ad slot inline3"
-    data-test-id="ad-slot-inline3"
-    data-name="inline3"
-    data-mobile="1,1|2,2|300,250|fluid"
-    data-desktop="1,1|2,2|300,250|620,1|fluid"></div>

--- a/static/test/javascripts/spec/common/commercial/create-ad-slot.spec.js
+++ b/static/test/javascripts/spec/common/commercial/create-ad-slot.spec.js
@@ -3,8 +3,6 @@ define([
     'helpers/injector',
     'text!fixtures/commercial/ad-slots/im.html',
     'text!fixtures/commercial/ad-slots/inline1.html',
-    'text!fixtures/commercial/ad-slots/inline2.html',
-    'text!fixtures/commercial/ad-slots/inline3.html',
     'text!fixtures/commercial/ad-slots/right.html',
     'text!fixtures/commercial/ad-slots/right-small.html'
 ], function (
@@ -12,8 +10,6 @@ define([
     Injector,
     imHtml,
     inline1Html,
-    inline2Html,
-    inline3Html,
     rightHtml,
     rightSmallHtml
 ) {
@@ -58,16 +54,6 @@ define([
                 name: 'inline1',
                 type: 'inline',
                 html: inline1Html
-            },
-            {
-                name: 'inline2',
-                type: 'inline',
-                html: inline2Html
-            },
-            {
-                name: 'inline3',
-                type: 'inline',
-                html: inline3Html
             }
         ].forEach(function (expectation) {
             it('should create "' + expectation.name + '" ad slot', function () {


### PR DESCRIPTION
Currently, outstream video ads like Teads Inreads break out of the ad slot. This is not desirable at all, for obvious reasons, but most importantly because we can't measure viewability. In this chance, we introduce a new ad size Teads said could allow them to run _in situ_. As a bonus, they will also be pushing towards delivering SafeFrame enabled creatives.