### PR TITLE
Fix URLs in design variations and always ask tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations.js
@@ -58,8 +58,8 @@ define([
     function buildVariant(variantId, templateArgs) {
         var args = { id: variantId };
         if (variantId !== 'control') {
-            args.template = function(membershipUrl, contributionUrl) {
-                return buildHtml(membershipUrl, contributionUrl, templateArgs)
+            args.template = function(variant) {
+                return buildHtml(variant.membershipURL, variant.contributeURL, templateArgs)
             }
         }
         return assign({}, defaultVariantArgs, args)

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -60,10 +60,10 @@ define([
 
             {
                 id: 'alwaysAsk',
-                template: function (membershipUrl, contributionUrl) {
+                template: function (variant) {
                     return template(contributionsEpicEqualButtons, {
-                        linkUrl1: membershipUrl,
-                        linkUrl2: contributionUrl,
+                        linkUrl1: variant.membershipURL,
+                        linkUrl2: variant.contributeURL,
                         title: 'Since you’re here…',
                         p1: '… we have a small favour to ask. More people are reading the Guardian than ever but far fewer are paying for it. And advertising revenues across the media are falling fast. So you can see why we need to ask for your help. The Guardian\'s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to pay for it, our future would be much more secure.',


### PR DESCRIPTION
This is an urgent fix as these tests are not linking to the contribution/membership sites so I'm going to merge it straight in.