### PR TITLE
Fixing comment acitivity link new header menu

### DIFF
--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -31,8 +31,8 @@
                             </a>
                         </li>
                     }
-                    <li class="personalisation__link js-add-comment-activity-link" hidden>
-                        <a data-link-name="nav2 : comment activity">
+                    <li class="personalisation__link">
+                        <a data-link-name="nav2 : comment activity" class="js-add-comment-activity-link" hidden>
                             Comment activity
                         </a>
                     </li>


### PR DESCRIPTION
## What does this change?
Currently we have a bug where the comment activity link is put on the wrong element in the new nav:
<img src="https://cloud.githubusercontent.com/assets/8774970/22367173/19dc08f8-e478-11e6-844f-10624bc089a9.png" width="400px"/>

This fixes that problem.
<img src="https://cloud.githubusercontent.com/assets/8774970/22367367/10cb8580-e479-11e6-8b3a-7934dfea2644.png" width="400px"/>


## What is the value of this and can you measure success?
People can easily access their comment history

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope

