### PR TITLE
Define a new AB test for A1 vs A2 supporter bundles

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,8 +22,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-bundles-thrasher",
-    "Test appetite for first batch of bundles",
+    "ab-membership-a1-a2-bundles-thrasher",
+    "Test A1 vs A2 bundle offers",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 3, 2), // Thursday March 2nd

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -12,7 +12,7 @@ define([
     'common/modules/experiments/tests/recommended-for-you',
     'common/modules/experiments/tests/membership-engagement-banner-tests',
     'common/modules/experiments/acquisition-test-selector',
-    'common/modules/experiments/tests/membership-ab-thrasher'
+    'common/modules/experiments/tests/membership-a1-a2-thrasher'
 ], function (reportError,
              config,
              cookies,
@@ -26,14 +26,14 @@ define([
              RecommendedForYou,
              MembershipEngagementBannerTests,
              acquisitionTestSelector,
-             MembershipABThrasher
+             MembershipA1A2Thrasher
     ) {
     var TESTS = compact([
         new EditorialEmailVariants(),
         new OpinionEmailVariants(),
         new RecommendedForYou(),
         acquisitionTestSelector.getTest(),
-        new MembershipABThrasher
+        new MembershipA1A2Thrasher()
     ].concat(MembershipEngagementBannerTests));
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
@@ -22,7 +22,7 @@ define([
         this.description = 'Test Supporter Bundle A1 (ad-free control) against A2 (with-ads variant)';
         this.showForSensitive = true;
         this.audience = 0.15;  // 7.5% per variant
-        this.audienceOffset = 0;
+        this.audienceOffset = 0.15; // use a new audience segment base
         this.successMeasure = '';
         this.audienceCriteria = 'People on UK network front with at least an 1140px wide display.';
         this.dataLinkNames = '';
@@ -59,7 +59,7 @@ define([
             if (this.thrasher()) {
                 var linkEl = document.querySelector('.membership-ab-thrasher--wrapper .link-button');
                 if (linkEl && linkEl.getAttribute('href')) {
-                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_THRASHER_' + config.page.edition + '_' + variant.toUpperCase());
+                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_THRASHER_' + config.page.edition.toUpperCase() + '_' + variant.toUpperCase());
                 }
             }
         };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
@@ -59,7 +59,7 @@ define([
             if (this.thrasher()) {
                 var linkEl = document.querySelector('.membership-ab-thrasher--wrapper .link-button');
                 if (linkEl && linkEl.getAttribute('href')) {
-                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_THRASHER_' + config.page.edition.toUpperCase() + '_' + variant.toUpperCase());
+                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_ADS_THRASHER_' + config.page.edition.toUpperCase() + '_' + variant.toUpperCase());
                 }
             }
         };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a1-a2-thrasher.js
@@ -1,9 +1,13 @@
 define([
+    'bean',
+    'qwery',
     'common/utils/config',
     'common/utils/detect',
     'common/modules/commercial/user-features'
 
 ], function (
+    bean,
+    qwery,
     config,
     detect,
     userFeatures
@@ -11,18 +15,19 @@ define([
     return function () {
         var self = this;
 
-        this.id = 'MembershipBundlesThrasher';
-        this.start = '2017-01-23';
+        this.id = 'MembershipA1A2BundlesThrasher';
+        this.start = '2017-02-06';
         this.expiry = '2017-03-02'; // Thursday 2nd March
         this.author = 'Justin Pinner';
-        this.description = 'Test appetite for membership bundles';
+        this.description = 'Test Supporter Bundle A1 (ad-free control) against A2 (with-ads variant)';
         this.showForSensitive = true;
-        this.audience = 0.15;  // 5% per variant
+        this.audience = 0.15;  // 7.5% per variant
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'People on UK network front with at least an 1140px wide display.';
         this.dataLinkNames = '';
-        this.idealOutcome = 'One landing page will accrue a higher number of intention interactions than the other';
+        this.idealOutcome = 'We understand which of the A bundle variants is most desirable.';
+        this.hypothesis = 'An ad-free offering is desired by more readers.';
 
         this.canRun = function () {
             return document.querySelector('#membership-ab-thrasher') &&
@@ -54,7 +59,7 @@ define([
             if (this.thrasher()) {
                 var linkEl = document.querySelector('.membership-ab-thrasher--wrapper .link-button');
                 if (linkEl && linkEl.getAttribute('href')) {
-                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_AB_THRASHER_' + config.page.edition + '_' + variant.toUpperCase());
+                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_THRASHER_' + config.page.edition + '_' + variant.toUpperCase());
                 }
             }
         };
@@ -74,24 +79,25 @@ define([
             this.showThrasher();
         };
 
+        this.completeFunc = function(complete) {
+            // fire on thrasher's [find out more -->] button click
+            bean.on(qwery('.membership-ab-thrasher--wrapper .link-button')[0], 'click', complete);
+        };
+
         this.variants = [
             {
-                id: 'A1',
+                id: 'control',
                 test: function () {
-                    self.setup('A1')
-                }
+                    self.setup('control');   // A1 is our control group (for the benefit of abacus)
+                },
+                success: this.completeFunc
             },
             {
-                id: 'B1',
+                id: 'variant',
                 test: function () {
-                    self.setup('B1');
-                }
-            },
-            {
-                id: 'B2',
-                test: function () {
-                    self.setup('B2');
-                }
+                    self.setup('variant');  // variant is A2
+                },
+                success: this.completeFunc
             }
         ];
     };


### PR DESCRIPTION
## What does this change?
(see also https://github.com/guardian/membership-frontend/pull/1483)

Replaces the current A1/B1/B2 bundles test with an A1/A2 version. Having dropped to two cohorts, we're leaving the audience at 15% to gather this round of data quickly.  

We've also changed the cohort names to `control` and `variant`, primarily to keep abacus happy.

## What is the value of this and can you measure success?
The previous test proved which overall layout was more widely appreciated, now we need to prove the demand difference between two variants (ad-free and with-ads) of the winning layout.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
There are no visible differences in frontend, except for the link params from the thrasher's 'find out more' buton, so you can refer to the screen grabs on the original test PR: https://github.com/guardian/frontend/pull/15661.

## Tested in CODE?
~~As soon as I have a PR build...~~ Yes;
![screen shot 2017-02-07 at 12 23 55](https://cloud.githubusercontent.com/assets/690395/22691028/651739bc-ed30-11e6-8904-370bf469ddc1.png)


<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
