### PR TITLE
De-duplicate collections/containers in emails

### DIFF
--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -1,0 +1,52 @@
+package layout
+
+import model.PressedPage
+import model.facia.PressedCollection
+import model.pressed.{CollectionConfig, PressedContent}
+
+import PartialFunction.condOpt
+
+object EmailContainer {
+
+  def fromPressedCollections(pressedCollections: List[PressedCollection]): List[EmailContainer] = {
+    val (_, reversedContainers) = pressedCollections.foldLeft((List.empty[EditionalisedLink], List.empty[EmailContainer])) {
+      case ((alreadySeen, emailContainers), pressedCollection) =>
+        val cards = cardsForCollection(pressedCollection, alreadySeen)
+        val emailContainer = fromCollectionAndCards(pressedCollection, cards)
+        val newUrls = cards.map(_.header.url)
+        (newUrls ::: alreadySeen, emailContainer :: emailContainers)
+    }
+    reversedContainers.reverse.filter(_.cards.nonEmpty)
+  }
+
+  private def cardsForCollection(collection: PressedCollection, seen: List[EditionalisedLink]): List[ContentCard] = {
+    collection
+      .curatedPlusBackfillDeduplicated
+      .flatMap(contentCard(_, collection.config))
+      .filterNot({ content => seen.contains(content.header.url) })
+      .take(collection.config.displayHints.flatMap(_.maxItemsToDisplay).getOrElse(6))
+  }
+
+  private def fromCollectionAndCards(collection: PressedCollection, cards: List[ContentCard]) =
+    EmailContainer(
+      displayName = collection.displayName,
+      cards = cards,
+      config = collection.config,
+      collectionType = collection.collectionType
+    )
+
+  private def contentCard(content: PressedContent, config: CollectionConfig): Option[ContentCard] = {
+    condOpt(FaciaCard.fromTrail(content, config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) {
+      case card: ContentCard => card
+    }
+  }
+}
+
+case class EmailContainer(displayName: String, cards: List[ContentCard], config: CollectionConfig, collectionType: String)
+
+object CollectionEmail {
+  def fromPressedPage(pressedPage: PressedPage) =
+    CollectionEmail(EmailContainer.fromPressedCollections(pressedPage.collections))
+}
+
+case class CollectionEmail(collections: List[EmailContainer])

--- a/common/test/common/commercial/FixtureBuilder.scala
+++ b/common/test/common/commercial/FixtureBuilder.scala
@@ -13,7 +13,7 @@ object FixtureBuilder {
       showByline = false,
       imageSlideshowReplace = false,
       maybeContent = None,
-      maybeContentId = None,
+      maybeContentId = Some(id.toString),
       isLiveBlog = false,
       isCrossword = false,
       byline = None,
@@ -38,7 +38,7 @@ object FixtureBuilder {
       kicker,
       seriesOrBlogKicker = None,
       headline = "",
-      url = "",
+      url = id.toString,
       hasMainVideoElement = None
     )
 

--- a/common/test/layout/CollectionEmailTest.scala
+++ b/common/test/layout/CollectionEmailTest.scala
@@ -1,0 +1,104 @@
+package layout
+
+import common.commercial.FixtureBuilder
+import model.facia.PressedCollection
+import model.pressed.{CollectionConfig, DisplayHints, PressedContent}
+import model.{FrontProperties, PressedPage, SeoData}
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import FixtureBuilder.mkPressedContent
+
+class CollectionEmailTest extends FlatSpec with Matchers with OptionValues {
+  it should "deduplicate content" in {
+    val duplicatedA = mkPressedContent(99)
+    val duplicatedB = mkPressedContent(88)
+
+    val pressedPage = mkPressedPage(
+      List(
+        mkPressedCollection(id = "1", curated = List(duplicatedA, mkContent(1)), backfill = List(mkContent(2))),
+        mkPressedCollection(id = "2", curated = List(mkContent(3)), backfill = List(duplicatedA, duplicatedB, mkContent(4))),
+        mkPressedCollection(id = "3", curated = List(duplicatedA, duplicatedB, mkContent(5)), backfill = List(mkContent(6)))
+      )
+    )
+
+    val result = CollectionEmail.fromPressedPage(pressedPage)
+    result.collections(1).cards.map(_.header.url) should not contain EditionalisedLink("/99")
+    result.collections(2).cards.map(_.header.url) should contain noneOf(EditionalisedLink("/99"), EditionalisedLink("/88"))
+  }
+
+  it should "default to 6 items per collection" in {
+    val pressedPage = mkPressedPage(
+      List(
+        mkPressedCollection(
+          id = "1",
+          curated = (1 to 4).map(mkContent),
+          backfill = (5 to 8).map(mkContent))
+      )
+    )
+
+    val result = CollectionEmail.fromPressedPage(pressedPage)
+    result.collections.headOption.map(_.cards.length) shouldEqual Some(6)
+  }
+
+  it should "respect the maxItemsToDisplay property if set" in {
+    val pressedPage = mkPressedPage(
+      List(mkPressedCollection(
+        id = "1",
+        curated = (1 to 4).map(mkContent),
+        backfill = (5 to 8).map(mkContent),
+        maxItemsToDisplay = Some(8))
+      )
+    )
+
+    val result = CollectionEmail.fromPressedPage(pressedPage)
+    result.collections.headOption.map(_.cards.length) shouldEqual Some(8)
+  }
+
+  it should "exclude empty containers" in {
+    val pressedPage = mkPressedPage(
+      List(
+        mkPressedCollection(id = "1", curated = (10 to 12).map(mkContent), backfill = (13 to 15).map(mkContent)),
+        mkPressedCollection(id = "2", curated = (10 to 12).map(mkContent), backfill = (13 to 15).map(mkContent)),
+        mkPressedCollection(id = "3", curated = (30 to 32).map(mkContent), backfill = (33 to 35).map(mkContent))
+      )
+    )
+
+    val result = CollectionEmail.fromPressedPage(pressedPage)
+    result.collections.length shouldEqual 2
+    result.collections.map(_.displayName) shouldEqual List("Test Collection 1", "Test Collection 3")
+  }
+
+  private def mkContent(id: Int): PressedContent = mkPressedContent(id)
+
+  private def mkPressedCollection(id: String, curated: Seq[PressedContent] = IndexedSeq.empty, backfill: Seq[PressedContent] = IndexedSeq.empty, maxItemsToDisplay: Option[Int] = None) = {
+    PressedCollection(
+      id = "test-colleciton",
+      displayName = s"Test Collection $id",
+      curated = curated.toList,
+      backfill = backfill.toList,
+      treats = List.empty,
+      lastUpdated = None,
+      updatedBy = None,
+      updatedEmail = None,
+      href = None,
+      description = None,
+      collectionType = "unknown",
+      groups = None,
+      uneditable = false,
+      showTags = false,
+      showSections = false,
+      hideKickers = false,
+      showDateHeader = false,
+      showLatestUpdate = false,
+      config = CollectionConfig.empty.copy(displayHints = maxItemsToDisplay.map(m => DisplayHints(Some(m))))
+    )
+  }
+
+  private def mkPressedPage(collections: List[PressedCollection]) = {
+    PressedPage(
+      id = "test-pressed-page",
+      seoData = SeoData.empty,
+      frontProperties= FrontProperties.empty,
+      collections = collections
+    )
+  }
+}

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -121,23 +121,18 @@
     @imgForFront(page.banner, page.email.map(_.name))
 }
 
-@page.collections.filterNot(_.curatedPlusBackfillDeduplicated.isEmpty).zipWithIndex.map { case (collection, collectionIndex) =>
+@layout.CollectionEmail.fromPressedPage(page).collections.zipWithIndex.map { case (collection, collectionIndex) =>
     @paddedRow {
         <h2 class="container-title @if(collectionIndex > 0) { container-title--not-first }">
             @collection.displayName
         </h2>
     }
 
-    @collection.curatedPlusBackfillDeduplicated.take(collection.config.displayHints.flatMap(_.maxItemsToDisplay).getOrElse(6)).zipWithIndex.map { case (pressedContent, cardIndex) =>
-        @defining(FaciaCard.fromTrail(pressedContent, collection.config, ItemClasses.showMore, showSeriesAndBlogKickers = false)) {
-            case card: ContentCard => {
-                @if(cardIndex == 0) {
-                    @firstCard(card, isFastLayout = collection.collectionType == "fast")
-                } else {
-                    @otherCard(card, isSlowLayout = collection.collectionType == "slow")
-                }
-            }
-            case _ => {}
+    @collection.cards.zipWithIndex.map { case (card, cardIndex) =>
+        @if(cardIndex == 0) {
+            @firstCard(card, isFastLayout = collection.collectionType == "fast")
+        } else {
+            @otherCard(card, isSlowLayout = collection.collectionType == "slow")
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Removes duplicate articles from containers on email fronts

## What is the value of this and can you measure success?

Simplifies curation of email fronts

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
