### PR TITLE
New styling for the tags at the bottom of the page

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -102,7 +102,7 @@
 
                         @fragments.witnessCallToAction(article.content)
 
-                        @fragments.submeta(article)
+                        @fragments.submeta(article, amp)
 
                         <div class="after-article js-after-article"></div>
                     </div>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -36,7 +36,7 @@
             <div class="content__header tonal__header u-cf">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--liveblog">
-                        @fragments.meta.metaInline(article, amp, page = model)
+                        @fragments.meta.metaInline(article, amp)
                         <h1 itemprop="headline" class="content__headline js-score">@Html(article.trail.headline)</h1>
                     </div>
                 </div>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -27,16 +27,18 @@
         </div>
 
         <header class="content__head tonal__head tonal__head--@toneClass(article)
-                      @if(ArticleBadgesSwitch.isSwitchedOn) {
-                          @badgeFor(article).map { badge => content__head--is-badged
-                              @badge.classModifier.map(modifier => s"content__head--$modifier")
-                          }
-                      }">
+            @if(ArticleBadgesSwitch.isSwitchedOn) {
+                @badgeFor(article).map { badge => content__head--is-badged
+                    @badge.classModifier.map(modifier => s"content__head--$modifier")
+                }
+            }">
             @* UPPER HEADER *@
             <div class="content__header tonal__header u-cf">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--liveblog">
-                        @fragments.meta.metaInline(article, amp)
+                        @if(!amp) {
+                            @fragments.meta.metaInline(article)
+                        }
                         <h1 itemprop="headline" class="content__headline js-score">@Html(article.trail.headline)</h1>
                     </div>
                 </div>
