### PR TITLE
make it an int

### DIFF
--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -6,7 +6,7 @@ import model.{ApplicationContext, ApplicationIdentity}
 object GoogleAnalyticsAccount {
 
   // NOTE that the 'samples rates' when set to 0, seem to be 100%
-  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 100)
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Int = 100)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")


### PR DESCRIPTION
## What does this change?

sets `siteSpeedSamplePercentage` to be an `Int`, like `samplePercentage`

## What is the value of this and can you measure success?

opening up `siteSpeedSamplePercentage ` too 100 in #15690 has not had any noticeable effect on the stats, which we'd expect it to. the result in page source is `{'sampleRate':100,'siteSpeedSampleRate':100.0}`, so this is a stab at the problem being that `.0`

