### PR TITLE
Fixing the occasional case of a double headline appearing on amp

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -39,7 +39,7 @@
                 @fragments.guBand()
             }
 
-            @if(!mvt.ABNewNavVariantSeven.isParticipating) {
+            @if(!mvt.ABNewNavVariantSeven.isParticipating || amp) {
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
                 @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
@@ -70,7 +70,7 @@
                             @fragments.mainMedia(article, amp)
                         }
 
-                        @if(mvt.ABNewNavVariantSeven.isParticipating) {
+                        @if(mvt.ABNewNavVariantSeven.isParticipating && !amp) {
                             <div class="mobile-only">
                                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
                             </div>


### PR DESCRIPTION
## What does this change?
Fixes: https://trello.com/c/8xV4abkp/199-amp-headline-standfirst-doubling-up-intermittent

If you are in the serverside test `ABNewNavVariantSeven` and on an AMP page you may occasionally see a double headline. This is because in the test the html for the headline is presented twice (can't use flexbox to reposition headline because of how the html is structured). On the site we have a lot of helper classes in css to only show certain things on mobile vs desktop, on AMP we don't have as many of those helper classes which is why both headlines show.

This is an intermittent issue because most of the pages are cached correctly. 


## What is the value of this and can you measure success?
Fixing a 🐛 

## Does this affect other platforms - Amp, Apps, etc?
This should only affect AMP

## Screenshots
Before:
<img width="400" src="https://cloud.githubusercontent.com/assets/8774970/22421119/90ef50d2-e6dd-11e6-820a-0e0ae9a81619.png"/>

After:
<img width="400" src="https://cloud.githubusercontent.com/assets/8774970/22421078/64c07e14-e6dd-11e6-9bcd-a68c190026b7.png"/>

## Tested in CODE?
No
