### PR TITLE
Media Atom Refactor: consolidate parameters into enum

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -89,7 +89,7 @@
                                             }
 
                                             @video.mediaAtom.map { mediaAtom =>
-                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true )
+                                                @fragments.atoms.media(mediaAtom, displayCaption = displayCaption, displayEndSlate = true, mediaWrapper = None)
                                             }
 
                                             @video.elements.mainVideo.map { videoElement =>

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -3,6 +3,7 @@ package views
 import common.Edition
 import layout.ContentWidths
 import layout.ContentWidths.{Inline, LiveBlogMedia, MainMedia, Showcase}
+import model.content.MediaWrapper
 import model.{ApplicationContext, Article}
 import play.api.mvc.RequestHeader
 import views.support._
@@ -29,7 +30,7 @@ object MainCleaner {
         if (amp) AmpEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
         MainFigCaptionCleaner,
-        AtomsCleaner(atoms = article.content.atoms, shouldFence = true, amp = amp, mainMedia = true)
+        AtomsCleaner(atoms = article.content.atoms, amp = amp, mediaWrapper = Some(MediaWrapper.MainMedia))
       )
   }
 }

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -9,6 +9,7 @@ import org.joda.time.{DateTime, DateTimeZone, Duration}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import quiz._
 import enumeratum._
+import model.content.MediaAssetPlatform.findValues
 
 final case class Atoms(
   quizzes: Seq[Quiz],
@@ -51,6 +52,16 @@ object MediaAssetPlatform extends Enum[MediaAssetPlatform] with PlayJsonEnum[Med
   case object Dailymotion extends MediaAssetPlatform
   case object Mainstream extends MediaAssetPlatform
   case object Url extends MediaAssetPlatform
+}
+
+sealed trait MediaWrapper extends EnumEntry
+
+object MediaWrapper extends Enum[MediaWrapper] with PlayJsonEnum[MediaWrapper] {
+  val values = findValues
+
+  case object MainMedia extends MediaWrapper
+  case object ImmersiveMainMedia extends MediaWrapper
+  case object Embed extends MediaWrapper
 }
 
 final case class MediaAsset(

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -61,7 +61,7 @@ object MediaWrapper extends Enum[MediaWrapper] with PlayJsonEnum[MediaWrapper] {
 
   case object MainMedia extends MediaWrapper
   case object ImmersiveMainMedia extends MediaWrapper
-  case object Embed extends MediaWrapper
+  case object EmbedPage extends MediaWrapper
 }
 
 final case class MediaAsset(

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,4 +1,5 @@
-@(media: model.content.MediaAtom,  displayCaption: Boolean, mainMedia: Boolean)(implicit request: RequestHeader)
+@import model.content.MediaWrapper
+@(media: model.content.MediaAtom,  displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
     <amp-youtube
     data-videoid="@media.assets.head.id"
@@ -7,7 +8,7 @@
     </amp-youtube>
 
 @if(displayCaption) {
-    @mediaAtomCaption(media.title, mainMedia)
+    @mediaAtomCaption(media.title, mediaWrapper.contains(MediaWrapper.MainMedia))
 }
 
 

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -6,7 +6,7 @@
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
-        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
+        case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,11 +1,12 @@
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mainMedia: Boolean, immersiveMainMedia: Boolean)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@import model.content.MediaWrapper
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz}
 
 @{
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
-        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true, displayEndSlate = mainMedia, mainMedia = mainMedia, immersiveMainMedia = immersiveMainMedia)
+        case media: MediaAtom => views.html.fragments.atoms.media(media, amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,10 +1,11 @@
 @import model.content.MediaAssetPlatform
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, embedPage: Boolean = false, displayEndSlate: Boolean = false, mainMedia: Boolean = false, immersiveMainMedia: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@import model.content.MediaWrapper
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, displayEndSlate: Boolean = false, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @{
     media match {
-            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mainMedia = mainMedia, amp = amp,picture = media.posterImage.get, caption = media.title)
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media = media, displayCaption = displayCaption, mainMedia = mainMedia) else views.html.fragments.atoms.youtube(media = media, displayCaption = displayCaption, embedPage = embedPage, displayEndSlate = displayEndSlate, mainMedia = mainMedia, immersiveMainMedia = immersiveMainMedia)
+            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia), amp = amp,picture = media.posterImage.get, caption = media.title)
+            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media = media, displayCaption = displayCaption, mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia)) else views.html.fragments.atoms.youtube(media = media, displayCaption = displayCaption, displayEndSlate = displayEndSlate)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media = media, displayCaption = displayCaption, amp = amp)
             case _ =>
         }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -4,9 +4,11 @@
 
 @{
     media match {
-            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper = mediaWrapper, amp = amp,picture = media.posterImage.get, caption = media.title)
-            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media = media, displayCaption = displayCaption, mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia)) else views.html.fragments.atoms.youtube(media = media, displayCaption = displayCaption, displayEndSlate = displayEndSlate)
-            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media = media, displayCaption = displayCaption, amp = amp)
+            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
+            case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
+                if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
+                else views.html.fragments.atoms.youtube(media, displayCaption, displayEndSlate, mediaWrapper)
+            case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }
 }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -4,7 +4,7 @@
 
 @{
     media match {
-            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia), amp = amp,picture = media.posterImage.get, caption = media.title)
+            case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper = mediaWrapper, amp = amp,picture = media.posterImage.get, caption = media.title)
             case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) => if(amp) views.html.fragments.atoms.ampYoutube(media = media, displayCaption = displayCaption, mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia)) else views.html.fragments.atoms.youtube(media = media, displayCaption = displayCaption, displayEndSlate = displayEndSlate)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media = media, displayCaption = displayCaption, amp = amp)
             case _ =>

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -17,7 +17,7 @@
         <base target="_parent"/>
     </head>
     <body>
