### PR TITLE
check for presence nonKeywordTagIds on recipe boot

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -174,7 +174,7 @@ define([
             });
         }
 
-        if (contains(config.page.nonKeywordTagIds.split(','), 'tone/recipes')) {
+        if (config.page.nonKeywordTagIds && contains(config.page.nonKeywordTagIds.split(','), 'tone/recipes')) {
             require(['bootstraps/enhanced/recipe-article'], function (recipes) {
                 bootstrapContext('recipes', recipes);
             });


### PR DESCRIPTION
## What does this change?

checks that `config.page.nonKeywordTagIds` exists before testing it

## What is the value of this and can you measure success?

clears up this:

![screen shot 2017-03-07 at 15 36 28](https://cloud.githubusercontent.com/assets/867233/23663883/dd88bf20-034b-11e7-9872-674e9804c715.png)

## Does this affect other platforms - Amp, Apps, etc?

no