### PR TITLE
Most popular MPU

### DIFF
--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -158,12 +158,11 @@ category: Common
     }
 }
 
-// Most Popular customisation: change layout to accomodate MPU
-.tabs--mostpop {
+// Most Popular customisation: change layout to accomodate MPU (with or without tabs)
+.tabs--mostpop .tabs__content,
+.fc-slice--popular {
     @include mq(desktop) {
-        .tabs__content {
-            display: table;
-            display: flex;
-        }
+        display: table;
+        display: flex;
     }
 }


### PR DESCRIPTION
## What does this fix?
On pages with only one set of most popular links (i.e. no tabs) the mpu is not positioned correctly in the container:

![image](https://cloud.githubusercontent.com/assets/6290008/23124043/d3aa0404-f762-11e6-8b60-535a2fb30c09.png)

https://www.theguardian.com/global/2017/jan/30/10-things-you-only-know-if-you-swim-through-winter-sally-goble