### PR TITLE
loadScript should reject Promise on script.onerror

### DIFF
--- a/static/src/javascripts-legacy/projects/common/utils/load-script.js
+++ b/static/src/javascripts-legacy/projects/common/utils/load-script.js
@@ -13,7 +13,7 @@ define([
             return Promise.resolve();
         }
 
-        return new Promise(function (resolve) {
+        return new Promise(function (resolve, reject) {
             var ref = document.scripts[0];
             var script = document.createElement('script');
             script.src = src;
@@ -21,6 +21,7 @@ define([
                 assign(script, props);
             }
             script.onload = resolve;
+            script.onerror = reject;
             ref.parentNode.insertBefore(script, ref);
         });
     }


### PR DESCRIPTION
## What does this change?

Reject the Promise returned by loadScript on script.onerror. 

## What is the value of this and can you measure success?

Rejecting this promise means the 'catch' chained to a call of loadScript is executed. For example if ima3.js (required for preroll ads on videos) fails to load for whatever reason (ad blockers) then the video player will still go on to be enhanced.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No

@guardian/dotcom-platform 