### PR TITLE
Adverts on recipe test page

### DIFF
--- a/article/app/views/fragments/recipeArticleBody.scala.html
+++ b/article/app/views/fragments/recipeArticleBody.scala.html
@@ -129,7 +129,17 @@
                 @recipe.data.steps.zipWithIndex.map{case(step, i) => <li><span class="number">@{i + 1}</span>@step</li> }
             </ul>
         </div>
+
+        <div class="ad-wrapper">
+            <div class="ad-container">
+                <div id="dfp-ad--inline@{i + 1}" class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right" data-link-name="ad slot inline@{i + 1}" data-test-id="ad-slot-inline@{i + 1}" data-name="inline@{i + 1}" data-mobile="1,1|2,2|300,250|fluid" data-desktop="1,1|2,2|300,250|fluid"></div>
+            </div>
+            <div class="ad-container--mobile">
+                <div id="dfp-ad--inline1@{i + 1}" class="js-ad-slot ad-slot ad-slot--inline ad-slot-inline1@{i + 1}" data-link-name="ad slot inline1@{i + 1}" data-test-id="ad-slot-inline1@{i + 1}" data-name="inline1@{i + 1}" data-mobile="1,1|2,2|300,250|fluid" data-desktop="1,1|2,2|300,250|fluid"></div>
+            </div>
+        </div>
     </div>
 }
+
 
 

--- a/article/app/views/fragments/recipeArticleBody.scala.html
+++ b/article/app/views/fragments/recipeArticleBody.scala.html
@@ -131,12 +131,8 @@
         </div>
 
         <div class="ad-wrapper">
-            <div class="hide-until-tablet">
-                <div id="dfp-ad--inline@{i + 1}" class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right" data-link-name="ad slot inline@{i + 1}" data-test-id="ad-slot-inline@{i + 1}" data-name="inline@{i + 1}" data-desktop="1,1|2,2|300,250|fluid"></div>
-            </div>
-            <div class="mobile-only">
-                <div id="dfp-ad--inline1@{i + 1}" class="js-ad-slot ad-slot ad-slot--inline ad-slot-inline1@{i + 1}" data-link-name="ad slot inline1@{i + 1}" data-test-id="ad-slot-inline1@{i + 1}" data-name="inline1@{i + 1}" data-mobile="1,1|2,2|300,250|fluid"></div>
-            </div>
+                <div id="dfp-ad--inline@{i + 1}" class="hide-until-tablet js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right" data-link-name="ad slot inline@{i + 1}" data-test-id="ad-slot-inline@{i + 1}" data-name="inline@{i + 1}" data-desktop="1,1|2,2|300,250|fluid"></div>
+                <div id="dfp-ad--inline1@{i + 1}" class="mobile-only js-ad-slot ad-slot ad-slot--inline ad-slot-inline1@{i + 1}" data-link-name="ad slot inline1@{i + 1}" data-test-id="ad-slot-inline1@{i + 1}" data-name="inline1@{i + 1}" data-mobile="1,1|2,2|300,250|fluid"></div>
         </div>
     </div>
 }

--- a/article/app/views/fragments/recipeArticleBody.scala.html
+++ b/article/app/views/fragments/recipeArticleBody.scala.html
@@ -131,11 +131,11 @@
         </div>
 
         <div class="ad-wrapper">
-            <div class="ad-container">
-                <div id="dfp-ad--inline@{i + 1}" class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right" data-link-name="ad slot inline@{i + 1}" data-test-id="ad-slot-inline@{i + 1}" data-name="inline@{i + 1}" data-mobile="1,1|2,2|300,250|fluid" data-desktop="1,1|2,2|300,250|fluid"></div>
+            <div class="hide-until-tablet">
+                <div id="dfp-ad--inline@{i + 1}" class="js-ad-slot ad-slot ad-slot--mpu-banner-ad ad-slot--right" data-link-name="ad slot inline@{i + 1}" data-test-id="ad-slot-inline@{i + 1}" data-name="inline@{i + 1}" data-desktop="1,1|2,2|300,250|fluid"></div>
             </div>
-            <div class="ad-container--mobile">
-                <div id="dfp-ad--inline1@{i + 1}" class="js-ad-slot ad-slot ad-slot--inline ad-slot-inline1@{i + 1}" data-link-name="ad slot inline1@{i + 1}" data-test-id="ad-slot-inline1@{i + 1}" data-name="inline1@{i + 1}" data-mobile="1,1|2,2|300,250|fluid" data-desktop="1,1|2,2|300,250|fluid"></div>
+            <div class="mobile-only">
+                <div id="dfp-ad--inline1@{i + 1}" class="js-ad-slot ad-slot ad-slot--inline ad-slot-inline1@{i + 1}" data-link-name="ad slot inline1@{i + 1}" data-test-id="ad-slot-inline1@{i + 1}" data-name="inline1@{i + 1}" data-mobile="1,1|2,2|300,250|fluid"></div>
             </div>
         </div>
     </div>

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -216,7 +216,9 @@ final case class Content(
     ("isImmersive", JsBoolean(isImmersive)),
     ("isExplore", JsBoolean(isExplore)),
     ("isPaidContent", JsBoolean(isPaidContent)),
-    ("campaigns", JsArray(campaigns.map(Campaign.toJson)))
+    ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
+    ("newRecipeDesign", JsBoolean(isRecipeArticle))
+
   )
 
   // Dynamic Meta Data may appear on the page for some content. This should be used for conditional metadata.

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -82,7 +82,7 @@
                 </div>
             }
             case page: model.ContentPage if (page.item.content.isRecipeArticle && false) => {
-                @fragments.header(page)
+                @headerAndTopAds(showAdverts, edition, content)
             }
             case _: commercial.hosted.HostedPage => {}
             case _ => {

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -81,9 +81,6 @@
                     @fragments.immersiveMainMedia(page)
                 </div>
             }
