### PR TITLE
Epic One Line Edits message test 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -109,4 +109,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 5, 1),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-one-line-edits",
+    "Tests 3 slight variations on the epic where one line is changed",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 2, 22),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -21,6 +21,11 @@ define([
         name: 'ContributionsEpicAskFourEarning',
         variants: ['control']
     };
+
+    var ContributionsEpicOneLineEdits = {
+        name: 'ContributionsEpicOneLineEdits',
+        variants: ['control', 'paywall', 'altfacts', 'billionaire']
+    };
     var GuardianTodaySignupMessaging = {
         name: 'GuardianTodaySignupMessaging',
         variants: ['message-a', 'message-b', 'message-c']
@@ -30,7 +35,8 @@ define([
         ContributionsEpicAlwaysAskStrategy,
         ContributionsEpicBrexit,
         ContributionsEpicAskFourStagger,
-        ContributionsEpicAskFourEarning
+        ContributionsEpicAskFourEarning,
+        ContributionsEpicOneLineEdits
     ];
 
     var emailTests = [

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -4,19 +4,21 @@ define([
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
-    'common/modules/experiments/tests/contributions-epic-ask-four-earning'
+    'common/modules/experiments/tests/contributions-epic-ask-four-earning',
+    'common/modules/experiments/tests/contributions-epic-one-line-edits'
 ], function (
     segmentUtil,
     viewLog,
     brexit,
     alwaysAsk,
     askFourStagger,
-    askFourEarning
+    askFourEarning,
+    oneLineEdits
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger];
+    var tests = [alwaysAsk, oneLineEdits, askFourEarning, brexit, askFourStagger];
 
     return {
         getTest: function() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -65,7 +65,7 @@ define([
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
                         title: 'Since you’re here…',
-                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
                         cta1: 'Become a Supporter',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -13,7 +13,7 @@ define([
             linkUrl1: membershipUrl,
             linkUrl2: contributionUrl,
             title: 'Since you’re here…',
-            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
             p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
             p3: '',
             cta1: 'Become a Supporter',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
@@ -13,7 +13,7 @@ define([
             linkUrl1: membershipUrl,
             linkUrl2: contributionUrl,
             title: 'Since you’re here…',
-            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
             p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
             p3: '',
             cta1: 'Become a Supporter',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -39,7 +39,7 @@ define([
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
                         title: 'Since you’re here…',
-                        p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
                         cta1: 'Become a Supporter',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
@@ -1,0 +1,54 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+    function getTemplate(contributionUrl, membershipUrl) {
+        return template(contributionsEpicEqualButtons, {
+            linkUrl1: membershipUrl,
+            linkUrl2: contributionUrl,
+            title: 'Since you’re here…',
+            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+            p3: '',
+            cta1: 'Become a Supporter',
+            cta2: 'Make a contribution'
+        });
+    }
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicOneLineEdits',
+        campaignId: 'kr1_epic_one_line_edits',
+
+        start: '2017-02-08',
+        expiry: '2017-02-22',
+
+        author: 'Jonathan Rankin',
+        description: 'This tests 3 slight variations on the epic where one line is changed',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Acquires many Supporters',
+
+        audienceCriteria: 'All',
+        audience: 0.88,
+        audienceOffset: 0.12,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: getTemplate,
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
@@ -8,18 +8,6 @@ define([
     contributionsEpicEqualButtons
 ) {
 
-    function getTemplate(contributionUrl, membershipUrl) {
-        return template(contributionsEpicEqualButtons, {
-            linkUrl1: membershipUrl,
-            linkUrl2: contributionUrl,
-            title: 'Since you’re here…',
-            p1: '…we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
-            p3: '',
-            cta1: 'Become a Supporter',
-            cta2: 'Make a contribution'
-        });
-    }
 
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicOneLineEdits',
@@ -29,12 +17,12 @@ define([
         expiry: '2017-02-22',
 
         author: 'Jonathan Rankin',
-        description: 'This tests 3 slight variations on the epic where one line is changed',
+        description: 'Tests 3 slight variations on the epic where one line is changed',
         successMeasure: 'Conversion rate',
         idealOutcome: 'Acquires many Supporters',
 
         audienceCriteria: 'All',
-        audience: 0.88,
+        audience: 0.40,
         audienceOffset: 0.12,
 
         variants: [
@@ -45,7 +33,84 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                template: getTemplate,
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'paywall',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'altfacts',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism, informed by our values, takes a lot of time, money and hard work to produce. But we do it because we believe in the power of truthful, in-depth reporting, especially in the face of fake news and ‘alternative facts.’ ',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'billionaire',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here…',
+                        p1: '… we have a small favour to ask. The Guardian has only one shareholder, The Scott Trust, which keeps our independent, investigative, public-interest journalism free from commercial or political interference. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             }


### PR DESCRIPTION
## What does this change?

This PR creates a new test that try out 3 new message variants against the control. 



## What is the value of this and can you measure success?

We might find a new control message

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
Paywall message:
![screenshot at feb 08 16-33-02](https://cloud.githubusercontent.com/assets/2844554/22777886/b174f54c-eeac-11e6-887e-505c313c2250.png)

Alternative facts message:
![screenshot at feb 09 09-44-39](https://cloud.githubusercontent.com/assets/2844554/22777888/b179d21a-eeac-11e6-9745-33cb937195da.png)

No billionaire owner message:
![screenshot at feb 09 09-45-19](https://cloud.githubusercontent.com/assets/2844554/22777889/b17e9d4a-eeac-11e6-9de2-35958980510e.png)

Control message:
![screenshot at feb 09 09
-46-15](https://cloud.githubusercontent.com/assets/2844554/22777887/b177e5b8-eeac-11e6-881c-102d5711c6a7.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
