### PR TITLE
send output to /dev/null

### DIFF
--- a/docs/generate-toc.sh
+++ b/docs/generate-toc.sh
@@ -38,7 +38,7 @@ echo ""
 for dir in */; do
     dirname=$(cleanDirectoryName $dir)
     echo "##[$dirname]($dir)"
-    cd $dir
+    cd $dir > /dev/null
     for doc in *.md; do
         if [ "$doc" != "README.md" ]; then
             filepath=$dir$doc


### PR DESCRIPTION
## What does this change?
Edits `generate-toc.sh` to send output to /dev/null when `cd`ing into directory. This fixes problem of path being adding to table of content.  

Now 🌞: 
```
##[Start here](01-start-here/)
- [Quick start guide](01-start-here/01-installation-steps.md)
- [Visual glossary of the Guardian.com](01-start-here/02-guardian-visual-glossary.md)
- [How to deploy](01-start-here/03-how-to-deploy.md)
- [Troubleshooting](01-start-here/04-troubleshooting.md)
- [Development tips](01-start-here/05-development-tips.md)
- [Testing tips](01-start-here/06-testing-tips.md)
- [FAQs](01-start-here/07-faqs.md)
```

Before 🌧:
```
##[Start here](01-start-here/)
/Users/emilner/Guardian/frontend/docs/01-start-here
- [Quick start guide](01-start-here/01-installation-steps.md)
- [Visual glossary of the Guardian.com](01-start-here/02-guardian-visual-glossary.md)
- [How to deploy](01-start-here/03-how-to-deploy.md)
- [Troubleshooting](01-start-here/04-troubleshooting.md)
- [Development tips](01-start-here/05-development-tips.md)
- [Testing tips](01-start-here/06-testing-tips.md)
- [FAQs](01-start-here/07-faqs.md)
```

@TBonnin 