### PR TITLE
Fix wrong advert.size test

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-load.js
@@ -15,7 +15,7 @@ define([
     */
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
-        if (advert.size === 'fluid') {
+        if (advert.size[0] === 0 && advert.size[1] === 0) {
             var iframe = advert.node.getElementsByTagName('iframe')[0];
             postMessage({ id: iframe.id, host: host }, iframe.contentWindow);
         }

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-load.js
@@ -15,7 +15,9 @@ define([
     */
     function onLoad(event) {
         var advert = getAdvertById(event.slot.getSlotElementId());
-        if (advert.size[0] === 0 && advert.size[1] === 0) {
+        if ((typeof advert.size === 'string' && advert.size === 'fluid') ||
+            (advert.size[0] === 0 && advert.size[1] === 0)
+        ) {
             var iframe = advert.node.getElementsByTagName('iframe')[0];
             postMessage({ id: iframe.id, host: host }, iframe.contentWindow);
         }


### PR DESCRIPTION
`advert.size` now is the [`size` of a render event](https://developers.google.com/doubleclick-gpt/reference#googletag.events.SlotRenderEndedEvent_size), which can either be a string or an array of numbers.