### PR TITLE
Do not show email signup boxes at the bottom of email signup pages

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/run-checks.js
@@ -129,6 +129,7 @@ define([
         return !config.page.shouldHideAdverts &&
                 !config.page.isSensitive &&
                 !config.page.isFront &&
+                (config.page.contentId.indexOf("email-sign-up") === -1) &&
                 config.switches.emailInArticle &&
                 !clash.userIsInAClashingAbTest(clash.nonEmailClashingTests) &&
                 storage.session.isAvailable() &&


### PR DESCRIPTION
## What does this change?

Stops displaying extra email signup boxes at the bottom of email sign-up articles

## What is the value of this and can you measure success?

Less confusing

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

Stops this:

![unnamed](https://cloud.githubusercontent.com/assets/2619836/23667239/1ce0ad46-0355-11e7-82d7-62a5fbb39a3b.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
