### PR TITLE
Fix exception when fixed/video container is used with atom media video page

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -40,33 +40,41 @@
         @containerDefinition.collectionEssentials.items.filter(_.header.isVideo).zipWithIndex.map { case (item, index) =>
             <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
                 @item.properties.maybeContent.map { content =>
-                    @defining(VideoPlayer(
-                        content.elements.mainVideo.get,
-                        Video640,
-                        item,
-                        autoPlay = false,
-                        showControlsAtStart = false,
-                        path = Some(content.metadata.id)
-                    )) { player =>
-                        <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
-                            <div class="fc-item__video-container">
-                                @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
-                            </div>
-                        </div>
-                        <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                            <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
-                            <div class="fc-item__media-wrapper">
-                                <div class="fc-item__image-container u-responsive-ratio inlined-image">
-                                @InlineImage.fromFaciaContent(item).map { fallbackImage =>
-                                    <img
-                                        @if(index > 1){data-}src="@Video700.bestFor(fallbackImage.imageMedia)" class="js-video-playlist-image js-video-playlist-image--@{index}" />
-                                }
+                    @content.elements.mainVideo match { case None =>
+                        case Some(mainVideo) => {
+                            @defining(VideoPlayer(
+                                mainVideo,
+                                Video640,
+                                item,
+                                autoPlay = false,
+                                showControlsAtStart = false,
+                                path = Some(content.metadata.id)
+                            )) { player =>
+                                <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
+                                    <div class="fc-item__video-container">
+                                        @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
+                                    </div>
                                 </div>
-                            </div>
-                        </div>
+                                <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
+                                    <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                                    <div class="fc-item__media-wrapper">
+                                        <div class="fc-item__image-container u-responsive-ratio inlined-image">
+                                        @InlineImage.fromFaciaContent(item).map { fallbackImage =>
+                                            <img
+                                            @if(index > 1) {data-}src="@Video700.bestFor(fallbackImage.imageMedia)" class="js-video-playlist-image js-video-playlist-image--@{
+                                            index
+                                        }" />
+                                        }
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                        }
                     }
                 }
             </li>
         }
     </ul>
 </div>
+
+


### PR DESCRIPTION
## What does this change?
The `fixed/video` container previously made an assumption that content with `type/video` tag contains a video element main media. This is not true in the case of Atom powered video pages, so when one was was added the container would throw an exception when `content.elements.mainVideo.get` was attempted.

This fix stops the exception but does leave a blank space in the container. Ideally we would filter out these unsupported items from the container, however, I thought it important to put something out to fix the exception in the first instance.

## What is the value of this and can you measure success?
Fix possible exception

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
#### Before
![screen shot 2017-01-27 at 11 40 57](https://cloud.githubusercontent.com/assets/1764158/22378292/0d256674-e4ad-11e6-9504-6cb68001c782.png)
#### After
<img width="1101" alt="screen shot 2017-01-27 at 16 29 17" src="https://cloud.githubusercontent.com/assets/1764158/22378531/d30a44c2-e4ad-11e6-9e15-cbb47984b6d9.png">


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
