### PR TITLE
Extended the expire date for the Remind me later banner.

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -80,7 +80,7 @@ define([
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
 
-    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-02-16', 'remind_me_later')
+    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-02-24', 'remind_me_later')
         .addMembershipVariant('control', {})
         .addMembershipVariant('remind_me', {showRemindMe : true})
     ];


### PR DESCRIPTION
## What does this change?

We are extending the limit of the "Remind Me" button A/B Test for one extra week, in order to gain more data and take a final decision.



## Does this affect other platforms - Amp, Apps, etc?
No
## Screenshots
![picture 181](https://cloud.githubusercontent.com/assets/825398/23067753/a38933ea-f518-11e6-8058-987c91fca93a.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
