### PR TITLE
Article Refresh/New Nav:  more subnav tweaks

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -230,23 +230,19 @@ object NewNavigation {
       NavLink("masterclasses", "/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"),
       NavLink("courses", "/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
       NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
-      NavLink("today's paper", "/theguardian"),
-      NavLink("the observer", "/observer"),
-      NavLink("crosswords", "/crosswords")
+      todaysPaper, observer, crosswords
     ))
 
     val au = NavLinkLists(List(
       NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
       NavLink("masterclasses", "/guardian-masterclasses-australia"),
-      NavLink("crosswords", "/crosswords"),
-      NavLink("video", "/video")
+      crosswords, video
     ))
 
     val us = NavLinkLists(List(
       NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
       NavLink("jobs", "https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS"),
-      NavLink("crosswords", "/crosswords"),
-      NavLink("video", "/video")
+      crosswords, video
     ))
 
     val int = NavLinkLists(List(
@@ -254,10 +250,7 @@ object NewNavigation {
       NavLink("dating", "https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES"),
       NavLink("jobs", "https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS"),
       NavLink("masterclasses", "/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"),
-      NavLink("today's paper", "/theguardian"),
-      NavLink("the observer", "/observer"),
-      NavLink("crosswords", "/crosswords"),
-      NavLink("video", "/video")
+      todaysPaper, observer, crosswords, video
     ))
   }
 
