### PR TITLE
Tags cleanup

### DIFF
--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -32,15 +32,15 @@
                             @Html(Localisation(content.content.sectionLabelName))
                     </a>
                 }
-            </div>
 
-            @content.content.blogOrSeriesTag.map { series =>
-                <a class="submeta2__link" href="@LinkTo {/@series.id}">@series.name</a>
-            }.getOrElse {
-                @if(content.content.isFromTheObserver) {
-                    <a class="submeta2__link" href="http://observer.theguardian.com">The Observer</a>
+                @content.content.blogOrSeriesTag.map { series =>
+                    <a class="submeta2__link" href="@LinkTo {/@series.id}">@series.name</a>
+                }.getOrElse {
+                    @if(content.content.isFromTheObserver) {
+                        <a class="submeta2__link" href="http://observer.theguardian.com">The Observer</a>
+                    }
                 }
-            }
+            </div>
         </div>
 
         <div class="submeta2__keywords">
@@ -69,7 +69,7 @@
                         }
                     }
                 }
-        </div>
+            </div>
         </div>
         @if(content.showBottomSocialButtons) {
             <div data-component="share" class="submeta__share">

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -10,7 +10,6 @@
 @if(amp || mvt.ABNewNavVariantSeven.isParticipating) {
     <div class="submeta2 mobile-only">
         <div class="submeta2__section-labels">
-
             @if(ArticleBadgesSwitch.isSwitchedOn) {
                 @badgeFor(content).map { badge =>
                     <div class="submeta2__badge">
@@ -25,13 +24,15 @@
                 }
             }
 
-            @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
-                <a class="submeta2__link submeta2__link--first"
-                    data-link-name="article section"
-                    href="@LinkTo {/@content.content.sectionLabelLink}">
-                        @Html(Localisation(content.content.sectionLabelName))
-                </a>
-            }
+            <div class="submeta2__links">
+                @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
+                    <a class="submeta2__link submeta2__link--first"
+                        data-link-name="article section"
+                        href="@LinkTo {/@content.content.sectionLabelLink}">
+                            @Html(Localisation(content.content.sectionLabelName))
+                    </a>
+                }
+            </div>
 
             @content.content.blogOrSeriesTag.map { series =>
                 <a class="submeta2__link" href="@LinkTo {/@series.id}">@series.name</a>
@@ -43,30 +44,32 @@
         </div>
 
         <div class="submeta2__keywords">
-            @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
-                    @if(shownKeywords.nonEmpty) {
-                        @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                            <a class="submeta2__link @if(row.rowNum == 1){submeta2__link--first}"
-                                href="@LinkTo(keyword.metadata.url)"
-                                data-link-name="keyword: @keyword.id">
-                                    @keyword.name
-                                    @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
+            <div class="submeta2__links">
+                @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
+                    @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
+                        @if(shownKeywords.nonEmpty) {
+                            @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
+                                <a class="submeta2__link @if(row.rowNum == 1){submeta2__link--first}"
+                                    href="@LinkTo(keyword.metadata.url)"
+                                    data-link-name="keyword: @keyword.id">
+                                        @keyword.name
+                                        @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
+                                </a>
+                            }
+                        }
+                    }
+
+                    @if(content.tags.isArticle && !content.tags.isLiveBlog) {
+                        @content.tags.tones.headOption.map { tone =>
+                            <a class="submeta2__link"
+                                href="@LinkTo(tone.metadata.url)"
+                                data-link-name="tone: @tone.name">
+                                    @tone.name.toLowerCase
                             </a>
                         }
                     }
                 }
