### PR TITLE
Clear left-hand side of inline ads in articles

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -245,6 +245,10 @@
         margin-top: $gs-baseline/3;
         margin-left: $gs-gutter;
     }
+
+    @include mq(tablet, leftCol) {
+        clear: left;
+    }
 }
 .ad-slot__content {
     > div {


### PR DESCRIPTION
Slightly improve the layout of articles when a rich link and an ad sit in the same area.

Before:
![picture 10](https://cloud.githubusercontent.com/assets/629976/23164229/111bfb3c-f82e-11e6-9504-e6fd492c1eca.jpg)

After:
![picture 9](https://cloud.githubusercontent.com/assets/629976/23164248/15ba6192-f82e-11e6-87c9-bd8b64854e32.jpg)
