### PR TITLE
set caption--main class on media atom main media

### DIFF
--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -4,8 +4,8 @@
 @{
     media match {
             case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mainMedia = mainMedia, amp = amp,picture = media.posterImage.get, caption = media.title)
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mainMedia) else views.html.fragments.atoms.youtube(media, displayCaption, embedPage, displayEndSlate)
-            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
+            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media = media, displayCaption = displayCaption, mainMedia = mainMedia) else views.html.fragments.atoms.youtube(media = media, displayCaption = displayCaption, embedPage = embedPage, displayEndSlate = displayEndSlate, mainMedia = mainMedia)
+            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media = media, displayCaption = displayCaption, amp = amp)
             case _ =>
         }
 }

--- a/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
+++ b/common/app/views/fragments/atoms/mediaAtomCaption.scala.html
@@ -4,7 +4,6 @@
 <figcaption class="@RenderClasses(Map(
     "caption" -> true,
     "caption--img" -> true,
-    "caption--media-atom" -> true,
     "caption--main" -> mainMedia))"
 itemprop="description">
     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon", "rounded-icon"))

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false)(implicit request: RequestHeader)
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
@@ -50,6 +50,6 @@
     </div>
 
     @if(displayCaption) {
-        @mediaAtomCaption(media.title)
+        @mediaAtomCaption(media.title, mainMedia)
     }
 


### PR DESCRIPTION
## What does this change?
Pass `mainMedia` attribute to `youtube` template caption, so that it inherits the corrects style.

## What is the value of this and can you measure success?
Consistent styling across elements

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
Before
<img width="345" alt="screen shot 2017-01-31 at 12 43 34" src="https://cloud.githubusercontent.com/assets/1764158/22465605/72d4af2a-e7b4-11e6-879f-01d1ea92db8c.png">
After
<img width="342" alt="screen shot 2017-01-31 at 12 42 43" src="https://cloud.githubusercontent.com/assets/1764158/22465613/7d4adb3c-e7b4-11e6-96e6-8d19038f527f.png">


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
