### PR TITLE
Make dropcaps cleaner safe

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -491,10 +491,14 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleane
     document.getElementsByTag("h2").foreach{ h2 =>
         if (isImmersive && h2.text() == "* * *") {
             h2.before("""<hr class="section-rule" />""")
-            val next = h2.nextElementSibling()
-            if (next.nodeName() == "p") {
-                next.html(setDropCap(next))
-            }
+
+            val maybeNext = Option(h2.nextElementSibling())
+            maybeNext
+              .filter(_.nodeName() == "p")
+              .foreach { el =>
+                el.html(setDropCap(el))
+              }
+
             h2.remove()
         }
     }


### PR DESCRIPTION
## What does this change?
Ensures that dropcaps are added to articles in the cleaner safely (particularly for articles ending in * * *).

## What is the value of this and can you measure success?
Avoids article errors.

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
