### PR TITLE
Fix issue with thin black line appearing above youtube atom overlay

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -75,7 +75,7 @@
 
     .youtube-media-atom__overlay {
         background-size: cover;
-        background-position: 50% 50%;
+        background-position: 49% 49%;
         background-repeat: no-repeat;
         z-index: 1;
         text-align: center;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -75,6 +75,11 @@
 
     .youtube-media-atom__overlay {
         background-size: cover;
+        /**
+         * Fixed 1px line appearing above overlay occasionally.
+         * http://stackoverflow.com/questions/38695492/1px-glitch-appearing-below-image-when-browser-re-sizes-background-image
+         * http://stackoverflow.com/questions/14376328/background-sizecover-1px-whitespace-to-the-left
+        **/
         background-position: 49% 49%;
         background-repeat: no-repeat;
         z-index: 1;


### PR DESCRIPTION
## What does this change?

Fixes issue in Chrome where when you use "background-size: cover", if the position of background-image isn't less than 50% then you sometimes see a 1px 'line' at the top of the overlay, setting position to 49%  instead will fix this problem.

## What is the value of this and can you measure success?

Fixes bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before...

![picture 34](https://cloud.githubusercontent.com/assets/1590704/22739142/4512884c-ee02-11e6-813f-1b429d114f30.png)

After...

![picture 33](https://cloud.githubusercontent.com/assets/1590704/22739148/4f66fd0a-ee02-11e6-8480-ce5af511fefe.png)

## Tested in CODE?

No

@akash1810 