### PR TITLE
Send campaign codes to ophan

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -141,7 +141,7 @@ define([
         this.maxViews = options.maxViews || maxViews;
         this.isUnlimited = options.isUnlimited || false;
 
-        this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'NOT_FOUND';
+        this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'not_found';
         this.contributeCampaignCode = getCampaignCode(test.contributionsCampaignPrefix, this.campaignId, this.id);
         this.membershipCampaignCode = getCampaignCode(test.membershipCampaignPrefix, this.campaignId, this.id);
         this.campaignCodes = uniq([this.contributeCampaignCode, this.membershipCampaignCode]);

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -1,4 +1,5 @@
 define([
+    'lodash/arrays/uniq',
     'commercial/modules/commercial-features',
     'common/modules/commercial/targeting-tool',
     'common/modules/commercial/acquisitions-view-log',
@@ -12,20 +13,22 @@ define([
     'common/utils/geolocation',
     'common/utils/template',
     'raw-loader!common/views/contributions-epic-equal-buttons.html'
-
-], function (commercialFeatures,
-             targetingTool,
-             viewLog,
-             $,
-             config,
-             cookies,
-             ElementInView,
-             fastdom,
-             mediator,
-             storage,
-             geolocation,
-             template,
-             contributionsEpicEqualButtons) {
+], function (
+    uniq,
+    commercialFeatures,
+    targetingTool,
+    viewLog,
+    $,
+    config,
+    cookies,
+    ElementInView,
+    fastdom,
+    mediator,
+    storage,
+    geolocation,
+    template,
+    contributionsEpicEqualButtons
+) {
 
     var membershipURL = 'https://membership.theguardian.com/supporter';
     var contributionsURL = 'https://contribute.theguardian.com';
@@ -141,7 +144,7 @@ define([
         this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'NOT_FOUND';
         this.contributeCampaignCode = getCampaignCode(test.contributionsCampaignPrefix, this.campaignId, this.id);
         this.membershipCampaignCode = getCampaignCode(test.membershipCampaignPrefix, this.campaignId, this.id);
-        this.campaignCodes = [this.contributeCampaignCode, this.membershipCampaignCode];
+        this.campaignCodes = uniq([this.contributeCampaignCode, this.membershipCampaignCode]);
 
         this.contributeURL = options.contributeURL || this.makeURL(contributionsURL, this.contributeCampaignCode);
         this.membershipURL = options.membershipURL || this.makeURL(membershipURL, this.membershipCampaignCode);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -164,11 +164,17 @@ define([
         return tag.join(',');
     }
 
-    function abData(variantName, complete) {
-        return {
+    function abData(variantName, complete, campaignCodes) {
+        var data = {
             'variantName': variantName,
             'complete': complete
-        };
+        }
+
+        if (campaignCodes) {
+            data.campaignCodes = campaignCodes;
+        }
+
+        return data;
     }
 
     function getAbLoggableObject() {
@@ -180,10 +186,11 @@ define([
                 .filter(isParticipating)
                 .filter(testCanBeRun)
                 .forEach(function (test) {
-                    var variant = getTestVariantId(test.id);
+                    var variantId = getTestVariantId(test.id);
+                    var variant = getVariant(test, variantId);
 
-                    if (variant && segmentUtil.isInTest(test)) {
-                        log[test.id] = abData(variant, 'false');
+                    if (variantId && segmentUtil.isInTest(test)) {
+                        log[test.id] = abData(variantId, 'false', variant.campaignCodes);
                     }
                 });
 
@@ -221,7 +228,9 @@ define([
      */
     function recordTestComplete(test, variantId, complete) {
         var data = {};
-        data[test.id] = abData(variantId, String(complete));
+        var variant = getVariant(test, variantId);
+
+        data[test.id] = abData(variantId, String(complete), variant.campaignCodes);
 
         return function () {
             recordOphanAbEvent(data);


### PR DESCRIPTION
## What does this change?
Attaches campaign codes to the A/B test event we fire to Ophan.

## What is the value of this and can you measure success?
Much easier analysis and tracking of test conversion rates. 