### PR TITLE
amp: fix position of cta button if amp-list is collapsed

### DIFF
--- a/static/src/stylesheets/amp/_buttons.scss
+++ b/static/src/stylesheets/amp/_buttons.scss
@@ -16,12 +16,20 @@
 }
 
 .cta--show-more {
-    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
     color: $neutral-1;
     background-color: #ffffff;
+
+    /*
+       According to the AMP docs we should be able to do this (https://www.ampproject.org/docs/reference/components/amp-list), but it was probably broken in https://github.com/ampproject/amphtml/pull/7061.
+
+      TODO: Remove this specificity hack, after [the issue](https://github.com/ampproject/amphtml/issues/7689) is resolved.
+    */
+    @at-root .cta#{&} {
+      position: absolute;
+    }
 
     svg {
         width: 18px;


### PR DESCRIPTION
## What does this change?

Overwrites the default cta position of an element within an `amp-list`.

## What is the value of this and can you measure success?

Temporarily bugfix, till the AMP issue is fixed.

## Does this affect other platforms - Amp, Apps, etc?

Amp