### PR TITLE
Substitute title correctly for manually inserted signup boxes

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -59,7 +59,7 @@
         <div class="fc-container__inner @wrapperClass @wrapperToneClass">
             <div class="fc-container__header">
                 <div class="@headerClass">
-                    <h2 class="email-sub__heading">
+                    <h2 class="email-sub__heading js-email-sub__heading">
                         <span class="js-email-sub__display-name-normal-text">@Html(formHeading)</span><span class="js-email-sub__display-name-accented-text email-sub__display-name-accented-text"></span>
                     </h2>
                 </div>

--- a/static/src/javascripts-legacy/projects/common/modules/email/email.js
+++ b/static/src/javascripts-legacy/projects/common/modules/email/email.js
@@ -117,16 +117,14 @@ define([
                 });
 
                 fastdom.write(function () {
-                    if (formTitle) {
-                        $('.js-email-sub__heading', el).text(formTitle);
-                    }
-
                     if (formDisplayNameNormalText) {
                         $('.js-email-sub__display-name-normal-text', el).text(formDisplayNameNormalText);
-                    }
 
-                    if (formDisplayNameAccentedText) {
-                        $('.js-email-sub__display-name-accented-text', el).text(formDisplayNameAccentedText);
+                        if (formDisplayNameAccentedText) {
+                            $('.js-email-sub__display-name-accented-text', el).text(formDisplayNameAccentedText);
+                        }
+                    } else if (formTitle) {
+                        $('.js-email-sub__heading', el).text(formTitle);
                     }
 
                     if (formDescription) {


### PR DESCRIPTION
#16006 broke the Composer-inserted signup iframes (e.g. https://www.theguardian.com/info/2016/mar/01/the-morning-briefing-start-the-day-one-step-ahead) which I wasn't aware existed

This should fix it! 