### PR TITLE
SubNav tweaks so that the most specific section (or tag) is the one that is highlighted

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -67,16 +67,6 @@ object NewNavigation {
     case "life" => Life
   }
 
-  def isCurrentSection(currentSection: String, navLink: NavLink): Boolean = {
-    val mainFront = List("uk", "au", "us", "international")
-
-    if (mainFront.contains(currentSection)) {
-      "headlines" == navLink.title
-    } else {
-      currentSection == navLink.uniqueSection
-    }
-  }
-
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
@@ -325,7 +315,7 @@ object NewNavigation {
         val section = sectionList.head
         val parentSection = section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
 
-        if (parentSection.contains(section.navLink)) {
+        if (parentSection.contains(section.navLink) || section.navLink == headlines) {
           parentSection
         } else {
           Seq(section.navLink) ++ parentSection

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -483,14 +483,14 @@ object NewNavigation {
 
     def getSectionOrTagId(page: Page) = {
       val tags = Navigation.getTagsFromPage(page)
-      val intersectionalKeywords = tagPages.intersect(tags.keywordIds)
+      val commonKeywords = tagPages.intersect(tags.keywordIds)
       val isTagPage = page.metadata.isFront && tagPages.contains(page.metadata.id)
-      val isArticleInTagPageSection = intersectionalKeywords.nonEmpty
+      val isArticleInTagPageSection = commonKeywords.nonEmpty
 
       if (isTagPage) {
         page.metadata.id
       } else if (isArticleInTagPageSection) {
-        intersectionalKeywords.head
+        commonKeywords.head
       } else {
         page.metadata.sectionId
       }

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -2,8 +2,9 @@ package common
 
 import conf.Configuration
 import NavLinks._
+import model.Page
 
-case class NavLink(title: String, url: String, longTitle: String = "", iconName: String = "", uniqueSection: String = "")
+case class NavLink(title: String, url: String, uniqueSection: String = "", longTitle: String = "", iconName: String = "")
 case class SectionsLink(pageId: String, navLink: NavLink, parentSection: NewNavigation.EditionalisedNavigationSection)
 case class SubSectionLink(pageId: String, parentSection: NavLinkLists)
 case class NavLinkLists(mostPopular: Seq[NavLink], leastPopular: Seq[NavLink] = List())
@@ -106,7 +107,7 @@ object NewNavigation {
         theGuardianView,
         columnists,
         cartoons,
-        NavLink("in my opinion", "/commentisfree/series/comment-is-free-weekly")
+        inMyOpinion
       ),
       List(
         NavLink("Polly Toynbee", "/profile/pollytoynbee"),
@@ -283,12 +284,40 @@ object NewNavigation {
       SectionsLink("global-development", globalDevelopment, News),
       SectionsLink("sustainable-business", sustainableBusiness, News),
       SectionsLink("law", law, News),
+      SectionsLink("technology/games", games, News),
+      SectionsLink("us-news/us-politics", usPolitics, News),
+      SectionsLink("australia-news/australian-politics", auPolitics, News),
+      SectionsLink("australia-news/australian-immigration-and-asylum", auImmigration, News),
+      SectionsLink("australia-news/indigenous-australians", indigenousAustralia, News),
 
       SectionsLink("commentisfree", opinion, Opinion),
-      SectionsLink("index", columnists, Opinion),
+      SectionsLink("cartoons", cartoons, Opinion),
+      SectionsLink("index/contributors", columnists, Opinion),
+      SectionsLink("commentisfree/series/comment-is-free-weekly", inMyOpinion, Opinion),
+      SectionsLink("profile/editorial", theGuardianView, Opinion),
+
 
       SectionsLink("sport", sport, Sport),
       SectionsLink("football", football, Sport),
+      SectionsLink("sport/rugby-union", rugbyUnion, Sport),
+      SectionsLink("sport/cricket", cricket, Sport),
+      SectionsLink("sport/tennis", tennis, Sport),
+      SectionsLink("sport/cycling", cycling, Sport),
+      SectionsLink("sport/golf", golf, Sport),
+      SectionsLink("sport/us-sport", usSports, Sport),
+      SectionsLink("sport/horse-racing", racing, Sport),
+      SectionsLink("sport/rugbyleague", rugbyLeague, Sport),
+      SectionsLink("sport/boxing", boxing, Sport),
+      SectionsLink("sport/formulaone", formulaOne, Sport),
+      SectionsLink("sport/nfl", NFL, Sport),
+      SectionsLink("sport/mlb", MLB, Sport),
+      SectionsLink("football/mls", MLS, Sport),
+      SectionsLink("sport/nba", NBA, Sport),
+      SectionsLink("sport/nhl", NHL, Sport),
+      SectionsLink("sport/afl", AFL, Sport),
+      SectionsLink("football/a-league", aLeague, Sport),
+      SectionsLink("sport/nrl", NRL, Sport),
+      SectionsLink("sport/australia-sport", australiaSport, Sport),
 
       SectionsLink("culture", culture, Arts),
       SectionsLink("film", film, Arts),
@@ -297,11 +326,19 @@ object NewNavigation {
       SectionsLink("books", books, Arts),
       SectionsLink("artanddesign", artAndDesign, Arts),
       SectionsLink("stage", stage, Arts),
+      SectionsLink("music/classicalmusicandopera", classical, Arts),
 
       SectionsLink("lifeandstyle", lifestyle, Life),
       SectionsLink("fashion", fashion, Life),
       SectionsLink("travel", travel, Life),
-      SectionsLink("society", society, Life)
+      SectionsLink("society", society, Life),
+      SectionsLink("lifeandstyle/food-and-drink", food, Life),
+      SectionsLink("tone/recipes", recipes, Life),
+      SectionsLink("lifeandstyle/women", women, Life),
+      SectionsLink("lifeandstyle/health-and-wellbeing", health, Life),
+      SectionsLink("lifeandstyle/family", family, Life),
+      SectionsLink("lifeandstyle/home-and-garden", home, Life),
+      SectionsLink("lifeandstyle/love-and-sex", loveAndSex, Life)
     )
 
     def getSectionLinks(sectionName: String, edition: Edition) = {
@@ -442,6 +479,21 @@ object NewNavigation {
 
     def isEditionalistedSubSection(sectionId: String) = {
       editionalisedSubSectionLinks.exists(_.pageId == sectionId)
+    }
+
+    def getSectionOrTagId(page: Page) = {
+      val tags = Navigation.getTagsFromPage(page)
+      val intersectionalKeywords = tagPages.intersect(tags.keywordIds)
+      val isTagPage = page.metadata.isFront && tagPages.contains(page.metadata.id)
+      val isArticleInTagPageSection = intersectionalKeywords.nonEmpty
+
+      if (isTagPage) {
+        page.metadata.id
+      } else if (isArticleInTagPageSection) {
+        intersectionalKeywords.head
+      } else {
+        page.metadata.sectionId
+      }
     }
 
     def getSubSectionNavLinks(sectionId: String, edition: Edition, isFront: Boolean) = {

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -109,7 +109,7 @@ object NewNavigation {
         NavLink("in my opinion", "/commentisfree/series/comment-is-free-weekly")
       ),
       List(
-        NavLink("Polly Toynbee", "/profile/pollytoyn"),
+        NavLink("Polly Toynbee", "/profile/pollytoynbee"),
         NavLink("Owen Jones", "/profile/owen-jones"),
         NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
         NavLink("Marina Hyde", "/profile/marinahyde"),

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -2,110 +2,182 @@ package common
 
 object NavLinks {
   /* NEWS */
-  val headlines = NavLink("headlines", "/", iconName = "home")
-  val ukNews = NavLink("UK", "/uk-news", longTitle = "UK news", uniqueSection = "uk-news")
-  val world = NavLink("world", "/world", longTitle = "world news", uniqueSection = "world")
-  val environment = NavLink("environment", "/environment", uniqueSection = "environment")
-  val business = NavLink("business", "/business", uniqueSection = "business")
+
+  val headlines = NavLink("headlines", "/", "", iconName = "home")
+  val ukNews = NavLink("UK", "/uk-news", "uk-news", longTitle = "UK news")
+  val world = NavLink("world", "/world", "world", longTitle = "world news")
+  val environment = NavLink("environment", "/environment", "environment")
+  val business = NavLink("business", "/business", "business")
   val economy = business.copy(title = "economy")
-  val money = NavLink("money", "/money", uniqueSection = "money")
-  val science = NavLink("science", "/science", uniqueSection = "science")
-  var tech = NavLink("tech", "/technology", uniqueSection = "technology")
-  var politics = NavLink("politics", "/politics", uniqueSection = "politics")
-  var media = NavLink("media", "/media", uniqueSection = "media")
-  var cities = NavLink("cities", "/cities", uniqueSection = "cities")
-  var globalDevelopment = NavLink("development", "/global-development", uniqueSection = "global-development")
-  var australiaNews = NavLink("australia", "/australia-news", longTitle = "australia news", uniqueSection = "australia-news")
-  var auPolitics = NavLink("politics", "/australia-news/australian-politics", "australian politics")
-  var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum")
-  var indigenousAustralia = NavLink("indigenous australia", "/australia-news/indigenous-australians")
-  var usNews = NavLink("US", "/us-news", longTitle = "US news", uniqueSection = "us-news")
-  var usPolitics = NavLink("politics", "/us-news/us-politics", "US politics")
-  val education = NavLink("education", "/education")
-  val society = NavLink("society", "/society")
-  val law = NavLink("law", "/law")
-  val scotland = NavLink("scotland", "/uk/scotland")
-  val wales = NavLink("wales", "/uk/wales")
-  val northernIreland = NavLink("northern ireland", "/uk/northernireland")
-  val europe = NavLink("europe", "/world/europe-news")
-  val americas = NavLink("americas", "/world/americas")
-  val asia = NavLink("asia", "/world/asia")
-  val africa = NavLink("africa", "/world/africa")
-  val middleEast = NavLink("middle east", "/world/middleeast")
-  val economics = NavLink("economics", "/business/economics")
-  val banking = NavLink("banking", "/business/banking")
-  val retail = NavLink("retail", "/business/retail")
-  val markets = NavLink("markets", "/business/stock-markets")
-  val eurozone = NavLink("eurozone", "/business/eurozone")
-  val sustainableBusiness = NavLink("sustainable business", "/us/sustainable-business")
-  val diversityEquality = NavLink("diversity & equality in business", "/business/diversity-and-equality")
-  val smallBusiness = NavLink("small business", "business/us-small-business")
-  val climateChange = NavLink("climate change", "/environment/climate-change")
-  val wildlife = NavLink("wildlife", "/environment/wildlife")
-  val energy = NavLink("energy", "/environment/energy")
-  val pollution = NavLink("pollution", "/environment/pollution")
-  val property = NavLink("property", "/money/property")
-  val pensions = NavLink("pensions", "/money/pensions")
-  val savings = NavLink("savings", "/money/savings")
-  val borrowing = NavLink("borrowing", "/money/debt")
-  val careers = NavLink("careers", "/money/work-and-careers")
+  val money = NavLink("money", "/money", "money")
+  val science = NavLink("science", "/science", "science")
+  var tech = NavLink("tech", "/technology", "technology")
+  var politics = NavLink("politics", "/politics", "politics")
+  var media = NavLink("media", "/media", "media")
+  var cities = NavLink("cities", "/cities", "cities")
+  var globalDevelopment = NavLink("development", "/global-development", "global-development")
+  var australiaNews = NavLink("australia", "/australia-news", "australia-news", longTitle = "australia news")
+  var auPolitics = NavLink("politics", "/australia-news/australian-politics", "australia-news/australian-politics", longTitle = "australian politics")
+  var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum", "australia-news/australian-immigration-and-asylum")
+  var indigenousAustralia = NavLink("indigenous australia", "/australia-news/indigenous-australians", "australia-news/indigenous-australians")
+  var usNews = NavLink("US", "/us-news", "us-news", longTitle = "US news")
+  var usPolitics = NavLink("politics", "/us-news/us-politics", "us-news/us-politics", longTitle = "US politics")
+  val education = NavLink("education", "/education", "education")
+  val society = NavLink("society", "/society", "society")
+  val law = NavLink("law", "/law", "law")
+  val scotland = NavLink("scotland", "/uk/scotland", "uk/scotland")
+  val wales = NavLink("wales", "/uk/wales", "uk/wales")
+  val northernIreland = NavLink("northern ireland", "/uk/northernireland", "uk/northernireland")
+  val europe = NavLink("europe", "/world/europe-news", "world/europe-news")
+  val americas = NavLink("americas", "/world/americas", "world/americas")
+  val asia = NavLink("asia", "/world/asia", "world/asia")
+  val africa = NavLink("africa", "/world/africa", "world/africa")
+  val middleEast = NavLink("middle east", "/world/middleeast", "world/middleeast")
+  val economics = NavLink("economics", "/business/economics", "business/economics")
+  val banking = NavLink("banking", "/business/banking", "business/banking")
+  val retail = NavLink("retail", "/business/retail", "business/retail")
+  val markets = NavLink("markets", "/business/stock-markets", "business/stock-markets")
+  val eurozone = NavLink("eurozone", "/business/eurozone", "business/eurozone")
+  val sustainableBusiness = NavLink("sustainable business", "/us/sustainable-business", "us/sustainable-business")
+  val diversityEquality = NavLink("diversity & equality in business", "/business/diversity-and-equality", "business/diversity-and-equality")
+  val smallBusiness = NavLink("small business", "/business/us-small-business", "business/us-small-business")
+  val climateChange = NavLink("climate change", "/environment/climate-change", "environment/climate-change")
+  val wildlife = NavLink("wildlife", "/environment/wildlife", "environment/wildlife")
+  val energy = NavLink("energy", "/environment/energy", "environment/energy")
+  val pollution = NavLink("pollution", "/environment/pollution", "environment/pollution")
+  val property = NavLink("property", "/money/property", "money/property")
+  val pensions = NavLink("pensions", "/money/pensions", "money/pensions")
+  val savings = NavLink("savings", "/money/savings", "money/savings")
+  val borrowing = NavLink("borrowing", "/money/debt", "money/debt")
+  val careers = NavLink("careers", "/money/work-and-careers", "money/work-and-careers")
 
   /* OPINION */
   val opinion = NavLink("opinion", "/commentisfree", longTitle = "opinion home", iconName = "home", uniqueSection = "commentisfree")
-  var columnists = NavLink("columnists", "/index/contributors")
-  val theGuardianView = NavLink("the guardian view", "/profile/editorial")
-  val cartoons = NavLink("cartoons", "/cartoons/archive")
+  var columnists = NavLink("columnists", "/index/contributors", "index/contributors")
+  val theGuardianView = NavLink("the guardian view", "/profile/editorial", "profile/editorial")
+  val cartoons = NavLink("cartoons", "/cartoons/archive", "cartoons/archive")
+  val inMyOpinion = NavLink("in my opinion", "/commentisfree/series/comment-is-free-weekly", "commentisfree/series/comment-is-free-weekly")
 
   /* SPORT */
   val sport = NavLink("sport", "/sport", longTitle = "sport home", iconName = "home", uniqueSection = "sport")
   val football = NavLink("football", "/football", uniqueSection = "football")
   val soccer = football.copy(title = "soccer")
-  val cricket = NavLink("cricket", "/sport/cricket")
-  var rugbyUnion = NavLink("rugby union", "/sport/rugby-union")
-  var formulaOne = NavLink("F1", "/sport/formulaone")
-  var tennis = NavLink("tennis", "/sport/tennis")
-  var golf = NavLink("golf", "/sport/golf")
-  var cycling = NavLink("cycling", "/sport/cycling")
-  var boxing = NavLink("boxing", "/sport/boxing")
-  var usSports = NavLink("US sports", "/sport/us-sport")
-  val racing = NavLink("racing", "/sport/horse-racing")
-  val rugbyLeague = NavLink("rugby league", "/sport/rugbyleague")
-  val australiaSport = NavLink("australia sport", "/sport/australia-sport")
-  val AFL = NavLink("AFL", "/sport/afl")
-  val NRL = NavLink("NRL", "/sport/nrl")
-  val aLeague = NavLink("a-league", "/football/a-league")
-  val NFL = NavLink("NFL", "/sport/nfl")
-  val MLS = NavLink("MLS", "/football/mls")
-  val MLB = NavLink("MLB", "/sport/mlb")
-  val NBA = NavLink("NBA", "/sport/nba")
-  val NHL = NavLink("NHL", "/sport/nhl")
+  val cricket = NavLink("cricket", "/sport/cricket", "sport/cricket")
+  var rugbyUnion = NavLink("rugby union", "/sport/rugby-union", "sport/rugby-union")
+  var formulaOne = NavLink("F1", "/sport/formulaone", "sport/formulaone")
+  var tennis = NavLink("tennis", "/sport/tennis", "sport/tennis")
+  var golf = NavLink("golf", "/sport/golf", "sport/golf")
+  var cycling = NavLink("cycling", "/sport/cycling", "sport/cycling")
+  var boxing = NavLink("boxing", "/sport/boxing", "sport/boxing")
+  var usSports = NavLink("US sports", "/sport/us-sport", "sport/us-sport")
+  val racing = NavLink("racing", "/sport/horse-racing", "sport/horse-racing")
+  val rugbyLeague = NavLink("rugby league", "/sport/rugbyleague", "sport/rugbyleague")
+  val australiaSport = NavLink("australia sport", "/sport/australia-sport", "sport/australia-sport")
+  val AFL = NavLink("AFL", "/sport/afl", "sport/afl")
+  val NRL = NavLink("NRL", "/sport/nrl", "sport/nrl")
+  val aLeague = NavLink("a-league", "/football/a-league", "football/a-league")
+  val NFL = NavLink("NFL", "/sport/nfl", "sport/nfl")
+  val MLS = NavLink("MLS", "/football/mls", "football/mls")
+  val MLB = NavLink("MLB", "/sport/mlb", "sport/mlb")
+  val NBA = NavLink("NBA", "/sport/nba", "sport/nba")
+  val NHL = NavLink("NHL", "/sport/nhl", "sport/nhl")
 
   /* ARTS */
-  val culture = NavLink("culture", "/culture", longTitle = "culture home", iconName = "home", uniqueSection = "culture")
-  val film = NavLink("film", "/film", uniqueSection = "film")
-  val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", uniqueSection = "tv-and-radio")
-  val music = NavLink("music", "/music", uniqueSection = "music")
-  val games = NavLink("games", "/technology/games")
-  val books = NavLink("books", "/books", uniqueSection = "books")
-  val artAndDesign = NavLink("art & design", "/artanddesign", uniqueSection = "artanddesign")
-  val stage = NavLink("stage", "/stage", uniqueSection = "stage")
-  val classical = NavLink("classical", "/music/classicalmusicandopera")
+  val culture = NavLink("culture", "/culture", "culture", longTitle = "culture home", iconName = "home")
+  val film = NavLink("film", "/film", "film")
+  val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", "tv-and-radio")
+  val music = NavLink("music", "/music", "music")
+  val games = NavLink("games", "/technology/games", "technology/games")
+  val books = NavLink("books", "/books", "books")
+  val artAndDesign = NavLink("art & design", "/artanddesign", "artanddesign")
+  val stage = NavLink("stage", "/stage", "stage")
+  val classical = NavLink("classical", "/music/classicalmusicandopera", "music/classicalmusicandopera")
 
   /* LIFE */
-  val lifestyle = NavLink("lifestyle", "/lifeandstyle", longTitle = "lifestyle home", iconName = "home", uniqueSection = "lifeandstyle")
-  val fashion = NavLink("fashion", "/fashion", uniqueSection = "fashion")
-  val food = NavLink("food", "/lifeandstyle/food-and-drink")
-  val travel = NavLink("travel", "/travel", uniqueSection = "travel")
-  val loveAndSex = NavLink("love & sex", "/lifeandstyle/love-and-sex")
-  var family = NavLink("family", "/lifeandstyle/family")
-  var home = NavLink("home & garden", "/lifeandstyle/home-and-garden")
-  var health = NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing")
-  var women = NavLink("women", "/lifeandstyle/women")
-  var recipes = NavLink("recipes", "/tone/recipes")
-  val travelUk = NavLink("UK", "/travel/uk")
-  val travelEurope = NavLink("europe", "/travel/europe")
-  val travelUs = NavLink("US", "/travel/usa")
-  val skiing = NavLink("skiing", "/travel/skiing")
-  val travelAustralasia = NavLink("australasia", "/travel/australasia")
-  val travelAsia = NavLink("asia", "/travel/asia")
+  val lifestyle = NavLink("lifestyle", "/lifeandstyle", "lifeandstyle", longTitle = "lifestyle home", iconName = "home")
+  val fashion = NavLink("fashion", "/fashion", "fashion")
+  val food = NavLink("food", "/lifeandstyle/food-and-drink", "lifeandstyle/food-and-drink")
+  val travel = NavLink("travel", "/travel", "travel")
+  val loveAndSex = NavLink("love & sex", "/lifeandstyle/love-and-sex", "lifeandstyle/love-and-sex")
+  var family = NavLink("family", "/lifeandstyle/family", "lifeandstyle/family")
+  var home = NavLink("home & garden", "/lifeandstyle/home-and-garden", "lifeandstyle/home-and-garden")
+  var health = NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing", "lifeandstyle/health-and-wellbeing")
+  var women = NavLink("women", "/lifeandstyle/women", "lifeandstyle/women")
+  var recipes = NavLink("recipes", "/tone/recipes", "tone/recipes")
+  val travelUk = NavLink("UK", "/travel/uk", "travel/uk")
+  val travelEurope = NavLink("europe", "/travel/europe", "travel/europe")
+  val travelUs = NavLink("US", "/travel/usa", "travel/usa")
+  val skiing = NavLink("skiing", "/travel/skiing", "travel/skiing")
+  val travelAustralasia = NavLink("australasia", "/travel/australasia", "travel/australasia")
+  val travelAsia = NavLink("asia", "/travel/asia", "travel/asia")
+
+  val tagPages = List(
+    "technology/games",
+    "us-news/us-politics",
+    "australia-news/australian-politics",
+    "australia-news/australian-immigration-and-asylum",
+    "australia-news/indigenous-australians",
+    "uk/scotland",
+    "uk/wales",
+    "uk/northernireland",
+    "world/europe-news",
+    "world/americas",
+    "world/asia",
+    "world/africa",
+    "world/middleeast",
+    "business/economics",
+    "business/banking",
+    "business/retail",
+    "business/stock-markets",
+    "business/eurozone",
+    "us/sustainable-business",
+    "business/diversity-and-equality",
+    "business/us-small-business",
+    "environment/climate-change",
+    "environment/wildlife",
+    "environment/energy",
+    "environment/pollution",
+    "money/property",
+    "money/pensions",
+    "money/savings",
+    "money/debt",
+    "money/work-and-careers",
+    "cartoons/archive",
+    "profile/editorial",
+    "index/contributors",
+    "commentisfree/series/comment-is-free-weekly",
+    "sport/rugby-union",
+    "sport/cricket",
+    "sport/tennis",
+    "sport/cycling",
+    "sport/golf",
+    "sport/us-sport",
+    "sport/horse-racing",
+    "sport/rugbyleague",
+    "sport/boxing",
+    "sport/formulaone",
+    "sport/nfl",
+    "sport/mlb",
+    "football/mls",
+    "sport/nba",
+    "sport/nhl",
+    "sport/afl",
+    "football/a-league",
+    "sport/nrl",
+    "sport/australia-sport",
+    "music/classicalmusicandopera",
+    "lifeandstyle/food-and-drink",
+    "tone/recipes",
+    "lifeandstyle/women",
+    "lifeandstyle/health-and-wellbeing",
+    "lifeandstyle/family",
+    "lifeandstyle/home-and-garden",
+    "lifeandstyle/love-and-sex",
+    "travel/uk",
+    "travel/europe",
+    "travel/usa",
+    "travel/skiing",
+    "travel/australasia",
+    "travel/asia"
+  )
 }

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -51,7 +51,7 @@ object NavLinks {
   val careers = NavLink("careers", "/money/work-and-careers")
 
   /* OPINION */
-  val opinion = NavLink("opinion", "/commentisfree", longTitle = "sport home", iconName = "home", uniqueSection = "commentisfree")
+  val opinion = NavLink("opinion", "/commentisfree", longTitle = "opinion home", iconName = "home", uniqueSection = "commentisfree")
   var columnists = NavLink("columnists", "/index/contributors")
   val theGuardianView = NavLink("the guardian view", "/profile/editorial")
   val cartoons = NavLink("cartoons", "/cartoons/archive")
@@ -75,7 +75,7 @@ object NavLinks {
   val NRL = NavLink("NRL", "/sport/nrl")
   val aLeague = NavLink("a-league", "/football/a-league")
   val NFL = NavLink("NFL", "/sport/nfl")
-  val MLS = NavLink("MLS", "/sport/mls")
+  val MLS = NavLink("MLS", "/football/mls")
   val MLB = NavLink("MLB", "/sport/mlb")
   val NBA = NavLink("NBA", "/sport/nba")
   val NHL = NavLink("NHL", "/sport/nhl")

--- a/common/app/views/fragments/nav/subSectionNav.scala.html
+++ b/common/app/views/fragments/nav/subSectionNav.scala.html
@@ -4,13 +4,17 @@
 @import views.support.RenderClasses
 
 <div class="tertiary-navigation">
-    @NewNavigation.SubSectionLinks.getSubSectionNavLinks(page.metadata.sectionId, Edition(request), page.metadata.isFront).map { link =>
-        <a class="@RenderClasses(Map(
-                "tertiary-navigation__link" -> true,
-                "tertiary-navigation__link--current-section" -> (page.metadata.sectionId == link.uniqueSection)
-            ))"
-            href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
-                @link.title
-        </a>
+    @defining(NewNavigation.SubSectionLinks.getSectionOrTagId(page)) { id =>
+
+        @NewNavigation.SubSectionLinks.getSubSectionNavLinks(id, Edition(request), page.metadata.isFront).map { link =>
+
+            <a class="@RenderClasses(Map(
+                    "tertiary-navigation__link" -> true,
+                    "tertiary-navigation__link--current-section" -> (id == link.uniqueSection)
+                ))"
+                href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
+                    @link.title
+            </a>
+        }
     }
 </div>

--- a/common/app/views/fragments/nav/subSectionNav.scala.html
+++ b/common/app/views/fragments/nav/subSectionNav.scala.html
@@ -7,7 +7,7 @@
     @NewNavigation.SubSectionLinks.getSubSectionNavLinks(page.metadata.sectionId, Edition(request), page.metadata.isFront).map { link =>
         <a class="@RenderClasses(Map(
                 "tertiary-navigation__link" -> true,
-                "tertiary-navigation__link--current-section" -> NewNavigation.isCurrentSection(page.metadata.sectionId, link)
+                "tertiary-navigation__link--current-section" -> (page.metadata.sectionId == link.uniqueSection)
             ))"
             href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
                 @link.title


### PR DESCRIPTION
## What does this change?
For the new nav, we have a subnav:
![image](https://cloud.githubusercontent.com/assets/8774970/22782707/4cd9d8dc-eec0-11e6-8145-b5d309f05a09.png)

At the moment, a context word should be highlighted for each article and front on both the subNav and the Nav 5 primary words. This is only happening for sections which is a problem, because the context word isn't accurate and actually could change unexpectedly for the user.

Current journey:
![broken-subnav-journey](https://cloud.githubusercontent.com/assets/8774970/22785289/9be1bcd2-eecb-11e6-802d-71c46eb7633f.gif)


Proposed journey:
![better-subnav-journey](https://cloud.githubusercontent.com/assets/8774970/22785403/0ac73a64-eecc-11e6-9387-4eb4d70e434f.gif)


## What is the value of this and can you measure success?
Nicer user experience!

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![image](https://cloud.githubusercontent.com/assets/8774970/22782933/363069f6-eec1-11e6-9a34-7fcc435e0d76.png)

## Tested in CODE?
Yes