### PR TITLE
Update error message for old flash-only videos

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/video/videojs-options.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/videojs-options.js
@@ -19,7 +19,8 @@ define(['lodash/objects/assign'], function(assign) {
         // `preload="auto"` on < Chrome 35 and `preload="metadata"` on old Safari
         autoplay: false,
         preload: 'metadata',
-        techOrder: ['html5']
+        techOrder: ['html5'],
+        notSupportedMessage: 'This video is no longer available.'
     };
 
     return function(overrides) {


### PR DESCRIPTION
## What does this change?
Currently when a video which only has a flash encoding (typically from <~2007) is viewed, the videojs player displays the default error *No compatible source was found for this video.* This resulted in many requests to userhelp for old videos, which we are not able to provide.
This PR updates this message to make it clearer these videos are no longer available.

## What is the value of this and can you measure success?
Less confusing message, hopefully results in fewer requests to User Help

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

#### Before

<img width="669" alt="screen shot 2017-02-15 at 11 14 08" src="https://cloud.githubusercontent.com/assets/1764158/22972552/fea8b154-f371-11e6-84a5-5ff808eb77b5.png">

#### After
<img width="661" alt="screen shot 2017-02-15 at 11 19 04" src="https://cloud.githubusercontent.com/assets/1764158/22972507/d7142286-f371-11e6-981c-a30806abf20b.png">


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
