### PR TITLE
config.page property should be hasYouTubeAtom not hasYouTubeMediaAtom

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
@@ -382,7 +382,7 @@ define([
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
             !config.page.hasMultipleVideosInPage &&
-            !config.page.hasYouTubeMediaAtom &&
+            !config.page.hasYouTubeAtom &&
             !config.page.isFront &&
             !config.page.isAdvertisementFeature &&
             !config.page.sponsorshipType;


### PR DESCRIPTION
## What does this change?

config.page property should be hasYouTubeAtom not hasYouTubeMediaAtom, incorrectly referencing hasYouTubeMediaAtom means the ima3.js bug still occurs.

## What is the value of this and can you measure success?

Should fix ima3.js bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No

@akash1810 