### PR TITLE
Update gender options

### DIFF
--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -8,7 +8,7 @@ import play.api.i18n.MessagesApi
 
 class AccountDetailsMapping(val messagesApi: MessagesApi) extends UserFormMapping[AccountFormData] with AddressMapping with DateMapping with TelephoneNumberMapping {
 
-  private val genders = List("Male", "Female", "Other", "unknown", "")
+  private val genders = List("Male", "Female", "Transgender", "Other", "unknown", "")
 
   protected lazy val formMapping = {
     mapping(

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -8,7 +8,7 @@ import play.api.i18n.MessagesApi
 
 class AccountDetailsMapping(val messagesApi: MessagesApi) extends UserFormMapping[AccountFormData] with AddressMapping with DateMapping with TelephoneNumberMapping {
 
-  private val genders = List("Male", "Female", "Transgender", "unknown", "")
+  private val genders = List("Male", "Female", "Other", "unknown", "")
 
   protected lazy val formMapping = {
     mapping(

--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -107,7 +107,7 @@
                 @inputField(Input(accountDetailsForm("secondName"), ('_label, "Last name"), Symbol("data-test-id") -> "last-name"))
                 @select(
                     accountDetailsForm("gender"),
-                    List(("Male", "Male"), ("Female", "Female"), ("Other", "Other"), ("unknown", "Prefer not to say")),
+                    List(("Male", "Male"), ("Female", "Female"), ("Transgender", "Transgender"), ("Other", "Other"), ("unknown", "Prefer not to say")),
                     ('_label, "Gender"),
                     ('_default, "")
                 )

--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -107,7 +107,7 @@
                 @inputField(Input(accountDetailsForm("secondName"), ('_label, "Last name"), Symbol("data-test-id") -> "last-name"))
                 @select(
                     accountDetailsForm("gender"),
-                    List(("Male", "Male"), ("Female", "Female"), ("Transgender", "Transgender"), ("unknown", "Prefer not to say")),
+                    List(("Male", "Male"), ("Female", "Female"), ("Other", "Other"), ("unknown", "Prefer not to say")),
                     ('_label, "Gender"),
                     ('_default, "")
                 )


### PR DESCRIPTION
## What does this change?

Adds "Other" to Gender options in Identity.  See [How to ask about gender](https://vimeo.com/album/3953264/video/166790858)

We have retained "Transgender" as 479 users have selected this preference.

## What is the value of this and can you measure success?

Fewer complaints about our gender options. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![screen shot 2017-02-10 at 11 58 33](https://cloud.githubusercontent.com/assets/406099/22827382/84277df6-ef8f-11e6-902f-aba0c2876f76.png)


## Tested in CODE?

No, tested locally.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@susiecoleman
