### PR TITLE
Provide Ophan URL for interactives

### DIFF
--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -36,7 +36,10 @@
     // it will break. so we're providing just incase that is true.
     window.curlConfig = {
         baseUrl: '@{Configuration.assets.path}javascripts',
-        apiName: 'require'
+        apiName: 'require',
+        paths: {
+            'ophan/ng': '@{Configuration.javascript.config("ophanJsUrl")}'
+        }
     };
     window.curl = window.curlConfig;
     @HtmlFormat.raw(common.Assets.js.curl)


### PR DESCRIPTION
## What does this change?

We have bundled Ophan's Tracker JS into our application, but interactives do not have access to our application.

This change provides the path to the hosted version of Ophan's Tracker JS in the curl config.

## What is the value of this and can you measure success?

Provides interactives with access to Ophan's Tracker JS.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
