### PR TITLE
Unstick paid for band when super sticky

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -43,6 +43,7 @@
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-new-header", mvt.ABNewNavVariantSeven.isParticipating),
+            ("has-super-sticky-banner", content.exists(_.tags.hasSuperStickyBanner)),
             ("is-immersive", content.exists(_.content.isImmersive)),
             ("is-immersive-interactive", content.exists(content => content.tags.isInteractive && content.content.isImmersive))))"
         itemscope itemtype="http://schema.org/WebPage">

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -133,7 +133,7 @@
     top: 0;
     z-index: $zindex-sticky;
 
-    .top-banner-ad-container ~ & {
+    .has-super-sticky-banner & {
         position: static;
     }
 


### PR DESCRIPTION
It turns out the position of the band in the DOM changes from page type to page type. A more robust approach is then to sign the `body` element with a class and use that as an anchor.