### PR TITLE
Extended Switch For Membership Bundles Thrasher

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -56,7 +56,7 @@ trait ABTestSwitches {
     "Test A3 vs A4 bundle offers",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 9), // Thursday March 9th
+    sellByDate = new LocalDate(2017, 3, 23), // Thursday March 23rd
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the switch for the membership bundles thrasher by two weeks.

## What is the value of this and can you measure success?

This prevents the switch from expiring; we don't want to strip the thrasher code out yet, because we may be doing further tests with it.

## Tested in CODE?

Not yet.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
