### PR TITLE
Add webpack to `make compile-dev`

### DIFF
--- a/makefile
+++ b/makefile
@@ -54,7 +54,7 @@ compile-dev: install
 	@./tools/task-runner/runner compile --dev
 
 # Compile all assets for watch.
-compile-watch: install
+compile-watch: install # PRIVATE
 	@./tools/task-runner/runner compile/index.watch
 
 compile-javascript: install # PRIVATE

--- a/makefile
+++ b/makefile
@@ -40,7 +40,7 @@ check-yarn: # PRIVATE
 
 # Watch and automatically compile/reload all JS/SCSS.
 # Uses port 3000 insead of 9000.
-watch: compile-dev
+watch: compile-watch
 	@./dev/watch.js
 
 # *********************** ASSETS ***********************
@@ -52,6 +52,10 @@ compile: install
 # Compile all assets in development.
 compile-dev: install
 	@./tools/task-runner/runner compile --dev
+
+# Compile all assets for watch.
+compile-watch: install
+	@./tools/task-runner/runner compile/index.watch
 
 compile-javascript: install # PRIVATE
 	@./tools/task-runner/runner compile/javascript

--- a/makefile
+++ b/makefile
@@ -45,11 +45,11 @@ watch: compile-dev
 
 # *********************** ASSETS ***********************
 
-# Compile all assets for production.
+# Compile all assets in production.
 compile: install
 	@./tools/task-runner/runner compile
 
-# Compile all assets for development.
+# Compile all assets in development.
 compile-dev: install
 	@./tools/task-runner/runner compile --dev
 

--- a/tools/__tasks__/compile/index.watch.js
+++ b/tools/__tasks__/compile/index.watch.js
@@ -1,0 +1,10 @@
+module.exports = {
+    description: 'Compile assets for development',
+    task: [
+        require('./conf/clean'),
+        require('./css/index.dev'),
+        require('./javascript/index.watch'),
+        require('./fonts'),
+        require('./conf'),
+    ],
+};

--- a/tools/__tasks__/compile/javascript/index.dev.js
+++ b/tools/__tasks__/compile/javascript/index.dev.js
@@ -4,5 +4,6 @@ module.exports = {
         require('../inline-svgs'),
         require('./clean'),
         require('./copy'),
+        require('./webpack.dev'),
     ],
 };

--- a/tools/__tasks__/compile/javascript/index.watch.js
+++ b/tools/__tasks__/compile/javascript/index.watch.js
@@ -1,0 +1,8 @@
+module.exports = {
+    description: 'Prepare JS for development',
+    task: [
+        require('../inline-svgs'),
+        require('./clean'),
+        require('./copy'),
+    ],
+};

--- a/tools/__tasks__/compile/javascript/webpack.dev.js
+++ b/tools/__tasks__/compile/javascript/webpack.dev.js
@@ -1,0 +1,31 @@
+// eslint-disable-next-line import/no-unassigned-import
+require('any-observable/register/rxjs-all');
+
+const Observable = require('any-observable');
+
+const webpack = require('webpack');
+const ProgressPlugin = require('webpack/lib/ProgressPlugin');
+const chalk = require('chalk');
+
+module.exports = {
+    description: 'Create Webpack bundles',
+    task: () => new Observable((observer) => {
+        const config = require('../../../../webpack.config.js')({
+            plugins: [
+                new ProgressPlugin((progress, msg) => observer.next(`${Math.round(progress * 100)}% ${msg}`)),
+            ],
+        });
+        const bundler = webpack(config);
+
+        bundler.run((err, stats) => {
+            if (err) {
+                throw new Error(chalk.red(err));
+            }
+            const info = stats.toJson();
+            if (stats.hasErrors()) {
+                throw new Error(chalk.red(info.errors));
+            }
+            observer.complete();
+        });
+    }),
+};


### PR DESCRIPTION
## What does this change?

- adds webpack step to `make compile-dev`
- creates a `make compile-watch` step to prepare for watching
  - doesn't include webpack , because webpack runs the initial build in watch mode anyway 

## What is the value of this and can you measure success?

ensures js bundles are present after running `make compile-dev`, which after removing `requirejs` from dev, they were not (only in `make watch`)

## Does this affect other platforms - Amp, Apps, etc?

no