### PR TITLE
Add publisher logo schema.org metadata for non-AMP pages

### DIFF
--- a/article/app/views/fragments/logo.scala.html
+++ b/article/app/views/fragments/logo.scala.html
@@ -1,12 +1,12 @@
+@import conf.Configuration
 @(amp: Boolean = false)
 
-@if(amp) {
-    @* AMP doesn't support sameAs *@
     <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
         <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
         <meta itemprop="width" content="300">
         <meta itemprop="height" content="60">
     </div>
-} else {
-    <link itemprop="sameAs" href="http://www.theguardian.com">
+    @if(!amp) {
+        @* AMP doesn't support sameAs *@
+    <link itemprop="sameAs" href="@Configuration.site.host">
 }


### PR DESCRIPTION
## What does this change?
Adds schema.org publisher [logo](https://schema.org/logo) metadata to all .com pages, previously this was only added for AMP pages.

## What is the value of this and can you measure success?
Attempting to please our robot overlords 🤖 
![screen shot 2017-02-16 at 12 19 40](https://cloud.githubusercontent.com/assets/1764158/23021264/077ef6ea-f443-11e6-8cfb-05a8dae0ba25.png)

## Does this affect other platforms - Amp, Apps, etc?
No. AMP already had the logo field, this just adds it to non-AMP pages.

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
