### PR TITLE
Server side test: Always use 5x3 image for youtube atom content cards

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -30,9 +30,11 @@ class OptInController extends Controller {
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
       case "headerseven" => headerSeven.opt(choice)
+      case "youtubeposter" => youtubePosterOverride.opt(choice)
       case _ => NotFound
     }))
   }
-
+//cookies should correspond with those checked by fastly-edge-cache
   val headerSeven = OptInFeature("new_header_seven_opt_in")
+  val youtubePosterOverride = OptInFeature("you_tube_poster_override_opt_in")
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -50,6 +50,17 @@ object CommercialClientLoggingVariant extends TestDefinition(
   }
 }
 
+object YouTubePosterOverride extends TestDefinition(
+  name = "youtube-poster-override",
+  description = "Users in the test will always see the trail image on YouTube atom content cards instead of the poster image",
+  owners = Seq(Owner.withGithub("gidsg")),
+  sellByDate = new LocalDate(2017, 4, 1)
+  ) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-youtube-poster-override").contains("true")
+  }
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -65,7 +76,8 @@ object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     ABNewNavVariantSeven,
     ABNewNavControl,
-    CommercialClientLoggingVariant
+    CommercialClientLoggingVariant,
+    YouTubePosterOverride
   )
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -54,7 +54,7 @@ object YouTubePosterOverride extends TestDefinition(
   name = "youtube-poster-override",
   description = "Users in the test will always see the trail image on YouTube atom content cards instead of the poster image",
   owners = Seq(Owner.withGithub("gidsg")),
-  sellByDate = new LocalDate(2017, 4, 1)
+  sellByDate = new LocalDate(2017, 4, 3)
   ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-youtube-poster-override").contains("true")

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -8,9 +8,12 @@
 @import model.ImageMedia
 @(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None)(implicit request: RequestHeader)
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
+@defining(playable && !posterImageOverride.exists(_ => mvt.YouTubePosterOverride.isParticipating)){sixteenByNine: Boolean =>
+
+
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
         ("u-responsive-ratio", true),
-        ("u-responsive-ratio--hd", playable),
+        ("u-responsive-ratio--hd", sixteenByNine),
         ("youtube-media-atom", true),
         ("no-player", !playable || expired )
     ))"
@@ -18,6 +21,8 @@
       data-end-slate="@endSlatePath"
     }
     >
+}
+
         @if(playable && !expired) {
             @defining(s"https://www.youtube.com/embed${
                 media.assets.head.id

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -35,7 +35,7 @@
                 </iframe>
                 }
             }
-        @defining(posterImageOverride.filterNot(_ => playable) orElse media.posterImage) { bestPosterImage =>
+        @defining(posterImageOverride.filter(_ => !playable || mvt.YouTubePosterOverride.isParticipating) orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 


### PR DESCRIPTION
## What does this change?
Adds a server side opt-in test which when enabled means youtube atom playable content cards on fronts will always use a 5x3 trail image. 

Note the fastly changes required for an opt-in link will follow in a subsequent PR.

This matches the current behaviour of playables for non-youtube media but has some downsides as described below.

### Pros
* Editorial can show a different image on fronts than on articles
* Better matches other cards in the grid

### Cons
* Noticeable flash when we enhance from YouTube holding image to Guardian one
* Letterboxing on video player on fronts

## What is the value of this and can you measure success?
Running this as a opt-in test will allow editorial to evaluate the pros and cons of this behaviour whilst using it in production.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
### Before

![16 x 9](https://cloud.githubusercontent.com/assets/1764158/23211682/230d44ea-f8fb-11e6-85da-83262bcfc15c.gif)

#### After (when switch enabled)

![5 by 3](https://cloud.githubusercontent.com/assets/1764158/23211696/37abeb7c-f8fb-11e6-9215-8a8a539010de.gif)


## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
