### PR TITLE
The great chevron rotation of 2017

### DIFF
--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -233,25 +233,25 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .main-menu__icon--chevron {
     //optical alignment
-    margin-top: -.05em;
+    margin-top: -.2em;
 
     &:before {
         content: '';
         display: inline-block;
         width: 8px;
         height: 8px;
-        transform: rotate(-45deg);
+        transform: rotate(45deg);
         border: 2px solid $news-support-2;
         border-top: 0;
         border-left: 0;
-        //optical alignment
-        margin-left: -.3em;
     }
 
-    section[expanded] &:before {
-        transform: rotate(45deg);
-        margin-bottom: .14em;
-        margin-left: 0;
+    section[expanded] & {
+        margin-top: .2em;
+
+        &:before {
+            transform: rotate(-135deg);
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -374,31 +374,31 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
     .main-menu__icon--chevron:before {
         border-color: $news-support-2;
-        //optical alignment
-        margin-left: -.3em;
     }
 }
 
 .main-menu__icon--chevron {
     //optical alignment
-    margin-top: -.05em;
+    margin-top: -.2em;
 
     &:before {
         content: '';
         display: inline-block;
         width: 8px;
         height: 8px;
-        transform: rotate(-45deg);
+        transform: rotate(45deg);
         border-width: 2px;
         border-style: solid;
         border-top: 0;
         border-left: 0;
     }
 
-    details[open] &:before {
-        transform: rotate(45deg);
-        margin-bottom: .14em;
-        margin-left: 0;
+    details[open] & {
+        margin-top: .1em;
+
+        &:before {
+            transform: rotate(-135deg);
+        }
     }
 }
 


### PR DESCRIPTION
Look, I know that this is a right can of worms. I'm mixing a batch of fresh concrete, throwing that can of worms into the concrete. I'm going to let that concrete set and then throw it into a canal. 

You can make a case for chevrons pointing right (closed) and down (open) or down (closed) and up (open). There are many examples of both all over the place. A user is most likely to open the menu when they can't find what they are looking for in the primary or secondary nav. With this in mind, chevrons pointing right could cause confusion into making people think that the words are links to fronts and not expandable (as we ). A downwards pointing chevron is clearer indicator that content will appear below upon tapping the area.

Furthermore we do have an established language of downwards pointing chevrons across the site as show and hide indicators.

Before:
<img width="318" alt="screen shot 2017-01-27 at 11 10 11" src="https://cloud.githubusercontent.com/assets/14570016/22369012/740bc5a8-e481-11e6-9301-bafb324fe977.png">

After:
<img width="319" alt="screen shot 2017-01-27 at 11 10 27" src="https://cloud.githubusercontent.com/assets/14570016/22369011/740ba74e-e481-11e6-992f-b251dbaf2a79.png">

