### PR TITLE
Include ophan-tracker-js in tests

### DIFF
--- a/static/test/javascripts-legacy/conf/settings.js
+++ b/static/test/javascripts-legacy/conf/settings.js
@@ -1,5 +1,23 @@
-var isTeamcityReporterEnabled = process.env.TEAMCITY === 'true',
-    karmaReporters = [ isTeamcityReporterEnabled ? 'teamcity' : 'spec' ];
+var isTeamcityReporterEnabled = process.env.TEAMCITY === 'true';
+var karmaReporters = [isTeamcityReporterEnabled ? 'teamcity' : 'spec'];
+var includeNodeModules = [
+    'bean',
+    'bonzo',
+    'react',
+    'wolfy87-eventemitter',
+    'fastclick',
+    'fastdom',
+    'fence',
+    'lodash-amd',
+    'when',
+    'qwery',
+    'reqwest',
+    'video.js',
+    'videojs-contrib-ads',
+    'text',
+    'raven-js',
+    'ophan-tracker-js'
+].join('|');
 
 module.exports = function (config) {
     return {
@@ -23,7 +41,7 @@ module.exports = function (config) {
 
             // this ugly, but also the most performant way to get
             // node_modules into karma/require
-            { pattern: 'node_modules/+(bean|bonzo|react|wolfy87-eventemitter|fastclick|fastdom|fence|lodash-amd|when|qwery|reqwest|video.js|videojs-contrib-ads|text|raven-js)/**/*.js', included: false },
+            { pattern: 'node_modules/+(' + includeNodeModules + ')/**/*.js', included: false },
         ],
 
         exclude: [],

--- a/static/test/javascripts-legacy/main.js
+++ b/static/test/javascripts-legacy/main.js
@@ -30,6 +30,7 @@ requirejs.config({
         videojs:      '/base/node_modules/video.js',
         'videojs-ads-lib': '/base/node_modules/videojs-contrib-ads',
         raven:        '/base/node_modules/raven-js/dist/raven',
+        'ophan/ng':   '/base/node_modules/ophan-tracker-js/build/ophan.ng',
 
         analytics:    'projects/common/modules/analytics/analytics',
         picturefill:  'projects/common/utils/picturefill',


### PR DESCRIPTION
## What does this change?

Ophan's tracker JS is needed in our Karma tests, specifically as a result of #15947

## What is the value of this and can you measure success?

Karma includes Ophan, RequireJS knows where to find it, tests pass, everyone happy 🌈 

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
