### PR TITLE
submeta: transform div into an unordered list

### DIFF
--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -23,52 +23,68 @@
             }
         }
 
-        <div class="submeta__links">
+        <ul class="submeta__links">
             @if(!(content.content.isImmersive && content.content.tags.isArticle)) {
-                <a class="submeta__link"
-                    data-link-name="article section"
-                    href="@LinkTo {/@content.content.sectionLabelLink}">
-                        @Html(Localisation(content.content.sectionLabelName))
-                </a>
+                <li class="submeta__link-item">
+                    <a class="submeta__link"
+                        data-link-name="article section"
+                        href="@LinkTo {/@content.content.sectionLabelLink}">
+                            @Html(Localisation(content.content.sectionLabelName))
+                    </a>
+                </li>
             }
 
             @content.content.blogOrSeriesTag.map { series =>
-                <a class="submeta__link" href="@LinkTo {/@series.id}">@series.name</a>
+                <li class="submeta__link-item">
+                    <a class="submeta__link"
+                       href="@LinkTo {/@series.id}">
+                            @series.name
+                    </a>
+                </li>
             }.getOrElse {
                 @if(content.content.isFromTheObserver) {
-                    <a class="submeta__link" href="http://observer.theguardian.com">The Observer</a>
+                    <li class="submeta__link-item">
+                        <a class="submeta__link"
+                           href="http://observer.theguardian.com">
+                               The Observer
+                        </a>
+                    </li>
                 }
             }
-        </div>
+        </ul>
     </div>
 
     <div class="submeta__keywords">
-        <div class="submeta__links">
+        <ul class="submeta__links">
             @if(content.tags.keywords.filterNot(_.isSectionTag).nonEmpty) {
                 @defining(content.tags.keywords.filterNot(_.isSectionTag).slice(1, 6)) { shownKeywords =>
                     @if(shownKeywords.nonEmpty) {
                         @shownKeywords.zipWithRowInfo.map{ case(keyword, row) =>
-                            <a class="submeta__link"
-                                href="@LinkTo(keyword.metadata.url)"
-                                data-link-name="keyword: @keyword.id">
-                                    @keyword.name
-                                    @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
-                            </a>
+                            <li class="submeta__link-item">
+                                <a class="submeta__link"
+                                    href="@LinkTo(keyword.metadata.url)"
+                                    data-link-name="keyword: @keyword.id">
+                                        @keyword.name
+                                        @if(content.tags.keywords.filter(_ != keyword).find(_.name == keyword.name)){ (@keyword.properties.sectionName) }
+                                </a>
+                            </li>
                         }
                     }
                 }
 
                 @if(content.tags.isArticle && !content.tags.isLiveBlog) {
                     @content.tags.tones.headOption.map { tone =>
-                        <a class="submeta__link"
-                            href="@LinkTo(tone.metadata.url)"
-                            data-link-name="tone: @tone.name">
-                                @tone.name.toLowerCase
-                        </a>
+                        <li class="submeta__link-item">
+                            <a class="submeta__link"
+                                href="@LinkTo(tone.metadata.url)"
+                                data-link-name="tone: @tone.name">
+                                    @tone.name.toLowerCase
+                            </a>
+                        </li>
                     }
                 }
             }
-        </div>
+        </ul>
     </div>
     @if(content.showBottomSocialButtons) {
         <div data-component="share" class="submeta__share">

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -27,29 +27,35 @@
 }
 
 .submeta__links {
+    list-style: none;
     overflow: hidden;
+    margin-bottom: 0;
     margin-left: -.3em;
+    margin-top: 0;
+}
+
+.submeta__link-item {
+    @include clearfix;
+    @include nav-links;
+
+    .submeta__keywords & {
+        &:after {
+            @include trailing-slash;
+            color: $neutral-5;
+        }
+
+        &:last-of-type:after {
+            content: none;
+        }
+    }
 }
 
 .submeta__link {
     font-weight: 500;
     line-height: 22px;
-    position: relative;
-    padding-left: .3em;
-    padding-right: .35em;
-    float: left;
-
-    &:after {
-        @include trailing-slash;
-        color: $neutral-5;
-    }
 
     .submeta__keywords & {
         color: $neutral-2;
-    }
-
-    &:last-of-type:after {
-        content: none;
     }
 }
 

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -26,25 +26,34 @@
 }
 
 .submeta__links {
+    list-style: none;
     overflow: hidden;
+    margin-bottom: 0;
     margin-left: -.3em;
+    margin-top: 0;
+}
+
+.submeta__link-item {
+    @include clearfix;
+    @include nav-links;
+
+    .submeta__keywords & {
+        &:after {
+            @include trailing-slash;
+            color: $neutral-5;
+        }
+
+        &:last-of-type:after {
+            content: none;
+        }
+    }
 }
 
 .submeta__link {
     font-weight: bold;
-    @include nav-links;
-
-    &:after {
-        @include trailing-slash;
-        color: $neutral-5;
-    }
 
     .submeta__keywords & {
         color: $neutral-2;
-    }
-
-    &:last-of-type:after {
-        content: none;
     }
 }
 

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -1,5 +1,5 @@
 .meta__extras,
-.submeta-container,
+.submeta__syndication,
 .gu-media-wrapper--video,
 .ad-slot,
 .article__fullscreen,


### PR DESCRIPTION
## What does this change?

Converts some `div`s of submeta into an unordered list.

## What is the value of this and can you measure success?

Better accessibility and semantics. Screen reader users can now decide based on the length of the list, whether they'd like to skip it or tab through it.

## Does this affect other platforms - Amp, Apps, etc?

Amp.

## Screenshots

** AMP before **

![screen shot 2017-02-23 at 14 02 44](https://cloud.githubusercontent.com/assets/2244375/23261961/c8e23a76-f9d0-11e6-8e50-852badd687da.png)

** AMP after **

![screen shot 2017-02-23 at 14 02 49](https://cloud.githubusercontent.com/assets/2244375/23261965/ccda52a8-f9d0-11e6-8de8-077c0d6dc6d9.png)

** Web before **

![screen shot 2017-02-23 at 14 03 25](https://cloud.githubusercontent.com/assets/2244375/23261980/e32f8488-f9d0-11e6-8eb4-2c805e6913ef.png)

** Web after **

![screen shot 2017-02-23 at 14 03 35](https://cloud.githubusercontent.com/assets/2244375/23261984/e65680bc-f9d0-11e6-8d8a-b9990bcb1e2f.png)


## Tested in CODE?

No.
