### PR TITLE
Set up Epic paywall and billionaire tests:

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -119,4 +119,24 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 2, 22),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-paywall",
+    "Tests a lack of paywall centric message on the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 2, 22),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-billionaire",
+    "Tests a lack of billionaire owner centric message on the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 2, 22),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -26,6 +26,16 @@ define([
         name: 'ContributionsEpicOneLineEdits',
         variants: ['control', 'paywall', 'altfacts', 'billionaire']
     };
+
+    var ContributionsEpicPaywall= {
+        name: 'ContributionsEpicPaywall',
+        variants: ['control', 'paywall']
+    };
+
+    var ContributionsEpicBillionaire = {
+        name: 'ContributionsEpicBillionaire',
+        variants: ['control', 'billionaire']
+    };
     var GuardianTodaySignupMessaging = {
         name: 'GuardianTodaySignupMessaging',
         variants: ['message-a', 'message-b', 'message-c']
@@ -36,7 +46,9 @@ define([
         ContributionsEpicBrexit,
         ContributionsEpicAskFourStagger,
         ContributionsEpicAskFourEarning,
-        ContributionsEpicOneLineEdits
+        ContributionsEpicOneLineEdits,
+        ContributionsEpicPaywall,
+        ContributionsEpicBillionaire
     ];
 
     var emailTests = [

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -5,7 +5,10 @@ define([
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
-    'common/modules/experiments/tests/contributions-epic-one-line-edits'
+    'common/modules/experiments/tests/contributions-epic-one-line-edits',
+    'common/modules/experiments/tests/contributions-epic-paywall',
+    'common/modules/experiments/tests/contributions-epic-billionaire'
+
 ], function (
     segmentUtil,
     viewLog,
@@ -13,12 +16,14 @@ define([
     alwaysAsk,
     askFourStagger,
     askFourEarning,
-    oneLineEdits
+    oneLineEdits,
+    paywall,
+    billionaire
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, oneLineEdits, askFourEarning, brexit, askFourStagger];
+    var tests = [alwaysAsk, oneLineEdits, paywall, billionaire, askFourEarning, brexit, askFourStagger];
 
     return {
         getTest: function() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -12,7 +12,7 @@ define([
         return template(contributionsEpicEqualButtons, {
             linkUrl1: membershipUrl,
             linkUrl2: contributionUrl,
-            title: 'Since you’re here…',
+            title: 'Since you’re here …',
             p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
             p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
             p3: '',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
@@ -12,7 +12,7 @@ define([
         return template(contributionsEpicEqualButtons, {
             linkUrl1: membershipUrl,
             linkUrl2: contributionUrl,
-            title: 'Since you’re here…',
+            title: 'Since you’re here …',
             p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
             p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
             p3: '',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-billionaire.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-billionaire.js
@@ -1,0 +1,75 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicBillionaire',
+        campaignId: 'kr1_epic_billionaire',
+
+        start: '2017-02-09',
+        expiry: '2017-02-22',
+
+        author: 'Jonathan Rankin',
+        description: 'Tests a rewrite of the epic centered around our lack of a billionaire owner',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Acquires many Supporters',
+
+        audienceCriteria: 'All',
+        audience: 0.2,
+        audienceOffset: 0.62,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here …',
+                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'billionaire',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'No billionaire owner … ',
+                        p1: '… and no hidden influences. The Guardian has only one shareholder, The Scott Trust, which keeps our independent, investigative, public-interest journalism free from commercial or political pressures.',
+                        p2: 'No one can tell us to censor, edit or drop a story.',
+                        p3: 'If you value reporting that seeks truth, not approval, that holds power to account on your behalf, then please support the Guardian and help make our future more secure.',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits.js
@@ -37,7 +37,7 @@ define([
                     return template(contributionsEpicEqualButtons, {
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
-                        title: 'Since you’re here…',
+                        title: 'Since you’re here …',
                         p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
@@ -59,7 +59,7 @@ define([
                     return template(contributionsEpicEqualButtons, {
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
-                        title: 'Since you’re here…',
+                        title: 'Since you’re here …',
                         p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
@@ -81,7 +81,7 @@ define([
                     return template(contributionsEpicEqualButtons, {
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
-                        title: 'Since you’re here…',
+                        title: 'Since you’re here …',
                         p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism, informed by our values, takes a lot of time, money and hard work to produce. But we do it because we believe in the power of truthful, in-depth reporting, especially in the face of fake news and ‘alternative facts.’ ',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
@@ -103,7 +103,7 @@ define([
                     return template(contributionsEpicEqualButtons, {
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
-                        title: 'Since you’re here…',
+                        title: 'Since you’re here …',
                         p1: '… we have a small favour to ask. The Guardian has only one shareholder, The Scott Trust, which keeps our independent, investigative, public-interest journalism free from commercial or political interference. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-paywall.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-paywall.js
@@ -1,0 +1,75 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicPaywall',
+        campaignId: 'kr1_epic_paywall',
+
+        start: '2017-02-09',
+        expiry: '2017-02-22',
+
+        author: 'Jonathan Rankin',
+        description: 'Tests a rewrite of the epic centered around our lack of a paywall',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Acquires many Supporters',
+
+        audienceCriteria: 'All',
+        audience: 0.1,
+        audienceOffset: 0.52,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Since you’re here …',
+                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'paywall',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Why we’re not behind a paywall',
+                        p1: 'In volatile times like these, we believe a more informed society can help to create a fairer, more equal world. Which is why the Guardian’s journalism is still open to everyone – not behind a paywall.',
+                        p2: 'Nobody should be excluded from the truth, just because they can’t afford it. Diverse voices deserve to be heard and valued. Politicians – and the rich and powerful – must be held to account for all.',
+                        p3: 'If you can, please help to secure the Guardian’s future – and ensure that our independent, investigative journalism remains open, for everyone.',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
+++ b/static/src/javascripts/projects/common/views/contributions-epic-equal-buttons.html
@@ -4,6 +4,7 @@
             <%=title%></h2>
         <p class="contributions__paragraph contributions__paragraph--epic"><%=p1%></p>
         <p class="contributions__paragraph contributions__paragraph--epic"><%=p2%></p>
+        <p class="contributions__paragraph contributions__paragraph--epic"><%=p3%></p>
     </div>
     <flex class="contributions__amount-field">
         <div>


### PR DESCRIPTION
## What does this change?

This introduces 2 new epic copy tests, both of which are radical rewrites of the the Epic, focussed on, respectively, our lack of a paywall and our lack of a billionaire owner.

They are split into 2 separate tests as they are being run on different audience sizes. 

I also had to add a placeholder for a third paragraph into the template for the epic. 

## What is the value of this and can you measure success?

We might find a new message that beats our control 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

control:
![screenshot at feb 09 09-46-15](https://cloud.githubusercontent.com/assets/2844554/22782236/09dc1010-eebe-11e6-9181-95fa4d4d35d5.png)

paywall:
![screenshot at feb 09 11-35-32](https://cloud.githubusercontent.com/assets/2844554/22782235/09dbc7f4-eebe-11e6-8dc8-30aa6274661a.png)

billionaire:
![screenshot at feb 09 11-37-05](https://cloud.githubusercontent.com/assets/2844554/22782237/09dce3aa-eebe-11e6-9302-fa1f44cd4dbd.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
