### PR TITLE
Implement a simple version of the  new footer on AMP

### DIFF
--- a/common/app/views/fragments/amp/footerAMP.scala.html
+++ b/common/app/views/fragments/amp/footerAMP.scala.html
@@ -8,17 +8,16 @@
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
     <div class="l-footer__primary">
-        <div id="footer-nav">
-            <div class="brand-bar modern-visible u-cf">
-                <a class="brand-bar__item brand-bar__item--action" data-link-name="back to top" href="#top">
-                    <span class="rounded-icon control__icon-wrapper">
-                        @fragments.inlineSvg("arrow-up", "icon")
-                    </span>
-                    <span class="control__info">back to top</span>
-                </a>
-            </div>
+        <div class="footer__primary">
+            <a data-link-name="back to top" href="#top">
+                <div class="footer__back-to-top__container">
+                    <div class="footer__back-to-top">
+                        <span class="back-to-top__text">back to top</span>
+                        @fragments.inlineSvg("arrow-up", "icon", List("back-to-top__icon"))
+                    </div>
+                </div>
+            </a>
 
-            @Page.getContentPage(page).map(fragments.breadcrumb(_))
         </div>
     </div>
 

--- a/common/app/views/fragments/amp/footerAMP.scala.html
+++ b/common/app/views/fragments/amp/footerAMP.scala.html
@@ -7,18 +7,15 @@
 @import model.Page
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
-    <div class="l-footer__primary">
-        <div class="footer__primary">
-            <a data-link-name="back to top" href="#top">
-                <div class="footer__back-to-top__container">
-                    <div class="footer__back-to-top">
-                        <span class="back-to-top__text">back to top</span>
-                        @fragments.inlineSvg("arrow-up", "icon", List("back-to-top__icon"))
-                    </div>
+    <div class="footer__primary">
+        <a data-link-name="back to top" href="#top">
+            <div class="footer__back-to-top__container">
+                <div class="footer__back-to-top">
+                    <span class="back-to-top__text">back to top</span>
+                    @fragments.inlineSvg("arrow-up", "icon", List("back-to-top__icon"))
                 </div>
-            </a>
-
-        </div>
+            </div>
+        </a>
     </div>
 
     <div class="l-footer__secondary gs-container" role="contentinfo">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -36,7 +36,6 @@
 
     @if(mvt.ABNewNavVariantSeven.isParticipating) {
         <div class="mobile-only footer__primary">
-            @* TODO: styling footer *@
             <a data-link-name="back to top" href="#top">
                 <div class="footer__back-to-top__container">
                     <div class="footer__back-to-top">

--- a/static/src/stylesheets/amp/_fonts.scss
+++ b/static/src/stylesheets/amp/_fonts.scss
@@ -82,7 +82,8 @@
     .old-article-message,
     .d2-permalink,
     .d2-body,
-    .meta__contact-header {
+    .meta__contact-header,
+    .back-to-top__text {
         font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     }
 }

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -9,15 +9,15 @@
 }
 
 .l-footer__secondary {
-    font-size: 12px;
+    @include content-gutter();
     line-height: 1;
-    padding-right: $gs-gutter / 2;
-    padding-left: $gs-gutter / 2;
     font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 
     a {
         color: $neutral-4;
         text-transform: lowercase;
+        display: inline-block;
+        padding-bottom: $gs-baseline;
     }
 }
 
@@ -28,17 +28,12 @@
     padding: ($gs-baseline * 2) 0 ($gs-baseline / 2);
     column-count: 2;
     column-gap: 0;