-
-                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-                    @content.tags.tones.headOption.map { tone =>
-                        <a class="submeta2__link"
-                            href="@LinkTo(tone.metadata.url)"
-                            data-link-name="tone: @tone.name">
-                                @tone.name.toLowerCase
-                        </a>
-                    }
-                }
-            }
+        </div>
         </div>
         @if(content.showBottomSocialButtons) {
             <div data-component="share" class="submeta__share">

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -26,7 +26,7 @@
 
             <div class="submeta2__links">
                 @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
-                    <a class="submeta2__link submeta2__link--first"
+                    <a class="submeta2__link"
                         data-link-name="article section"
                         href="@LinkTo {/@content.content.sectionLabelLink}">
                             @Html(Localisation(content.content.sectionLabelName))
@@ -49,7 +49,7 @@
                     @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
                         @if(shownKeywords.nonEmpty) {
                             @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                                <a class="submeta2__link @if(row.rowNum == 1){submeta2__link--first}"
+                                <a class="submeta2__link"
                                     href="@LinkTo(keyword.metadata.url)"
                                     data-link-name="keyword: @keyword.id">
                                         @keyword.name

--- a/static/src/stylesheets/amp/_fonts.scss
+++ b/static/src/stylesheets/amp/_fonts.scss
@@ -83,7 +83,8 @@
     .d2-permalink,
     .d2-body,
     .meta__contact-header,
-    .back-to-top__text {
+    .back-to-top__text,
+    .submeta2 {
         font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     }
 }

--- a/static/src/stylesheets/amp/_footer.scss
+++ b/static/src/stylesheets/amp/_footer.scss
@@ -2,7 +2,6 @@
     position: absolute;
     padding: 0;
     margin-top: $gs-baseline * 2;
-    background: $multimedia-support-4;
     z-index: $zindex-content;
     width: 100%;
     max-width: 600px;
@@ -13,6 +12,8 @@
     @include content-gutter();
     line-height: 1;
     font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    background: $multimedia-support-4;
+    z-index: 1;
 
     a {
         color: $neutral-4;

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -26,31 +26,34 @@
     margin-bottom: $gs-baseline / 2;
 }
 
+.submeta2__links {
+    overflow: hidden;
+    margin-left: -.3em;
+}
+
 .submeta2__link {
     font-weight: 500;
     line-height: 22px;
     position: relative;
     padding-left: .3em;
     padding-right: .35em;
+    float: left;
 
-    &:before {
+    &:after {
         position: absolute;
         pointer-events: none;
         content: '/';
         //optically aligns slashes
-        left: -.28em;
+        top: 0;
+        right: -.19em;
         color: $neutral-5;
     }
 
     .submeta2__keywords & {
         color: $neutral-2;
     }
-}
 
-.submeta2__link--first {
-    padding-left: 0;
-
-    &:before {
+    &:last-of-type:after {
         content: none;
     }
 }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -917,7 +917,6 @@ $caption-button-size: 32px;
     border-bottom: 1px dotted $neutral-5;
     padding: $gs-baseline / 2 0 $gs-baseline;
 
-
     &:before {
         @include fs-textSans(1);
         content: "More";
@@ -930,34 +929,30 @@ $caption-button-size: 32px;
 .submeta2__keywords {
     @include fs-textSans(4);
     padding: $gs-baseline / 2 0 $gs-baseline;
+    min-height: $gs-baseline * 2;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;
 }
 
+.submeta2__links {
+    overflow: hidden;
+    margin-left: -.3em;
+}
+
 .submeta2__link {
     font-weight: bold;
-    position: relative;
-    padding-left: .3em;
-    padding-right: .35em;
+    @include nav-links;
 
-    &:before {
-        position: absolute;
-        pointer-events: none;
-        content: '/';
-        //optically aligns slashes
-        left: -.28em;
+    &:after {
+        @include trailing-slash;
         color: $neutral-5;
     }
 
     .submeta2__keywords & {
         color: $neutral-2;
     }
-}
 
-.submeta2__link--first {
-    padding-left: 0;
-
-    &:before {
+    &:last-of-type:after {
         content: none;
     }
 }


### PR DESCRIPTION
Have re-used mixins for trailing slash separated lists, for consistency and larger tap area. And replicated some code on AMP. Results in cleaner appearance when wrapping onto two lines.

# Before:
<img width="320" alt="screen shot 2017-02-13 at 15 05 35" src="https://cloud.githubusercontent.com/assets/14570016/22890931/aa619786-f205-11e6-989c-f5ffd77f7611.png">

# After:
<img width="320" alt="screen shot 2017-02-13 at 15 06 00" src="https://cloud.githubusercontent.com/assets/14570016/22890934/aa8d65dc-f205-11e6-8a0b-45d62c7f1c2b.png">

Also prevented slashes from appearing before single items:
# Before:
<img width="314" alt="screen shot 2017-02-13 at 16 05 49" src="https://cloud.githubusercontent.com/assets/14570016/22891156/5b37e966-f206-11e6-92b8-69066d347fe3.png">

# After:
<img width="315" alt="screen shot 2017-02-13 at 15 26 27" src="https://cloud.githubusercontent.com/assets/14570016/22891086/1f5a0b7c-f206-11e6-8e4a-f15a810a28b8.png">

And a finally tweak, making the amp back to top button overlap correctly:

# After:
<img width="319" alt="screen shot 2017-02-13 at 15 26 33" src="https://cloud.githubusercontent.com/assets/14570016/22890932/aa769456-f205-11e6-8832-210536aa5e74.png">

*Don't worry about the difference in font weight - that's AMPs lack of font weights.