### PR TITLE
Epic new control

### DIFF
--- a/dev-build/app/controllers/FakeGeolocationController.scala
+++ b/dev-build/app/controllers/FakeGeolocationController.scala
@@ -9,7 +9,7 @@ class FakeGeolocationController extends Controller {
   implicit val jf: Format[FakeGeolocation] = Json.format[FakeGeolocation]
 
   def geolocation = Action {
-    val fake = FakeGeolocation("AU")
+    val fake = FakeGeolocation("GB")
     Ok(Json.toJson(fake))
   }
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -9,7 +9,9 @@ define([
     'common/utils/fastdom-promise',
     'common/utils/mediator',
     'common/utils/storage',
-    'common/utils/geolocation'
+    'common/utils/geolocation',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
 
 ], function (commercialFeatures,
              targetingTool,
@@ -21,7 +23,9 @@ define([
              fastdom,
              mediator,
              storage,
-             geolocation) {
+             geolocation,
+             template,
+             contributionsEpicEqualButtons) {
 
     var membershipURL = 'https://membership.theguardian.com/supporter';
     var contributionsURL = 'https://contribute.theguardian.com';
@@ -114,6 +118,19 @@ define([
         return this.id + ':' + event;
     };
 
+    function controlTemplate(membershipUrl, contributionUrl) {
+        return template(contributionsEpicEqualButtons, {
+            linkUrl1: membershipUrl,
+            linkUrl2: contributionUrl,
+            title: 'Since you’re here …',
+            p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+            p3: '',
+            cta1: 'Become a Supporter',
+            cta2: 'Make a contribution'
+        });
+    }
+
     function ContributionsABTestVariant(options, test) {
         this.campaignId = test.campaignId;
         this.id = options.id;
@@ -123,10 +140,12 @@ define([
         this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, test.contributionsCampaignPrefix);
         this.membershipURL = options.membershipURL || this.makeURL(membershipURL, test.membershipCampaignPrefix);
 
+        this.template = options.template || controlTemplate;
+
         var trackingCampaignId  = test.epic ? 'epic_' + test.campaignId : test.campaignId;
 
         this.test = function () {
-            var component = $.create(options.template(this.contributeURL, this.membershipURL));
+            var component = $.create(this.template(this.contributeURL, this.membershipURL));
             var onInsert = options.onInsert || noop;
             var onView = options.onView || noop;
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -1,25 +1,8 @@
 define([
-    'common/modules/commercial/contributions-utilities',
-    'common/utils/template',
-    'text!common/views/contributions-epic-equal-buttons.html'
+    'common/modules/commercial/contributions-utilities'
 ], function (
-    contributionsUtilities,
-    template,
-    contributionsEpicEqualButtons
+    contributionsUtilities
 ) {
-
-    function getTemplate(contributionUrl, membershipUrl) {
-        return template(contributionsEpicEqualButtons, {
-            linkUrl1: membershipUrl,
-            linkUrl2: contributionUrl,
-            title: 'Since you’re here …',
-            p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
-            p3: '',
-            cta1: 'Become a Supporter',
-            cta2: 'Make a contribution'
-        });
-    }
 
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicAskFourEarning',
@@ -45,7 +28,6 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                template: getTemplate,
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-stagger.js
@@ -1,25 +1,8 @@
 define([
-    'common/modules/commercial/contributions-utilities',
-    'common/utils/template',
-    'text!common/views/contributions-epic-equal-buttons.html'
+    'common/modules/commercial/contributions-utilities'
 ], function (
-    contributionsUtilities,
-    template,
-    contributionsEpicEqualButtons
+    contributionsUtilities
 ) {
-
-    function getTemplate(contributionUrl, membershipUrl) {
-        return template(contributionsEpicEqualButtons, {
-            linkUrl1: membershipUrl,
-            linkUrl2: contributionUrl,
-            title: 'Since you’re here …',
-            p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
-            p3: '',
-            cta1: 'Become a Supporter',
-            cta2: 'Make a contribution'
-        });
-    }
 
     return contributionsUtilities.makeABTest({
         id: 'ContributionsEpicAskFourStagger',
@@ -45,7 +28,6 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                template: getTemplate,
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             },
@@ -57,7 +39,6 @@ define([
                     count: 4,
                     minDaysBetweenViews: 1
                 },
-                template: getTemplate,
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             },
@@ -69,7 +50,6 @@ define([
                     count: 4,
                     minDaysBetweenViews: 3
                 },
-                template: getTemplate,
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -1,11 +1,7 @@
 define([
-    'common/modules/commercial/contributions-utilities',
-    'common/utils/template',
-    'text!common/views/contributions-epic-equal-buttons.html'
+    'common/modules/commercial/contributions-utilities'
 ], function (
-    contributionsUtilities,
-    template,
-    contributionsEpicEqualButtons
+    contributionsUtilities
 ) {
 
     return contributionsUtilities.makeABTest({
@@ -33,22 +29,7 @@ define([
                     count: 6,
                     minDaysBetweenViews: 1
                 },
-
-                template: function (contributionUrl, membershipUrl) {
-                    return template(contributionsEpicEqualButtons, {
-                        linkUrl1: membershipUrl,
-                        linkUrl2: contributionUrl,
-                        title: 'Since you’re here…',
-                        p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
-                        p3: '',
-                        cta1: 'Become a Supporter',
-                        cta2: 'Make a contribution'
-                    });
-                },
-
                 insertBeforeSelector: '.submeta',
-
                 successOnView: true
             }
         ]

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-one-line-edits-v2.js
@@ -39,18 +39,6 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                template: function (contributionUrl, membershipUrl) {
-                    return template(contributionsEpicEqualButtons, {
-                        linkUrl1: membershipUrl,
-                        linkUrl2: contributionUrl,
-                        title: 'Since you’re here …',
-                        p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                        p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-                        p3: '',
-                        cta1: 'Become a Supporter',
-                        cta2: 'Make a contribution'
-                    });
-                },
                 insertBeforeSelector: '.submeta',
                 successOnView: true
             },


### PR DESCRIPTION
## What does this change?

The Epic control message.

## What is the value of this and can you measure success?

Increases the conversion rate of the Epic.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![new_control](https://cloud.githubusercontent.com/assets/4085817/23127701/e39bfb54-f773-11e6-9743-a3125c13689a.jpg)

## Tested in CODE?

No, tested locally on the following test-variant pairs:

- ask four earning - control
- ask four earning stagger - control
- ask four earning stagger - stagger one day
- ask four earning stagger - stagger three days
- brexit - control
- contributions epic one line edits v2 - control

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 