### PR TITLE
Expand ad slot for outstream ads

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
@@ -83,6 +83,12 @@ define([
         });
     };
 
+    sizeCallbacks[adSizes.video2] = function (_, advert) {
+        fastdom.write(function () {
+            advert.node.classList.add('ad-slot--outstream');
+        });
+    };
+
     /**
      * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
      * and their containers closed up.

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -305,6 +305,13 @@
     background-color: $paid-article-mpu;
 }
 
+.ad-slot--outstream {
+    @include mq(desktop) {
+        width: 620px;
+        height: $mpu-ad-label-height + 350px;
+    }
+}
+
 /**
  * Commercial Components
  */


### PR DESCRIPTION
The new teads remain inside the ad slot, we must make sure it can accommodate the creative by updating its dimensions.

Before:
![picture 3](https://cloud.githubusercontent.com/assets/629976/22507422/6893bb22-e87d-11e6-891f-93f9c7347ae3.jpg)

After:
![picture 2](https://cloud.githubusercontent.com/assets/629976/22507384/467444e4-e87d-11e6-9a39-7aa6ae552170.jpg)
