### PR TITLE
AMP + New header tag tweaks

### DIFF
--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -44,26 +44,26 @@
 
         <div class="submeta2__keywords">
             @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-                    @content.tags.tones.headOption.map { tone =>
-                        <a class="submeta2__link submeta2__link--first"
-                            href="@LinkTo(tone.metadata.url)"
-                            data-link-name="tone: @tone.name">
-                                @tone.name.toLowerCase
-                        </a>
-                    }
-                }
-
-                @defining(content.tags.keywords.filterNot(_.isSectionTag).take(5)) { shownKeywords =>
+                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
                     @if(shownKeywords.nonEmpty) {
                         @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                            <a class="submeta2__link @if(content.tags.isLiveBlog && row.rowNum == 1){submeta2__link--first}"
+                            <a class="submeta2__link @if(row.rowNum == 1){submeta2__link--first}"
                                 href="@LinkTo(keyword.metadata.url)"
                                 data-link-name="keyword: @keyword.id">
                                     @keyword.name
                                     @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
                             </a>
                         }
+                    }
+                }
+
+                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
+                    @content.tags.tones.headOption.map { tone =>
+                        <a class="submeta2__link"
+                            href="@LinkTo(tone.metadata.url)"
+                            data-link-name="tone: @tone.name">
+                                @tone.name.toLowerCase
+                        </a>
                     }
                 }
             }

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -77,7 +77,7 @@
 
 }
 @if(!amp) {
-    <div class="submeta hide-on-mobile">
+    <div class="submeta @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}">
         @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
             <hr/>
             <div data-link-name="keywords" data-component="keywords">


### PR DESCRIPTION
## What does this change?
This changes two things. First, a big where we were accidentally hiding the tags on mobile outside the test.

The second thing that has changed is tweaks  to what shows up in the submeta keyword list. The tone is moved to the end of the list as it isn't as important for the user. The first tag which is the section id and is already showing up about the keyword list is dropped to avoid  the duplication.

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
Tweaking what is shown to be more relevant to the user

## Does this affect other platforms - Amp, Apps, etc?
This affects AMP too

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/22735119/48c19fbc-edf0-11e6-9984-17b685ff959f.png)


After:
![image](https://cloud.githubusercontent.com/assets/8774970/22735182/8d1299aa-edf0-11e6-85ab-45baa53b5504.png)


## Tested in CODE?
No
