### PR TITLE
Fix lucky positioning

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -29,7 +29,7 @@ define([
         container.className = 'fc-container fc-container--commercial';
         container.appendChild(createSlot(config.page.isPaidContent ? 'high-merch-paid' : 'high-merch'));
 
-        if (isLuckyBastard()) {
+        if (commercialFeatures.outbrain && isLuckyBastard()) {
             insertAlternativeSlot();
         }
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -53,6 +53,8 @@ define([
             if (!isHiResLoaded || !isLoResLoaded) {
                 var container = document.querySelector(isHiResLoaded ?
                     '.js-container--commercial' :
+                    !(config.page.seriesId || config.page.blogIds) ?
+                    '.js-related, .js-outbrain-anchor' :
                     '.js-outbrain-anchor'
                 );
                 return [

--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -64,7 +64,7 @@ define([
         .then(function (args) {
             if (args) {
                 fastdom.write(function () {
-                    args[1].appendChild(args[0]);
+                    args[1].parentNode.insertBefore(args[0], args[1].nextSibling);
                     addSlot(args[0]);
                 });
             }

--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -53,8 +53,6 @@ define([
             if (!isHiResLoaded || !isLoResLoaded) {
                 var container = document.querySelector(isHiResLoaded ?
                     '.js-container--commercial' :
-                    !(config.page.seriesId || config.page.blogIds) ?
-                    '.js-related, .js-outbrain-anchor' :
                     '.js-outbrain-anchor'
                 );
                 return [


### PR DESCRIPTION
Moves the high merchandising lucky slot after its anchor, rather than inside.

Before (invisible because inside invisible element):
![picture 3](https://cloud.githubusercontent.com/assets/629976/23264616/dc3a12a2-f9d9-11e6-8164-e350f1b762f5.jpg)

After (visible):
![picture 2](https://cloud.githubusercontent.com/assets/629976/23264624/e809d93c-f9d9-11e6-9188-973d20341080.jpg)
