### PR TITLE
Byline and date should be below social shares

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -19,25 +19,6 @@
 }
 
 @metaBody() = {
-    @if(!item.content.isImmersiveGallery && !item.content.isExplore) {
-        @if(!item.content.hasTonalHeaderByline) {
-            @byline()
-        }
-
-        @item.content.contributorBio.map { bio => <p class="meta__bio" data-link-name="byline" data-component="meta-byline">@bio</p> }
-
-        @if(item.content.tags.contributors.length == 1) {
-            @if(item.content.hasTonalHeaderByline && (item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty) || item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty))) {
-                <p class="meta__contact-header">Contact author</p>
-            }
-            @fragments.meta.contactAuthor(item.tags, amp)
-        }
-
-        @if(!item.trail.shouldHidePublicationDate) {
-            @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, item.content.hasBeenModified, item.fields.firstPublicationDate, item.tags.isLiveBlog, item.fields.isLive)
-        }
-    }
-
     @if(showExtras) {
         <div class="meta__extras @if(!ageNotice.isEmpty){ meta__extras--notice }">
             <div class="meta__social" data-component="share">
@@ -58,6 +39,31 @@
             }
         </div>
     }
+
+    @if(item.content.showCircularBylinePicAtSide) {
+        <div class="media__img meta__image">
+            @fragments.meta.bylineImage(item.tags)
+        </div>
+    }
+
+    @if(!item.content.isImmersiveGallery && !item.content.isExplore) {
+        @if(!item.content.hasTonalHeaderByline) {
+            @byline()
+        }
+
+        @item.content.contributorBio.map { bio => <p class="meta__bio" data-link-name="byline" data-component="meta-byline">@bio</p> }
+
+        @if(item.content.tags.contributors.length == 1) {
+            @if(item.content.hasTonalHeaderByline && (item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty) || item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty))) {
+                <p class="meta__contact-header">Contact author</p>
+            }
+            @fragments.meta.contactAuthor(item.tags, amp)
+        }
+
+        @if(!item.trail.shouldHidePublicationDate) {
+            @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, item.content.hasBeenModified, item.fields.firstPublicationDate, item.tags.isLiveBlog, item.fields.isLive)
+        }
+    }
 }
 
 <div class="content__meta-container js-content-meta js-football-meta u-cf
@@ -77,14 +83,5 @@
         @fragments.commercial.badge(item, page)
     }
 
