### PR TITLE
Make search popup dismissible

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -80,7 +80,7 @@
                 </div>
             </div>
 
-            <div class="popup popup--default popup--search is-off"><div class="js-search-placeholder"></div></div>
+            <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
 
             <div class="l-header-main">
                 @if((page.metadata.sectionId == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {

--- a/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
@@ -34,8 +34,32 @@ define([
             });
 
             bean.on(document, 'click', '.js-search-toggle', function (e) {
-                searchLoader();
+                var searchToggleLink = $('.js-search-toggle');
+                var searchPopup = $('.popup--search');
+                var maybeDismissSearchPopup = function(e) {
+                    var el = $(e.target);
+                    var clickedPop = false;
 
+                    while (el.length && !clickedPop) {
+                        if (el.hasClass('popup--search')) {
+                            clickedPop = true;
+                        }
+                        el = el.parent();
+                    }
+
+                    if (!clickedPop) {
+                        e.preventDefault();
+                        searchToggleLink.removeClass('is-active');
+                        searchPopup.addClass('is-off');
+                        bean.off(document, 'click', maybeDismissSearchPopup);
+                    }
+                };
+
+                if (searchToggleLink.hasClass('is-active')) {
+                    bean.on(document, 'click', maybeDismissSearchPopup);
+                }
+
+                searchLoader();
                 // Make sure search is always in the correct state
                 self.focusSearchField();
                 e.preventDefault();

--- a/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
@@ -35,13 +35,13 @@ define([
 
             bean.on(document, 'click', '.js-search-toggle', function (e) {
                 var searchToggleLink = $('.js-search-toggle');
-                var searchPopup = $('.popup--search');
+                var searchPopup = $('.js-search-popup');
                 var maybeDismissSearchPopup = function(e) {
                     var el = $(e.target);
                     var clickedPop = false;
 
                     while (el.length && !clickedPop) {
-                        if (el.hasClass('popup--search')) {
+                        if (el.hasClass('js-search-popup')) {
                             clickedPop = true;
                         }
                         el = el.parent();

--- a/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
@@ -37,7 +37,6 @@ define([
                 searchLoader();
 
                 // Make sure search is always in the correct state
-                self.checkResults();
                 self.focusSearchField();
                 e.preventDefault();
                 mediator.emit('modules:search');


### PR DESCRIPTION
## What does this change?

Currently, it is not easy to dismiss the search popup once it has been opened. The only way to dismiss it is to click the "Search" link a second time.

With this change, the user will be able to dismiss the search popup by clicking anywhere on the page (other than the search popup itself)

I have also removed the `checkResults()` call, as this method is [no longer with us](https://github.com/guardian/frontend/pull/11975). This issue has generated about 1000 errors in Sentry

## What is the value of this and can you measure success?

This makes the search feature more accessible as it is easier to dismiss.

## Does this affect other platforms - Amp, Apps, etc?

No

![picture 185](https://cloud.githubusercontent.com/assets/5931528/22984664/06f6d2ce-f39e-11e6-8d74-958030cc0fdc.png)

## Tested in CODE?

Oh gosh, no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
