### PR TITLE
Add ability to boost fidelity of timing metrics in GA

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -85,10 +85,10 @@ trait MonitoringSwitches {
     exposeClientSide = false
   )
 
-  val GAMegaPerfMonitoring = Switch(
+  val BoostGAUserTimingFidelity = Switch(
     SwitchGroup.Monitoring,
-    "ga-mega-perf-monitoring",
-    "CAUTION: check with Google.Analyticscore@guardian.co.uk before enabling. Sends GA timing events as standard events, to avoid the 0.1% sampling that affects timing events. Will send a LOT more JS timing events to GA.",
+    "boost-ga-user-timing-fidelity",
+    "CAUTION: check with Google.Analyticscore@guardian.co.uk before enabling. Extends the standard 0.1% sampling of user timing events on Google Analytics to 100%. Will send a LOT more events to GA, which costs $$$.",
     owners = Seq(Owner.withGithub("sndrs")),
     safeState = Off,
     never,

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -85,4 +85,14 @@ trait MonitoringSwitches {
     exposeClientSide = false
   )
 
+  val GAMegaPerfMonitoring = Switch(
+    SwitchGroup.Monitoring,
+    "ga-mega-perf-monitoring",
+    "**CHECK WITH Google.Analyticscore@guardian.co.uk BEFORE ENABLING** – sends GA timing events as standard events, to avoid the 0.1% sampling that affects timing events. Will send a LOT more JS timing events to GA.",
+    owners = Seq(Owner.withGithub("sndrs")),
+    safeState = Off,
+    never,
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -88,7 +88,7 @@ trait MonitoringSwitches {
   val GAMegaPerfMonitoring = Switch(
     SwitchGroup.Monitoring,
     "ga-mega-perf-monitoring",
-    "**CHECK WITH Google.Analyticscore@guardian.co.uk BEFORE ENABLING** – sends GA timing events as standard events, to avoid the 0.1% sampling that affects timing events. Will send a LOT more JS timing events to GA.",
+    "CAUTION: check with Google.Analyticscore@guardian.co.uk before enabling. Sends GA timing events as standard events, to avoid the 0.1% sampling that affects timing events. Will send a LOT more JS timing events to GA.",
     owners = Seq(Owner.withGithub("sndrs")),
     safeState = Off,
     never,

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -6,7 +6,7 @@ import model.{ApplicationContext, ApplicationIdentity}
 object GoogleAnalyticsAccount {
 
   // NOTE that the 'samples rates' when set to 0, seem to be 100%
-  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Int = 100)
+  case class Tracker(trackingId: String, trackerName: String, samplePercentage: Int = 100, siteSpeedSamplePercentage: Double = 0.1)
 
   // The "All editorial" property in the main GA account ("GNM Universal")
   val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -62,6 +62,7 @@ define([
             });
         }
 
+        userTiming.mark('commercial request');
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
@@ -75,6 +76,7 @@ define([
 
     var bootEnhanced = function () {
         if (guardian.isEnhanced) {
+            userTiming.mark('enhanced request');
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
                     userTiming.mark('enhanced boot');

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -21,16 +21,10 @@ define([
     'Promise',
     'domReady',
     'common/utils/raven',
-    'common/utils/user-timing',
-    'common/utils/robust',
-    'common/modules/analytics/google'
 ], function (
     Promise,
     domReady,
-    raven,
-    userTiming,
-    robust,
-    ga
+    raven
 ) {
     // curl’s promise API is broken, so we must cast it to a real Promise
     // https://github.com/cujojs/curl/issues/293
@@ -46,10 +40,6 @@ define([
     var bootStandard = function () {
         return promiseRequire(['bootstraps/standard/main'])
             .then(function (boot) {
-                userTiming.mark('standard boot');
-                robust.catchErrorsAndLog('ga-user-timing-standard-boot', function () {
-                    ga.trackPerformance('Javascript Load', 'standardBoot', 'Standard boot time');
-                });
                 boot();
             });
     };
@@ -73,10 +63,6 @@ define([
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
                     function (commercial) {
-                        userTiming.mark('commercial boot');
-                        robust.catchErrorsAndLog('ga-user-timing-commercial-boot', function () {
-                            ga.trackPerformance('Javascript Load', 'commercialBoot', 'commercial boot time');
-                        });
                         commercial.init();
                     }
                 )
@@ -87,10 +73,6 @@ define([
         if (guardian.isEnhanced) {
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
-                    userTiming.mark('enhanced boot');
-                    robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', function () {
-                        ga.trackPerformance('Javascript Load', 'enhancedBoot', 'Enhanced boot time');
-                    });
                     boot();
                 });
         }

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -69,11 +69,6 @@ define([
             });
         }
 
-        userTiming.mark('commercial request');
-        robust.catchErrorsAndLog('ga-user-timing-commercial-request', function () {
-            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
-        });
-
         return promiseRequire(['bootstraps/commercial'])
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
@@ -90,11 +85,6 @@ define([
 
     var bootEnhanced = function () {
         if (guardian.isEnhanced) {
-            userTiming.mark('enhanced request');
-            robust.catchErrorsAndLog('ga-user-timing-enhanced-request', function () {
-                ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
-            });
-
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
                     userTiming.mark('enhanced boot');

--- a/static/src/javascripts-legacy/boot.js
+++ b/static/src/javascripts-legacy/boot.js
@@ -21,10 +21,12 @@ define([
     'Promise',
     'domReady',
     'common/utils/raven',
+    'common/utils/user-timing'
 ], function (
     Promise,
     domReady,
-    raven
+    raven,
+    userTiming
 ) {
     // curl’s promise API is broken, so we must cast it to a real Promise
     // https://github.com/cujojs/curl/issues/293
@@ -40,6 +42,7 @@ define([
     var bootStandard = function () {
         return promiseRequire(['bootstraps/standard/main'])
             .then(function (boot) {
+                userTiming.mark('standard boot');
                 boot();
             });
     };
@@ -63,6 +66,7 @@ define([
             .then(raven.wrap(
                     { tags: { feature: 'commercial' } },
                     function (commercial) {
+                        userTiming.mark('commercial boot');
                         commercial.init();
                     }
                 )
@@ -73,6 +77,7 @@ define([
         if (guardian.isEnhanced) {
             return promiseRequire(['bootstraps/enhanced/main'])
                 .then(function (boot) {
+                    userTiming.mark('enhanced boot');
                     boot();
                 });
         }

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -56,6 +56,11 @@ define([
 
     function sendPerformanceEvent(event) {
         window.ga(send, 'timing', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel);
+
+        // temporaily send performance events as normal events, so we can get a lot of them
+        window.ga(config.googleAnalytics.trackers.editorial + '.send', 'event', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel, {
+            nonInteraction: true // to avoid affecting bounce rate
+        });
     }
 
     // Track important user timing metrics so that we can be notified and measure over time in GA

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/google.js
@@ -7,7 +7,7 @@ define([
 ) {
     var trackerName = config.googleAnalytics.trackers.editorial;
     var send = trackerName + '.send';
-    var gaMegaPerfMetrics = {
+    var boostGaUserTimingFidelityMetrics = {
         standardStart: 'metric18',
         standardEnd: 'metric19',
         commercialStart: 'metric20',
@@ -65,10 +65,11 @@ define([
     function sendPerformanceEvent(event) {
         window.ga(send, 'timing', event.timingCategory, event.timingVar, event.timeSincePageLoad, event.timingLabel);
 
-        // send performance events as normal events, so we can avoid the 0.1% sampling that affects timing events
-        if (config.switches.gaMegaPerfMonitoring) {
+        // send performance events as normal events too,
+        // so we can avoid the 0.1% sampling that affects timing events
+        if (config.switches.boostGaUserTimingFidelity) {
             // these are our own metrics that map to our timing events
-            var metric = gaMegaPerfMetrics[event.timingVar];
+            var metric = boostGaUserTimingFidelityMetrics[event.timingVar];
 
             var fieldsObject = {
                 nonInteraction: true, // to avoid affecting bounce rate

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -32,10 +32,6 @@ domready(() => {
             });
         }
 
-        userTiming.mark('commercial request');
-        robust.catchErrorsAndLog('ga-user-timing-commercial-request', () => {
-            ga.trackPerformance('Javascript Load', 'commercialRequest', 'commercial request time');
-        });
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
                 userTiming.mark('commercial boot');
@@ -48,10 +44,6 @@ domready(() => {
                 // this is defined here so that webpack's code-splitting algo
                 // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
-                    userTiming.mark('enhanced request');
-                    robust.catchErrorsAndLog('ga-user-timing-enhanced-request', () => {
-                        ga.trackPerformance('Javascript Load', 'enhancedRequest', 'Enhanced request time');
-                    });
                     require(['bootstraps/enhanced/main'], (bootEnhanced) => {
                         userTiming.mark('enhanced boot');
                         robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', () => {

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -2,6 +2,7 @@ import domready from 'domready';
 import raven from 'common/utils/raven';
 import bootStandard from 'bootstraps/standard/main';
 import config from 'common/utils/config';
+import userTiming from 'common/utils/user-timing';
 
 // let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -11,6 +12,7 @@ __webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
 domready(() => {
     // 1. boot standard, always
+    userTiming.mark('standard boot');
     bootStandard();
 
     // 2. once standard is done, next is commercial
@@ -27,6 +29,7 @@ domready(() => {
 
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
+                userTiming.mark('commercial boot');
                 commercial.init();
 
                 // 3. finally, try enhanced
@@ -34,6 +37,7 @@ domready(() => {
                 // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
                     require(['bootstraps/enhanced/main'], (bootEnhanced) => {
+                        userTiming.mark('enhanced boot');
                         bootEnhanced();
                     });
                 }

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -2,9 +2,6 @@ import domready from 'domready';
 import raven from 'common/utils/raven';
 import bootStandard from 'bootstraps/standard/main';
 import config from 'common/utils/config';
-import userTiming from 'common/utils/user-timing';
-import robust from 'common/utils/robust';
-import ga from 'common/modules/analytics/google';
 
 // let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -14,10 +11,6 @@ __webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
 domready(() => {
     // 1. boot standard, always
-    userTiming.mark('standard boot');
-    robust.catchErrorsAndLog('ga-user-timing-standard-boot', () => {
-        ga.trackPerformance('Javascript Load', 'standardBoot', 'Standard boot time');
-    });
     bootStandard();
 
     // 2. once standard is done, next is commercial
@@ -34,10 +27,6 @@ domready(() => {
 
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
-                userTiming.mark('commercial boot');
-                robust.catchErrorsAndLog('ga-user-timing-commercial-boot', () => {
-                    ga.trackPerformance('Javascript Load', 'commercialBoot', 'commercial boot time');
-                });
                 commercial.init();
 
                 // 3. finally, try enhanced
@@ -45,10 +34,6 @@ domready(() => {
                 // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
                     require(['bootstraps/enhanced/main'], (bootEnhanced) => {
-                        userTiming.mark('enhanced boot');
-                        robust.catchErrorsAndLog('ga-user-timing-enhanced-boot', () => {
-                            ga.trackPerformance('Javascript Load', 'enhancedBoot', 'Enhanced boot time');
-                        });
                         bootEnhanced();
                     });
                 }

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -27,6 +27,7 @@ domready(() => {
             });
         }
 
+        userTiming.mark('commercial request');
         require(['bootstraps/commercial'], raven.wrap({ tags: { feature: 'commercial' } },
             (commercial) => {
                 userTiming.mark('commercial boot');
@@ -36,6 +37,7 @@ domready(() => {
                 // this is defined here so that webpack's code-splitting algo
                 // excludes all the modules bundled in the commercial chunk from this one
                 if (window.guardian.isEnhanced) {
+                    userTiming.mark('enhanced request');
                     require(['bootstraps/enhanced/main'], (bootEnhanced) => {
                         userTiming.mark('enhanced boot');
                         bootEnhanced();


### PR DESCRIPTION
## What does this change?

- adds switch-based standard GA event to track performance timings
- restores GA timing throttle to 0.1%, reverting #15690 and #15693
- removes the extra events added in #15672

## What is the value of this and can you measure success?

Standard timing events are throttled to 0.1%. This should enable us to temporarily open performance monitoring to 100% when needed (and ok'd by the GA team).

## Does this affect other platforms - Amp, Apps, etc?

cost of GA, potentially (hence always check with GA team before using it)