### PR TITLE
New tags design outside the new nav test, and on desktop

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -517,7 +517,7 @@ import collection.JavaConversions._
         import browser._
 
         Then("I should see links to keywords")
-        $(".keyword-list a").size should be(16)
+        $(".submeta__link").size should be(7)
       }
     }
 

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -1,121 +1,86 @@
 @(content: model.ContentType, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.{LinkTo, Localisation}
-@import conf.switches.Switches.{SaveForLaterSwitch, ArticleBadgesSwitch}
+@import conf.switches.Switches.ArticleBadgesSwitch
 @import model.ShareLinkMeta
 @import model.Badges.badgeFor
 @import views.support.ContentLayout.ContentLayout
 @import views.support.Seq2zipWithRowInfo
 
-@if(amp || mvt.ABNewNavVariantSeven.isParticipating) {
-    <div class="submeta2 mobile-only">
-        <div class="submeta2__section-labels">
-            @if(ArticleBadgesSwitch.isSwitchedOn) {
-                @badgeFor(content).map { badge =>
-                    <div class="submeta2__badge">
-                        <a href="@LinkTo {/@badge.seriesTag}">
-                            @if(amp) {
-                                <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
-                            } else {
-                                <img class="badge-slot__img" src="@badge.imageUrl" alt="@content.content.blogOrSeriesTag.map(_.name)"/>
-                            }
-                        </a>
-                    </div>
-                }
+<div class="submeta">
+    <div class="submeta__section-labels">
+        @if(ArticleBadgesSwitch.isSwitchedOn) {
+            @badgeFor(content).map { badge =>
+                <div class="submeta__badge">
+                    <a href="@LinkTo {/@badge.seriesTag}">
+                        @if(amp) {
+                            <amp-img class="badge-slot__img" src="@badge.imageUrl" layout="fixed" height="33" width="33"></amp-img>
+                        } else {
+                            <img class="badge-slot__img" src="@badge.imageUrl" alt="@content.content.blogOrSeriesTag.map(_.name)"/>
+                        }
+                    </a>
+                </div>
+            }
+        }
+
+        <div class="submeta__links">
+            @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
+                <a class="submeta__link"
+                    data-link-name="article section"
+                    href="@LinkTo {/@content.content.sectionLabelLink}">
+                        @Html(Localisation(content.content.sectionLabelName))
+                </a>
             }
 
-            <div class="submeta2__links">
-                @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
-                    <a class="submeta2__link"
-                        data-link-name="article section"
-                        href="@LinkTo {/@content.content.sectionLabelLink}">
-                            @Html(Localisation(content.content.sectionLabelName))
-                    </a>
+            @content.content.blogOrSeriesTag.map { series =>
+                <a class="submeta__link" href="@LinkTo {/@series.id}">@series.name</a>
+            }.getOrElse {
+                @if(content.content.isFromTheObserver) {
+                    <a class="submeta__link" href="http://observer.theguardian.com">The Observer</a>
                 }
-
-                @content.content.blogOrSeriesTag.map { series =>
-                    <a class="submeta2__link" href="@LinkTo {/@series.id}">@series.name</a>
-                }.getOrElse {
-                    @if(content.content.isFromTheObserver) {
-                        <a class="submeta2__link" href="http://observer.theguardian.com">The Observer</a>
-                    }
-                }
-            </div>
+            }
         </div>
+    </div>
 
-        <div class="submeta2__keywords">
-            <div class="submeta2__links">
-                @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-                    @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
-                        @if(shownKeywords.nonEmpty) {
-                            @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                                <a class="submeta2__link"
-                                    href="@LinkTo(keyword.metadata.url)"
-                                    data-link-name="keyword: @keyword.id">
-                                        @keyword.name
-                                        @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
-                                </a>
-                            }
-                        }
-                    }
-
-                    @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-                        @content.tags.tones.headOption.map { tone =>
-                            <a class="submeta2__link"
-                                href="@LinkTo(tone.metadata.url)"
-                                data-link-name="tone: @tone.name">
-                                    @tone.name.toLowerCase
+    <div class="submeta__keywords">
+        <div class="submeta__links">
+            @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
+                @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
+                    @if(shownKeywords.nonEmpty) {
+                        @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
+                            <a class="submeta__link"
+                                href="@LinkTo(keyword.metadata.url)"
+                                data-link-name="keyword: @keyword.id">
+                                    @keyword.name
+                                    @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
                             </a>
                         }
                     }
                 }
