### PR TITLE
Make paidFor icons teal, apply badge layout to branded cards

### DIFF
--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -14,7 +14,7 @@
   minimiseOnMobile: Boolean = false,
   useCardBranding: Boolean)(implicit request: RequestHeader)
 
-<div class="@CssClassBuilder.advertContainer(optClassNames)">
+<div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a href="@item.targetUrl"
         data-link-name="@omnitureId"
         class="@CssClassBuilder.linkFromStandardCard(item, optAdvertClassNames, useCardBranding)"

--- a/common/app/views/fragments/commercial/cards/itemLargeCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemLargeCard.scala.html
@@ -14,7 +14,7 @@
   minimiseOnMobile: Boolean = false,
   useCardBranding: Boolean)(implicit request: RequestHeader)
 
-<div class="@CssClassBuilder.advertContainer(optClassNames)">
+<div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a class="@CssClassBuilder.linkFromLargeCard(item, optAdvertClassNames, useCardBranding)"
         href="@item.targetUrl"
         data-link-name="@omnitureId">

--- a/common/app/views/fragments/commercial/cards/itemSmallCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemSmallCard.scala.html
@@ -8,7 +8,7 @@
 @import views.html.fragments.inlineSvg
 @import views.support.Commercial.CssClassBuilder
 
-<div class="@CssClassBuilder.advertContainer(optClassNames)">
+<div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a href="@item.targetUrl"
         class="@CssClassBuilder.linkFromSmallCard(item, optAdvertClassNames, useCardBranding)"
         data-link-name="@omnitureId">

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -195,8 +195,8 @@ object Commercial {
       cardLink(cardContent, adClasses, sizeClass = Some("advert--large"), useCardBranding)
     }
 
-    def advertContainer(otherClasses: Option[Seq[String]]): String =
-      "advert-container " + otherClasses.map(_.mkString(" ")).getOrElse("")
+    def paidForContainer(otherClasses: Option[Seq[String]]): String =
+      "paidfor-container " + otherClasses.map(_.mkString(" ")).getOrElse("")
   }
 
   object TrackingCodeBuilder extends implicits.Requests {

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -122,7 +122,7 @@
     color: $paid-card-kicker;
 }
 
-.advert-container {
+.paidfor-container {
     display: flex;
     align-items: stretch;
 }

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -1,5 +1,28 @@
 .advert--branded {
-    padding-bottom: 80px;
+    padding-bottom: $gs-baseline * 8;
+}
+
+// general BASIC styles for all the branded badges
+.paidfor-container {
+    .badge--branded {
+        padding-right: 0;
+        max-width: 100%;
+    }
+
+    .badge__link {
+        /* [1] Prevents IE11 bug where the height would go ballooney */
+        height: 100%;
+    }
+
+    .badge__label {
+        text-align: center;
+        width: 100%;
+    }
+
+    .badge__logo {
+        max-width: 100%;
+        margin-left: 0;
+    }
 }
 
 .adverts--capi {
@@ -38,7 +61,7 @@
         margin-bottom: 0;
     }
 
-    .advert-container {
+    .paidfor-container {
         @include mq($until: tablet) {
 
             .advert__standfirst {
@@ -61,31 +84,11 @@
                 min-height: 80px;
             }
 
-            > .badge {
+            .badge {
                 display: flex;
                 flex-direction: column;
                 width: 60px;
             }
-        }
-
-        .badge {
-            padding-right: 0;
-            max-width: 100%;
-        }
-
-        .badge__link {
-            /* [1] Prevents IE11 bug where the height would go ballooney */
-            height: 100%;
-        }
-
-        .badge__label {
-            text-align: center;
-            width: 100%;
-        }
-
-        .badge__logo {
-            max-width: 100%;
-            margin-left: 0;
         }
     }
 }
@@ -118,8 +121,12 @@
 .adverts--tone-paidfor {
     background-color: $neutral-6;
 
-    > .adverts__header {
+    .adverts__header {
         background: $paidfor-background;
+    }
+
+    .inline-icon {
+      fill: $paid-article-brand;
     }
 
     .adverts__title {
@@ -298,7 +305,6 @@
     background: $paid-article-card-bg;
     border-top-color: $paid-article-brand;
     width: 100%;
-    padding-bottom: $gs-baseline * 8;
 
     &:hover,
     &:focus {
@@ -309,7 +315,7 @@
         @include f-headlineSans;
         font-weight: 400;
 
-        > .inline-icon svg {
+        .inline-icon {
             fill: $paid-article-icon;
         }
     }


### PR DESCRIPTION
## What does this change?

- Make the icons in paidFor containers use the paidFor teal tone
- Apply badge layout changes to all badges (remove some specificity)
- Fix specificity of the padding so it only targets branded cards

Nothing else to see here, lets just move along... 😈 

Okay.. for the curious, this is the reason for the final change:

<img width="755" alt="picture 601" src="https://cloud.githubusercontent.com/assets/8607683/23707818/a17fc7ec-040b-11e7-9e36-21762d890337.png">

## What is the value of this and can you measure success?

- Pretty icons and badges
- paidFor cards in mixed containers do not have their display blocked
- Fix a layout bug 😞 

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

BEFORE:

<img width="373" alt="picture 609" src="https://cloud.githubusercontent.com/assets/8607683/23711723/945c9cae-0418-11e7-845d-386be44fdfde.png">

<img width="964" alt="picture 602" src="https://cloud.githubusercontent.com/assets/8607683/23708498/0278581e-040e-11e7-94a3-0eaadc1f2906.png">

AFTER:

<img width="369" alt="picture 608" src="https://cloud.githubusercontent.com/assets/8607683/23711715/8fe431be-0418-11e7-8980-9953b2117879.png">

<img width="973" alt="picture 603" src="https://cloud.githubusercontent.com/assets/8607683/23708520/0f03273a-040e-11e7-8dbf-dfc8429fdcd7.png">

## Tested in CODE?

TODO
