### PR TITLE
Live-blog: fix broken positioning for byline on desktop-like screens

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -39,6 +39,7 @@ $block-padding-right: $gs-gutter;
         position: static;
 
         .meta__numbers {
+            @include clearfix;
             position: static;
             border-top: 1px dotted $neutral-5;
             border-bottom: 0;


### PR DESCRIPTION
## What does this change?

Fixes broken positioning for byline on desktop-like screens. [Trello reference](https://trello.com/c/EVQfIYYD/233-visual-mess-in-liveblog-meta)

## What is the value of this and can you measure success?

Proper layout, happy people.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** Before **

![screen shot 2017-02-23 at 17 11 34](https://cloud.githubusercontent.com/assets/2244375/23270301/53d624fc-f9eb-11e6-95ef-4a4fb1085d72.png)

** After **

![screen shot 2017-02-23 at 17 10 59](https://cloud.githubusercontent.com/assets/2244375/23270298/4eae04c2-f9eb-11e6-8972-8ee622f2feb6.png)

## Tested in CODE?

No.
