### PR TITLE
New header ux feedback

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -216,34 +216,50 @@ object NewNavigation {
     val name = ""
 
     val uk = NavLinkLists(List(
-      apps.copy(url = apps.url),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
-      NavLink("professional networks", "/guardian-professional"),
-      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_uk_web_newheader"),
-      NavLink("courses", "/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
       NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
-      todaysPaper, observer, crosswords
+      NavLink("courses", "https://courses.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
+      ukMasterClasses.copy(url = ukMasterClasses.url + "?INTCMP=masterclasses_uk_web_newheader"),
+      NavLink("professional networks", "/guardian-professional"),
+      apps.copy(url = apps.url),
+      podcasts,
+      video,
+      newsletters,
+      todaysPaper,
+      observer,
+      crosswords
     ))
 
     val au = NavLinkLists(List(
+      jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
+      auMasterClasses.copy(url = auMasterClasses.url + "?INTCMP=masterclasses_au_web_newheader"),
       apps.copy(url = apps.url),
-      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_au_web_newheader"),
-      crosswords, video
+      podcasts,
+      video,
+      newsletters,
+      crosswords
     ))
 
     val us = NavLinkLists(List(
-      apps.copy(url = apps.url),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
-      crosswords, video
+      apps.copy(url = apps.url),
+      podcasts,
+      video,
+      newsletters,
+      crosswords
     ))
 
     val int = NavLinkLists(List(
-      apps.copy(url = apps.url),
-      dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
-      masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_int_web_newheader"),
-      todaysPaper, observer, crosswords, video
+      dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
+      apps.copy(url = apps.url),
+      podcasts,
+      video,
+      newsletters,
+      todaysPaper,
+      observer,
+      crosswords
     ))
   }
 

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -64,7 +64,7 @@ object NewNavigation {
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(List(headlines, ukNews, world, politics, business, science, football))
+    val uk = NavLinkLists(List(headlines, ukNews, world, business, environment, tech, football))
     val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, auImmigration, football))
     val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, science, soccer))
     val int = NavLinkLists(List(headlines, world, ukNews, science, cities, globalDevelopment, football))
