### PR TITLE
Extend the ArticleBadgesSwitch another month

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -384,7 +384,7 @@ trait FeatureSwitches {
     "When ON, articles specified in the badges file will have visual elements added",
     owners = Seq(Owner.withGithub("superfrank")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 2, 28),
+    sellByDate = new LocalDate(2017, 3, 28),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extends the feature switch for `article-header-badge`

## What is the value of this and can you measure success?

Keeping master green 💚