### PR TITLE
Fixing bug where football scores won't show up

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -63,7 +63,7 @@
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.tags.isSudoku) {sudoku}">
-
+                        <div class="js-score"></div>
                         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
 
                         @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -19,7 +19,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline js-score" itemprop="headline">
+                <h1 class="content__headline" itemprop="headline">
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {


### PR DESCRIPTION
## What does this change?

There is a bug on the new header test where the football scores will never be visible. They are loading attached to a headline that is hidden and therefore being hidden too. 

The reason there are two headlines in the html for the test is because they are in very different positions in the html for our mobile test version and the current desktop layout. This will hopefully be resolved when we "refresh" the desktop article layout too 😉 .

This just moves the class `js-score` off of the headline and into its own div. Solves the problem!

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
People can see football scores in the new header test

## Does this affect other platforms - Amp, Apps, etc?
Nope, amp injects the scores in a different way

## Screenshots
**Before:**
![image](https://cloud.githubusercontent.com/assets/8774970/22937513/b82971ba-f2d0-11e6-886f-15bdd90e7957.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/22937533/c13df3e8-f2d0-11e6-8e98-06ef7d523e48.png)

## Tested in CODE?
Nope
