### PR TITLE
Z-index doesn't have to be that high

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -832,7 +832,7 @@ $caption-button-size: 32px;
 .l-footer {
     // these two lines are needed so that the footer sits over the nav
     position: absolute;
-    z-index: 9999;
+    z-index: $zindex-content;
     width: 100%;
 }
 .footer__back-to-top__container {


### PR DESCRIPTION
## What does this change?
I hastily made the z-index needlessly high in https://github.com/guardian/frontend/pull/15620.

This moves it down to a sensible z-index.

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
Still looks good, but should no longer cover the membership banner

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
![image](https://cloud.githubusercontent.com/assets/8774970/22587033/c6fa9bba-e9f7-11e6-896e-8717a6657a4f.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
