### PR TITLE
ES6: Make conversion script less error prone

### DIFF
--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+const git = require('simple-git')();
 const gitUser = require('git-user-name');
 const chalk = require('chalk');
 const execa = require('execa');
@@ -22,64 +23,84 @@ if (!userModules || !userModules.length) {
     process.exit();
 }
 
-const moduleId = userModules.shift();
-const unique = `${Date.now()}`.slice(-4);
-const es5Module = path.join('static', 'src', 'javascripts-legacy', moduleId);
-
-const es6Module = path.join('static', 'src', 'javascripts', moduleId);
-const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
-const branchName = `es6-${es6Name}`;
-
-const steps = {
-    'Create a branch for the conversion': `git checkout -b "${branchName}" master || git checkout -b "${branchName}-${unique}" master`,
-    'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
-    'Commit the move': `git add ${es6Module} ${es5Module}; git commit -m "move ${moduleId} from legacy to standard JS"`,
-    'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
-    'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to es6 module"`,
-    'Convert contents to es6': `npm run -s lebab -- ${es6Module}`,
-    'Commit the content tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} content to es6"`,
-    'Fix lint errors': `npm run -s eslint-fix -- ${es6Module}`,
-    'Commit any lint fixes': `git commit ${es6Module} -m "fix lint errors with ${moduleId} after transform to es6"`,
-};
-
-Object.keys(steps)
-    .reduce(
-        (allSteps, step, i) => allSteps.then(() => {
-            console.log('');
-            console.log(chalk.blue(`${i + 1}. ${step}`));
-            console.log(chalk.dim(steps[step]));
-            return execa
-                .shell(steps[step].trim(), {
-                    stdio: 'inherit',
-                })
-                .then(() => {
-                    console.log(chalk.green('done'));
-                })
-                .catch(e => {
-                    console.log(chalk.red(e.stack));
-                    megalog.error(
-                        `\`${step}\` did not complete.
-
-Once you have fixed the problem, you'll need to run the remaining steps manually:
-${Object.keys(steps)
-                            .slice(i)
-                            .map((remaingStep, remainingCount) => `
-${i + 1 + remainingCount}. ${remaingStep}
-\`${steps[remaingStep]}\`
-`)
-                            .join('')}
-If you get stuck, feel free to ping us in https://theguardian.slack.com/messages/dotcom-platform.`
-                    );
-                    process.exit(1);
-                });
-        }),
-        Promise.resolve()
-    )
+git
+    .status((err, status) => {
+        if (
+            status.files.length > 0 || status.ahead !== 0 || status.behind !== 0
+        ) {
+            console.log(
+                chalk.red(
+                    'Please run this in a clean, up to date copy of master.'
+                )
+            );
+            process.exit(1);
+        }
+    })
     .then(() => {
-        console.log(
-            chalk.blue(
-                `\n💫  Module is now ES6! Double check the code, then create a PR.`
-            )
+        const moduleId = userModules.shift();
+        const unique = `${Date.now()}`.slice(-4);
+        const es5Module = path.join(
+            'static',
+            'src',
+            'javascripts-legacy',
+            moduleId
         );
-        console.log(chalk.dim(`New location: ${es6Module}\n`));
+
+        const es6Module = path.join('static', 'src', 'javascripts', moduleId);
+        const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
+        const branchName = `es6-${es6Name}`;
+
+        const steps = {
+            'Create a branch for the conversion': `git checkout -b "${branchName}" master || git checkout -b "${branchName}-${unique}" master`,
+            'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
+            'Commit the move': `git add ${es6Module} ${es5Module}; git commit -m "move ${moduleId} from legacy to standard JS"`,
+            'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
+            'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to es6 module"`,
+            'Convert contents to es6': `npm run -s lebab -- ${es6Module}`,
+            'Commit the content tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} content to es6"`,
+            'Fix lint errors': `npm run -s eslint-fix -- ${es6Module}`,
+            'Commit any lint fixes': `git commit ${es6Module} -m "fix lint errors with ${moduleId} after transform to es6"`,
+        };
+
+        Object.keys(steps)
+            .reduce(
+                (allSteps, step, i) => allSteps.then(() => {
+                    console.log('');
+                    console.log(chalk.blue(`${i + 1}. ${step}`));
+                    console.log(chalk.dim(steps[step]));
+                    return execa
+                        .shell(steps[step].trim(), {
+                            stdio: 'inherit',
+                        })
+                        .then(() => {
+                            console.log(chalk.green('done'));
+                        })
+                        .catch(e => {
+                            console.log(chalk.red(e.stack));
+                            megalog.error(
+                                `\`${step}\` did not complete.
+
+        Once you have fixed the problem, you'll need to run the remaining steps manually:
+        ${Object.keys(steps)
+                                    .slice(i)
+                                    .map((remaingStep, remainingCount) => `
+        ${i + 1 + remainingCount}. ${remaingStep}
+        \`${steps[remaingStep]}\`
+        `)
+                                    .join('')}
+        If you get stuck, feel free to ping us in https://theguardian.slack.com/messages/dotcom-platform.`
+                            );
+                            process.exit(1);
+                        });
+                }),
+                Promise.resolve()
+            )
+            .then(() => {
+                console.log(
+                    chalk.blue(
+                        `\n💫  Module is now ES6! Double check the code, then create a PR.`
+                    )
+                );
+                console.log(chalk.dim(`New location: ${es6Module}\n`));
+            });
     });

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -26,7 +26,10 @@ if (!userModules || !userModules.length) {
 git
     .status((err, status) => {
         if (
-            status.files.length > 0 || status.ahead !== 0 || status.behind !== 0
+            status.current !== 'master' ||
+            status.files.length > 0 ||
+            status.ahead !== 0 ||
+            status.behind !== 0
         ) {
             console.log(
                 chalk.red(
@@ -48,12 +51,13 @@ git
 
         const es6Module = path.join('static', 'src', 'javascripts', moduleId);
         const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
+        const responsibilityFile = path.resolve('./es5to6.json');
         const branchName = `es6-${es6Name}`;
 
         const steps = {
             'Create a branch for the conversion': `git checkout -b "${branchName}" master || git checkout -b "${branchName}-${unique}" master`,
             'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
-            'Commit the move': `git add ${es6Module} ${es5Module}; git commit -m "move ${moduleId} from legacy to standard JS"`,
+            'Commit the move': `git add ${es6Module} ${es5Module} ${responsibilityFile}; git commit -m "move ${moduleId} from legacy to standard JS"`,
             'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
             'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to es6 module"`,
             'Convert contents to es6': `npm run -s lebab -- ${es6Module}`,

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -31,7 +31,7 @@ const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
 const branchName = `es6-${es6Name}`;
 
 const steps = {
-    'Create a branch for the conversion': `git checkout -b "${branchName}" || git checkout -b "${branchName}-${unique}"`,
+    'Create a branch for the conversion': `git checkout -b "${branchName}" master || git checkout -b "${branchName}-${unique}" master`,
     'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
     'Commit the move': `git add ${es6Module} ${es5Module}; git commit -m "move ${moduleId} from legacy to standard JS"`,
     'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const git = require('simple-git')();
 const gitUser = require('git-user-name');
 const chalk = require('chalk');
 const execa = require('execa');
@@ -17,91 +16,75 @@ process.on('uncaughtException', handleError);
 const remainingModules = require('./es5to6.json');
 
 const userModules = remainingModules[gitUser()];
+
 if (!userModules || !userModules.length) {
     console.log(chalk.green('⭐️  You have no more modules to convert! ⭐️'));
     process.exit();
 }
 
-git
-    .status((err, status) => {
-        if (
-            status.current !== 'master' ||
-            status.files.length > 0 ||
-            status.ahead !== 0 ||
-            status.behind !== 0
-        ) {
-            console.log(
-                chalk.red(
-                    'Please run this in a clean, up to date copy of master.'
-                )
-            );
-            process.exit(1);
-        }
-    })
-    .then(() => {
-        const moduleId = userModules.shift();
-        const unique = `${Date.now()}`.slice(-4);
-        const es5Module = path.join(
-            'static',
-            'src',
-            'javascripts-legacy',
-            moduleId
-        );
-        const es6Module = path.join('static', 'src', 'javascripts', moduleId);
-        const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
-        const branchName = `es6-${es6Name}`;
+const moduleId = userModules.shift();
+const unique = `${Date.now()}`.slice(-4);
+const es5Module = path.join(
+    'static',
+    'src',
+    'javascripts-legacy',
+    moduleId
+);
 
-        const steps = {
-            'Create a branch for the conversion': `git checkout -b "${branchName}" || git checkout -b "${branchName}-${unique}"`,
-            'Move the legacy module to the new location': `mkdir -p ${path.dirname(es6Module)}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
-            'Commit the move': `git add .; git commit -m "move ${moduleId} from legacy to standard JS"`,
-            'Convert module to ES6': `npm run -s amdtoes6 -- -d ${path.dirname(es6Module)} -o ${path.dirname(es6Module)} -g **/${path.basename(es6Module)} `,
-            'Commit the module tranform': `git add .; git commit -m "transform ${moduleId} to ES6 module"`,
-            'Convert contents to ES6': `npm run -s lebab -- ${es6Module}`,
-            'Commit the content tranform': `git add .; git commit -m "transform ${moduleId} content to ES6"`,
-            'Fix lint errors': `npm run -s eslint-fix -- ${es6Module}`,
-            'Commit any lint fixes': `git add .; git commit -m "fix lint errors with ${moduleId} after transform to ES6"`,
-        };
+const es6Module = path.join('static', 'src', 'javascripts', moduleId);
+const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
+const branchName = `es6-${es6Name}`;
 
-        Object.keys(steps)
-            .reduce(
-                (allSteps, step, i) => allSteps.then(() => {
-                    console.log('');
-                    console.log(chalk.blue(`${i + 1}. ${step}`));
-                    console.log(chalk.dim(steps[step]));
-                    return execa
-                        .shell(steps[step].trim(), {
-                            stdio: 'inherit',
-                        })
-                        .then(() => {
-                            console.log(chalk.green('done'));
-                        })
-                        .catch(e => {
-                            console.log(chalk.red(e.stack));
-                            megalog.error(
-                                `\`${step}\` did not complete.
+const steps = {
+    'Create a branch for the conversion': `git checkout -b "${branchName}" || git checkout -b "${branchName}-${unique}"`,
+    'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
+    'Commit the move': `git add ${es6Module} ${es5Module}; git commit -m "move ${moduleId} from legacy to standard JS"`,
+    'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
+    'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to es6 module"`,
+    'Convert contents to es6': `npm run -s lebab -- ${es6Module}`,
+    'Commit the content tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} content to es6"`,
+    'Fix lint errors': `npm run -s eslint-fix -- ${es6Module}`,
+    'Commit any lint fixes': `git commit ${es6Module} -m "fix lint errors with ${moduleId} after transform to es6"`,
+};
+
+Object.keys(steps)
+    .reduce(
+        (allSteps, step, i) => allSteps.then(() => {
+            console.log('');
+            console.log(chalk.blue(`${i + 1}. ${step}`));
+            console.log(chalk.dim(steps[step]));
+            return execa
+                .shell(steps[step].trim(), {
+                    stdio: 'inherit',
+                })
+                .then(() => {
+                    console.log(chalk.green('done'));
+                })
+                .catch(e => {
+                    console.log(chalk.red(e.stack));
+                    megalog.error(
+                        `\`${step}\` did not complete.
 
 Once you have fixed the problem, you'll need to run the remaining steps manually:
 ${Object.keys(steps)
-                                    .slice(i)
-                                    .map((remaingStep, remainingCount) => `
+                            .slice(i)
+                            .map((remaingStep, remainingCount) => `
 ${i + 1 + remainingCount}. ${remaingStep}
 \`${steps[remaingStep]}\`
 `)
-                                    .join('')}
+                            .join('')}
 If you get stuck, feel free to ping us in https://theguardian.slack.com/messages/dotcom-platform.`
-                            );
-                            process.exit(1);
-                        });
-                }),
-                Promise.resolve()
+                    );
+                    process.exit(1);
+                });
+        }),
+        Promise.resolve()
+    )
+    .then(() => {
+        console.log(
+            chalk.blue(
+                `\n💫  Module is now ES6! Double check the code, then create a PR.`
             )
-            .then(() => {
-                console.log(
-                    chalk.blue(
-                        `\n💫  Module is now es6! Double check the code, then create a PR.`
-                    )
-                );
-                console.log(chalk.dim(`New location: ${es6Module}\n`));
-            });
+        );
+        console.log(chalk.dim(`New location: ${es6Module}\n`));
     });

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -58,12 +58,12 @@ git
             'Create a branch for the conversion': `git checkout -b "${branchName}" master || git checkout -b "${branchName}-${unique}" master`,
             'Move the legacy module to the new location': `mkdir -p ${es6Module}; mv ${es5Module} $_; node ./tools/es5to6-remove-module.js ${moduleId}`,
             'Commit the move': `git add ${es6Module} ${es5Module} ${responsibilityFile}; git commit -m "move ${moduleId} from legacy to standard JS"`,
-            'Convert module to es6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
-            'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to es6 module"`,
-            'Convert contents to es6': `npm run -s lebab -- ${es6Module}`,
-            'Commit the content tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} content to es6"`,
+            'Convert module to ES6': `npm run -s amdtoes6 -- -d ${es6Module} -o ${es6Module} -g **/${path.basename(es6Module)} `,
+            'Commit the module tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} to ES6 module"`,
+            'Convert contents to ES6': `npm run -s lebab -- ${es6Module}`,
+            'Commit the content tranform': `git add ${es6Module}; git commit -m "transform ${moduleId} content to ES6"`,
             'Fix lint errors': `npm run -s eslint-fix -- ${es6Module}`,
-            'Commit any lint fixes': `git commit ${es6Module} -m "fix lint errors with ${moduleId} after transform to es6"`,
+            'Commit any lint fixes': `git commit ${es6Module} -m "fix lint errors with ${moduleId} after transform to ES6"`,
         };
 
         Object.keys(steps)

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -26,7 +26,7 @@ if (!userModules || !userModules.length) {
 git
     .status((err, status) => {
         if (
-            status.current !== 'master' ||
+            status.current !== 'gp-es6-conversion-simplify' ||
             status.files.length > 0 ||
             status.ahead !== 0 ||
             status.behind !== 0

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -24,12 +24,7 @@ if (!userModules || !userModules.length) {
 
 const moduleId = userModules.shift();
 const unique = `${Date.now()}`.slice(-4);
-const es5Module = path.join(
-    'static',
-    'src',
-    'javascripts-legacy',
-    moduleId
-);
+const es5Module = path.join('static', 'src', 'javascripts-legacy', moduleId);
 
 const es6Module = path.join('static', 'src', 'javascripts', moduleId);
 const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -84,15 +84,15 @@ git
                             megalog.error(
                                 `\`${step}\` did not complete.
 
-        Once you have fixed the problem, you'll need to run the remaining steps manually:
-        ${Object.keys(steps)
+Once you have fixed the problem, you'll need to run the remaining steps manually:
+${Object.keys(steps)
                                     .slice(i)
                                     .map((remaingStep, remainingCount) => `
-        ${i + 1 + remainingCount}. ${remaingStep}
-        \`${steps[remaingStep]}\`
-        `)
+${i + 1 + remainingCount}. ${remaingStep}
+\`${steps[remaingStep]}\`
+`)
                                     .join('')}
-        If you get stuck, feel free to ping us in https://theguardian.slack.com/messages/dotcom-platform.`
+If you get stuck, feel free to ping us in https://theguardian.slack.com/messages/dotcom-platform.`
                             );
                             process.exit(1);
                         });


### PR DESCRIPTION
## What does this change?

- The conversion branch is always created from `master`
- Only the ES5 and ES6 files are commited - nothing else, which allows to have unstaged files.

## What is the value of this and can you measure success?

Easier conversion.