-    @if(item.content.showCircularBylinePicAtSide) {
-        <div class="media__body meta__body">
-            <div class="media__img meta__image">
-                @fragments.meta.bylineImage(item.tags)
-            </div>
-            @metaBody()
-        </div>
-    } else {
-        @metaBody()
-    }
+    @metaBody()
 </div>

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -143,14 +143,14 @@
 
 .meta__extras {
     clear: both;
+    border-top: 1px dotted $neutral-5;
+    border-bottom: 1px dotted $neutral-5;
 }
 
 .content__meta-container {
     min-height: gs-height(1);
     position: relative;
     margin-bottom: $gs-baseline;
-    border-top: 1px dotted $neutral-5;
-    border-bottom: 1px dotted $neutral-5;
 
     .byline-img {
         @include circular;
@@ -223,6 +223,10 @@
         fill: $neutral-2;
         margin-bottom: -1px;
     }
+}
+
+.meta__twitter {
+    display: inline-block;
 }
 
 .control__icon-wrapper {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -441,54 +441,14 @@
 
 .badge +.content__dateline { clear: left; }
 
-.content__meta-container .byline-img {
-    @include circular;
-    position: relative;
-    width: gs-span(1);
-    height: 60px; //Intentionally off grid
-    margin: $gs-baseline/2 0;
-    overflow: hidden;
-    background-color: $neutral-7;
-
-    // fixes for webkit not properly scaling/clipping the child element (still broken on some android browsers...)
-    -webkit-transform: translateZ(0);
-    -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
-
-    @include mq(leftCol) {
-        width: gs-span(2);
-        height: gs-span(2); //This is intentionally square
-        margin-right: 0;
-        margin-bottom: $gs-baseline;
-    }
-}
-
-.content__meta-container .byline-img__img {
-    position: absolute;
-    width: auto;
-    //This centres the image within its container
-    height: 110%;
-    bottom: -6px;
-    left: -9999px;
-    right: -9999px;
-    margin: auto;
-
-    @include mq(leftCol) {
-        bottom: -14px;
-    }
-}
-
 .content__meta-container {
     min-height: gs-height(1);
     position: relative;
     margin-bottom: $gs-baseline;
-    border-top: 1px dotted $neutral-5;
-    border-bottom: 1px dotted $neutral-5;
 
     @include mq(leftCol) {
         position: absolute;
         top: 0;
-        border-top: 0;
-        border-bottom: 0;
         margin-left: ($left-column + $gs-gutter)*-1;
         margin-bottom: ($gs-baseline/3)*4;
         width: $left-column;
@@ -497,6 +457,46 @@
     @include mq(wide) {
         margin-left: ($left-column-wide + $gs-gutter)*-1;
         width: $left-column-wide;
+    }
+
+    .byline-img {
+        @include circular;
+        position: relative;
+        width: gs-span(1);
+        height: 60px; //Intentionally off grid
+        margin: $gs-baseline/2 0;
+        overflow: hidden;
+        background-color: $neutral-7;
+
+        // fixes for webkit not properly scaling/clipping the child element (still broken on some android browsers...)
+        -webkit-transform: translateZ(0);
+        -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
+
+        @include mq(leftCol) {
+            width: gs-span(2);
+            height: gs-span(2); //This is intentionally square
+            margin-right: 0;
+            margin-bottom: $gs-baseline;
+        }
+    }
+
+    .byline-img__img {
+        position: absolute;
+        width: auto;
+        //This centres the image within its container
+        height: 110%;
+        bottom: -6px;
+        left: -9999px;
+        right: -9999px;
+        margin: auto;
+
+        @include mq(leftCol) {
+            bottom: -14px;
+        }
+    }
+
+    .meta__image {
+        border-top: 1px dotted $neutral-5;
     }
 }
 
@@ -547,7 +547,6 @@
 
     @include mq(leftCol) {
         border-top: 1px dotted $neutral-5;
-        border-bottom: 1px dotted $neutral-5;
         position: static;
         height: 36px;
         padding: $gs-baseline / 4 0;
@@ -600,9 +599,9 @@
         clear: both;
         margin-right: 0;
         display: block;
-        padding-top: $gs-baseline/6;
         border-top: 1px dotted $neutral-5;
         box-sizing: border-box;
+        padding-top: $gs-baseline/6;
         padding-bottom: $gs-baseline;
         min-height: $gs-baseline*4;
     }
@@ -1022,12 +1021,6 @@
     }
 }
 
-.meta__body {
-    @include mq(leftCol) {
-        clear: left;
-    }
-}
-
 .content__meta-heading {
     @include fs-header(1);
     padding-top: ($gs-baseline/3);
@@ -1040,6 +1033,12 @@
     position: relative;
     clear: both;
     min-height: 45px;
+    border-top: 1px dotted $neutral-5;
+    border-bottom: 1px dotted $neutral-5;
+
+    @include mq(leftCol) {
+        border: 0;
+    }
 
     .content__head--crossword & {
         clear: none;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -468,10 +468,6 @@
         overflow: hidden;
         background-color: $neutral-7;
 
-        // fixes for webkit not properly scaling/clipping the child element (still broken on some android browsers...)
-        -webkit-transform: translateZ(0);
-        -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
-
         @include mq(leftCol) {
             width: gs-span(2);
             height: gs-span(2); //This is intentionally square

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -496,7 +496,9 @@
     }
 
     .meta__image {
-        border-top: 1px dotted $neutral-5;
+        @include mq(leftCol) {
+            border-top: 1px dotted $neutral-5;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?
As part of the article refresh, bylines should go below social shares. 

## What is the value of this and can you measure success?
It is part of a series of changes with the aim to make an entire article page look better

## Does this affect other platforms - Amp, Apps, etc?
It does affect AMP as well

## Screenshots
BEFORE:
![image](https://cloud.githubusercontent.com/assets/8774970/22377132/97ccffa8-e4a8-11e6-9516-6634d6035587.png)

<img width="400" src="https://cloud.githubusercontent.com/assets/8774970/22377123/8e455aca-e4a8-11e6-8a8e-4100e68c088c.png"/>

AFTER:
![image](https://cloud.githubusercontent.com/assets/8774970/22377037/4bb87aa2-e4a8-11e6-81f9-24e2f3539e24.png)

<img width="400" src="https://cloud.githubusercontent.com/assets/8774970/22377063/5c557f7c-e4a8-11e6-8087-b1f1a2e01092.png"/>


## Tested in CODE?
Nope