### PR TITLE
Expanded sharing at small break points

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -154,6 +154,10 @@ category: Common
     clear: both;
     box-sizing: border-box;
 
+    @include mq($until: mobileMedium) {
+        min-height: $gs-baseline * 8;
+    }
+
     @include mq($until: mobileLandscape) {
         right: 0;
     }


### PR DESCRIPTION
On really small devices you see a slither of timestamp when you expand the menu.
That's not sexy and it certainly isn't cricket.

Before
<img width="322" alt="screen shot 2017-02-22 at 16 54 28" src="https://cloud.githubusercontent.com/assets/14570016/23222507/03cce20a-f920-11e6-8595-47e610540397.png">

After
<img width="322" alt="screen shot 2017-02-22 at 16 54 34" src="https://cloud.githubusercontent.com/assets/14570016/23222509/06412ae6-f920-11e6-8c2d-7955d44fed52.png">