-            case page: model.ContentPage if (page.item.content.isRecipeArticle && false) => {
-                @headerAndTopAds(showAdverts, edition, content)
-            }
             case _: commercial.hosted.HostedPage => {}
             case _ => {
                 @headerAndTopAds(showAdverts, edition, content)

--- a/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
@@ -74,6 +74,7 @@ define([
             isArticle &&
             !isLiveBlog &&
             !isHosted &&
+            !config.page.newRecipeDesign &&
             switches.commercial;
 
         this.articleAsideAdverts =
@@ -81,6 +82,7 @@ define([
             !isMinuteArticle &&
             !isMatchReport &&
             !!(isArticle || isLiveBlog) &&
+            !config.page.newRecipeDesign &&
             switches.commercial;
 
         this.sliceAdverts =
@@ -103,6 +105,7 @@ define([
             !isHosted &&
             !isInteractive &&
             !config.page.isFront &&
+            !config.page.newRecipeDesign &&
             switches.commercial;
 
         this.thirdPartyTags =

--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -6,6 +6,14 @@ $purple:#B72166;
 
 $padding-wide: 100px;
 
+.content--recipes {
+    padding-bottom: 0;
+}
+
+.recipes__main {
+    display: flex;
+    flex-wrap: nowrap;
+}
 
 .recipe__article .recipe__article--headline h1,
  .recipe__article .recipe__article--structured-headline h1 {
@@ -57,8 +65,8 @@ $padding-wide: 100px;
     width: 100%;
 
     @include mq($from: tablet){
-        width: 40%;
-        position: fixed;
+        flex-basis: 40%;
+        position: sticky;
         height: 100vh;
         min-height: 600px;
     }
@@ -118,12 +126,12 @@ $padding-wide: 100px;
 
 .recipe__article-wrapper {
     @include mq($from: tablet){
-        width: 60%;
+        flex-basis: 60%;
         float: right;
     }
 
     @include mq($from: wide) {
-        width: 55%;
+        flex-basis: 55%;
     }
 }
 
@@ -216,6 +224,7 @@ $padding-wide: 100px;
     position: fixed;
     bottom: 0px;
     transition: opacity 0.5s ease-in-out;
+    z-index: 1050;
 
     @include mq($from: tablet) {
         color: $grey-three;
@@ -425,4 +434,35 @@ $padding-wide: 100px;
         margin-right: 12px;
         color: $purple;
     }
+}
+
+.ad-wrapper {
+  background-color: $grey-two;
+  margin-left: -20px;
+  margin-top: 20px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+
+  .ad-container{
+    margin-left: auto;
+    margin-right: auto;
+    width: max-content;
+  }
+}
+
+
+.ad-container--mobile {
+  display: block;
+
+  @include mq($from: tablet) {
+    display: none;
+  }
+}
+
+.ad-container {
+  display: none;
+
+  @include mq($from: desktop) {
+    display: block;
+  }
 }

--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -12,8 +12,13 @@ $padding-wide: 100px;
 
 .recipes__main {
     display: flex;
-    flex-wrap: nowrap;
     justify-content: space-between;
+    flex-wrap: wrap;
+
+    @include mq($from: tablet) {
+        flex-wrap: nowrap;
+    }
+
 }
 
 .recipe__article .recipe__article--headline h1,
@@ -452,18 +457,3 @@ $padding-wide: 100px;
 }
 
 
-.ad-container--mobile {
-  display: block;
-
-  @include mq($from: tablet) {
-    display: none;
-  }
-}
-
-.ad-container {
-  display: none;
-
-  @include mq($from: desktop) {
-    display: block;
-  }
-}

--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -13,6 +13,7 @@ $padding-wide: 100px;
 .recipes__main {
     display: flex;
     flex-wrap: nowrap;
+    justify-content: space-between;
 }
 
 .recipe__article .recipe__article--headline h1,


### PR DESCRIPTION
## What does this change?

- Banner ad at the top.
- In-body ads after each recipe atom. 
- Uses 💥`position: sticky`💥 to make the image fixed after scrolling past the top ad/ nav.

## What is the value of this and can you measure success?
Consistency between the new view and control view. Ad revenue.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
![adsadsads](https://cloud.githubusercontent.com/assets/8484757/23704058/f2ee3c00-03fa-11e7-9c8c-ca520ff40647.gif)
Fixing the next button (currently overlaying the image) will be in another PR.

![screen shot 2017-03-14 at 12 30 13](https://cloud.githubusercontent.com/assets/8484757/23900819/776cd28c-08b2-11e7-8218-5fac4c395e83.jpg)


## Tested in CODE?
no

Thanks @regiskuckaertz for help with this! 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