@@ -109,7 +111,7 @@
 
                     @if(amp) {
                         @views.html.liveblog.liveBlogBodyContentAMP(model)
-                        @fragments.submeta(article)
+                        @fragments.submeta(article, amp)
                         <div class="after-article js-after-article"></div>
                         <div class="js-bottom-marker"></div>
                     } else {

--- a/common/app/views/fragments/exploreSeries.scala.html
+++ b/common/app/views/fragments/exploreSeries.scala.html
@@ -60,7 +60,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                   <div class="series-identity-explore__container">
-                      @fragments.meta.metaInline(page.item, page = page)
+                      @fragments.meta.metaInline(page.item)
                       <div class="series-identity__byline">
                       <span class="byline-meta">with</span>  @fragments.meta.byline(page.item.trail.byline, page.item.tags)
                       </div>

--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -4,7 +4,7 @@
     <div class="gs-container">
         <div class="content__main-column">
 
-            @fragments.meta.metaInline(item, page = page)
+            @fragments.meta.metaInline(item)
 
             <h1 class="content__headline js-score" itemprop="headline">@Html(item.trail.headline)</h1>
 

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -15,8 +15,8 @@
         <div class="gs-container">
             <div class="content__main-column u-cf">
 
-                @if(showMeta) {
-                    @fragments.meta.metaInline(item, amp)
+                @if(showMeta && !amp) {
+                    @fragments.meta.metaInline(item)
                 }
 
                 <h1 class="content__headline js-score" itemprop="headline">

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -1,6 +1,5 @@
 @(item: model.ContentType, page: model.Page, showBadge: Boolean = false, showMeta: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 
-@import common.Edition
 @import model.Badges.badgeFor
 @import views.support.Commercial.isPaidContent
 @import views.support.ContributorLinks
@@ -17,7 +16,7 @@
             <div class="content__main-column u-cf">
 
                 @if(showMeta) {
-                    @fragments.meta.metaInline(item, amp, page = page)
+                    @fragments.meta.metaInline(item, amp)
                 }
 
                 <h1 class="content__headline js-score" itemprop="headline">

--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -19,7 +19,7 @@
 
     <div class="immersive-main-media__headline-container--dark immersive-main-media__headline-container">
         <div class="gs-container">
-            @fragments.meta.metaInline(page.item, page = page)
+            @fragments.meta.metaInline(page.item)
 
             <h1 class="content__headline content__headline--immersive content__headline--gallery content__headline--immersive--with-main-media">
                 @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -87,7 +87,7 @@
             <div class="gs-container">
                 @if(!isTheMinuteArticle) {
                     <div class="content__main-column">
-                    @fragments.meta.metaInline(page.item, page = page)
+                    @fragments.meta.metaInline(page.item)
                 }
 
                 <h1 class="@RenderClasses(Map(

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -1,4 +1,4 @@
-@(item: model.ContentType, isAmp: Boolean = false)(implicit request: RequestHeader)
+@(item: model.ContentType)(implicit request: RequestHeader)
 
 @import common.{LinkTo, Localisation}
 @import conf.switches.Switches.ArticleBadgesSwitch
@@ -14,11 +14,7 @@
         @badgeFor(item).map { badge =>
             <div class="badge-slot">
                 <a href="@LinkTo {/@badge.seriesTag}">
-                    @if(isAmp) {
-                        <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
-                    } else {
-                        <img class="badge-slot__img" src="@badge.imageUrl"/>
-                    }
+                    <img class="badge-slot__img" src="@badge.imageUrl"/>
                 </a>
             </div>
         }
@@ -46,17 +42,3 @@
         }
     }
 </div>
-
-@ObserverOrSectionLabel() = {
-    @if(item.content.isFromTheObserver) {
-        <div class="content__series-label">
-            <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
-        </div>
-    } else {
-        <div class="content__series-label @if(item.content.isImmersive && item.content.tags.isArticle) { content__series-label--immersive-article }">
-            <a class="content__series-label__link" href="@LinkTo {/@item.content.sectionLabelLink}">
-                @Html(Localisation(item.content.sectionLabelName))
-            </a>
-        </div>
-    }
-}

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -14,7 +14,7 @@
         @badgeFor(item).map { badge =>
             <div class="badge-slot">
                 <a href="@LinkTo {/@badge.seriesTag}">
-                    <img class="badge-slot__img" src="@badge.imageUrl"/>
+                    <img class="badge-slot__img" src="@badge.imageUrl" alt="@item.content.blogOrSeriesTag.map(_.name)"/>
                 </a>
             </div>
         }

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -1,6 +1,6 @@
-@(item: model.ContentType, isAmp: Boolean = false, page: model.Page)(implicit request: RequestHeader)
+@(item: model.ContentType, isAmp: Boolean = false)(implicit request: RequestHeader)
 
-@import common.{LinkTo, Localisation, NewNavigation, Edition}
+@import common.{LinkTo, Localisation}
 @import conf.switches.Switches.ArticleBadgesSwitch
 @import model.Badges.badgeFor
 @import views.support.RenderClasses

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -15,11 +15,11 @@
                 @badgeFor(content).map { badge =>
                     <div class="submeta2__badge">
                         <a href="@LinkTo {/@badge.seriesTag}">
-                        @if(amp) {
-                            <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
-                        } else {
-                            <img class="badge-slot__img" src="@badge.imageUrl"/>
-                        }
+                            @if(amp) {
+                                <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
+                            } else {
+                                <img class="badge-slot__img" src="@badge.imageUrl" alt="@content.content.blogOrSeriesTag.map(_.name)"/>
+                            }
                         </a>
                     </div>
                 }

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -7,8 +7,8 @@
 @import views.support.ContentLayout.ContentLayout
 @import views.support.Seq2zipWithRowInfo
 
-@if(amp) {
-    <div class="submeta2">
+@if(amp || mvt.ABNewNavVariantSeven.isParticipating) {
+    <div class="submeta2 mobile-only">
         <div class="submeta2__section-labels">
 
             @if(ArticleBadgesSwitch.isSwitchedOn) {
@@ -75,8 +75,9 @@
         }
     </div>
 
-} else {
-    <div class="submeta">
+}
+@if(!amp) {
+    <div class="submeta hide-on-mobile">
         @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
             <hr/>
             <div data-link-name="keywords" data-component="keywords">

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -1,19 +1,81 @@
-@(content: model.ContentType)(implicit request: RequestHeader)
-@import common.{LinkTo, RichRequestHeader}
-@import conf.switches.Switches.SaveForLaterSwitch
+@(content: model.ContentType, amp: Boolean = false)(implicit request: RequestHeader)
+
+@import common.{LinkTo, Localisation}
+@import conf.switches.Switches.{SaveForLaterSwitch, ArticleBadgesSwitch}
 @import model.ShareLinkMeta
+@import model.Badges.badgeFor
 @import views.support.ContentLayout.ContentLayout
+@import views.support.Seq2zipWithRowInfo
 
-@toneLink = {
-    @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-        @content.tags.tones.headOption.map { tone =>
-            <a class="submeta__tone button button--small button--tag @content.tagTone.map("button--tone-" + _).getOrElse("button--secondary")"
-            href="@LinkTo(tone.metadata.url)" data-link-name="tone: @tone.name" itemprop="keywords">More @tone.name.toLowerCase </a>
+@if(amp) {
+    <div class="submeta2">
+        <div class="submeta2__section-labels">
+
+            @if(ArticleBadgesSwitch.isSwitchedOn) {
+                @badgeFor(content).map { badge =>
+                    <div class="submeta2__badge">
+                        <a href="@LinkTo {/@badge.seriesTag}">
+                        @if(amp) {
+                            <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
+                        } else {
+                            <img class="badge-slot__img" src="@badge.imageUrl"/>
+                        }
+                        </a>
+                    </div>
+                }
+            }
+
+            @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
+                <a class="submeta2__link submeta2__link--first"
+                    data-link-name="article section"
+                    href="@LinkTo {/@content.content.sectionLabelLink}">
+                        @Html(Localisation(content.content.sectionLabelName))
+                </a>
+            }
+
+            @content.content.blogOrSeriesTag.map { series =>
+                <a class="submeta2__link" href="@LinkTo {/@series.id}">@series.name</a>
+            }.getOrElse {
+                @if(content.content.isFromTheObserver) {
+                    <a class="submeta2__link" href="http://observer.theguardian.com">The Observer</a>
+                }
+            }
+        </div>
+
+        <div class="submeta2__keywords">
+            @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
+                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
+                    @content.tags.tones.headOption.map { tone =>
+                        <a class="submeta2__link submeta2__link--first"
+                            href="@LinkTo(tone.metadata.url)"
+                            data-link-name="tone: @tone.name">
+                                @tone.name.toLowerCase
+                        </a>
+                    }
+                }
+
+                @defining(content.tags.keywords.filterNot(_.isSectionTag).take(5)) { shownKeywords =>
+                    @if(shownKeywords.nonEmpty) {
+                        @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
+                            <a class="submeta2__link @if(content.tags.isLiveBlog && row.rowNum == 1){submeta2__link--first}"
+                                href="@LinkTo(keyword.metadata.url)"
+                                data-link-name="keyword: @keyword.id">
+                                    @keyword.name
+                                    @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
+                            </a>
+                        }
+                    }
+                }
+            }
+        </div>
+        @if(content.showBottomSocialButtons) {
+            <div data-component="share" class="submeta__share">
+                @Social(content.sharelinks.pageShares)
+            </div>
         }
-    }
-}
+    </div>
 
