### PR TITLE
Break one-word email names in the appropriate place

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -60,7 +60,7 @@
             <div class="fc-container__header">
                 <div class="@headerClass">
                     <h2 class="email-sub__heading js-email-sub__heading">
-                        <span class="js-email-sub__display-name-normal-text">@Html(formHeading)</span><span class="js-email-sub__display-name-accented-text email-sub__display-name-accented-text"></span>
+                        <span class="js-email-sub__display-name-normal-text">@Html(formHeading)</span>&shy;<span class="js-email-sub__display-name-accented-text email-sub__display-name-accented-text"></span>
                     </h2>
                 </div>
             </div>

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -191,6 +191,7 @@ body {
         @include fs-header(4);
         color: #ffffff;
         padding-right: 40px; // Avoid close icon
+        hyphens: none; // Allow invisible line breaks in "one-word" names, e.g. theguardiantoday
     }
 
     .email-sub__description {

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -253,6 +253,7 @@ body {
         }
 
         .email-sub__heading {
+            line-height: $gs-baseline * 2;
             color: $tone-colour-title;
         }
 


### PR DESCRIPTION
Fixes a bug from #16006.

# before
![picture 481](https://cloud.githubusercontent.com/assets/5122968/23662779/86ede77e-0348-11e7-8477-a40375f88763.png)


# after
![picture 484](https://cloud.githubusercontent.com/assets/5122968/23662702/586b236c-0348-11e7-8daa-62a8bd19df3c.png)
![picture 485](https://cloud.githubusercontent.com/assets/5122968/23662701/583e678c-0348-11e7-8a96-729e9fd47e42.png)

@superfrank @gidsg 