### PR TITLE
engagement banner copy tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,6 +22,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-membership-engagement-banner-copy-test",
+    "Test copy for the engagement banner in all countries aside from the US and Australia",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 3, 10),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-paid-content-vs-outbrain",
     "Displays a paid content widget instead of Outbrain",
     owners = Seq(Owner.withGithub("regiskuckaertz")),

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -132,6 +132,11 @@ define([
                 return variant.id == ab.getTestVariantId(engagementBannerTest.id);
             }) : undefined;
 
+            // If we have found a copy test variant, then defer building the banner params to the variant.
+            if (engagementBannerTest && engagementBannerTest.id === 'MembershipEngagementBannerCopyTest' && userVariant) {
+                return userVariant.deriveBannerParams()
+            }
+
             // offering = 'membership' or 'contributions'
             var offering = Object.keys(userVariant?userVariant.params:paramsByOfferingForUserEdition)[0];
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -171,8 +171,8 @@ define([
 
     var CopyTest = function() {
         this.id = 'MembershipEngagementBannerCopyTest';
-        this.start = '2017-02-22'; // TODO
-        this.expiry = '2017-03-10'; // TODO
+        this.start = '2017-02-27';
+        this.expiry = '2017-03-13';
         this.author = 'Guy Dawson';
         this.description = 'Test different copy for the engagement banner.';
         this.audience = 0.5;

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -2,6 +2,7 @@ define([
     'bean',
     'qwery',
     'common/utils/config',
+    'common/utils/geolocation',
     'common/utils/storage',
     'common/utils/template',
     'commercial/modules/commercial-features',
@@ -11,6 +12,7 @@ define([
     bean,
     qwery,
     config,
+    geolocation,
     storage,
     template,
     commercialFeatures,
@@ -54,7 +56,6 @@ define([
 
     };
 
-
     EditionTest.prototype.addMessageVariant = function (variantId, variantParams) {
         this.variants.push({
             id: variantId,
@@ -79,9 +80,172 @@ define([
 
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
+    // Below are the 6 messages that are being tested, modulo the currency/amount which is dependent on the user's geolocation.
+    // The reader's geolocation is also used on the membership website to determine the currency/amount,
+    // therefore, the pricing should remain consistent between the engagement banner and the membership website.
+    //
+    // CONTROL
+    // For less than the price of a coffee a week, you could help secure the Guardian's future.
+    // Support our journalism for £5 a month.
+    //
+    // WEEKLY PRICE
+    // For less than the price of a coffee a week, you could help secure the Guardian's future.
+    // Support our journalism from 95p a week.
+    //
+    // SOCIAL PROOF
+    // Join hundreds of thousands of Guardian readers and help secure our future.
+    // Support our journalism today for just £5 a month.
+    //
+    // OPPORTUNITY
+    // If you’ve been thinking about supporting us, we’ve never needed you more.
+    // Support our journalism today for just £5 a month.
+    //
+    // SPEED
+    // It only takes two minutes to play your part in helping to secure the Guardian’s future.
+    // Support our journalism today for just £5 a month.
+    //
+    // LOW COST / BIG IMPACT
+    // From helping us hold power to account, to giving a voice to the voiceless, your money can do a lot of good.
+    // Support our journalism for just £5 a month.
 
-    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-06', 'remind_me_later')
-        .addMembershipVariant('control', {})
-        .addMembershipVariant('remind_me', {showRemindMe : true})
-    ];
+    // We don't want to run these tests on the US or Australia audience, as this would delay releasing them by ~ week.
+    function isNotInUSOrAU() {
+        var countryCode = geolocation.getSync();
+        return countryCode !== 'US' && countryCode !== 'AU'
+    }
+
+    // Prices taken from https://membership.theguardian.com/<region>/supporter
+    var monthlySupporterCost = {
+        GB:  '£5',
+        US:  'US$6.99',
+        AU:  'AU$10',
+        CA:  'CA$6.99',
+        EU:  '€4.99',
+        INT: 'US$6.99'
+    };
+
+    // today boolean argument accounts for the fact that some monthly CTA's contain the word 'today', and others don't
+    function monthlySupporterCta(today) {
+        var prefix;
+        if (today) {
+            prefix = 'Support our journalism today for just'
+        }
+        else {
+            prefix = 'Support our journalism for just'
+        }
+        return function() {
+            var region = geolocation.getSupporterPaymentRegion();
+            var cost = monthlySupporterCost[region];
+            return prefix + ' ' + cost + ' a month.'
+        }
+    }
+
+    var monthlySupporterCtaWithToday = monthlySupporterCta(true);
+
+    var monthlySupporterCtaWithoutToday = monthlySupporterCta(false);
+
+    // Prices based on https://membership.theguardian.com/<region>/supporter
+    var weeklySupporterCost = {
+        GB:  '95p',
+        US:  'US$1.33',
+        AU:  'AU$1.92',
+        CA:  'CA$1.33',
+        EU:  '€0.95',
+        INT: 'US$1.33'
+    };
+
+    function weeklySupporterCta() {
+        var region = geolocation.getSupporterPaymentRegion();
+        var cost = weeklySupporterCost[region];
+        return 'Support our journalism today from ' + cost + ' a week.'
+    }
+
+    function completer(complete) {
+        mediator.on('membership-message:display', function () {
+            // When the button link is clicked, call the function that indicates the A/B test is 'complete'
+            // ...note that for Membership & Contributions this completion is only the start of a longer
+            // journey that will hopefully end pages later with the user giving us money.
+            bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
+        });
+    }
+
+    var CopyTest = function() {
+        this.id = 'MembershipEngagementBannerCopyTest';
+        this.start = '2017-02-22'; // TODO
+        this.expiry = '2017-03-10'; // TODO
+        this.author = 'Guy Dawson';
+        this.description = 'Test different copy for the engagement banner.';
+        this.audience = 0.5;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'Supporter click-through rate and/or acquisition rate';
+        this.audienceCriteria = 'All readers.';
+        this.idealOutcome = 'We are able to establish which copy is best, with statistical significance';
+
+        this.canRun = function() {
+            return commercialFeatures.canReasonablyAskForMoney && isNotInUSOrAU();
+        };
+
+        this.variants = [];
+    };
+
+    // cta should be a function which returns the call-to-action which is placed after the message text.
+    CopyTest.prototype.addVariant = function(variantId, messageText, cta) {
+
+        this.variants.push({
+            id: variantId,
+
+            // We don't want to run any 'code' in this test, we just want a variant to be selected.
+            // All message display is performed in membership-engagement-banner.js,
+            // modifying the banner using the data in variantParams.
+            test: function () {},
+
+            success: completer,
+
+            // This allows a lot of the deriveBannerParams() logic (in membership-engagement-banner.js) to be by-passed.
+            // If that function has picked up a variant from the CopyTest test, call this method and be done with it.
+            deriveBannerParams: function() {
+                return {
+                    minArticles: 3,
+                    messageText: messageText + ' ' + cta(),
+                    colourStrategy: function() {
+                        return 'membership-prominent dark-blue'
+                    },
+                    linkUrl: 'https://membership.theguardian.com/supporter',
+                    buttonCaption: 'Become a Supporter',
+                    // TODO
+                    campaignCode: 'TODO!'
+                }
+            }
+        });
+
+        return this;
+    };
+
+    return [
+        new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-06', 'remind_me_later')
+            .addMembershipVariant('control', {})
+            .addMembershipVariant('remind_me', {showRemindMe : true}),
+
+        new CopyTest()
+            .addVariant(
+                'control',
+                'For less than the price of a coffee a week, you could help secure the Guardian’s future.',
+                monthlySupporterCtaWithoutToday
+            )
+            .addVariant(
+                'weekly_price',
+                'For less than the price of a coffee a week, you could help secure the Guardian’s future.',
+                weeklySupporterCta
+            )
+            .addVariant(
+                'social_proof',
+                'Join hundreds of thousands of Guardian readers and help secure our future.',
+                monthlySupporterCtaWithToday
+            )
+            .addVariant(
+                'opportunity',
+                'If you’ve been thinking about supporting us, we’ve never needed you more.',
+                monthlySupporterCtaWithToday
+            )
+    ]
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -191,6 +191,11 @@ define([
     // cta should be a function which returns the call-to-action which is placed after the message text.
     CopyTest.prototype.addVariant = function(variantId, messageText, cta) {
 
+        function createCampaignCode(variantId) {
+            // Campaign code follows convention. Talk to Alex for more information.
+            return 'gdnwb_copts_mem_kr3_learn_banner_copy_' + variantId;
+        }
+
         this.variants.push({
             id: variantId,
 
@@ -212,8 +217,7 @@ define([
                     },
                     linkUrl: 'https://membership.theguardian.com/supporter',
                     buttonCaption: 'Become a Supporter',
-                    // TODO
-                    campaignCode: 'TODO!'
+                    campaignCode: createCampaignCode(variantId)
                 }
             }
         });
@@ -226,6 +230,7 @@ define([
             .addMembershipVariant('control', {})
             .addMembershipVariant('remind_me', {showRemindMe : true}),
 
+        // Release the first 3 variants. The remaining 2 will be released when the 'Remind Me Later' test is complete.
         new CopyTest()
             .addVariant(
                 'control',

--- a/static/src/javascripts-legacy/projects/common/utils/geolocation.js
+++ b/static/src/javascripts-legacy/projects/common/utils/geolocation.js
@@ -121,7 +121,9 @@ define([
         'AX'
     ];
 
-    // Returns one of { GB, US, AU, CA, EU, INT }.
+    // Returns one of { GB, US, AU, CA, EU, INT }
+    // These are the different 'regions' we accept when taking payment.
+    // See https://membership.theguardian.com/uk/supporter# for more context.
     function getSupporterPaymentRegion() {
         var location = getSync();
         for (var i = 0; i < regionCountryCodes.length; i++) {

--- a/static/src/javascripts-legacy/projects/common/utils/geolocation.js
+++ b/static/src/javascripts-legacy/projects/common/utils/geolocation.js
@@ -10,7 +10,7 @@ define([
     storage
 ) {
     var location;
-    var storageKey = 'gu.geolocation'
+    var storageKey = 'gu.geolocation';
     var editionToGeolocationMap = {
         'UK' : 'GB',
         'US' : 'US',
@@ -51,14 +51,96 @@ define([
         });
     }
 
+    function getSync() {
+        var geolocationFromStorage = storage.local.get(storageKey);
+        return geolocationFromStorage ? geolocationFromStorage : editionToGeolocation(config.page.edition)
+    }
+
+    var regionCountryCodes = [
+        'AU',
+        'CA',
+        'GB',
+        'US'
+    ];
+
+    var europeCountryCodes = [
+        'AD',
+        'AL',
+        'AT',
+        'BA',
+        'BE',
+        'BG',
+        'BL',
+        'CH',
+        'CY',
+        'CZ',
+        'DE',
+        'DK',
+        'EE',
+        'ES',
+        'FI',
+        'FO',
+        'FR',
+        'GF',
+        'GL',
+        'GP',
+        'GR',
+        'HR',
+        'HU',
+        'IE',
+        'IT',
+        'LI',
+        'LT',
+        'LU',
+        'LV',
+        'MC',
+        'ME',
+        'MF',
+        'IS',
+        'MQ',
+        'MT',
+        'NL',
+        'NO',
+        'PF',
+        'PL',
+        'PM',
+        'PT',
+        'RE',
+        'RO',
+        'RS',
+        'SE',
+        'SI',
+        'SJ',
+        'SK',
+        'SM',
+        'TF',
+        'TR',
+        'WF',
+        'YT',
+        'VA',
+        'AX'
+    ];
+
+    // Returns one of { GB, US, AU, CA, EU, INT }.
+    function getSupporterPaymentRegion() {
+        var location = getSync();
+        for (var i = 0; i < regionCountryCodes.length; i++) {
+            if (location === regionCountryCodes[i]) {
+                return location;
+            }
+        }
+        for (var j = 0; j < europeCountryCodes.length; j++) {
+            if (location === europeCountryCodes[j]) {
+                return 'EU'
+            }
+        }
+        return 'INT';
+    }
+
     return {
         get: get,
-
-        getSync: function() {
-            var geolocationFromStorage = storage.local.get(storageKey);
-            return geolocationFromStorage ? geolocationFromStorage : editionToGeolocation(config.page.edition)
-        },
-
+        getSupporterPaymentRegion: getSupporterPaymentRegion,
+        getSync: getSync,
         init: init
     };
 });

--- a/static/src/javascripts-legacy/projects/common/utils/geolocation.js
+++ b/static/src/javascripts-legacy/projects/common/utils/geolocation.js
@@ -126,15 +126,11 @@ define([
     // See https://membership.theguardian.com/uk/supporter# for more context.
     function getSupporterPaymentRegion() {
         var location = getSync();
-        for (var i = 0; i < regionCountryCodes.length; i++) {
-            if (location === regionCountryCodes[i]) {
-                return location;
-            }
+        if (regionCountryCodes.indexOf(location) > -1) {
+            return location;
         }
-        for (var j = 0; j < europeCountryCodes.length; j++) {
-            if (location === europeCountryCodes[j]) {
-                return 'EU'
-            }
+        if (europeCountryCodes.indexOf(location) > -1) {
+            return 'EU';
         }
         return 'INT';
     }


### PR DESCRIPTION
@guardian/contributions 

## What does this change?

Tests 3 new copies for the membership engagement banner. For each variant, any reference to the cost of membership will be given in local currency (as defined by the reader's geo location). This should improve consistency between the banner and the membership website. As we are testing the copy, the colour of the banner (dark blue) has been kept consistent for this test.

## What is the value of this and can you measure success?

To find a copy with a higher conversion rate than the control. Success can be measured by conversion rate.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

### Control (Pounds)

![control_pounds](https://cloud.githubusercontent.com/assets/4085817/23311892/920f8942-faaf-11e6-9a90-31a46de5bb1c.jpg)

### Control (Euros)

![control_euros](https://cloud.githubusercontent.com/assets/4085817/23311916/a982a992-faaf-11e6-84c1-b08cee36e55f.jpg)

### Control (Canadian Dollars)

![control_ca_dollars](https://cloud.githubusercontent.com/assets/4085817/23311931/b34a91ec-faaf-11e6-8de6-eb9bb397333a.jpg)

### Control (US Dollars)

![control_us_dollars](https://cloud.githubusercontent.com/assets/4085817/23311942/bd595c54-faaf-11e6-9333-12af4005bde8.jpg)

### Weekly (Pounds)

![weekly_pounds](https://cloud.githubusercontent.com/assets/4085817/23311964/d8342518-faaf-11e6-829c-4585ce1d1892.jpg)

### Social Proof (Pounds)

![social_proof_pounds](https://cloud.githubusercontent.com/assets/4085817/23311973/df79baf4-faaf-11e6-9e3a-7bd653c94c3f.jpg)

### Opportunity (Pounds)

![opportunity_pounds](https://cloud.githubusercontent.com/assets/4085817/23311975/e4234f3e-faaf-11e6-8e9f-f358802017d2.jpg)

## Tested in CODE?

No. Tested locally.
