### PR TITLE
Don't show address type for restaurant reviews if part isn't present.

### DIFF
--- a/common/app/views/fragments/atoms/structureddata/restaurant/address.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/restaurant/address.scala.html
@@ -1,13 +1,15 @@
 @import com.gu.contententity.thrift.Address
 
 @(address: Address)(implicit request: RequestHeader)
-{
+@if(isPartOfAddressPresent) {
+"address" :{
 "@@type": "PostalAddress",
-@streetName(address).map { name => "streetAddress": "@name", }
-@address.locality.map { locality => "addressLocality": "@locality", }
-@address.neighbourhood.map { neighbourhood => "addressRegion": "@neighbourhood", }
-@address.postCode.map { postCode => "postalCode": "@postCode", }
-@address.country.map { country => "addressCountry": "@country" }
+    @streetName(address).map { name => "streetAddress": "@name", }
+    @address.locality.map { locality => "addressLocality": "@locality", }
+    @address.neighbourhood.map { neighbourhood => "addressRegion": "@neighbourhood", }
+    @address.postCode.map { postCode => "postalCode": "@postCode", }
+    @address.country.map { country => "addressCountry": "@country" }
+},
 }
 
 @streetName(address: Address) = @{
@@ -15,4 +17,12 @@
         streetNumber <- address.streetNumber.map(_.toString) orElse Some("")
         streetName <- address.streetName
     } yield {s"$streetNumber $streetName".trim}
+}
+
+@isPartOfAddressPresent = @{
+    address.streetName.isDefined ||
+    address.streetNumber.isDefined ||
+    address.locality.isDefined ||
+    address.postCode.isDefined ||
+    address.country.isDefined
 }

--- a/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
@@ -24,7 +24,7 @@
     "name": "@entity.restaurantName",
     @entity.webAddress.map{ webAddress => "sameAs": "@webAddress", }
     "priceRange": "£££",
-    @for(address <- entity.address) { "address" : @fragments.atoms.structureddata.restaurant.address(address), }
+    @for(address <- entity.address) { @fragments.atoms.structureddata.restaurant.address(address) }
     @for(geoLocation <- entity.geolocation) { "geo" : @fragments.atoms.structureddata.restaurant.geo(geoLocation), }
     "image": ""
   },


### PR DESCRIPTION
## What does this change?
This change makes showing the address block of structured data for a restaurant review optional depending if we have any parts of the address to display.

## What is the value of this and can you measure success?
Providing richer structure for reviews via Google rich cards.

## Does this affect other platforms - Amp, Apps, etc?
Can effect AMP.

## Screenshots
None.

## Tested in CODE?
Tested AMP validation locally.

@mchv @stephanfowler 