-
-    a {
-        display: inline-block;
-        padding-bottom: $gs-baseline;
-    }
 }
 
 .really-serious-copyright {
     color: $neutral-4;
-    font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     margin-bottom: .25rem;
+    font-size: 12px;
 }
 
 .l-footer__misc {

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -1,16 +1,12 @@
-$c-primary-footer-background-side-bar: mix($guardian-brand, #ffffff, 90%);
-
-.l-footer__primary {
-    position: relative;
-    overflow: hidden;
-    background: $c-primary-footer-background-side-bar;
-}
-
 .l-footer {
+    position: absolute;
     padding: 0;
     margin-top: $gs-baseline * 2;
     background: $multimedia-support-4;
+    z-index: $zindex-content;
+    width: 100%;
     clear: both;
+    font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
 .l-footer__secondary {
@@ -21,48 +17,8 @@ $c-primary-footer-background-side-bar: mix($guardian-brand, #ffffff, 90%);
 
     a {
         color: $neutral-4;
-        font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
         text-transform: lowercase;
     }
-}
-
-.brand-bar {
-    background-color: $guardian-brand;
-    line-height: 0;
-    box-sizing: border-box;
-    padding-left: $gs-gutter / 2;
-    padding-right: $gs-gutter / 2;
-}
-
-.brand-bar__item--action, .brand-bar__item--action:focus {
-    margin: 0;
-    cursor: pointer;
-    color: #ffffff;
-    display: inline-block;
-    vertical-align: middle;
-    text-decoration: none;
-    line-height: 2.25rem;
-}
-
-.brand-bar__item {
-    height: $gs-row-height;
-    padding-top: $gs-baseline / 3;
-    padding-bottom: $gs-baseline / 3;
-    font-size: 14px;
-}
-
-.control__info {
-    display: inline-block;
-    height: $gs-row-height;
-    line-height: 2.25rem;
-    margin-left: $gs-gutter / 2;
-    max-width: gs-span(2);
-    vertical-align: top;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    float: left;
-    text-align: left;
 }
 
 .colophon {
@@ -91,32 +47,68 @@ $c-primary-footer-background-side-bar: mix($guardian-brand, #ffffff, 90%);
     border-top: 1px solid $neutral-2;
 }
 
-.breadcrumb {
-    text-transform: lowercase;
+.footer__back-to-top__container {
+    @include content-gutter();
+    background-color: $guardian-brand;
+
+    a:hover > &,
+    a:focus > & {
+        background-color: $guardian-brand-dark;
+    }
 }
 
-.signposting {
-    background: $neutral-5;
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
+.footer__back-to-top {
+    position: relative;
+    text-align: right;
+
+    @include mq($from: mobile, $until: mobileLandscape) {
+        font-size: 14px;
+        font-size: 4.6vw;
+    }
+
+    @include mq(mobileLandscape) {
+        font-size: 20px;
+    }
 }
 
-.signposting__item {
-    white-space: nowrap;
+.back-to-top__text {
     display: inline-block;
-    height: $gs-row-height;
-    line-height: $gs-row-height;
+    color: white;
+    line-height: 30px;
+    padding-right: $gs-gutter / 2;
+
+    @include mq(mobileMedium) {
+        line-height: 40px;
+    }
 }
 
-.signposting__action {
-    padding: 0 $gs-gutter / 2;
-    vertical-align: middle;
-}
+.back-to-top__icon {
+    position: relative;
+    float: right;
+    margin-top: -($gs-baseline / 2);
+    margin-bottom: -($gs-baseline / 2);
+    border-radius: 100%;
+    background-color: $news-main-2;
+    cursor: pointer;
+    height: $veggie-burger-small;
+    min-width: $veggie-burger-small;
 
-.signposting__separator {
-    color: $neutral-2;
-    vertical-align: -3px;
-    font-size: 24px;
-    margin: 0 -6px;
+    @include mq(mobileMedium) {
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+    }
+
+    svg {
+        position: absolute;
+        top: -($gs-baseline / 2);
+        bottom: 0;
+        right: 0;
+        left: 0;
+        margin: auto;
+
+        @include mq(mobileMedium) {
+            width: 30px;
+            height: 24px;
+        }
+    }
 }

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -6,7 +6,6 @@
     z-index: $zindex-content;
     width: 100%;
     clear: both;
-    font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
 .l-footer__secondary {
@@ -14,6 +13,7 @@
     line-height: 1;
     padding-right: $gs-gutter / 2;
     padding-left: $gs-gutter / 2;
+    font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 
     a {
         color: $neutral-4;

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -51,7 +51,6 @@
     @include content-gutter();
     background-color: $guardian-brand;
 
-    a:hover > &,
     a:focus > & {
         background-color: $guardian-brand-dark;
     }


### PR DESCRIPTION
## What does this change?
The new footer was implemented in the new header test, but not on AMP where the new header already is. This fixes that discrepancy. I think its likely that @zeftilldeath will make some edits to this 🎨 

@guardian/dotcom-platform 

## What is the value of this and can you measure success?
Most consistent visually

## Does this affect other platforms - Amp, Apps, etc?
Only AMP

## Screenshots
![image](https://cloud.githubusercontent.com/assets/8774970/22587926/8e1a223a-e9fb-11e6-893d-d3681c2bc9a7.png)


## Tested in CODE?
No
