### PR TITLE
Extend email a/b tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -46,7 +46,7 @@ trait ABTestSwitches {
     "Assign users to variants of our editorial emails",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 16),
+    sellByDate = new LocalDate(2017, 2, 23),
     exposeClientSide = true
   )
 
@@ -56,7 +56,7 @@ trait ABTestSwitches {
     "Assign users to variants of opinion emails",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 16),
+    sellByDate = new LocalDate(2017, 2, 23),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -16,7 +16,7 @@ define([
     return function () {
         this.id = 'EditorialEmailVariants';
         this.start = '2016-12-01';
-        this.expiry = '2017-02-16';
+        this.expiry = '2017-02-23';
         this.author = 'Kate Whalen';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB function in ExactTarget re-randomises all recipients on each send, and we need users to receive their variant for several weeks. This test will ensure users are added to the corresponding email list (listId) in ExactTarget';
         this.audience = 1;

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -16,7 +16,7 @@ define([
     return function () {
         this.id = 'OpinionEmailVariants';
         this.start = '2017-01-12';
-        this.expiry = '2017-02-16';
+        this.expiry = '2017-02-23';
         this.author = 'David Furey';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB ' +
             'function in ExactTarget re-randomises all recipients on each send, and we need users to receive their ' +


### PR DESCRIPTION
## What does this change?

Extends two a/b tests

## What is the value of this and can you measure success?

Opinion - we don’t have enough data yet
Flyer - we need to work out the best way of segmenting email lists for future a/b tests

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