-@if(!request.isAmp) {
+} else {
     <div class="submeta">
         @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
             <hr/>
@@ -27,7 +89,7 @@
             <hr/>
             <div class="u-cf">
                 <div data-component="share" class="submeta__share">
-                    @Social(content.sharelinks.pageShares)
+                @Social(content.sharelinks.pageShares)
                 </div>
                 @if(SaveForLaterSwitch.isSwitchedOn) {
                     <div class="js-save-for-later submeta__save-for-later" data-position="bottom"></div>
@@ -43,4 +105,13 @@
 
 @Social(shares: ShareLinkMeta) = {
     @fragments.social(ShareLinkMeta.noneHidden(shares))
+}
+
+@toneLink = {
+    @if(content.tags.isArticle && !content.tags.isLiveBlog) {
+        @content.tags.tones.headOption.map { tone =>
+            <a class="submeta__tone button button--small button--tag @content.tagTone.map("button--tone-" + _).getOrElse("button--secondary")"
+            href="@LinkTo(tone.metadata.url)" data-link-name="tone: @tone.name" itemprop="keywords">More @tone.name.toLowerCase </a>
+        }
+    }
 }

--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -15,6 +15,7 @@
 @include grid-system;
 @import 'amp/_header';
 @import 'amp/_footer';
+@import 'amp/_submeta';
 @import 'module/nav/_supporter-trapezoid';
 
 @import 'amp/_rich-link';

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -14,34 +14,6 @@
     box-sizing: border-box;
 }
 
-.content__labels {
-    box-sizing: border-box;
-    padding: $gs-baseline/2 0;
-    position: relative;
-    z-index: 1; // bring-to-front fix to make it clickable
-    overflow: hidden;
-}
-
-.content__labels--not-immersive {
-    border-bottom: 1px dotted $neutral-5;
-}
-
-.content__section-label {
-    float: left;
-    padding-right: $gs-gutter/3;
-
-    &,
-    .content__series-label {
-        float: left;
-    }
-}
-
-.content__series-label__link {
-    font-size: 1rem;
-    line-height: 1.25rem;
-    color: $neutral-2;
-}
-
 .content__headline {
     font-size: 28px;
     line-height: 32px;

--- a/static/src/stylesheets/amp/_helpers.scss
+++ b/static/src/stylesheets/amp/_helpers.scss
@@ -39,17 +39,9 @@
     padding-bottom: aspect-ratio-height(16, 9);
 }
 
-.u-responsive-ratio--letterbox {
-    padding-bottom: aspect-ratio-height(5, 2);
-}
-
 .u-text-hyphenate {
     word-wrap: break-word;
     hyphens: auto;
-}
-
-.u-test-ellipsis {
-    @include ellipsis();
 }
 
 .u-button-reset {
@@ -80,23 +72,9 @@
     }
 }
 
