### PR TITLE
Fixing overflow and layout of paidFor labels

### DIFF
--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -18,7 +18,9 @@
     }
 }
 
-@branding.logo.label
+<div class="badge__label">
+  @branding.logo.label
+</div>
 <a class="badge__link" href="@branding.logo.link" data-sponsor="@branding.sponsorName.toLowerCase">
     @if(request.isAmp) {
         @if(onDarkBackground && branding.logoForDarkBackground.nonEmpty) {

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -126,9 +126,9 @@
     display: flex;
     align-items: stretch;
 
-    > * {
-        width: 100%;
-    }
+    // > * {
+    //     width: 100%;
+    // }
 }
 
 /* [1] Prevents IE11 bug where the image container's height would go ballooney */

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -125,10 +125,6 @@
 .advert-container {
     display: flex;
     align-items: stretch;
-
-    // > * {
-    //     width: 100%;
-    // }
 }
 
 /* [1] Prevents IE11 bug where the image container's height would go ballooney */

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -73,6 +73,11 @@
             max-width: 100%;
         }
 
+        .badge__link {
+            /* [1] Prevents IE11 bug where the height would go ballooney */
+            height: 100%;
+        }
+
         .badge__label {
             text-align: center;
             width: 100%;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -40,6 +40,11 @@
 
     .advert-container {
         @include mq($until: tablet) {
+
+            .advert__standfirst {
+                min-height: $gs-row-height;
+            }
+
             &:first-child > .advert {
                 padding-bottom: $gs-baseline / 2;
             }
@@ -61,10 +66,21 @@
                 flex-direction: column;
                 width: 60px;
             }
+        }
 
-            .badge__logo {
-                max-width: 100%;
-            }
+        .badge {
+            padding-right: 0;
+            max-width: 100%;
+        }
+
+        .badge__label {
+            text-align: center;
+            width: 100%;
+        }
+
+        .badge__logo {
+            max-width: 100%;
+            margin-left: 0;
         }
     }
 }
@@ -276,6 +292,8 @@
     @include f-textSans;
     background: $paid-article-card-bg;
     border-top-color: $paid-article-brand;
+    width: 100%;
+    padding-bottom: $gs-baseline * 8;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
## What does this change?

css ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn 🐙

Besides the css, lets wrap some text in a DIV so it can bully other elements for space, and have class

## What is the value of this and can you measure success?

Desired behaviour:

- Badge label (`Paid for by`) should always be above, and centred over, the badge logo
- Badge logo should never be wider than the card
- Reserve space for the badge label, and badge logo, so that the standfirst text doesn't collide when the label uses the full height
- Not breaking layout anywhere else, in the great game of css-whack-a-mole
- Headache free IE styling?

## BEFORE:

<img width="979" alt="picture 584" src="https://cloud.githubusercontent.com/assets/8607683/23622351/2ef20030-0296-11e7-90f6-0e2ef9bdd20b.png">

<img width="351" alt="picture 585" src="https://cloud.githubusercontent.com/assets/8607683/23622508/e5dd3422-0296-11e7-9f2c-21d371304d31.png">

<img width="364" alt="picture 587" src="https://cloud.githubusercontent.com/assets/8607683/23623408/ddbcf180-0299-11e7-9f67-67deb471acc2.png">

<img width="328" alt="picture 589" src="https://cloud.githubusercontent.com/assets/8607683/23623595/80f280ea-029a-11e7-8175-10044a538a46.png">


## AFTER:

<img width="862" alt="picture 581" src="https://cloud.githubusercontent.com/assets/8607683/23622269/e5e0da60-0295-11e7-87a9-7167e19ab5b7.png">

<img width="351" alt="picture 586" src="https://cloud.githubusercontent.com/assets/8607683/23622594/339a3bd8-0297-11e7-9cc2-cf5d3825f8b1.png">

<img width="367" alt="picture 588" src="https://cloud.githubusercontent.com/assets/8607683/23623488/215e7eea-029a-11e7-9cec-57c09538c6b6.png">

<img width="324" alt="picture 582" src="https://cloud.githubusercontent.com/assets/8607683/23623517/38e73c3c-029a-11e7-9a3e-cadf11361cdb.png">


## Tested in CODE?

DONE ✅