### PR TITLE
Paid interactives fix

### DIFF
--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -108,7 +108,7 @@
     }
 
     // Ensure margins don't overlay full-page take over interactives
-    .element-interactive {
+    &:not(.content--paid-content) .element-interactive{
         background-color: #ffffff;
     }
 


### PR DESCRIPTION
## What does this change?
Gets rid of a white gap appearing underneath the iframe on some paid content interactives, e.g.
https://www.theguardian.com/salesforce-the-unfair-advantage/ng-interactive/2016/dec/07/the-unfair-advantage
https://www.theguardian.com/telfast-break-through-with-confidence/ng-interactive/2016/oct/25/track-your-allergy-symptoms

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/22259670/1e272896-e25e-11e6-89d5-5e99f1f9ae9d.png)