### PR TITLE
Add work for us links and correct some data-link-name attributes

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -100,10 +100,10 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="https://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
                             subscribe</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                        <li class="colophon__item"><a data-link-name="uk : footer : all topics" href="@LinkTo {/index/subjects/a}">
                             all topics</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                        <li class="colophon__item"><a data-link-name="uk : footer : all contributors" href="@LinkTo {/index/contributors}">
                             all contributors</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/info}">
@@ -112,18 +112,20 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
                             contact us</a>
                         </li>
-                        <li class="colophon__item">
-                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        <li class="colophon__item"><a data-link-name="uk : footer : work for us" href="https://workforus.theguardian.com/locations/london">
+                            work for us</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
                                 report technical issue
                             </a>
                         </li>
                     }
 
                     case Us => {
-                        <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/GuardianUs">
+                        <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
                             Facebook</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/GuardianUs">
+                        <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
                             Twitter</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
@@ -135,14 +137,13 @@
                         <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="https://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
                             subscribe</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                        <li class="colophon__item"><a data-link-name="us : footer : all topics" href="@LinkTo {/index/subjects/a}">
                             all topics</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                        <li class="colophon__item"><a data-link-name="us : footer : all contributors" href="@LinkTo {/index/contributors}">
                             all contributors</a>
                         </li>
-                        <li class="colophon__item">
-                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
                                 solve technical issue
                             </a>
                         </li>
@@ -152,13 +153,16 @@
                         <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
                             contact us</a>
                         </li>
+                        <li class="colophon__item"><a data-link-name="us : footer : work for us" href="https://workforus.theguardian.com/locations/new-york">
+                            work for us</a>
+                        </li>
                     }
 
                     case Au => {
-                        <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
+                        <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
                             Facebook</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/GuardianAus">
+                        <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
                             Twitter</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
@@ -176,21 +180,20 @@
                         <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
                             UK jobs</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                        <li class="colophon__item"><a data-link-name="au : footer : all topics" href="@LinkTo {/index/subjects/a}">
                             all topics</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                        <li class="colophon__item"><a data-link-name="au : footer : all contributors" href="@LinkTo {/index/contributors}">
                             all contributors</a>
                         </li>
-                        <li class="colophon__item">
-                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
                                 solve technical issue
                             </a>
                         </li>
                         <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
                             about us</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
+                        <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://workforus.theguardian.com/locations/sydney">
                             vacancies</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
@@ -202,28 +205,31 @@
                     }
 
                     case International => {
-                        <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                        <li class="colophon__item"><a data-link-name="international : footer : facebook" href="https://www.facebook.com/theguardian">
                             Facebook</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                        <li class="colophon__item"><a data-link-name="international : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
                         </li>
-                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="international : footer : facebook" href="https://www.facebook.com/theguardian">
                             Facebook</a>
                         </li>
-                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="international : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                        <li class="colophon__item"><a data-link-name="international : footer : all topics" href="@LinkTo {/index/subjects/a}">
                             all topics</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                        <li class="colophon__item"><a data-link-name="international : footer : all contributors" href="@LinkTo {/index/contributors}">
                             all contributors</a>
                         </li>
                         <li class="colophon__item">
-                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                            <a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
                                 solve technical issue
                             </a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="international : footer : work for us" href="https://workforus.theguardian.com">
+                            work for us</a>
                         </li>
                     }
                 }


### PR DESCRIPTION
## What does this change?

- Add 'work for us' link in to footer for following editions:
  - International: https://workforus.theguardian.com
  - UK: https://workforus.theguardian.com/locations/london
  - US: https://workforus.theguardian.com/locations/new-york

- Update 'vacancies' link in footer for Australian edition to point to https://workforus.theguardian.com/locations/sydney/

- Make naming of data-link-name attributes consistent (eg. make sure edition uk/us/au prefix is correct)

## What is the value of this and can you measure success?

Work for us is easier to find.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before...

![picture 36](https://cloud.githubusercontent.com/assets/1590704/23068433/98ac21d2-f51b-11e6-9e21-1b8a1f94b9bd.png)

After...

![picture 38](https://cloud.githubusercontent.com/assets/1590704/23068442/9e3abbea-f51b-11e6-8509-0dc90f447a15.png)

## Tested in CODE?

No
