### PR TITLE
Facia: fix broken description alignment for documentaries container

### DIFF
--- a/static/src/stylesheets/inline/story-package.scss
+++ b/static/src/stylesheets/inline/story-package.scss
@@ -31,6 +31,7 @@
     .fc-container__header__title {
         border-top-color: $story-package;
         color: $news-support-2;
+        float: none;
 
         & a:hover {
             color: $story-package;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -106,17 +106,14 @@ $header-image-size-desktop: 100px;
 
         .fc-container__header__title {
             float: left;
-        }
-        .fc-container__header__description {
-            float: right;
-        }
-        .fc-container__header__title {
             padding-right: $gs-gutter / 4;
         }
+
         .fc-container__header__description {
             margin-top: 2px;
             text-align: left;
         }
+
         .fc-container--tag & {
             border-bottom: 0;
         }
@@ -250,7 +247,6 @@ $header-image-size-desktop: 100px;
     @include fs-headline(2);
     padding-bottom: $gs-baseline / 2;
     color: $neutral-2;
-    text-align: right;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline;
@@ -261,7 +257,6 @@ $header-image-size-desktop: 100px;
         clear: left;
         float: left;
         margin-top: 0;
-        text-align: left;
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?

Fixes a styling regression on documentaries container seen [here](https://www.theguardian.com/video). [Trello reference](https://trello.com/c/ZnKr7jdG/234-glitch-in-documentaries-container). This is the second try after [the initial PR](https://github.com/guardian/frontend/pull/15946) [got reverted](https://github.com/guardian/frontend/pull/15956).

## What is the value of this and can you measure success?

Better styling, happier users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![screen shot 2017-02-24 at 11 34 48](https://cloud.githubusercontent.com/assets/2244375/23302173/8637bdb2-fa85-11e6-8789-dab785b63d8e.png)
![screen shot 2017-02-24 at 11 34 37](https://cloud.githubusercontent.com/assets/2244375/23302174/863a7390-fa85-11e6-8a41-35868fefe669.png)
![screen shot 2017-02-24 at 11 34 26](https://cloud.githubusercontent.com/assets/2244375/23302175/863be856-fa85-11e6-83e1-4f30032c7418.png)

** proper weather alignment **

![screen shot 2017-02-27 at 15 05 40](https://cloud.githubusercontent.com/assets/2244375/23366340/39ff2374-fcfe-11e6-92e8-e7a13ed53eb3.png)
![screen shot 2017-02-27 at 15 05 31](https://cloud.githubusercontent.com/assets/2244375/23366342/3a058e3a-fcfe-11e6-91f0-819e3ee3115b.png)


## Tested in CODE?

No.


