### PR TITLE
Adding sameAs field for reviews (Google rich card markup)

### DIFF
--- a/common/app/views/fragments/atoms/structureddata/contributor.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/contributor.scala.html
@@ -1,4 +1,5 @@
 @import model.Tag
+@import conf.Configuration
 
 @(fullName: String, contributors: Seq[Tag])(implicit request: RequestHeader)
 {
@@ -9,7 +10,7 @@
 
 @authorSameAs = @{
     val byName: Tag => Boolean = _.id.contains(fullName.toLowerCase.replaceAll("\\s", "") || fullName.toLowerCase.replaceAll("//s", "-"))
-    val guardianUrl = "https://www.theguardian.com/"
+    val guardianUrl = Configuration.site.host
     def toContributorLink: Tag => String = guardianUrl + _.id
 
     contributors

--- a/common/app/views/fragments/atoms/structureddata/contributor.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/contributor.scala.html
@@ -1,0 +1,19 @@
+@import model.Tag
+
+@(fullName: String, contributors: Seq[Tag])(implicit request: RequestHeader)
+{
+"@@type": "Person",
+@authorSameAs.map { sameAs => "sameAs": "@sameAs", }
+"name": "@fullName"
+}
+
+@authorSameAs = @{
+    val byName: Tag => Boolean = _.id.contains(fullName.toLowerCase.replaceAll("\\s", "") || fullName.toLowerCase.replaceAll("//s", "-"))
+    val guardianUrl = "https://www.theguardian.com/"
+    def toContributorLink: Tag => String = guardianUrl + _.id
+
+    contributors
+        .find(byName).map(toContributorLink)
+        .orElse(contributors.headOption.map(toContributorLink))
+        .orElse(Some(guardianUrl)) // if they don't have a contributor tag we default to the URL for the Guardian so it still renders as a rich card.
+}

--- a/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
@@ -3,6 +3,7 @@
 @import play.api.libs.json.Json
 @import play.api.libs.json.JsArray
 @import model.Tag
+@import conf.Configuration
 
 @(review: model.content.ReviewAtom, entity: Film, contributors: Seq[Tag])(implicit request: RequestHeader)
 
@@ -17,7 +18,7 @@
   "publisher": {
       "@@type":"Organization",
       "name":"The Guardian",
-      "sameAs":"https://www.theguardian.com"
+      "sameAs": "@Configuration.site.host"
   },
   "description":"@review.data.reviewSnippet",
   "inLanguage":"en",

--- a/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
@@ -2,14 +2,15 @@
 @import org.joda.time.DateTime
 @import play.api.libs.json.Json
 @import play.api.libs.json.JsArray
+@import model.Tag
 
-@(review: model.content.ReviewAtom, entity: Film)(implicit request: RequestHeader)
+@(review: model.content.ReviewAtom, entity: Film, contributors: Seq[Tag])(implicit request: RequestHeader)
 
 <script type="application/ld+json">
 {
   "@@context":"http://schema.org",
   "@@type":"Review",
-  "author": @fragments.atoms.structureddata.person(review.data.reviewer),
+  "author": @fragments.atoms.structureddata.contributor(review.data.reviewer, contributors),
   @review.data.sourceArticleId.map { articleId => "url" : s"https://www.theguardian.com/${articleId}",}
   @review.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
   @review.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}

--- a/common/app/views/fragments/atoms/structureddata/gameReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/gameReview.scala.html
@@ -1,7 +1,8 @@
 @import com.gu.contententity.thrift.entity.game.Game
 @import org.joda.time.DateTime
+@import model.Tag
 
-@(review: model.content.ReviewAtom, entity: Game)(implicit request: RequestHeader)
+@(review: model.content.ReviewAtom, entity: Game, contributors: Seq[Tag])(implicit request: RequestHeader)
 
 <script type="application/ld+json">
 {
@@ -25,7 +26,7 @@
   },
 
   "name": "@entity.title",
-  "author": @{fragments.atoms.structureddata.person(review.data.reviewer)},
+  "author": @{fragments.atoms.structureddata.contributor(review.data.reviewer, contributors)},
   "reviewBody": "@review.data.reviewSnippet",
   "publisher": {
     "@@type": "Organization",

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -1,7 +1,9 @@
-@(recipe: model.content.RecipeAtom)(implicit request: RequestHeader)
 @import play.api.libs.json.Json
 @import views.support.{ImgSrc, GoogleStructuredData}
 @import org.joda.time.DateTime
+@import model.Tag
+
+@(recipe: model.content.RecipeAtom, contributors: Seq[Tag])(implicit request: RequestHeader)
 
 <script type="application/ld+json">
      {
@@ -10,7 +12,7 @@
       "name": "@recipe.data.title",
       @for(category <- recipe.data.tags.category) {"recipeCategory": "@category",}
       @recipe.data.images.headOption.map {img => "image": "@imgValue(img)",}
-      @recipe.data.credits.headOption.map { name => "author": @fragments.atoms.structureddata.person(name),}
+      @recipe.data.credits.headOption.map { name => "author": @fragments.atoms.structureddata.contributor(name, contributors),}
       @recipe.atom.contentChangeDetails.created.map { created => "dateCreated": "@{new DateTime(created.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}

--- a/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
@@ -1,12 +1,13 @@
 @import org.joda.time.DateTime
 @import com.gu.contententity.thrift.entity.restaurant.Restaurant
+@import model.Tag
 
-@(review: model.content.ReviewAtom, entity: Restaurant)(implicit request: RequestHeader)
+@(review: model.content.ReviewAtom, entity: Restaurant, contributors: Seq[Tag])(implicit request: RequestHeader)
 <script type="application/ld+json">
 {
   "@@context":"http://schema.org",
   "@@type":"Review",
-  "author": @fragments.atoms.structureddata.person(review.data.reviewer),
+  "author": @fragments.atoms.structureddata.contributor(review.data.reviewer, contributors),
   @review.data.sourceArticleId.map { articleId => "url": "https://www.theguardian.com/@articleId", }
   @review.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
   @review.atom.contentChangeDetails.lastModified.map { modified => "dateModified": "@{new DateTime(modified.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}

--- a/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
@@ -1,6 +1,7 @@
 @import org.joda.time.DateTime
 @import com.gu.contententity.thrift.entity.restaurant.Restaurant
 @import model.Tag
+@import conf.Configuration
 
 @(review: model.content.ReviewAtom, entity: Restaurant, contributors: Seq[Tag])(implicit request: RequestHeader)
 <script type="application/ld+json">
@@ -14,7 +15,7 @@
   "publisher": {
       "@@type":"Organization",
       "name":"The Guardian",
-      "sameAs":"https://www.theguardian.com"
+      "sameAs":"@Configuration.site.host"
   },
   "description":"@review.data.reviewSnippet",
   "inLanguage":"en",

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -171,13 +171,13 @@
 *@
 @Page.getContentPage(page).map(_.item).map { item =>
     @for(recipe <- item.content.atoms.map(_.recipes).getOrElse(Nil)) {
-        @fragments.atoms.structureddata.recipe(recipe)
+        @fragments.atoms.structureddata.recipe(recipe, item.tags.contributors)
     }
 
     @for(review <- item.content.atoms.map(_.reviews).getOrElse(Nil)) {
-        @review.data.game.map { game => @fragments.atoms.structureddata.gameReview(review, game) }
-        @review.data.film.map { film => @fragments.atoms.structureddata.filmReview(review, film) }
-        @review.data.restaurant.map { restaurant => @fragments.atoms.structureddata.restaurant.restaurantReview(review, restaurant) }
+        @review.data.game.map { game => @fragments.atoms.structureddata.gameReview(review, game, item.tags.contributors) }
+        @review.data.film.map { film => @fragments.atoms.structureddata.filmReview(review, film, item.tags.contributors) }
+        @review.data.restaurant.map { restaurant => @fragments.atoms.structureddata.restaurant.restaurantReview(review, restaurant, item.tags.contributors) }
     }
 
     @* add here another atom (organisations, people, events, ...) *@


### PR DESCRIPTION
## What does this change?
The associated changes add the 'sameAs' field for 'author' on reviews. This attempts to link to their respective contributor tag.

## What is the value of this and can you measure success?
Further structure to support Google rich cards for reviews meaning more will pass the rich card validation and be rendered.

## Does this affect other platforms - Amp, Apps, etc?
This may effect AMP.

## Screenshots
None.

## Tested in CODE?
AMP validation tested locally for reviews of each type.

@stephanfowler @mchv 