### PR TITLE
Release Cookie timing issue fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   val cucumberVersion = "1.1.5"
-  val identityLibVersion = "3.71"
+  val identityLibVersion = "3.78"
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"


### PR DESCRIPTION
Bump Identity version to force release of https://github.com/guardian/identity/pull/612/files

See above PR for more details.

@jfsoul 

