### PR TITLE
Fix closed comment caching (behind a switch)

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -164,7 +164,7 @@ class CommentsController(val discussionApi: DiscussionApiLike, csrfCheck: CSRFCh
   // caches "closed" comment threads for an hour.
   // if the thread is switched on again the url changes and it cache busts itself.
   private def cacheTime(request: RequestHeader) = {
-    val commentsClosed = request.getParameter("commentable").contains("false")
+    val commentsClosed = request.getParameter("commentsClosed").contains("true")
     if (commentsClosed && LongCacheCommentsSwitch.isSwitchedOn) CacheTime(3800) else CacheTime(60)
   }
 }

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/comments.js
@@ -163,7 +163,7 @@ Comments.prototype.fetchComments = function(options) {
         orderBy: orderBy,
         pageSize: options.pagesize || this.options.pagesize,
         displayThreaded: this.options.threading !== 'unthreaded',
-        commentable: config.page.commentable
+        commentsClosed: options.commentsClosed
     };
 
     if (options.page) {
@@ -182,7 +182,8 @@ Comments.prototype.fetchComments = function(options) {
             discussionId: this.options.discussionId,
             orderBy: queryParams.orderBy,
             displayThreaded: queryParams.displayThreaded,
-            maxResponses: queryParams.maxResponses
+            maxResponses: queryParams.maxResponses,
+            commentsClosed: queryParams.commentsClosed
         })
         .loadAllComments()
         .catch(function() {

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
@@ -69,7 +69,7 @@ Loader.prototype.initTopComments = function() {
         this.gotoComment(commentId);
     });
 
-    return fetchJson('/discussion/top-comments/' + this.getDiscussionId() + '.json?commentable=' + config.page.commentable, {
+    return fetchJson('/discussion/top-comments/' + this.getDiscussionId() + '.json?commentsClosed=' + this.getDiscussionClosed(), {
         mode: 'cors'
     }).then(
         function render(resp) {
@@ -446,6 +446,9 @@ Loader.prototype.loadComments = function(options) {
     if (options && options.shouldTruncate && this.comments.isAllPageSizeActive()) {
         options.pageSize = 10;
     }
+    
+    // Closed state of comments is passed so we bust cache of comment thread when it is reopened
+    options.commentsClosed = this.getDiscussionClosed();
 
     return this.comments.fetchComments(options)
     .then(function(){

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/whole-discussion.js
@@ -62,7 +62,8 @@ define([
         this.params = {
             orderBy: options.orderBy,
             displayThreaded: options.displayThreaded,
-            maxResponses: options.maxResponses
+            maxResponses: options.maxResponses,
+            commentsClosed: options.commentsClosed
         };
     }
 
@@ -105,7 +106,8 @@ define([
             orderBy: 'oldest',
             page: pageNumber,
             pageSize: commentsPerPage,
-            displayThreaded: this.params.displayThreaded
+            displayThreaded: this.params.displayThreaded,
+            commentsClosed: this.params.commentsClosed
         };
 
         if (this.params.maxResponses) {


### PR DESCRIPTION
## What does this change?
The way that the closed comment long cache switch was implemented previously didn't work.  It relied on `config.page.commentable` which would always be true if the comment component was actually loaded - therefore we never saw any `commentable=false` requests.

This switches to using the existing "is this closed for comment?" (`getDiscussionClosed`) method so that we are now using the correct property.  There is also a read-only flag, but I'm not entirely clear on what that is used for (if at all) - so I'm only changing the cache on the closed ones.

## What is the value of this and can you measure success?
We can test whether caching closed comment threads for longer has an effect on the number of discussion requests.

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
