### PR TITLE
Remove NPE on adblock detection under phantomJS

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -28,7 +28,9 @@ try {
                 var adStyles = window.getComputedStyle(ad);
 
                 // Due to an update to AdblockPlus we now need an extra check for adblock being used on Firefox as the sacrificial ad check does not work.
-                adBlockers.active = adStyles.getPropertyValue('display') === 'none'|| adStyles.getPropertyValue('-moz-binding').indexOf('about:')!== -1;
+                var displayProp = adStyles.getPropertyValue('display');
+                var mozBindingProp = adStyles.getPropertyValue('-moz-binding');
+                adBlockers.active = displayProp === 'none' || (mozBindingProp !== null && mozBindingProp.indexOf('about:') !== -1);
 
                 // Run each listener
                 runEachListener(adBlockers.onDetect);

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -30,7 +30,7 @@ try {
                 // Due to an update to AdblockPlus we now need an extra check for adblock being used on Firefox as the sacrificial ad check does not work.
                 var displayProp = adStyles.getPropertyValue('display');
                 var mozBindingProp = adStyles.getPropertyValue('-moz-binding');
-                adBlockers.active = displayProp === 'none' || (mozBindingProp !== null && mozBindingProp.indexOf('about:') !== -1);
+                adBlockers.active = displayProp === 'none' || (mozBindingProp && mozBindingProp.indexOf('about:') !== -1);
 
                 // Run each listener
                 runEachListener(adBlockers.onDetect);


### PR DESCRIPTION
## What does this change?

Small tweak to fix an NPE exception generated by the adblocker detection code, where 'adStyles.getPropertyValue('-moz-binding')' returns null and is then dereferenced.

## What is the value of this and can you measure success?

This should remove one of the exceptions from the PRBuilds thrown-exceptions.txt file, reducing noise for devs.

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
