### PR TITLE
Make closed discussion long cache change permanent

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -56,16 +56,6 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  val LongCacheCommentsSwitch = Switch(
-    SwitchGroup.Performance,
-    "long-cache-comments-switch",
-    "If this switch is on then closed comment threads will get a longer cache time",
-    owners = Seq(Owner.withGithub("jfsoul")),
-    safeState = On,
-    sellByDate = new LocalDate(2017, 2, 1),
-    exposeClientSide = false
-  )
-
   val interactivePressing = Switch(
     SwitchGroup.Performance,
     "interactive-pressing",

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -24,6 +24,8 @@ object CacheTime {
   object ArchiveRedirect extends CacheTime(300)
   object ShareCount extends CacheTime(600)
   object NotFound extends CacheTime(10) // This will be overwritten by fastly
+  object DiscussionDefault extends CacheTime(60)
+  object DiscussionClosed extends CacheTime(3800)
 
   def LastDayUpdated = CacheTime(extended(60))
   def NotRecentlyUpdated = CacheTime(extended(300))


### PR DESCRIPTION
## What does this change?
Removes the switch controlling longer cache TTL on closed discussion threads.  I've turned this switch on and there seem to be about half the number of requests coming through for closed discussion threads.  Planning to keep an eye on this for the rest of the day, just to be extra safe and then merge tomorrow.

I would also advocate increasing this cache length even further in the future (24 hours or longer).  Leaving as is for now.

## What is the value of this and can you measure success?
Less requests to discussion for content that doesn't change.

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
