### PR TITLE
use smaller enumeratum-play-json dependency

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -41,7 +41,7 @@ final case class MediaAtom(
 
 sealed trait MediaAssetPlatform extends EnumEntry
 
-object MediaAssetPlatform extends PlayEnum[MediaAssetPlatform] {
+object MediaAssetPlatform extends Enum[MediaAssetPlatform] with PlayJsonEnum[MediaAssetPlatform] {
 
   val values = findValues
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
   val targetingClient = "com.gu" %% "targeting-client" % "0.11.0"
   val scanamo = "com.gu" %% "scanamo" % "0.8.3"
-  val enumeratumPlay = "com.beachape" %% "enumeratum-play" % "1.5.6"
+  val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.6"
   val commercialShared = "com.gu" %% "commercial-shared" % "0.5.0"
 
   // Web jars

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -24,7 +24,7 @@ object Frontend extends Build with Prototypes {
       awsSts,
       awsSqs,
       contentApiClient,
-      enumeratumPlay,
+      enumeratumPlayJson,
       filters,
       commonsLang,
       configMagic,


### PR DESCRIPTION
## What does this change?
use smaller [enumeratum-play-json](https://github.com/lloydmeta/enumeratum#play-json) dependency instead of `enumeratum-play` as we are not using any of the additional play features.

## What is the value of this and can you measure success?
12kb JAR ➡️ 3kb JAR

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
