### PR TITLE
Fix asset hashing

### DIFF
--- a/tools/__tasks__/compile/hash/index.js
+++ b/tools/__tasks__/compile/hash/index.js
@@ -19,7 +19,7 @@ module.exports = {
         {
             description: 'Hash assets',
             task: () => {
-                const webpackRegex = /[app-webpack|admin-webpack]/;
+                const webpackRegex = /webpack/;
                 const webpackChunkRegex = /chunk/;
                 const sourcemapRegex = /\.map$/;
 


### PR DESCRIPTION
## What does this change?

simplifies the regexused to recognise webpack assets

## What is the value of this and can you measure success?

the regex was faulty and some files were going unhashed

## Does this affect other platforms - Amp, Apps, etc?

no

## Tested in CODE?

- [x] tested on CODE