@@ -74,8 +74,8 @@ object NewNavigation {
     val name = "news"
 
     val uk = NavLinkLists(
-      List(headlines, ukNews, world, politics, science, business),
-      List(tech, environment, money)
+      List(headlines, ukNews, world, business, environment, tech, politics),
+      List(science, money, globalDevelopment, cities)
     )
     val au = NavLinkLists(
       List(headlines, australiaNews, world, auPolitics, auImmigration),
@@ -195,8 +195,8 @@ object NewNavigation {
     val name = "life"
 
     val uk = NavLinkLists(
-      List(lifestyle, fashion, food, recipes, loveAndSex, family),
-      List(home, health, women, travel, tech)
+      List(lifestyle, fashion, food, recipes, travel, loveAndSex, family),
+      List(home, health, women, tech)
     )
     val au = NavLinkLists(
       List(lifestyle, fashion, food, loveAndSex, health),
@@ -362,7 +362,7 @@ object NewNavigation {
   object SubSectionLinks {
 
     val ukNewsSubNav = NavLinkLists(
-      List(ukNews, education, media, society, law, scotland),
+      List(ukNews, politics, education, media, society, law, scotland),
       List(wales, northernIreland)
     )
 
@@ -427,7 +427,7 @@ object NewNavigation {
     case object businessSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(business, economics, banking, retail, markets, eurozone))
+      val uk = NavLinkLists(List(business, economics, banking, money, markets, eurozone))
       val us = NavLinkLists(List(business, economics, sustainableBusiness, diversityEquality, smallBusiness))
       val au = NavLinkLists(List(business, markets, money))
       val int = uk

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -220,9 +220,9 @@ object NewNavigation {
       dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
       NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
       NavLink("courses", "https://courses.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
-      ukMasterClasses.copy(url = ukMasterClasses.url + "?INTCMP=masterclasses_uk_web_newheader"),
+      ukMasterClasses,
       NavLink("professional networks", "/guardian-professional"),
-      apps.copy(url = apps.url),
+      apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
       podcasts,
       video,
       newsletters,
@@ -233,8 +233,8 @@ object NewNavigation {
 
     val au = NavLinkLists(List(
       jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
-      auMasterClasses.copy(url = auMasterClasses.url + "?INTCMP=masterclasses_au_web_newheader"),
-      apps.copy(url = apps.url),
+      auMasterClasses,
+      apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
       podcasts,
       video,
       newsletters,
@@ -243,7 +243,7 @@ object NewNavigation {
 
     val us = NavLinkLists(List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
-      apps.copy(url = apps.url),
+      apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
       podcasts,
       video,
       newsletters,
@@ -253,7 +253,7 @@ object NewNavigation {
     val int = NavLinkLists(List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
-      apps.copy(url = apps.url),
+      apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
       podcasts,
       video,
       newsletters,

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -216,10 +216,10 @@ object NewNavigation {
     val name = ""
 
     val uk = NavLinkLists(List(
-      apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
+      apps.copy(url = apps.url),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
-      NavLink("professional", "/guardian-professional"),
+      NavLink("professional networks", "/guardian-professional"),
       masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_uk_web_newheader"),
       NavLink("courses", "/?INTCMP=NGW_TOPNAV_UK_GU_COURSES"),
       NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
@@ -227,19 +227,19 @@ object NewNavigation {
     ))
 
     val au = NavLinkLists(List(
-      apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
+      apps.copy(url = apps.url),
       masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_au_web_newheader"),
       crosswords, video
     ))
 
     val us = NavLinkLists(List(
-      apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
+      apps.copy(url = apps.url),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
       crosswords, video
     ))
 
     val int = NavLinkLists(List(
-      apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
+      apps.copy(url = apps.url),
       dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
       jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
       masterClasses.copy(url = masterClasses.url + "?INTCMP=masterclasses_int_web_newheader"),

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -7,7 +7,7 @@ import org.joda.time.DateTimeZone
 
 object International extends Edition(
   id = "INT",
-  displayName = "International",
+  displayName = "International edition",
   timezone = DateTimeZone.forID("Europe/London"),
   locale = Locale.forLanguageTag("en"),
   networkFrontId = "international",

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -120,8 +120,8 @@ object NavLinks {
   val jobs = NavLink("jobs", "https://jobs.theguardian.com")
   val dating = NavLink("dating", "https://soulmates.theguardian.com")
   val apps = NavLink("the guardian app", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
-  val ukMasterClasses = NavLink("masterclasses", "/guardian-masterclasses")
-  val auMasterClasses = NavLink("masterclasses", "/guardian-masterclasses-australia")
+  val ukMasterClasses = NavLink("masterclasses", "/guardian-masterclasses?INTCMP=masterclasses_uk_web_newheader")
+  val auMasterClasses = NavLink("masterclasses", "/guardian-masterclasses-australia?INTCMP=masterclasses_au_web_newheader")
 
   val tagPages = List(
     "technology/games",

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -115,10 +115,13 @@ object NavLinks {
   val observer = NavLink("the observer", "/observer", "observer")
   val crosswords = NavLink("crosswords", "/crosswords", "crosswords")
   val video =  NavLink("video", "/video")
+  val podcasts =  NavLink("podcasts", "/podcasts")
+  val newsletters =  NavLink("newsletters", "/email-newsletters")
   val jobs = NavLink("jobs", "https://jobs.theguardian.com")
   val dating = NavLink("dating", "https://soulmates.theguardian.com")
-  val apps = NavLink("apps", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
-  val masterClasses = NavLink("masterclasses", "/guardian-masterclasses")
+  val apps = NavLink("the guardian app", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
+  val ukMasterClasses = NavLink("masterclasses", "/guardian-masterclasses")
+  val auMasterClasses = NavLink("masterclasses", "/guardian-masterclasses-australia")
 
   val tagPages = List(
     "technology/games",

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -117,7 +117,7 @@ object NavLinks {
   val video =  NavLink("video", "/video")
   val jobs = NavLink("jobs", "https://jobs.theguardian.com")
   val dating = NavLink("dating", "https://soulmates.theguardian.com")
-  val apps = NavLink("apps", "/global/ng-interactive/2014/may/29/-sp-the-guardian-app-for-ios-and-android")
+  val apps = NavLink("apps", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
   val masterClasses = NavLink("masterclasses", "/guardian-masterclasses")
 
   val tagPages = List(

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -15,7 +15,7 @@ object NavLinks {
   var politics = NavLink("politics", "/politics", "politics")
   var media = NavLink("media", "/media", "media")
   var cities = NavLink("cities", "/cities", "cities")
-  var globalDevelopment = NavLink("development", "/global-development", "global-development")
+  var globalDevelopment = NavLink("global development", "/global-development", "global-development")
   var australiaNews = NavLink("australia", "/australia-news", "australia-news", longTitle = "australia news")
   var auPolitics = NavLink("politics", "/australia-news/australian-politics", "australia-news/australian-politics", longTitle = "australian politics")
   var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum", "australia-news/australian-immigration-and-asylum")
@@ -56,7 +56,7 @@ object NavLinks {
   var columnists = NavLink("columnists", "/index/contributors", "index/contributors")
   val theGuardianView = NavLink("the guardian view", "/profile/editorial", "profile/editorial")
   val cartoons = NavLink("cartoons", "/cartoons/archive", "cartoons/archive")
-  val inMyOpinion = NavLink("in my opinion", "/commentisfree/series/comment-is-free-weekly", "commentisfree/series/comment-is-free-weekly")
+  val inMyOpinion = NavLink("opinion videos", "/commentisfree/series/comment-is-free-weekly", "commentisfree/series/comment-is-free-weekly")
 
   /* SPORT */
   val sport = NavLink("sport", "/sport", longTitle = "sport home", iconName = "home", uniqueSection = "sport")

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -9,22 +9,21 @@
         data-link-name="nav2 : edition picker">
 
             <i class="main-menu__icon main-menu__icon--chevron personalisation__icon"></i>
-            change your edition
+            @Edition(request).displayName
         </summary>
 
         <ul class="personalisation__links">
             @Edition.all.map { edition =>
-                <li class="@RenderClasses(Map(
-                    "personalisation__link" -> true,
-                    "personalisation__link--active" -> (edition == Edition(request))
-                    ))">
-                    <a data-link-name="nav2 : edition-picker: @edition.id"
-                        href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")">
+                 @if((edition != Edition(request))) {
+                    <li class="personalisation__link">
+                        <a data-link-name="nav2 : edition-picker: @edition.id"
+                            href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")">
 
-                        <span class="u-h"> switch to the </span>
-                        <span> @edition.displayName </span>
-                    </a>
-                </li>
+                            <span class="u-h"> switch to the </span>
+                            <span> @edition.displayName </span>
+                        </a>
+                    </li>
+                }
             }
         </ul>
     </details>

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -96,7 +96,6 @@ $gutter-large: 55px;
     background-color: $news-main-2;
     cursor: pointer;
     bottom: -$gs-baseline / 2;
-    transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
 
     @include mq($until: mobileMedium) {
         //Smaller menu button
@@ -116,11 +115,6 @@ $gutter-large: 55px;
     @include mq(mobileLandscape) {
         //Align with the 'i' in 'theguardian'
         right: $gutter-large;
-    }
-
-    &:hover,
-    &:focus {
-        transform: scale(1.1);
     }
 }
 
@@ -870,7 +864,6 @@ $caption-button-size: 32px;
     cursor: pointer;
     height: $veggie-burger-small;
     min-width: $veggie-burger-small;
-    transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
 
     @include mq(mobileMedium) {
         height: $veggie-burger-medium;
@@ -889,11 +882,6 @@ $caption-button-size: 32px;
             width: 30px;
             height: 24px;
         }
-    }
-
-    .footer__back-to-top:hover &,
-    .footer__back-to-top:focus & {
-        transform: scale(1.1);
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -218,11 +218,6 @@ $gutter-large: 55px;
     }
 }
 
-[data-link-name='nav2 : primary : life'] {
-    padding-left: .35em;
-    padding-right: .8em;
-}
-
 /****************
  * Menu Styling
  ****************/
@@ -338,6 +333,10 @@ $gutter-large: 55px;
     list-style: none;
     color: $news-support-1;
     width: 100%;
+
+    &:last-child > details[open] {
+        margin-bottom: $gs-baseline;
+    }
 }
 
 //This variable is only used in open menu styling
@@ -476,9 +475,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     a {
         display: block;
         padding-top: $gs-baseline / 1.5;
-        padding-left: $navigation-horizontal-padding;
         padding-right: $gs-gutter;
         padding-bottom: $gs-baseline / 1.5;
+        padding-left: $navigation-horizontal-padding;
+
         // Override a from user agent stylesheet
         color: inherit;
 
@@ -651,10 +651,9 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 .tertiary-navigation {
     background-color: #747a81;
     padding-top: $gs-baseline / 3;
-    // Spacer that prevents links flowing beneath the veggie burger
-    //padding-right: $gutter-medium + ($veggie-burger-medium / 2);
     padding-left: $gs-gutter / 2;
-    padding-right: $gutter-medium + ($veggie-burger-medium / 2);
+    // Spacer that prevents links flowing beneath the veggie burger
+    padding-right: $gutter-medium + $veggie-burger-medium;
     margin-left: -4px;
     border-bottom: $gs-baseline / 3 solid #747a81;
     max-height: $gs-baseline * 3.4;
@@ -672,7 +671,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
         max-height: $gs-baseline * 4.8;
         padding-left: $gs-gutter;
         margin-left: -5px;
-        padding-right: $gutter-large + ($veggie-burger-medium / 2);
+        padding-right: $gutter-large + $veggie-burger-medium;
     }
 }
 
@@ -811,9 +810,9 @@ $caption-button-size: 32px;
             &:before {
                 content: '';
                 position: absolute;
-                left: 50%;
+                left: 49%;
                 bottom: 0;
-                margin-left: -$gs-baseline / 2;
+                transform: translateX(-50%);
                 border-bottom: $gs-baseline / 2 solid #747a81;
                 border-left: $gs-baseline / 2 solid transparent;
                 border-right: $gs-baseline / 2 solid transparent;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -407,8 +407,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .main-navigation__secondary {
     color: #ffffff;
-    background-color: #003b5e;
-    padding-bottom: $gs-baseline / 2;
+    background: darken($guardian-brand-dark, 4%);
 
     .main-menu__icon__svg {
         margin-top: -.24em;
@@ -431,13 +430,14 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
         left: $navigation-horizontal-padding;
         right: 0;
         height: 1px;
-        background: #003b5e;
+        background: darken($guardian-brand-dark, 4%);
     }
 }
 
 [data-link-name='nav2 : crosswords'],
-[data-link-name='nav2 : today\'s paper'] {
-    margin-top: $gs-baseline;
+[data-link-name='nav2 : today\'s paper'],
+[data-link-name='nav2 : facebook'] {
+    margin-top: $gs-baseline * 2;
 }
 
 .navigation-group {
@@ -447,15 +447,12 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     margin-top: 0;
     // Unset ul from user agent stylesheet
     margin-bottom: 0;
-
-    & li:last-child {
-        padding-bottom: $gs-baseline;
-    }
 }
 
 .navigation-group--contrast {
     color: $guardian-brand-dark;
     background-color: $news-main-2;
+    padding-bottom: $gs-baseline;
 
     .main-menu__icon__svg {
         fill: $guardian-brand;
@@ -471,6 +468,10 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     list-style: none;
     position: relative;
     font-size: 1em;
+
+    details[open] &:last-child {
+        padding-bottom: $gs-baseline;
+    }
 
     a {
         display: block;
@@ -609,13 +610,17 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
         padding-bottom: $gs-baseline / 1.5;
     }
 
-    .personalisation__links {
+    details[open] .personalisation__links {
         margin-bottom: -$gs-baseline;
     }
 }
 
 .personalisation__link {
     color: $guardian-brand-dark;
+
+    &:last-child {
+        padding-bottom: $gs-baseline;
+    }
 }
 
 .no-text-transform {

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -96,6 +96,7 @@ $gutter-large: 55px;
     background-color: $news-main-2;
     cursor: pointer;
     bottom: -$gs-baseline / 2;
+    transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
 
     @include mq($until: mobileMedium) {
         //Smaller menu button
@@ -115,6 +116,11 @@ $gutter-large: 55px;
     @include mq(mobileLandscape) {
         //Align with the 'i' in 'theguardian'
         right: $gutter-large;
+    }
+
+    &:hover,
+    &:focus {
+        transform: scale(1.1);
     }
 }
 
@@ -196,7 +202,6 @@ $gutter-large: 55px;
     &:focus,
     &:hover {
         text-decoration: none;
-        color: #ffffff;
     }
 
     &:first-child {
@@ -520,7 +525,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
     // autoprefixer handles all the appropriate psuedo element selectors for placeholders
     &::placeholder {
-        color: #ffffff;
+        color: $news-support-1;
     }
 
     &:focus {
@@ -675,7 +680,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     &:hover,
     &:focus {
         text-decoration: none;
-        color: #ffffff;
     }
 
     @include mq($from: mobile, $until: mobileLandscape) {
@@ -826,11 +830,6 @@ $caption-button-size: 32px;
 .footer__back-to-top__container {
     @include content-gutter();
     background-color: $guardian-brand;
-
-    a:hover > &,
-    a:focus > & {
-        background-color: $guardian-brand-dark;
-    }
 }
 
 .footer__back-to-top {
@@ -869,6 +868,7 @@ $caption-button-size: 32px;
     cursor: pointer;
     height: $veggie-burger-small;
     min-width: $veggie-burger-small;
+    transition: transform 300ms cubic-bezier(.25, .46, .45, .94);
 
     @include mq(mobileMedium) {
         height: $veggie-burger-medium;
@@ -887,6 +887,11 @@ $caption-button-size: 32px;
             width: 30px;
             height: 24px;
         }
+    }
+
+    .footer__back-to-top:hover &,
+    .footer__back-to-top:focus & {
+        transform: scale(1.1);
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -613,28 +613,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     color: $guardian-brand-dark;
 }
 
-.personalisation__link--active {
-    color: $guardian-brand-dark;
-    position: relative;
-    font-weight: bold;
-
-    // Tick icon
-    &:before {
-            content: '';
-            position: absolute;
-            top: 8px;
-            left: 26px;
-            width: $gs-gutter / 4;
-            height: $gs-baseline;
-            border-width: 2px;
-            border-style: solid;
-            border-color: currentColor;
-            border-top: 0;
-            border-left: 0;
-            transform: rotate(45deg);
-        }
-}
-
 .no-text-transform {
     text-transform: none;
 }

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -416,8 +416,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 }
 
 .navigation-border,
-[data-link-name='nav2 : crosswords'],
-[data-link-name='nav2 : today\'s paper'] {
+[data-link-name='nav2 : the guardian app'] {
     // Creates a seamless line when section has dark background
     margin-top: -1px;
     position: relative;
@@ -433,8 +432,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     }
 }
 
-[data-link-name='nav2 : crosswords'],
-[data-link-name='nav2 : today\'s paper'],
+[data-link-name='nav2 : the guardian app'],
 [data-link-name='nav2 : facebook'] {
     margin-top: $gs-baseline * 2;
 }


### PR DESCRIPTION
Numerous changes to the secondary navigation and the expanded navigation menu.

The edition switcher has been improved, the current edition now being visible without having to expand. Contrast and spacing of dividing lines has been increased.

Search color was toned back slightly. 

Spacing and styling tweaks, including better centring of the active section marker. 

There are further accessibility and logic based tweaks to be made in a later PR

<img width="372" alt="screen shot 2017-03-01 at 10 57 09" src="https://cloud.githubusercontent.com/assets/14570016/23457032/e538f2cc-fe6d-11e6-8358-9eb220b3d085.png">


