### PR TITLE
Support super sticky banner in CSS

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -8,12 +8,19 @@
 @headerAndTopAds(showAdverts: Boolean, edition: Edition, content: Option[model.ContentType]) = {
   @if(!page.metadata.shouldHideHeaderAndTopAds) {
     @defining(showAdverts && !content.exists(_.tags.isTheMinuteArticle)) { showTopSlot =>
-      <div id="bannerandheader">
-        @if(showTopSlot) {
-          @fragments.commercial.topBanner(page.metadata)
-        }
-        @fragments.header(page)
-      </div>
+      @if(content.exists(_.tags.hasSuperStickyBanner)) {
+          @if(showTopSlot) {
+            @fragments.commercial.topBanner(page.metadata)
+          }
+          @fragments.header(page)
+      } else {
+          <div id="bannerandheader">
+              @if(showTopSlot) {
+                @fragments.commercial.topBanner(page.metadata)
+              }
+              @fragments.header(page)
+          </div>
+      }
       <div id="maincontent" tabindex="0"></div>
     }
   }

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -133,6 +133,10 @@
     top: 0;
     z-index: $zindex-sticky;
 
+    .top-banner-ad-container ~ & {
+        position: static;
+    }
+
     .paidfor-meta,
     .paidfor-meta__label,
     .paidfor-label {


### PR DESCRIPTION
An upcoming campaign is the only instance of a super sticky banner, that goes all the way down the page.

In that situation:

- it must not be wrapped with the header, otherwise it will just disappear
- the paid for band must not be sticky