### PR TITLE
Cast arguments into array

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
@@ -119,11 +119,10 @@ define([
     }
 
     function defer(name, fn) {
-        var start = moduleStart.bind(null, name);
-        var stop = moduleEnd.bind(null, name);
+        var startStop = [moduleStart.bind(null, name), moduleEnd.bind(null, name)];
         return function() {
             try {
-                fn.apply(null, [start, stop].concat(arguments));
+                fn.apply(null, startStop.concat(startStop.slice.call(arguments)));
             } catch (e) {
                 stop();
                 throw e;


### PR DESCRIPTION
It turns out `Array.prototype.concat` is pretty adamant that it won't cast array-like objects into arrays. And so, `array.contat(arguments)` will give `[arr0, ..., arrN, arguments]` rather than `[arr0, ..., arrN, arg0, ..., argN]`.