### PR TITLE
Use returned DFP size when setting the height of the sticky banner

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-render.js
@@ -34,6 +34,7 @@ define([
             reportEmptyResponse(advert.id, event);
             emitRenderEvents(false);
         } else {
+            advert.size = event.size;
             dfpEnv.creativeIDs.push(event.creativeId);
             renderAdvert(advert, event)
             .then(emitRenderEvents);

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
@@ -154,12 +154,12 @@ define([
                 });
 
             function callSizeCallback() {
-                advert.size = slotRenderEvent.size.join(',');
-                if (advert.size === '0,0') {
-                    advert.size = 'fluid';
+                var size = advert.size.toString();
+                if (size === '0,0') {
+                    size = 'fluid';
                 }
-                return Promise.resolve(sizeCallbacks[advert.size] ?
-                    sizeCallbacks[advert.size](slotRenderEvent, advert) :
+                return Promise.resolve(sizeCallbacks[size] ?
+                    sizeCallbacks[size](slotRenderEvent, advert) :
                     null
                 );
             }

--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
@@ -84,7 +84,7 @@ define([
         .then(function (isRendered) {
             if (isRendered) {
                 var advert = getAdvertById(topSlotId);
-                if (advert.size[1] > 0) {
+                if (advert.size && advert.size[1] > 0) {
                     fastdom.read(function () {
                         var styles = window.getComputedStyle(topSlot);
                         return parseInt(styles.paddingTop) + parseInt(styles.paddingBottom) + advert.size[1];

--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
@@ -7,6 +7,7 @@ define([
     'common/utils/fastdom-promise',
     'common/modules/commercial/dfp/track-ad-render',
     'common/modules/commercial/commercial-features',
+    'commercial/modules/dfp/get-advert-by-id',
     'commercial/modules/messenger'
 ], function (
     Promise,
@@ -17,6 +18,7 @@ define([
     fastdom,
     trackAdRender,
     commercialFeatures,
+    getAdvertById,
     messenger
 ) {
     var topSlotId = 'dfp-ad--top-above-nav';
@@ -81,10 +83,19 @@ define([
         trackAdRender(topSlotId)
         .then(function (isRendered) {
             if (isRendered) {
-                fastdom.read(function () {
-                    return topSlot.offsetHeight;
-                })
-                .then(resizeStickyBanner);
+                var advert = getAdvertById(topSlotId);
+                if (advert.size[1] > 0) {
+                    fastdom.read(function () {
+                        var styles = window.getComputedStyle(topSlot);
+                        return parseInt(styles.paddingTop) + parseInt(styles.paddingBottom) + advert.size[1];
+                    })
+                    .then(resizeStickyBanner);
+                } else {
+                    fastdom.read(function () {
+                        return topSlot.offsetHeight;
+                    })
+                    .then(resizeStickyBanner);
+                }
             }
         });
     }


### PR DESCRIPTION
For those browsers that don't support native sticky positioning yet, the `sticky-top-banner` module kicks off. It is waiting for the ad to be rendered before setting the height of the containing `DIV`.

Recently though, it appears the value read from the CSSOM when the `onSlotRender` callback is called is not always correct, i.e. GPT has not resized the ad slot yet. So we get around that, by using the size returned by DFP instead. This also many not always be correct, but it is closer to the truth, and we have ways to deal with dynamic resizing.

For native ads, where the size is `[0, 0]`, we still read off the CSSOM though.