### PR TITLE
Enable Guardian Today email signup a/b/c test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/guardian-today-messaging.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/guardian-today-messaging.js
@@ -7,8 +7,8 @@ define([
         this.expiry = '2017-03-28';
         this.author = 'David Furey';
         this.description = 'Test 3 different messages to encourage users to signup to the Guardian Today email newsletter';
-        this.audience = 0.01;
-        this.audienceOffset = 0;
+        this.audience = 0.05;
+        this.audienceOffset = 0.5;
         this.successMeasure = 'Signup rate is higher for one variant';
         this.audienceCriteria = 'All users who visit an applicable article';
         this.dataLinkNames = '';


### PR DESCRIPTION
## What does this change?

Shows Guardian Today email signup to 5% of visitors.  Offset set to 0.5 to avoid membership tests.  See https://github.com/guardian/frontend/pull/15714

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
