### PR TITLE
Upgrade version of CSS parser

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
   val commonsLang = "commons-lang" % "commons-lang" % "2.4"
   val commonsIo = "commons-io" % "commons-io" % "2.4"
-  val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.18"
+  val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.21"
   val contentApiClient = "com.gu" %% "content-api-client" % "11.0"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "2.20.0"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % dispatchVersion


### PR DESCRIPTION
We've been having some intermittent bugs with CSS parsing, as mentioned in #15720. The logging introduced in that PR shows that [this error is still occurring](https://kibana.gu-web.net/app/kibana#/doc/logstash-*/logstash-2017.02.07/logs?id=AVoXUrZNrEL75Ra5C3cM&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-7d,mode:quick,to:now))).

Interestingly in the case above, it failed on the first two (immediately retried) attempts but succeeded on the third, suggesting that something very time-sensitive like thread interference might be the cause. And indeed there was a multithreading-related fix included in a [recent version of the CSS parser](https://sourceforge.net/p/cssparser/code/640/)

Since we were using a [version from 2015](http://cssparser.sourceforge.net/changes-report.html#a0.9.18) it seems wise to upgrade in any case. If we're lucky it might solve the intermittent issue we're having