### PR TITLE
Enhance async CSS loading performance

### DIFF
--- a/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
+++ b/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
@@ -2,7 +2,7 @@
 
 /* Based on loadCSS. [c]2017 Filament Group, Inc. MIT License */
 (function(w) {
-    var exposeLoadStatus = function() {
+    var exposeLoadedState = function() {
         // Set flag for when the CSS loads before the JS
         w.guardian.css.loaded = true;
 
@@ -74,7 +74,7 @@
             }
 
             ss.media = media || 'all';
-            exposeLoadStatus();
+            exposeLoadedState();
         }
 
         // once loaded, set link's media back to `all` so that the stylesheet applies once it loads
@@ -110,7 +110,7 @@
 
     // if link[rel=preload] is not supported, we must fetch the CSS manually using loadCSS
     if (preloadSpported()) {
-        exposeLoadStatus();
+        exposeLoadedState();
         return;
     }
 

--- a/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
+++ b/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
@@ -88,7 +88,7 @@
         return ss;
     };
 
-    preloadSpported = function() {
+    var preloadSpported = function() {
       try {
         return document.createElement('link').relList.supports('preload');
       } catch (e) {
@@ -97,7 +97,7 @@
     };
 
     // loop preload links and fetch using loadCSS
-    preloadPolyfill = function() {
+    var preloadPolyfill = function() {
       var links = document.getElementsByTagName('link');
       for (var i = 0; i < links.length; i++) {
           var link = links[i];

--- a/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
+++ b/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
@@ -116,15 +116,14 @@
         }
 
         preloadPolyfill();
-        var run = setInterval(preloadPolyfill, 300);
 
         if (w.addEventListener) {
+            var run = setInterval(preloadPolyfill, 300);
+
             w.addEventListener('load', function() {
               preloadPolyfill();
               clearInterval(run);
             });
-        } else {
-            clearInterval(run);
         }
     };
 

--- a/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
+++ b/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
@@ -1,38 +1,126 @@
 @()(implicit request: RequestHeader)
 
-// CSS is already loading, tell the browser to use it.
-// Borrows heavily from https://github.com/filamentgroup/loadCSS.
-(function (styleSheetLinks, documentStyleSheets) {
+/* Based on loadCSS. [c]2017 Filament Group, Inc. MIT License */
+(function(w) {
+    var exposeLoadStatus = function() {
+        // Set flag for when the CSS loads before the JS
+        w.guardian.css.loaded = true;
 
-    // Check the stylesheet has downloaded, then set media to `screen`. If not, go again.
-    function setMedia (styleSheet) {
-        for (var i = 0, totalSheets = documentStyleSheets.length; i < totalSheets ; i++) {
-            var sheet = documentStyleSheets[i];
-            if (sheet.href && sheet.href.indexOf(styleSheet.href) > -1) {
-                styleSheet.media = "screen";
-                // Set flag for when the CSS loads before the JS
-                window.guardian.css.loaded = true;
-                // Execute callback for when the JS loads before the CSS
-                try { window.guardian.css.onLoad(); } catch(e) {};
-                return true;
-            }
+        // Execute callback for when the JS loads before the CSS
+        try {
+            w.guardian.css.onLoad()
+        } catch (e) {};
+    };
+
+    var loadCSS = function(href, before, media) {
+        // Arguments explained:
+        // `href` [REQUIRED] is the URL for your CSS file.
+        // `before` [OPTIONAL] is the element the script should use as a reference for injecting our stylesheet <link> before
+        // By default, loadCSS attempts to inject the link after the last stylesheet or script in the DOM. However, you might desire a more specific location in your document.
+        // `media` [OPTIONAL] is the media type or query of the stylesheet. By default it will be 'all'
+        var doc = w.document;
+        var ss = doc.createElement( 'link' );
+        var ref;
+
+        if (before) {
+            ref = before;
+        } else {
+            var refs = (doc.body || doc.getElementsByTagName( 'head' )[ 0 ]).childNodes;
+            ref = refs[refs.length - 1];
         }
-        requestAnimationFrame(function () {
-            setMedia(styleSheet);
+
+        var sheets = doc.styleSheets;
+        ss.rel = 'stylesheet';
+        ss.href = href;
+        // temporarily set media to something inapplicable to ensure it'll fetch without blocking render
+        ss.media = 'only x';
+
+        // wait until body is defined before injecting link. This ensures a non-blocking load in IE11.
+        function ready( cb ) {
+            if (doc.body) {
+                return cb();
+            }
+
+            setTimeout(function() {
+                ready(cb);
+            });
+        }
+
+        // Inject link
+        // Note: the ternary preserves the existing behavior of 'before' argument, but we could choose to change the argument to 'after' in a later release and standardize on ref.nextSibling for all refs
+        // Note: `insertBefore` is used instead of `appendChild`, for safety re: http://www.paulirish.com/2011/surefire-dom-element-insertion/
+        ready(function() {
+            ref.parentNode.insertBefore(ss, (before ? ref : ref.nextSibling));
         });
 
-    }
-
-    // Watch for load on all `link` elements with media of `only x`
-    function useCss () {
-        for (var i = 0, totalStyleSheetLinks = styleSheetLinks.length; i < totalStyleSheetLinks ; i++) {
-            if (styleSheetLinks[i].getAttribute('media') === 'only x') {
-                setMedia(styleSheetLinks[i]);
+        // A method (exposed on return object for external use) that mimics onload by polling document.styleSheets until it includes the new sheet.
+        var onloadcssdefined = function(cb) {
+            var resolvedHref = ss.href;
+            var i = sheets.length;
+            while (i--) {
+                if (sheets[ i ].href === resolvedHref){
+                    return cb();
+                }
             }
+
+            setTimeout(function() {
+                onloadcssdefined( cb );
+            });
+        };
+
+        function loadCB() {
+            if (ss.addEventListener) {
+                ss.removeEventListener('load', loadCB);
+            }
+
+            ss.media = media || 'all';
+            exposeLoadStatus();
         }
+
+        // once loaded, set link's media back to `all` so that the stylesheet applies once it loads
+        if (ss.addEventListener) {
+            ss.addEventListener('load', loadCB);
+        }
+
+        ss.onloadcssdefined = onloadcssdefined;
+        onloadcssdefined(loadCB);
+
+        return ss;
+    };
+
+    preloadSpported = function() {
+      try {
+        return document.createElement('link').relList.supports('preload');
+      } catch (e) {
+        return false;
+      }
+    };
+
+    // loop preload links and fetch using loadCSS
+    preloadPolyfill = function() {
+      var links = document.getElementsByTagName('link');
+      for (var i = 0; i < links.length; i++) {
+          var link = links[i];
+          if(link.rel === 'preload' && link.getAttribute('as') === 'style') {
+              loadCSS(link.href, link, link.getAttribute('media'));
+              link.rel = null;
+          }
+      }
+    };
+
+    // if link[rel=preload] is not supported, we must fetch the CSS manually using loadCSS
+    if (preloadSpported()) {
+        exposeLoadStatus();
+        return;
     }
 
-    // GO!
-    useCss();
-})(document.getElementsByTagName('link'), window.document.styleSheets)
+    preloadPolyfill();
+    var run = setInterval(preloadPolyfill, 300);
 
+    if (w.addEventListener) {
+        w.addEventListener('load', function() {
+          preloadPolyfill();
+          clearInterval(run);
+        });
+    }
+}(window));

--- a/common/app/views/fragments/stylesheetLink.scala.html
+++ b/common/app/views/fragments/stylesheetLink.scala.html
@@ -3,10 +3,18 @@
 
 @* temporarily disable async css on crossword pages so they're usable on safari 6 and below *@
 @if(AsyncCss.isSwitchedOn && !isCrossword) {
-    <link rel="stylesheet" type="text/css" href="@Static(stylesheet)" media="only x" />
+    <link rel="preload"
+          as="style"
+          href="@Static(stylesheet)"
+          onload="this.rel='stylesheet'" />
+
     <noscript>
-        <link rel="stylesheet" type="text/css" href="@Static(stylesheet)" />
+        <link rel="stylesheet"
+              type="text/css"
+              href="@Static(stylesheet)" />
     </noscript>
 } else {
-    <link rel="stylesheet" type="text/css" href="@Static(stylesheet)" />
+    <link rel="stylesheet"
+          type="text/css"
+          href="@Static(stylesheet)" />
 }


### PR DESCRIPTION
## What does this change?

Changes the way we async load CSS files. Before we always loaded all `<link rel="stylesheet" />` tags with a JS function. Now we rely on `rel="preload"` and polyfill the attribute behavoir for browsers which don't understand it yet.

It's supported currently on Chrome and Android and is under development in [FF and Safari](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/preload/).

Bonus: async CSS loading works in FF at all now (through the polyfill).

Although the new JS loader looks much bigger, it's actually only an increase of ~100 Bytes after being gzipped.

## What is the value of this and can you measure success?

Improved loading times, reduce the initial paint flickering on articles with async CSS, which then leads to a better UX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

### Chrome

We should see a better performance.

** before (with Queueing) **

![screen shot 2017-02-28 at 10 59 33](https://cloud.githubusercontent.com/assets/2244375/23402805/18cc77cc-fda5-11e6-905b-0673684d8bba.png)

** after (without Queueing) **

![screen shot 2017-02-28 at 10 58 15](https://cloud.githubusercontent.com/assets/2244375/23402810/1d06a196-fda5-11e6-9a5c-b5670de7b30d.png)


### Firefox

We should see about the same performance.

** before **

![screen shot 2017-02-28 at 12 24 07](https://cloud.githubusercontent.com/assets/2244375/23405200/0fcd9226-fdb1-11e6-9ed4-672250f7e82e.png)

** after **

![screen shot 2017-02-28 at 12 18 52](https://cloud.githubusercontent.com/assets/2244375/23405187/03de7e62-fdb1-11e6-9522-4309a19f69fb.png)


### Android 4.4

We should see about the same performance.

** before **

![screen shot 2017-02-28 at 12 28 03](https://cloud.githubusercontent.com/assets/2244375/23405470/46e80dc6-fdb2-11e6-9917-8d974d0fa310.png)

** after **

![screen shot 2017-02-28 at 12 34 03](https://cloud.githubusercontent.com/assets/2244375/23405475/4a2433d4-fdb2-11e6-99d0-32f0cb15739f.png)


### Android 7

We should see a better performance.

** before **

![screen shot 2017-02-28 at 12 39 45](https://cloud.githubusercontent.com/assets/2244375/23405619/054047a2-fdb3-11e6-89ad-31204a2e6dc4.png)

** after **

![screen shot 2017-02-28 at 12 36 05](https://cloud.githubusercontent.com/assets/2244375/23405558/b140abe2-fdb2-11e6-9181-80f6fa8d9a06.png)


## Tested in CODE?

No.
