### PR TITLE
Fix link to foresee asset

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -42,7 +42,7 @@
             "timingEvents": []
         },
         "libs": {
-            "foresee": "vendor/foresee/20150703/foresee-trigger.js",
+            "foresee": "/assets/javascripts/vendor/foresee/20150703/foresee-trigger.js",
             "googletag": "@{Configuration.javascript.config("googletagJsUrl")}",
             "sonobi": "@{ if(!environment.isCode) Configuration.javascript.config("sonobiHeaderBiddingJsUrl") else "//mtrx.go.sonobi.com/morpheus.theguardian.12911_us_.js"}"
         }

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -42,7 +42,7 @@
             "timingEvents": []
         },
         "libs": {
-            "foresee": "/assets/javascripts/vendor/foresee/20150703/foresee-trigger.js",
+            "foresee": "@Static("javascripts/vendor/foresee/20150703/foresee-trigger.js")",
             "googletag": "@{Configuration.javascript.config("googletagJsUrl")}",
             "sonobi": "@{ if(!environment.isCode) Configuration.javascript.config("sonobiHeaderBiddingJsUrl") else "//mtrx.go.sonobi.com/morpheus.theguardian.12911_us_.js"}"
         }

--- a/tools/__tasks__/compile/javascript/copy.js
+++ b/tools/__tasks__/compile/javascript/copy.js
@@ -13,6 +13,7 @@ module.exports = {
             'stripe/**/*',
             'react/**/*',
             'ophan/**/*',
+            'foresee/**/*',
         ], path.resolve(target, 'javascripts', 'vendor'), {
             cwd: path.resolve(vendor, 'javascripts'),
             parents: true,


### PR DESCRIPTION
## What does this change?

Currently, the path to `foresee-trigger.js` does not include `assets/javascript`, therefore the network returns a 404. This issue was introduced as a result of moving from using `require` to load external scripts, to using `loadScript` (#15582)

## What is the value of this and can you measure success?

Correct path to foresee will ensure that lucky users get to see the foresee survey modal 🎉 

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
