### PR TITLE
Live-blog: prevent sidebar from jumping, by inlining CSS

### DIFF
--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -16,6 +16,7 @@
 @import 'module/content/_article';
 @import 'module/content/_content';
 @import 'module/content/_media.head';
+@import 'module/content/live-blog/_live-blog.head';
 @import 'module/_breadcrumbs';
 @import 'module/_social';
 @import 'module/_layout-hints';

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -11,15 +11,6 @@ $block-padding-right: $gs-gutter;
 }
 
 .content__main-column--liveblog {
-    @include mq(desktop) {
-        margin-left: $right-column + $gs-gutter;
-        margin-right: 0;
-        max-width: none;
-    }
-    @include mq(wide) {
-        margin-right: gs-span(4) + $gs-gutter;
-    }
-
     .caption--main {
         padding-bottom: 0;
     }
@@ -31,13 +22,6 @@ $block-padding-right: $gs-gutter;
     border-bottom: 0;
 
     @include mq(desktop) {
-        border-top: 0;
-        padding-top: 0;
-        margin-left: 0;
-        width: $right-column;
-        min-height: gs-height(1)*1.5;
-        position: static;
-
         .meta__numbers {
             @include clearfix;
             position: static;
@@ -69,14 +53,6 @@ $block-padding-right: $gs-gutter;
             top: $gs-baseline/1.5;
         }
     }
-}
-
-.content__updated-container--liveblog {
-    @include fs-textSans(1);
-    padding: $gs-baseline/6 0;
-    margin-left: -($right-column + $gs-gutter);
-    position: absolute;
-    top: 0;
 }
 
 /* Timestamps
@@ -825,15 +801,6 @@ $timeline-width: 15px;
         }
     }
 
-    .content__labels {
-        @include mq(desktop) {
-            float: left;
-            width: gs-span(3);
-            margin-left: (gs-span(4) + $gs-gutter) * -1;
-            border-bottom: 0;
-        }
-    }
-
     .content__section-label {
         @include mq(desktop) {
             @include fs-header(3);
@@ -852,16 +819,6 @@ $timeline-width: 15px;
         @include mq($until: wide) {
             display: none;
         }
-    }
-}
-
-@include mq(desktop) {
-    .blog__left-col {
-        position: absolute;
-        top: 0;
-        z-index: 200;
-        margin-left: ($right-column + $gs-gutter) * - 1;
-        width: $right-column;
     }
 }
 

--- a/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
@@ -1,0 +1,50 @@
+&.content__main-column--liveblog {
+    @include mq(desktop) {
+        margin-left: gs-span(4) + $gs-gutter;
+        margin-right: 0;
+        max-width: none;
+    }
+
+    @include mq(wide) {
+        margin-right: gs-span(4) + $gs-gutter;
+    }
+}
+
+.content__meta-container--liveblog {
+    @include mq(desktop) {
+        border-top: 0;
+        margin-left: 0;
+        min-height: gs-height(1)*1.5;
+        padding-top: 0;
+        position: static;
+        width: 100%;
+    }
+}
+
+.content__updated-container--liveblog {
+    @include fs-textSans(1);
+    padding-bottom: $gs-baseline / 6;
+    padding-top: $gs-baseline / 6;
+    margin-left: -($right-column + $gs-gutter);
+    position: absolute;
+    top: 0;
+}
+
+.content__labels {
+    @include mq(desktop) {
+        float: left;
+        width: gs-span(3);
+        margin-left: (gs-span(4) + $gs-gutter) * -1;
+        border-bottom: 0;
+    }
+}
+
+@include mq(desktop) {
+    .blog__left-col {
+        position: absolute;
+        top: 0;
+        z-index: 200;
+        left: ($right-column + $gs-gutter) * - 1;
+        width: $right-column;
+    }
+}


### PR DESCRIPTION
## What does this change?

Inlines more CSS in order to prevent the left sidebar of live-blogsfrom jumping, while waiting for async loaded styles.

However, there are a few more issues to discuss:

- timeline content in the left sidebar looks unstyled, till all CSS is loaded
- content in the right column flashes, because of missing default styles

Both don't trigger any column-width changes, but create the feeling of a flickering page.

## What is the value of this and can you measure success?

Less flickering leads to better a UX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** before **

![kapture 2017-02-27 at 13 16 40](https://cloud.githubusercontent.com/assets/2244375/23362854/97abea20-fcef-11e6-8d9c-61be37acc8ea.gif)

** after **

![kapture 2017-02-27 at 13 20 46](https://cloud.githubusercontent.com/assets/2244375/23362853/97939650-fcef-11e6-8891-ced5f5d9a5bf.gif)

## Tested in CODE?

No.

