### PR TITLE
Remind me banner test extension.

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -80,7 +80,7 @@ define([
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
 
-    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-02-28', 'remind_me_later')
+    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-04', 'remind_me_later')
         .addMembershipVariant('control', {})
         .addMembershipVariant('remind_me', {showRemindMe : true})
     ];

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -80,7 +80,7 @@ define([
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
 
-    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-04', 'remind_me_later')
+    return [new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-06', 'remind_me_later')
         .addMembershipVariant('control', {})
         .addMembershipVariant('remind_me', {showRemindMe : true})
     ];


### PR DESCRIPTION
## What does this change?

It extends the length of the test. We need to gather more data in order to come up with a final decision about the test.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
