### PR TITLE
use standard seconds to derive iso8601 duration

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -35,7 +35,7 @@ final case class MediaAtom(
   endSlatePath: Option[String]
 ) extends Atom {
   def isoDuration: Option[String] = {
-    duration.map(d => new Duration(d * 1000.toLong).toString)
+    duration.map(d => new Duration(Duration.standardSeconds(d)).toString)
   }
 }
 


### PR DESCRIPTION
## What does this change?
Very <sup>small</sup> refactor. Use `standardSeconds` to create Duration from seconds.

## What is the value of this and can you measure success?
Use built-in function rather than hand-rolled implementation.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
