### PR TITLE
Extend live blog notifications switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -483,7 +483,7 @@ trait FeatureSwitches {
     "Live blog chrome notifications - prod",
     owners = Seq(Owner.withGithub("janua")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 1),
+    sellByDate = new LocalDate(2017, 4, 5),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Just extending the live blog notifications switch until we decide what to do with the feature.

P.s. 5th April is a Wednesday.

cc: @guardian/dotcom-platform 
