### PR TITLE
Epic design variations

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -169,4 +169,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 3, 31),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-design-variations",
+    "Test design variations to the Epic",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 3, 17),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -22,6 +22,11 @@ define([
         variants: ['control']
     };
 
+    var AcquisitionsEpicDesignVariations = {
+        name: 'AcquisitionsDesignVariations',
+        variants: ['control', 'paragraph']
+    };
+
     var GuardianTodaySignupMessaging = {
         name: 'GuardianTodaySignupMessaging',
         variants: ['message-a', 'message-b', 'message-c']
@@ -31,7 +36,8 @@ define([
         ContributionsEpicAlwaysAskStrategy,
         ContributionsEpicBrexit,
         ContributionsEpicAskFourStagger,
-        ContributionsEpicAskFourEarning
+        ContributionsEpicAskFourEarning,
+        AcquisitionsEpicDesignVariations
     ];
 
     var emailTests = [

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -24,7 +24,7 @@ define([
 
     var AcquisitionsEpicDesignVariations = {
         name: 'AcquisitionsDesignVariations',
-        variants: ['control', 'paragraph']
+        variants: ['control', 'extra_paragraph', 'large_hook', 'subtle', 'prominent', 'highlight']
     };
 
     var GuardianTodaySignupMessaging = {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -4,19 +4,27 @@ define([
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
-    'common/modules/experiments/tests/contributions-epic-ask-four-earning'
+    'common/modules/experiments/tests/contributions-epic-ask-four-earning',
+    'common/modules/experiments/tests/acquisitions-epic-design-variations'
 ], function (
     segmentUtil,
     viewLog,
     brexit,
     alwaysAsk,
     askFourStagger,
-    askFourEarning
+    askFourEarning,
+    acquisitionsEpicDesignVariations
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
-    var tests = [alwaysAsk, askFourEarning, brexit, askFourStagger];
+    var tests = [
+        acquisitionsEpicDesignVariations,
+        alwaysAsk,
+        askFourEarning,
+        brexit,
+        askFourStagger
+    ];
 
     return {
         getTest: function() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -19,8 +19,8 @@ define([
      * acquisition tests in priority order (highest to lowest)
      */
     var tests = [
-        acquisitionsEpicDesignVariations,
         alwaysAsk,
+        acquisitionsEpicDesignVariations,
         askFourEarning,
         brexit,
         askFourStagger

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
@@ -1,0 +1,126 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lib/template',
+    'lodash/objects/assign',
+    'raw-loader!common/views/acquisitions-epic-design-variations.html'
+], function(
+    contributionUtilities,
+    template,
+    assign,
+    acquisitionEpicDesignVariations
+) {
+
+    // Building the Epic component using the template acquisitions-epic-design-variations.html
+    // =======================================================================================
+
+    // Default arguments for the template.
+    function defaultTemplateArguments() {
+        return {
+            // copy
+            p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+            p1Highlight: '',
+            p1PostHighlight: '',
+            p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+            p3: '',
+
+            // element classes
+            epicClass: '' ,
+            epicTitleClass: '',
+            p1Class: '',
+            p1HighlightClass: '',
+            supporterButtonClass: '',
+            contributorButtonClass: ''
+        };
+    }
+
+    // Merges submitted and default template arguments.
+    function buildTemplateArguments(args) {
+        var out = defaultTemplateArguments();
+        assign(out, args);
+        return out;
+    }
+
+    function buildHtml(args) {
+        return template(acquisitionEpicDesignVariations, buildTemplateArguments(args));
+    }
+
+    // Building a test variant
+    // =======================
+
+    // Common variant properties.
+    var maxViews = {};
+    var successOnView = true;
+
+    function defaultVariantArgs() {
+        return {
+            maxViews: maxViews,
+            successOnView: successOnView
+        }
+    }
+
+    function buildVariant(id, templateArgs) {
+        var out = defaultVariantArgs();
+        out.id = id;
+        if (id !== 'control') {
+            out.template = function() {
+                return buildHtml(templateArgs)
+            }
+        }
+        return out;
+    }
+
+    // Building the test
+    // =================
+
+    return contributionUtilities.makeABTest({
+        id: 'AcquisitionsEpicDesignVariations',
+        campaignId: 'kr1_design_variations',
+
+        start: '2017-03-07',
+        expiry: '2017-03-17',
+
+        author: 'Guy Dawson',
+        description: 'Test 5 new design variants to the Epic',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Find a variant which has a higher conversion rate than the control',
+
+        audienceCriteria: 'All',
+        audience: 1, // TODO
+        audienceOffset: 0, // TODO
+
+        variants: [
+            buildVariant('control'),
+
+            buildVariant('extra_paragraph', {
+                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help.',
+                p2: 'The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p3: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.'
+            }),
+
+            buildVariant('large_hook', {
+                epicTitleClass: 'contributions__title--epic--large'
+            }),
+
+            buildVariant('subtle', {
+                epicClass: 'contributions__epic--subtle',
+                epicTitleClass: 'contributions__title--epic--subtle',
+                p1Class: 'contributions__paragraph--subtle'
+            }),
+
+            buildVariant('prominent', {
+                epicClass: 'contributions__epic--prominent',
+                epicTitleClass: 'contributions__title--epic--large',
+                supporterButtonClass: 'contributions__option--button--prominent',
+                contributorButtonClass: 'contributions__option--button--prominent'
+            }),
+
+            buildVariant('highlight', {
+                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ',
+                p1Highlight: 'unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all',
+                p1PostHighlight: '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+                p1HighlightClass: 'contributions__paragraph--highlight'
+            })
+        ]
+    })
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
@@ -14,34 +14,32 @@ define([
     // =======================================================================================
 
     // Default arguments for the template.
-    function defaultTemplateArguments() {
-        return {
-            // copy
-            p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            p1Highlight: '',
-            p1PostHighlight: '',
-            p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-            p3: '',
+    var defaultTemplateArgument = {
+        // copy
+        p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+        p1Highlight: '',
+        p1PostHighlight: '',
+        p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
+        p3: '',
 
-            // element classes
-            epicClass: '' ,
-            epicTitleClass: '',
-            p1Class: '',
-            p1HighlightClass: '',
-            supporterButtonClass: '',
-            contributorButtonClass: ''
-        };
-    }
+        // element classes
+        epicClass: '' ,
+        epicTitleClass: '',
+        p1Class: '',
+        p1HighlightClass: '',
+        buttonClass: ''
+    };
 
     // Merges submitted and default template arguments.
-    function buildTemplateArguments(args) {
-        var out = defaultTemplateArguments();
-        assign(out, args);
-        return out;
+    function buildTemplateArguments(membershipUrl, contributionUrl, args) {
+        return assign({}, defaultTemplateArgument, args, {
+            membershipUrl: membershipUrl,
+            contributionUrl: contributionUrl
+        });
     }
 
-    function buildHtml(args) {
-        return template(acquisitionEpicDesignVariations, buildTemplateArguments(args));
+    function buildHtml(membershipUrl, contributionUrl, args) {
+        return template(acquisitionEpicDesignVariations, buildTemplateArguments(membershipUrl, contributionUrl, args));
     }
 
     // Building a test variant
@@ -51,22 +49,19 @@ define([
     var maxViews = {};
     var successOnView = true;
 
-    function defaultVariantArgs() {
-        return {
-            maxViews: maxViews,
-            successOnView: successOnView
-        }
-    }
+    var defaultVariantArgs = {
+        maxViews: maxViews,
+        successOnView: successOnView
+    };
 
-    function buildVariant(id, templateArgs) {
-        var out = defaultVariantArgs();
-        out.id = id;
-        if (id !== 'control') {
-            out.template = function() {
-                return buildHtml(templateArgs)
+    function buildVariant(variantId, templateArgs) {
+        var args = { id: variantId };
+        if (variantId !== 'control') {
+            args.template = function(membershipUrl, contributionUrl) {
+                return buildHtml(membershipUrl, contributionUrl, templateArgs)
             }
         }
-        return out;
+        return assign({}, defaultVariantArgs, args)
     }
 
     // Building the test
@@ -74,7 +69,7 @@ define([
 
     return contributionUtilities.makeABTest({
         id: 'AcquisitionsEpicDesignVariations',
-        campaignId: 'kr1_design_variations',
+        campaignId: 'kr1_epic_design_variations',
 
         start: '2017-03-07',
         expiry: '2017-03-17',
@@ -110,8 +105,7 @@ define([
             buildVariant('prominent', {
                 epicClass: 'contributions__epic--prominent',
                 epicTitleClass: 'contributions__title--epic--large',
-                supporterButtonClass: 'contributions__option--button--prominent',
-                contributorButtonClass: 'contributions__option--button--prominent'
+                buttonClass: 'contributions__option--button--prominent'
             }),
 
             buildVariant('highlight', {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
@@ -85,8 +85,8 @@ define([
         idealOutcome: 'Find a variant which has a higher conversion rate than the control',
 
         audienceCriteria: 'All',
-        audience: 1, // TODO
-        audienceOffset: 0, // TODO
+        audience: 0.5,
+        audienceOffset: 0.5,
 
         variants: [
             buildVariant('control'),

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-design-variations.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-design-variations.html
@@ -1,0 +1,34 @@
+<div class="contributions__epic <%=epicClass%>">
+    <div>
+        <h2 class="contributions__title contributions__title--epic <%=epicTitleClass%>">
+            Since you’re here …
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic <%=p1Class%>">
+            <%=p1%><span class="<%=p1HighlightClass%>"><%=p1Highlight%></span><%=p1PostHighlight%>
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            <%=p2%>
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            <%=p3%>
+        </p>
+    </div>
+
+    <div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top <%=supporterButtonClass%>"
+               href="https://membership.theguardian.com/supporter"
+               target="_blank">
+                Become a supporter
+            </a>
+        </div>
+
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member <%=contributorButtonClass%>"
+               href="https://contribute.theguardian.com"
+               target="_blank">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-design-variations.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-design-variations.html
@@ -16,16 +16,16 @@
 
     <div class="contributions__amount-field">
         <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top <%=supporterButtonClass%>"
-               href="https://membership.theguardian.com/supporter"
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top <%=buttonClass%>"
+               href="<%=membershipUrl%>"
                target="_blank">
                 Become a supporter
             </a>
         </div>
 
         <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member <%=contributorButtonClass%>"
-               href="https://contribute.theguardian.com"
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member <%=buttonClass%>"
+               href="<%=contributionUrl%>"
                target="_blank">
                 Make a contribution
             </a>

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -26,3 +26,4 @@
 @import 'module/experiments/embed';
 @import 'module/experiments/svg';
 @import 'module/experiments/_ab-acquisitions-love-boat';
+@import 'module/experiments/_acquisitions-epic-design-variations';

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
@@ -27,8 +27,8 @@
     // Unset border top as it will be set for the inline header element
     border-top: 0;
     background-color: #ffffff;
-    margin-top: 50px;
-    margin-bottom: 50px;
+    margin-top: $gs-baseline * 4;
+    margin-bottom: $gs-baseline * 4;
 }
 
 .contributions__title--epic--subtle {

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
@@ -26,7 +26,7 @@
 .contributions__epic--subtle {
     // Unset border top as it will be set for the inline header element
     border-top: 0;
-    background-color: white;
+    background-color: #ffffff;
     margin-top: 50px;
     margin-bottom: 50px;
 }
@@ -48,18 +48,18 @@
 // uses large title
 
 .contributions__epic--prominent {
-    background-color: #ffd964;
+    background-color: transparentize($multimedia-main-2, .5);
 }
 
 .contributions__option--button--prominent {
     color: white;
-    background-color: #005689;
+    background-color: $guardian-brand;
     &:after {
         background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="white" stroke="white" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
     }
     &:hover {
-        color: white;
-        background-color: #003557;
+        color: #ffffff;
+        background-color: $multimedia-support-3;
     }
 }
 
@@ -67,5 +67,5 @@
 // ============
 
 .contributions__paragraph--highlight {
-    background-color: rgba(255, 187, 0, 0.4);
+    background-color: transparentize($multimedia-main-2, .6);
 }

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-design-variations.scss
@@ -1,0 +1,71 @@
+@import "svg";
+
+// Classes used by multiple variants
+// =================================
+
+.contributions__title--epic--large {
+    @include font-size(36px);
+    @include mq(tablet) {
+        @include font-size(38px);
+    }
+}
+
+// 1. extra_paragraph variant
+// ==========================
+
+// copy changes only
+
+// 2. large hook variant
+// =====================
+
+// uses large title
+
+// 3. subtle variant
+// =================
+
+.contributions__epic--subtle {
+    // Unset border top as it will be set for the inline header element
+    border-top: 0;
+    background-color: white;
+    margin-top: 50px;
+    margin-bottom: 50px;
+}
+
+.contributions__title--epic--subtle {
+    display: inline;
+    border-top: 1px solid $multimedia-main-2;
+    @include fs-header(3);
+    padding-top: $gs-baseline / 3;
+}
+
+.contributions__paragraph--subtle {
+    margin-top: 0;
+}
+
+// 4. prominent variant
+// ====================
+
+// uses large title
+
+.contributions__epic--prominent {
+    background-color: #ffd964;
+}
+
+.contributions__option--button--prominent {
+    color: white;
+    background-color: #005689;
+    &:after {
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="white" stroke="white" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>');
+    }
+    &:hover {
+        color: white;
+        background-color: #003557;
+    }
+}
+
+// 5. highlight
+// ============
+
+.contributions__paragraph--highlight {
+    background-color: rgba(255, 187, 0, 0.4);
+}


### PR DESCRIPTION
@guardian/contributions

## What does this change?

Releases a new AB test to evaluate Epic design variations.

## What is the value of this and can you measure success?

We may  establish a design variation of the Epic which has a high conversion rate than the control.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

### Control

- desktop:
![control_desktop](https://cloud.githubusercontent.com/assets/4085817/23667734/c4d7e20c-0356-11e7-8e3b-0a400a2a38ec.jpg)

- mobile:
![control_mobile](https://cloud.githubusercontent.com/assets/4085817/23667804/032eb256-0357-11e7-93a6-24d6c44bab34.jpg)

### Extra paragraph

- desktop:
![extra_paragraph_desktop](https://cloud.githubusercontent.com/assets/4085817/23667839/182e6fb6-0357-11e7-9876-9fcf89f3a4b3.jpg)

- mobile:
![extra_paragraph_mobile](https://cloud.githubusercontent.com/assets/4085817/23667852/25a5df62-0357-11e7-8cef-c382e3516ab6.jpg)

### Highlight

- desktop:
![highlight_desktop](https://cloud.githubusercontent.com/assets/4085817/23667857/2e8cba9c-0357-11e7-98f6-5071a74f876f.jpg)

- mobile:
![highlight_mobile](https://cloud.githubusercontent.com/assets/4085817/23667872/3d60f344-0357-11e7-8c64-19fb5c9a44ef.jpg)

### Large hook

- desktop:
![large_hook_desktop](https://cloud.githubusercontent.com/assets/4085817/23667888/469d0038-0357-11e7-85da-c1d3cd8759ee.jpg)

- mobile:
![large_hook_mobile](https://cloud.githubusercontent.com/assets/4085817/23667913/54b5e39c-0357-11e7-81e1-17ca0dad7cf2.jpg)

### Prominent

- desktop:
![prominent_desktop](https://cloud.githubusercontent.com/assets/4085817/23667931/5d502f26-0357-11e7-9a8d-c1bddcd699d4.jpg)

- mobile:
![prominent_mobile](https://cloud.githubusercontent.com/assets/4085817/23667942/6902d058-0357-11e7-8ff3-3c113c22ef2c.jpg)

### Subtle

- desktop:
![subtle_desktop](https://cloud.githubusercontent.com/assets/4085817/23667957/723dfd00-0357-11e7-8e72-33e3c73e6519.jpg)

- mobile:
![subtle_mobile](https://cloud.githubusercontent.com/assets/4085817/23667971/7c201736-0357-11e7-8684-1057a9a9595b.jpg)

## Tested in CODE?

No, tested locally.
