### PR TITLE
initilaise youtube atoms in video onward journeys

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/video/more-in-series-container.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/more-in-series-container.js
@@ -1,9 +1,11 @@
 define([
     'common/modules/component',
-    'common/utils/mediator'
+    'common/utils/mediator',
+    'common/modules/atoms/youtube'
 ], function(
     Component,
-    mediator
+    mediator,
+    youtube
 ) {
 
     function init(el, mediaType, section, shortUrl, series) {
@@ -17,6 +19,7 @@ define([
         component.endpoint = endpoint;
 
         component.fetch(el).then(function () {
+            youtube.checkElemsForVideos(el);
             mediator.emit('page:media:moreinloaded', el);
             mediator.emit('page:new-content', el);
         });


### PR DESCRIPTION
## What does this change?

Initialise youtube atoms if they appear in the outward journey's for videos

## What is the value of this and can you measure success?

Enhances youtube atoms with all the added benefits

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before...

![picture 39](https://cloud.githubusercontent.com/assets/1590704/23133038/8ea4fdf8-f787-11e6-93e1-bee54e549850.png)

After...

![picture 40](https://cloud.githubusercontent.com/assets/1590704/23133055/9fb2974a-f787-11e6-89de-7a5f8d85a6e1.png)

## Tested in CODE?

@akash1810 @gidsg 