### PR TITLE
Revert "Video main media caption"

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -42,24 +42,10 @@
 
 
                     @mainVideo.videos.caption.map { caption =>
-                        @if(mvt.ABNewNavVariantSeven.isParticipating) {
-                            <div class="js-hide-on-play">
-                                <input type="checkbox" id="show-caption" class="mobile-only u-h">
-
-                                <label class="mobile-only reveal-caption reveal-caption--video" for="show-caption">
-                                    @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon"))
-                                </label>
-
-                                <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                                    @Html(caption)
-                                </figcaption>
-                            </div>
-                        } else {
-                            <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
-                                @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
-                                @Html(caption)
-                            </figcaption>
-                        }
+                        <figcaption data-link-name="Video caption link" class="caption caption--main caption--video" itemprop="description">
+                            @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
+                            @Html(caption)
+                        </figcaption>
                     }
 
                 </figure>

--- a/static/src/javascripts-legacy/projects/common/modules/video/events.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/events.js
@@ -278,17 +278,12 @@ define([
         events.ready();
     }
 
-    function hideCaption() {
-        $('.js-hide-on-play').hide();
-    }
-
     // These events are so that other libraries (e.g. Ophan) can hook into events without
     // needing to know about videojs
     function bindGlobalEvents(player) {
         player.on('playing', function () {
             kruxTracking(player, 'videoPlaying');
             bean.fire(document.body, 'videoPlaying');
-            hideCaption();
         });
         player.on('pause', function () {
             bean.fire(document.body, 'videoPause');

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -743,27 +743,21 @@ $caption-button-size: 32px;
         .reveal-caption {
             position: absolute;
             right: $gs-gutter / 4;
-            bottom: $gs-baseline/2;
             width: $caption-button-size;
             height: $caption-button-size;
             z-index: 1;
             background-color: rgba($neutral-1, .4);
             border-radius: 50%;
-
-            &:after {
-                content: '';
-                position: absolute;
-                top: -$gs-gutter;
-                right: -$gs-gutter;
-                bottom: -$gs-gutter;
-                left: -$gs-gutter;
-                border-radius: 50%;
-                z-index: -1;
-            }
+        }
+        .reveal-caption--img {
+            bottom: $gs-baseline/2;
         }
 
-        .caption--main.caption--img,
         .caption--main.caption--video {
+            padding-bottom: 0;
+        }
+
+        .caption--main.caption--img {
             position: absolute;
             background: rgba($multimedia-support-5, .8);
             color: #ffffff;
@@ -779,8 +773,7 @@ $caption-button-size: 32px;
                 color: #ffffff;
             }
 
-            &.caption--img,
-            &.caption--video {
+            &.caption--img {
                 bottom: 0;
                 padding-bottom: $gs-baseline;
             }

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -229,14 +229,6 @@ $ima-controls-height: 70px;
         transition-delay: 0s;
     }
 
-    .gu-media-wrapper:hover .vjs-has-started.vjs-mousemoved & {
-        @include mq($until: tablet) {
-            bottom: 0;
-            transition: bottom 0s;
-            transition-delay: 0s;
-        }
-    }
-
     .vjs-using-native-controls & {
         display: none;
     }
@@ -1108,27 +1100,18 @@ $ima-controls-height: 70px;
 // We have to use vjs classes here, and not BEM modifiers as videojs
 // changes the classes names via JS, and last time we messed with that,
 // we had major refactoring issues.
-.gu-media--show-controls-at-start {
+.gu-media--show-controls-at-start.vjs-paused {
     .vjs-control-bar {
         bottom: 0;
-        
-        @include mq($until: tablet) {
-            bottom: $gs-baseline*-5;
-        }
     }
-    &.vjs-has-started.vjs-paused {
-        .vjs-control-bar {
-            bottom: 0;
+
+    .vjs-big-play-button .vjs-control-text {
+        &:before {
+            background-color: $media-default;
         }
 
-        .vjs-big-play-button .vjs-control-text {
-            &:before {
-                background-color: $media-default;
-            }
-
-            &:after {
-                border-left-color: #333333;
-            }
+        &:after {
+            border-left-color: #333333;
         }
     }
 }


### PR DESCRIPTION
Reverts guardian/frontend#15952

Something seems to be keeping the video controls from auto-hiding when the video plays. Going to revert then look into why. 