### PR TITLE
Make Plista switch permanent - it is used as a toggle by AU commercial team

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -71,7 +71,7 @@ trait FeatureSwitches {
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 8),
+    sellByDate = never,
     exposeClientSide = true
   )
 


### PR DESCRIPTION
The AU commercial team use this switch to toggle between serving two different - yet equally sterling - third party services (Outbrain and Plista).

This switch has been in place for about a year and until one or both of these services is removed from the sight (a sad day indeed), this switch will need to be present.

@guardian/commercial-dev 