### PR TITLE
Liveblog: prevent share-numbers container from changing its height

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -538,16 +538,18 @@
 }
 
 .meta__numbers {
-    padding: $gs-baseline / 2 0;
+    padding-bottom: $gs-baseline / 2;
+    padding-top: $gs-baseline / 2;
     position: absolute;
     right: 0;
     top: 0;
 
     @include mq(leftCol) {
         border-top: 1px dotted $neutral-5;
-        position: static;
         height: 36px;
-        padding: $gs-baseline / 4 0;
+        padding-bottom: $gs-baseline / 4;
+        padding-top: $gs-baseline / 4;
+        position: static;
     }
 }
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -40,9 +40,12 @@ $block-padding-right: $gs-gutter;
 
         .meta__numbers {
             @include clearfix;
-            position: static;
-            border-top: 1px dotted $neutral-5;
             border-bottom: 0;
+            border-top: 1px dotted $neutral-5;
+            height: 36px;
+            padding-bottom: $gs-baseline / 4;
+            padding-top: $gs-baseline / 4;
+            position: static;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Prevents share-number container next to liveblog from changing its height, while fetching the counts.

## What is the value of this and can you measure success?

Less visual changes, happier users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
