### PR TITLE
Expanded meta at desktop breakpoints

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -722,7 +722,7 @@ $caption-button-size: 32px;
 
     // When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
     // TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
-    .content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live) {
+    .content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live, .tonal__head--tone-media) {
         @include mq($until: mobileLandscape) {
             margin-right: -$gs-gutter / 2;
             margin-left: -$gs-gutter / 2;

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -145,9 +145,7 @@ category: Common
 
 .social--expanded-top {
     position: absolute;
-    padding-left: $gs-gutter/4;
-    padding-right: calc(#{$gs-gutter/4} - 3px);
-    left: -$gs-gutter/4;
+    left: 0;
     height: auto;
     background: #ffffff;
     z-index: $zindex-popover;
@@ -155,20 +153,17 @@ category: Common
     display: inline-block;
     clear: both;
     box-sizing: border-box;
-    border-bottom: 1px dotted $neutral-4;
 
     @include mq($until: mobileLandscape) {
         right: 0;
     }
 
-    @include mq(tablet) {
-        padding-left: $gs-gutter/2;
-        padding-right: calc(#{$gs-gutter/2} - 3px);
-        left: -$gs-gutter/2;
+    @include mq($from: desktop) {
+        min-width: gs-span(2);
     }
 
-    @include mq($from: leftCol) {
-        min-width: 227px;
+    @include mq($from: wide) {
+        min-width: gs-span(3);
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -1273,14 +1273,16 @@
 
     .meta__social {
         .social--expanded-top {
-            background-color: $neutral-1;
+            background-color: $multimedia-support-5;
+            border-color: $neutral-1;
+            padding-bottom: 1px;
         }
 
         .social__tray-close .inline-close {
-            background-color: darken($neutral-1, 5%);
+            background-color: $neutral-1;
 
             &:hover {
-                background-color: $multimedia-support-5;
+                background-color: $neutral-2;
             }
 
             svg {

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -237,7 +237,7 @@
         position: relative;
         border: 0 none;
         height: auto;
-        padding: $gs-baseline/2 0;
+        padding: $gs-baseline/2 0 0;
     }
 
     .meta__number {


### PR DESCRIPTION
Desktop breakpoints of expanded meta are cleaners now.

I also fixed a bug with gallery standfirsts touching the edge of the page with the new header.

<img width="562" alt="screen shot 2017-01-27 at 16 15 10" src="https://cloud.githubusercontent.com/assets/14570016/22378085/2e74488c-e4ac-11e6-9e83-366d230debd6.png">
<img width="477" alt="screen shot 2017-01-27 at 16 15 17" src="https://cloud.githubusercontent.com/assets/14570016/22378084/2e6fa138-e4ac-11e6-9efa-507400a3b66a.png">
