### PR TITLE
Add new limit cap to brexit test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -28,6 +28,11 @@ define([
         variants: [
             {
                 id: 'control',
+                maxViews: {
+                    days: 7,
+                    count: 6,
+                    minDaysBetweenViews: 1
+                },
 
                 template: function (contributionUrl, membershipUrl) {
                     return template(contributionsEpicEqualButtons, {


### PR DESCRIPTION
## What does this change?

We decided that we should impose a minimum of 1 day between impressions of the epic on the Brexit test, as 6 in one day may be overwhelming. 

## What is the value of this and can you measure success?



## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
