### PR TITLE
Don't show play button on non-playable non-media cards

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -3,9 +3,10 @@
 @import views.support.{RenderClasses, Video700}
 @import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
+@import model.pressed.CardStyle
 
 @import model.ImageMedia
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterImageOverride: Option[ImageMedia] = None)(implicit request: RequestHeader)
+@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None)(implicit request: RequestHeader)
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
@@ -39,7 +40,11 @@
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 
                 @if(!expired) {
-                    <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
+                    @defining(!cardStyle.exists(c => c.toneString != "media" && !playable)) { showPlayButton =>
+                        @if(showPlayButton) {
+                            <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
+                        }
+                    }
                     @if(displayDuration) {
                         <div class="youtube-media-atom__bottom-bar">
                             <div class="youtube-media-atom__bottom-bar__icon">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -40,7 +40,7 @@
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 
                 @if(!expired) {
-                    @defining(!cardStyle.exists(c => c.toneString != "media" && !playable)) { showPlayButton =>
+                    @defining(!cardStyle.exists(c => c.toneString != "media" && !playable)) { showPlayButton: Boolean =>
                         @if(showPlayButton) {
                             <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
                         }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -98,7 +98,8 @@ data-test-id="facia-card"
                         displayDuration = false,
                         displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate,
                         playable = item.cardTypes.showYouTubeMediaAtomPlayer,
-                        posterImageOverride = media.posterImageOverride)
+                        posterImageOverride = media.posterImageOverride,
+                        cardStyle = Some(item.cardStyle))
                     </div>
                 </div>
             }


### PR DESCRIPTION
## What does this change?
This PR stops the play button appearing on small non-playable non-video page cards, as this could give a false impression they will autoplay when clicked, when in fact only video content type pages are eligible for autoplay.

## What is the value of this and can you measure success?
More consistent user experience regarding expected behaviour of play button

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

#### Before
![screen shot 2017-02-16 at 16 16 04](https://cloud.githubusercontent.com/assets/1764158/23031286/59125b62-f468-11e6-9b62-c36453dfb4e1.png)

#### After

![screen shot 2017-02-16 at 16 15 35](https://cloud.githubusercontent.com/assets/1764158/23031355/98082aea-f468-11e6-8e05-bf11ed164aaf.png)


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
