### PR TITLE
Submeta: Fix missing slashes styling regression

### DIFF
--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -20,7 +20,6 @@
 
 .submeta__keywords {
     font-size: 15px;
-    padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;
@@ -35,18 +34,15 @@
 }
 
 .submeta__link-item {
-    @include clearfix;
     @include nav-links;
 
-    .submeta__keywords & {
-        &:after {
-            @include trailing-slash;
-            color: $neutral-5;
-        }
+    &:after {
+        @include trailing-slash;
+        color: $neutral-5;
+    }
 
-        &:last-of-type:after {
-            content: none;
-        }
+    &:last-of-type:after {
+        content: none;
     }
 }
 

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -20,6 +20,7 @@
 
 .submeta__keywords {
     font-size: 15px;
+    padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
     margin-bottom: $gs-baseline / 2;

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -34,18 +34,15 @@
 }
 
 .submeta__link-item {
-    @include clearfix;
     @include nav-links;
 
-    .submeta__keywords & {
-        &:after {
-            @include trailing-slash;
-            color: $neutral-5;
-        }
+    &:after {
+        @include trailing-slash;
+        color: $neutral-5;
+    }
 
-        &:last-of-type:after {
-            content: none;
-        }
+    &:last-of-type:after {
+        content: none;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Fixes a styling regression, possibly introduced in https://github.com/guardian/frontend/pull/15933

## What is the value of this and can you measure success?

Improved layout.

## Does this affect other platforms - Amp, Apps, etc?

Amp.

## Screenshots

** AMP before **

![screen shot 2017-02-28 at 15 48 29](https://cloud.githubusercontent.com/assets/2244375/23412423/61e97860-fdcd-11e6-9745-ba446bc4b212.png)

** AMP after **

![screen shot 2017-02-28 at 15 51 44](https://cloud.githubusercontent.com/assets/2244375/23412582/d834b0de-fdcd-11e6-8f87-4589031e6e9b.png)


** Web before **

![screen shot 2017-02-28 at 15 49 08](https://cloud.githubusercontent.com/assets/2244375/23412454/78403842-fdcd-11e6-8c11-bd8d1a521d9c.png)

** Web after **

![screen shot 2017-02-28 at 15 49 35](https://cloud.githubusercontent.com/assets/2244375/23412472/8864e34e-fdcd-11e6-83dc-79de3183007c.png)


## Tested in CODE?

No.
