### PR TITLE
don't enhance expired media atoms on fronts

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -35,7 +35,8 @@ object FaciaContentFrontendHelpers {
        bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
        atomId <- Some(bodyElement.attr("data-atom-id"))
        mainMediaAtom <- atoms.media.find(ma => ma.id == atomId && ma.assets.exists(_.platform == MediaAssetPlatform.Youtube))
-     } yield mainMediaAtom
+       nonExpiredMediaAtom <- if (!mainMediaAtom.expired.getOrElse(false)) Some(mainMediaAtom) else None
+     } yield nonExpiredMediaAtom
 
 
     def mainVideo: Option[VideoElement] = {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -50,12 +50,12 @@
             } else {
                 <div class="vjs-error-display vjs-modal-dialog">
                     <div class="vjs-modal-dialog-content">
-                        This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.</div>
+                        This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
                 </div>
             </div>
 
         }
-            </div>
+          </div>
       }
         </div>
 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -49,11 +49,13 @@
                 }
             } else {
                 <div class="vjs-error-display vjs-modal-dialog">
-                    <div class="vjs-modal-dialog-content" role="document">
+                    <div class="vjs-modal-dialog-content">
                         This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.</div>
                 </div>
             </div>
+
         }
+            </div>
       }
         </div>
 }


### PR DESCRIPTION
## What does this change?
Don't enhance expired media atoms on fronts.
(Fixes broken layout when expired media atom is on front)

## What is the value of this and can you measure success?
When a media atom was expired the youtube template causes the front template to mess up. I don't know exactly why this happens, so for now this PR just stops the card being enhanced in this case.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

#### Before

<img width="1193" alt="screen shot 2017-02-13 at 12 16 08" src="https://cloud.githubusercontent.com/assets/1764158/22883070/3bb079fc-f1e6-11e6-9b6a-916b98466ba3.png">

#### After

<img width="1165" alt="screen shot 2017-02-13 at 12 09 08" src="https://cloud.githubusercontent.com/assets/1764158/22883083/500598a6-f1e6-11e6-8907-aa969529a755.png">


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
