### PR TITLE
Cleanup Wednesday #1

### DIFF
--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -13,7 +13,6 @@
     id="dfp-ad--@optId.getOrElse(name)"
     class="js-ad-slot ad-slot ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ") @optClassNames"
     data-link-name="ad slot @name"
-    data-test-id="ad-slot-@name"
     data-name="@name"
     @if(!showLabel){ data-label="false" }
     @if(!refresh){ data-refresh="false" }

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,12 +1,11 @@
-@import model.Tags
 @import views.support.Commercial.topAboveNavSlot
 
 @(metaData: model.MetaData)
 
 <div class="@topAboveNavSlot.cssClasses(metaData)">
-    @fragments.commercial.standardAd(
-        "top-above-nav",
-        topAboveNavSlot.slotCssClasses,
-        topAboveNavSlot.adSizes
-    )
+  @fragments.commercial.standardAd(
+    "top-above-nav",
+    topAboveNavSlot.slotCssClasses,
+    topAboveNavSlot.adSizes
+  )
 </div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -7,7 +7,7 @@
 
 @headerAndTopAds(showAdverts: Boolean, edition: Edition, content: Option[model.ContentType]) = {
   @if(!page.metadata.shouldHideHeaderAndTopAds) {
-    @defining(showAdverts && (content.isEmpty || content.exists(content => !content.tags.isTheMinuteArticle))) { showTopSlot =>
+    @defining(showAdverts && !content.exists(_.tags.isTheMinuteArticle)) { showTopSlot =>
       <div id="bannerandheader">
         @if(showTopSlot) {
           @fragments.commercial.topBanner(page.metadata)

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -5,16 +5,18 @@
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
 
-@headerAndTopAds(showAdverts: Boolean, edition: Edition) = {
-    @if(!page.metadata.shouldHideHeaderAndTopAds) {
-        <div id="bannerandheader">
-            @if(showAdverts) {
-                @fragments.commercial.topBanner(page.metadata)
-            }
-            @fragments.header(page)
-        </div>
-        <div id="maincontent" tabindex="0"></div>
+@headerAndTopAds(showAdverts: Boolean, edition: Edition, content: Option[model.ContentType]) = {
+  @if(!page.metadata.shouldHideHeaderAndTopAds) {
+    @defining(showAdverts && (content.isEmpty || content.exists(content => !content.tags.isTheMinuteArticle))) { showTopSlot =>
+      <div id="bannerandheader">
+        @if(showTopSlot) {
+          @fragments.commercial.topBanner(page.metadata)
+        }
+        @fragments.header(page)
+      </div>
+      <div id="maincontent" tabindex="0"></div>
     }
+  }
 }
 
 <!DOCTYPE html>
@@ -23,7 +25,7 @@
     @fragments.head(page, projectName, head)
 </head>
 
-@defining(Commercial.shouldShowAds(page), Edition(request)) { case (showAdverts, edition) =>
+@defining(getContent(page), Commercial.shouldShowAds(page), Edition(request)) { case (content, showAdverts, edition) =>
     @defining(Navigation.topLevelItem(edition.navigation, page)) { navigation =>
 
     <body
@@ -34,8 +36,8 @@
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-new-header", mvt.ABNewNavVariantSeven.isParticipating),
-            ("is-immersive", getContent(page).exists(_.content.isImmersive)),
-            ("is-immersive-interactive", getContent(page).exists(content => content.tags.isInteractive && content.content.isImmersive))))"
+            ("is-immersive", content.exists(_.content.isImmersive)),
+            ("is-immersive-interactive", content.exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">
 
         @fragments.message(page.metadata)
@@ -49,7 +51,7 @@
         @page match {
             case page: model.ContentPage if (page.item.content.isImmersiveGallery && !page.item.content.tags.isInteractive) => {
                 <div class="immersive-header-container">
-                    @headerAndTopAds(showAdverts, edition)
+                    @headerAndTopAds(showAdverts, edition, content)
 
                     @fragments.immersiveGalleryMainMedia(page)
                 </div>
@@ -60,20 +62,20 @@
                     ("immersive-header-container--explore-series", page.item.content.tags.isExploreSeries),
                     ("explore-video-container", page.item.content.elements.hasMainVideo)))">
 
-                    @headerAndTopAds(showAdverts, edition)
+                    @headerAndTopAds(showAdverts, edition, content)
 
                     @fragments.exploreSeries(page)
                 </div>
             }
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
-                    @headerAndTopAds(showAdverts, edition)
+                    @headerAndTopAds(showAdverts, edition, content)
                     @fragments.immersiveMainMedia(page)
                 </div>
             }
             case _: commercial.hosted.HostedPage => {}
             case _ => {
-                @headerAndTopAds(showAdverts, edition)
+                @headerAndTopAds(showAdverts, edition, content)
             }
         }
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/close-disabled-slots.js
@@ -48,14 +48,10 @@ define([
     }
 
     function shouldDisableAdSlot($adSlot) {
-        return isAdfreeUser() || isVisuallyHidden() || isDisabledCommercialFeature();
+        return isAdfreeUser() || isVisuallyHidden();
 
         function isVisuallyHidden() {
             return $css($adSlot, 'display') === 'none';
-        }
-
-        function isDisabledCommercialFeature() {
-            return !commercialFeatures.topBannerAd && $adSlot.data('name') === 'top-above-nav';
         }
 
         function isAdfreeUser() {

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/define-slot.js
@@ -8,7 +8,7 @@ define([
     return defineSlot;
 
     function defineSlot(adSlotNode, sizes) {
-        var slotTarget = adSlotNode.getAttribute('data-slot-target') || adSlotNode.getAttribute('data-name');
+        var slotTarget = adSlotNode.getAttribute('data-name');
         var adUnitOverride = urlUtils.getUrlVars()['ad-unit'];
         // if ?ad-unit=x, use that
         var adUnit = adUnitOverride ?

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/on-slot-render.js
@@ -16,8 +16,6 @@ define([
         beacon.fire('/count/ad-render.gif');
     });
 
-    var allAdsAreRendered;
-
     return onSlotRender;
 
     function onSlotRender(event) {
@@ -43,7 +41,6 @@ define([
         function emitRenderEvents(isRendered) {
             Advert.stopRendering(advert, isRendered);
             mediator.emit('modules:commercial:dfp:rendered', event);
-            allAdsRendered();
         }
     }
 
@@ -63,17 +60,6 @@ define([
                 adSlot: adSlotId,
                 adKeywords: adKeywords
             }, false);
-        }
-    }
-
-    function allAdsRendered() {
-        if (!allAdsAreRendered) {
-            allAdsAreRendered = Promise.all(dfpEnv.adverts.map(function (_) { return _.whenRendered; }))
-            .then(function () {
-                userTiming.mark('All ads are rendered');
-                mediator.emit('modules:commercial:dfp:alladsrendered');
-                window.dispatchEvent(new CustomEvent('alladsrendered'));
-            });
         }
     }
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert-label.js
@@ -30,7 +30,7 @@ define([
                 });
                 feedbackThanksMessage = '<i class="ad-feedback__thanks-message"> Thanks for your feedback </i>';
             }
-            var labelDiv = '<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement' +
+            var labelDiv = '<div class="ad-slot__label">Advertisement' +
                 feedbackPopup + feedbackThanksMessage +
                 '</div>';
             return fastdom.write(function () {

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/commercial-features.js
@@ -60,12 +60,7 @@ define([
             externalAdvertising &&
             !sensitiveContent;
 
-        this.topBannerAd =
-            this.dfpAdvertising &&
-            !isMinuteArticle;
-
         this.stickyTopBannerAd =
-            this.topBannerAd &&
             !config.page.disableStickyTopBanner &&
             !supportsSticky;
 

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
@@ -98,8 +98,8 @@ define([
         return adSlot;
     }
 
-    return function (name, slotTypes, series, keywords, slotTarget) {
-        var slotName = slotTarget ? slotTarget : name,
+    return function (name, slotTypes) {
+        var slotName = name,
             attributes = {},
             definition,
             classes = [];
@@ -115,18 +115,6 @@ define([
 
         if (definition.refresh === false) {
             attributes.refresh = 'false';
-        }
-
-        if (slotTarget) {
-            attributes['slot-target'] = slotTarget;
-        }
-
-        if (series) {
-            attributes.series = series;
-        }
-
-        if (keywords) {
-            attributes.keywords = keywords;
         }
 
         if (slotTypes) {

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
@@ -93,7 +93,6 @@ define([
         adSlot.id = 'dfp-ad--' + name;
         adSlot.className = 'js-ad-slot ad-slot ' + classes.join(' ');
         adSlot.setAttribute('data-link-name', 'ad slot ' + name);
-        adSlot.setAttribute('data-test-id', 'ad-slot-' + name);
         adSlot.setAttribute('data-name', name);
         Object.keys(attrs).forEach(function (attr) { adSlot.setAttribute(attr, attrs[attr]); });
         return adSlot;

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v1.html
@@ -2,7 +2,7 @@
 
 <div class="creative--expandable-video <%=data.videoOptions%>">
 
-    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>
     </div>
 

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v2.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v2.html
@@ -1,6 +1,6 @@
 <div class="creative--expandable-video creative--expandable-video-v2 <%=data.videoOptions%>">
 
-    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>
     </div>
 

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expanding-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expanding-v1.html
@@ -1,5 +1,5 @@
 <div class="creative--expandable creative--fabric-expanding-v1">
-    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>
     </div>
     <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: <%=data.backgroundColor%>">

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-v1.html
@@ -1,6 +1,6 @@
 <%if (data.hasContainer) {%><div class="creative--fabric-v1-bg-container"><%}%>
 <%if (data.showLabel) {%>
-<div class="ad-slot__label creative--fabric-v1__label fc-container--layout-front" data-test-id="ad-slot-label">
+<div class="ad-slot__label creative--fabric-v1__label fc-container--layout-front">
     <div class="fc-container__inner">Advertisement</div>
 </div>
 <%}%>

--- a/static/test/javascripts/fixtures/commercial/ad-slots/im.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/im.html
@@ -1,7 +1,6 @@
 <div id="dfp-ad--im"
     class="js-ad-slot ad-slot ad-slot--im ad-slot--im"
     data-link-name="ad slot im"
-    data-test-id="ad-slot-im"
     data-name="im"
     data-mobile="1,1|2,2|88,85|fluid"
     data-label="false"

--- a/static/test/javascripts/fixtures/commercial/ad-slots/inline1.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/inline1.html
@@ -1,7 +1,6 @@
 <div id="dfp-ad--inline1"
     class="js-ad-slot ad-slot ad-slot--inline ad-slot--inline1"
     data-link-name="ad slot inline1"
-    data-test-id="ad-slot-inline1"
     data-name="inline1"
     data-mobile="1,1|2,2|300,250|fluid"
     data-desktop="1,1|2,2|300,250|620,1|620,350|fluid"></div>

--- a/static/test/javascripts/fixtures/commercial/ad-slots/right-small.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/right-small.html
@@ -1,6 +1,5 @@
 <div id="dfp-ad--right"
     class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right"
     data-link-name="ad slot right"
-    data-test-id="ad-slot-right"
     data-name="right"
     data-mobile="1,1|2,2|300,250|fluid"></div>

--- a/static/test/javascripts/fixtures/commercial/ad-slots/right.html
+++ b/static/test/javascripts/fixtures/commercial/ad-slots/right.html
@@ -1,6 +1,5 @@
 <div id="dfp-ad--right"
     class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right"
     data-link-name="ad slot right"
-    data-test-id="ad-slot-right"
     data-name="right"
     data-mobile="1,1|2,2|300,250|300,600|fluid"></div>

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -87,19 +87,6 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
             });
         });
 
-        describe('Top banner ad', function () {
-            it('Runs by default', function () {
-                features = new CommercialFeatures;
-                expect(features.topBannerAd).toBe(true);
-            });
-
-            it('Doesn`t run in minute articles', function () {
-                config.page.isMinuteArticle = true;
-                features = new CommercialFeatures;
-                expect(features.topBannerAd).toBe(false);
-            });
-        });
-
         describe('Article body adverts', function () {
             it('Runs by default', function () {
                 features = new CommercialFeatures;


### PR DESCRIPTION
First of a series of small cleanups of the commercial code:

- remove the `data-test-id` attribute
- remove the `data-slot-target` attribute
- move `commercialFeatures.topBannerAd` into Scala-land
- remove unused `alladsrendered` event, which is also false by the way