### PR TITLE
eslint: enable linter on test directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,5 +10,5 @@ static/vendor/javascripts
 static/src/javascripts-legacy/projects/common/utils/atob.js
 static/src/javascripts-legacy/projects/common/utils/picturefill.js
 
-# tests #karma-jest
-static/test/javascripts/components
+# tests
+static/test/javascripts-legacy/components

--- a/.eslintignore
+++ b/.eslintignore
@@ -10,5 +10,5 @@ static/vendor/javascripts
 static/src/javascripts-legacy/projects/common/utils/atob.js
 static/src/javascripts-legacy/projects/common/utils/picturefill.js
 
-# tests
+# tests #karma-jest
 static/test/javascripts-legacy/components

--- a/static/test/javascripts-legacy/.eslintrc.js
+++ b/static/test/javascripts-legacy/.eslintrc.js
@@ -6,24 +6,24 @@ module.exports = {
         commonjs: false
     },
     extends: 'eslint:recommended',
-	parserOptions: {
-		ecmaVersion: 5
-	},
-	rules: {
-		camelcase: 'off',
-		'no-shadow': 'off',
-        'no-undef': 'error',
-        'no-use-before-define': [
-            'error',
-            'nofunc'
-        ],
-        'no-multi-spaces': 'off',
-        'no-underscore-dangle': 'off',
-        'key-spacing': 'off',
-        'import/no-amd': 'off',
-        'import/no-dynamic-require': 'off'
-	},
-	globals: {
-		sinon: true
-	}
+    parserOptions: {
+        ecmaVersion: 5
+    },
+    rules: {
+      camelcase: 'off',
+      'no-shadow': 'off',
+          'no-undef': 'error',
+          'no-use-before-define': [
+              'error',
+              'nofunc'
+          ],
+          'no-multi-spaces': 'off',
+          'no-underscore-dangle': 'off',
+          'key-spacing': 'off',
+          'import/no-amd': 'off',
+          'import/no-dynamic-require': 'off'
+    },
+    globals: {
+        sinon: true
+    }
 }

--- a/tools/__tasks__/lint/javascript-fix.js
+++ b/tools/__tasks__/lint/javascript-fix.js
@@ -13,9 +13,9 @@ const handleSuccess = (ctx) => {
 module.exports = {
     description: 'Fix JS linting errors',
     task: [{
-        description: 'Fix static/tests',
+        description: 'Fix static/tests/javascripts-legacy',
         task: ctx => execa('eslint', [
-            'static/test/javascripts/**/*.js',
+            'static/test/javascripts-legacy/**/*.js',
         ].concat(config)).then(handleSuccess.bind(null, ctx)),
     }, {
         description: 'Fix static/src',

--- a/tools/__tasks__/lint/javascript.js
+++ b/tools/__tasks__/lint/javascript.js
@@ -10,7 +10,7 @@ const error = (ctx) => {
 module.exports = {
     description: 'Lint JS',
     task: [{
-        description: 'Lint static/test/javascript-legacy',
+        description: 'Lint static/test/javascripts-legacy',
         task: `eslint static/test/javascripts-legacy/**/*.js ${config}`,
         onError: error,
     }, {

--- a/tools/__tasks__/lint/javascript.js
+++ b/tools/__tasks__/lint/javascript.js
@@ -10,8 +10,8 @@ const error = (ctx) => {
 module.exports = {
     description: 'Lint JS',
     task: [{
-        description: 'Lint static/tests',
-        task: `eslint static/test/javascripts/**/*.js ${config}`,
+        description: 'Lint static/test/javascript-legacy',
+        task: `eslint static/test/javascripts-legacy/**/*.js ${config}`,
         onError: error,
     }, {
         description: 'Lint static/src',


### PR DESCRIPTION
## What does this change?

Enables eslint on `static/test/javascripts-legacy/**`.

## What is the value of this and can you measure success?

Code quality.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.