### PR TITLE
New bundles test with exclusive content

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -32,11 +32,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-a1-a2-bundles-thrasher",
-    "Test A1 vs A2 bundle offers",
+    "ab-membership-a3-a4-bundles-thrasher",
+    "Test A3 vs A4 bundle offers",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 2), // Thursday March 2nd
+    sellByDate = new LocalDate(2017, 3, 9), // Thursday March 9th
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -13,7 +13,7 @@ define([
     'common/modules/experiments/tests/membership-engagement-banner-tests',
     'common/modules/experiments/tests/guardian-today-messaging',
     'common/modules/experiments/acquisition-test-selector',
-    'common/modules/experiments/tests/membership-a1-a2-thrasher'
+    'common/modules/experiments/tests/membership-a3-a4-bundles-thrasher'
 ], function (reportError,
              config,
              cookies,
@@ -28,7 +28,7 @@ define([
              MembershipEngagementBannerTests,
              GuardianTodayMessaging,
              acquisitionTestSelector,
-             MembershipA1A2Thrasher
+             MembershipA3A4BundlesThrasher
     ) {
     var TESTS = compact([
         new EditorialEmailVariants(),
@@ -36,7 +36,7 @@ define([
         new RecommendedForYou(),
         new GuardianTodayMessaging(),
         acquisitionTestSelector.getTest(),
-        new MembershipA1A2Thrasher()
+        new MembershipA3A4BundlesThrasher()
     ].concat(MembershipEngagementBannerTests));
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a3-a4-bundles-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-a3-a4-bundles-thrasher.js
@@ -15,19 +15,19 @@ define([
     return function () {
         var self = this;
 
-        this.id = 'MembershipA1A2BundlesThrasher';
-        this.start = '2017-02-06';
-        this.expiry = '2017-03-02'; // Thursday 2nd March
+        this.id = 'MembershipA3A4BundlesThrasher';
+        this.start = '2017-02-14';
+        this.expiry = '2017-03-09'; // Thursday 9th March
         this.author = 'Justin Pinner';
-        this.description = 'Test Supporter Bundle A1 (ad-free control) against A2 (with-ads variant)';
+        this.description = 'Test Exclusive Content Supporter Bundle A3 (ad-free, control) against A2 (with-ads, variant)';
         this.showForSensitive = true;
         this.audience = 0.15;  // 7.5% per variant
-        this.audienceOffset = 0.15; // use a new audience segment base
+        this.audienceOffset = 0.30; // use a new audience segment base
         this.successMeasure = '';
         this.audienceCriteria = 'People on UK network front with at least an 1140px wide display.';
         this.dataLinkNames = '';
         this.idealOutcome = 'We understand which of the A bundle variants is most desirable.';
-        this.hypothesis = 'An ad-free offering is desired by more readers.';
+        this.hypothesis = 'An ad-free offering is desired by more readers (unaffected by commenting)';
 
         this.canRun = function () {
             return document.querySelector('#membership-ab-thrasher') &&
@@ -59,7 +59,7 @@ define([
             if (this.thrasher()) {
                 var linkEl = document.querySelector('.membership-ab-thrasher--wrapper .link-button');
                 if (linkEl && linkEl.getAttribute('href')) {
-                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_ADS_THRASHER_' + config.page.edition.toUpperCase() + '_' + variant.toUpperCase());
+                    linkEl.setAttribute('href', config.page.membershipUrl + '/bundles?INTCMP=MEMBERSHIP_A_ADX_THRASHER_' + config.page.edition.toUpperCase() + '_' + variant.toUpperCase());
                 }
             }
         };
@@ -88,14 +88,14 @@ define([
             {
                 id: 'control',
                 test: function () {
-                    self.setup('control');   // A1 is our control group (for the benefit of abacus)
+                    self.setup('control');   // A3 is our control group (for the benefit of abacus)
                 },
                 success: this.completeFunc
             },
             {
                 id: 'variant',
                 test: function () {
-                    self.setup('variant');  // variant is A2
+                    self.setup('variant');  // variant is A4
                 },
                 success: this.completeFunc
             }


### PR DESCRIPTION
## What does this change?
Starts a new AB test, replacing the previous A1/A2 bundles test (https://github.com/guardian/frontend/pull/15767) with a new one that swaps commenting for exclusive content.

## What is the value of this and can you measure success?
We need to eliminate commenting from the test.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
Control group journey:
![screen shot 2017-02-14 at 15 24 30](https://cloud.githubusercontent.com/assets/690395/22936449/77de5ee8-f2cd-11e6-912c-01b24c4cccbb.png)
![screen shot 2017-02-14 at 15 26 53](https://cloud.githubusercontent.com/assets/690395/22936462/7e9ad112-f2cd-11e6-9e59-527d5170c237.png)
![screen shot 2017-02-14 at 15 27 10](https://cloud.githubusercontent.com/assets/690395/22936472/88720930-f2cd-11e6-8db2-9ea89e1fd1fc.png)

Variant group journey:
![screen shot 2017-02-14 at 15 29 11](https://cloud.githubusercontent.com/assets/690395/22936491/96d5fc20-f2cd-11e6-8b60-c839deee929f.png)
![screen shot 2017-02-14 at 15 29 37](https://cloud.githubusercontent.com/assets/690395/22936499/9b9fb232-f2cd-11e6-8b9c-0af2aca6545d.png)
![screen shot 2017-02-14 at 15 29 59](https://cloud.githubusercontent.com/assets/690395/22936505/a331c9a4-f2cd-11e6-8875-a3bc3afd4c78.png)

## Tested in CODE?
~~Just as soon as this PR builds...~~ Yes.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
