### PR TITLE
Fix for sticky ads

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
@@ -69,7 +69,7 @@ define([
      */
     sizeCallbacks[adSizes.mpu] = function (_, advert) {
         var $node = bonzo(advert.node);
-        if ($node.hasClass('ad-slot--right')) {
+        if ($node.hasClass('js-sticky-mpu')) {
             stickyMpu($node);
         } else {
             return addFluid(['ad-slot--revealer'])(_, advert);

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/dfp/create-slot.js
@@ -99,13 +99,14 @@ define([
     }
 
     return function (name, slotTypes) {
-        var slotName = name,
+        var slotName,
             attributes = {},
             definition,
             classes = [];
 
-        definition = adSlotDefinitions[slotName] || adSlotDefinitions.inline;
-        name = definition.name || name;
+        definition = adSlotDefinitions[name] || adSlotDefinitions.inline;
+
+        slotName = definition.name || name;
 
         assign(attributes, definition.sizeMappings);
 
@@ -123,10 +124,14 @@ define([
             });
         }
 
-        classes.push('ad-slot--' + name);
+        if(name === 'right-sticky') {
+            classes.push('js-sticky-mpu');
+        }
+
+        classes.push('ad-slot--' + slotName);
 
         return createAdSlotElement(
-            name,
+            slotName,
             Object.keys(attributes).reduce(function (result, key) {
                 result['data-' + key] = attributes[key];
                 return result;


### PR DESCRIPTION
## What does this change?
There isn't enough space in the right column for the MPU to be sticky on some shorter articles eg. [here](https://www.theguardian.com/stage/2017/feb/16/miranda-hart-west-end-debut-annie-musical-miss-hannigan) and [here](https://www.theguardian.com/business/2017/feb/15/lingerie-brand-agent-provocateur-could-be-heading-for-administration). 

This disables the sticky behaviour in those articles so Most Pop container doesn't crash into the bottom of the article:

![image](https://cloud.githubusercontent.com/assets/6290008/23072400/723bc616-f529-11e6-8107-53a5346cff81.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
