### PR TITLE
Amend supporter bundles thrasher AB test audience

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
@@ -17,7 +17,7 @@ define([
         this.author = 'Justin Pinner';
         this.description = 'Test appetite for membership bundles';
         this.showForSensitive = true;
-        this.audience = 0.05;  // 5% ~ 7,000 unique browser thrasher views per variant per day
+        this.audience = 0.09;  // 9% ~ 45,000 thrasher impressions per variant per day
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'People on UK network front with at least an 1140px wide display.';


### PR DESCRIPTION
## What does this change?
Increase audience capture size from 1.6% to 3% per variant as we're not seeing enough click-throughs to attain statistical significance in a useful timeframe.

## What is the value of this and can you measure success?
The test will need to run for too long to arrive at a meaningful conclusion at its current rate.

We're able to tweak the participation numbers as we're sampling a random audience, so that won't invalidate the data we've already captured.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
See https://github.com/guardian/frontend/pull/15661

## Tested in CODE?
~~Not yet.~~ ~~In progress.~~ Yes.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
