### PR TITLE
Expired fronts handling refactor

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -34,9 +34,8 @@ object FaciaContentFrontendHelpers {
        atomContainer <- Option(document.getElementsByClass("element-atom").first())
        bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
        atomId <- Some(bodyElement.attr("data-atom-id"))
-       mainMediaAtom <- atoms.media.find(ma => ma.id == atomId && ma.assets.exists(_.platform == MediaAssetPlatform.Youtube))
-       nonExpiredMediaAtom <- if (!mainMediaAtom.expired.getOrElse(false)) Some(mainMediaAtom) else None
-     } yield nonExpiredMediaAtom
+       mainMediaAtom <- atoms.media.find(ma => (ma.id == atomId && !ma.expired.getOrElse(false)) && ma.assets.exists(_.platform == MediaAssetPlatform.Youtube))
+     } yield mainMediaAtom
 
 
     def mainVideo: Option[VideoElement] = {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -59,7 +59,6 @@
       }
         </div>
 }
-</div>
 
 @if(displayCaption) {
     @mediaAtomCaption(media.title, mainMedia)


### PR DESCRIPTION
## What does this change?
Follow-up from #15810
* Fixes un-matched `</div>` which can cause the rest of the page to break. 
* Fixes case where atoms on fronts did not get enhanced if expired field was not set as they were failing the for comprehension
 
## What is the value of this and can you measure success?
Fixes fronts playable behaviour and expired atoms can no longer break rest of page

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

#### Before

<img width="259" alt="screen shot 2017-02-13 at 14 07 40" src="https://cloud.githubusercontent.com/assets/1764158/22886482/051779da-f1f6-11e6-86ae-cf5bea06290f.png">

#### After
<img width="248" alt="screen shot 2017-02-13 at 14 08 04" src="https://cloud.githubusercontent.com/assets/1764158/22886495/10a67314-f1f6-11e6-96cd-a9d3f88a0937.png">

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
