### PR TITLE
Retry CSS parsing on failure

### DIFF
--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -4,14 +4,15 @@ import java.io.StringReader
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import com.steadystate.css.parser.{SACParserCSS3, CSSOMParser}
+import com.steadystate.css.parser.{CSSOMParser, SACParserCSS3}
 import org.w3c.css.sac.InputSource
-import org.w3c.dom.css.{CSSRule => W3CSSRule, CSSRuleList}
+import org.w3c.dom.css.{CSSRuleList, CSSRule => W3CSSRule}
+import play.api.Logger
 import play.twirl.api.Html
 
 import scala.collection.JavaConversions._
 import scala.collection.immutable.ListMap
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 case class CSSRule(selector: String, styles: ListMap[String, String]) {
   val canInline = !selector.contains(":")
@@ -93,6 +94,28 @@ object InlineStyles {
   }
 
   /**
+    * Execute some code n times, or until no exception is thrown
+    * (If n is 0, code still gets executed once)
+    */
+  def retry[T](n: Int)(r: => T)(implicit onFail: (Throwable, Int) => Unit) = {
+    def go(i: Int): Try[T] = {
+      Try(r) match {
+        case Failure(e) if i < n => {
+          onFail(e, i)
+          go(i + 1)
+        }
+        case f@Failure(e) => {
+          onFail(e, i)
+          f
+        }
+        case s@Success(v) => s
+      }
+    }
+
+    go(1)
+  }
+
+  /**
     * Convert the styles in a document's <style> tags to a pair.
     * The first item is the styles that should stay in the head, the second is everything that should be inlined.
     */
@@ -100,14 +123,19 @@ object InlineStyles {
     document.getElementsByTag("style").foldLeft((Seq.empty[CSSRule], Seq.empty[String])) { case ((inline, head), element) =>
       val source = new InputSource(new StringReader(element.html))
 
-      Try(cssParser.parseStyleSheet(source, null, null)).toOption map { sheet =>
-        val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
-        val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
-        val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
+      retry(3)(cssParser.parseStyleSheet(source, null, null)) { (e: Throwable, i: Int) =>
+        Logger.error(s"Attempt ${i} to parse stylesheet failed", e)
+      } match {
+        case Failure(exception) => {
+          (inline, head :+ element.html)
+        }
+        case Success(sheet) => {
+          val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
+          val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
+          val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
 
-        (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
-      } getOrElse {
-        (inline, head :+ element.html)
+          (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
+        }
       }
     }
   }

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -103,8 +103,8 @@ object InlineStyles {
     document.getElementsByTag("style").foldLeft((Seq.empty[CSSRule], Seq.empty[String])) { case ((inline, head), element) =>
       val source = new InputSource(new StringReader(element.html))
 
-      Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (e: Throwable, i: Int) =>
-        Logger.error(s"Attempt ${i} to parse stylesheet failed", e)
+      Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
+        Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
       } match {
         case Failure(exception) => {
           (inline, head :+ element.html)

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -106,16 +106,14 @@ object InlineStyles {
       Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
         Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
       } match {
-        case Failure(exception) => {
+        case Failure(exception) =>
           (inline, head :+ element.html)
-        }
-        case Success(sheet) => {
+        case Success(sheet) =>
           val (styles, others) = seq(sheet.getCssRules).partition(isStyleRule)
           val (inlineStyles, headStyles) = styles.flatMap(CSSRule.fromW3).flatten.partition(_.canInline)
           val newHead = (headStyles.map(_.toString) ++ others.map(_.getCssText)).mkString("\n")
 
           (inline ++ inlineStyles, (head :+ newHead).filter(_.nonEmpty))
-        }
       }
     }
   }

--- a/common/app/common/Retry.scala
+++ b/common/app/common/Retry.scala
@@ -10,15 +10,13 @@ object Retry {
   def apply[T](n: Int)(r: => T)(implicit onFail: (Throwable, Int) => Unit) = {
     def go(i: Int): Try[T] = {
       Try(r) match {
-        case Failure(e) if i < n => {
+        case Failure(e) if i < n =>
           onFail(e, i)
           go(i + 1)
-        }
-        case f@Failure(e) => {
+        case f @ Failure(e) =>
           onFail(e, i)
           f
-        }
-        case s@Success(v) => s
+        case s: Success[T] => s
       }
     }
 

--- a/common/app/common/Retry.scala
+++ b/common/app/common/Retry.scala
@@ -7,7 +7,7 @@ object Retry {
     * Execute some code n times, or until no exception is thrown
     * (If n is 0, code still gets executed once)
     */
-  def apply[T](n: Int)(r: => T)(implicit onFail: (Throwable, Int) => Unit) = {
+  def apply[T](n: Int)(r: => T)(onFail: (Throwable, Int) => Unit) = {
     def go(i: Int): Try[T] = {
       Try(r) match {
         case Failure(e) if i < n =>

--- a/common/app/common/Retry.scala
+++ b/common/app/common/Retry.scala
@@ -1,0 +1,27 @@
+package common
+
+import scala.util.{Failure, Success, Try}
+
+object Retry {
+  /**
+    * Execute some code n times, or until no exception is thrown
+    * (If n is 0, code still gets executed once)
+    */
+  def apply[T](n: Int)(r: => T)(implicit onFail: (Throwable, Int) => Unit) = {
+    def go(i: Int): Try[T] = {
+      Try(r) match {
+        case Failure(e) if i < n => {
+          onFail(e, i)
+          go(i + 1)
+        }
+        case f@Failure(e) => {
+          onFail(e, i)
+          f
+        }
+        case s@Success(v) => s
+      }
+    }
+
+    go(1)
+  }
+}

--- a/common/test/common/InlineStylesTest.scala
+++ b/common/test/common/InlineStylesTest.scala
@@ -3,8 +3,8 @@ package common
 import org.jsoup.Jsoup
 import org.scalatest.{FlatSpec, Matchers}
 import play.twirl.api.Html
+
 import scala.collection.immutable.ListMap
-import scala.util.{Failure, Success, Try}
 
 class InlineStylesTest extends FlatSpec with Matchers {
   val stub: ListMap[String, String] = ListMap.empty
@@ -116,34 +116,5 @@ class InlineStylesTest extends FlatSpec with Matchers {
     // !important styles should end up on the right so expect "padding: 1px" and "color: red" to be on the right
 
     inlinedDocument.getElementById("h1").attr("style") should be("margin: 1px; border: 1px; padding: 1px; color: red")
-  }
-
-  implicit val onFail = (x: Throwable, y: Int) => ()
-
-  "retry" should "execute code once even if n is 0" in {
-    InlineStyles.retry(0)("hello") should be(Success("hello"))
-  }
-
-  it should "execute failing code n times" in {
-    var n = 0
-    val e = new Exception("problem")
-
-    InlineStyles.retry(3) {
-      n = n + 1
-      throw e
-    } should be(Failure(e))
-
-    n should be(3)
-  }
-
-  it should "only execute code once if it immediately succeeds" in {
-    var n = 0
-
-    InlineStyles.retry(3) {
-      n = n + 1
-      "hello"
-    } should be(Success("hello"))
-
-    n should be(1)
   }
 }

--- a/common/test/common/Retry.scala
+++ b/common/test/common/Retry.scala
@@ -1,0 +1,35 @@
+package common
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.util.{Failure, Success}
+
+class RetryTest extends FlatSpec with Matchers  {
+  val onFail = (x: Throwable, y: Int) => ()
+
+  it should "execute code once even if n is 0" in {
+    Retry(0)("hello")(onFail) should be(Success("hello"))
+  }
+
+  it should "execute failing code n times" in {
+    var n = 0
+    val e = new Exception("problem")
+
+    Retry(3) {
+      n = n + 1
+      throw e
+    }(onFail) should be(Failure(e))
+
+    n should be(3)
+  }
+
+  it should "only execute code once if it immediately succeeds" in {
+    var n = 0
+
+    Retry(3) {
+      n = n + 1
+      "hello"
+    }(onFail) should be(Success("hello"))
+
+    n should be(1)
+  }
+}


### PR DESCRIPTION
We have an intermittent bug (it's occurred twice now, as far as we know, but I can't reproduce it) which seems to be caused by an exception thrown from within `.parseStyleSheet`. Thanks to `Try`, the exception is swallowed and the fallback behaviour results in lots of the styles remaining in the `<head>` when they should be inlined - meaning the email looks horrific in Gmail.

I've added in some logging if parsing fails, so we can get some extra info from the logs if it ever happens again. I've also added in some retry logic, so it will make 3 attempts to parse if parsing fails. If the failure is some strange transient kind of error, there's a slim chance that trying again might succeed and mean we at least avoid sending out an ugly email. In any case, any failed attempts will be logged.