### PR TITLE
Extended recommended for you test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,7 +86,7 @@ trait ABTestSwitches {
     "Test personalised container on fronts",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 7),
+    sellByDate = new LocalDate(2017, 4, 4),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/recommended-for-you.js
@@ -38,12 +38,12 @@ define([
     return function () {
         this.id = 'RecommendedForYouRecommendations';
         this.start = '2017-01-17';
-        this.expiry = '2017-03-08';
+        this.expiry = '2017-04-05';
         this.author = 'David Furey';
         this.description = 'Add an extra container above Opinion on the home front with recommended content based on ' +
             'each users history.  Users in the test group are prompted to opt-in.  Recommendations are only fetched' +
             'if the user opts-in.';
-        this.audience = 0.02;
+        this.audience = 0.05;
         this.audienceOffset = 0.2;
         this.successMeasure = 'Visit frequency';
         this.audienceCriteria = 'All users';


### PR DESCRIPTION
## What does this change?

Extended the recommended for you a/b test and increases from 2% to 5%

## What is the value of this and can you measure success?

The visit frequency of people who have opted in to the test increased.  This change will give us more data, and will also show us how the server side copes with more load.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
