### PR TITLE
Use 5x3 trail image for non-playable YouTube atom cards

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -277,7 +277,7 @@ case class ContentCard(
 
   def hasImage = displayElement match {
     case Some(InlineVideo(_, _, _, Some(_))) => true
-    case Some(InlineYouTubeMediaAtom(_)) => true
+    case Some(InlineYouTubeMediaAtom(_, _)) => true
     case Some(InlineImage(_)) => true
     case Some(InlineSlideshow(_)) => true
     case Some(CrosswordSvg(_)) => true

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -64,7 +64,7 @@ case class InlineVideo(
   fallBack: Option[InlineImage]
 ) extends FaciaDisplayElement
 
-case class InlineYouTubeMediaAtom(youTubeAtom: MediaAtom, posterOverride: Option[ImageMedia]) extends FaciaDisplayElement
+case class InlineYouTubeMediaAtom(youTubeAtom: MediaAtom, posterImageOverride: Option[ImageMedia]) extends FaciaDisplayElement
 
 object InlineImage {
   def fromFaciaContent(faciaContent: PressedContent): Option[InlineImage] =

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -23,7 +23,7 @@ object FaciaDisplayElement {
       case _ if faciaContent.properties.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
       case _ if faciaContent.properties.showMainVideo && faciaContent.mainYouTubeMediaAtom.isDefined  =>
-        Some(InlineYouTubeMediaAtom(faciaContent.mainYouTubeMediaAtom.get))
+        Some(InlineYouTubeMediaAtom(faciaContent.mainYouTubeMediaAtom.get, faciaContent.trailPicture))
       case _ => InlineImage.fromFaciaContent(faciaContent)
     }
   }
@@ -64,7 +64,7 @@ case class InlineVideo(
   fallBack: Option[InlineImage]
 ) extends FaciaDisplayElement
 
-case class InlineYouTubeMediaAtom(youTubeAtom: MediaAtom) extends FaciaDisplayElement
+case class InlineYouTubeMediaAtom(youTubeAtom: MediaAtom, posterOverride: Option[ImageMedia]) extends FaciaDisplayElement
 
 object InlineImage {
   def fromFaciaContent(faciaContent: PressedContent): Option[InlineImage] =

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -4,7 +4,8 @@
 @import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
 
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false)(implicit request: RequestHeader)
+@import model.ImageMedia
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, overrideImage: Option[ImageMedia] = None)(implicit request: RequestHeader)
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
@@ -33,30 +34,31 @@
                 </iframe>
                 }
             }
+        @defining(overrideImage orElse media.posterImage) { bestPosterImage =>
+            @bestPosterImage.map { image =>
+                <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 
-        @media.posterImage.map { image =>
-            <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
-
-            @if(!expired) {
-                <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
-                @if(displayDuration) {
-                    <div class="youtube-media-atom__bottom-bar">
-                        <div class="youtube-media-atom__bottom-bar__icon">
-                        @fragments.inlineSvg("video-icon", "icon")
+                @if(!expired) {
+                    <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
+                    @if(displayDuration) {
+                        <div class="youtube-media-atom__bottom-bar">
+                            <div class="youtube-media-atom__bottom-bar__icon">
+                            @fragments.inlineSvg("video-icon", "icon")
+                            </div>
+                            <div class="youtube-media-atom__bottom-bar__duration"></div>
                         </div>
-                        <div class="youtube-media-atom__bottom-bar__duration"></div>
+                    }
+                } else {
+                    <div class="vjs-error-display vjs-modal-dialog">
+                        <div class="vjs-modal-dialog-content">
+                            This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
+                        </div>
                     </div>
-                }
-            } else {
-                <div class="vjs-error-display vjs-modal-dialog">
-                    <div class="vjs-modal-dialog-content">
-                        This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
-                </div>
-            </div>
 
+                }
+                </div>
+            }
         }
-          </div>
-      }
         </div>
 }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -5,11 +5,11 @@
 @import com.netaporter.uri.dsl._
 
 @import model.ImageMedia
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, overrideImage: Option[ImageMedia] = None)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterOverride: Option[ImageMedia] = None)(implicit request: RequestHeader)
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
-        ("u-responsive-ratio--hd", true),
+        ("u-responsive-ratio--hd", playable),
         ("youtube-media-atom", true),
         ("no-player", !playable || expired )
     ))"
@@ -34,7 +34,7 @@
                 </iframe>
                 }
             }
-        @defining(overrideImage orElse media.posterImage) { bestPosterImage =>
+        @defining(posterOverride orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -5,7 +5,7 @@
 @import com.netaporter.uri.dsl._
 
 @import model.ImageMedia
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterOverride: Option[ImageMedia] = None)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterImageOverride: Option[ImageMedia] = None)(implicit request: RequestHeader)
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
@@ -34,7 +34,7 @@
                 </iframe>
                 }
             }
-        @defining(posterOverride orElse media.posterImage) { bestPosterImage =>
+        @defining(posterImageOverride.filterNot(_ => playable) orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 
@@ -54,7 +54,6 @@
                             This video has been removed. This could be because it launched early, our rights have expired, there was a legal issue, or for another reason.
                         </div>
                     </div>
-
                 }
                 </div>
             }
@@ -65,4 +64,3 @@
 @if(displayCaption) {
     @mediaAtomCaption(media.title, mainMedia)
 }
-

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -88,10 +88,17 @@ data-test-id="facia-card"
                 </div>
             }
 
-            case Some(media@InlineYouTubeMediaAtom(_)) => {
+            case Some(media@InlineYouTubeMediaAtom(_,_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__video-container">
-                    @youtube(media = media.youTubeAtom, displayCaption = false, embedPage = false, displayDuration = false, displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate, playable = item.cardTypes.showYouTubeMediaAtomPlayer)
+                    @youtube(
+                        media = media.youTubeAtom,
+                        displayCaption = false,
+                        embedPage = false,
+                        displayDuration = false,
+                        displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate,
+                        playable = item.cardTypes.showYouTubeMediaAtomPlayer,
+                        posterOverride = if(!item.cardTypes.showYouTubeMediaAtomPlayer) media.posterOverride else None)
                     </div>
                 </div>
             }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -98,7 +98,7 @@ data-test-id="facia-card"
                         displayDuration = false,
                         displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate,
                         playable = item.cardTypes.showYouTubeMediaAtomPlayer,
-                        posterOverride = if(!item.cardTypes.showYouTubeMediaAtomPlayer) media.posterOverride else None)
+                        posterImageOverride = media.posterImageOverride)
                     </div>
                 </div>
             }


### PR DESCRIPTION
## What does this change?
Previously YouTube Media Atom facia cards always used a 16x9 image to match the player aspect ratio.
This PR changes non-playable YouTube cards to use a 5x3 trail image, to better match other content cards.

## What is the value of this and can you measure success?
More consistent with other cards.

This fixes the issue raised in https://github.com/guardian/frontend/pull/15699#issuecomment-275670268

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

#### Before

<img width="483" alt="screen shot 2017-02-14 at 11 34 29" src="https://cloud.githubusercontent.com/assets/1764158/22934239/33264448-f2c6-11e6-80ae-93e3f3608638.png">

#### After
<img width="498" alt="screen shot 2017-02-14 at 11 34 07" src="https://cloud.githubusercontent.com/assets/1764158/22934290/5a6bd176-f2c6-11e6-9029-629214fee9fa.png">


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
