### PR TITLE
Wait for commercial end

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/commercial.js
+++ b/static/src/javascripts-legacy/bootstraps/commercial.js
@@ -149,6 +149,10 @@ define([
                     // There are no MPUs on hosted pages, so no slot render events, and therefore no reporting would be done.
                     Promise.all(customTimingModules).then(performanceLogging.reportTrackingData);
                 }
+            })
+            .catch(function () {
+                // Just in case something goes wrong, we don't want it to
+                // prevent enhanced from loading
             });
         }
     };

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -35,23 +35,24 @@ domready(() => {
             ['bootstraps/commercial'],
             raven.wrap({ tags: { feature: 'commercial' } }, commercial => {
                 userTiming.mark('commercial boot');
-                commercial.init();
+                commercial.init().then(function () {;
 
-                // 3. finally, try enhanced
-                // this is defined here so that webpack's code-splitting algo
-                // excludes all the modules bundled in the commercial chunk from this one
-                if (window.guardian.isEnhanced) {
-                    userTiming.mark('enhanced request');
-                    require(['bootstraps/enhanced/main'], bootEnhanced => {
-                        userTiming.mark('enhanced boot');
-                        bootEnhanced();
-                        if (document.readyState === 'complete') {
-                            capturePerfTimings();
-                        } else {
-                            window.addEventListener('load', capturePerfTimings);
-                        }
-                    });
-                }
+                    // 3. finally, try enhanced
+                    // this is defined here so that webpack's code-splitting algo
+                    // excludes all the modules bundled in the commercial chunk from this one
+                    if (window.guardian.isEnhanced) {
+                        userTiming.mark('enhanced request');
+                        require(['bootstraps/enhanced/main'], bootEnhanced => {
+                            userTiming.mark('enhanced boot');
+                            bootEnhanced();
+                            if (document.readyState === 'complete') {
+                                capturePerfTimings();
+                            } else {
+                                window.addEventListener('load', capturePerfTimings);
+                            }
+                        });
+                    }
+                });
             })
         );
     }

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -47,7 +47,10 @@ domready(() => {
                             if (document.readyState === 'complete') {
                                 capturePerfTimings();
                             } else {
-                                window.addEventListener('load', capturePerfTimings);
+                                window.addEventListener(
+                                    'load',
+                                    capturePerfTimings
+                                );
                             }
                         });
                     }

--- a/static/src/javascripts/boot-webpack.js
+++ b/static/src/javascripts/boot-webpack.js
@@ -35,8 +35,7 @@ domready(() => {
             ['bootstraps/commercial'],
             raven.wrap({ tags: { feature: 'commercial' } }, commercial => {
                 userTiming.mark('commercial boot');
-                commercial.init().then(function () {;
-
+                commercial.init().then(() => {
                     // 3. finally, try enhanced
                     // this is defined here so that webpack's code-splitting algo
                     // excludes all the modules bundled in the commercial chunk from this one


### PR DESCRIPTION
The `enhanced` bootstrap is loaded in parallel with the sonobi and google libraries:

![picture 10](https://cloud.githubusercontent.com/assets/629976/23512407/60dec7f4-ff58-11e6-845a-14bb4623398d.jpg)

That's because all the commercial stuff is done via promises. The commercial bootstrap returns a promise that resolves when all the commercial modules have been initiated, which takes half a second on average:

![untitled](https://cloud.githubusercontent.com/assets/629976/23512527/c856da34-ff58-11e6-93f3-08cf73daf87e.png)

All the heavy work is pushed into the google command queue which is itself asynchronous (at least until GPT has been evaluated). In this PR, I'm just waiting on the global promise, it gives the commercial stuff some room to breathe -- not too much though, because we never wait on anything.