### PR TITLE
Dont reorder subnav in new nav, and current section first if it isn't exist

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -326,9 +326,9 @@ object NewNavigation {
         val parentSection = section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
 
         if (parentSection.contains(section.navLink)) {
-          section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
+          parentSection
         } else {
-          Seq(section.navLink) ++ section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
+          Seq(section.navLink) ++ parentSection
         }
       }
     }

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -4,7 +4,7 @@ import conf.Configuration
 import NavLinks._
 
 case class NavLink(title: String, url: String, longTitle: String = "", iconName: String = "", uniqueSection: String = "")
-case class SectionsLink(pageId: String, parentSection: NewNavigation.EditionalisedNavigationSection)
+case class SectionsLink(pageId: String, navLink: NavLink, parentSection: NewNavigation.EditionalisedNavigationSection)
 case class SubSectionLink(pageId: String, parentSection: NavLinkLists)
 case class NavLinkLists(mostPopular: Seq[NavLink], leastPopular: Seq[NavLink] = List())
 
@@ -65,6 +65,16 @@ object NewNavigation {
     case "sport" => Sport
     case "arts" => Arts
     case "life" => Life
+  }
+
+  def isCurrentSection(currentSection: String, navLink: NavLink): Boolean = {
+    val mainFront = List("uk", "au", "us", "international")
+
+    if (mainFront.contains(currentSection)) {
+      "headlines" == navLink.title
+    } else {
+      currentSection == navLink.uniqueSection
+    }
   }
 
   case object MostPopular extends EditionalisedNavigationSection {
@@ -264,44 +274,44 @@ object NewNavigation {
 
     var sectionLinks = List(
 
-      SectionsLink("uk", MostPopular),
-      SectionsLink("us", MostPopular),
-      SectionsLink("au", MostPopular),
-      SectionsLink("international", MostPopular),
-      SectionsLink("uk-news", News),
-      SectionsLink("world", News),
-      SectionsLink("politics", News),
-      SectionsLink("environment", News),
-      SectionsLink("business", News),
-      SectionsLink("technology", News),
-      SectionsLink("science", News),
-      SectionsLink("money", News),
-      SectionsLink("australia-news", News),
-      SectionsLink("media", News),
-      SectionsLink("us-news", News),
-      SectionsLink("cities", News),
-      SectionsLink("global-development", News),
-      SectionsLink("sustainable-business", News),
-      SectionsLink("law", News),
+      SectionsLink("uk", headlines, MostPopular),
+      SectionsLink("us", headlines, MostPopular),
+      SectionsLink("au", headlines, MostPopular),
+      SectionsLink("international", headlines, MostPopular),
+      SectionsLink("uk-news", ukNews,News),
+      SectionsLink("world", world, News),
+      SectionsLink("politics", politics, News),
+      SectionsLink("environment", environment, News),
+      SectionsLink("business", business, News),
+      SectionsLink("technology", tech, News),
+      SectionsLink("science", science, News),
+      SectionsLink("money", money, News),
+      SectionsLink("australia-news", australiaNews, News),
+      SectionsLink("media", media, News),
+      SectionsLink("us-news", usNews, News),
+      SectionsLink("cities", cities, News),
+      SectionsLink("global-development", globalDevelopment, News),
+      SectionsLink("sustainable-business", sustainableBusiness, News),
+      SectionsLink("law", law, News),
 
-      SectionsLink("commentisfree", Opinion),
-      SectionsLink("index", Opinion),
+      SectionsLink("commentisfree", opinion, Opinion),
+      SectionsLink("index", columnists, Opinion),
 
-      SectionsLink("sport", Sport),
-      SectionsLink("football", Sport),
+      SectionsLink("sport", sport, Sport),
+      SectionsLink("football", football, Sport),
 
-      SectionsLink("culture", Arts),
-      SectionsLink("film", Arts),
-      SectionsLink("tv-and-radio", Arts),
-      SectionsLink("music", Arts),
-      SectionsLink("books", Arts),
-      SectionsLink("artanddesign", Arts),
-      SectionsLink("stage", Arts),
+      SectionsLink("culture", culture, Arts),
+      SectionsLink("film", film, Arts),
+      SectionsLink("tv-and-radio", tvAndRadio, Arts),
+      SectionsLink("music", music, Arts),
+      SectionsLink("books", books, Arts),
+      SectionsLink("artanddesign", artAndDesign, Arts),
+      SectionsLink("stage", stage, Arts),
 
-      SectionsLink("lifeandstyle", Life),
-      SectionsLink("fashion", Life),
-      SectionsLink("travel", Life),
-      SectionsLink("society", Life)
+      SectionsLink("lifeandstyle", lifestyle, Life),
+      SectionsLink("fashion", fashion, Life),
+      SectionsLink("travel", travel, Life),
+      SectionsLink("society", society, Life)
     )
 
     def getSectionLinks(sectionName: String, edition: Edition) = {
@@ -313,11 +323,13 @@ object NewNavigation {
         News.getPopularEditionalisedNavLinks(edition).drop(1)
       } else {
         val section = sectionList.head
-        val parentSections = section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
+        val parentSection = section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
 
-        val (a, b) = parentSections.partition(_.uniqueSection != section.pageId)
-
-        b ++ a
+        if (parentSection.contains(section.navLink)) {
+          section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
+        } else {
+          Seq(section.navLink) ++ section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
+        }
       }
     }
 
@@ -423,9 +435,9 @@ object NewNavigation {
     }
 
     val editionalisedSubSectionLinks = List(
-      SectionsLink("business", businessSubNav),
-      SectionsLink("environment", environmentSubNav),
-      SectionsLink("travel", travelSubNav)
+      SectionsLink("business", business, businessSubNav),
+      SectionsLink("environment", environment, environmentSubNav),
+      SectionsLink("travel", travel, travelSubNav)
     )
 
     val subSectionLinks = List(

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -51,13 +51,13 @@ object NavLinks {
   val careers = NavLink("careers", "/money/work-and-careers")
 
   /* OPINION */
-  val opinion = NavLink("opinion home", "/commentisfree", iconName = "home", uniqueSection = "commentisfree")
+  val opinion = NavLink("opinion", "/commentisfree", longTitle = "sport home", iconName = "home", uniqueSection = "commentisfree")
   var columnists = NavLink("columnists", "/index/contributors")
   val theGuardianView = NavLink("the guardian view", "/profile/editorial")
   val cartoons = NavLink("cartoons", "/cartoons/archive")
 
   /* SPORT */
-  val sport = NavLink("sport home", "/sport", iconName = "home", uniqueSection = "sport")
+  val sport = NavLink("sport", "/sport", longTitle = "sport home", iconName = "home", uniqueSection = "sport")
   val football = NavLink("football", "/football", uniqueSection = "football")
   val soccer = football.copy(title = "soccer")
   val cricket = NavLink("cricket", "/sport/cricket")
@@ -81,7 +81,7 @@ object NavLinks {
   val NHL = NavLink("NHL", "/sport/nhl")
 
   /* ARTS */
-  val culture = NavLink("culture home", "/culture", iconName = "home", uniqueSection = "culture")
+  val culture = NavLink("culture", "/culture", longTitle = "culture home", iconName = "home", uniqueSection = "culture")
   val film = NavLink("film", "/film", uniqueSection = "film")
   val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", uniqueSection = "tv-and-radio")
   val music = NavLink("music", "/music", uniqueSection = "music")
@@ -92,7 +92,7 @@ object NavLinks {
   val classical = NavLink("classical", "/music/classicalmusicandopera")
 
   /* LIFE */
-  val lifestyle = NavLink("lifestyle home", "/lifeandstyle", iconName = "home", uniqueSection = "lifeandstyle")
+  val lifestyle = NavLink("lifestyle", "/lifeandstyle", longTitle = "lifestyle home", iconName = "home", uniqueSection = "lifeandstyle")
   val fashion = NavLink("fashion", "/fashion", uniqueSection = "fashion")
   val food = NavLink("food", "/lifeandstyle/food-and-drink")
   val travel = NavLink("travel", "/travel", uniqueSection = "travel")

--- a/common/app/views/fragments/nav/subSectionNav.scala.html
+++ b/common/app/views/fragments/nav/subSectionNav.scala.html
@@ -1,10 +1,14 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
 @import common.{NewNavigation, Edition, LinkTo}
+@import views.support.RenderClasses
 
 <div class="tertiary-navigation">
     @NewNavigation.SubSectionLinks.getSubSectionNavLinks(page.metadata.sectionId, Edition(request), page.metadata.isFront).map { link =>
-        <a class="tertiary-navigation__link @if((link.uniqueSection == page.metadata.sectionId)) {tertiary-navigation__link--current-section}"
+        <a class="@RenderClasses(Map(
+                "tertiary-navigation__link" -> true,
+                "tertiary-navigation__link--current-section" -> NewNavigation.isCurrentSection(page.metadata.sectionId, link)
+            ))"
             href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
                 @link.title
         </a>


### PR DESCRIPTION
## What does this change?
This change should do two things.
* Stops the reordering of the subnav list depending on weather you are in a section or not
* If you are in a section that isn't in the nav, it will be added and put at the front.

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
Better UX

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Before on an article in the stage section:
<img width="400px" src="https://cloud.githubusercontent.com/assets/8774970/22587408/73b688c2-e9f9-11e6-9793-7651fcbba047.png"/>

After:
<img width="400px" src="https://cloud.githubusercontent.com/assets/8774970/22587416/7fc4c3c2-e9f9-11e6-8ade-b32c1c771650.png"/>

No reordering:
<img width="400px" src="https://cloud.githubusercontent.com/assets/8774970/22587354/4491ad9c-e9f9-11e6-99cf-5ddd43a3fb2c.png"/>

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
