### PR TITLE
Avoid empty call to PubAdsService.refresh

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/refresh-on-resize.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/refresh-on-resize.js
@@ -24,7 +24,10 @@ define([
     // TODO: reset advert flags
     function refresh(currentBreakpoint, previousBreakpoint) {
         // only refresh if the slot needs to
-        window.googletag.pubads().refresh(dfpEnv.advertsToRefresh.filter(shouldRefresh).map(function (_) { return _.slot; }));
+        var advertsToRefresh = dfpEnv.advertsToRefresh.filter(shouldRefresh);
+        if (advertsToRefresh.length) {
+            window.googletag.pubads().refresh(advertsToRefresh.map(function (_) { return _.slot; }));
+        }
 
         function shouldRefresh(advert) {
             // get the slot breakpoints


### PR DESCRIPTION
I have noticed that calling `window.googletag.pubads().refresh([])` will refresh all the slots when Sonobi is enabled. The GPT specs do not explicitly say what to do in such a case, so this PR will just prevent it from happening ever again.