### PR TITLE
Bugfix, changing threading in discussion

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
@@ -442,11 +442,13 @@ Loader.prototype.loadComments = function(options) {
 
     this.setState('loading');
 
+    options = options || {};
+
     // If the caller specified truncation, do not load all comments.
     if (options && options.shouldTruncate && this.comments.isAllPageSizeActive()) {
         options.pageSize = 10;
     }
-    
+
     // Closed state of comments is passed so we bust cache of comment thread when it is reopened
     options.commentsClosed = this.getDiscussionClosed();
 


### PR DESCRIPTION
## What does this change?

When the `loadComments` function is called without an options object it fails out because we try to set a property on a non-existent object.

## What is the value of this and can you measure success?

Users can switch between threaded / unthreaded comments.

## Does this affect other platforms - Amp, Apps, etc?

No.

