### PR TITLE
Fix email signup button mobile view

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -49,7 +49,7 @@
                 }
                 <input class="js-email-sub__listid-input" type="hidden" name="listId" value="@listId" />
             </div>
-            <button type="submit" class="email-sub__submit-input js-email-sub__submit-input button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))@submitText</button>
+            <button type="submit" class="email-sub__submit-button js-email-sub__submit-button button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))@submitText</button>
         </div>
     </form>
 }

--- a/static/src/javascripts-legacy/projects/common/modules/email/email.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/email.js
@@ -163,7 +163,7 @@ define([
                 if (userFromId && userFromId.primaryEmailAddress) {
                     fastdom.write(function () {
                         $('.js-email-sub__inline-label', el).addClass('email-sub__inline-label--is-hidden');
-                        $('.js-email-sub__submit-input', el).addClass('email-sub__submit-input--solo');
+                        $('.js-email-sub__submit-button', el).addClass('email-sub__submit-button--solo');
                         $('.js-email-sub__text-input', el).val(userFromId.primaryEmailAddress);
                     });
                 }

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -83,7 +83,7 @@
     padding: .667em 1.25em;
 }
 
-.email-sub__submit-input {
+.email-sub__submit-button {
     background-color: transparent;
     border: 1px solid $news-support-1;
     color: $form-primary-colour;
@@ -96,7 +96,7 @@
     }
 }
 
-.email-sub__submit-input--solo {
+.email-sub__submit-button--solo {
 
     .submit-input__icon {
         display: inline-block;
@@ -105,12 +105,12 @@
 }
 
 .email-sub__text-input,
-.email-sub__submit-input {
+.email-sub__submit-button {
     width: 100%;
 }
 
 .email-sub__label,
-.email-sub__submit-input,
+.email-sub__submit-button,
 .email-sub__text-input {
     @include fs-textSans(1, $size-only: true);
     line-height: 1.5;
@@ -197,7 +197,7 @@
     margin-bottom: $gs-baseline;
     padding: 0 $gs-gutter;
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         background-color: $neutral-2;
         border-color: $neutral-2;
         margin-bottom: $gs-baseline;
@@ -260,13 +260,13 @@
         border-color: $neutral-3;
     }
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         background-color: $guardian-brand;
         border-color: $guardian-brand;
     }
 
     .email-sub__label,
-    .email-sub__submit-input,
+    .email-sub__submit-button,
     .email-sub__text-input {
         @include fs-textSans(3, $size-only: true);
     }
@@ -289,7 +289,7 @@
 .email-sub__form--plaindark {
     padding: 0;
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         background-color: $neutral-4;
         border-color: $neutral-4;
         color: $neutral-1;
@@ -308,7 +308,7 @@
 .email-sub__form--plaintone {
     padding: 0;
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         background-color: $neutral-4;
         border-color: $neutral-4;
         color: $neutral-1;
@@ -344,7 +344,7 @@
             }
         }
 
-        .email-sub__submit-input {
+        .email-sub__submit-button {
             background-color: $tone-colour-accent;
             border-color: $tone-colour-accent;
             color: #ffffff;
@@ -366,7 +366,7 @@
             border-color: $tone-colour-border;
         }
 
-        .email-sub__submit-input {
+        .email-sub__submit-button {
             border-color: $tone-colour-border;
             color: $tone-colour-text;
         }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -270,5 +270,9 @@ body {
                 background-color: darken($tone-colour-accent, 10%);
             }
         }
+
+        .submit-input__icon svg {
+            fill: $tone-colour-button-text;
+        }
     }
 }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -42,36 +42,52 @@ body {
 // When we are in an iframe, our widths are based on the iframe so we need to set
 // our media queries explicitly to match what the element width is (hey there, element queries)
 
+@mixin separate-input {
+    border: thin solid;
+    border-radius: 1000px;
+    float: left;
+    width: 70%;
+}
+
+@mixin separate-button {
+    border: thin solid;
+    border-radius: 1000px;
+    width: 25%;
+    margin: 0 0 0 3%;
+}
+
 @mixin separate-input-and-button {
     .email-sub__text-input {
-        border: thin solid;
-        border-radius: 1000px;
-        float: left;
-        width: 70%;
+        @include separate-input;
     }
 
     .email-sub__submit-input {
-        border: thin solid;
-        border-radius: 1000px;
-        width: 25%;
-        margin: 0 0 0 3%;
+        @include separate-button;
     }
+}
+
+@mixin pill-style-input {
+    border-right: 0;
+    border-radius: 1000px 0 0 1000px;
+    float: left;
+    width: 62%;
+}
+
+@mixin pill-style-button {
+    border-radius: 0 1000px 1000px 0;
+    border-left-width: 0px;
+    float: left;
+    margin-right: 0;
+    width: 38%;
 }
 
 @mixin pill-style-input-and-button {
     .email-sub__text-input {
-        border-right: 0;
-        border-radius: 1000px 0 0 1000px;
-        float: left;
-        width: 62%;
+        @include pill-style-input;
     }
 
     .email-sub__submit-input {
-        border-radius: 0 1000px 1000px 0;
-        border-left-width: 0px;
-        float: left;
-        margin-right: 0;
-        width: 38%;
+        @include pill-style-button;
     }
 }
 
@@ -87,6 +103,7 @@ body {
         .email-sub__submit-input--solo {
             border-radius: 1000px;
             border-left-width: 1px;
+            margin-left: 0;
         }
 
         .email-sub__small--mark {
@@ -129,6 +146,9 @@ body {
 @include mq($from: 606px) {
     .email-sub--plaintone {
         @include separate-input-and-button;
+        .email-sub__submit-input--solo {
+            margin-left: 0;
+        }
    }
 }
 
@@ -190,6 +210,12 @@ body {
 
     @include mq(phablet) {
         @include separate-input-and-button;
+    }
+
+    .email-sub__submit-input--solo {
+        @include separate-button;
+        width: 33%;
+        margin-left: 0;
     }
 
     .email-sub__text-input {

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -7,11 +7,11 @@ body {
 * IFRAME MODS
 */
 .email-sub__text-input,
-.email-sub__submit-input {
+.email-sub__submit-button {
     border-radius: 1000px;
 }
 
-.email-sub__submit-input {
+.email-sub__submit-button {
     // Duplicate some required styles so we don't have to include pasteUp buttons in email.css
     border-width: 1px;
     border-style: solid;
@@ -61,7 +61,7 @@ body {
         @include separate-input;
     }
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         @include separate-button;
     }
 }
@@ -86,7 +86,7 @@ body {
         @include pill-style-input;
     }
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         @include pill-style-button;
     }
 }
@@ -100,7 +100,7 @@ body {
 
         // Solo submit button - for logged in users where we remove the input
         // because we know the email address already
-        .email-sub__submit-input--solo {
+        .email-sub__submit-button--solo {
             border-radius: 1000px;
             border-left-width: 1px;
             margin-left: 0;
@@ -116,7 +116,7 @@ body {
     .email-sub__form--plain,
     .email-sub__form--plaindark,
     .email-sub__form--plaintone {
-        .email-sub__submit-input {
+        .email-sub__submit-button {
             padding-left: $gs-gutter / 2;
         }
     }
@@ -134,7 +134,7 @@ body {
             border-radius: 1000px;
         }
 
-        .email-sub__submit-input {
+        .email-sub__submit-button {
             margin-right: 0;
             width: 100%;
         }
@@ -146,7 +146,7 @@ body {
 @include mq($from: 606px) {
     .email-sub--plaintone {
         @include separate-input-and-button;
-        .email-sub__submit-input--solo {
+        .email-sub__submit-button--solo {
             margin-left: 0;
         }
    }
@@ -212,7 +212,7 @@ body {
         @include separate-input-and-button;
     }
 
-    .email-sub__submit-input--solo {
+    .email-sub__submit-button--solo {
         @include separate-button;
         width: 33%;
         margin-left: 0;
@@ -225,7 +225,7 @@ body {
         }
     }
 
-    .email-sub__submit-input {
+    .email-sub__submit-button {
         @include mq(mobile) {
             border: none;
         }
@@ -259,7 +259,7 @@ body {
             color: $tone-colour-text;
         }
 
-        .email-sub__submit-input {
+        .email-sub__submit-button {
             color: $tone-colour-button-text;
             background-color: $tone-colour-accent;
             border-color: $tone-colour-accent;


### PR DESCRIPTION
Fixes some stuff broken in #16006 (half-pill button on mobile view, icon colour not the same as text colour on button), and something that's been not quite right for a while (button not aligned with text on wider breakpoints).

And renames `email-sub__submit-input` to `email-sub__submit-button` since that kept tripping me up when trying to make this change

# Before
![picture 477](https://cloud.githubusercontent.com/assets/5122968/23658733/8c6b9cb2-033b-11e7-92d1-a59dda09a7bf.png)
![picture 482](https://cloud.githubusercontent.com/assets/5122968/23658734/8c6c05da-033b-11e7-8a21-64853c0da8e8.png)
![picture 483](https://cloud.githubusercontent.com/assets/5122968/23658735/8c70f6a8-033b-11e7-8d0e-bae943b043a6.png)

# After
![picture 478](https://cloud.githubusercontent.com/assets/5122968/23658780/add79202-033b-11e7-8e3f-2f1678ad037d.png)
![picture 479](https://cloud.githubusercontent.com/assets/5122968/23658782/add792fc-033b-11e7-9360-98ba3aee0c6e.png)
![picture 480](https://cloud.githubusercontent.com/assets/5122968/23658781/add8ec06-033b-11e7-9542-e63597a6b123.png)

@superfrank 