### PR TITLE
Sleeve notes test: put all new subscribers in the test

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -230,7 +230,7 @@ object EmailNewsletters {
     listId = 39,
     aliases = List(3834, 3835),
     tone = Some("review"),
-    signupPage = Some("/info/ng-interactive/2017/feb/23/sign-up-for-the-sleeve-notes-email")
+    signupPage = Some("/info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email")
   )
 
   val closeUp = EmailNewsletter(

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
@@ -11,7 +11,7 @@ define([
             author: 'Leigh-Anne Mathieson',
             audience: 0, //will be 0.3
             audienceOffset: 0.7,
-            signupPage: 'info/ng-interactive/2017/feb/23/sign-up-for-the-sleeve-notes-email',
+            signupPage: 'info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email',
             canonicalListId: 39,
             testIds: [
                 { variantId: 'SleeveNotes-Legacy', listId: 3835 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
@@ -9,7 +9,7 @@ define([
             start: '2017-03-02',
             end: '2017-03-31',
             author: 'Leigh-Anne Mathieson',
-            audience: 0, //will be 0.3
+            audience: 0.3,
             audienceOffset: 0.7,
             signupPage: 'info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email',
             canonicalListId: 39,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
@@ -11,7 +11,7 @@ define([
             author: 'Leigh-Anne Mathieson',
             audience: 0, //will be 0.7
             audienceOffset: 0,
-            signupPage: 'info/ng-interactive/2017/feb/23/sign-up-for-the-sleeve-notes-email',
+            signupPage: 'info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email',
             canonicalListId: 39,
             testIds: [
                 { variantId: 'SleeveNotes-New', listId: 3834 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
@@ -9,7 +9,7 @@ define([
             start: '2017-03-02',
             end: '2017-03-31',
             author: 'Leigh-Anne Mathieson',
-            audience: 0, //will be 0.7
+            audience: 0.7,
             audienceOffset: 0,
             signupPage: 'info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email',
             canonicalListId: 39,


### PR DESCRIPTION
## What does this change?
In [PR 15996](https://github.com/guardian/frontend/pull/15996), I set up an a/b test so that new subscribers could either be assigned to the receive the new email or be allocated into the control group.

15996 set the audience percentage at 0%. Until this PR is merged, any new subscribers to Sleeve notes will only be able to be added to the existing email list with the old Sleeve notes email. 

This change sets the audience percentages so that once merged, if the corresponding ab test switches are on:
- 70% of new subscribers receive the new Sleeve notes email
- The remaining 30% of new subscribers are in the control group and receive the old email 

Additionally:
- Adds the url of the new sign up page 

## What is the value of this and can you measure success?
Allows us to test a new version of the Sleeve notes email.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

## Tested in CODE?
No. 
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
