### PR TITLE
Make membership banner show on third article ... everywhere

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -41,7 +41,7 @@ define([
         var messageCode = 'engagement-banner-2017-01-11';
 
         var baseParams = {
-            minArticles: 10,
+            minArticles: 3,
             colourStrategy: function() {
                 return 'membership-prominent ' + selectSequentiallyFrom(['yellow', 'purple', 'bright-blue', 'dark-blue']);
             }
@@ -80,8 +80,7 @@ define([
             INT: {
                 membership: {
                     messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for $7 / €5 a month.',
-                    campaignCode: "mem_int_banner",
-                    minArticles: 3
+                    campaignCode: "mem_int_banner"
                 }
             }
         };


### PR DESCRIPTION
## What does this change?
This PR makes the membership banner show on the users  third article across all regions.
It previously showed their 10th article, expect in Rest of World, where it showed on their 3rd article :world_map: 
Once the banner is dismissed, it never shows again, as per the current behavior. ❌ 


## What is the value of this and can you measure success?
Our AB testing showed a 48% increase in membership acquisitions when displayed on the 3rd article.
 📈 
## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
Yep!

@guardian/dotcom-platform @guardian/contributions 
