### PR TITLE
Immersive embeds covered by sidebar

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -96,7 +96,6 @@
     position: absolute;
     top: 0;
     right: 0;
-    height: 100%;
     margin-right: $gs-gutter;
     width: gs-span(4);
     padding-left: $gs-gutter;


### PR DESCRIPTION
On immersive articles, an immersive embed is part covered by the sidebar due to height: 100%. This is getting in the way of immersive embeds being fully interactive. 