-.u-nobr {
-    white-space: nowrap;
-}
-
 .meta-button {
     background: transparent;
     border: 0;
     margin: 0;
     padding: 0;
-}
-
-.u-font-weight-normal {
-    font-weight: normal;
-}
-
-.u-vertical-align-middle-icon {
-    svg {
-        vertical-align: middle;
-    }
 }

--- a/static/src/stylesheets/amp/_rich-link.scss
+++ b/static/src/stylesheets/amp/_rich-link.scss
@@ -9,7 +9,6 @@
     font-size: 14px;
 
     p {
-        margin: 0;
         font-size: 14px;
         line-height: 16px;
     }
@@ -19,8 +18,6 @@
     }
 
     a {
-        display: block;
-        padding: 0;
         color: $neutral-1;
         border: 0;
         padding-bottom: 1.125rem;

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -1,0 +1,58 @@
+.submeta2 {
+    font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+}
+
+.submeta2__section-labels {
+    min-height: $gs-row-height;
+    font-size: 16px;
+    border-top: 1px dotted $neutral-5;
+    border-bottom: 1px dotted $neutral-5;
+    padding: $gs-baseline / 2 0;
+
+
+    &:before {
+        content: "More";
+        font-size: 12px;
+        color: $neutral-2;
+        display: block;
+        margin-bottom: -($gs-baseline / 4);
+    }
+}
+
+.submeta2__keywords {
+    font-size: 14px;
+    padding: $gs-baseline / 2 0;
+    border-bottom: 1px dotted $neutral-5;
+    margin-bottom: $gs-baseline / 2;
+}
+
+.submeta2__link {
+    font-weight: 500;
+    line-height: 22px;
+    position: relative;
+    padding-left: .3em;
+    padding-right: .35em;
+
+    &:before {
+        position: absolute;
+        pointer-events: none;
+        content: '/';
+        //optically aligns slashes
+        left: -.28em;
+        color: $neutral-5;
+    }
+}
+
+.submeta2__link--first {
+    padding-left: 0;
+
+    &:before {
+        content: none;
+    }
+}
+
+.submeta2__badge {
+    float: right;
+    margin-top: -$gs-baseline;
+    margin-left: $gs-gutter / 2;
+}

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -7,7 +7,7 @@
     font-size: 16px;
     border-top: 1px dotted $neutral-5;
     border-bottom: 1px dotted $neutral-5;
-    padding: $gs-baseline / 2 0;
+    padding: $gs-baseline / 2 0 $gs-baseline;
 
 
     &:before {
@@ -20,8 +20,8 @@
 }
 
 .submeta2__keywords {
-    font-size: 14px;
-    padding: $gs-baseline / 2 0;
+    font-size: 15px;
+    padding: $gs-baseline / 2 0 $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;
 }
@@ -40,6 +40,10 @@
         //optically aligns slashes
         left: -.28em;
         color: $neutral-5;
+    }
+
+    .submeta2__keywords & {
+        color: $neutral-2;
     }
 }
 

