### PR TITLE
Add research pixels to all Fabric creatives

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-tracking-pixel.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-tracking-pixel.js
@@ -1,14 +1,9 @@
-define([
-    'common/utils/template',
-    'raw-loader!commercial/views/creatives/tracking-pixel.html'
-], function (
-    template,
-    trackingPixelStr
-) {
-    var trackingPixelTpl = template(trackingPixelStr);
-    function addTrackingPixel($adSlot, url) {
-        $adSlot.before(trackingPixelTpl({ url: encodeURI(url) }));
-    }
+define(function () {
 
     return addTrackingPixel;
+
+    function addTrackingPixel(url) {
+        new Image().src = url;
+    }
+
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
@@ -92,7 +92,10 @@ define([
             $ad.css('height', this.closedHeight);
             $('.ad-exp-collapse__slide', $fabricExpandableVideo).css('height', this.closedHeight);
             if (this.params.trackingPixel) {
-                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
+            }
+            if (this.params.researchPixel) {
+                addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
             }
             $fabricExpandableVideo.appendTo(this.$adSlot);
             this.$adSlot.addClass('ad-slot--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
@@ -61,7 +61,10 @@ define([
                 $ad.css('height', closedHeight);
                 $('.ad-exp-collapse__slide', $fabricExpandableVideo).css('height', closedHeight);
                 if (params.trackingPixel) {
-                    addTrackingPixel($adSlot, params.trackingPixel + params.cacheBuster);
+                    addTrackingPixel(params.trackingPixel + params.cacheBuster);
+                }
+                if (params.researchPixel) {
+                    addTrackingPixel(params.researchPixel + params.cacheBuster);
                 }
                 $fabricExpandableVideo.appendTo($adSlot);
                 $adSlot.addClass('ad-slot--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -227,7 +227,11 @@ define([
             $('.ad-exp-collapse__slide', $fabricExpandingV1).css('height', this.closedHeight);
 
             if (this.params.trackingPixel) {
-                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
+            }
+
+            if (this.params.researchPixel) {
+                addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
             }
 
             $fabricExpandingV1.appendTo(this.$adSlot);

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
@@ -75,7 +75,11 @@ define([
         }
 
         if (this.params.trackingPixel) {
-            addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+            addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
+        }
+
+        if (this.params.researchPixel) {
+            addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
         }
 
         return fastdom.write(function () {

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-video.js
@@ -39,7 +39,10 @@ define([
         function create() {
             return fastdom.write(function () {
                 if (params.Trackingpixel) {
-                    addTrackingPixel(bonzo(adSlot), params.Trackingpixel + params.cacheBuster);
+                    addTrackingPixel(params.Trackingpixel + params.cacheBuster);
+                }
+                if (params.Researchpixel) {
+                    addTrackingPixel(params.Researchpixel + params.cacheBuster)
                 }
                 adSlot.insertAdjacentHTML('beforeend', fabricVideoTpl({ data: params }));
                 adSlot.classList.add('ad-slot--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
@@ -40,7 +40,10 @@ define([
             this.$adSlot[0].lastElementChild.insertAdjacentHTML('afterbegin', labelMarkup);
             this.$adSlot.addClass('ad-slot--frame');
             if (this.params.trackingPixel) {
-                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
+            }
+            if (this.params.researchPixel) {
+                addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
             }
             new Toggles(this.$adSlot[0]).init();
             return true;

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/gu-style-comcontent.js
@@ -74,7 +74,7 @@ define([
             this.$adSlot[0].insertAdjacentHTML('beforeend', markup);
 
             if (this.params.trackingPixel) {
-                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
             }
         }, this).then(gustyle.addLabel.bind(gustyle)).then(function () {
             return true;

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/hosted-thrasher-multi.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/hosted-thrasher-multi.js
@@ -26,7 +26,7 @@ define([
 
             this.$adSlot.append(hostedThrasherTemplate({ data: this.params }));
             if (this.params.trackingPixel) {
-                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster);
             }
 
             return true;

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/revealer.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/revealer.js
@@ -21,7 +21,10 @@ define([
                 $adSlot[0].insertAdjacentHTML('beforeend', markup);
                 $adSlot.addClass('ad-slot--revealer ad-slot--fabric content__mobile-full-width');
                 if (params.trackingPixel) {
-                    addTrackingPixel($adSlot, params.trackingPixel + params.cacheBuster);
+                    addTrackingPixel(params.trackingPixel + params.cacheBuster);
+                }
+                if (params.researchPixel) {
+                    addTrackingPixel(params.researchPixel + params.cacheBuster);
                 }
             }).then(function () {
                 return fastdom.read(function () {

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -6,7 +6,7 @@ define([
     'common/utils/mediator',
     'common/utils/template',
     'raw-loader!commercial/views/creatives/scrollable-mpu-v2.html',
-    'raw-loader!commercial/views/creatives/tracking-pixel.html',
+    'commercial/modules/creatives/add-tracking-pixel',
     'lodash/functions/bindAll'
 ], function (
     Promise,
@@ -16,7 +16,7 @@ define([
     mediator,
     template,
     scrollableMpuTpl,
-    trackingPixelStr,
+    addTrackingPixel,
     bindAll
 ) {
 
@@ -66,10 +66,17 @@ define([
             destination:      this.params.destination,
             layer1Image:      ScrollableMpu.hasScrollEnabled ? this.params.layer1Image : this.params.mobileImage,
             backgroundImage:       ScrollableMpu.hasScrollEnabled && this.params.backgroundImage ?
-                '<div class="creative--scrollable-mpu-image" style="background-image: url(' + this.params.backgroundImage + ');"></div>' : '',
-            trackingPixelImg: this.params.trackingPixel ? template(trackingPixelStr, { url: encodeURI(this.params.trackingPixel) }) : ''
+                '<div class="creative--scrollable-mpu-image" style="background-image: url(' + this.params.backgroundImage + ');"></div>' : ''
         };
         this.$scrollableMpu = $.create(template(scrollableMpuTpl, templateOptions)).appendTo(this.$adSlot);
+
+        if (this.params.trackingPixel) {
+            addTrackingPixel(this.params.trackingPixel + this.params.cacheBuster)
+        }
+
+        if (this.params.researchPixel) {
+            addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
+        }
 
         if (ScrollableMpu.hasScrollEnabled) {
             // update bg position

--- a/static/src/javascripts/projects/commercial/views/creatives/scrollable-mpu-v2.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/scrollable-mpu-v2.html
@@ -6,4 +6,3 @@
     	<div class="creative--scrollable-mpu-static-image" style="background-image: url('<%=layer1Image%>');"></div>
     </div>
 </a>
-<%=trackingPixelImg%>

--- a/static/src/javascripts/projects/commercial/views/creatives/tracking-pixel.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/tracking-pixel.html
@@ -1,1 +1,0 @@
-<img src="<%=url%>" class="creative__tracking-pixel">


### PR DESCRIPTION
This changes addresses a need for advertisers to be able to supply a research pixel in addition to an impression pixel. Also I removed the pixels from the markup, because a JS-only solution works just as well.