### PR TITLE
Add a listener to identify the type of ad being displayed

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
@@ -14,6 +14,7 @@ define([
     'commercial/modules/dfp/performance-logging',
 
     // These are cross-frame protocol messaging routines:
+    'commercial/modules/messenger/type',
     'commercial/modules/messenger/get-stylesheet',
     'commercial/modules/messenger/resize',
     'commercial/modules/messenger/scroll',

--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/type.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/type.js
@@ -1,0 +1,17 @@
+define([
+    'common/utils/closest',
+    'common/utils/fastdom-promise',
+    'commercial/modules/messenger'
+], function (closest, fastdom, messenger) {
+    messenger.register('type', function(specs, ret, iframe) {
+        return setType(specs, closest(iframe, '.js-ad-slot'));
+    });
+
+    return setType;
+
+    function setType(type, adSlot) {
+        return fastdom.write(function () {
+            adSlot.classList.add('ad-slot--' + type);
+        });
+    }
+});

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -361,6 +361,7 @@
     }
 }
 
+.ad-slot--inline-book,
 .ad-slot--books-inline {
     @include mq(mobileLandscape) {
         width: gs-span(2);


### PR DESCRIPTION
This is because in particular, the inline merchandising components have slightly different layouts depending on their content. An inline event will look like this:

![picture 4](https://cloud.githubusercontent.com/assets/629976/22885692/753d6d36-f1f2-11e6-8a23-8a39a94818b1.jpg)

... whereas an inline book will be skinnier:

![picture 5](https://cloud.githubusercontent.com/assets/629976/22885705/80aa9180-f1f2-11e6-8a7c-5f78f52df3e6.jpg)

(I used the same example pre- and post-change)