--- a/static/src/stylesheets/amp/_tones.scss
+++ b/static/src/stylesheets/amp/_tones.scss
@@ -97,16 +97,7 @@
     background-color: $comment-support-2;
 }
 
-.tonal--tone-comment .tonal__header .content__labels,
-.tonal--tone-analysis .tonal__header .content__labels,
-.tonal--tone-editorial .tonal__header .content__labels,
-.tonal--tone-letters .tonal__header .content__labels {
-    border-bottom-color: rgba(118, 118, 118, .3);
-}
-
-.tonal--tone-comment .tonal__header .content__section-label__link,
 .tonal--tone-comment .tone-colour,
-.tonal--tone-letters .tonal__header .content__section-label__link,
 .tonal--tone-comment .tonal__main .element-pullquote cite,
 .tonal--tone-letters .tonal__main .element-pullquote cite,
 .tonal--tone-comment .tonal__main .drop-cap,
@@ -123,20 +114,6 @@
 .tonal--tone-review .tonal__main .element-pullquote cite,
 .tonal--tone-review .tonal__main .drop-cap {
     color: #615b52;
-}
-
-.tonal--tone-special-report .tonal__header .content__section-label__link {
-    color: $news-support-1;
-}
-
-.tonal--tone-feature .tonal__header .content__labels,
-.tonal--tone-review .tonal__header .content__labels,
-.tonal--tone-live .tonal__header .content__labels {
-    border-bottom-color: rgba(234, 234, 234, .3);
-}
-
-.tonal--tone-feature .tonal__header .content__section-label__link {
-    color: $features-support-3;
 }
 
 .tonal--tone-feature .tonal__standfirst ul>li:before,
@@ -160,10 +137,6 @@
     color: $comment-support-1;
 }
 
-.tonal--tone-review .tonal__header .content__section-label__link {
-    color: #ffce4b;
-}
-
 .tonal--tone-review .stars {
     margin-top: -1.125rem;
     margin-bottom: 1.125rem;
@@ -182,8 +155,6 @@
 .tonal--tone-feature .tonal__header .content__headline,
 .tonal--tone-live .tonal__header .content__headline,
 .tonal--tone-special-report .tonal__header .content__headline,
-.tonal--tone-special-report .tonal__header .content__series-label__link,
-.tonal--tone-live .tonal__header .content__section-label__link,
 .tonal--tone-letters .tonal__standfirst,
 .tonal--tone-letters .tonal__standfirst .content__standfirst,
 .tone-media .fc-item__title,
@@ -194,13 +165,6 @@
     color: #ffffff;
 }
 
-.tonal--tone-review .tonal__header .content__series-label__link,
-.tonal--tone-feature .tonal__header .content__series-label__link,
-.tonal--tone-live .tonal__header .content__series-label__link {
-    color: $neutral-5;
-}
-
-.tonal--tone-editorial .tonal__header .content__section-label__link,
 .tonal--tone-editorial .tone-colour,
 .tonal--tone-editorial .tonal__main .element-pullquote cite,
 .tonal--tone-editorial .tonal__main .drop-cap {
@@ -215,7 +179,6 @@
     color: $news-main-2;
 }
 
-.tonal--tone-dead .tonal__header .content__section-label__link,
 .tonal--tone-live .tone-colour,
 .tonal--tone-dead .tone-colour {
     color: $live-main-1;
@@ -226,7 +189,6 @@
     border-bottom-color: rgba(72, 72, 72, .3);
 }
 
-.tonal--tone-media .tonal__header .content__section-label__link,
 .tonal--tone-media .tone-colour {
     color: $multimedia-main-2;
 }
@@ -243,7 +205,6 @@
 .tonal--tone-live .tonal__standfirst .u-underline,
 .tonal--tone-media .tonal__standfirst .u-underline,
 .tonal--tone-special-report .tonal__standfirst .u-underline,
