### PR TITLE
bump brexit test end date to be after the end of the quarter

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,7 +86,7 @@ trait ABTestSwitches {
     "Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles",
     owners = Seq(Owner.withGithub("alexduf")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 1),
+    sellByDate = new LocalDate(2017, 4, 10),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -9,7 +9,7 @@ define([
         campaignId: 'epic_brexit_2017_01',
 
         start: '2017-01-06',
-        expiry: '2017-03-01',
+        expiry: '2017-04-10',
 
         author: 'Alex Dufournet',
         description: 'Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles',


### PR DESCRIPTION
## What does this change?

This pushes the end date of the brexit test until after the end of the quarter so we can have a week to decide what to do afterwards.

## What is the value of this and can you measure success?
test continue to run

## Does this affect other platforms - Amp, Apps, etc?
No
## Screenshots
n/a
## Tested in CODE?
no