-        @views.html.fragments.atoms.media(page.atom, displayCaption = displayCaption, mediaWrapper = Some(MediaWrapper.Embed))
+        @views.html.fragments.atoms.media(page.atom, displayCaption = displayCaption, mediaWrapper = Some(MediaWrapper.EmbedPage))
  <script>
         var guardian = {
             isEmbed: true,

--- a/common/app/views/fragments/atoms/mediaEmbed.scala.html
+++ b/common/app/views/fragments/atoms/mediaEmbed.scala.html
@@ -2,6 +2,7 @@
 @import model.MediaAtomEmbedPage
 @import conf.Configuration
 
+@import model.content.MediaWrapper
 @(page: MediaAtomEmbedPage, displayCaption: Boolean)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
@@ -16,7 +17,7 @@
         <base target="_parent"/>
     </head>
     <body>
-        @views.html.fragments.atoms.media(page.atom, displayCaption = displayCaption, embedPage = true)
+        @views.html.fragments.atoms.media(page.atom, displayCaption = displayCaption, mediaWrapper = Some(MediaWrapper.Embed))
  <script>
         var guardian = {
             isEmbed: true,

--- a/common/app/views/fragments/atoms/posterImage.scala.html
+++ b/common/app/views/fragments/atoms/posterImage.scala.html
@@ -1,9 +1,9 @@
+@import model.content.MediaWrapper
 @import layout.ContentWidths.MainMedia
-
-@(mainMedia: Boolean, amp: Boolean, picture: model.ImageMedia, caption: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(mediaWrapper: Option[MediaWrapper], amp: Boolean, picture: model.ImageMedia, caption: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
     @defining(
-        if(mainMedia) {
+        if(mediaWrapper.contains(MediaWrapper.MainMedia)) {
             Seq("maxed", "responsive-img")
         } else {
             Seq("gu-image")
@@ -23,6 +23,6 @@
             )
         }
     }
-    @fragments.atoms.mediaAtomCaption(caption, mainMedia = mainMedia)
+    @fragments.atoms.mediaAtomCaption(caption, mainMedia = mediaWrapper.contains(MediaWrapper.MainMedia))
 
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -6,7 +6,9 @@
 @import model.pressed.CardStyle
 
 @import model.ImageMedia
-@(media: model.content.MediaAtom, displayCaption: Boolean, embedPage: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, mainMedia: Boolean = false, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, immersiveMainMedia: Boolean = false)(implicit request: RequestHeader)
+@import model.content.MediaWrapper._
+@import model.content.MediaWrapper
+@(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None)(implicit request: RequestHeader)
 
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
 @defining(playable && !posterImageOverride.exists(_ => mvt.YouTubePosterOverride.isParticipating)){sixteenByNine: Boolean =>
@@ -32,7 +34,7 @@
                 "enablejsapi" -> 1,
                 "rel" -> 0,
                 "showinfo" -> 1,
-                "origin" -> (if(embedPage) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                "origin" -> (if(mediaWrapper.contains(Embed)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>
                 <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"
@@ -46,7 +48,7 @@
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 
                 @if(!expired) {
-                    @if(immersiveMainMedia) {
+                    @if(mediaWrapper.contains(ImmersiveMainMedia)) {
                         <div class='gs-container'>
                             <div class='content__main-column'>
                                 <div class='youtube-media-atom__immersive-interface'>
@@ -86,6 +88,6 @@
         </div>
 }
 
-@if(displayCaption & !immersiveMainMedia) {
-    @mediaAtomCaption(media.title, mainMedia)
+@if(displayCaption & !mediaWrapper.contains(ImmersiveMainMedia)) {
+    @mediaAtomCaption(media.title, mediaWrapper.contains(MainMedia))
 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -34,7 +34,7 @@
                 "enablejsapi" -> 1,
                 "rel" -> 0,
                 "showinfo" -> 1,
-                "origin" -> (if(mediaWrapper.contains(Embed)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
+                "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>
                 <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -94,7 +94,6 @@ data-test-id="facia-card"
                     @youtube(
                         media = media.youTubeAtom,
                         displayCaption = false,
-                        embedPage = false,
                         displayDuration = false,
                         displayEndSlate = item.cardTypes.showYouTubeMediaAtomEndSlate,
                         playable = item.cardTypes.showYouTubeMediaAtomPlayer,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -8,7 +8,7 @@ import conf.switches.Switches._
 import layout.ContentWidths
 import layout.ContentWidths._
 import model._
-import model.content.{Atom, Atoms}
+import model.content.{Atom, Atoms, MediaWrapper}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
@@ -601,7 +601,7 @@ object MembershipEventCleaner extends HtmlCleaner {
     }
 }
 
-case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, mainMedia: Boolean = false, immersiveMainMedia: Boolean = false)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
+case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: Boolean = false, mediaWrapper: Option[MediaWrapper] = None)(implicit val request: RequestHeader, context: ApplicationContext) extends HtmlCleaner {
   private def findAtom(id: String): Option[Atom] = {
     atoms.flatMap(_.all.find(_.id == id))
   }
@@ -614,7 +614,7 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomData <- findAtom(atomId)
       } {
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mainMedia, immersiveMainMedia).toString()
+        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper).toString()
         bodyElement.remove()
         atomContainer.append(html)
       }

--- a/common/app/views/support/ImmersiveMainCleaner.scala
+++ b/common/app/views/support/ImmersiveMainCleaner.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import common.Edition
+import model.content.MediaWrapper
 import model.{ApplicationContext, Article}
 import play.api.mvc.RequestHeader
 
@@ -8,7 +9,7 @@ object ImmersiveMainCleaner {
   def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader, context: ApplicationContext) = {
     implicit val edition = Edition(request)
     withJsoup(BulletCleaner(html))(
-      AtomsCleaner(article.content.atoms, shouldFence = true, amp, immersiveMainMedia = true)
+      AtomsCleaner(article.content.atoms, shouldFence = true, amp, mediaWrapper = Some(MediaWrapper.ImmersiveMainMedia))
     )
   }
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -1,7 +1,7 @@
 package views.support.cleaner
 
 import implicits.FakeRequests
-import model.content.{Atoms, MediaAsset, MediaAssetPlatform, MediaAtom}
+import model.content._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.{FlatSpec, Matchers}
@@ -59,9 +59,15 @@ class AtomCleanerTest extends FlatSpec
   }
 
   "Youtube template" should "include endslate path" in {
-    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = false, embedPage = false)(TestRequest())
+    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = false, mediaWrapper = None)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.select("div.youtube-media-atom").first().attr("data-end-slate") should be("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z")
+  }
+
+  "Youtube template" should "include main media caption" in {
+    val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = true, mediaWrapper = Some(MediaWrapper.MainMedia))(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+    doc.select("figcaption").hasClass("caption--main") should be(true)
   }
 
 


### PR DESCRIPTION
## What does this change?
Consolidates three  presentational boolean parameters which cannot co-occur:
* embedPage
* mainMedia
* immersiveMainMedia

into an enum `MediaWrapper`

## What is the value of this and can you measure success?
Code should be cleaner to read as fewer parameters are passed to media template and by extension in places they are called such as Cleaners and templates

## Does this affect other platforms - Amp, Apps, etc?
This is a refactor. So existing behaviour on AMP should continue.

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
