### PR TITLE
add `--has-items` class to end-slate fragment

### DIFF
--- a/onward/app/views/fragments/videoEndSlate.scala.html
+++ b/onward/app/views/fragments/videoEndSlate.scala.html
@@ -1,9 +1,15 @@
 @(videos: Seq[model.Video], componentId: String, heading: String)(implicit request: RequestHeader)
 
 @import views.support.Seq2zipWithRowInfo
+@import views.support.RenderClasses
 
-
-<div class="end-slate-container end-slate-container--video" data-component="video-end-slate-@componentId">
+<div class="@RenderClasses(
+    Map(
+        "end-slate-container--has-items" -> videos.nonEmpty
+    ),
+    "end-slate-container",
+    "end-slate-container--video"
+)" data-component="video-end-slate-@componentId">
     @if(videos.nonEmpty) {
         <div class="end-slate-container__header">
             <h3 class="end-slate-container__heading">@heading</h3>

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -826,8 +826,10 @@ $ima-controls-height: 70px;
     max-width: gs-span(7);
     cursor: initial;
 
-    .vjs-has-ended & {
-        display: block;
+    &--has-items {
+        .vjs-has-ended & {
+            display: block;
+        }
     }
 
     .vjs-fullscreen & {
@@ -895,8 +897,10 @@ $ima-controls-height: 70px;
     }
 
     @include mq(mobileLandscape) {
-        .gu-video-embed .vjs-has-ended & {
-            display: block;
+        &--has-items {
+            .gu-video-embed .vjs-has-ended & {
+                display: block;
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?
Currently if there are no items available in the endslate (e.g. https://api.nextgen.guardianapps.co.uk/video/end-slate/section/beyond-the-lights.json?shortUrl=https://gu.com/p/62k36) we're still displaying an empty `div` which looks strange (e.g. https://www.theguardian.com/beyond-the-lights/video/2017/feb/28/las-vegas-nature-parks-trails-desert-canyon).

This change will add the class `end-slate-container--has-items` to the end-slate `div` if there are items and we can then `display: block` if we have the class else we `display: none`.

Ideally we'd just set [`data-show-end-slate`](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/media/video.scala.html#L42) to `false` if there are no items in the end-slate but alas always set it to `true`. Not entirely sure why, I think its because it relies on a (blocking) CAPI request so we set it to `true` and make the request client-side? Hiding the end-slate this way is cheaper than answering this question.

## What is the value of this and can you measure success?
Better UX.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
Before
![image](https://cloud.githubusercontent.com/assets/836140/23482924/b8e12a36-fec8-11e6-9c2e-5ba551a441ce.png)


After
![image](https://cloud.githubusercontent.com/assets/836140/23482914/b0a8d206-fec8-11e6-9914-756544052d1f.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
