### PR TITLE
Rendering for tailor survey

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts-legacy/projects/common/modules/article/space-filler.js
@@ -31,25 +31,20 @@ define([
      * @returns {Promise} - when insertion attempt completed, resolves 'true' if inserted, or 'false' if no space found
      */
     SpaceFiller.prototype.fillSpace = function (rules, writer, options) {
-        console.log("filling space");
         var write = (options && options.domWriter) || fastdom.write;
-        // console.log("write " + write);
         return queue.add(insertNextContent);
 
         function insertNextContent() {
-            console.log("insertNextContent");
             return spacefinder.findSpace(rules, options).then(onSpacesFound, onNoSpacesFound);
         }
 
         function onSpacesFound(paragraphs) {
-            console.log("spaces found");
             return write(function () {
                 return writer(paragraphs);
             });
         }
 
         function onNoSpacesFound(ex) {
-            console.log("no spaces found");
             if (ex instanceof spacefinder.SpaceError) {
                 return false;
             } else {

--- a/static/src/javascripts-legacy/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts-legacy/projects/common/modules/article/space-filler.js
@@ -31,20 +31,25 @@ define([
      * @returns {Promise} - when insertion attempt completed, resolves 'true' if inserted, or 'false' if no space found
      */
     SpaceFiller.prototype.fillSpace = function (rules, writer, options) {
+        console.log("filling space");
         var write = (options && options.domWriter) || fastdom.write;
+        // console.log("write " + write);
         return queue.add(insertNextContent);
 
         function insertNextContent() {
+            console.log("insertNextContent");
             return spacefinder.findSpace(rules, options).then(onSpacesFound, onNoSpacesFound);
         }
 
         function onSpacesFound(paragraphs) {
+            console.log("spaces found");
             return write(function () {
                 return writer(paragraphs);
             });
         }
 
         function onNoSpacesFound(ex) {
+            console.log("no spaces found");
             if (ex instanceof spacefinder.SpaceError) {
                 return false;
             } else {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -135,8 +135,8 @@ define([
         }
 
         // Rules to use when finding a space for the survey
-        function getSpacefinderRules() {
-            return {
+        var spacefinderRules =
+             {
                 bodySelector: '.js-article__body',
                 slotSelector: ' > p',
                 minAbove: 0,
@@ -151,11 +151,11 @@ define([
                     ' .ad-slot': {minAbove: 0, minBelow: 0}
                 }
             };
-        }
+
 
         // we can write a survey into a spare space using spaceFiller
         var inArticleWriter = function (survey, surveyId) {
-            return spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
+            return spaceFiller.fillSpace(spacefinderRules, function (paras) {
                 var componentName = 'data_tailor_survey_' + surveyId;
                 mediator.emit('register:begin', componentName);
                 bonzo(survey).insertBefore(paras[0]);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -134,38 +134,22 @@ define([
             };
         }
 
-        // Rules to use when finding a space for the survey -  copied from default spacefinder rules
+        // Rules to use when finding a space for the survey
         function getSpacefinderRules() {
-            return { // these are written for adverts
+            return {
                 bodySelector: '.js-article__body',
                 slotSelector: ' > p',
-                absoluteMinAbove: 0, // minimum from slot to top of page
-                minAbove: 250, // minimum from para to top of article
-                minBelow: 300, // minimum from (top of) para to bottom of article
-                clearContentMeta: 50, // vertical px to clear the content meta element (byline etc) by. 0 to ignore
-                selectors: { // custom rules using selectors. format:
-                    //'.selector': {
-                    //   minAbove: <min px above para to bottom of els matching selector>,
-                    //   minBelow: <min px below (top of) para to top of els matching selector> }
-                    ' > h2': {minAbove: 0, minBelow: 250}, // hug h2s
-                    ' > *:not(p):not(h2)': {minAbove: 25, minBelow: 250} // require spacing for all other elements
-                },
-
-                // filter:(slot:Element, index:Integer, slots:Collection<Element>) -> Boolean
-                // will run each slot through this fn to check if it must be counted in
-                filter: null,
-
-                // startAt:Element
-                // will remove slots before this one
-                startAt: null,
-
-                // stopAt:Element
-                // will remove slots from this one on
-                stopAt: null,
-
-                // fromBotton:Boolean
-                // will reverse the order of slots (this is useful for lazy loaded content)
-                fromBottom: false
+                minAbove: 0,
+                minBelow: 0,
+                clearContentMeta: 50,
+                selectors: {
+                    ' .element-rich-link': {minAbove: 250, minBelow: 250},
+                    ' .player': {minAbove: 0, minBelow: 0},
+                    ' > h1': {minAbove: 0, minBelow: 0},
+                    ' > h2': {minAbove: 0, minBelow: 0},
+                    ' > *:not(p):not(h2):not(blockquote)': {minAbove: 0, minBelow: 0},
+                    ' .ad-slot': {minAbove: 0, minBelow: 0}
+                }
             };
         }
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -143,8 +143,9 @@ define([
                 minBelow: 0,
                 clearContentMeta: 50,
                 selectors: {
-                    ' .element-rich-link': {minAbove: 0, minBelow: 0},
+                    ' .element-rich-link': {minAbove: 10, minBelow: 10},
                     ' .player': {minAbove: 0, minBelow: 0},
+                    ' > h1': {minAbove: 0, minBelow: 0},
                     ' > h2': {minAbove: 0, minBelow: 0},
                     ' > *:not(p):not(h2):not(blockquote)': {minAbove: 0, minBelow: 0},
                     ' .ad-slot': {minAbove: 0, minBelow: 0}

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -134,22 +134,38 @@ define([
             };
         }
 
-        // Rules to use when finding a space for the survey
+        // Rules to use when finding a space for the survey -  copied from default spacefinder rules
         function getSpacefinderRules() {
-            return {
+            return { // these are written for adverts
                 bodySelector: '.js-article__body',
                 slotSelector: ' > p',
-                minAbove: 0,
-                minBelow: 0,
-                clearContentMeta: 50,
-                selectors: {
-                    ' .element-rich-link': {minAbove: 10, minBelow: 10},
-                    ' .player': {minAbove: 0, minBelow: 0},
-                    ' > h1': {minAbove: 0, minBelow: 0},
-                    ' > h2': {minAbove: 0, minBelow: 0},
-                    ' > *:not(p):not(h2):not(blockquote)': {minAbove: 0, minBelow: 0},
-                    ' .ad-slot': {minAbove: 0, minBelow: 0}
-                }
+                absoluteMinAbove: 0, // minimum from slot to top of page
+                minAbove: 250, // minimum from para to top of article
+                minBelow: 300, // minimum from (top of) para to bottom of article
+                clearContentMeta: 50, // vertical px to clear the content meta element (byline etc) by. 0 to ignore
+                selectors: { // custom rules using selectors. format:
+                    //'.selector': {
+                    //   minAbove: <min px above para to bottom of els matching selector>,
+                    //   minBelow: <min px below (top of) para to top of els matching selector> }
+                    ' > h2': {minAbove: 0, minBelow: 250}, // hug h2s
+                    ' > *:not(p):not(h2)': {minAbove: 25, minBelow: 250} // require spacing for all other elements
+                },
+
+                // filter:(slot:Element, index:Integer, slots:Collection<Element>) -> Boolean
+                // will run each slot through this fn to check if it must be counted in
+                filter: null,
+
+                // startAt:Element
+                // will remove slots before this one
+                startAt: null,
+
+                // stopAt:Element
+                // will remove slots from this one on
+                stopAt: null,
+
+                // fromBotton:Boolean
+                // will reverse the order of slots (this is useful for lazy loaded content)
+                fromBottom: false
             };
         }
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -210,7 +210,6 @@ define([
         }
 
         function handleSurveyResponse(surveyId) {
-            console.log("surveyId " + surveyId);
             var surveyQuestions = document.getElementsByClassName('fi-survey__button');
 
             forEach(surveyQuestions, function (question) {
@@ -233,7 +232,6 @@ define([
 
         function recordOphanAbEvent(answer, surveyId) {
             var componentId = 'data_tailor_survey_' + surveyId;
-            console.log("componentId: " + componentId);
             ophan.record({
                 component: componentId,
                 value: answer

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -14,7 +14,8 @@ define([
     'lib/fetch-json',
     'lodash/collections/forEach',
     'ophan/ng',
-    'lodash/utilities/template'
+    'lodash/utilities/template',
+    'common/modules/article/space-filler'
 ], function (
     bean,
     bonzo,
@@ -31,7 +32,8 @@ define([
     fetchJson,
     forEach,
     ophan,
-    template
+    template,
+    spaceFiller
 ) {
     return function () {
         this.id = 'TailorSurvey';
@@ -134,6 +136,41 @@ define([
             };
         }
 
+        function getSpacefinderRules() {
+            return {
+                bodySelector: '.js-article__body',
+                slotSelector: ' > p',
+                minAbove: 0,
+                minBelow: 0,
+                clearContentMeta: 50,
+                selectors: {
+                    ' .element-rich-link': {minAbove: 0, minBelow: 0},
+                    ' .player': {minAbove: 0, minBelow: 0},
+                    ' > h2': {minAbove: 0, minBelow: 0},
+                    ' > *:not(p):not(h2):not(blockquote)': {minAbove: 0, minBelow: 0},
+                    ' .ad-slot': {minAbove: 0, minBelow: 0}
+                }
+            };
+        }
+
+        var inArticleWriter = function (component) {
+
+            console.log("writing");
+
+            return spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
+                console.log("inserting");
+                component.insertBefore(paras[0]);
+                console.log("inserted");
+                embed.init();
+                console.log("finished init");
+                mediator.emit('data-tailor-survey:insert', component);
+                console.log("finished inserting");
+
+                return 1;
+            });
+
+        };
+
         function renderQuickSurvey() {
 
             var bwid = cookies.get('bwid');
@@ -158,17 +195,31 @@ define([
 
                         mediator.emit('register:begin', componentName);
 
+                        var survey = bonzo.create(template(tailorSurvey, json));
+
+                        // var component = bonzo.create(template(contributionsEmbed, {
+                        //     position : 'supporting',
+                        //     linkHref : 'https://interactive.guim.co.uk/contributions-embeds/embed/embed.html',
+                        //     variant : 'in-article',
+                        //     intCMP : 'co_uk_cobedpos_like_article'
+                        //
+                        // }));
+                        //
+                        return inArticleWriter(survey);
+
+                        // return surveySuggestionToShow.data.survey.surveyId;
+
                         // renders the survey, and returns the survey ID
 
-                        return fastdomPromise.write(function () {
-                            var article = document.getElementsByClassName('content__article-body')[0];
-                            var insertionPoint = article.getElementsByTagName('p')[1];
-                            var survey = bonzo.create(template(tailorSurvey, json));
-                            bonzo(survey).insertBefore(insertionPoint);
-                            mediator.emit('register:end', componentName);
-
-                            return surveySuggestionToShow.data.survey.surveyId;
-                        });
+                        // return fastdomPromise.write(function () {
+                        //     var article = document.getElementsByClassName('content__article-body')[0];
+                        //     var insertionPoint = article.getElementsByTagName('p')[1];
+                        //
+                        //     bonzo(survey).insertBefore(insertionPoint);
+                        //     mediator.emit('register:end', componentName);
+                        //
+                        //     return surveySuggestionToShow.data.survey.surveyId;
+                        // });
                     }
                 });
             }
@@ -214,7 +265,7 @@ define([
 
         function recordOphanAbEvent(answer, surveyId) {
             ophan.record({
-                component: 'tailor-survey-' + surveyId,
+                component: 'data_tailor_survey_' + surveyId,
                 value: answer
             });
         }

--- a/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
+++ b/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
@@ -6,7 +6,7 @@
     </div>
 </div>
 
-<div class="impressions-survey__body" data-link-name="tailor_survey_<%=id%>" data-component="data_tailor_survey_<%=id%>">
+<div class="impressions-survey__body" data-link-name="data_tailor_survey_<%=id%>" data-component="data_tailor_survey_<%=id%>">
 
     <div class="impressions-survey__content">
         <h3 class="impressions-survey__question">

--- a/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
+++ b/static/src/javascripts-legacy/projects/common/views/experiments/tailor-survey.html
@@ -6,7 +6,7 @@
     </div>
 </div>
 
-<div class="impressions-survey__body" data-link-name="tailor-survey-<%=id%>" data-component="data_tailor_survey_<%=id%>">
+<div class="impressions-survey__body" data-link-name="tailor_survey_<%=id%>" data-component="data_tailor_survey_<%=id%>">
 
     <div class="impressions-survey__content">
         <h3 class="impressions-survey__question">

--- a/static/src/stylesheets/module/experiments/_survey.scss
+++ b/static/src/stylesheets/module/experiments/_survey.scss
@@ -9,6 +9,8 @@
     @include fs-bodyHeading(4);
     display: inline-block;
     margin-right: $gs-gutter;
+    color: $neutral-1;
+    font-style: normal;
 }
 
 .impressions-survey__about {
@@ -39,6 +41,7 @@
 
 .impressions-survey__question {
     @include fs-bodyHeading(2);
+    font-style: normal;
 }
 
 .fi-survey__button {
@@ -49,6 +52,8 @@
 
 .fi-survey__label {
     display: block;
+    font-style: normal;
+    color: #ffffff;
 }
 
 .impressions-survey__thanks {
@@ -58,6 +63,7 @@
     top: 20%;
     opacity: 0;
     visibility: collapse;
+    font-style: normal;
 }
 
 .js-impressions-survey__fadein {


### PR DESCRIPTION
Some more changes to tailor's survey:
- CSS modifications to make sure the styling looks right, e.g. on [https://www.theguardian.com/business/2017/mar/08/nike-launches-hijab-for-female-muslim-athletes](url)
<img width="659" alt="screen shot 2017-03-09 at 13 14 53" src="https://cloud.githubusercontent.com/assets/10598156/23751712/6c21c54a-04ca-11e7-87e6-41adda1c5eeb.png">
now becomes
<img width="657" alt="screen shot 2017-03-09 at 14 57 48" src="https://cloud.githubusercontent.com/assets/10598156/23755596/ca445fa8-04d8-11e7-9321-75d810bc7229.png">

- Change to use space filler to find location for survey, as the current method sometimes doesn't look right (I've played around with the rules and these seem ok, but if anyone has further suggestions that would be great), e.g. on [https://www.theguardian.com/business/2017/mar/08/nike-launches-hijab-for-female-muslim-athletes](url)
<img width="686" alt="screen shot 2017-03-09 at 13 10 40" src="https://cloud.githubusercontent.com/assets/10598156/23751561/d9151b3a-04c9-11e7-8a4f-cade898c9c36.png">
now becomes 
<img width="682" alt="screen shot 2017-03-09 at 13 12 55" src="https://cloud.githubusercontent.com/assets/10598156/23751640/228832b6-04ca-11e7-83e9-782fa2ea9e77.png">

- Tracking changes to follow @JPodmore's new naming convention

@lindseydew @oilnam @GHaberis @stephanfowler @SiAdcock @mike-ruane