### PR TITLE
Make amp-youtube change permanent

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -497,15 +497,4 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 2, 27),
     exposeClientSide = true
   )
-
-  //Owner Gideon Goldberg
-  val UseAmpYouTubeTagForMediaAtoms = Switch(
-    SwitchGroup.Feature,
-    "use-amp-youtube-tag-for-media-atoms",
-    "Use amp-youtube tag to render YouTube media atoms on AMP pages",
-    owners = Seq(Owner.withGithub("michaelwmcnamara")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 8),
-    exposeClientSide = true
-  )
 }

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,25 +1,11 @@
 @(media: model.content.MediaAtom,  displayCaption: Boolean, mainMedia: Boolean)(implicit request: RequestHeader)
-@import conf.Configuration
-@import views.support.Video700
-@import conf.switches.Switches.UseAmpYouTubeTagForMediaAtoms
 @import views.html.fragments.atoms.mediaAtomCaption
-
-@if(UseAmpYouTubeTagForMediaAtoms.isSwitchedOn){
     <amp-youtube
     data-videoid="@media.assets.head.id"
     layout="responsive"
     width="16" height="9" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="1">
     </amp-youtube>
-} else {
-    <amp-iframe
-    sandbox="allow-scripts allow-same-origin allow-popups"
-    layout="responsive"
-    width="16" height="9" src="@Configuration.Media.externalEmbedHost/embed/atom/media/@media.id">
-    @media.posterImage.map { posterImage =>
-        <amp-img layout="fill" src="@Video700.bestFor(posterImage)" placeholder></amp-img>
-    }
-    </amp-iframe>
-}
+
 @if(displayCaption) {
     @mediaAtomCaption(media.title, mainMedia)
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -51,10 +51,10 @@ class AtomCleanerTest extends FlatSpec
     result.select("figcaption").html should include("Bird")
   }
 
-  "AtomsCleaner" should "use amp-iframe markup if amp is true" in {
+  "AtomsCleaner" should "use amp-youtube markup if amp is true" in {
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc, youTubeAtom, amp = true)
-    result.select("amp-iframe").attr("src") should include("887fb7b4-b31d-4a38-9d1f-26df5878cf9c")
+    result.select("amp-youtube").attr("data-videoid") should be("nQuN9CUsdVg")
   }
 
 


### PR DESCRIPTION
## What does this change?
Removes the amp-youtube switch and uses `amp-youtube` permanently instead of `amp-iframe` 

## What is the value of this and can you measure success?
`amp-youtube` is more performant, as `amp-iframe` rendering is deferred until later in the loading process.

## Does this affect other platforms - Amp, Apps, etc?
AMP only

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
