### PR TITLE
Relax criteria to show gu today signup box

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
@@ -60,20 +60,6 @@ define([
         return userListSubs;
     }
 
-    function userReferredFromNetworkFront() {
-        // Check whether the referring url ends in the edition
-        var networkFront = ['uk', 'us', 'au', 'international'],
-            originPathName = document.referrer.split(/\?|#/)[0];
-
-        if (originPathName) {
-            return some(networkFront, function (frontName) {
-                return originPathName.substr(originPathName.lastIndexOf('/') + 1) === frontName;
-            });
-        }
-
-        return false;
-    }
-
     function isParagraph($el) {
         return $el.nodeName && $el.nodeName === 'P';
     }
@@ -115,7 +101,6 @@ define([
         theGuardianToday: function () {
             return config.switches.emailInArticleGtoday &&
                 !pageHasBlanketBlacklist() &&
-                userReferredFromNetworkFront() &&
                 allowedArticleStructure();
         },
         sleevenotes: function () {


### PR DESCRIPTION
## What does this change?

Removes the requirement for the referrer to be a network to display the GU Today email signup box

## What is the value of this and can you measure success?

So that we get more impressions for our a/b test

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
