### PR TITLE
Add viewability tracking ability to Fabrics

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
@@ -1,0 +1,7 @@
+define(function () {
+    return addViewabilityTracker;
+
+    function addViewabilityTracker(adSlot, creativeId, viewabilityTracker) {
+        adSlot.insertAdjacentHTML('beforeend', viewabilityTracker.replace('INSERT_UNIQUE_ID', creativeId));
+    }
+})

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v1.js
@@ -10,7 +10,8 @@ define([
     'common/views/svgs',
     'raw-loader!commercial/views/creatives/fabric-expandable-video-v1.html',
     'lodash/objects/merge',
-    'commercial/modules/creatives/add-tracking-pixel'
+    'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker'
 ], function (
     bean,
     bonzo,
@@ -23,7 +24,8 @@ define([
     svgs,
     fabricExpandableVideoHtml,
     merge,
-    addTrackingPixel
+    addTrackingPixel,
+    addViewabilityTracker
 ) {
     // Forked from expandable-video-v2.js
 
@@ -52,6 +54,7 @@ define([
                 '<iframe id="YTPlayer" width="100%" height="' + videoHeight + '" src="' + this.params.YoutubeVideoURL + '?showinfo=0&amp;rel=0&amp;controls=0&amp;fs=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="expandable-video"></iframe>'
                 : ''
         };
+        this.params.id = 'fabric-expandable-' + (Math.random() * 10000 | 0).toString(16);
         var $fabricExpandableVideo = $.create(template(fabricExpandableVideoHtml, { data: merge(this.params, showmoreArrow, showmorePlus, videoSource) }));
         var $ad = $('.ad-exp--expand', $fabricExpandableVideo);
 
@@ -98,6 +101,9 @@ define([
                 addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
             }
             $fabricExpandableVideo.appendTo(this.$adSlot);
+            if (this.params.viewabilityTracker) {
+                addViewabilityTracker(this.$adSlot[0], this.params.id, this.params.viewabilityTracker);
+            }
             this.$adSlot.addClass('ad-slot--fabric');
             if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {
                 this.$adSlot.parent().addClass('top-banner-ad-container--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
@@ -7,7 +7,8 @@ define([
     'common/views/svgs',
     'raw-loader!commercial/views/creatives/fabric-expandable-video-v2.html',
     'raw-loader!commercial/views/creatives/fabric-expandable-video-v2-cta.html',
-    'commercial/modules/creatives/add-tracking-pixel'
+    'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker'
 ], function (
     bean,
     fastdom,
@@ -17,7 +18,8 @@ define([
     svgs,
     fabricExpandableVideoHtml,
     fabricExpandableCtaHtml,
-    addTrackingPixel
+    addTrackingPixel,
+    addViewabilityTracker
 ) {
     return FabricExpandableVideoV2;
 
@@ -34,6 +36,7 @@ define([
             var videoHeight = openedHeight;
             var plusIconPosition = params.showCrossInContainer.substring(3);
             var additionalParams = {
+                id: 'fabric-expandable-' + (Math.random() * 10000 | 0).toString(16),
                 desktopCTA: params.ctaDesktopImage ? ctaTpl({ media: 'hide-until-tablet', link: params.link, image: params.ctaDesktopImage, position: params.ctaDesktopPosition }): '',
                 mobileCTA: params.ctaMobileImage ? ctaTpl({ media: 'mobile-only', link: params.link, image: params.ctaMobileImage, position: params.ctaMobilePosition }): '',
                 showArrow: (params.showMoreType === 'arrow-only' || params.showMoreType === 'plus-and-arrow') ?
@@ -67,6 +70,9 @@ define([
                     addTrackingPixel(params.researchPixel + params.cacheBuster);
                 }
                 $fabricExpandableVideo.appendTo($adSlot);
+                if (params.viewabilityTracker) {
+                    addViewabilityTracker($adSlot[0], params.id, params.viewabilityTracker);
+                }
                 $adSlot.addClass('ad-slot--fabric');
                 if( $adSlot.parent().hasClass('top-banner-ad-container') ) {
                     $adSlot.parent().addClass('top-banner-ad-container--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -12,7 +12,8 @@ define([
     'raw-loader!commercial/views/creatives/fabric-expanding-video.html',
     'lodash/functions/bindAll',
     'lodash/objects/merge',
-    'commercial/modules/creatives/add-tracking-pixel'
+    'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker'
 ], function (
     bean,
     bonzo,
@@ -27,7 +28,8 @@ define([
     fabricExpandingVideoHtml,
     bindAll,
     merge,
-    addTrackingPixel
+    addTrackingPixel,
+    addViewabilityTracker
 ) {
     // Forked from expandable-v3.js
 
@@ -191,6 +193,7 @@ define([
             scrollbg: this.params.backgroundImagePType !== 'none' ?
             '<div class="ad-exp--expand-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: ' + this.params.backgroundImagePPosition + ' ' + scrollbgDefaultY + '; background-repeat: ' + this.params.backgroundImagePRepeat + ';"></div>' : ''
         };
+        this.params.id = 'fabric-expanding-' + (Math.random() * 10000 | 0).toString(16);
         var $fabricExpandingV1 = $.create(template(fabricExpandingV1Html, { data: merge(this.params, showmoreArrow, showmorePlus, videoDesktop, videoMobile, scrollingbg) }));
 
         mediator.on('window:throttledScroll', this.listener);
@@ -235,6 +238,11 @@ define([
             }
 
             $fabricExpandingV1.appendTo(this.$adSlot);
+
+            if (this.params.viewabilityTracker) {
+                addViewabilityTracker(this.$adSlot[0], this.params.id, this.params.viewabilityTracker);
+            }
+
             this.$adSlot.addClass('ad-slot--fabric');
 
             if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
@@ -51,6 +51,7 @@ define([
         };
 
         var templateOptions = {
+            id: 'fabric-' + (Math.random() * 10000 | 0).toString(16),
             showLabel: this.params.showAdLabel !== 'hide',
             video: this.params.videoURL ? iframeVideoTpl(merge(this.params, videoPosition)) : '',
             hasContainer: 'layerTwoAnimation' in this.params,

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
@@ -6,6 +6,7 @@ define([
     'common/utils/template',
     'common/utils/mediator',
     'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker',
     'raw-loader!commercial/views/creatives/fabric-v1.html',
     'raw-loader!commercial/views/creatives/iframe-video.html',
     'raw-loader!commercial/views/creatives/scrollbg.html',
@@ -18,6 +19,7 @@ define([
     template,
     mediator,
     addTrackingPixel,
+    addViewabilityTracker,
     fabricV1Html,
     iframeVideoStr,
     scrollBgStr,
@@ -102,6 +104,10 @@ define([
             this.$adSlot.addClass('ad-slot--fabric-v1 ad-slot--fabric content__mobile-full-width');
             if( this.$adSlot.parent().hasClass('top-banner-ad-container') ) {
                 this.$adSlot.parent().addClass('top-banner-ad-container--fabric');
+            }
+
+            if (this.params.viewabilityTracker) {
+                addViewabilityTracker(this.$adSlot[0], this.params.id, this.params.viewabilityTracker);
             }
 
             return true;

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-video.js
@@ -6,8 +6,9 @@ define([
     'common/utils/detect',
     'common/utils/template',
     'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker',
     'raw-loader!commercial/views/creatives/fabric-video.html'
-], function (qwery, bonzo, addEventListener, fastdom, detect, template, addTrackingPixel, fabricVideoStr) {
+], function (qwery, bonzo, addEventListener, fastdom, detect, template, addTrackingPixel, addViewabilityTracker, fabricVideoStr) {
     var fabricVideoTpl;
 
     return FabricVideo;
@@ -21,6 +22,8 @@ define([
         fabricVideoTpl || (fabricVideoTpl = template(fabricVideoStr));
 
         hasVideo = !(detect.isIOS() || detect.isAndroid() || isSmallScreen);
+
+        params.id = 'fabric-video-' + (Math.random() * 10000 | 0).toString(16);
 
         if (isSmallScreen) {
             params.posterMobile = '<div class="creative__poster" style="background-image:url(' + params.Videobackupimage + ')"></div>';
@@ -45,6 +48,9 @@ define([
                     addTrackingPixel(params.Researchpixel + params.cacheBuster)
                 }
                 adSlot.insertAdjacentHTML('beforeend', fabricVideoTpl({ data: params }));
+                if (params.viewabilityTracker) {
+                    addViewabilityTracker(adSlot, params.id, params.viewabilityTracker);
+                }
                 adSlot.classList.add('ad-slot--fabric');
                 if( adSlot.parentNode.classList.contains('top-banner-ad-container') ) {
                     adSlot.parentNode.classList.add('top-banner-ad-container--fabric');

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
@@ -4,6 +4,7 @@ define([
     'common/views/svgs',
     'common/modules/ui/toggles',
     'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker',
     'raw-loader!commercial/views/creatives/frame.html',
     'raw-loader!commercial/views/creatives/gustyle-label.html'
 ], function (
@@ -12,6 +13,7 @@ define([
     svgs,
     Toggles,
     addTrackingPixel,
+    addViewabilityTracker,
     frameStr,
     labelStr
 ) {
@@ -24,6 +26,7 @@ define([
     Frame.prototype.create = function () {
         this.params.externalLinkIcon = svgs('externalLink', ['gu-external-icon']);
         this.params.target = this.params.newWindow === 'yes' ? '_blank' : '_self';
+        this.params.id = 'frame-' + (Math.random() * 10000 | 0).toString(16);
 
         var frameMarkup = template(frameStr, { data: this.params });
         var labelMarkup = template(labelStr, { data: {
@@ -44,6 +47,9 @@ define([
             }
             if (this.params.researchPixel) {
                 addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
+            }
+            if (this.params.viewabilityTracker) {
+                addViewabilityTracker(this.$adSlot[0], this.params.id, this.params.viewabilityTracker);
             }
             new Toggles(this.$adSlot[0]).init();
             return true;

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/revealer.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/revealer.js
@@ -3,12 +3,15 @@ define([
     'common/utils/template',
     'common/utils/detect',
     'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker',
     'raw-loader!commercial/views/creatives/revealer.html'
-], function(fastdom, template, detect, addTrackingPixel, revealerStr) {
+], function(fastdom, template, detect, addTrackingPixel, addViewabilityTracker, revealerStr) {
     var revealerTpl;
 
     function Revealer($adSlot, params) {
         revealerTpl || (revealerTpl = template(revealerStr));
+
+        params.id = 'revealer-' + (Math.random() * 10000 | 0).toString(16);
 
         return Object.freeze({
             create: create
@@ -25,6 +28,9 @@ define([
                 }
                 if (params.researchPixel) {
                     addTrackingPixel(params.researchPixel + params.cacheBuster);
+                }
+                if (params.viewabilityTracker) {
+                    addViewabilityTracker($adSlot[0], params.id, params.viewabilityTracker);
                 }
             }).then(function () {
                 return fastdom.read(function () {

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -7,6 +7,7 @@ define([
     'common/utils/template',
     'raw-loader!commercial/views/creatives/scrollable-mpu-v2.html',
     'commercial/modules/creatives/add-tracking-pixel',
+    'commercial/modules/creatives/add-viewability-tracker',
     'lodash/functions/bindAll'
 ], function (
     Promise,
@@ -17,6 +18,7 @@ define([
     template,
     scrollableMpuTpl,
     addTrackingPixel,
+    addViewabilityTracker,
     bindAll
 ) {
 
@@ -26,7 +28,6 @@ define([
     var ScrollableMpu = function ($adSlot, params) {
         this.$adSlot = $adSlot;
         this.params  = params;
-
         bindAll(this, 'updateBgPosition');
     };
 
@@ -62,6 +63,7 @@ define([
 
     ScrollableMpu.prototype.create = function () {
         var templateOptions = {
+            id:               'scrollable-mpu-' + (Math.random() * 10000 | 0).toString(16),
             clickMacro:       this.params.clickMacro,
             destination:      this.params.destination,
             layer1Image:      ScrollableMpu.hasScrollEnabled ? this.params.layer1Image : this.params.mobileImage,
@@ -76,6 +78,10 @@ define([
 
         if (this.params.researchPixel) {
             addTrackingPixel(this.params.researchPixel + this.params.cacheBuster);
+        }
+
+        if (this.params.viewabilityTracker) {
+            addViewabilityTracker(this.$adSlot[0], this.params.id, this.params.viewabilityTracker);
         }
 
         if (ScrollableMpu.hasScrollEnabled) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/apply-creative-template.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/apply-creative-template.js
@@ -72,6 +72,7 @@ define([
         if (creativeConfig) {
             return hideIframe()
                 .then(JSON.parse)
+                .then(mergeViewabilityTracker)
                 .then(renderCreative)
                 .catch(function (err) {
                 reportError('Failed to get creative JSON ' + err);
@@ -88,6 +89,17 @@ define([
                 return null;
             }
 
+        }
+
+        function mergeViewabilityTracker(json) {
+            var viewabilityTrackerDiv = iFrame.contentDocument.getElementById('viewabilityTracker');
+            var viewabilityTracker = viewabilityTrackerDiv ?
+                viewabilityTrackerDiv.childNodes[0].nodeValue.trim() :
+                null;
+            if (viewabilityTracker) {
+                json.params.viewabilityTracker = viewabilityTracker;
+            }
+            return json;
         }
 
         function renderCreative(config) {

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v1.html
@@ -1,6 +1,6 @@
 <% /* Forked from expandable-video-v2.html */ %>
 
-<div class="creative--expandable-video <%=data.videoOptions%>">
+<div id="<%= data.id %>" class="creative--expandable-video <%=data.videoOptions%>">
 
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v2.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expandable-video-v2.html
@@ -1,4 +1,4 @@
-<div class="creative--expandable-video creative--expandable-video-v2 <%=data.videoOptions%>">
+<div id="<%= data.id %>" class="creative--expandable-video creative--expandable-video-v2 <%=data.videoOptions%>">
 
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-expanding-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-expanding-v1.html
@@ -1,4 +1,4 @@
-<div class="creative--expandable creative--fabric-expanding-v1">
+<div id="<%= data.id %>" class="creative--expandable creative--fabric-expanding-v1">
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front">
         <div class="facia-container__inner">Advertisement</div>
     </div>

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-v1.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-v1.html
@@ -4,7 +4,7 @@
     <div class="fc-container__inner">Advertisement</div>
 </div>
 <%}%>
-<div class="creative--fabric-v1 l-side-margins hide-until-tablet" style="
+<div id="<%= data.id %>" class="creative--fabric-v1 l-side-margins hide-until-tablet" style="
     background-color: <%=data.backgroundColor%>;
     background-image: url(<%=data.backgroundImage%>);
     background-position: <%=data.backgroundPosition%>;

--- a/static/src/javascripts/projects/commercial/views/creatives/fabric-video.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/fabric-video.html
@@ -1,4 +1,4 @@
-<div class="creative creative--fabric-video">
+<div id="<%= data.id %>" class="creative creative--fabric-video">
     <a class="creative__link" href="<%=data.clickMacro%><%=data.Link%>" target="_blank">
         <div class="creative__alt creative__alt--tablet hide-until-tablet"  style="background-color:<%=data.Backgroundcolour%>;background-image:url(<%=data.Backgroundimage%>);background-position:<%=data.Backgroundposition%>;background-repeat:<%=data.Backgroundrepeat%>;">
             <%=data.posterTablet%>

--- a/static/src/javascripts/projects/commercial/views/creatives/frame.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/frame.html
@@ -1,4 +1,4 @@
-<aside class="frame" data-link-name="creative | frame">
+<aside id="<%= data.id %>" class="frame" data-link-name="creative | frame">
     <div class="frame__background">
         <img class="frame__background-image" src="<%=data.backgroundImage%>">
     </div>

--- a/static/src/javascripts/projects/commercial/views/creatives/revealer.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/revealer.html
@@ -1,4 +1,4 @@
-<aside class="creative creative--revealer">
+<aside id="<%= id %>" class="creative creative--revealer">
     <a class="creative__cta" href="<%=clickMacro%><%=link%>" target="_blank">
         <div class="creative__background" style="background-image: url('<%=backgroundImage%>')"></div>
         <img class="creative__button creative__button--<%=buttonVPos%> creative__button--<%=buttonHPos%>" src="<%=button%>" alt>

--- a/static/src/javascripts/projects/commercial/views/creatives/scrollable-mpu-v2.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/scrollable-mpu-v2.html
@@ -1,4 +1,4 @@
-<a class="creative--scrollable-mpu"
+<a id="<%= id %>" class="creative--scrollable-mpu"
     href="<%=clickMacro%><%=destination%>"
     target="_new">
     <div class="creative--scrollable-mpu-inner">


### PR DESCRIPTION
All the custom template now have a `DIV` like so:

```
<div id="viewabilityTracker"><!-- [%Viewabilitytracker%] --></div>
```

If AdOps supply a viewability tracking script, it will be extracted during the `applyCreativeTemplate` phase and passed to the template. Each template then adds the script after the creative, leaving it as is or replace the string `INSERT_UNIQUE_ID` with the id of the creative ... just in case the viewability script needs that piece of data.

(I also threw up in my mouth 😭 )