### PR TITLE
Membership bundles AB test - revised variants

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
@@ -76,12 +76,6 @@ define([
 
         this.variants = [
             {
-                id: 'A1',
-                test: function () {
-                    self.setup('A1')
-                }
-            },
-            {
                 id: 'B1',
                 test: function () {
                     self.setup('B1');


### PR DESCRIPTION
## What does this change?
Drop the A1 variant from the AB test defined [here](https://github.com/guardian/frontend/pull/15661)

## What is the value of this and can you measure success?
We need to make some changes to the bundle definitions, but in the meantime we can continue with data gathering for the other variants (B1 and B2).

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
N/A

## Tested in CODE?
~~Not yet. Need a build first!~~ Yes. Looks fine.

cc @svillafe @Ap0c 

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
