### PR TITLE
Turn sticky top banner into a wrapped module

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/commercial.js
+++ b/static/src/javascripts-legacy/bootstraps/commercial.js
@@ -66,7 +66,7 @@ define([
     ];
 
     var secondaryModules = [
-        ['cm-stickyTopBanner', stickyTopBanner.init, true],
+        ['cm-stickyTopBanner', stickyTopBanner.init],
         ['cm-fill-advert-slots', fillAdvertSlots.init, true],
         ['cm-paidContainers', paidContainers.init],
         ['cm-paidforBand', paidforBand.init]

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
@@ -108,12 +108,13 @@ define([
             start();
             var ret = fn.apply(null, arguments);
             if (ret instanceof Promise) {
-                ret.then(stop, function(reason) {
+                return ret.then(stop, function(reason) {
                     stop();
                     throw reason;
                 });
             } else {
                 stop();
+                return ret;
             }
         };
     }
@@ -122,7 +123,7 @@ define([
         var startStop = [moduleStart.bind(null, name), moduleEnd.bind(null, name)];
         return function() {
             try {
-                fn.apply(null, startStop.concat(startStop.slice.call(arguments)));
+                return fn.apply(null, startStop.concat(startStop.slice.call(arguments)));
             } catch (e) {
                 stop();
                 throw e;

--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
@@ -30,11 +30,8 @@ define([
         onScroll: onScroll
     };
 
-    function init(start, stop, _window) {
-        start();
-
+    function init(_window) {
         if (!commercialFeatures.stickyTopBannerAd) {
-            stop();
             return Promise.resolve();
         }
 
@@ -46,15 +43,11 @@ define([
 
             // First, let's assign some default values so that everything
             // is in good order before we start animating changes in height
-            var promise = initState()
+            return initState()
             // Second, start listening for height and scroll changes
-            .then(setupListeners);
-            promise
-            .then(onFirstRender)
-            .then(stop);
-            return promise;
+            .then(setupListeners)
+            .then(onFirstRender);
         } else {
-            stop();
             topSlot = null;
             return Promise.resolve();
         }

--- a/static/test/javascripts/spec/commercial/sticky-top-banner.spec.js
+++ b/static/test/javascripts/spec/commercial/sticky-top-banner.spec.js
@@ -7,9 +7,6 @@ define([
     Injector,
     Promise
 ) {
-    function noop() {
-    }
-
     describe('Sticky ad banner', function () {
         var sticky, detect, header, stickyBanner, messenger, register, commercialFeatures;
 
@@ -65,7 +62,7 @@ define([
         });
 
         it('should add listeners and classes', function (done) {
-            sticky.init(noop, noop, mockWindow)
+            sticky.init(mockWindow)
             .then(function () {
                 expect(register.calls.count()).toBe(1);
                 expect(mockWindow.addEventListener).toHaveBeenCalled();
@@ -78,7 +75,7 @@ define([
 
         it('should not add classes when scrolled past the header', function (done) {
             mockWindow.pageYOffset = 501;
-            sticky.init(noop, noop, mockWindow)
+            sticky.init(mockWindow)
             .then(function () {
                 mockWindow.pageYOffset = 0;
                 expect(header.classList.contains('l-header--animate')).toBe(false);
@@ -90,7 +87,7 @@ define([
 
         it('should set the slot height and the header top margin', function (done) {
             var randomHeight = Math.random() * 500 | 0;
-            sticky.init(noop, noop)
+            sticky.init()
             .then(function () {
                 return sticky.resize(randomHeight);
             })
@@ -105,7 +102,7 @@ define([
         it('should adjust the scroll position', function (done) {
             var randomHeight = Math.random() * 500 | 0;
             mockWindow.pageYOffset = 501;
-            sticky.init(noop, noop, mockWindow)
+            sticky.init(mockWindow)
             .then(function () {
                 return sticky.resize(randomHeight);
             })
@@ -124,7 +121,7 @@ define([
             var topSlot = document.getElementById('dfp-ad--top-above-nav');
             topSlot.style.paddingTop = pt + 'px';
             topSlot.style.paddingBottom = pb + 'px';
-            sticky.init(noop, noop)
+            sticky.init()
             .then(function () {
                 return sticky.update(h, topSlot);
             })
@@ -147,7 +144,7 @@ define([
 
         it('should position the banner absolutely past the header', function (done) {
             mockWindow.pageYOffset = 501;
-            sticky.init(noop, noop, mockWindow)
+            sticky.init(mockWindow)
             .then(sticky.onScroll)
             .then(function () {
                 expect(stickyBanner.style.position).toBe('absolute');


### PR DESCRIPTION
The `onFirstRender` call was not blocking on anything, and so the manual module timing did not add any value, so I'm removing it. Besides, there is a slight chance the `trackAdRender` call did not happen before the top banner was displayed ... which would be surprising, but I don't want to take any chances.