### PR TITLE
Show youtube atoms placeholder on small cards on fronts

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -4,19 +4,19 @@
 @import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, isPlayable: Boolean = true)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
         ("u-responsive-ratio--hd", true),
         ("youtube-media-atom", true),
-        ("no-player", !isPlayable)
+        ("no-player", !playable)
     ))"
     @for(endSlatePath <- media.endSlatePath if displayCaption)  {
       data-end-slate="@endSlatePath"
     }
     >
-            @if(isPlayable) {
+            @if(playable) {
                 @defining(s"https://www.youtube.com/embed${
                 media.assets.head.id
                 .addParams(List(

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -4,31 +4,34 @@
 @import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, isPlayable: Boolean = true)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
-        "u-responsive-ratio" -> true,
-        "u-responsive-ratio--hd" -> true,
-        "youtube-media-atom" -> true
+        ("u-responsive-ratio", true),
+        ("u-responsive-ratio--hd", true),
+        ("youtube-media-atom", true),
+        ("no-player", !isPlayable)
     ))"
     @for(endSlatePath <- media.endSlatePath if displayCaption)  {
       data-end-slate="@endSlatePath"
     }
     >
-            @defining(s"https://www.youtube.com/embed${
+            @if(isPlayable) {
+                @defining(s"https://www.youtube.com/embed${
                 media.assets.head.id
-                    .addParams(List(
-                    "modestbranding" -> 1,
-                    "enablejsapi" -> 1,
-                    "rel" -> 0,
-                    "showinfo" -> 1,
-                    "origin" -> (if(embedPage) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                .addParams(List(
+                "modestbranding" -> 1,
+                "enablejsapi" -> 1,
+                "rel" -> 0,
+                "showinfo" -> 1,
+                "origin" -> (if(embedPage) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
-            }") { embedUri: String  =>
+                }") { embedUri: String  =>
                 <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"
-                src="@embedUri" frameborder="0"
-                allowfullscreen="">
+                        src="@embedUri" frameborder="0"
+                        allowfullscreen="">
                 </iframe>
+                }
             }
 
             @media.posterImage.map { image =>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -88,10 +88,10 @@ data-test-id="facia-card"
                 </div>
             }
 
-            case Some(media@InlineYouTubeMediaAtom(_)) if item.cardTypes.showYouTubeMediaAtomPlayer => {
+            case Some(media@InlineYouTubeMediaAtom(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false, displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate)
+                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false, displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate, isPlayable = item.cardTypes.showYouTubeMediaAtomPlayer)
                     </div>
                 </div>
             }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -91,7 +91,7 @@ data-test-id="facia-card"
             case Some(media@InlineYouTubeMediaAtom(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false, displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate, isPlayable = item.cardTypes.showYouTubeMediaAtomPlayer)
+                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false, displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate, playable = item.cardTypes.showYouTubeMediaAtomPlayer)
                     </div>
                 </div>
             }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -178,8 +178,13 @@ define([
     function checkElemForVideo(elem) {
         fastdom.read(function () {
             $('.youtube-media-atom', elem).each(function (el) {
-                var atomId = el.getAttribute('data-media-atom-id');
                 var iframe = el.querySelector('iframe');
+
+                if (!iframe) {
+                    return;
+                }
+
+                var atomId = el.getAttribute('data-media-atom-id');
                 var overlay = el.querySelector('.youtube-media-atom__overlay');
                 var youtubeId = iframe.id;
 

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -428,8 +428,13 @@ $video-width-desktop: 700px;
 }
 
 .fc-item__video-container {
+
     .youtube-media-atom {
         z-index: 1;
+    }
+
+    .youtube-media-atom.no-player {
+        z-index: 0;
     }
 
     .youtube-media-atom__iframe:not(.youtube__video-ready) {


### PR DESCRIPTION
## What does this change?

Youtube atoms in small cards on fronts should not be not playable. Because of this they currently don't use the youtube template fragment. This change means non-playable cards will use the youtube template fragment, but only the poster image and play button will be rendered, the player's iframe won't be rendered.

## What is the value of this and can you measure success?

Youtube atom poster images appear on front now for small cards

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before
![picture 32](https://cloud.githubusercontent.com/assets/1590704/22369510/18380c7a-e484-11e6-9d78-c09f3538bc5c.png)
After
![picture 31](https://cloud.githubusercontent.com/assets/1590704/22369514/1e7ffe80-e484-11e6-9fca-77a31cae23b6.png)

## Tested in CODE?

No

@gidsg 