### PR TITLE
Extend recommendations expiry date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -66,7 +66,7 @@ trait ABTestSwitches {
     "Test personalised container on fronts",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 2, 21),
+    sellByDate = new LocalDate(2017, 3, 7),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -38,7 +38,7 @@ define([
     return function () {
         this.id = 'RecommendedForYouRecommendations';
         this.start = '2017-01-17';
-        this.expiry = '2017-02-21';
+        this.expiry = '2017-03-08';
         this.author = 'David Furey';
         this.description = 'Add an extra container above Opinion on the home front with recommended content based on ' +
             'each users history.  Users in the test group are prompted to opt-in.  Recommendations are only fetched' +


### PR DESCRIPTION
## What does this change?

Extends the recommendations expiry date by two weeks because we don’t have enough data yet

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
