### PR TITLE
svg-loader: unify export between webpack and require-js

### DIFF
--- a/static/src/javascripts-legacy/projects/common/utils/svg-loader.js
+++ b/static/src/javascripts-legacy/projects/common/utils/svg-loader.js
@@ -22,7 +22,8 @@ define([
                     buildText[name] = text.jsEscape(svg);
                 }
 
-                onLoad(svg);
+                // returning an object creates webpack compatibility
+                onLoad({markup: svg});
 
             }, onLoad.error);
         },

--- a/static/src/javascripts-legacy/projects/common/views/svgs.js
+++ b/static/src/javascripts-legacy/projects/common/views/svgs.js
@@ -137,11 +137,6 @@ define([
     };
 
     return function (name, classes, title) {
-        // #karma-jest - needed by karma
-        if (svgs[name].markup) { // webpack way
-            return svg(svgs[name].markup, classes, title);
-        }
-        // require way
-        return svg(svgs[name], classes, title);
+        return svg(svgs[name].markup, classes, title);
     };
 });


### PR DESCRIPTION
## What does this change?

Unifies export format of `svg-loader` between webpack und require-js

## What is the value of this and can you measure success?

Webpack migration continues.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.