### PR TITLE
adds switch for recipes

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -122,7 +122,7 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit context: Ap
         else if (article.article.isExplore) views.html.articleExplore(article)
         else if (article.article.isImmersive) views.html.articleImmersive(article)
         else if (request.isAmp) views.html.articleAMP(article)
-        else if (article.article.isRecipeArticle && false) {
+        else if (article.article.isRecipeArticle) {
           val recipeAtoms = article.article.content.atoms.fold(Nil: Seq[RecipeAtom])(_.recipes)
           val maybeMainImage: Option[ImageMedia] = article.article.content.elements.mainPicture.map{ _.images}
           views.html.recipeArticle(article, recipeAtoms, maybeMainImage)

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -504,7 +504,7 @@ trait FeatureSwitches {
     "changes design of articles with strucutred recipe data",
     owners = Seq(Owner.withGithub("tsop14"), Owner.withGithub("blongden73")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 12, 1),
+    sellByDate = new LocalDate(2017, 4, 4),
     exposeClientSide = true
 
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -497,4 +497,15 @@ trait FeatureSwitches {
     exposeClientSide = true
 
   )
+
+  val ArticleWithStructuredRecipe = Switch(
+    SwitchGroup.Feature,
+    "is-article-with-structured-recipe-data",
+    "changes design of articles with strucutred recipe data",
+    owners = Seq(Owner.withGithub("tsop14"), Owner.withGithub("blongden73")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 12, 1),
+    exposeClientSide = true
+
+  )
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -82,7 +82,7 @@ final case class Content(
   lazy val isImmersive = fields.displayHint.contains("immersive") || isImmersiveGallery || tags.isTheMinuteArticle || isExplore
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
-  lazy val isRecipeArticle: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty)
+  lazy val isRecipeArticle: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty) && ArticleWithStructuredRecipe.isSwitchedOn
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -445,7 +445,7 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && (content.elements.hasMainMedia || content.fields.main.nonEmpty))) && content.tags.isArticle,
-      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle) || (content.isRecipeArticle && false)
+      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle) || content.isRecipeArticle
     )
   }
 


### PR DESCRIPTION
## What does this change?

- Adds a switch for recipe articles: `ArticleWithStructuredRecipe`.
- Sets default value to `false`. 
- Uses switch to set value of `isRecipeArticle`, which determines if new template design is used and sets slim header.
- Removes `false` if statements.

## What is the value of this and can you measure success?
Easier to turn on / off new design. 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

## Tested in CODE?
No

@TBonnin @NataliaLKB 

Thanks @blongden73 for help!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
