### PR TITLE
Intro text as outro text in emails

### DIFF
--- a/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
+++ b/common/app/views/fragments/email/stylesheets/connectedStyleOverride.scala.html
@@ -20,7 +20,7 @@
         padding: 0 !important;
     }
 
-    .introduction {
+    .message {
         background: #fee9ed;
     }
 

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -30,7 +30,7 @@
         font-size: 14px;
         line-height: 18px;
         background: #f6f6f6;
-        padding: 6px 10px 36px 10px;
+        padding: 6px 10px 6px 10px;
     }
 
     .container-title {

--- a/common/app/views/fragments/email/stylesheets/front.scala.html
+++ b/common/app/views/fragments/email/stylesheets/front.scala.html
@@ -25,7 +25,7 @@
         border: none;
     }
 
-    .introduction {
+    .message {
         font-family: Helvetica, Arial, sans-serif;
         font-size: 14px;
         line-height: 18px;

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -112,12 +112,6 @@
     @imgForFront(page.banner, page.email.map(_.name))
 }
 
-@page.frontProperties.onPageDescription.map { description =>
-    @paddedRow {
-        <p class="introduction">@description</p>
-    }
-}
-
 @page.collections.filterNot(_.curatedPlusBackfillDeduplicated.isEmpty).zipWithIndex.map { case (collection, collectionIndex) =>
     @paddedRow {
         <h2 class="container-title @if(collectionIndex > 0) { container-title--not-first }">
@@ -133,5 +127,11 @@
                 @otherCard(card, isSlowLayout = collection.collectionType == "slow")
             }
         }
+    }
+}
+
+@page.frontProperties.onPageDescription.map { description =>
+    @paddedRow {
+        <p class="message">@Html(description)</p>
     }
 }


### PR DESCRIPTION
Email fronts have a currently unused feature where the On-Page Description from the config tools gets inserted as text at the top. This is a bit of a hack. Ultimately we'll add functionality to the main fronts tool to allow editorial staff to edit this and choose whether it goes at the top or bottom, since the config tool is supposed to be for infrequent changes and has more restricted access control.

However, in the meantime we want to use the hack to insert some messaging of our own - a link to a feedback survey. For this we need:
- the message to be at the bottom
- the message to not escape HTML (so we can put links in, among other things)

## Screenshot
![picture 404](https://cloud.githubusercontent.com/assets/5122968/22744944/d1e08972-ee16-11e6-9072-21f44f46537e.png)
