### PR TITLE
Remove React alias

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/accessibility.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/accessibility.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'common/modules/accessibility/main'
 ], function (
     React,

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/clue-input.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/clue-input.js
@@ -1,5 +1,5 @@
 define([
-    'react'
+    'react/addons'
 ], function (
     React
 ) {

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/clue-preview.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/clue-preview.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'lodash/collections/some',
     'lodash/collections/map'
 ], function (

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/main.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/main.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'common/views/svgs',
     './clue-input',
     './clue-preview',

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/ring.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/anagram-helper/ring.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'lodash/collections/map'
 ], function (
     React,

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/cell.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/cell.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     './helpers',
     './constants',
     './classNames'

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/clues.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'bean',
     'fastdom',
     './classNames',

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/confirm-button.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'lodash/objects/assign',
     './classNames'
 ], function (

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/controls.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/controls.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     './confirm-button'
 ], function (
     React,

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/crossword.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'bonzo',
     'bean',
     'fastdom',

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/grid.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/grid.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     './helpers',
     './constants',
     './cell',

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/hidden-input.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'bonzo',
     'fastdom',
     'common/utils/$',

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/main.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'bonzo',
     'bean',
     'fastdom',

--- a/static/src/javascripts-legacy/projects/common/modules/preferences/main.js
+++ b/static/src/javascripts-legacy/projects/common/modules/preferences/main.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'common/utils/$',
     'common/utils/config',
     'common/modules/onward/history',

--- a/static/src/javascripts-legacy/projects/common/modules/sudoku/cell.js
+++ b/static/src/javascripts-legacy/projects/common/modules/sudoku/cell.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'common/modules/sudoku/constants',
     'common/modules/sudoku/utils',
     'lodash/arrays/compact',

--- a/static/src/javascripts-legacy/projects/common/modules/sudoku/controls.js
+++ b/static/src/javascripts-legacy/projects/common/modules/sudoku/controls.js
@@ -1,6 +1,6 @@
 /* eslint-disable new-cap */
 define([
-    'react',
+    'react/addons',
     'common/modules/sudoku/constants',
     'lodash/collections/map',
     'lodash/arrays/range'

--- a/static/src/javascripts-legacy/projects/common/modules/sudoku/grid.js
+++ b/static/src/javascripts-legacy/projects/common/modules/sudoku/grid.js
@@ -1,6 +1,6 @@
 /*eslint-disable new-cap*/
 define([
-    'react',
+    'react/addons',
     'common/modules/sudoku/cell',
     'common/modules/sudoku/controls',
     'common/modules/sudoku/constants',

--- a/static/src/javascripts-legacy/projects/common/modules/sudoku/main.js
+++ b/static/src/javascripts-legacy/projects/common/modules/sudoku/main.js
@@ -1,7 +1,7 @@
 /* eslint-disable new-cap */
 define([
     'bonzo',
-    'react',
+    'react/addons',
     'common/utils/$',
     'common/modules/sudoku/flatMap',
     'common/modules/sudoku/grid',

--- a/static/src/javascripts-legacy/projects/common/modules/sudoku/utils.js
+++ b/static/src/javascripts-legacy/projects/common/modules/sudoku/utils.js
@@ -1,5 +1,5 @@
 define([
-    'react',
+    'react/addons',
     'common/modules/sudoku/constants'
 ], function (
     React,

--- a/static/test/javascripts-legacy/main.js
+++ b/static/test/javascripts-legacy/main.js
@@ -18,7 +18,7 @@ requirejs.config({
 
         bean:         '/base/node_modules/bean/bean',
         bonzo:        '/base/node_modules/bonzo/bonzo',
-        react:        '/base/node_modules/react/dist/react-with-addons',
+        'react/addons': '/base/node_modules/react/dist/react-with-addons',
         EventEmitter: '/base/node_modules/wolfy87-eventemitter/EventEmitter',
         fastclick:    '/base/node_modules/fastclick/fastclick',
         fastdom:      '/base/node_modules/fastdom/index',

--- a/static/test/javascripts-legacy/spec/common/crosswords/main.spec.js
+++ b/static/test/javascripts-legacy/spec/common/crosswords/main.spec.js
@@ -1,6 +1,6 @@
 
 define([
-    'react',
+    'react/addons',
     'common/modules/crosswords/crossword'
 ], function (React, Crossword) {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,9 +71,6 @@ module.exports = ({ env = 'dev', plugins = [] } = {}) => ({
             svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),
             'ophan/ng': 'ophan-tracker-js',
             'ophan/embed': 'ophan-tracker-js/build/ophan.embed',
-
-            // #wp-rjs once r.js is gone, these can be unaliased and modules updated
-            react: 'react/addons',
         },
     },
     resolveLoader: {


### PR DESCRIPTION
## What does this change?

We no longer need to alias `react` as `react/addons` in the Webpack config. We can do this inline in the module definition.

## What is the value of this and can you measure success?

Less legacy config from the RequireJS times.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
