### PR TITLE
Move urgency test up the precedence ordering

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -18,7 +18,7 @@ define([
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger, urgency];
+    var tests = [alwaysAsk, urgency, askFourEarning, brexit, askFourStagger];
 
     return {
         getTest: function() {


### PR DESCRIPTION
## What does this change?

The urgency test needs to be set as having a higher precedence than the ask4 earning test in order for it to show. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
