### PR TITLE
add manual refresh to the service worker

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -9,6 +9,9 @@
 
 "use strict";
 
+// increment number to force a refresh
+// version 1
+
 /**
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * CACHE HELPERS


### PR DESCRIPTION
## What does this change?

add a counter in comment we can use to manually force a refresh of the sw on its next check

## What is the value of this and can you measure success?

we're seeing assets being requested multiplied times by SW-enabled browsers. 

forcing the SW to update _seems_ to fix it, but we cannot do it manually currently. 

this is a hopeful stab in fixing that issue!
