### PR TITLE
Load enhanced if commercial switch is off

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -75,5 +75,21 @@ domready(() => {
             },
             'commercial'
         );
+    } else if (window.guardian.isEnhanced) {
+        userTiming.mark('enhanced request');
+        require.ensure(
+            [],
+            require => {
+                userTiming.mark('enhanced boot');
+                require('bootstraps/enhanced/main')();
+
+                if (document.readyState === 'complete') {
+                    capturePerfTimings();
+                } else {
+                    window.addEventListener('load', capturePerfTimings);
+                }
+            },
+            'enhanced-no-commercial'
+        );
     }
 });


### PR DESCRIPTION
## What does this change?

Currently, if the Commercial Switch is off, the Enhanced chunk is never loaded. 

This change adds a new split point that creates an Enhanced chunk containing all dependencies that are also part of the Commercial chunk. The `enhanced-no-commercial` chunk is loaded if the Commercial Switch is off.

## What is the value of this and can you measure success?

Enhanced JavaScript is loaded regardless of the state of the Commercial Switch 

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
