### PR TITLE
Share recipe formatting functions

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -9,7 +9,6 @@ import org.joda.time.{DateTime, DateTimeZone, Duration}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import quiz._
 import enumeratum._
-import model.content.MediaAssetPlatform.findValues
 
 final case class Atoms(
   quizzes: Seq[Quiz],
@@ -311,9 +310,18 @@ object RecipeAtom {
   def yieldServingType(serves: com.gu.contentatom.thrift.atom.recipe.Serves): String = {
     serves.`type` match {
       case "serves" => "servings"
-      case "makes" => s"${serves.unit}"
+      case "makes" => s"${serves.unit.getOrElse("")}"
       case "quantity" => "portions"
     }
+  }
+
+  def formatServingValue(serves: com.gu.contentatom.thrift.atom.recipe.Serves): String = {
+    val portions = if (serves.from != serves.to) s"from ${serves.from} to ${serves.to} " else s"${serves.from} "
+    portions ++ yieldServingType(serves)
+  }
+
+  def formatIngredientValues(ingredients: Seq[com.gu.contentatom.thrift.atom.recipe.Ingredient]): Seq[String] = {
+    ingredients.map(formatIngredientValue)
   }
 
   def formatIngredientValue(ingredient: com.gu.contentatom.thrift.atom.recipe.Ingredient): String = {

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -43,7 +43,7 @@
      },
      *@
      "recipeIngredient": @Html(Json.stringify(Json.toJson(RecipeAtom.formatIngredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients))))),
-     "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"$index. $step" })))
+     "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"${index +1}. $step" })))
     }
 </script>
 

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -2,6 +2,7 @@
 @import views.support.{ImgSrc, GoogleStructuredData}
 @import org.joda.time.DateTime
 @import model.Tag
+@import model.content.RecipeAtom
 
 @(recipe: model.content.RecipeAtom, contributors: Seq[Tag])(implicit request: RequestHeader)
 
@@ -30,8 +31,8 @@
      *@
       @recipe.data.time.preparation.map {minutes => "prepTime": "PT@{minutes}M",}
       @recipe.data.time.cooking.map {minutes => "cookTime": "PT@{minutes}M",}
-      @totalTime(recipe).map { minutes => "totalTime": "PT@{minutes}M",}
-      @recipe.data.serves.map { serves => "recipeYield": "@yieldValue(serves)",}
+      @RecipeAtom.totalTime(recipe).map { minutes => "totalTime": "PT@{minutes}M",}
+      @recipe.data.serves.map { serves => "recipeYield": "@RecipeAtom.formatServingValue(serves)",}
      @*
      TODO - We do not have nutrition in the model yet
      "nutrition": {
@@ -41,54 +42,13 @@
        "fatContent": "20.2 g"
      },
      *@
-     "recipeIngredient": @Html(Json.stringify(Json.toJson(ingredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients))))),
+     "recipeIngredient": @Html(Json.stringify(Json.toJson(RecipeAtom.formatIngredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients))))),
      "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"$index. $step" })))
     }
 </script>
-
-@totalTime(recipe: model.content.RecipeAtom) = @{
-    (recipe.data.time.preparation ++ recipe.data.time.cooking).map(_.toInt).reduceOption(_ + _)
-}
 
 @imgValue(image: com.gu.contentatom.thrift.Image) = @{
     val media =  model.content.MediaAtom.imageMediaMake(image, "")
     ImgSrc.findLargestSrc(media, GoogleStructuredData).getOrElse("")
 }
 
-@yieldValue(serves: com.gu.contentatom.thrift.atom.recipe.Serves) = @{
-    serves.`type` match {
-        case "serves" => if (serves.from == serves.to) s"${serves.from} servings" else s"from ${serves.from} to ${serves.to} servings"
-        case "makes" => if (serves.from == serves.to) s"${serves.from} ${serves.unit}" else s"from ${serves.from} to ${serves.to} ${serves.unit}"
-        case "quantity" => if(serves.from == serves.to) s"${serves.from} portions" else s"from ${serves.from} to ${serves.to} portions"
-    }
-}
-
-@ingredientValues(ingredients: Seq[com.gu.contentatom.thrift.atom.recipe.Ingredient]) = @{
-    ingredients.map { ingredient =>
-        val q = ingredient.quantity
-          .map(formatQuantity)
-          .orElse(ingredient.quantityRange.map(range => s"${formatQuantity(range.from)}-${formatQuantity(range.to)}" ))
-          .getOrElse("")
-        s"""${q} ${formatUnit(ingredient.unit.getOrElse(""))} ${ingredient.item}"""
-    }
-}
-
-@formatUnit(unit: String) = @{
-        unit match {
-            case "dsp" => "dessert spoon"
-            case "tsp" => "teaspoon"
-            case "tbsp" => "tablespoon"
-            case _ => unit
-        }
-}
-
-@formatQuantity(q: Double) = @{
-    q match {
-        case qty if qty == qty.toInt => qty.toInt.toString
-        case 0.75 => "3/4"
-        case 0.5 => "1/2"
-        case 0.25 => "1/4"
-        case 0.125 => "1/8"
-        case _ => q.toString
-    }
-}


### PR DESCRIPTION
## What does this change?

- Moves recipe schema JSON-LD formatting logic from template to `RecipeAtom` object.
- Shares logic with the `recipeArticleBody` view. 
- Starts instructions at 1.
- Uses empty string when unit Option is `None`.

## What is the value of this and can you measure success?
Less code, safer code (properly compiled as no longer in a template file), shared code. ✌️

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@mchv 
