### PR TITLE
ES6: remove deleted utility-files from ES6 conversion list

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -159,14 +159,12 @@
     "lib/client-rects.js",
     "lib/closest.js",
     "lib/config.js",
-    "lib/contains.js",
     "lib/cookies.js"
   ],
   "NataliaLKB": [
     "lib/create-store.js",
     "lib/date-formats.js",
     "lib/detect.js",
-    "lib/drop-while.js",
     "lib/easing.js",
     "lib/element-inview.js",
     "lib/fastdom-errors.js",
@@ -197,7 +195,6 @@
     "lib/robust.js"
   ],
   "stephanfowler": [
-    "lib/scan.js",
     "lib/scroller.js",
     "lib/sha1.js",
     "lib/steady-page.js",


### PR DESCRIPTION
## What does this change?

Updates ES6 conversion responsibility files.