### PR TITLE
add dateModified schema.org metadata

### DIFF
--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -38,3 +38,4 @@
         <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>
+<meta itemprop="dateModified" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">


### PR DESCRIPTION
## What does this change?
Adds [dateModified](https://schema.org/dateModified) schema.org metadata to articles.

## What is the value of this and can you measure success?
Pleases 🤖  [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool):
![screen shot 2017-02-15 at 15 16 20](https://cloud.githubusercontent.com/assets/1764158/22981507/7b1a893e-f394-11e6-9b43-e42c07bb0031.png)


## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
