### PR TITLE
Add commercial endpoints for getting Preview Urls for creatives

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -111,9 +111,9 @@ class CommercialController(implicit context: ApplicationContext) extends Control
     val previewUrls: Seq[String] =
       (for {
         lineItemId <- Try(lineitemId.toLong).toOption
-        section <- validSections.find(_ == section)
+        validSection <- validSections.find(_ == section)
       } yield {
-          DfpApi.getCreativeIds(lineItemId) flatMap (DfpApi.getPreviewUrl(lineItemId, _, s"https://theguardian.com/$section"))
+          DfpApi.getCreativeIds(lineItemId) flatMap (DfpApi.getPreviewUrl(lineItemId, _, s"https://theguardian.com/$validSection"))
       }) getOrElse Nil
 
     Cached(5.minutes) {

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -136,8 +136,10 @@ object DfpApi extends Logging {
   }
 
   def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): Option[String] =
-    for (session <- SessionWrapper())
-      yield session.lineItemCreativeAssociations.getPreviewUrl(lineItemId, creativeId, url)
+    for {
+      session <- SessionWrapper()
+      previewUrl <- session.lineItemCreativeAssociations.getPreviewUrl(lineItemId, creativeId, url)
+    } yield previewUrl
 
   private def withDfpSession[T](block: SessionWrapper => Seq[T]): Seq[T] = {
     val results = for (session <- SessionWrapper()) yield block(session)

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -125,6 +125,20 @@ object DfpApi extends Logging {
     } sortBy (_._2)
   }
 
+  def getCreativeIds(lineItemId: Long): Seq[Long] = {
+    val stmtBuilder = new StatementBuilder().where("status = :status AND lineItemId = :lineItemId")
+      .withBindVariableValue("status", LineItemCreativeAssociationStatus._ACTIVE)
+      .withBindVariableValue("lineItemId", lineItemId)
+
+    withDfpSession { session =>
+      session.lineItemCreativeAssociations.get(stmtBuilder) map (id => Long2long(id.getCreativeId))
+    }
+  }
+
+  def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): Option[String] =
+    for (session <- SessionWrapper())
+      yield session.lineItemCreativeAssociations.getPreviewUrl(lineItemId, creativeId, url)
+
   private def withDfpSession[T](block: SessionWrapper => Seq[T]): Seq[T] = {
     val results = for (session <- SessionWrapper()) yield block(session)
     results getOrElse Nil

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -12,6 +12,10 @@ private[dfp] object SessionLogger extends Logging {
     logAroundSeq(typesToRead, opName = "reading", Some(stmtBuilder.toStatement))(read)
   }
 
+  def logAroundReadSingle[T](typesToRead: String)(read: => T): Option[T] = {
+    logAround(typesToRead, "reading")(read)((_: T) => 1)
+  }
+
   def logAroundCreate[T](typesToCreate: String)(create: => Seq[T]): Seq[T] = {
     logAroundSeq(typesToCreate, opName = "creating")(create)
   }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -8,7 +8,7 @@ import com.google.api.ads.dfp.lib.client.DfpSession
 import common.Logging
 import conf.{AdminConfiguration, Configuration}
 import dfp.Reader.read
-import dfp.SessionLogger.{logAroundCreate, logAroundPerform, logAroundRead}
+import dfp.SessionLogger.{logAroundCreate, logAroundPerform, logAroundRead, logAroundReadSingle}
 
 import scala.util.control.NonFatal
 
@@ -115,8 +115,10 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
       }
     }
 
-    def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): String =
-      licaService.getPreviewUrl(lineItemId, creativeId, url) //TODO: Create a new logAround method for this
+    def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): Option[String] =
+      logAroundReadSingle(typeName) {
+        licaService.getPreviewUrl(lineItemId, creativeId, url)
+      }
 
     def create(licas: Seq[LineItemCreativeAssociation]): Seq[LineItemCreativeAssociation] = {
       logAroundCreate(typeName) {

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -115,6 +115,9 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
       }
     }
 
+    def getPreviewUrl(lineItemId: Long, creativeId: Long, url: String): String =
+      licaService.getPreviewUrl(lineItemId, creativeId, url) //TODO: Create a new logAround method for this
+
     def create(licas: Seq[LineItemCreativeAssociation]): Seq[LineItemCreativeAssociation] = {
       logAroundCreate(typeName) {
         licaService.createLineItemCreativeAssociations(licas.toArray)

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -93,6 +93,8 @@ GET         /commercial/adops/takeovers-empty-mpus/create                       
 POST        /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.create()
 POST        /commercial/adops/takeovers-empty-mpus/remove                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(takeoverStr)
 GET         /commercial/invalid-lineitems                                                           controllers.admin.CommercialController.renderInvalidItems()
+GET         /commercial/adgrabber/order/:orderId                                                    controllers.admin.CommercialController.getLineItemsForOrder(orderId: String)
+GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 
 # Metrics
 GET         /metrics/loadbalancers                                                                  controllers.admin.MetricsController.renderLoadBalancers()


### PR DESCRIPTION
### Background
We are developing a small tool for the Ad Ops team that will ultimately provide a way of screen grabbing all ads from a given campaign as they appear on various sections of theguardian.com. To force a creative to show on a given page a Preview URL can be generated by DFP.

### What does this PR do?
This PR creates a couple of "ad grabber" API routes that can be used to get:

a) All the line items for a given DFP order
b) A list of preview URLs for each creative in a line item, provided a section of the website

This leverages all of the caching and fetching that is set up in frontend/admin.

@guardian/commercial-dev 