### PR TITLE
Use first published date to determine hasBeenModified

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -97,7 +97,7 @@ final case class Content(
   }
 
   lazy val hasBeenModified: Boolean =
-    new Duration(trail.webPublicationDate, fields.lastModified).isLongerThan(Duration.standardSeconds(60))
+    new Duration(fields.firstPublicationDate.getOrElse(trail.webPublicationDate), fields.lastModified).isLongerThan(Duration.standardSeconds(60))
 
   lazy val hasTonalHeaderIllustration: Boolean = tags.isLetters
 


### PR DESCRIPTION
## What does this change?

We compare the `webPublicationDate` and `lastModifiedDate` in articles to check if an article `hasBeenModifed`. With this change, we will instead compare the `firstPublicationDate` as `webPublicationDate` is updated with the 'update to now' button so `hasBeenModified` in that case is false.

- If 'update to now' has not been clicked but a small modification has happened, show the 'last modified' timestamp when clicking on the timestamp.
- If 'update to now' has been clicked, do not show 'last modified' and instead show 'first published'

## What is the value of this and can you measure success?

More useful meta information relating to the article will be available to the audience.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 190](https://cloud.githubusercontent.com/assets/5931528/23269891/ef0c9aa2-f9e9-11e6-964c-18e211e1cd97.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
