### PR TITLE
Amp Cleaner - Allow cleaning of elements embedded as element-embed

### DIFF
--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -107,7 +107,6 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
     }
 
     def getTrackIdFromUrl(soundcloudUrl: String): Option[String] = {
-      //val pattern = ".*api.soundcloud.com/tracks/(\\d+).*".r
       URLDecoder.decode(soundcloudUrl,"UTF-8") match {
         case soundCloudPattern(trackId) => {
           Some(trackId)}

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -462,7 +462,8 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
   /*
   * Element-embed cleaner:
-  * Only soundcloud elements should be converted. All other element-embed's should be removed
+  * Converts Soundcloud, Audioboom, Instagram, GoogleMaps and Eternal Video embeds.
+  * Embeds that don't match any of these types others are removed.
   */
 
   "AmpEmbedCleaner" should "replace an iframe in an element that has a src url from soundcloud.com with an amp-soundcloud element" in {
@@ -478,9 +479,10 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   "AmpEmbedCleaner" should " not create an amp-soundcloud element from an iframe src that does not have a track id" in {
     val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlNoTrackId)
     result.getElementsByTag("amp-soundcloud").size should be (0)
+    result.getElementsByTag("amp-iframe").size should be (0)
   }
 
-  "AmpEmbedCleaner" should "not add an amp-soundcloud element if an element-embed does not contain an iframe" in {
+  "AmpEmbedCleaner" should "not add any kind of amp element if an element-embed does not contain an iframe" in {
     val doc = <html>
                   <body>
                     <figure class="element-embed"></figure>
@@ -488,7 +490,28 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
               </html>.toString()
     val document: Document = parseTestData(doc)
     val result: Document = clean(document)
+    result.getElementsByTag("iframe").size should be(0)
+    result.getElementsByTag("amp-iframe").size should be(0)
     result.getElementsByTag("amp-soundcloud").size should be(0)
+    result.getElementsByTag("amp-instagram").size should be(0)
+    result.getElementsByTag("amp-youtube").size should be(0)
+    result.getElementsByTag("amp-vimeo").size should be(0)
+    result.getElementsByTag("amp-facebook").size should be(0)
+  }
+
+  "AmpEmbedCleaner" should "not add an amp-iframe element, if an element-embed contains an iframe with src url from any unknown src" in {
+    val frameborder = "0"
+    val width = "460"
+    val height = "300"
+    val src = "http://www.someotherurl.com/video/123"
+    val result: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
+    result.getElementsByTag("iframe").size should be (0)
+    result.getElementsByTag("amp-iframe").size should be (0)
+    result.getElementsByTag("amp-soundcloud").size should be (0)
+    result.getElementsByTag("amp-instagram").size should be(0)
+    result.getElementsByTag("amp-youtube").size should be(0)
+    result.getElementsByTag("amp-vimeo").size should be(0)
+    result.getElementsByTag("amp-facebook").size should be(0)
   }
 
   "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with src url from audioboom.com" in {
@@ -496,42 +519,19 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     val width = "460"
     val height = "300"
     val src = audioBoomUrl
-    val document: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
-    val result = document.getElementsByTag("amp-iframe").size
-    result should be (1)
-  }
-
-  "AmpEmbedCleaner" should "not add an amp-iframe element, if an element-embed contains an iframe with src url from any expected src" in {
-    val frameborder = "0"
-    val width = "460"
-    val height = "300"
-    val src = "http://www.someotherurl.com/video/123"
-    val cleanDoc: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
-    val result = (cleanDoc.getElementsByTag("amp-iframe").size, cleanDoc.getElementsByTag("amp-soundcloud").size)
-    result should be ((0,0))
-  }
-
-  "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with a known external video src url " in {
-    val document = cleanDocumentWithVideos("element-embed", "https://vimeo.com/1234")
-    val result = document.getElementsByTag("amp-vimeo").size
-    result should be (1)
+    val result: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
+    result.getElementsByTag("amp-iframe").size should be (1)
+    result.getElementsByTag("amp-iframe").first.attr("src") should be(audioBoomUrl)
   }
 
   "AmpEmbedCleaner" should "add an amp-instagram element, if an element-embed contains an iframe with a valid instagram src url " in {
     val document = <figure class="element element-instagram">
-      <blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
         <div style="padding:8px;">
-          <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;">
-            <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div>
-          </div>
-          <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BB0CN8PMWdz/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank" data-link-name="in body link" class="u-underline">Happy Presidents' Day! Mr presidents are on sale. Original $2.25 and littles $1. And Cin-Ful cinnamon rolls are $2!! #hurrybeforeitsgone</a></p>
-          <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A photo posted by FAT Cupcake (@fatcupcakeor) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-02-15T16:07:32+00:00">Feb 15, 2016 at 8:07am PST</time></p>
+          <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BB0CN8PMWdz/">Happy Presidents' Day! Mr presidents are on sale. Original $2.25 and littles $1. And Cin-Ful cinnamon rolls are $2!! #hurrybeforeitsgone</a></p>
         </div>
-      </blockquote>
     </figure>.toString()
 
     val result = clean(parseTestData(document))
-    val src = "https://www.instagram.com/p/BB0CN8PMWdz/"
     val shortcode = "BB0CN8PMWdz"
 
     result.getElementsByTag("amp-instagram").size should be(1)
@@ -544,6 +544,39 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with a valid google maps src url " in {
     val result: Document = cleanDocumentWithMapsEmbed("element-embed", googleMapsUrl)
     result.getElementsByTag("amp-iframe").size should be(1)
+    result.getElementsByTag("amp-iframe").first.attr("src") should be (googleMapsUrl)
   }
+
+  "AmpEmbedCleaner" should "replace an iframe an embed-element, that contains a YouTube video with an amp-youtube element" in {
+    val result = cleanDocumentWithVideos("element-embed", "https://www.youtube.com/watch?v=foo_12-34")
+    result.getElementsByTag("amp-youtube").size should be(1)
+    result.getElementsByTag("amp-youtube").attr("data-videoid") should be("foo_12-34")
+    result.getElementsByTag("amp-youtube").attr("width") should be("5")
+    result.getElementsByTag("amp-youtube").attr("height") should be("3")
+    result.getElementsByTag("amp-youtube").attr("layout") should be("responsive")
+  }
+
+  "AmpEmbedCleaner" should "replace an iframe an embed-element, that contains a Vimeo video with an amp-vimeo element" in {
+    val result = cleanDocumentWithVideos("element-embed", "https://vimeo.com/1234")
+    result.getElementsByTag("amp-vimeo").size should be (1)
+    result.getElementsByTag("amp-vimeo").attr("data-videoid") should be("1234")
+    result.getElementsByTag("amp-vimeo").attr("width") should be("5")
+    result.getElementsByTag("amp-vimeo").attr("height") should be("3")
+    result.getElementsByTag("amp-vimeo").attr("layout") should be("responsive")
+  }
+
+  "AmpEmbedCleaner" should "replace an iframe an embed-element, that contains a Facebook video with an amp-facebook element" in {
+    val faceookVideoId = "123456"
+    val facebookVideoUrl = s"https://www.facebook.com/theguardian/videos/$faceookVideoId/"
+    val result = cleanDocumentWithVideos("element-embed", facebookVideoUrl)
+    result.getElementsByTag("amp-facebook").size should be(1)
+    result.getElementsByTag("amp-facebook").attr("data-href") should be(s"https://www.facebook.com/theguardian/videos/$faceookVideoId")
+    result.getElementsByTag("amp-facebook").attr("data-embed-as") should be("video")
+    result.getElementsByTag("amp-facebook").attr("width") should be("5")
+    result.getElementsByTag("amp-facebook").attr("height") should be("3")
+    result.getElementsByTag("amp-facebook").attr("layout") should be("responsive")
+  }
+
+
 
 }

--- a/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpEmbedCleanerTest.scala
@@ -52,11 +52,11 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     Article.make(content)
   }
 
-  private def cleanDocumentWithVideos(videoUrls: String*): Document = {
+  private def cleanDocumentWithVideos(elementType: String, videoUrls: String*): Document = {
     val doc = <html>
                   <body>
                      {
-                        videoUrls.map { url: String => <figure class="element-video" data-canonical-url={url}>
+                        videoUrls.map { url: String => <figure class={elementType} data-canonical-url={url}>
                           <iframe></iframe>
                         </figure>
                         }
@@ -65,15 +65,6 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
               </html>.toString()
     val document: Document = parseTestData(doc)
     clean(document)
-  }
-
-
-/*
- * The format we are using for the test data - while eminently readable - is treated as XML when toString() is run on it.
- * To parse it into a JSoup element, it is necessary to remove all the XML character encodings that have been introduced.
- */
-  private def parseTestData(doc: String):Document = {
-    Jsoup.parse(StringEscapeUtils.unescapeXml(doc))
   }
 
   private def cleanDocumentWithAudioEmbed(elementType: String, frameborder: String, width: String, height: String, src: String): Document = {
@@ -94,6 +85,20 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     clean(document)
   }
 
+  private def cleanDocumentWithMapsEmbed(elementType: String, src: String): Document = {
+
+    val iframe = if(src.nonEmpty) s"<iframe src='$src'></iframe>" else ""
+
+    val doc = <html>
+      <body>
+        <figure class={elementType}>
+          {iframe}
+        </figure>
+      </body>
+    </html>.toString()
+    val document: Document = parseTestData(doc)
+    clean(document)
+  }
 
   private def cleanDocumentWithCommentEmbed(className: String, src: String, width: String, height: String, alt: String): Document = {
     val classString = if(className.nonEmpty) s"class='$className' " else ""
@@ -105,19 +110,27 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
     val doc = <html>
       <body>
-       <figure class="element element-comment" data-canonical-url="https://discussion.theguardian.com/comment-permalink/88222201">
-        <div class="d2-comment-embedded" itemtype="http://schema.org/Comment">
-          <div class="d2-left-col">
-            <a href="https://profile.theguardian.com/user/id/12345678">
-              {avatarImage}
-            </a>
+        <figure class="element element-comment" data-canonical-url="https://discussion.theguardian.com/comment-permalink/88222201">
+          <div class="d2-comment-embedded" itemtype="http://schema.org/Comment">
+            <div class="d2-left-col">
+              <a href="https://profile.theguardian.com/user/id/12345678">
+                {avatarImage}
+              </a>
+            </div>
           </div>
-        </div>
-       </figure>
+        </figure>
       </body>
     </html>.toString()
     val document: Document = parseTestData(doc)
     clean(document)
+  }
+
+  /*
+ * The format we are using for the test data - while eminently readable - is treated as XML when toString() is run on it.
+ * To parse it into a JSoup element, it is necessary to remove all the XML character encodings that have been introduced.
+ */
+  private def parseTestData(doc: String):Document = {
+    Jsoup.parse(StringEscapeUtils.unescapeXml(doc))
   }
 
 
@@ -126,12 +139,12 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
    */
 
   "AmpEmbedCleaner" should "replace an iframe in a http YouTube video-element with an amp-youtube element" in {
-    val result = cleanDocumentWithVideos("http://www.youtube.com/watch?v=foo_12-34")
+    val result = cleanDocumentWithVideos("element-video", "http://www.youtube.com/watch?v=foo_12-34")
     result.getElementsByTag("amp-youtube").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https YouTube video-element with an amp-youtube element" in {
-    val result = cleanDocumentWithVideos("https://www.youtube.com/watch?v=foo_12-34")
+    val result = cleanDocumentWithVideos("element-video", "https://www.youtube.com/watch?v=foo_12-34")
     result.getElementsByTag("amp-youtube").size should be(1)
     result.getElementsByTag("amp-youtube").attr("data-videoid") should be("foo_12-34")
     result.getElementsByTag("amp-youtube").attr("width") should be("5")
@@ -140,7 +153,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake YouTube video-element with an amp-youtube element" in {
-    val result = cleanDocumentWithVideos(
+    val result = cleanDocumentWithVideos("element-video",
       "http://www.youtube.com.de/watch?v=foo_12-34",
       "http://myyoutube.com/watch?v=foo_12-34",
       "https://www.youtuber.com/watch?v=foo_12-34"
@@ -149,17 +162,17 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not create an amp-youtube element if videoid missing" in {
-    val result = cleanDocumentWithVideos("https://www.youtube.com/")
+    val result = cleanDocumentWithVideos("element-video", "https://www.youtube.com/")
     result.getElementsByTag("amp-youtube").size should be(0)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a http Vimeo video-element with an amp-vimeo element" in {
-    val result = cleanDocumentWithVideos("http://vimeo.com/1234")
+    val result = cleanDocumentWithVideos("element-video", "http://vimeo.com/1234")
     result.getElementsByTag("amp-vimeo").size should be(1)
   }
 
   "AmpEmbedCleaner" should "replace an iframe in a https Vimeo video-element with an amp-vimeo element" in {
-    val result = cleanDocumentWithVideos("https://vimeo.com/1234")
+    val result = cleanDocumentWithVideos("element-video", "https://vimeo.com/1234")
     result.getElementsByTag("amp-vimeo").size should be(1)
     result.getElementsByTag("amp-vimeo").attr("data-videoid") should be("1234")
     result.getElementsByTag("amp-vimeo").attr("width") should be("5")
@@ -168,7 +181,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake Vimeo video-element with an amp-vimeo element" in {
-    val result = cleanDocumentWithVideos(
+    val result = cleanDocumentWithVideos("element-video",
       "https://vimeo.com.zz/1234",
       "https://vimeofake.com/1234",
       "https://myvimeo.com/1234"
@@ -177,14 +190,14 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
   }
 
   "AmpEmbedCleaner" should "not create an amp-vimeo element if videoid missing" in {
-    val result = cleanDocumentWithVideos("https://vimeo.com/")
+    val result = cleanDocumentWithVideos("element-video", "https://vimeo.com/")
     result.getElementsByTag("amp-vimeo").size should be(0)
   }
 
   "AmpEmbedCleaner" should "replace a facebook video embed with a valid amp-facebook video embed" in {
     val faceookVideoId = "123456"
     val facebookVideoUrl = s"https://www.facebook.com/theguardian/videos/$faceookVideoId/"
-    val result = cleanDocumentWithVideos(facebookVideoUrl)
+    val result = cleanDocumentWithVideos("element-video", facebookVideoUrl)
     result.getElementsByTag("amp-facebook").size should be(1)
     result.getElementsByTag("amp-facebook").attr("data-href") should be(s"https://www.facebook.com/theguardian/videos/$faceookVideoId")
     result.getElementsByTag("amp-facebook").attr("data-embed-as") should be("video")
@@ -197,7 +210,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     val facebookOrganisationId = "Channel4"
     val faceookVideoId = "10154084521542330"
     val facebookVideoUrl = s"https://www.facebook.com/$facebookOrganisationId/videos/$faceookVideoId/"
-    val result = cleanDocumentWithVideos(facebookVideoUrl)
+    val result = cleanDocumentWithVideos("element-video", facebookVideoUrl)
     result.getElementsByTag("amp-facebook").size should be(1)
     result.getElementsByTag("amp-facebook").attr("data-href") should be(s"https://www.facebook.com/$facebookOrganisationId/videos/$faceookVideoId")
     result.getElementsByTag("amp-facebook").attr("data-embed-as") should be("video")
@@ -210,24 +223,24 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     val facebookOrganisationId = "Channel.4"
     val faceookVideoId = "10154084521542330"
     val facebookVideoUrl = s"https://www.facebook.com/$facebookOrganisationId/videos/$faceookVideoId/"
-    val result = cleanDocumentWithVideos(facebookVideoUrl)
+    val result = cleanDocumentWithVideos("element-video", facebookVideoUrl)
     result.getElementsByTag("amp-facebook").size should be(1)
   }
 
   "AmpEmbedCleaner" should "not replace an iframe in a fake Facebook video-element with an amp-facebook element" in {
-    val result = cleanDocumentWithVideos(
+    val result = cleanDocumentWithVideos("element-video",
       "https://www.facebook.com.zz/theguardian/123456/"
     )
     result.getElementsByTag("amp-facebook").size should be(0)
   }
 
   "AmpEmbedCleaner" should "not create an amp-facebook element if videoid missing" in {
-    val result = cleanDocumentWithVideos("https://www.facebook.com/theguardian/videos/")
+    val result = cleanDocumentWithVideos("element-video", "https://www.facebook.com/theguardian/videos/")
     result.getElementsByTag("amp-facebook").size should be(0)
   }
 
   "AmpEmbedCleaner" should "be able to create an amp-youtube element, an amp-vimeo element and an amp facebook element in the same document" in {
-    val result = cleanDocumentWithVideos(
+    val result = cleanDocumentWithVideos("element-video",
       "https://www.youtube.com/watch?v=foo_12-34",
       "https://vimeo.com/1234",
       "https://www.facebook.com/theguardian/videos/123456/"
@@ -372,49 +385,6 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
 
 
   /*
-  * Element-embed cleaner:
-  * Only soundcloud elements should be converted. All other element-embed's should be removed
-  */
-
-  "AmpEmbedCleaner" should "replace an iframe in an audio-element that has a src url from soundcloud.com with an amp-soundcloud element" in {
-    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlV2)
-    result.getElementsByTag("amp-soundcloud").size should be(1)
-  }
-
-  "AmpEmbedCleaner" should "create an amp-soundcloud element with a trackid from an iframe src tht contains a url from soundcloud.com" in {
-    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlV1)
-    result.getElementsByTag("amp-soundcloud").first.attr("data-trackid") should be(soundcloudTrackid.toString)
-  }
-
-  "AmpEmbedCleaner" should " not create an amp-soundcloud element from an iframe src that does not have a track id" in {
-    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlNoTrackId)
-    result.getElementsByTag("amp-soundcloud").size should be (0)
-  }
-
-  "AmpEmbedCleaner" should "not add an amp-iframe or amp-soundcloud element, if an audio element contains an iframe with src url from that is not from soundcloud.com" in {
-    val frameborder = "0"
-    val width = "460"
-    val height = "300"
-    val src = audioBoomUrl
-    val cleanDoc: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
-    val result = (cleanDoc.getElementsByTag("amp-iframe").size, cleanDoc.getElementsByTag("amp-soundcloud").size)
-    result should be ((0,0))
-  }
-
-  "AmpEmbedCleaner" should "not add an amp-soundcloud element if an audio element does not contain an iframe" in {
-    val doc = <html>
-                  <body>
-                    <figure class="element-audio"></figure>
-                  </body>
-              </html>.toString()
-    val document: Document = parseTestData(doc)
-    val result: Document = clean(document)
-    result.getElementsByTag("amp-soundcloud").size should be(0)
-  }
-
-
-
-  /*
   *  Maps cleaner
   */
 
@@ -429,6 +399,7 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     val document: Document = parseTestData(doc)
     val result: Document = clean(document)
     result.getElementsByTag("amp-iframe").size should be(1)
+    result.getElementsByTag("amp-iframe").first.attr("src") should be(googleMapsUrl)
   }
 
   "AmpEmbedCleaner" should "not add an amp-iframe element if an map element does not contain an iframe" in {
@@ -438,21 +409,8 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
                   </body>
               </html>.toString()
     val document: Document = parseTestData(doc)
-    val result: Document = clean(document)
+    val result: Document = cleanDocumentWithMapsEmbed("element-map", "")
     result.getElementsByTag("amp-iframe").size should be(0)
-  }
-
-  "AmpEmbedCleaner" should "create an amp-iframe element with an iframe from the iframe src" in {
-    val doc = <html>
-                  <body>
-                    <figure class="element-map">
-                      <iframe src={googleMapsUrl}></iframe>
-                    </figure>
-                  </body>
-              </html>.toString()
-    val document: Document = parseTestData(doc)
-    val result: Document = clean(document)
-    result.getElementsByTag("amp-iframe").first.attr("src") should be(googleMapsUrl)
   }
 
 
@@ -500,5 +458,92 @@ class AmpEmbedCleanerTest extends FlatSpec with Matchers {
     result.getElementsByTag("amp-img").size + result.getElementsByTag("img").size should be(0)
   }
 
+
+
+  /*
+  * Element-embed cleaner:
+  * Only soundcloud elements should be converted. All other element-embed's should be removed
+  */
+
+  "AmpEmbedCleaner" should "replace an iframe in an element that has a src url from soundcloud.com with an amp-soundcloud element" in {
+    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlV2)
+    result.getElementsByTag("amp-soundcloud").size should be(1)
+  }
+
+  "AmpEmbedCleaner" should "create an amp-soundcloud element with a trackid from an iframe src that contains a url from soundcloud.com" in {
+    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlV1)
+    result.getElementsByTag("amp-soundcloud").first.attr("data-trackid") should be(soundcloudTrackid.toString)
+  }
+
+  "AmpEmbedCleaner" should " not create an amp-soundcloud element from an iframe src that does not have a track id" in {
+    val result: Document = cleanDocumentWithAudioEmbed("element-embed", "", "", "", soundcloudUrlNoTrackId)
+    result.getElementsByTag("amp-soundcloud").size should be (0)
+  }
+
+  "AmpEmbedCleaner" should "not add an amp-soundcloud element if an element-embed does not contain an iframe" in {
+    val doc = <html>
+                  <body>
+                    <figure class="element-embed"></figure>
+                  </body>
+              </html>.toString()
+    val document: Document = parseTestData(doc)
+    val result: Document = clean(document)
+    result.getElementsByTag("amp-soundcloud").size should be(0)
+  }
+
+  "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with src url from audioboom.com" in {
+    val frameborder = "0"
+    val width = "460"
+    val height = "300"
+    val src = audioBoomUrl
+    val document: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
+    val result = document.getElementsByTag("amp-iframe").size
+    result should be (1)
+  }
+
+  "AmpEmbedCleaner" should "not add an amp-iframe element, if an element-embed contains an iframe with src url from any expected src" in {
+    val frameborder = "0"
+    val width = "460"
+    val height = "300"
+    val src = "http://www.someotherurl.com/video/123"
+    val cleanDoc: Document = cleanDocumentWithAudioEmbed("element-embed", frameborder, width, height, src)
+    val result = (cleanDoc.getElementsByTag("amp-iframe").size, cleanDoc.getElementsByTag("amp-soundcloud").size)
+    result should be ((0,0))
+  }
+
+  "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with a known external video src url " in {
+    val document = cleanDocumentWithVideos("element-embed", "https://vimeo.com/1234")
+    val result = document.getElementsByTag("amp-vimeo").size
+    result should be (1)
+  }
+
+  "AmpEmbedCleaner" should "add an amp-instagram element, if an element-embed contains an iframe with a valid instagram src url " in {
+    val document = <figure class="element element-instagram">
+      <blockquote class="instagram-media" data-instgrm-version="7" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
+        <div style="padding:8px;">
+          <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;">
+            <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAMUExURczMzPf399fX1+bm5mzY9AMAAADiSURBVDjLvZXbEsMgCES5/P8/t9FuRVCRmU73JWlzosgSIIZURCjo/ad+EQJJB4Hv8BFt+IDpQoCx1wjOSBFhh2XssxEIYn3ulI/6MNReE07UIWJEv8UEOWDS88LY97kqyTliJKKtuYBbruAyVh5wOHiXmpi5we58Ek028czwyuQdLKPG1Bkb4NnM+VeAnfHqn1k4+GPT6uGQcvu2h2OVuIf/gWUFyy8OWEpdyZSa3aVCqpVoVvzZZ2VTnn2wU8qzVjDDetO90GSy9mVLqtgYSy231MxrY6I2gGqjrTY0L8fxCxfCBbhWrsYYAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div>
+          </div>
+          <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/p/BB0CN8PMWdz/" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank" data-link-name="in body link" class="u-underline">Happy Presidents' Day! Mr presidents are on sale. Original $2.25 and littles $1. And Cin-Ful cinnamon rolls are $2!! #hurrybeforeitsgone</a></p>
+          <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A photo posted by FAT Cupcake (@fatcupcakeor) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-02-15T16:07:32+00:00">Feb 15, 2016 at 8:07am PST</time></p>
+        </div>
+      </blockquote>
+    </figure>.toString()
+
+    val result = clean(parseTestData(document))
+    val src = "https://www.instagram.com/p/BB0CN8PMWdz/"
+    val shortcode = "BB0CN8PMWdz"
+
+    result.getElementsByTag("amp-instagram").size should be(1)
+    result.getElementsByTag("amp-instagram").attr("width") should be ("7")
+    result.getElementsByTag("amp-instagram").attr("height") should be ("8")
+    result.getElementsByTag("amp-instagram").attr("layout") should be ("responsive")
+    result.getElementsByTag("amp-instagram").attr("data-shortcode") should be (shortcode)
+  }
+
+  "AmpEmbedCleaner" should "add an amp-iframe element, if an element-embed contains an iframe with a valid google maps src url " in {
+    val result: Document = cleanDocumentWithMapsEmbed("element-embed", googleMapsUrl)
+    result.getElementsByTag("amp-iframe").size should be(1)
+  }
 
 }


### PR DESCRIPTION
Certain frequently used page elements, including youtube, vimeo and googleMaps, can be embedded in composer using embed code rather than a url. When this happens they are created inside a figure container of class "element-embed" instead of "element-<embed-type>".
Our current cleaner removes any embeds of this type (with the exception of soundcloud embeds).
This change is to allow the embedding of other embed types frequently added in this way.

Embed types that will now display on amp even if in an "element-embed" figure are:
- soundcloud 
- audioboom (the other commonly used audio embed)
- external videos (eg: youtube, facebook and vimeo)
- instagram
- googlemap

This passes all tests and passes the make validate-amp test
## Tested in CODE?
Nope

As mentioned above, this is working, but I suspect there are more elegant ways to achieve this and am keen for suggestions.
cc @guardian/dotcom-platform 