### PR TITLE
Use CSSOM for Fabrics

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
@@ -84,7 +84,12 @@ define([
         .then(function (isRendered) {
             if (isRendered) {
                 var advert = getAdvertById(topSlotId);
-                if (advert.size && advert.size[1] > 0) {
+                if (advert.size &&
+                    // skip for Fabric/Fluid250 creatives
+                    advert.size[0] !== 88 &&
+                    // skip for native ads
+                    advert.size[1] > 0
+                ) {
                     fastdom.read(function () {
                         var styles = window.getComputedStyle(topSlot);
                         return parseInt(styles.paddingTop) + parseInt(styles.paddingBottom) + advert.size[1];


### PR DESCRIPTION
We have remnant creatives still using the old sizes (88x87) and so reading that size will certainly not provide any useful value. For these creatives, we use the traditional route of reading the dimensions of the slot.

Before:
![picture 2](https://cloud.githubusercontent.com/assets/629976/22930540/b2f4f7ea-f2b8-11e6-90e6-a34b81aceba7.jpg)

After:
![picture 3](https://cloud.githubusercontent.com/assets/629976/22930543/b68ec598-f2b8-11e6-8f89-62af0363b7b2.jpg)
