### PR TITLE
expiry date of always ask switch extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,7 +86,7 @@ trait ABTestSwitches {
     "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 6),
+    sellByDate = new LocalDate(2017, 5, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -32,7 +32,7 @@ define([
         campaignId: 'epic_always_ask_strategy',
 
         start: '2016-12-06',
-        expiry: '2017-02-06',
+        expiry: '2017-05-01',
 
         author: 'Guy Dawson',
         description: 'Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period.',


### PR DESCRIPTION
## What does this change?

Extends the always ask test for the Epic.

## What is the value of this and can you measure success?

It investigates running the Epic for a segment over an extended period of time. It also allows devs to deploy to frontend! 😅 

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@jfsoul 
