### PR TITLE
Facia: fix broken description alignment for documentaries container

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -105,12 +105,6 @@ $header-image-size-desktop: 100px;
         overflow: hidden;
 
         .fc-container__header__title {
-            float: left;
-        }
-        .fc-container__header__description {
-            float: right;
-        }
-        .fc-container__header__title {
             padding-right: $gs-gutter / 4;
         }
         .fc-container__header__description {
@@ -139,7 +133,6 @@ $header-image-size-desktop: 100px;
     color: $guardian-brand-dark;
 
     @include mq(tablet, leftCol) {
-        float: left;
         width: gs-span(4);
     }
 
@@ -250,7 +243,7 @@ $header-image-size-desktop: 100px;
     @include fs-headline(2);
     padding-bottom: $gs-baseline / 2;
     color: $neutral-2;
-    text-align: right;
+    text-align: left;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline;
@@ -261,7 +254,6 @@ $header-image-size-desktop: 100px;
         clear: left;
         float: left;
         margin-top: 0;
-        text-align: left;
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?

Fixes a styling regression on documentaries container seen [here](https://www.theguardian.com/video). [Trello reference](https://trello.com/c/ZnKr7jdG/234-glitch-in-documentaries-container).

## What is the value of this and can you measure success?

Better styling, happier users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![screen shot 2017-02-24 at 11 34 48](https://cloud.githubusercontent.com/assets/2244375/23302173/8637bdb2-fa85-11e6-8789-dab785b63d8e.png)
![screen shot 2017-02-24 at 11 34 37](https://cloud.githubusercontent.com/assets/2244375/23302174/863a7390-fa85-11e6-8a41-35868fefe669.png)
![screen shot 2017-02-24 at 11 34 26](https://cloud.githubusercontent.com/assets/2244375/23302175/863be856-fa85-11e6-83e1-4f30032c7418.png)


## Tested in CODE?

No.


