### PR TITLE
Remove separate ophan request if not enhanced

### DIFF
--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -12,23 +12,6 @@
 
 @fragments.analytics.comscore(page)
 
-<script>
-    @*
-        GA runs on both Core & 'Full experience'
-        We just need to run Ophan here.
-    *@
-
-    if (!guardian.isEnhanced) {
-        var ophanScript = document.createElement('script'),
-                sc = document.getElementsByTagName('script')[0];
-
-        ophanScript.src = '@Static("javascripts/bootstraps/enhanced/ophan.js")';
-        ophanScript.async = true;
-        sc.parentNode.insertBefore(ophanScript, sc);
-    }
-</script>
-
-
 @******************************************************************************
                             'Other' Analytics
 ******************************************************************************@


### PR DESCRIPTION
## What does this change?

- stops trying to download ophan if we're not enhancing

## What is the value of this and can you measure success?

- it's already bundled in standard, so this is pointless
- as well as being unnecessary, it was causing #15845 to fail