-            </div>
-        </div>
-        @if(content.showBottomSocialButtons) {
-            <div data-component="share" class="submeta__share">
-                @Social(content.sharelinks.pageShares)
-            </div>
-        }
-    </div>
 
-}
-@if(!amp) {
-    <div class="submeta @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}">
-        @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
-            <hr/>
-            <div data-link-name="keywords" data-component="keywords">
-                @toneLink
-                <h2 class="submeta__head">Topics</h2>
-                @fragments.keywordList(content.tags.keywords, tone = content.tagTone)
-            </div>
-        }
-        @if(content.showBottomSocialButtons) {
-            <hr/>
-            <div class="u-cf">
-                <div data-component="share" class="submeta__share">
-                @Social(content.sharelinks.pageShares)
-                </div>
-                @if(SaveForLaterSwitch.isSwitchedOn) {
-                    <div class="js-save-for-later submeta__save-for-later" data-position="bottom"></div>
+                @if(content.tags.isArticle && !content.tags.isLiveBlog) {
+                    @content.tags.tones.headOption.map { tone =>
+                        <a class="submeta__link"
+                            href="@LinkTo(tone.metadata.url)"
+                            data-link-name="tone: @tone.name">
+                                @tone.name.toLowerCase
+                        </a>
+                    }
                 }
-                @fragments.syndication(content)
+            }
+        </div>
+    </div>
+    @if(content.showBottomSocialButtons) {
+        <div data-component="share" class="submeta__share">
+            @Social(content.sharelinks.pageShares)
+        </div>
 
-            </div>
-        } else {
+        @if(!amp) {
             @fragments.syndication(content)
         }
-    </div>
-}
+    }
+</div>
 
 @Social(shares: ShareLinkMeta) = {
     @fragments.social(ShareLinkMeta.noneHidden(shares))
-}
-
-@toneLink = {
-    @if(content.tags.isArticle && !content.tags.isLiveBlog) {
-        @content.tags.tones.headOption.map { tone =>
-            <a class="submeta__tone button button--small button--tag @content.tagTone.map("button--tone-" + _).getOrElse("button--secondary")"
-            href="@LinkTo(tone.metadata.url)" data-link-name="tone: @tone.name" itemprop="keywords">More @tone.name.toLowerCase </a>
-        }
-    }
 }

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -246,3 +246,21 @@
         padding-right: $gs-gutter;
     }
 }