-.tonal--tone-special-report .tonal__header .content__labels,
 .tonal--tone-letters .tonal__standfirst .u-underline {
     color: #ffffff;
     border-bottom-color: rgba(255, 255, 255, .3);

--- a/static/src/stylesheets/amp/_type.scss
+++ b/static/src/stylesheets/amp/_type.scss
@@ -49,7 +49,3 @@ h3 {
     font-weight: normal;
     margin-bottom: 7px;
 }
-
-b, strong {
-    font-weight: 500;
-}

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -902,4 +902,69 @@ $caption-button-size: 32px;
     }
 }
 
+/****************
+ * Submeta
+ ****************/
+
+.submeta2 {
+    margin-top: $gs-baseline;
+}
+
+.submeta2__section-labels {
+    @include fs-textSans(5);
+    min-height: $gs-row-height;
+    border-top: 1px dotted $neutral-5;
+    border-bottom: 1px dotted $neutral-5;
+    padding: $gs-baseline / 2 0;
+
+
+    &:before {
+        @include fs-textSans(1);
+        content: "More";
+        color: $neutral-2;
+        display: block;
+        margin-bottom: -($gs-baseline / 4);
+    }
+}
+
+.submeta2__keywords {
+    @include fs-textSans(2);
+    line-height: 22px;
+    padding: $gs-baseline / 2 0 $gs-baseline;
+    border-bottom: 1px dotted $neutral-5;
+    margin-bottom: $gs-baseline / 2;
+}
+
+.submeta2__link {
+    font-weight: bold;
+    position: relative;
+    padding-left: .3em;
+    padding-right: .35em;
+
+    &:before {
+        position: absolute;
+        pointer-events: none;
+        content: '/';
+        //optically aligns slashes
+        left: -.28em;
+        color: $neutral-5;
+    }
+}
+
+.submeta2__link--first {
+    padding-left: 0;
+
+    &:before {
+        content: none;
+    }
+}
+
+.submeta2__badge {
+    width: 33px;
+    float: right;
+    margin-top: -$gs-baseline;
+    margin-left: $gs-gutter / 2;
+}
+
+
 @import '../module/nav/_supporter-trapezoid';

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -915,7 +915,7 @@ $caption-button-size: 32px;
     min-height: $gs-row-height;
     border-top: 1px dotted $neutral-5;
     border-bottom: 1px dotted $neutral-5;
-    padding: $gs-baseline / 2 0;
+    padding: $gs-baseline / 2 0 $gs-baseline;
 
 
     &:before {
@@ -928,8 +928,7 @@ $caption-button-size: 32px;
 }
 
 .submeta2__keywords {
-    @include fs-textSans(2);
-    line-height: 22px;
+    @include fs-textSans(4);
     padding: $gs-baseline / 2 0 $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;
@@ -948,6 +947,10 @@ $caption-button-size: 32px;
         //optically aligns slashes
         left: -.28em;
         color: $neutral-5;
+    }
+
+    .submeta2__keywords & {
+        color: $neutral-2;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Implementing the new tag style designed by @zeftilldeath. The changes are on AMP and on the new header test.

## What is the value of this and can you measure success?
Updating the style to go with the rest of the "article refresh" look. The design may tweak a bit more.

## Does this affect other platforms - Amp, Apps, etc?
This does affect AMP.

## Screenshots
On a normal article:
![image](https://cloud.githubusercontent.com/assets/8774970/22644808/dcedec9a-ec5b-11e6-98de-13322d19bb55.png)

On a liveblog:
![image](https://cloud.githubusercontent.com/assets/8774970/22644897/5180fe76-ec5c-11e6-9fdb-6484c60d26fe.png)

With a badge:
![image](https://cloud.githubusercontent.com/assets/8774970/22644886/47966ee6-ec5c-11e6-9470-1403c3fe3dde.png)

AMP normal article:
![image](https://cloud.githubusercontent.com/assets/8774970/22644832/0240ee48-ec5c-11e6-96d9-c7ec5c56b7e0.png)

AMP liveblog:
![image](https://cloud.githubusercontent.com/assets/8774970/22644860/2dfdc1e6-ec5c-11e6-8865-1deb68e1a0cf.png)

AMP badge:
![image](https://cloud.githubusercontent.com/assets/8774970/22644820/f12a39d4-ec5b-11e6-916f-3a3bd4ba5ec2.png)


## Tested in CODE?
Nope
