### PR TITLE
membership engagement banner copy tests extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,7 +26,7 @@ trait ABTestSwitches {
     "Test copy for the engagement banner in all countries aside from the US and Australia",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 10),
+    sellByDate = new LocalDate(2017, 3, 17),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -172,7 +172,7 @@ define([
     var CopyTest = function() {
         this.id = 'MembershipEngagementBannerCopyTest';
         this.start = '2017-02-27';
-        this.expiry = '2017-03-13';
+        this.expiry = '2017-03-17';
         this.author = 'Guy Dawson';
         this.description = 'Test different copy for the engagement banner.';
         this.audience = 0.5;


### PR DESCRIPTION
@guardian/contributions 

## What does this change?

Extends the sale by date for the engagement banner copy tests.

## What is the value of this and can you measure success?

Allows the tests to run for long enough to reach statistical significance.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No