### PR TITLE
Track identityId in Google Analytics

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -68,7 +68,8 @@
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest)) {
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
             'sampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.samplePercentage },
-            'siteSpeedSampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.siteSpeedSamplePercentage }
+            'siteSpeedSampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.siteSpeedSamplePercentage },
+            'userId': identityId
         });
     }
 


### PR DESCRIPTION
## What does this change?

Google Analytics now provides a way of [tracking a user's unique ID](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#user_id) across sessions and devices. This has already been implemented in native apps.

We are currently using the `identityId` for logged-in users to this end, by capturing the ID in [a custom dimension](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics/google.scala.html#L99). This change will also capture the `identityId` in the new `userId` param

## What is the value of this and can you measure success?

This allows us to identify unique users across multiple devices or sessions. This will give us more accurate user data that better reflects the real-world.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
