### PR TITLE
Load the alternative merchandising component instantly

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -174,7 +174,9 @@ define([
     }
 
     function addSlots(totalCount) {
-        qwery('.ad-slot--inline').forEach(addSlot);
+        qwery('.ad-slot--inline').forEach(function (slot) {
+            addSlot(slot);
+        });
         return totalCount;
     }
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/add-slot.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/add-slot.js
@@ -9,27 +9,27 @@ define([
 ], function (mediator, dfpEnv, Advert, queueAdvert, loadAdvert, enableLazyLoad, performanceLogging) {
     return addSlot;
 
-    function addSlot(adSlot) {
+    function addSlot(adSlot, forceDisplay) {
         adSlot = adSlot instanceof HTMLElement ? adSlot : adSlot[0];
 
         if (dfpEnv.firstAdDisplayed && !(adSlot.id in dfpEnv.advertIds)) { // dynamically add ad slot
             // this is horrible, but if we do this before the initial ads have loaded things go awry
             if (dfpEnv.firstAdRendered) {
-                displayAd(adSlot);
+                displayAd(adSlot, forceDisplay);
             } else {
                 mediator.once('modules:commercial:dfp:rendered', function () {
-                    displayAd(adSlot);
+                    displayAd(adSlot, forceDisplay);
                 });
             }
         }
     }
 
-    function displayAd(adSlot) {
+    function displayAd(adSlot, forceDisplay) {
         var advert = Advert(adSlot);
 
         dfpEnv.adverts.push(advert);
         queueAdvert(advert);
-        if (dfpEnv.shouldLazyLoad()) {
+        if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
             performanceLogging.updateAdvertMetric(advert, 'loadingMethod', 'add-slot-lazy');
             enableLazyLoad(advert);
         } else {

--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -67,7 +67,9 @@ define([
             if (args) {
                 fastdom.write(function () {
                     args[1].parentNode.insertBefore(args[0], args[1].nextSibling);
-                    addSlot(args[0]);
+                })
+                .then(function () {
+                    addSlot(args[0], true);
                 });
             }
         });


### PR DESCRIPTION
The alternative slot that is inserted for people in the Oubtrain_less_ A/B test variant needs to be loaded instantly to be 100% reflective of the current Outbrain_ful_ situation. We add an argument to `addSlot` in order to force instant display and make sure the flag is never set by accident elsewhere.