### PR TITLE
Bugfix for liveblog splash updates

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -81,8 +81,8 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit context: Ap
         liveBlog.blocks.toSeq.flatMap { blocks =>
         blocks.requestedBodyBlocks.get(Canonical.firstPage).toSeq.flatMap { bodyBlocks: Seq[BodyBlock] =>
           bodyBlocks.collect {
-            case BodyBlock(id, html, _, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
-              TextBlock(id, title, publishedAt, updatedAt, html)
+            case BodyBlock(id, html, summary, title, _, _, _, publishedAt, _, updatedAt, _, _) if html.trim.nonEmpty =>
+              TextBlock(id, title, publishedAt, updatedAt, summary)
           }
         }
       }.take(number)
@@ -166,7 +166,7 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit context: Ap
       lastUpdate.map(ParseBlockId.fromBlockId) match {
         case Some(ParsedBlockId(id)) => renderWithRange(SinceBlockId(id))
         case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
-        case None => if (rendered.contains(false)) mapModel(path) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
+        case None => if (rendered.contains(false)) mapModel(path, Some(Canonical)) { model => blockText(model, 6) } else renderWithRange(Canonical) // no page param
       }
     }
   }


### PR DESCRIPTION
## What does this change?

Bugfix for https://trello.com/c/Q5mTqXho/162-choosing-show-updates-with-liveblog-splash-on-fronts-no-longer-displays-a-rolling-update

Two fixes to this code:

1. We must request at least a few blocks from CAPI or else it isn't recognised as being a live blog, so adding Some(Canonical) will request a standard five blocks.
2. The body of the live blog update must be plaintext, not html, so use the new summary field from CAPI.

## What is the value of this and can you measure success?

When you see a liveblog on a front, we will now correctly load in the second-to-most-recent update summary into the liveblog box, then it will auto-scroll to the most recent update. Updates the user has already seen will not be shown.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
