### PR TITLE
Video main media caption

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -42,10 +42,22 @@
 
 
                     @mainVideo.videos.caption.map { caption =>
-                        <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                            @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
-                            @Html(caption)
-                        </figcaption>
+                        @if(mvt.ABNewNavVariantSeven.isParticipating) {
+                            <input type="checkbox" id="show-caption" class="mobile-only u-h">
+
+                            <label class="mobile-only reveal-caption reveal-caption--img" for="show-caption">
+                                @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon"))
+                            </label>
+
+                            <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
+                                @Html(caption)
+                            </figcaption>
+                        } else {
+                            <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
+                                @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
+                                @Html(caption)
+                            </figcaption>
+                        }
                     }
 
                 </figure>

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -43,15 +43,17 @@
 
                     @mainVideo.videos.caption.map { caption =>
                         @if(mvt.ABNewNavVariantSeven.isParticipating) {
-                            <input type="checkbox" id="show-caption" class="mobile-only u-h">
+                            <div class="js-hide-on-play">
+                                <input type="checkbox" id="show-caption" class="mobile-only u-h">
 
-                            <label class="mobile-only reveal-caption reveal-caption--img" for="show-caption">
-                                @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon"))
-                            </label>
+                                <label class="mobile-only reveal-caption reveal-caption--video" for="show-caption">
+                                    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon"))
+                                </label>
 
-                            <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                                @Html(caption)
-                            </figcaption>
+                                <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
+                                    @Html(caption)
+                                </figcaption>
+                            </div>
                         } else {
                             <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
                                 @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))

--- a/static/src/javascripts-legacy/projects/common/modules/video/events.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/events.js
@@ -275,12 +275,17 @@ define([
         events.ready();
     }
 
+    function hideCaption() {
+        $('.js-hide-on-play').hide();
+    }
+
     // These events are so that other libraries (e.g. Ophan) can hook into events without
     // needing to know about videojs
     function bindGlobalEvents(player) {
         player.on('playing', function () {
             kruxTracking(player, 'videoPlaying');
             bean.fire(document.body, 'videoPlaying');
+            hideCaption();
         });
         player.on('pause', function () {
             bean.fire(document.body, 'videoPause');

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -744,16 +744,25 @@ $caption-button-size: 32px;
             z-index: 1;
             background-color: rgba($neutral-1, .4);
             border-radius: 50%;
+
+            &:after {
+                content: '';
+                position: absolute;
+                top: -$gs-gutter;
+                right: -$gs-gutter;
+                bottom: -$gs-gutter;
+                left: -$gs-gutter;
+                border-radius: 50%;
+                z-index: -1;
+            }
         }
+
         .reveal-caption--img {
             bottom: $gs-baseline/2;
         }
 
+        .caption--main.caption--img,
         .caption--main.caption--video {
-            padding-bottom: 0;
-        }
-
-        .caption--main.caption--img {
             position: absolute;
             background: rgba($multimedia-support-5, .8);
             color: #ffffff;
@@ -769,7 +778,8 @@ $caption-button-size: 32px;
                 color: #ffffff;
             }
 
-            &.caption--img {
+            &.caption--img,
+            &.caption--video {
                 bottom: 0;
                 padding-bottom: $gs-baseline;
             }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -739,6 +739,7 @@ $caption-button-size: 32px;
         .reveal-caption {
             position: absolute;
             right: $gs-gutter / 4;
+            bottom: $gs-baseline/2;
             width: $caption-button-size;
             height: $caption-button-size;
             z-index: 1;
@@ -755,10 +756,6 @@ $caption-button-size: 32px;
                 border-radius: 50%;
                 z-index: -1;
             }
-        }
-
-        .reveal-caption--img {
-            bottom: $gs-baseline/2;
         }
 
         .caption--main.caption--img,

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -229,6 +229,14 @@ $ima-controls-height: 70px;
         transition-delay: 0s;
     }
 
+    .gu-media-wrapper:hover .vjs-has-started.vjs-mousemoved & {
+        @include mq($until: tablet) {
+            bottom: 0;
+            transition: bottom 0s;
+            transition-delay: 0s;
+        }
+    }
+
     .vjs-using-native-controls & {
         display: none;
     }
@@ -1096,18 +1104,27 @@ $ima-controls-height: 70px;
 // We have to use vjs classes here, and not BEM modifiers as videojs
 // changes the classes names via JS, and last time we messed with that,
 // we had major refactoring issues.
-.gu-media--show-controls-at-start.vjs-paused {
+.gu-media--show-controls-at-start {
     .vjs-control-bar {
         bottom: 0;
+        
+        @include mq($until: tablet) {
+            bottom: $gs-baseline*-5;
+        }
     }
-
-    .vjs-big-play-button .vjs-control-text {
-        &:before {
-            background-color: $media-default;
+    &.vjs-has-started.vjs-paused {
+        .vjs-control-bar {
+            bottom: 0;
         }
 
-        &:after {
-            border-left-color: #333333;
+        .vjs-big-play-button .vjs-control-text {
+            &:before {
+                background-color: $media-default;
+            }
+
+            &:after {
+                border-left-color: #333333;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, within the new-header test we're getting some horrible banding due to the placement of captions under video-main-media. If this becomes permanent we'll need to support youtube videos too. 

## This will not do
<img width="375" alt="screen shot 2017-02-24 at 15 57 30" src="https://cloud.githubusercontent.com/assets/14570016/23310307/049aa47a-faaa-11e6-8068-96e003e69846.png">

## This will do
<img width="374" alt="screen shot 2017-02-24 at 15 55 47" src="https://cloud.githubusercontent.com/assets/14570016/23310308/04a47568-faaa-11e6-9198-3502c5e91797.png">

When a video is main media AND has a caption AND there is a feature tone, you get this horrible white banding under the image to make room for the caption. Instead with a lot of help from @NataliaLKB I have used the caption toggle just like images that are main media. 