### PR TITLE
Putting back the old version of handling svgs.

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -15,8 +15,7 @@ define([
         'common/modules/experiments/tests/membership-engagement-banner-tests',
         'lodash/objects/defaults',
         'lodash/collections/find',
-        'common/views/svg',
-        'inlineSvg!svgs/icon/arrow-white-right.svg',
+        'common/views/svgs',
         'common/utils/fetch'
     ], function (bean,
                  $,
@@ -34,7 +33,7 @@ define([
                  MembershipEngagementBannerTests,
                  defaults,
                  find,
-                 svg,
+                 svgs,
                  arrowWhiteRight,
                  fetch) {
 
@@ -161,7 +160,7 @@ define([
                 messageText: messageText,
                 buttonCaption: params.buttonCaption,
                 colourClass: colourClass,
-                arrowWhiteRight: svg(arrowWhiteRight),
+                arrowWhiteRight: svgs('arrowWhiteRight'),
                 showRemindMe: params.showRemindMe || false
             });
 


### PR DESCRIPTION
## What does this change?

This PR handles the edge case of the banner rendering svgs that are generated using webpack 2. Before this PR, the users of the US edition see the text **[Object object]** instead of a white arrow.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

# Before

![before](https://cloud.githubusercontent.com/assets/825398/22656986/cba1eafa-ec8c-11e6-890c-f4a1db0b7bdb.png)


# After

<img width="1245" alt="picture 116" src="https://cloud.githubusercontent.com/assets/825398/22657632/113a6900-ec8f-11e6-8d4e-e18040e46bc3.png">

## Tested in CODE?

Yes