### PR TITLE
tests: replace two more legacy rjs text-loader occurences

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-love-boat.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-love-boat.js
@@ -7,8 +7,8 @@ define([
     'common/views/svg',
     'svg-loader!svgs/icon/hand.svg',
     'svg-loader!svgs/icon/arrow-right.svg',
-    'text!common/views/epic-supporter-cta.html',
-    'text!common/views/acquisitions-visual.html'
+    'raw-loader!common/views/epic-supporter-cta.html',
+    'raw-loader!common/views/acquisitions-visual.html'
 ], function (
     bean,
     contributionsUtilities,


### PR DESCRIPTION
## What does this change?

Fixes regression with two forgotten `text!` require-js references.

## What is the value of this and can you measure success?

Tests succeed.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Tested in CODE?

No.