### PR TITLE
Update AMI when deploying

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,7 +10,7 @@ templates:
       bucket: aws-frontend-artifacts
     dependencies:
     - frontend-static
-    - frontend-ami
+    - update-ami
 
 deployments:
   admin:
@@ -47,10 +47,13 @@ deployments:
       bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
-  frontend-ami:
+  update-ami:
     type: ami-cloudformation-parameter
     parameters:
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: frontend
       amiParametersToTags:
-        AmiId:
+        AMI:
           Recipe: frontend-base
           AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,6 +10,7 @@ templates:
       bucket: aws-frontend-artifacts
     dependencies:
     - frontend-static
+    - frontend-ami
 
 deployments:
   admin:
@@ -46,3 +47,10 @@ deployments:
       bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
+  frontend-ami:
+    type: ami-cloudformation-parameter
+    parameters:
+      amiParametersToTags:
+        AmiId:
+          Recipe: frontend-base
+          AmigoStage: PROD

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -57,3 +57,6 @@ deployments:
         AMI:
           Recipe: frontend-base
           AmigoStage: PROD
+        RouterAMI:
+          Recipe: frontend-router
+          AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

Adds a `ami-cloudformation-parameter` deployment type to the riff-raff deployment that updates the AMI param of frontend cfns to the latest bake AMI ID. 

## What is the value of this and can you measure success?

Don't have to deploy Platform to get the latest baked AMI, it'll be updated with every dotcom deployment.

## Tested in CODE?

Deployed in CODE, AMI updated on instances.