### PR TITLE
Fix double-width top border in article social below desktop

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -1052,9 +1052,12 @@
 }
 
 .meta__social {
-    border-top: 1px dotted $neutral-5;
     padding: 0;
     box-sizing: border-box;
+
+    @include mq(leftCol) {
+        border-top: 1px dotted $neutral-5;
+    }
 
     .meta__extras--crossword & {
         @include mq(leftCol) {


### PR DESCRIPTION
## What does this change?

applies top border to `.meta__social` only at/above `leftCol` bp

## What is the value of this and can you measure success?

stops double border appearing below desktop

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

### before
![screen shot 2017-02-09 at 10 47 37](https://cloud.githubusercontent.com/assets/867233/22780528/f5d30684-eeb6-11e6-8bad-e3c5cc7179c5.png)
![screen shot 2017-02-09 at 10 47 47](https://cloud.githubusercontent.com/assets/867233/22780541/02abb7b6-eeb7-11e6-95de-03908dc3a4c3.png)

### after
![screen shot 2017-02-09 at 10 48 47](https://cloud.githubusercontent.com/assets/867233/22780546/07ae2d84-eeb7-11e6-8a15-c6ee4bca9881.png)
![screen shot 2017-02-09 at 10 48 55](https://cloud.githubusercontent.com/assets/867233/22780547/0a348d00-eeb7-11e6-8343-c84b8d1c5d83.png)

@NataliaLKB any idea if i've missed a case where it was needed?