### PR TITLE
Fix double high-merch lucky display call

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -3,11 +3,13 @@ define([
     'lib/config',
     'lib/fastdom-promise',
     'common/modules/experiments/ab',
+    'commercial/modules/dfp/dfp-env',
     'commercial/modules/dfp/add-slot',
     'commercial/modules/dfp/create-slot',
     'commercial/modules/dfp/track-ad-render',
+    'commercial/modules/dfp/get-advert-by-id',
     'commercial/modules/commercial-features'
-], function (Promise, config, fastdom, ab, addSlot, createSlot, trackAdRender, commercialFeatures) {
+], function (Promise, config, fastdom, ab, dfpEnv, addSlot, createSlot, trackAdRender, getAdvertById, commercialFeatures) {
     return {
         init: init
     };
@@ -70,6 +72,11 @@ define([
                 })
                 .then(function () {
                     addSlot(args[0], true);
+
+                    // Horrible but temporary hack. addSlot queue the ad for display,
+                    // i.e. it adds in onto the advertsToLoad stack
+                    var advert = getAdvertById(args[0].id);
+                    dfpEnv.advertsToLoad.splice(dfpEnv.advertsToLoad.indexOf(advert));
                 });
             }
         });


### PR DESCRIPTION
Instantly loading a slot that is added after the initial commercial load never happened before, so I hacked a quick solution. This fix makes sure the slot does not appear in the `advertsToLoad` queue, for those browsers relying on the scroll listener.

Later, we'll review the `queueAdvert` function, I think it is doing too much.