### PR TITLE
Fix end slate display on Media Atom video pages

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -13,7 +13,7 @@
         ("youtube-media-atom", true),
         ("no-player", !playable || expired )
     ))"
-    @for(endSlatePath <- media.endSlatePath if displayCaption)  {
+    @for(endSlatePath <- media.endSlatePath if displayEndSlate)  {
       data-end-slate="@endSlatePath"
     }
     >

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -21,7 +21,7 @@ class AtomCleanerTest extends FlatSpec
       duration = None,
       source = None,
       posterImage = None,
-      endSlatePath = None,
+      endSlatePath = Some("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z"),
       expired = None)
     ),
     interactives = Nil,
@@ -56,6 +56,12 @@ class AtomCleanerTest extends FlatSpec
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc, youTubeAtom, amp = true)
     result.select("amp-youtube").attr("data-videoid") should be("nQuN9CUsdVg")
+  }
+
+  "Youtube template" should "include endslate path" in {
+    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = false, embedPage = false)(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+    doc.select("div.youtube-media-atom").first().attr("data-end-slate") should be("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z")
   }
 
 


### PR DESCRIPTION
## What does this change?
The End Slate was not displaying when `displayEndSlate=true` parameter was set because were checking the wrong parameter within the template

## What is the value of this and can you measure success?
Restore previous end slate behaviour

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
<img width="650" alt="screen shot 2017-02-17 at 12 30 49" src="https://cloud.githubusercontent.com/assets/1764158/23065349/014e8d60-f50d-11e6-9e2e-7f08fe64350a.png">


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
