### PR TITLE
100% webpack (in prod)

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,6 +1,6 @@
 @(page: InteractivePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.Edition
-@import mvt.WebpackTest
+@import conf.switches.Switches.Webpack
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
 @import views.InteractiveBodyCleaner
@@ -68,7 +68,7 @@
         </div>
     }
 
-    @if(!WebpackTest.isParticipating) {
+    @if(!Webpack.isSwitchedOn) {
         <script>
             @HtmlFormat.raw(common.Assets.js.curl)
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -497,4 +497,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 2, 27),
     exposeClientSide = true
   )
+
+  // Owner: Alex Sanders
+  val Webpack = Switch(
+    SwitchGroup.Feature,
+    "webpack",
+    "When ON, will serve webpack bundles instead of curl.",
+    owners = Seq(Owner.withGithub("asanders")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 2, 17),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -504,7 +504,7 @@ trait FeatureSwitches {
     "webpack",
     "When ON, will serve webpack bundles instead of curl.",
     owners = Seq(Owner.withGithub("asanders")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2017, 2, 17),
     exposeClientSide = true
   )

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -50,28 +50,6 @@ object CommercialClientLoggingVariant extends TestDefinition(
   }
 }
 
-object WebpackTest extends TestDefinition(
-  name = "ab-webpack-bundle",
-  description = "for users in this test, website will serve standard JavaScript that has been bundled by Webpack",
-  owners = Seq(Owner.withGithub("siadcock")),
-  sellByDate = new LocalDate(2017, 2, 13)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-webpack-bundle").contains("webpack")
-  }
-}
-
-object WebpackControl extends TestDefinition(
-  name = "ab-webpack-bundle-control",
-  description = "control for Webpack test",
-  owners = Seq(Owner.withGithub("siadcock")),
-  sellByDate = new LocalDate(2017, 2, 13)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-webpack-bundle").contains("control")
-  }
-}
-
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -87,9 +65,7 @@ object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     ABNewNavVariantSeven,
     ABNewNavControl,
-    CommercialClientLoggingVariant,
-    WebpackTest,
-    WebpackControl
+    CommercialClientLoggingVariant
   )
 }
 

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -2,7 +2,6 @@
 @import play.api.Mode.Dev
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.{Commercial, GoogleAnalyticsAccount}
-@import mvt.{WebpackTest,WebpackControl}
 
 <script id='google_analytics'>
 
@@ -37,15 +36,8 @@
 
     // Please email Dotcom Platform before changing this value
     function getExperienceValue() {
-        @if(WebpackTest.isParticipating) {
-            return 'webpack';
-        } else {
-            @if(WebpackControl.isParticipating) {
-                return 'webpack-control';
-            } else {
-                return 'curl';
-            }
-        }
+        // return 'none' if you're not testing anything
+        return 'none';
     }
 
     var identityId = null;

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,7 +1,7 @@
 @(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.Page.getContent
 @import play.api.Mode.Dev
-@import mvt.WebpackTest
+@import conf.switches.Switches.Webpack
 
 <meta charset="utf-8" />
 <!--
@@ -23,7 +23,7 @@ http://developers.theguardian.com/join-the-team.html
 @fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
 
 @if(!(context.environment.mode == Dev)) {
-    @if(WebpackTest.isParticipating) {
+    @if(Webpack.isSwitchedOn) {
         <link rel="prefetch" href="@Static("javascripts/app-webpack.js")">
     } else {
         <link rel="prefetch" href="@Static("javascripts/app.js")">

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -1,6 +1,5 @@
 @import common.InlineJs
-@import conf.switches.Switches.{AsyncCss, FontSwitch}
-@import mvt.WebpackTest
+@import conf.switches.Switches.{AsyncCss, FontSwitch, Webpack}
 @import model.Page.getContent
 @import templates.inlineJS.blocking.js.{applyRenderConditions, config, curlConfig, enableStylesheets, loadFonts, shouldEnhance}
 @import templates.inlineJS.blocking.polyfills.js.{classlist, details, matches, raf, setTimeout}
@@ -69,7 +68,7 @@
         (function (document) {
             var script = document.createElement('script');
             var ref = document.getElementsByTagName('script')[0];
-            @if(WebpackTest.isParticipating) {
+            @if(Webpack.isSwitchedOn) {
                 script.src = '@Static("javascripts/app-webpack.js")';
             } else {
                 script.src = '@Static("javascripts/app.js")';

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -1,7 +1,6 @@
 @import common.InlineJs
-@import conf.switches.Switches.{IdentityProfileNavigationSwitch}
+@import conf.switches.Switches.{IdentityProfileNavigationSwitch,Webpack}
 @import conf.Configuration
-@import mvt.WebpackTest
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._
 
@@ -27,7 +26,7 @@
 // Ophan pageview ID and browser ID are needed by Google Analytics, which runs just after this script tag
 @InlineJs(ophanConfig().body, "ophanConfig.js")
 
-@if(WebpackTest.isParticipating &&
+@if(Webpack.isSwitchedOn &&
     (
         page.metadata.contentType == "Article" ||
         page.metadata.contentType == "LiveBlog" ||

--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/video-player.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/video-player.js
@@ -10,7 +10,7 @@ define([
     // In rjs this module is shimmed in the config
     // https://github.com/guardian/frontend/blob/webpack-redux/tools/__tasks__/compile/javascript/rjs.config.js#L42
     // We can move this up to the define() when we go 100% WP
-    if (config.tests && config.tests.abWebpackBundle) {
+    if (config.switches.webpack) {
         require('videojs-ads-lib');
     }
 

--- a/static/src/javascripts-legacy/bootstraps/standard/main.js
+++ b/static/src/javascripts-legacy/bootstraps/standard/main.js
@@ -91,7 +91,7 @@ define([
          *  Interactives are content, we want them booting as soon (and as stable) as possible.
          */
 
-        if (!config.tests.abWebpackBundle && /Article|LiveBlog/.test(config.page.contentType)) {
+        if (!config.switches.webpack && /Article|LiveBlog/.test(config.page.contentType)) {
             qwery('figure.interactive').forEach(function (el) {
                 var mainJS = el.getAttribute('data-interactive');
                 if (!mainJS) {

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
@@ -58,7 +58,7 @@ define([
         // - Once fixed, or a global fetch is available through a polyfill, one can
         //   modify discussion-frontend to remove `fetch` polyfill and pass, if needed,
         //   opts.net = { json: fetchJson }
-        if (config.tests && config.tests.abWebpackBundle) {
+        if (config.switches.webpack) {
             return loadScript(config.page.discussionFrontendUrl)
                 .then(function() {
                     init(window.guardian.app.discussion);

--- a/static/src/javascripts-legacy/projects/common/views/svgs.js
+++ b/static/src/javascripts-legacy/projects/common/views/svgs.js
@@ -166,7 +166,7 @@ define([
     };
 
     return function (name, classes, title) {
-        if (config.tests && config.tests.abWebpackBundle) {
+        if (config.switches.webpack) {
             return svg(svgs[name].markup, classes, title);
         }
 


### PR DESCRIPTION
## What does this change?

- removes the webpack MVT test 
- puts webpack on a switch, which is on by default

## What is the value of this and can you measure success?

- put the whole site to webpack, but enables us to revert to requirejs if it turns out there's a fault we've overlooked
- enables a fix that means we can re-merge #15791

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

no

## Tested in CODE?

- [x] test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->