### PR TITLE
Make all site links point to the supporter page for membership

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -83,7 +83,7 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
                             membership</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -58,11 +58,11 @@
                     </li>
                 </ul>
                 <div class="brand-bar__popup--membership hide-on-desktop show-on-slim-header">
-                    <h3 class="popup__group-header">join us:</h3>
+                    <h3 class="popup__group-header">support us:</h3>
                     <ul class="popup__group">
                         <li class="popup__item">
                             <a class="brand-bar__item--action" data-link-name="uk : topNav : membership"
-                            href="https://membership.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_MEMBERSHIP">membership</a>
+                            href="https://membership.theguardian.com/supporter?INTCMP=NGW_TOPNAV_UK_GU_MEMBERSHIP">membership</a>
                         </li>
                         <li class="popup__item">
                             <a class="brand-bar__item--action" data-link-name="uk : topNav : subscribe"


### PR DESCRIPTION
## What does this change?
This update the 2 remaining links on the site to point to the supporter landing page.

## What is the value of this and can you measure success?
The supporter landing page describes membership just as well as the homepage, but converts better. 💸 

## Does this affect other platforms - Amp, Apps, etc?
No

@guardian/contributions 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