@@ -375,20 +368,21 @@ object NewNavigation {
 
   object SubSectionLinks {
 
-    val ukNews = NavLinkLists(
-      List(education, media, society, law, scotland),
+    val ukNewsSubNav = NavLinkLists(
+      List(ukNews, education, media, society, law, scotland),
       List(wales, northernIreland)
     )
 
     val worldSubNav = NavLinkLists(
-      List(europe, usNews, americas, asia, australiaNews),
+      List(world, europe, usNews, americas, asia, australiaNews),
       List(africa, middleEast, cities, globalDevelopment)
     )
 
     val moneySubNav = NavLinkLists(List(property, pensions, savings, borrowing, careers))
 
-    val football = NavLinkLists(
+    val footballSubNav = NavLinkLists(
       List(
+        football,
         NavLink("live scores", "/football/live"),
         NavLink("tables", "/football/tables"),
         NavLink("competitions", "/football/competitions"),
@@ -398,8 +392,9 @@ object NewNavigation {
       )
     )
 
-    val todaysPaper = NavLinkLists(
+    val todaysPaperSubNav = NavLinkLists(
       List(
+        todaysPaper,
         NavLink("editorials & letters", "/theguardian/mainsection/editorialsandreply"),
         NavLink("obituaries", "/tone/obituaries"),
         NavLink("g2", "/theguardian/g2"),
@@ -409,16 +404,18 @@ object NewNavigation {
       )
     )
 
-    val theObserver = NavLinkLists(
+    val theObserverSubNav = NavLinkLists(
       List(
+        observer,
         NavLink("comment", "/theobserver/news/comment"),
         NavLink("the new review", "/theobserver/new-review"),
         NavLink("observer magazine", "/theobserver/magazine")
       )
     )
 
-    val crosswords = NavLinkLists(
+    val crosswordsSubNav = NavLinkLists(
       List(
+        crosswords,
         NavLink("blog", "/crosswords/crossword-blog"),
         NavLink("editor", "/crosswords/series/crossword-editor-update"),
         NavLink("quick", "/crosswords/series/quick"),
@@ -437,18 +434,18 @@ object NewNavigation {
     case object businessSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(economics, banking, retail, markets, eurozone))
-      val us = NavLinkLists(List(economics, sustainableBusiness, diversityEquality, smallBusiness))
-      val au = NavLinkLists(List(markets, money))
+      val uk = NavLinkLists(List(business, economics, banking, retail, markets, eurozone))
+      val us = NavLinkLists(List(business, economics, sustainableBusiness, diversityEquality, smallBusiness))
+      val au = NavLinkLists(List(business, markets, money))
       val int = uk
     }
 
     case object environmentSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(climateChange, wildlife, energy, pollution))
+      val uk = NavLinkLists(List(environment, climateChange, wildlife, energy, pollution))
       val us = uk
-      val au = NavLinkLists(List(cities, globalDevelopment, sustainableBusiness))
+      val au = NavLinkLists(List(environment, cities, globalDevelopment, sustainableBusiness))
       val int = uk
     }
 
@@ -468,13 +465,13 @@ object NewNavigation {
     )
 
     val subSectionLinks = List(
-      SubSectionLink("uk-news", ukNews),
+      SubSectionLink("uk-news", ukNewsSubNav),
       SubSectionLink("world", worldSubNav),
       SubSectionLink("money", moneySubNav),
-      SubSectionLink("football", football),
-      SubSectionLink("todayspaper", todaysPaper),
-      SubSectionLink("theobserver", theObserver),
-      SubSectionLink("crosswords", crosswords)
+      SubSectionLink("football", footballSubNav),
+      SubSectionLink("todayspaper", todaysPaperSubNav),
+      SubSectionLink("theobserver", theObserverSubNav),
+      SubSectionLink("crosswords", crosswordsSubNav)
     )
 
     def isEditionalistedSubSection(sectionId: String) = {

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -216,33 +216,33 @@ object NewNavigation {
     val name = ""
 
     val uk = NavLinkLists(List(
-      NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
-      NavLink("jobs", "https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS"),
-      NavLink("dating", "https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES"),
+      apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
+      dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
       NavLink("professional", "/guardian-professional"),
-      NavLink("masterclasses", "/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"),
+      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_uk_web_newheader"),
       NavLink("courses", "/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
       NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
       todaysPaper, observer, crosswords
     ))
 
     val au = NavLinkLists(List(
-      NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
-      NavLink("masterclasses", "/guardian-masterclasses-australia"),
+      apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
+      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_au_web_newheader"),
       crosswords, video
     ))
 
     val us = NavLinkLists(List(
-      NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
-      NavLink("jobs", "https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS"),
+      apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
       crosswords, video
     ))
 
     val int = NavLinkLists(List(
-      NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android"),
-      NavLink("dating", "https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES"),
-      NavLink("jobs", "https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_JOBS"),
-      NavLink("masterclasses", "/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"),
+      apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
+      dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
+      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_int_web_newheader"),
       todaysPaper, observer, crosswords, video
     ))
   }

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -11,14 +11,7 @@ case class NavLinkLists(mostPopular: Seq[NavLink], leastPopular: Seq[NavLink] = 
 
 object NewNavigation {
 
-  var PrimaryLinks = List(
-    NavLink("news", "/"),
-    NavLink("opinion", "/commentisfree"),
-    NavLink("sport", "/sport"),
-    NavLink("arts", "/culture"),
-    NavLink("life", "/lifeandstyle")
-  )
-
+  var PrimaryLinks = List(headlines, opinion, sport, culture, lifestyle)
   val topLevelSections = List(News, Opinion, Sport, Arts, Life)
 
   def getMembershipLinks(edition: Edition) = {
@@ -345,7 +338,7 @@ object NewNavigation {
         val section = sectionList.head
         val parentSection = section.parentSection.getPopularEditionalisedNavLinks(edition).drop(1)
 
-        if (parentSection.contains(section.navLink) || section.navLink == headlines) {
+        if (parentSection.contains(section.navLink) || NewNavigation.PrimaryLinks.contains(section.navLink)) {
           parentSection
         } else {
           Seq(section.navLink) ++ parentSection

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -115,6 +115,10 @@ object NavLinks {
   val observer = NavLink("the observer", "/observer")
   val crosswords = NavLink("crosswords", "/crosswords")
   val video =  NavLink("video", "/video")
+  val jobs = NavLink("jobs", "https://jobs.theguardian.com")
+  val dating = NavLink("dating", "https://soulmates.theguardian.com")
+  val apps = NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android")
+  val masterClasses = NavLink("masterclasses", "/guardian-masterclasses")
 
   val tagPages = List(
     "technology/games",

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -3,7 +3,7 @@ package common
 object NavLinks {
   /* NEWS */
 
-  val headlines = NavLink("headlines", "/", "", iconName = "home")
+  val headlines = NavLink("news", "/", "",longTitle = "headlines", iconName = "home")
   val ukNews = NavLink("UK", "/uk-news", "uk-news", longTitle = "UK news")
   val world = NavLink("world", "/world", "world", longTitle = "world news")
   val environment = NavLink("environment", "/environment", "environment")
@@ -83,7 +83,7 @@ object NavLinks {
   val NHL = NavLink("NHL", "/sport/nhl", "sport/nhl")
 
   /* ARTS */
-  val culture = NavLink("culture", "/culture", "culture", longTitle = "culture home", iconName = "home")
+  val culture = NavLink("arts", "/culture", "culture", longTitle = "culture home", iconName = "home")
   val film = NavLink("film", "/film", "film")
   val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", "tv-and-radio")
   val music = NavLink("music", "/music", "music")
@@ -94,7 +94,7 @@ object NavLinks {
   val classical = NavLink("classical", "/music/classicalmusicandopera", "music/classicalmusicandopera")
 
   /* LIFE */
-  val lifestyle = NavLink("lifestyle", "/lifeandstyle", "lifeandstyle", longTitle = "lifestyle home", iconName = "home")
+  val lifestyle = NavLink("life", "/lifeandstyle", "lifeandstyle", longTitle = "lifestyle home", iconName = "home")
   val fashion = NavLink("fashion", "/fashion", "fashion")
   val food = NavLink("food", "/lifeandstyle/food-and-drink", "lifeandstyle/food-and-drink")
   val travel = NavLink("travel", "/travel", "travel")

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -111,6 +111,11 @@ object NavLinks {
   val travelAustralasia = NavLink("australasia", "/travel/australasia", "travel/australasia")
   val travelAsia = NavLink("asia", "/travel/asia", "travel/asia")
 
+  val todaysPaper = NavLink("today's paper", "/theguardian")
+  val observer = NavLink("the observer", "/observer")
+  val crosswords = NavLink("crosswords", "/crosswords")
+  val video =  NavLink("video", "/video")
+
   val tagPages = List(
     "technology/games",
     "us-news/us-politics",


### PR DESCRIPTION
## What does this change?

Three things:
* adding campaign codes to the footer https://github.com/guardian/frontend/commit/768de74503b783bd4364e812812c80e1daf224b2
* adding the parentSection on tertiary nav lists https://github.com/guardian/frontend/commit/a6a7670dafeb01d7656752a5897bd77f84635658 for example football here:
![image](https://cloud.githubusercontent.com/assets/8774970/22891062/11a4ca30-f206-11e6-8ddb-13ae7d964d53.png)
* ensuring the primary links (news, life, arts, sports, opinion) don't show up in the subnav, because they are already visible.
**Before:**
![image](https://cloud.githubusercontent.com/assets/8774970/22891119/3a88f804-f206-11e6-8cc6-c914ddf64584.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/22891107/320e7b7c-f206-11e6-94b6-71158a870d38.png)

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
campaign codes are good for tracking clicks. Other things are for user experience reasons.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope
