### PR TITLE
Increase frequency of email front refresh

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -29,7 +29,7 @@ object RefreshFrontsJob extends Logging with ExecutionContexts {
         case Some(EditorialPriority) => StandardFrequency
         case Some(CommercialPriority) => LowFrequency
         case Some(TrainingPriority) => LowFrequency
-        case Some(EmailPriority) => LowFrequency
+        case Some(EmailPriority) => StandardFrequency
         case None => LowFrequency
       }
   }


### PR DESCRIPTION
We have email fronts which consist entirely of backfill (e.g. https://www.theguardian.com/email/us/daily) and need to refresh in a more timely manner to make sure the email is in sync with recent changes to the front we're backfilling from.