### PR TITLE
Removes default NewsArticle schema type on AMP articles

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,4 +1,3 @@
-@import model.ArticleSchemas
 @(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.LinkTo
@@ -7,13 +6,10 @@
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
 
-@* Feb 2015: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/Review *@
-@schemaType(page: ArticlePage) = @{
-    if (amp) ArticleSchemas.NewsArticle else page.article.metadata.schemaType
-}
+@schemaType(page: ArticlePage) = @{page.article.metadata.schemaType}
 
 @bodyType(page: ArticlePage) = @{
-    if (page.article.tags.isReview && !amp) "reviewBody" else "articleBody"
+    if (page.article.tags.isReview) "reviewBody" else "articleBody"
 }
 
 @defining(model.article) { article =>

--- a/docs/03-dev-howtos/17-working-with-amp.md
+++ b/docs/03-dev-howtos/17-working-with-amp.md
@@ -46,11 +46,19 @@ Please note to enable browsersync when styling amp pages we have added this code
  * Please note that the tests will NOT pass validation with this line.
  * It won't affect prod but please comment out this line when running tests in DEV
  *@
-@if(env.mode == Dev) {
-    <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+@if(context.environment.mode == Dev) {
+    @if(page.metadata.isHosted) {
+        <link rel="stylesheet" id="head-css" data-reload="head.hosted-amp" type="text/css" href="@Static("stylesheets/head.hosted-amp.css")" />
+    } else {
+        @if(page.metadata.contentType == "LiveBlog"){
+            <link rel="stylesheet" id="head-css" data-reload="head.amp-liveblog" type="text/css" href="@Static("stylesheets/head.amp-liveblog.css")" />
+        } else {
+            <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />
+        }
+    }
 }
-
 ```
+in common/app/views/fragments/amp/customStyles.scala.html.
 
 When validating locally please comment out the <link> as this will always fail validation.
 This change was made to improve the experience of developing and styling amp pages. If there is a better way please suggest it!


### PR DESCRIPTION
## What does this change?
Google now [supports schema types](https://github.com/ampproject/amphtml/tree/master/examples/metadata-examples) in their amp carousel; it no longer needs to default to 'NewsArticle'. https://www.ampproject.org/docs/guides/discovery

## What is the value of this and can you measure success?
More accurate description of content. 

## Does this affect other platforms - Amp, Apps, etc?
It only effects AMP. 

## Screenshots

## Tested in CODE?
No

Spotted by @NataliaLKB on separate [PR](https://github.com/guardian/frontend/pull/16001) which copied this code.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
