### PR TITLE
Repurpose server-side share count switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -9,7 +9,7 @@ trait FeatureSwitches {
     "server-share-counts",
     "If this switch is on, share counts are fetched from the Facebook Graph API on the server",
     owners = Seq(Owner.withGithub("jfsoul")),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = true
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -4,13 +4,13 @@ import conf.switches.Expiry.never
 import org.joda.time.LocalDate
 
 trait FeatureSwitches {
-  val ServerSideShareCounts = Switch(
+  val ShareCounts = Switch(
     SwitchGroup.Feature,
     "server-share-counts",
-    "If this switch is on, share counts are fetched from a more recent Facebook Graph API version, server-side",
+    "If this switch is on, share counts are fetched from the Facebook Graph API on the server",
     owners = Seq(Owner.withGithub("jfsoul")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 8),
+    sellByDate = never,
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts-legacy/projects/common/modules/social/share-count.js
@@ -68,9 +68,7 @@ define([
         incrementShareCount(val);
     }
 
-    var fetch = config.switches.serverShareCounts ? fetchFromServer : fetchDirect;
-
-    function fetchFromServer() {
+    function fetch() {
         ajax({
             url: config.page.ajaxUrl + '/sharecount/' + config.page.pageId + '.json',
             type: 'json',
@@ -84,25 +82,11 @@ define([
         });
     }
 
-    function fetchDirect() {
-        ajax({
-            url: 'https://graph.facebook.com/http://www.theguardian.com/' + config.page.pageId,
-            type: 'json',
-            method: 'get',
-            crossOrigin: true
-        }).then(function (resp) {
-            var count = resp.share && resp.share.share_count || 0;
-            counts.facebook = count;
-            addToShareCount(count);
-            updateTooltip();
-        });
-    }
-
     return function () {
         // asking for social counts in preview "leaks" upcoming URLs to social sites.
         // when they then crawl them they get 404s which affects later sharing.
         // don't call counts in preview
-        if ($shareCountEls.length && !config.page.isPreview) {
+        if (config.switches.serverShareCounts && $shareCountEls.length && !config.page.isPreview) {
             try {
                 fetch()
             } catch (e) {


### PR DESCRIPTION
## What does this change?
Repurposes the server-side facebook share count switch so that it's now a permanent feature switch for share count in general.  Share count is now always fetched server-side, but I'm leaving a switch there to turn it off in exceptional circumstances.  When off, the share count container will not be populated.

## What is the value of this and can you measure success?
Avoids switch expiry and concludes trial period for the feature.

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
