### PR TITLE
Epic Urgency Copy Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -132,6 +132,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-epic-urgency",
+    "Test 3 new variants with messaging that highlights the urgency of supporting the Guardian",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 3, 15),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-tailor-recommended-email",
     "Use Tailor to target email signup form",
     owners = Seq(Owner.withGithub("lindseydew")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -136,7 +136,7 @@ trait ABTestSwitches {
     "Test 3 new variants with messaging that highlights the urgency of supporting the Guardian",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 15),
+    sellByDate = new LocalDate(2017, 3, 17),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -35,7 +35,8 @@ define([
         ContributionsEpicAlwaysAskStrategy,
         ContributionsEpicBrexit,
         ContributionsEpicAskFourStagger,
-        ContributionsEpicAskFourEarning
+        ContributionsEpicAskFourEarning,
+        ContributionsEpicUrgency
     ];
 
     var emailTests = [

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -21,6 +21,10 @@ define([
         name: 'ContributionsEpicAskFourEarning',
         variants: ['control']
     };
+    var ContributionsEpicUrgency = {
+        name: 'ContributionsEpicUrgency',
+        variants: ['control', 'paywall_tweak', 'values_tweak', 'values_full']
+    };
 
     var GuardianTodaySignupMessaging = {
         name: 'GuardianTodaySignupMessaging',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -4,19 +4,21 @@ define([
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
-    'common/modules/experiments/tests/contributions-epic-ask-four-earning'
+    'common/modules/experiments/tests/contributions-epic-ask-four-earning',
+    'common/modules/experiments/tests/contributions-epic-urgency'
 ], function (
     segmentUtil,
     viewLog,
     brexit,
     alwaysAsk,
     askFourStagger,
-    askFourEarning
+    askFourEarning,
+    urgency
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger];
+    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger, urgency];
 
     return {
         getTest: function() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-urgency.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-urgency.js
@@ -1,7 +1,7 @@
 define([
     'common/modules/commercial/contributions-utilities',
     'common/utils/template',
-    'text!common/views/contributions-epic-equal-buttons.html'
+    'raw-loader!common/views/contributions-epic-equal-buttons.html'
 ], function (
     contributionsUtilities,
     template,
@@ -9,8 +9,8 @@ define([
 ) {
 
     return contributionsUtilities.makeABTest({
-        id: 'ContributionsEpicOneLineEditsV2',
-        campaignId: 'kr1_epic_one_line_edits_v2',
+        id: 'ContributionsEpicUrgency',
+        campaignId: 'kr1_epic_urgency',
 
         start: '2017-03-01',
         expiry: '2017-03-15',
@@ -24,12 +24,6 @@ define([
         audience: 0.40,
         audienceOffset: 0.12,
 
-        // We don't want to run these tests in Australia,
-        // since they don't have a single shareholder,
-        // contrary to what one of the variants says.
-        locationCheck: function (countyCode) {
-            return countyCode !== 'AU';
-        },
 
         variants: [
             {
@@ -65,7 +59,7 @@ define([
                 successOnView: true
             },
             {
-                id: 'values_tweaks',
+                id: 'values_tweak',
                 maxViews: {
                     days: 30,
                     count: 4,
@@ -76,7 +70,7 @@ define([
                         linkUrl1: membershipUrl,
                         linkUrl2: contributionUrl,
                         title: 'Now is the time …',
-                        p1: '… to defend progressive values and truthful, in-depth reporting. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So now we need your support. The Guardians independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because, at a time of fake news and ‘alternative facts’, we believe our perspective matters more than ever.',
+                        p1: '… to defend progressive values and truthful, in-depth reporting. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So now we need your support. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because, at a time of fake news and ‘alternative facts’, we believe our perspective matters more than ever.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
                         p3: '',
                         cta1: 'Become a Supporter',
@@ -85,7 +79,8 @@ define([
                 },
                 insertBeforeSelector: '.submeta',
                 successOnView: true
-            },{
+            },
+            {
                 id: 'values_full',
                 maxViews: {
                     days: 30,
@@ -106,7 +101,7 @@ define([
                 },
                 insertBeforeSelector: '.submeta',
                 successOnView: true
-            },
+            }
 
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-urgency.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-urgency.js
@@ -1,0 +1,113 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'common/utils/template',
+    'text!common/views/contributions-epic-equal-buttons.html'
+], function (
+    contributionsUtilities,
+    template,
+    contributionsEpicEqualButtons
+) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicOneLineEditsV2',
+        campaignId: 'kr1_epic_one_line_edits_v2',
+
+        start: '2017-03-01',
+        expiry: '2017-03-15',
+
+        author: 'Jonathan Rankin',
+        description: 'Test 3 new variants with messaging that highlights the urgency of supporting the Guardian',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Establish which variant has the highest conversion rate',
+
+        audienceCriteria: 'All',
+        audience: 0.40,
+        audienceOffset: 0.12,
+
+        // We don't want to run these tests in Australia,
+        // since they don't have a single shareholder,
+        // contrary to what one of the variants says.
+        locationCheck: function (countyCode) {
+            return countyCode !== 'AU';
+        },
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'paywall_tweak',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Now is the time …',
+                        p1: '… to support independent journalism. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall. So now we need your support. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+            {
+                id: 'values_tweaks',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Now is the time …',
+                        p1: '… to defend progressive values and truthful, in-depth reporting. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So now we need your support. The Guardians independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because, at a time of fake news and ‘alternative facts’, we believe our perspective matters more than ever.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },{
+                id: 'values_full',
+                maxViews: {
+                    days: 30,
+                    count: 4,
+                    minDaysBetweenViews: 0
+                },
+                template: function (contributionUrl, membershipUrl) {
+                    return template(contributionsEpicEqualButtons, {
+                        linkUrl1: membershipUrl,
+                        linkUrl2: contributionUrl,
+                        title: 'Now is the time …',
+                        p1: '… to defend truthful, in-depth reporting. With the rise of fake news and ‘alternative facts’, the role of independent, investigative journalism is more important than ever. We do it because we believe our perspective matters – because it might well be your perspective, too. But it takes a lot of time, money and hard work to produce. Increasing numbers of people are turning to the Guardian, and now we need your support so that progressive ideas and voices can continue to inform and challenge.',
+                        p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',
+                        p3: '',
+                        cta1: 'Become a Supporter',
+                        cta2: 'Make a contribution'
+                    });
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            },
+
+        ]
+    });
+});


### PR DESCRIPTION
## What does this change?

Creates a new Epic message test, testing 3 new messages centered around urgency agains the control

## What is the value of this and can you measure success?

Conversions

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

Paywall message (tweak of control)
<img width="699" alt="screenshot at mar 01 15-50-52" src="https://cloud.githubusercontent.com/assets/2844554/23468141/e3a87c14-fe97-11e6-9e4c-34facef53df2.png">

Values message (rewrite of control)
<img width="660" alt="screenshot at mar 01 15-51-15" src="https://cloud.githubusercontent.com/assets/2844554/23468142/e3ad79ee-fe97-11e6-8b31-acaf44146b00.png">

Values message (tweak of control)
![urgent1](https://cloud.githubusercontent.com/assets/2844554/23468140/e3a47650-fe97-11e6-9347-5ec494e0c74d.png)




## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
