### PR TITLE
ES6: remove custom `lib/to-array`

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/facia.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/facia.js
@@ -7,7 +7,7 @@ define([
     'lib/mediator',
     'lib/robust',
     'lib/storage',
-    'lib/to-array',
+    'lodash/collections/toArray',
     'common/modules/accessibility/helpers',
     'common/modules/experiments/ab',
     'common/modules/business/stocks',

--- a/static/src/javascripts-legacy/lib/to-array.js
+++ b/static/src/javascripts-legacy/lib/to-array.js
@@ -1,8 +1,0 @@
-define(function () {
-
-    function toArray(list) {
-        return Array.prototype.slice.call(list);
-    }
-    return toArray;
-
-}); // define

--- a/static/src/javascripts-legacy/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts-legacy/projects/facia/modules/ui/snaps.js
@@ -7,7 +7,7 @@ define([
     'lib/fetch',
     'lib/mediator',
     'lib/template',
-    'lib/to-array',
+    'lodash/collections/toArray',
     'lib/proximity-loader',
     'lib/report-error',
     'common/modules/ui/relativedates',

--- a/static/test/javascripts-legacy/main.js
+++ b/static/test/javascripts-legacy/main.js
@@ -47,7 +47,7 @@ requirejs.config({
     }
 });
 
-require(['Promise', 'lib/to-array'], function (Promise, toArray) {
+require(['Promise', 'lodash/collections/toArray'], function (Promise, toArray) {
     require(tests, function () {
         Promise.all(toArray(arguments)).then(function () {
             window.__karma__.start();

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -159,14 +159,12 @@
     "lib/client-rects.js",
     "lib/closest.js",
     "lib/config.js",
-    "lib/contains.js",
     "lib/cookies.js"
   ],
   "NataliaLKB": [
     "lib/create-store.js",
     "lib/date-formats.js",
     "lib/detect.js",
-    "lib/drop-while.js",
     "lib/easing.js",
     "lib/element-inview.js",
     "lib/fastdom-errors.js",
@@ -197,7 +195,6 @@
     "lib/robust.js"
   ],
   "stephanfowler": [
-    "lib/scan.js",
     "lib/scroller.js",
     "lib/sha1.js",
     "lib/steady-page.js",

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -203,7 +203,6 @@
     "lib/template.js",
     "lib/time.js",
     "lib/timeout.js",
-    "lib/to-array.js",
     "lib/url.js",
     "lib/user-timing.js",
     "projects/admin/bootstraps/abtests.js",


### PR DESCRIPTION
## What does this change?

Removes custom `lib/to-array` implementation and replaces it with lodash functions. This allows an easier ES6 transformation later on.

## What is the value of this and can you measure success?

Less code, easier ES6 conversion.
