### PR TITLE
Fix misaligned content-labels due to lack of scoping

### DIFF
--- a/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
@@ -8,6 +8,15 @@
     @include mq(wide) {
         margin-right: gs-span(4) + $gs-gutter;
     }
+
+    .content__labels {
+        @include mq(desktop) {
+            float: left;
+            width: gs-span(3);
+            margin-left: (gs-span(4) + $gs-gutter) * -1;
+            border-bottom: 0;
+        }
+    }
 }
 
 .content__meta-container--liveblog {
@@ -28,15 +37,6 @@
     margin-left: -($right-column + $gs-gutter);
     position: absolute;
     top: 0;
-}
-
-.content__labels {
-    @include mq(desktop) {
-        float: left;
-        width: gs-span(3);
-        margin-left: (gs-span(4) + $gs-gutter) * -1;
-        border-bottom: 0;
-    }
 }
 
 @include mq(desktop) {


### PR DESCRIPTION
## What does this change?

Fixes misaligned content labels. The regression was introduced in https://github.com/guardian/frontend/pull/15961.

## What is the value of this and can you measure success?

Proper layout, happy users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** before **

![screen shot 2017-02-27 at 15 36 26](https://cloud.githubusercontent.com/assets/2244375/23367566/94ecefba-fd02-11e6-99b4-03875de9ebfa.png)

** after **

![screen shot 2017-02-27 at 15 40 21](https://cloud.githubusercontent.com/assets/2244375/23367686/118bdf72-fd03-11e6-9acb-05331f363ee4.png)

## Tested in CODE?

No.