+
+// Nav Mixins
+
+@mixin nav-links {
+    position: relative;
+    padding-left: .3em;
+    padding-right: .35em;
+    float: left;
+}
+
+@mixin trailing-slash {
+    position: absolute;
+    pointer-events: none;
+    content: '/';
+    //optically aligns slashes
+    top: 0;
+    right: -.19em;
+}

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -1,13 +1,12 @@
-.submeta2 {
+.submeta {
     font-family: 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }
 
-.submeta2__section-labels {
+.submeta__section-labels {
     min-height: $gs-row-height;
     font-size: 16px;
     border-top: 1px dotted $neutral-5;
-    border-bottom: 1px dotted $neutral-5;
-    padding: $gs-baseline / 2 0 $gs-baseline;
+    padding-top: $gs-baseline / 2;
 
 
     &:before {
@@ -19,19 +18,20 @@
     }
 }
 
-.submeta2__keywords {
+.submeta__keywords {
     font-size: 15px;
-    padding: $gs-baseline / 2 0 $gs-baseline;
+    padding-top: $gs-baseline / 2;
+    padding-bottom: $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;
 }
 
-.submeta2__links {
+.submeta__links {
     overflow: hidden;
     margin-left: -.3em;
 }
 
-.submeta2__link {
+.submeta__link {
     font-weight: 500;
     line-height: 22px;
     position: relative;
@@ -49,7 +49,7 @@
         color: $neutral-5;
     }
 
-    .submeta2__keywords & {
+    .submeta__keywords & {
         color: $neutral-2;
     }
 
@@ -58,7 +58,7 @@
     }
 }
 
-.submeta2__badge {
+.submeta__badge {
     float: right;
     margin-top: -$gs-baseline;
     margin-left: $gs-gutter / 2;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -5,22 +5,6 @@ $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
 
-@mixin trailing-slash {
-    position: absolute;
-    pointer-events: none;
-    content: '/';
-    //optically aligns slashes
-    top: 0;
-    right: -.19em;
-}
-
-@mixin nav-links {
-    position: relative;
-    padding-left: .3em;
-    padding-right: .35em;
-    float: left;
-}
-
 // When the menu is open this class is added to the html to prevent users from scrolling
 .nav-is-open {
     overflow: hidden;
@@ -901,68 +885,5 @@ $caption-button-size: 32px;
         }
     }
 }
-
-/****************
- * Submeta
- ****************/
-
-.submeta2 {
-    margin-top: $gs-baseline;
-}
-
-.submeta2__section-labels {
-    @include fs-textSans(5);
-    min-height: $gs-row-height;
-    border-top: 1px dotted $neutral-5;
-    border-bottom: 1px dotted $neutral-5;
-    padding: $gs-baseline / 2 0 $gs-baseline;
-
-    &:before {
-        @include fs-textSans(1);
-        content: "More";
-        color: $neutral-2;
-        display: block;
-        margin-bottom: -($gs-baseline / 4);
-    }
-}
-
-.submeta2__keywords {
-    @include fs-textSans(4);
-    padding: $gs-baseline / 2 0 $gs-baseline;
-    min-height: $gs-baseline * 2;
-    border-bottom: 1px dotted $neutral-5;
-    margin-bottom: $gs-baseline / 2;
-}
-
-.submeta2__links {
-    overflow: hidden;
-    margin-left: -.3em;
-}
-
-.submeta2__link {
-    font-weight: bold;
-    @include nav-links;
-
-    &:after {
-        @include trailing-slash;
-        color: $neutral-5;
-    }
-
-    .submeta2__keywords & {
-        color: $neutral-2;
-    }
-
-    &:last-of-type:after {
-        content: none;
-    }
-}
-
-.submeta2__badge {
-    width: 33px;
-    float: right;
-    margin-top: -$gs-baseline;
-    margin-left: $gs-gutter / 2;
-}
-
 
 @import '../module/nav/_supporter-trapezoid';

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -1,54 +1,58 @@
 .submeta {
+    margin-top: $gs-baseline;
+}
 
-    padding-top: $gs-baseline;
+.submeta__section-labels {
+    @include fs-textSans(5);
+    min-height: $gs-row-height;
+    border-top: 1px dotted $neutral-5;
+    padding-top: $gs-baseline / 2;
 
-    .gallery-lightbox__item--endslate & {
-        display: none;
-    }
-
-    hr {
-        border: 0;
-        margin: 0 0 $gs-baseline / 2;
-        border-top: 1px dotted $neutral-4;
-    }
-
-    .submeta__tone {
-        float: left;
-        margin-right: $gs-gutter / 2;
-    }
-
-    .keyword-list {
-        margin-bottom: $gs-baseline * 1.5;
-    }
-
-    .content--liveblog & {
-        padding-top: $gs-baseline * 2;
-    }
-
-    .submeta__share {
-        float: left;
-    }
-
-    .submeta__syndication {
-        display: none;
-        @include mq(desktop) {
-            @include fs-textSans(1);
-            padding-top: $gs-baseline/2;
-            display: inline-block;
-            height: 32px;
-            float: right;
-            line-height: 15px;
-            margin-bottom: 0;
-        }
+    &:before {
+        @include fs-textSans(1);
+        content: "More";
+        color: $neutral-2;
+        display: block;
+        margin-bottom: -($gs-baseline / 4);
     }
 }
 
-.submeta__head {
-    @include fs-textSans(1);
-    color: $neutral-2;
-    padding: $gs-baseline/3 0 $gs-baseline;
-    float: left;
-    margin-right: $gs-gutter / 2;
+.submeta__keywords {
+    @include fs-textSans(4);
+    padding-bottom: $gs-baseline;
+    min-height: $gs-baseline * 2;
+    border-bottom: 1px dotted $neutral-5;
+    margin-bottom: $gs-baseline / 2;
+}
+
+.submeta__links {
+    overflow: hidden;
+    margin-left: -.3em;
+}
+
+.submeta__link {
+    font-weight: bold;
+    @include nav-links;
+
+    &:after {
+        @include trailing-slash;
+        color: $neutral-5;
+    }
+
+    .submeta__keywords & {
+        color: $neutral-2;
+    }
+
+    &:last-of-type:after {
+        content: none;
+    }
+}
+
+.submeta__badge {
+    width: 33px;
+    float: right;
+    margin-top: -$gs-baseline;
+    margin-left: $gs-gutter / 2;
 }
 
 .submeta__share {
@@ -61,11 +65,15 @@
     }
 }
 
-.submeta__save-for-later {
-    // Shown with test
+.submeta__syndication {
     display: none;
-
-    @include mq(tablet) {
-        float: left;
+    @include mq(desktop) {
+        @include fs-textSans(1);
+        padding-top: $gs-baseline/2;
+        display: inline-block;
+        height: 32px;
+        float: right;
+        line-height: 15px;
+        margin-bottom: 0;
     }
 }

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -76,7 +76,6 @@
     .byline,
     .content__dateline,
     .content__meta-container,
-    .submeta hr,
     .commentcount,
     .meta__numbers,
     .meta__social,
@@ -105,5 +104,21 @@
             }
         }
     }
+    .submeta__section-labels .submeta__link{
+        color: $neutral-6;
+    }
 
+    .submeta__section-labels,
+    .submeta__keywords {
+        border-color: $neutral-2;
+    }
+
+    .submeta__keywords .submeta__link {
+        color: $neutral-3;
+    }
+
+
+    .submeta__link:after {
+        color: $neutral-2;
+    }
 }

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -61,9 +61,6 @@
         .content__dateline,
         .meta__numbers .sharecount__heading,
         .meta__numbers .sharecount__value,
-        .submeta__head {
-            color: #ffffff;
-        }
 
         .meta__numbers .inline-share {
             fill: #ffffff;
@@ -77,9 +74,6 @@
         .meta__social,
         .meta__numbers,
         .most-viewed-container--media,
-        .submeta {
-            border-color: mix($news-support-6, #ffffff, 70%);
-        }
 
         .button--tag {
             background-color: mix($news-support-6, $neutral-1, 70%);


### PR DESCRIPTION
## What does this change?

The new header test we have been running on mobile has been successful! We are still not 100% ready to role out all the changes, but we are working on taking some of the changes out of the test. 

This PR is taking the newly designed submeta outside the test, and add it to desktop too. 

_Note: if you want to opt into the test on mobile go to www.theguardian.com/opt/in/headerseven_

## What is the value of this and can you measure success?
Better submeta area at the bottom of the article

## Does this affect other platforms - Amp, Apps, etc?
The new submeta is on AMP already, but it should get the slight style update.

## Screenshots
**Before:**
Desktop:
![image](https://cloud.githubusercontent.com/assets/8774970/23210579/26da66b6-f8f6-11e6-81c1-65205440545e.png)

Mobile:
![image](https://cloud.githubusercontent.com/assets/8774970/23210611/4c162df2-f8f6-11e6-812b-7906140c8f35.png)

AMP:
![image](https://cloud.githubusercontent.com/assets/8774970/23210626/586b2b5c-f8f6-11e6-9df8-6bc8ca433952.png)


**After:**
Desktop:
![image](https://cloud.githubusercontent.com/assets/8774970/23210863/461dbcca-f8f7-11e6-8267-eeb5481c7871.png)


Mobile:
![image](https://cloud.githubusercontent.com/assets/8774970/23210840/3d10643e-f8f7-11e6-8f1c-14b691d99134.png)


AMP:
![image](https://cloud.githubusercontent.com/assets/8774970/23210834/3132e7c2-f8f7-11e6-9cb0-4d45250a4e57.png)



## Tested in CODE?
Nope!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
