### PR TITLE
Improve layout of paid containers

### DIFF
--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -127,10 +127,6 @@
     color: $paid-card-kicker;
 }
 
-.advert--branded {
-    padding-bottom: $gs-row-height + $gs-baseline * 5; //96px = $gs-row-height + height of the logo
-}
-
 .advert-container {
     display: flex;
     align-items: stretch;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -1,3 +1,7 @@
+.advert--branded {
+    padding-bottom: 80px;
+}
+
 .adverts--capi {
     .adverts__title {
         font-size: get-font-size(headline, 3);
@@ -26,6 +30,39 @@
 
             & > * + :nth-child(even)::before {
                 content: none;
+            }
+        }
+    }
+
+    .advert > :last-child {
+        margin-bottom: 0;
+    }
+
+    .advert-container {
+        @include mq($until: tablet) {
+            &:first-child > .advert {
+                padding-bottom: $gs-baseline / 2;
+            }
+
+            &:first-child .advert__title,
+            &:first-child .advert__standfirst {
+                padding-right: 80px;
+            }
+
+            &:not(:first-child) > .advert {
+                padding-right: 80px;
+                padding-bottom: 0;
+                min-height: 80px;
+            }
+
+            > .badge {
+                display: flex;
+                flex-direction: column;
+                width: 60px;
+            }
+
+            .badge__logo {
+                max-width: 100%;
             }
         }
     }
@@ -208,7 +245,7 @@
             }
         }
 
-        .advert__standfirst {
+        .advert__standfirst:not(:last-child) {
             margin-bottom: $gs-baseline / 2;
         }
     }

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -47,6 +47,7 @@
             &:first-child .advert__title,
             &:first-child .advert__standfirst {
                 padding-right: 80px;
+                max-width: 520px;
             }
 
             &:not(:first-child) > .advert {

--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -317,8 +317,9 @@
 
 .badge--branded {
     position: absolute;
-    right: 0;
+    right: 10px;
     bottom: 10px;
+    margin: 0;
 }
 
 .badge__logo {


### PR DESCRIPTION
Reduces negative space across breakpoints in multi-branded paid containers.

### Desktop

Before:
![picture 5](https://cloud.githubusercontent.com/assets/629976/23159698/ae7b4ed6-f81b-11e6-95c2-29925ec67f95.jpg)

After:
![picture 7](https://cloud.githubusercontent.com/assets/629976/23159701/b35a1a18-f81b-11e6-9e06-d5899c2565c6.jpg)

### Mobile

Before:
![picture 8](https://cloud.githubusercontent.com/assets/629976/23159708/bad05208-f81b-11e6-851d-32ea77e366e2.jpg)

After:
![picture 6](https://cloud.githubusercontent.com/assets/629976/23159711/bfd5681a-f81b-11e6-8ba3-8b4334145752.jpg)
