### PR TITLE
Zero-dimension slots and IntersectionObserver

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/lazy-load.js
@@ -53,7 +53,7 @@ define([
 
         entries
         .filter(function (entry) {
-            return (!'isIntersecting' in entry) || entry.isIntersecting;
+            return !('isIntersecting' in entry) || entry.isIntersecting;
         })
         .forEach(function (entry) {
             observer.unobserve(entry.target);

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/lazy-load.js
@@ -51,7 +51,11 @@ define([
     function onIntersect(entries, observer) {
         var advertIds = [];
 
-        entries.forEach(function (entry) {
+        entries
+        .filter(function (entry) {
+            return (!'isIntersecting' in entry) || entry.isIntersecting;
+        })
+        .forEach(function (entry) {
             observer.unobserve(entry.target);
             displayAd(entry.target.id);
             advertIds.push(entry.target.id);


### PR DESCRIPTION
The IO spec has been recently changed to account for [zero-dimension elements](https://github.com/WICG/IntersectionObserver/issues/69), resulting in the addition of a new `isIntersecting` property. We need to take it into account, otherwise newest versions of Chrome will display all slots at once.

Before:
![picture 4](https://cloud.githubusercontent.com/assets/629976/23124948/77d89f00-f767-11e6-96c3-ec7732d3709c.jpg)

After:
![picture 3](https://cloud.githubusercontent.com/assets/629976/23124932/64f29fd0-f767-11e6-967f-21778a8054b4.jpg)
