### PR TITLE
Include lodash find in check-dispatcher

### DIFF
--- a/static/src/javascripts-legacy/lib/check-dispatcher.js
+++ b/static/src/javascripts-legacy/lib/check-dispatcher.js
@@ -1,10 +1,12 @@
 define([
+    'lodash/collections/find',
     'lib/config',
     'lib/check-mediator',
     'common/modules/email/run-checks',
     'common/modules/email/email-article',
     'common/modules/experiments/ab-test-clash'
 ], function(
+    find,
     config,
     checkMediator,
     emailRunChecks,
@@ -20,7 +22,7 @@ define([
             return emailRunChecks.allEmailCanRun();
         },
         listCanRun: function() {
-            return find(emailArticle.getListConfigs(), emailRunChecks.listCanRun) ? true : false;
+            return !!find(emailArticle.getListConfigs(), emailRunChecks.listCanRun);
         },
         emailInArticleOutbrainEnabled: function() {
             return config.switches.emailInArticleOutbrain;


### PR DESCRIPTION
## What does this change?

It looks like the lodash `find` method was not included in `check-dispatcher` when it was created in #15802. The behaviour was reverting to the non-standard [`window.find`](https://developer.mozilla.org/en-US/docs/Web/API/Window/find) method, which does something completely different to lodash's `find` and doesn't exist in some browsers, throwing a `ReferenceError`.

## What is the value of this and can you measure success?

Check now does the correct thing. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
