### PR TITLE
Update Australian edition’s vacancies link in the footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -193,7 +193,7 @@
                         <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
                             about us</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://workforus.theguardian.com/locations/sydney">
+                        <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="https://www.theguardian.com/info/2015/aug/04/guardian-australia-job-vacancies">
                             vacancies</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">


### PR DESCRIPTION
## What does this change?

Update 'vacancies' link in the Australian editions footer

## What is the value of this and can you measure success?

Links to desired location...

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

N/A