### PR TITLE
Remove US campaign minute email signup and associated logic

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/email-article.js
@@ -42,25 +42,7 @@ define([
     var insertBottomOfArticle = function ($iframeEl) {
             $iframeEl.appendTo('.js-article__body');
         },
-        isUSMinuteArticle = config.page.isMinuteArticle && config.page.keywordIds.indexOf('us-news/us-elections-2016') > -1,
         listConfigs = {
-            theCampaignMinute: {
-                listId: '3599',
-                listName: 'theCampaignMinute',
-                campaignCode: isUSMinuteArticle ? 'the_minute_footer' : 'the_minute_election_article',
-                headline: isUSMinuteArticle ? 'Enjoying the minute?' : 'Want the latest election news?',
-                description: 'Sign up and we’ll send you the campaign minute every weekday.',
-                successHeadline: 'Thank you for signing up to the Guardian US Campaign minute',
-                successDescription: 'We will send you the biggest political story lines of the day',
-                modClass: isUSMinuteArticle ? 'post-article' : 'end-article',
-                insertMethod: function ($iframeEl) {
-                    if (isUSMinuteArticle ) {
-                        $iframeEl.insertAfter('.js-article__container');
-                    } else {
-                        insertBottomOfArticle($iframeEl);
-                    }
-                }
-            },
             theFilmToday: {
                 listId: '1950',
                 listName: 'theFilmToday',
@@ -69,7 +51,6 @@ define([
                 description: 'Sign up to the Guardian Film Today email and we’ll make sure you don’t miss a thing - the day’s insider news and our latest reviews, plus big name interviews and film festival coverage.',
                 successHeadline: 'Thank you for signing up to Film Today',
                 successDescription: 'You’ll receive an email every afternoon.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             theFiver: {
@@ -80,7 +61,6 @@ define([
                 description: 'Sign up to the Fiver, our daily email on the world of football. We’ll deliver the day’s news and gossip in our own belligerent, sometimes intelligent and — very occasionally — funny way.',
                 successHeadline: 'Thank you for signing up',
                 successDescription: 'You’ll receive the Fiver daily, around 5pm.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             labNotes: {
@@ -91,7 +71,6 @@ define([
                 description: 'Sign up to Lab Notes and we’ll email you the top stories in science, from medical breakthroughs to dinosaur discoveries - plus brainteasers, podcasts and more.',
                 successHeadline: 'Thank you for signing up for Lab notes',
                 successDescription: 'You’ll receive an email every week.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             euRef: {
@@ -102,7 +81,6 @@ define([
                 description: 'Sign up and we’ll email you the key developments and most important debates as Britain takes its first steps on the long road to leaving the EU.',
                 successHeadline: 'Thank you for signing up for the Brexit weekly briefing',
                 successDescription: 'You’ll receive an email every morning.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             usBriefing: {
@@ -113,7 +91,6 @@ define([
                 description: 'Sign up to the Guardian US briefing to get the top stories in your inbox every weekday.',
                 successHeadline: 'Thank you for signing up to the Guardian US briefing',
                 successDescription: 'We will send you our pick of the most important stories.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             sleevenotes: {
@@ -124,7 +101,6 @@ define([
                 description: 'Get music news, bold reviews and unexpected extras emailed direct to you from the Guardian’s music desk every Friday.',
                 successHeadline: 'Thank you for signing up to sleeve notes',
                 successDescription: 'You’ll receive an email every Friday.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             longReads: {
@@ -135,7 +111,6 @@ define([
                 description: 'Look a little deeper with The Long Read. Sign up to our weekly email for inside stories, murder, politics, and much more. Great writing, worth reading.',
                 successHeadline: 'Thank you for signing up to The Long Read',
                 successDescription: 'You’ll receive an email every weekend.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             bookmarks: {
@@ -146,7 +121,6 @@ define([
                 description: 'Sign up for our weekly email for book lovers and discover top 10s, expert book reviews, author interviews, and enjoy highlights from our columnists and community every weekend.',
                 successHeadline: 'Thank you for signing up to Bookmarks',
                 successDescription: 'You’ll receive an email every weekend.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             greenLight: {
@@ -157,7 +131,6 @@ define([
                 description: 'Sign up to Green Light for environment news emailed direct to you every Friday. And besides the week’s biggest stories and debates, you can expect beautifully curated wildlife galleries, absorbing podcasts and eco-living guides.',
                 successHeadline: 'Thank you for signing up to Green Light',
                 successDescription: 'You’ll receive an email every Friday.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
             theGuardianToday: {
@@ -196,7 +169,6 @@ define([
                 }()),
                 successHeadline: 'Thank you for signing up to the Guardian Today',
                 successDescription: 'We will send you our picks of the most important headlines tomorrow morning.',
-                modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             }
         },

--- a/static/src/javascripts-legacy/projects/common/modules/email/email.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/email.js
@@ -107,7 +107,6 @@ define([
                     formSuccessHeadline = (opts && opts.formSuccessHeadline) || formData.formSuccessHeadline,
                     formSuccessDesc = (opts && opts.formSuccessDesc) || formData.formSuccessDesc,
                     removeComforter = (opts && opts.removeComforter) || formData.removeComforter || false,
-                    formModClass = (opts && opts.formModClass) || formData.formModClass || false,
                     formCloseButton = (opts && opts.formCloseButton) || formData.formCloseButton || false,
                     formSuccessEventName = (opts && opts.formSuccessEventName) || formData.formSuccessEventName || false;
 
@@ -126,10 +125,6 @@ define([
 
                     if (removeComforter) {
                         $('.js-email-sub__small', el).remove();
-                    }
-
-                    if (formModClass) {
-                        $(el).addClass('email-sub--' + formModClass);
                     }
 
                     if (formCloseButton) {

--- a/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
@@ -94,11 +94,6 @@ define([
     }
 
     var canRunList = {
-        theCampaignMinute: function () {
-            var isUSElection = page.keywordExists(['US elections 2016']);
-            var isNotUSBriefingSeries = config.page.series !== 'Guardian US briefing';
-            return isUSElection && isNotUSBriefingSeries;
-        },
         theFilmToday: function () {
             return config.page.section === 'film';
         },

--- a/static/src/javascripts/projects/common/views/email/iframe.html
+++ b/static/src/javascripts/projects/common/views/email/iframe.html
@@ -6,11 +6,10 @@
     data-form-campaign-code="<%=campaignCode%>"
     data-form-success-headline="<%=successHeadline%>"
     data-form-success-desc="<%=successDescription%>"
-    data-form-mod-class="<%=modClass%>"
     data-form-success-event-name="<%=successEventName%>"
     data-form-close-button="true"
     scrolling="no"
     seamless
     frameborder="0"
-    class="iframed--overflow-hidden email-sub__iframe email-sub__iframe--<%=modClass%> js-email-sub__iframe js-email-sub__iframe--article"
+    class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
 ></iframe>

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -341,43 +341,6 @@
     }
 }
 
-// POST-ARTICLE
-
-.email-sub__iframe--post-article {
-    box-sizing: border-box;
-    display: block;
-    margin: $gs-baseline auto;
-    padding: 0 $gs-gutter/2;
-    width: 100%;
-
-    @include mq($from: mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
-    }
-
-    @include mq($from: tablet) {
-        padding: 0;
-        width: gs-span(8);
-    }
-
-    @include mq($from: desktop) {
-        width: gs-span(11);
-    }
-
-    @include mq($from: leftCol) {
-        width: gs-span(12);
-    }
-
-}
-
-.email-sub--post-article {
-    border: 0 none;
-
-    .email-sub__form {
-        padding-bottom: 0;
-    }
-}
-
 // TONE SPECIFIC MODS
 @each $tone-class, $tone-colour-accent, $tone-colour-headline, $tone-colour-border, $tone-colour-text in $tones {
 


### PR DESCRIPTION
The email signup box at the bottom of a minute-style article was a special case which applied only the US campaign minute signup. This signup box is defunct so I've removed and the associated logic for `end-article` vs `post-article` mod classes. This doesn't affect the appearance of any active signup boxes.

This is a precursor to a restyle which will have all the signup boxes in post-article position, giving it a more "related content" look and allowing us to recommend emails from different sections without it seeming to jarring (e.g. recommending a film email at the end of a football article because we think the user likes film).

@lindseydew @davidfurey 

