### PR TITLE
Make sure value is returned from canRun function

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-recommended-email.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-recommended-email.js
@@ -19,7 +19,7 @@ define([
         this.idealOutcome = 'Tailor recommended email list has a higher sign-up than standard';
 
         this.canRun = function () {
-            storage.local.isStorageAvailable();
+            return storage.local.isStorageAvailable();
         };
 
         this.variants = [


### PR DESCRIPTION
## What does this change?

Fixes small bug with the email sign-up test which allocates users to the test

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
