### PR TITLE
Send performance events to GA as normal events too

### DIFF
--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -6,7 +6,7 @@ import model.{ApplicationContext, ApplicationIdentity}
 object GoogleAnalyticsAccount {
 
   // NOTE that the 'samples rates' when set to 0, seem to be 100%
-  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Int = 100)
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 0.1)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -69,11 +69,6 @@ define([
             });
         }
 
-        userTiming.mark('commercial request');
-        robust.catchErrorsAndLog('ga-user-timing-commercial-request', function () {
-            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
-        });
-
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
@@ -90,11 +85,6 @@ define([
 
     var bootEnhanced = function () {
         if (guardian.isEnhanced) {
-            userTiming.mark('enhanced request');
-            robust.catchErrorsAndLog('ga-user-timing-enhanced-request', function () {
-                ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
-            });
-
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
                     userTiming.mark('enhanced boot');

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -56,6 +56,11 @@ define([
 
     function sendPerformanceEvent(event) {
         window.ga(send, 'timing', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel);
+
+        // temporaily send performance events as normal events, so we can get a lot of them
+        window.ga(config.googleAnalytics.trackers.editorial + '.send', 'event', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel, {
+            nonInteraction: true // to avoid affecting bounce rate
+        });
     }
 
     // Track important user timing metrics so that we can be notified and measure over time in GA

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -32,10 +32,6 @@ domready(() => {
             });
         }
 
-        userTiming.mark('commercial request');
-        robust.catchErrorsAndLog('ga-user-timing-commercial-request', () => {
-            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
-        });
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
                 userTiming.mark('commercial boot');
@@ -48,10 +44,6 @@ domready(() => {
                 // this is defined here so that webpack's code-splitting algo
                 // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
-                    userTiming.mark('enhanced request');
-                    robust.catchErrorsAndLog('ga-user-timing-enhanced-request', () => {
-                        ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
-                    });
                     require(['bootstraps/enhanced/main'], (bootEnhanced) => {
                         userTiming.mark('enhanced boot');
                         robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', () => {


### PR DESCRIPTION
## What does this change?

- temporarily adds a standard GA event to track performance timings, since timing events are throttled by GA
- restore GA timing throttle to 0.1% (reverting #15690 and #15693)
- remove 2 events (the bundle request events)

## What is the value of this and can you measure success?

#15690 is still not collection much data. this should be unlimited
