### PR TITLE
Docs update: Chrome AB test extension broken

### DIFF
--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -184,7 +184,7 @@ You can stop and start the test using our [switchboard](https://frontend.gutools
 
 To see the test in action locally: `localhost:9000/[articleId]#ab-[testName]=[variantName]`
 
-To see the tests you are part of using Google Chrome: open the Dev Console -> Resources -> Local Storage -> choose `http://[domain]` (e.g. localhost or www.theguardian.com)  -> check the `gu.ab.participations` row. Alternatively, if you're using Chrome, use the [extension](https://chrome.google.com/webstore/detail/guardian-ab-tests/nehbenedinjacnhlkjbdneedibcagmno).
+To see the tests you are part of using Google Chrome: open the Dev Console -> Resources -> Local Storage -> choose `http://[domain]` (e.g. localhost or www.theguardian.com)  -> check the `gu.ab.participations` row. ~~Alternatively, if you're using Chrome, use the [extension](https://chrome.google.com/webstore/detail/guardian-ab-tests/nehbenedinjacnhlkjbdneedibcagmno).~~ (currently broken as it does not support our new Webpack-bundled application)
 
 ## Analysis of the test data
 


### PR DESCRIPTION
# What does this change?

The [Chrome extension](https://github.com/OliverJAsh/chrome-guardian-ab-tests) to support A/B testing is broken. This change updates the docs to clarify this until a fix is implemented.

## What is the value of this and can you measure success?

Clarity of documentation
