### PR TITLE
Fix lodash forIn enumerating over inherited properties in AB targeting

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -104,7 +104,7 @@ define([
 
     function adtestParams() {
         var cookieAdtest = cookies.get('adtest');
-        if (cookiesAdtest) {
+        if (cookieAdtest) {
             if (cookieAdtest.substring(0, 4) === 'demo') {
                 cookies.remove('adtest');
             }

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -11,8 +11,7 @@ define([
     'lodash/arrays/compact',
     'lodash/objects/merge',
     'lodash/arrays/uniq',
-    'lodash/objects/pick',
-    'lodash/objects/isArray'
+    'lodash/objects/pick'
 ], function (
     config,
     cookies,
@@ -26,8 +25,7 @@ define([
     compact,
     merge,
     uniq,
-    pick,
-    isArray
+    pick
 ) {
 
     function format(keyword) {
@@ -198,7 +196,7 @@ define([
 
         // filter out empty values
         return pick(pageTargets, function (target) {
-            if (isArray(target)) {
+            if (Array.isArray(target)) {
                 return target.length > 0;
             } else {
                 return target;

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -10,8 +10,6 @@ define([
     'common/modules/experiments/ab',
     'lodash/arrays/compact',
     'lodash/collections/map',
-    'lodash/objects/forIn',
-    'lodash/objects/keys',
     'lodash/objects/merge',
     'lodash/arrays/uniq',
     'lodash/objects/pick',
@@ -28,8 +26,6 @@ define([
     ab,
     compact,
     map,
-    forIn,
-    keys,
     merge,
     uniq,
     pick,
@@ -83,23 +79,29 @@ define([
             ));
         },
         abParam = function () {
-            var abParams = [],
-                abParticipations = ab.getParticipations();
+            var cmRegex = /^(cm|commercial)/;
+            var abParticipations = ab.getParticipations();
+            var abParams = [];
 
-            forIn(abParticipations, function (n, testKey) {
-                if (n.variant && n.variant !== 'notintest') {
-                    var testData = testKey + '-' + n.variant;
+            Object.keys(abParticipations).forEach(function (testKey) {
+                var testValue = abParticipations[testKey];
+                if (testValue.variant && testValue.variant !== 'notintest') {
+                    var testData = testKey + '-' + testValue.variant;
                     // DFP key-value pairs accept value strings up to 40 characters long
                     abParams.push(testData.substring(0, 40));
                 }
             });
 
-            forIn(keys(config.tests), function (n) {
-                if (n.toLowerCase().match(/^cm/) ||
-                    n.toLowerCase().match(/^commercial/)) {
+            Object.keys(config.tests).forEach(function (testKey) {
+                var testValue = config.tests[testKey];
+                if (typeof testValue === 'string' && isCommercialTest(testValue.toLowerCase())) {
                     abParams.push(n);
                 }
             });
+
+            function isCommercialTest(test) {
+                return cmRegex.test(test) || commercialRegex.test(test);
+            }
 
             return abParams;
         },

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -51,6 +51,7 @@ define([
         if (page.seriesId) {
             return parseId(page.seriesId);
         }
+
         var seriesIdFromUrl = /\/series\/(.+)$/.exec(page.pageId);
         if (seriesIdFromUrl) {
             return seriesIdFromUrl[1];
@@ -69,10 +70,7 @@ define([
     }
 
     function parseIds(ids) {
-        if (!ids) {
-            return null;
-        }
-        return compact(ids.split(',').map(parseId));
+        return ids ? compact(ids.split(',').map(parseId)) : null;
     }
 
     function abParam() {
@@ -102,10 +100,9 @@ define([
     }
 
     function adtestParams() {
-        if (cookies.get('adtest')) {
-            var cookieAdtest = cookies.get('adtest'),
-                first4Char = cookieAdtest.substring(0, 4);
-            if (first4Char === 'demo') {
+        var cookieAdtest = cookies.get('adtest');
+        if (cookiesAdtest) {
+            if (cookieAdtest.substring(0, 4) === 'demo') {
                 cookies.remove('adtest');
             }
             return cookieAdtest;
@@ -164,35 +161,35 @@ define([
     }
 
     return function (opts) {
-        var win         = (opts || {}).window || window,
-            page        = config.page,
-            contentType = formatTarget(page.contentType),
-            pageTargets = merge({
-                url:     win.location.pathname,
-                edition: page.edition && page.edition.toLowerCase(),
-                se:      getSeries(page),
-                ct:      contentType,
-                p:       'ng',
-                k:       page.keywordIds ? parseIds(page.keywordIds) : parseId(page.pageId),
-                x:       krux.getSegments(),
-                su:      page.isSurging,
-                pv:      config.ophan.pageViewId,
-                bp:      detect.getBreakpoint(),
-                at:      adtestParams(),
-                si:      identity.isUserLoggedIn() ? 't' : 'f',
-                gdncrm:  userAdTargeting.getUserSegments(),
-                ab:      abParam(),
-                ref:     getReferrer(),
-                co:      parseIds(page.authorIds),
-                bl:      parseIds(page.blogIds),
-                ob:      page.publication === 'The Observer' ? 't' : '',
-                ms:      formatTarget(page.source),
-                fr:      getVisitedValue(),
-                tn:      parseIds(page.tones),
-                br:      getBrandingType(),
-                // round video duration up to nearest 30 multiple
-                vl:      page.videoDuration ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
-            }, getWhitelistedQueryParams());
+        var win         = (opts || {}).window || window;
+        var page        = config.page;
+        var contentType = formatTarget(page.contentType);
+        var pageTargets = merge({
+            url:     win.location.pathname,
+            edition: page.edition && page.edition.toLowerCase(),
+            se:      getSeries(page),
+            ct:      contentType,
+            p:       'ng',
+            k:       page.keywordIds ? parseIds(page.keywordIds) : parseId(page.pageId),
+            x:       krux.getSegments(),
+            su:      page.isSurging,
+            pv:      config.ophan.pageViewId,
+            bp:      detect.getBreakpoint(),
+            at:      adtestParams(),
+            si:      identity.isUserLoggedIn() ? 't' : 'f',
+            gdncrm:  userAdTargeting.getUserSegments(),
+            ab:      abParam(),
+            ref:     getReferrer(),
+            co:      parseIds(page.authorIds),
+            bl:      parseIds(page.blogIds),
+            ob:      page.publication === 'The Observer' ? 't' : '',
+            ms:      formatTarget(page.source),
+            fr:      getVisitedValue(),
+            tn:      parseIds(page.tones),
+            br:      getBrandingType(),
+            // round video duration up to nearest 30 multiple
+            vl:      page.videoDuration ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
+        }, getWhitelistedQueryParams());
 
         // filter out empty values
         return pick(pageTargets, function (target) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -95,14 +95,10 @@ define([
             if (config.tests) {
                 Object.keys(config.tests).forEach(function (testKey) {
                     var testValue = config.tests[testKey];
-                    if (typeof testValue === 'string' && isCommercialTest(testValue.toLowerCase())) {
-                        abParams.push(n);
+                    if (typeof testValue === 'string' && cmRegex.test(test)) {
+                        abParams.push(testValue);
                     }
                 });
-            }
-
-            function isCommercialTest(test) {
-                return cmRegex.test(test) || commercialRegex.test(test);
             }
 
             return abParams;

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -58,12 +58,15 @@ define([
         }
 
         if (page.keywordIds) {
-            var seriesIdFromKeywords = page.keywordIds.split(',').filter(function (keyword) {
+            return page.keywordIds
+            .split(',')
+            .filter(function (keyword) {
                 return keyword.indexOf('series/') === 0;
-            }).slice(0, 1);
-            if (seriesIdFromKeywords.length) {
-                return seriesIdFromKeywords[0].split('/')[1];
-            }
+            })
+            .slice(0, 1)
+            .map(function (seriesId) {
+                return seriesId.split('/')[1];
+            });
         }
 
         return null;

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -9,7 +9,6 @@ define([
     'common/modules/commercial/user-ad-targeting',
     'common/modules/experiments/ab',
     'lodash/arrays/compact',
-    'lodash/collections/map',
     'lodash/objects/merge',
     'lodash/arrays/uniq',
     'lodash/objects/pick',
@@ -25,7 +24,6 @@ define([
     userAdTargeting,
     ab,
     compact,
-    map,
     merge,
     uniq,
     pick,
@@ -76,11 +74,7 @@ define([
         if (!ids) {
             return null;
         }
-        return compact(map(
-            ids.split(','), function (id) {
-                return parseId(id);
-            }
-        ));
+        return compact(ids.split(',').map(parseId));
     }
 
     function abParam() {

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -92,12 +92,14 @@ define([
                 }
             });
 
-            Object.keys(config.tests).forEach(function (testKey) {
-                var testValue = config.tests[testKey];
-                if (typeof testValue === 'string' && isCommercialTest(testValue.toLowerCase())) {
-                    abParams.push(n);
-                }
-            });
+            if (config.tests) {
+                Object.keys(config.tests).forEach(function (testKey) {
+                    var testValue = config.tests[testKey];
+                    if (typeof testValue === 'string' && isCommercialTest(testValue.toLowerCase())) {
+                        abParams.push(n);
+                    }
+                });
+            }
 
             function isCommercialTest(test) {
                 return cmRegex.test(test) || commercialRegex.test(test);

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -93,7 +93,7 @@ define([
         if (config.tests) {
             Object.keys(config.tests).forEach(function (testKey) {
                 var testValue = config.tests[testKey];
-                if (typeof testValue === 'string' && cmRegex.test(test)) {
+                if (typeof testValue === 'string' && cmRegex.test(testValue)) {
                     abParams.push(testValue);
                 }
             });

--- a/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/build-page-targeting.js
@@ -3,13 +3,13 @@ define([
     'common/utils/cookies',
     'common/utils/detect',
     'common/utils/storage',
+    'common/utils/assign',
     'common/utils/url',
     'commercial/modules/third-party-tags/krux',
     'common/modules/identity/api',
     'common/modules/commercial/user-ad-targeting',
     'common/modules/experiments/ab',
     'lodash/arrays/compact',
-    'lodash/objects/merge',
     'lodash/arrays/uniq',
     'lodash/objects/pick'
 ], function (
@@ -17,13 +17,13 @@ define([
     cookies,
     detect,
     storage,
+    assign,
     url,
     krux,
     identity,
     userAdTargeting,
     ab,
     compact,
-    merge,
     uniq,
     pick
 ) {
@@ -167,7 +167,7 @@ define([
         var win         = (opts || {}).window || window;
         var page        = config.page;
         var contentType = formatTarget(page.contentType);
-        var pageTargets = merge({
+        var pageTargets = assign({
             url:     win.location.pathname,
             edition: page.edition && page.edition.toLowerCase(),
             se:      getSeries(page),


### PR DESCRIPTION
People in the AdOps team noticed they were not always getting back the ads they were supposed to see in a HPTO. That was due to a `toLowerCase` call on a non-String value when building the page targeting. It turns out `forIn` in lodash will enumerate over inherited properties of an object, and because of prototypal inheritance this may lead to unexpected results.

Good thing we can do without lodash for most of our needs, so I cleaned up this module quite a bit.