### PR TITLE
Remove unused A4A beta attribute from AMP ads

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -5,7 +5,6 @@
 @import common.Edition
 @import views.support.{AmpAd, AmpAdDataSlot}
 @import org.joda.time.DateTimeZone
-@import play.api.Mode.Dev
 
 @liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
     @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
@@ -15,9 +14,7 @@
         @if(blockGroup.length == 5 && index < 8) {
             <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick"
-                @if(context.environment.mode != Dev) {
-                  data-use-beta-a4a-implementation="true"
-                } data-loading-strategy="prefer-viewability-over-views"
+                data-loading-strategy="prefer-viewability-over-views"
                     json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
                     data-slot=@AmpAdDataSlot(article).toString()>
                 </amp-ad>

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -4,7 +4,6 @@ import common.Edition
 import model.Article
 import org.jsoup.nodes.{Document, Element}
 import views.support.{AmpAd, AmpAdDataSlot, HtmlCleaner}
-import conf.Configuration
 
 import scala.collection.JavaConversions._
 
@@ -88,25 +87,13 @@ object AmpAdCleaner {
 case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends HtmlCleaner {
 
   def adAfter(element: Element) = {
-    // data-use-beta-a4a-implementation will throw an error if the page is not in the AMP CDN
-    // Lets prevent it appearing in Dev
-    if(Configuration.environment.stage.toLowerCase == "dev") {
-      val ampAd = <div class="amp-ad-container">
-        <amp-ad width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
-                json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
-                data-slot={AmpAdDataSlot(article).toString()}>
-        </amp-ad>
-      </div>
-      element.after(ampAd.toString())
-    } else {
-      val ampAd = <div class="amp-ad-container">
-        <amp-ad width="300" height="250" type="doubleclick" data-use-beta-a4a-implementation="true" data-loading-strategy="prefer-viewability-over-views"
-                json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
-                data-slot={AmpAdDataSlot(article).toString()}>
-        </amp-ad>
-      </div>
-      element.after(ampAd.toString())
-    }
+    val ampAd = <div class="amp-ad-container">
+      <amp-ad width="300" height="250" type="doubleclick" data-loading-strategy="prefer-viewability-over-views"
+              json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
+              data-slot={AmpAdDataSlot(article).toString()}>
+      </amp-ad>
+    </div>
+    element.after(ampAd.toString())
   }
 
   override def clean(document: Document): Document = {

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -11,7 +11,7 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
   val tenChars = "qwertyasdf"
 
   private def adAfter(element: Element) = {
-    element.after("""<div class="amp-ad-container"><amp-ad width=300 height=250 type="doubleclick" data-use-beta-a4a-implementation="true" json='{"targeting":{"sc":["1"]}}' data-slot="/59666047/theguardian.com/uk"></amp-ad></div>""")
+    element.after("""<div class="amp-ad-container"><amp-ad width=300 height=250 type="doubleclick" json='{"targeting":{"sc":["1"]}}' data-slot="/59666047/theguardian.com/uk"></amp-ad></div>""")
   }
 
   private def clean(document: Document): Document = {


### PR DESCRIPTION
## What does this change?

Removes the unused `data-use-beta-a4a-implementation` attribute from AMP ads.

## What is the value of this and can you measure success?

Removes some errors from the console in AMP pages

## Does this affect other platforms - Amp, Apps, etc?

Yep, AMP pages

## Tested in CODE?

Nope, but tests pass