### PR TITLE
Constraining amp header in footer the same as the body

### DIFF
--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -5,6 +5,7 @@
     background: $multimedia-support-4;
     z-index: $zindex-content;
     width: 100%;
+    max-width: 600px;
     clear: both;
 }
 

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -7,6 +7,8 @@ $veggie-burger-medium: 52px;
 
 .header {
     background-color: $guardian-brand;
+    max-width: 600px;
+    margin: 0 auto;
 }
 
 .header__inner {


### PR DESCRIPTION
## What does this change?
We put a max-width of 600px on the body on AMP. This is adding it to the header and footer as well. 

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
We can't determine all the places an AMP page could show up, but as its meant for mobile and we only style for mobile this prevents it from looking broken if it does show up on a desktop/big tablet.

## Does this affect other platforms - Amp, Apps, etc?
This only affects AMP

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/22736249/2c7ff678-edf5-11e6-8652-c675aa5dccfc.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/22736258/32d3128a-edf5-11e6-869c-2e0d17553d36.png)

## Tested in CODE?
no
