### PR TITLE
Add ISBN to inline merchandising slot targeting when available

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/define-slot.js
@@ -26,6 +26,10 @@ define([
             slot = window.googletag.defineSlot(adUnitOverride || config.page.adUnit, sizeOpts.size, id).defineSizeMapping(sizeOpts.sizeMapping);
         }
 
+        if (slotTarget === 'im' && config.page.isbn) {
+            slot.setTargeting('isbn', config.page.isbn);
+        }
+
         slot.addService(window.googletag.pubads())
             .setTargeting('slot', slotTarget);
 


### PR DESCRIPTION
The inline book component may need this value specified in composer. This is to ease the process of setting up inline components for the merchandising team, who doesn't have to manually specify the ISBN corresponding to each book-related article.

(It is not elegant but I have a refactoring of `createSlot` and `defineSlot` in the pipeline, so enough for now)

Tested on [this article](https://www.theguardian.com/books/2017/feb/22/utopia-for-realists-and-how-we-can-get-there-by-rutger-bregman-review?adtest=native-inline-book).

![picture 5](https://cloud.githubusercontent.com/assets/629976/23211675/1ebd8a1c-f8fb-11e6-817b-ed4fe85d6a12.jpg)
