### PR TITLE
Fixes caption padding on AMP

### DIFF
--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,4 +1,4 @@
-@(media: model.content.MediaAtom,  displayCaption: Boolean)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom,  displayCaption: Boolean, mainMedia: Boolean)(implicit request: RequestHeader)
 @import conf.Configuration
 @import views.support.Video700
 @import conf.switches.Switches.UseAmpYouTubeTagForMediaAtoms
@@ -21,7 +21,7 @@
     </amp-iframe>
 }
 @if(displayCaption) {
-    @mediaAtomCaption(media.title)
+    @mediaAtomCaption(media.title, mainMedia)
 }
 
 

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -5,7 +5,7 @@
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
-        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true, displayEndSlate = mainMedia)
+        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true, displayEndSlate = mainMedia, mainMedia = mainMedia)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -3,14 +3,9 @@
 
 @{
     media match {
-            case posterOnly if media.posterImage.isDefined && media.assets.isEmpty => views.html.fragments.imageFigure(media.posterImage.get,
-                amp = amp,
-                doCaption = displayCaption,
-                // image_figureClasses needs to be defined to avoid extra indent on AMP (see imageFigure fragment)
-                image_figureClasses = Some(media.posterImage.get.largestImage.get, ""))
+            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mainMedia = mainMedia, amp = amp,picture = media.posterImage.get, caption = media.title)
             case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mainMedia) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage, displayEndSlate)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }
-
 }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,5 +1,5 @@
 @import model.content.MediaAssetPlatform
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, embedPage: Boolean = false, displayEndSlate: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, embedPage: Boolean = false, displayEndSlate: Boolean = false, mainMedia: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
     media match {
@@ -8,7 +8,7 @@
                 doCaption = displayCaption,
                 // image_figureClasses needs to be defined to avoid extra indent on AMP (see imageFigure fragment)
                 image_figureClasses = Some(media.posterImage.get.largestImage.get, ""))
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage, displayEndSlate)
+            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mainMedia) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage, displayEndSlate)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -1,5 +1,12 @@
-@(captionText: String)(implicit request: RequestHeader)
-<figcaption class="caption caption--img caption--media-atom" itemprop="description">
+@import views.support.RenderClasses
+
+@(captionText: String, mainMedia: Boolean = false)(implicit request: RequestHeader)
+<figcaption class="@RenderClasses(Map(
+    "caption" -> true,
+    "caption--img" -> true,
+    "caption--media-atom" -> true,
+    "caption--main" -> mainMedia))"
+itemprop="description">
     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))
     @captionText
 </figcaption>

--- a/common/app/views/fragments/atoms/posterImage.scala.html
+++ b/common/app/views/fragments/atoms/posterImage.scala.html
@@ -1,0 +1,28 @@
+@import layout.ContentWidths.MainMedia
+
+@(mainMedia: Boolean, amp: Boolean, picture: model.ImageMedia, caption: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+    @defining(
+        if(mainMedia) {
+            Seq("maxed", "responsive-img")
+        } else {
+            Seq("gu-image")
+        }
+    ) { classes =>
+
+        @if(amp) {
+            @fragments.amp.ampImage(picture, caption)
+        } else {
+            @fragments.image(
+                picture,
+                classes,
+                MainMedia.inline,
+                caption,
+                isFeatureAndShowcase = false,
+                isImmersiveMainMedia = false
+            )
+        }
+    }
+    @fragments.atoms.mediaAtomCaption(caption, mainMedia = mainMedia)
+
+

--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -183,7 +183,9 @@ figure {
         margin-bottom: $gs-baseline;
         position: relative;
     }
-    &.element-image {
+    &.element-image,
+    &.element-atom
+    {
         position: relative;
         figcaption {
             padding-top: ($gs-baseline/6)*4;

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -96,7 +96,8 @@ figure.element.element--showcase {
 }
 
 figure.element.element--supporting,
-figure.element-video {
+figure.element-video,
+figure.element-atom {
     figcaption {
         padding-top: ($gs-baseline/3)*2;
         padding-bottom: ($gs-baseline/3)*2;
@@ -107,11 +108,6 @@ figure.element-video {
             top: 100%;
         }
     }
-}
-
-figcaption.caption--media-atom {
-    padding-top: ($gs-baseline/3)*2;
-    padding-bottom: ($gs-baseline/3)*2;
 }
 
 figure.element.element--showcase {


### PR DESCRIPTION
## What does this change?
Fixes caption padding for Media Atoms. 

Note this creates a new fragment for the poster image case using the `image` and `ampImage` fragments, rather than using the entirety of the `imageFigure` which was causing additional classes to be added which caused unwanted behaviour.

## What is the value of this and can you measure success?
Consistency with other elements

## Does this affect other platforms - Amp, Apps, etc?
Also affects AMP.

## Screenshots
### BEFORE
In-Body
<img width="584" alt="screen shot 2017-01-26 at 17 15 10" src="https://cloud.githubusercontent.com/assets/1764158/22342107/1a101cc0-e3eb-11e6-8ae9-e7a6e316a796.png">
Main Media
<img width="627" alt="screen shot 2017-01-26 at 17 15 33" src="https://cloud.githubusercontent.com/assets/1764158/22342117/218d213c-e3eb-11e6-9134-5ef849fc9c05.png">

### AFTER
<img width="584" alt="screen shot 2017-01-26 at 17 26 13" src="https://cloud.githubusercontent.com/assets/1764158/22342574/c15ae0a4-e3ec-11e6-95b4-63fec54628a9.png">
<img width="550" alt="screen shot 2017-01-26 at 17 25 44" src="https://cloud.githubusercontent.com/assets/1764158/22342575/c165efe4-e3ec-11e6-8bf9-2211ce5eafda.png">

#### Poster Only
<img width="579" alt="screen shot 2017-01-26 at 17 34 14" src="https://cloud.githubusercontent.com/assets/1764158/22342847/b45b1eae-e3ed-11e6-93d7-49c0c7a0b6ef.png">
<img width="613" alt="screen shot 2017-01-26 at 17 34 08" src="https://cloud.githubusercontent.com/assets/1764158/22342846/b455244a-e3ed-11e6-9d38-7b7526375fce.png">

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
