### PR TITLE
Fix tests, broken by removing `lib/template`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
@@ -1,6 +1,6 @@
 define([
     'common/modules/commercial/contributions-utilities',
-    'lib/template',
+    'lodash/utilities/template',
     'lodash/objects/assign',
     'raw-loader!common/views/acquisitions-epic-design-variations.html'
 ], function(

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
@@ -1,6 +1,6 @@
 define([
     'common/modules/commercial/contributions-utilities',
-    'lib/template',
+    'lodash/utilities/template',
     'lib/cookies',
     'raw-loader!common/views/contributions-epic-equal-buttons.html',
     'common/modules/tailor/tailor'


### PR DESCRIPTION
## What does this change?

Fixes tests, which broke in https://github.com/guardian/frontend/pull/16104

## What is the value of this and can you measure success?

Tests.
