### PR TITLE
Increase membership thrasher AB audience size to 5% per variant

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-ab-thrasher.js
@@ -17,7 +17,7 @@ define([
         this.author = 'Justin Pinner';
         this.description = 'Test appetite for membership bundles';
         this.showForSensitive = true;
-        this.audience = 0.09;  // 9% ~ 45,000 thrasher impressions per variant per day
+        this.audience = 0.15;  // 5% per variant
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'People on UK network front with at least an 1140px wide display.';


### PR DESCRIPTION
## What does this change?
Increase from 3% to 5% per variant.

## What is the value of this and can you measure success?
Following on from https://github.com/guardian/frontend/pull/15731

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
See original test PR https://github.com/guardian/frontend/pull/15661

## Tested in CODE?
Not yet.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
