### PR TITLE
Use all testCanRun checks in aquisitions-test-selector

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -10,7 +10,7 @@ define([
     'common/modules/experiments/tests/acquisitions-epic-design-variations'
 ], function (
     segmentUtil,
-    canRunChecks,
+    testCanRunChecks,
     viewLog,
     brexit,
     alwaysAsk,
@@ -43,7 +43,7 @@ define([
                     viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews) === 0) ||
                     variant.isUnlimited);
 
-                return forced || (canRunChecks.testCanBeRun(t) && segmentUtil.isInTest(t) && hasNotReachedRateLimit);
+                return forced || (testCanRunChecks.testCanBeRun(t) && segmentUtil.isInTest(t) && hasNotReachedRateLimit);
             });
 
             return eligibleTests[0] && new eligibleTests[0]();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -1,5 +1,6 @@
 define([
     'common/modules/experiments/segment-util',
+    'common/modules/experiments/test-can-run-checks',
     'common/modules/commercial/acquisitions-view-log',
     'common/modules/experiments/tests/contributions-epic-brexit',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
@@ -9,6 +10,7 @@ define([
     'common/modules/experiments/tests/acquisitions-epic-design-variations'
 ], function (
     segmentUtil,
+    canRunChecks,
     viewLog,
     brexit,
     alwaysAsk,
@@ -41,7 +43,7 @@ define([
                     viewLog.viewsInPreviousDays(variant.maxViews.minDaysBetweenViews) === 0) ||
                     variant.isUnlimited);
 
-                return forced || (t.canRun() && segmentUtil.isInTest(t) && hasNotReachedRateLimit);
+                return forced || (canRunChecks.testCanBeRun(t) && segmentUtil.isInTest(t) && hasNotReachedRateLimit);
             });
 
             return eligibleTests[0] && new eligibleTests[0]();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
@@ -1,0 +1,27 @@
+define([
+    'lib/config'
+], function(config) {
+    function isTestSwitchedOn(test) {
+        return config.switches['ab' + test.id];
+    }
+
+    function isExpired(testExpiry) {
+        // new Date(test.expiry) sets the expiry time to 00:00:00
+        // Using SetHours allows a test to run until the END of the expiry day
+        var startOfToday = new Date().setHours(0, 0, 0, 0);
+        return startOfToday > new Date(testExpiry);
+    }
+
+    function testCanBeRun(test) {
+        var expired = isExpired(test.expiry),
+            isSensitive = config.page.isSensitive;
+
+        return ((isSensitive ? test.showForSensitive : true)
+            && isTestSwitchedOn(test)) && !expired && test.canRun();
+    }
+
+    return {
+        isExpired: isExpired,
+        testCanBeRun: testCanBeRun
+    }
+})


### PR DESCRIPTION
## What does this change?
Currently the selector module ignores a test's switch, so disabled tests
can still be passed into ab.js. This refactor moves the canRun checks
from ab.js into their own module, which is used by both ab.js and the
selector, so the same criteria (including switch checks) is applied.