### PR TITLE
support multiples of the same youtube atoms on the same page

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -35,7 +35,7 @@ define([
 
         killProgressTracker(atomId);
         setProgressTracker(atomId);
-        tracking.track('play', atomId);
+        tracking.track('play', getTrackingId(atomId));
 
         if (player.endSlate &&
             !player.overlay.parentNode.querySelector('.end-slate-container')) {
@@ -49,7 +49,7 @@ define([
 
     function onPlayerEnded(atomId) {
         killProgressTracker(atomId);
-        tracking.track('end', atomId);
+        tracking.track('end', getTrackingId(atomId));
         players[atomId].pendingTrackingCalls = [25, 50, 75];
     }
 
@@ -79,12 +79,10 @@ define([
         var percentPlayed = Math.round(((currentTime / player.duration) * 100));
 
         if (percentPlayed >= pendingTrackingCalls[0]) {
-            tracking.track(pendingTrackingCalls[0], atomId);
+            tracking.track(pendingTrackingCalls[0], getTrackingId(atomId));
             pendingTrackingCalls.shift();
         }
     }
-
-
 
     function shouldAutoplay(){
 
@@ -177,25 +175,30 @@ define([
 
     function checkElemForVideo(elem) {
         fastdom.read(function () {
-            $('.youtube-media-atom', elem).each(function (el) {
+            $('.youtube-media-atom', elem).each(function (el, index) {
                 var iframe = el.querySelector('iframe');
 
                 if (!iframe) {
                     return;
                 }
 
-                var atomId = el.getAttribute('data-media-atom-id');
-                var overlay = el.querySelector('.youtube-media-atom__overlay');
-                var youtubeId = iframe.id;
+                iframe.id += '/' + index;
 
-                tracking.init(atomId);
+                var atomId = el.getAttribute('data-media-atom-id') + '/' + index;
+                var overlay = el.querySelector('.youtube-media-atom__overlay');
+
+                tracking.init(getTrackingId(atomId));
 
                 youtubePlayer.init(iframe, {
                     onPlayerReady: onPlayerReady.bind(null, atomId, overlay),
                     onPlayerStateChange: onPlayerStateChange.bind(null, atomId)
-                }, youtubeId);
+                }, iframe.id);
             });
         });
+    }
+
+    function getTrackingId(atomId) {
+        return atomId.split('/')[0];
     }
 
     return {

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -182,8 +182,10 @@ define([
                     return;
                 }
 
+                // append index of atom as iframe.id must be unique
                 iframe.id += '/' + index;
 
+                // append index of atom as atomId must be unique
                 var atomId = el.getAttribute('data-media-atom-id') + '/' + index;
                 var overlay = el.querySelector('.youtube-media-atom__overlay');
 
@@ -197,6 +199,7 @@ define([
         });
     }
 
+    // retrieves actual id of atom without appended index
     function getTrackingId(atomId) {
         return atomId.split('/')[0];
     }


### PR DESCRIPTION
## What does this change?

Fixes a bug which prevented a youtube atom being enhanced if the same atom existed elsewhere on the page (because they shared the same ID).

## What is the value of this and can you measure success?

We can have an atom on the page twice.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No

@akash1810 @gidsg 