### PR TITLE
AMP: align usage of CTA in amt-list with official documentation

### DIFF
--- a/static/src/stylesheets/amp/_buttons.scss
+++ b/static/src/stylesheets/amp/_buttons.scss
@@ -15,21 +15,13 @@
     line-height: $gs-row-height;
 }
 
-.cta--show-more {
+.cta--show-more[overflow] {
+    position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
     color: $neutral-1;
     background-color: #ffffff;
-
-    /*
-       According to the AMP docs we should be able to do this (https://www.ampproject.org/docs/reference/components/amp-list), but it was probably broken in https://github.com/ampproject/amphtml/pull/7061.
-
-      TODO: Remove this specificity hack, after [the issue](https://github.com/ampproject/amphtml/issues/7689) is resolved.
-    */
-    @at-root .cta#{&} {
-      position: absolute;
-    }
 
     svg {
         width: 18px;


### PR DESCRIPTION
## What does this change?

Fixes CSS selector for amp-list according to the docs. Reply of the AMP team: https://github.com/ampproject/amphtml/pull/7736

## What is the value of this and can you measure success?

Aligned with AMP documentation.

## Does this affect other platforms - Amp, Apps, etc?

AMP

## Screenshots

No.

## Tested in CODE?

No.