### PR TITLE
Filter fixed/video container to only show items with Main Media Video Element

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -1,5 +1,6 @@
 package model.pressed
 
+import com.gu.contentapi.client.model.v1.ElementType
 import com.gu.facia.api.utils.FaciaContentUtils
 import com.gu.facia.api.{models => fapi, utils => fapiutils}
 import com.gu.facia.client.models.{Backfill, Branded, CollectionConfigJson, Metadata}
@@ -181,7 +182,8 @@ object PressedCardHeader {
       isGallery = FaciaContentUtils.isGallery(content),
       seriesOrBlogKicker = capiContent.flatMap(item =>
         fapiutils.ItemKicker.seriesOrBlogKicker(item).map(ItemKicker.makeTagKicker)),
-      url = capiContent.map(SupportedUrl(_)).getOrElse(FaciaContentUtils.id(content))
+      url = capiContent.map(SupportedUrl(_)).getOrElse(FaciaContentUtils.id(content)),
+      hasMainVideoElement = capiContent.flatMap(_.elements).exists(_.exists(e => e.`type` == ElementType.Video && e.relation == "main"))
     )
   }
 }
@@ -194,7 +196,8 @@ final case class PressedCardHeader(
   kicker: Option[ItemKicker],
   seriesOrBlogKicker: Option[TagKicker],
   headline: String,
-  url: String
+  url: String,
+  hasMainVideoElement: Boolean
 )
 
 object PressedDisplaySettings {

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -183,7 +183,7 @@ object PressedCardHeader {
       seriesOrBlogKicker = capiContent.flatMap(item =>
         fapiutils.ItemKicker.seriesOrBlogKicker(item).map(ItemKicker.makeTagKicker)),
       url = capiContent.map(SupportedUrl(_)).getOrElse(FaciaContentUtils.id(content)),
-      hasMainVideoElement = capiContent.flatMap(_.elements).exists(_.exists(e => e.`type` == ElementType.Video && e.relation == "main"))
+      hasMainVideoElement = Some(capiContent.flatMap(_.elements).exists(_.exists(e => e.`type` == ElementType.Video && e.relation == "main")))
     )
   }
 }
@@ -197,7 +197,7 @@ final case class PressedCardHeader(
   seriesOrBlogKicker: Option[TagKicker],
   headline: String,
   url: String,
-  hasMainVideoElement: Boolean
+  hasMainVideoElement: Option[Boolean]
 )
 
 object PressedDisplaySettings {

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -37,43 +37,41 @@
             @treats(containerDefinition, frontProperties)
         </li>
 
-        @containerDefinition.collectionEssentials.items.filter(_.header.isVideo).zipWithIndex.map { case (item, index) =>
-            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
+        @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo && i.header.hasMainVideoElement).zipWithIndex.map { case (item, index) =>
+           <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
                 @item.properties.maybeContent.map { content =>
-                    @content.elements.mainVideo match { case None =>
-                        case Some(mainVideo) => {
-                            @defining(VideoPlayer(
-                                mainVideo,
-                                Video640,
-                                item,
-                                autoPlay = false,
-                                showControlsAtStart = false,
-                                path = Some(content.metadata.id)
-                            )) { player =>
-                                <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
-                                    <div class="fc-item__video-container">
-                                        @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
-                                    </div>
+                    @content.elements.mainVideo.map { mainVideo =>
+                        @defining(VideoPlayer(
+                            mainVideo,
+                            Video640,
+                            item,
+                            autoPlay = false,
+                            showControlsAtStart = false,
+                            path = Some(content.metadata.id)
+                        )) { player =>
+                        <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
+                            <div class="fc-item__video-container">
+                            @video(player, enhance = false, showEndSlate = false, showOverlay = true, showPoster = false)
+                            </div>
+                        </div>
+                        <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
+                            <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                            <div class="fc-item__media-wrapper">
+                                <div class="fc-item__image-container u-responsive-ratio inlined-image">
+                                @InlineImage.fromFaciaContent(item).map { fallbackImage =>
+                                    <img
+                                    @if(index > 1) {data-}src="@Video700.bestFor(fallbackImage.imageMedia)" class="js-video-playlist-image js-video-playlist-image--@{
+                                    index
+                                }" />
+                                }
                                 </div>
-                                <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                                    <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
-                                    <div class="fc-item__media-wrapper">
-                                        <div class="fc-item__image-container u-responsive-ratio inlined-image">
-                                        @InlineImage.fromFaciaContent(item).map { fallbackImage =>
-                                            <img
-                                            @if(index > 1) {data-}src="@Video700.bestFor(fallbackImage.imageMedia)" class="js-video-playlist-image js-video-playlist-image--@{
-                                            index
-                                        }" />
-                                        }
-                                        </div>
-                                    </div>
-                                </div>
-                            }
-                        }
+                            </div>
+                        </div>
                     }
                 }
             </li>
         }
+      }
     </ul>
 </div>
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -37,7 +37,7 @@
             @treats(containerDefinition, frontProperties)
         </li>
 
-        @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo && i.header.hasMainVideoElement).zipWithIndex.map { case (item, index) =>
+        @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo && i.header.hasMainVideoElement.exists(identity)).zipWithIndex.map { case (item, index) =>
            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
                 @item.properties.maybeContent.map { content =>
                     @content.elements.mainVideo.map { mainVideo =>

--- a/common/test/common/commercial/FixtureBuilder.scala
+++ b/common/test/common/commercial/FixtureBuilder.scala
@@ -38,7 +38,8 @@ object FixtureBuilder {
       kicker,
       seriesOrBlogKicker = None,
       headline = "",
-      url = ""
+      url = "",
+      hasMainVideoElement = false
     )
 
     def mkCard(): PressedCard = PressedCard(

--- a/common/test/common/commercial/FixtureBuilder.scala
+++ b/common/test/common/commercial/FixtureBuilder.scala
@@ -39,7 +39,7 @@ object FixtureBuilder {
       seriesOrBlogKicker = None,
       headline = "",
       url = "",
-      hasMainVideoElement = false
+      hasMainVideoElement = None
     )
 
     def mkCard(): PressedCard = PressedCard(


### PR DESCRIPTION
## What does this change?
Filter video pages without Main Video Element from appearing in `fixed/video` container.

## What is the value of this and can you measure success?
Removes blank space when non Elements style video page is added

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
Before

<img width="1229" alt="screen shot 2017-01-30 at 14 31 09" src="https://cloud.githubusercontent.com/assets/1764158/22427013/6514578e-e6f9-11e6-9f0a-4764b1e4d2cc.png">

After
<img width="1226" alt="screen shot 2017-01-30 at 14 32 34" src="https://cloud.githubusercontent.com/assets/1764158/22427023/6c004b48-e6f9-11e6-9ac2-8feb24aa3838.png">



## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
