### PR TITLE
Readable text on Gmail mobile

### DIFF
--- a/common/app/views/fragments/email/stylesheets/ink.scala.html
+++ b/common/app/views/fragments/email/stylesheets/ink.scala.html
@@ -823,6 +823,15 @@ body.outlook p {
         width: 100% !important;
     }
 
+    /*
+     * Mad hack: Apple mail seems to be the only mobile client that
+     * understands the attribute notation, and on this client the email is
+     * full-bleed so we *do* want some padding on the sides
+     */
+    table[class="body"] .container {
+        width: 95% !important;
+    }
+
     table.body .row {
         width: 100% !important;
         display: block !important;

--- a/common/app/views/fragments/email/stylesheets/ink.scala.html
+++ b/common/app/views/fragments/email/stylesheets/ink.scala.html
@@ -810,31 +810,31 @@ body.outlook p {
 /*  Media Queries */
 
 @@media only screen and (max-width: 600px) {
-    table[class="body"] img {
+    table.body img {
         max-width: auto !important;
         max-height: auto !important;
     }
 
-    table[class="body"] center {
+    table.body center {
         min-width: 0 !important;
     }
 
-    table[class="body"] .container {
-        width: 95% !important;
+    table.body .container {
+        width: 100% !important;
     }
 
-    table[class="body"] .row {
+    table.body .row {
         width: 100% !important;
         display: block !important;
     }
 
-    table[class="body"] .wrapper {
+    table.body .wrapper {
         display: block !important;
         padding-right: 0 !important;
     }
 
-    table[class="body"] .columns,
-    table[class="body"] .column {
+    table.body .columns,
+    table.body .column {
         table-layout: fixed !important;
         float: none !important;
         width: 100% !important;
@@ -843,111 +843,111 @@ body.outlook p {
         display: block !important;
     }
 
-    table[class="body"] .wrapper.first .columns,
-    table[class="body"] .wrapper.first .column {
+    table.body .wrapper.first .columns,
+    table.body .wrapper.first .column {
         display: table !important;
     }
 
-    table[class="body"] table.columns td,
-    table[class="body"] table.column td {
+    table.body table.columns td,
+    table.body table.column td {
         width: 100% !important;
     }
 
-    table[class="body"] .columns td.one,
-    table[class="body"] .column td.one {
+    table.body .columns td.one,
+    table.body .column td.one {
         width: 8.333333% !important;
     }
 
-    table[class="body"] .columns td.two,
-    table[class="body"] .column td.two {
+    table.body .columns td.two,
+    table.body .column td.two {
         width: 16.666666% !important;
     }
 
-    table[class="body"] .columns td.three,
-    table[class="body"] .column td.three {
+    table.body .columns td.three,
+    table.body .column td.three {
         width: 25% !important;
     }
 
-    table[class="body"] .columns td.four,
-    table[class="body"] .column td.four {
+    table.body .columns td.four,
+    table.body .column td.four {
         width: 33.333333% !important;
     }
 
-    table[class="body"] .columns td.five,
-    table[class="body"] .column td.five {
+    table.body .columns td.five,
+    table.body .column td.five {
         width: 41.666666% !important;
     }
 
-    table[class="body"] .columns td.six,
-    table[class="body"] .column td.six {
+    table.body .columns td.six,
+    table.body .column td.six {
         width: 50% !important;
     }
 
-    table[class="body"] .columns td.seven,
-    table[class="body"] .column td.seven {
+    table.body .columns td.seven,
+    table.body .column td.seven {
         width: 58.333333% !important;
     }
 
-    table[class="body"] .columns td.eight,
-    table[class="body"] .column td.eight {
+    table.body .columns td.eight,
+    table.body .column td.eight {
         width: 66.666666% !important;
     }
 
-    table[class="body"] .columns td.nine,
-    table[class="body"] .column td.nine {
+    table.body .columns td.nine,
+    table.body .column td.nine {
         width: 75% !important;
     }
 
-    table[class="body"] .columns td.ten,
-    table[class="body"] .column td.ten {
+    table.body .columns td.ten,
+    table.body .column td.ten {
         width: 83.333333% !important;
     }
 
-    table[class="body"] .columns td.eleven,
-    table[class="body"] .column td.eleven {
+    table.body .columns td.eleven,
+    table.body .column td.eleven {
         width: 91.666666% !important;
     }
 
-    table[class="body"] .columns td.twelve,
-    table[class="body"] .column td.twelve {
+    table.body .columns td.twelve,
+    table.body .column td.twelve {
         width: 100% !important;
     }
 
-    table[class="body"] td.offset-by-one,
-    table[class="body"] td.offset-by-two,
-    table[class="body"] td.offset-by-three,
-    table[class="body"] td.offset-by-four,
-    table[class="body"] td.offset-by-five,
-    table[class="body"] td.offset-by-six,
-    table[class="body"] td.offset-by-seven,
-    table[class="body"] td.offset-by-eight,
-    table[class="body"] td.offset-by-nine,
-    table[class="body"] td.offset-by-ten,
-    table[class="body"] td.offset-by-eleven {
+    table.body td.offset-by-one,
+    table.body td.offset-by-two,
+    table.body td.offset-by-three,
+    table.body td.offset-by-four,
+    table.body td.offset-by-five,
+    table.body td.offset-by-six,
+    table.body td.offset-by-seven,
+    table.body td.offset-by-eight,
+    table.body td.offset-by-nine,
+    table.body td.offset-by-ten,
+    table.body td.offset-by-eleven {
         padding-left: 0 !important;
     }
 
-    table[class="body"] table.columns td.expander {
+    table.body table.columns td.expander {
         width: 1px !important;
     }
 
-    table[class="body"] .right-text-pad,
-    table[class="body"] .text-pad-right {
+    table.body .right-text-pad,
+    table.body .text-pad-right {
         padding-left: 10px !important;
     }
 
-    table[class="body"] .left-text-pad,
-    table[class="body"] .text-pad-left {
+    table.body .left-text-pad,
+    table.body .text-pad-left {
         padding-right: 10px !important;
     }
 
-    table[class="body"] .hide-for-small,
-    table[class="body"] .show-for-desktop {
+    table.body .hide-for-small,
+    table.body .show-for-desktop {
         display: none !important;
     }
 
-    table[class="body"] .show-for-small,
-    table[class="body"] .hide-for-desktop {
+    table.body .show-for-small,
+    table.body .hide-for-desktop {
         display: block !important;
         width: auto !important;
         overflow: visible !important;


### PR DESCRIPTION
This fixes a very longstanding issue with the rendering of emails on mobile. Because we were getting the 500px fixed-width desktop view on mobile, the text was always tiny.

Gmail (as of recently) supports media queries, but doesn't support these attribute-style selectors. So if we make them class selectors, Gmail will actually render the email with the correct 100% width on mobile, making the text much more readable.