### PR TITLE
Max items email

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -602,6 +602,7 @@ object FaciaImageFormat {
 }
 
 object PressedCollectionFormat {
+  implicit val displayHintsFormat = Json.format[DisplayHints]
   implicit val collectionConfigFormat = Json.format[CollectionConfig]
   implicit val pressedContentFormat = PressedContentFormat.format
   val format  = Json.format[PressedCollection]

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -9,6 +9,14 @@ import common.Edition
 import model.{ContentType, SupportedUrl}
 import org.joda.time.DateTime
 
+object DisplayHints {
+  def make(displayHints: fapi.DisplayHints): DisplayHints = {
+    DisplayHints(displayHints.maxItemsToDisplay)
+  }
+}
+
+final case class DisplayHints(maxItemsToDisplay: Option[Int])
+
 object CollectionConfig {
   def make(config: fapi.CollectionConfig): CollectionConfig = {
     CollectionConfig(
@@ -27,7 +35,8 @@ object CollectionConfig {
       showLatestUpdate = config.showLatestUpdate,
       excludeFromRss = config.excludeFromRss,
       showTimestamps = config.showTimestamps,
-      hideShowMore = config.hideShowMore
+      hideShowMore = config.hideShowMore,
+      displayHints = config.displayHints.map(DisplayHints.make)
     )
   }
 
@@ -53,7 +62,8 @@ final case class CollectionConfig(
   showLatestUpdate: Boolean,
   excludeFromRss: Boolean,
   showTimestamps: Boolean,
-  hideShowMore: Boolean
+  hideShowMore: Boolean,
+  displayHints: Option[DisplayHints]
 ) {
   def showBranding = metadata exists (_ contains Branded)
 }

--- a/common/test/common/commercial/ContainerModelTest.scala
+++ b/common/test/common/commercial/ContainerModelTest.scala
@@ -32,7 +32,8 @@ class ContainerModelTest extends FlatSpec with Matchers with OptionValues {
       showLatestUpdate = false,
       excludeFromRss = false,
       showTimestamps = false,
-      hideShowMore
+      hideShowMore,
+      displayHints = None
     )
 
     PressedCollection(

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -60,7 +60,8 @@ class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
         showLatestUpdate = None,
         excludeFromRss = None,
         showTimestamps = None,
-        hideShowMore = None
+        hideShowMore = None,
+        displayHints = None
       )
     )
   )

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -134,7 +134,7 @@
         </h2>
     }
 
-    @collection.curatedPlusBackfillDeduplicated.take(6).zipWithIndex.map { case (pressedContent, cardIndex) =>
+    @collection.curatedPlusBackfillDeduplicated.take(collection.config.displayHints.flatMap(_.maxItemsToDisplay).getOrElse(6)).zipWithIndex.map { case (pressedContent, cardIndex) =>
         @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) { card =>
             @if(cardIndex == 0) {
                 @firstCard(card, isFastLayout = collection.collectionType == "fast")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
-  val faciaVersion = "2.0.8"
+  val faciaVersion = "2.0.11"
   val dispatchVersion = "0.11.3"
   val configurationMagicVersion = "1.2.2"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
   val targetingClient = "com.gu" %% "targeting-client" % "0.11.0"
   val scanamo = "com.gu" %% "scanamo" % "0.8.3"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.6"
-  val commercialShared = "com.gu" %% "commercial-shared" % "1.1.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "1.2.1"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"


### PR DESCRIPTION
## What does this change?

Adds editorial control of the maximum number of items in an email container

## What is the value of this and can you measure success?

Allows editorial to make use of backfill but still retain control over how many items will be in the container (saves editorial time!)

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
