### PR TITLE
Add a/b test for surveys using Tailor

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -120,4 +120,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-tailor-survey",
+    "Integrate Tailor with ab tests",
+    owners = Seq(Owner.withGithub("oilnam")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 4, 10),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -13,7 +13,8 @@ define([
     'common/modules/experiments/tests/membership-engagement-banner-tests',
     'common/modules/experiments/tests/guardian-today-messaging',
     'common/modules/experiments/acquisition-test-selector',
-    'common/modules/experiments/tests/membership-a3-a4-bundles-thrasher'
+    'common/modules/experiments/tests/membership-a3-a4-bundles-thrasher',
+    'common/modules/experiments/tests/tailor-survey'
 ], function (reportError,
              config,
              cookies,
@@ -28,7 +29,8 @@ define([
              MembershipEngagementBannerTests,
              GuardianTodayMessaging,
              acquisitionTestSelector,
-             MembershipA3A4BundlesThrasher
+             MembershipA3A4BundlesThrasher,
+             TailorSurvey
     ) {
     var TESTS = compact([
         new EditorialEmailVariants(),
@@ -36,7 +38,8 @@ define([
         new RecommendedForYou(),
         new GuardianTodayMessaging(),
         acquisitionTestSelector.getTest(),
-        new MembershipA3A4BundlesThrasher()
+        new MembershipA3A4BundlesThrasher(),
+        new TailorSurvey()
     ].concat(MembershipEngagementBannerTests));
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -1,0 +1,150 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'Promise',
+    'lodash/functions/debounce',
+    'common/utils/config',
+    'common/utils/cookies',
+    'common/utils/storage',
+    'common/utils/mediator',
+    'common/utils/fastdom-promise',
+    'common/utils/private-browsing',
+    'text!common/views/experiments/tailor-survey.html',
+    'common/utils/fetch-json',
+    'lodash/collections/forEach'
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    Promise,
+    debounce,
+    config,
+    cookies,
+    storage,
+    mediator,
+    fastdomPromise,
+    privateBrowsing,
+    quickSurvey,
+    fetchJson,
+    forEach
+) {
+    return function () {
+        this.id = 'TailorSurvey';
+        this.start = '2017-01-25';
+        this.expiry = '2017-03-31';
+        this.author = 'Manlio';
+        this.description = 'Testing Tailor surveys';
+        this.audience = 0.01;
+        this.audienceOffset = 0.7;
+        this.successMeasure = 'We can show a survey on Frontend to regular users only (as decided by Tailor)';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = 'Tailor survey';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return !(config.page.isAdvertisementFeature) &&
+                config.page.contentType === 'Article'
+        };
+
+        function callTailor(bwid) {
+            var endpoint = 'https://tailor.guardianapis.com/suggestions?browserId=' + bwid;
+            return fetchJson(endpoint, {
+                type: 'json',
+                method: 'get'
+            });
+        }
+
+        function renderQuickSurvey() {
+            var bwid = cookies.get('bwid');
+            var hasSeenTheSurveyAlready = cookies.get('GU_TAILOR_SURVEY_1') || false;
+
+            if (bwid && !hasSeenTheSurveyAlready) {
+                return callTailor(bwid).then(function (response) {
+                    if (response.userDataForClient.regular) {
+
+                        cookies.add('GU_TAILOR_SURVEY_1', 1, 100); // do not show this survey to the user for the next 100 days
+
+                        return fastdomPromise.write(function () {
+                            var article = document.getElementsByClassName('content__article-body')[0];
+                            var insertionPoint = article.getElementsByTagName('p')[1];
+                            var surveyDiv = document.createElement('div');
+                            surveyDiv.innerHTML = quickSurvey;
+                            article.insertBefore(surveyDiv, insertionPoint);
+                        });
+                    }
+                });
+            }
+        }
+
+        function disableRadioButtons(buttonClassName) {
+            var radioButtons = document.getElementsByClassName(buttonClassName);
+            bonzo(radioButtons).each(function(button) {
+                button.disabled=true;
+            });
+        }
+
+        function surveyFadeOut() {
+            var surveyContent = document.getElementsByClassName('impressions-survey__content');
+            surveyContent[0].classList.add('js-impressions-survey__fadeout');
+        }
+
+        function thankyouFadeIn() {
+            var surveyThanks = document.getElementsByClassName('impressions-survey__thanks');
+            surveyThanks[0].classList.add('js-impressions-survey__fadein');
+        }
+
+        function handleSurveyResponse() {
+            var surveyQuestions = document.getElementsByClassName('fi-survey__button');
+
+            forEach(surveyQuestions, function(question) {
+                bean.on(question, 'click', function (event) {
+                    if (event.target.attributes.getNamedItem("data-link-name")) {
+                        var answer = event.target.attributes.getNamedItem("data-link-name").value;
+                        recordOphanAbEvent(answer);
+
+                        mediator.emit('tailor:survey:clicked');
+                        fastdom.write(function () {
+                            disableRadioButtons('fi-survey__button');
+                            surveyFadeOut();
+                            thankyouFadeIn();
+                        });
+                    }
+                });
+                }
+            );
+        }
+
+        function recordOphanAbEvent(answer) {
+            require(['ophan/ng'], function (ophan) {
+                ophan.record({
+                    component: 'tailor-survey',
+                    value: answer
+                });
+            });
+        }
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+                }
+            },
+            {
+                id: 'variant',
+                test: function () {
+                    Promise.all([renderQuickSurvey(), privateBrowsing]).then(function () {
+                        mediator.emit('survey-added');
+                        handleSurveyResponse();
+                    });
+                },
+                impression: function(track) {
+                    mediator.on('survey-added', track);
+                },
+                success: function(complete) {
+                    mediator.on('tailor:survey:clicked', complete);
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
+++ b/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
@@ -1,0 +1,36 @@
+
+<div class="impressions-survey__heading">
+    <div class="impressions-survey__title">Survey</div>
+    <div class="impressions-survey__title">
+        <a href="https://www.theguardian.com/help/terms-of-service" target="_blank" class="impressions-survey__about">About</a>
+    </div>
+</div>
+
+<div class="impressions-survey__body" data-link-name="impressions-frequency-survey">
+
+    <div class="impressions-survey__content">
+        <h3 class="impressions-survey__question">
+            I value that The Guardian offers me a unique perspective I can't get elsewhere</h3>
+        <div class="impressions-survey__select">
+            <label class="fi-survey__label">
+                <input type="radio" class="fi-survey__button" data-link-name="answer5" value="answer5">
+                Strongly agree</label>
+            <label class="fi-survey__label">
+                <input type="radio" class="fi-survey__button" data-link-name="answer4" value="answer4">
+                Slightly agree</label>
+            <label class="fi-survey__label">
+                <input type="radio" class="fi-survey__button" data-link-name="answer3" value="answer3">
+                Neither agree nor disagree</label>
+            <label class="fi-survey__label">
+                <input type="radio" class="fi-survey__button" data-link-name="answer2" value="answer2">
+                Slightly disagree</label>
+            <label class="fi-survey__label">
+                <input type="radio" class="fi-survey__button" data-link-name="answer1" value="answer1">
+                Strongly disagree</label>
+        </div>
+    </div>
+
+    <div class="impressions-survey__thanks">
+        Thank you for helping us<br>improve the Guardian
+    </div>
+</div>

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -116,6 +116,7 @@
 // Consider head.*.scss instead
 
 @import 'module/experiments/_affix';
+@import 'module/experiments/_survey';
 
 /* ==========================================================================
    Icons

--- a/static/src/stylesheets/module/experiments/_survey.scss
+++ b/static/src/stylesheets/module/experiments/_survey.scss
@@ -1,0 +1,73 @@
+.impressions-survey__heading {
+  @include content-gutter;
+  padding-top: $gs-baseline / 2;
+  padding-bottom: $gs-baseline / 2;
+  background-color: #aad7e4;
+}
+
+.impressions-survey__title {
+  @include fs-bodyHeading(4);
+  display: inline-block;
+  margin-right: $gs-gutter;
+}
+
+.impressions-survey__about {
+  font-weight: normal;
+  color: inherit;
+  padding-left: $gs-gutter;
+  border-left: solid #ffffff;
+}
+
+.impressions-survey__about:hover,
+.impressions-survey__about:link,
+.impressions-survey__about:active,
+.impressions-survey__about:visited {
+  text-decoration: none;
+}
+
+.impressions-survey__body {
+  @include fs-bodyCopy(1);
+  @include content-gutter;
+  padding-top: $gs-baseline;
+  padding-bottom: $gs-baseline;
+  color: #ffffff;
+  margin-bottom: $gs-baseline;
+  background-color: $guardian-brand;
+  opacity: 1;
+  position: relative;
+}
+
+.impressions-survey__question {
+  @include fs-bodyHeading(2);
+}
+
+.fi-survey__button {
+  display: inline-block;
+  float: none;
+  margin: 0;
+}
+
+.fi-survey__label {
+  display: block;
+}
+
+.impressions-survey__thanks {
+  @include fs-bodyHeading(4);
+  color: #ffffff;
+  position: absolute;
+  top: 20%;
+  opacity: 0;
+  visibility: collapse;
+}
+
+.js-impressions-survey__fadein {
+  visibility: visible;
+  opacity: 1;
+  transition: visibility 2s ease-in .5s, opacity .5s linear;
+}
+
+.js-impressions-survey__fadeout {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s ease-in .5s, opacity .5s linear;
+}


### PR DESCRIPTION
### Intro

This PR is a proof-of-concept that we can show a survey and integrate it with Tailor. This is not really an A/B test, although it uses the A/B test framework for conveniency. 

It's also my first PR to frontend so apologies if I messed up a few things 😇 

### ASCII diagram because ASCII

```
A\B test -> load survey logic -> ask Tailor -> display a survey (maybe)
```

### Key points

- The **control** group doesn't do anything. We only want to trigger this for a tiny fraction of our audience. It's 1pc now, not sure if this is the right number.

- If you fall in the **variant** group, [a call is made to Tailor](https://tailor.guardianapis.com/) to determine if you're a regular

- If Tailor says you're a regular **and** you haven't seen this survey before, you'll see a survey in all its beauty:

![screen shot 2017-02-07 at 18 23 24](https://cloud.githubusercontent.com/assets/3343647/22706063/c93ae76a-ed65-11e6-9ee9-6b0954b106eb.jpg)

- To check if you've seen the survey or not, we drop a cookie called `GU_TAILOR_SURVEY_1` and we check if it's present or not.

- To actually register what the answer to the survey was, when the user clicks on any answer we're sending a special key-value information to the Ophan `a` (additional) endpont; proof:

![screen shot 2017-02-07 at 18 24 06](https://cloud.githubusercontent.com/assets/3343647/22706292/977b30e4-ed66-11e6-8dba-081809855022.jpg)

which should magically end up in the Data Lake under `interactions`.

(I don't understand why it's wrapped in quotes; I suspect it shouldn't be but I'm using `ophan/ng` so I'm not sure about it :roll_eyes: )

### Nominations

@lindseydew because Ophan
@GHaberis because Frontend
@MahanaC because she's Tailor's mom
@desbo because he's a legend
@katebee because she designed the original survey a/b test
@mike-ruane so he doesn't feel left behind :)

(and thanks to all of you above for your help 😊 )