### PR TITLE
Update JS expiry date on opinion to match ab switch expiry

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -16,7 +16,7 @@ define([
     return function () {
         this.id = 'OpinionEmailVariants';
         this.start = '2017-01-12';
-        this.expiry = '2017-02-08';
+        this.expiry = '2017-02-16';
         this.author = 'David Furey';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB ' +
             'function in ExactTarget re-randomises all recipients on each send, and we need users to receive their ' +


### PR DESCRIPTION
## What does this change?

Updates JS expiry date on opinion to match ab switch expiry

## What is the value of this and can you measure success?

Keeps the test running longer so that we can collect more data.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
