### PR TITLE
Await upvote unset before reporting error

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/upvote.js
@@ -29,9 +29,10 @@ define([
                 return setRecommended(target);
             })
             .catch(function (ex) {
-                unsetClicked(target);
-                reportError(ex, {
-                    feature: 'comments-recommend'
+                return unsetClicked(target).then(function() {
+                    reportError(ex, {
+                        feature: 'comments-recommend'
+                    });
                 });
             });
         }


### PR DESCRIPTION
## What does this change?

There is currently a race condition in our recommendation tests. `unsetClicked` adds the `js-recommend-comment` class to the `target` asynchronously using `fastdomPromise`. If `reportError` throws an error before `unsetClicked` has resolved, [one of the recommendation tests](https://github.com/guardian/frontend/blob/master/static/test/javascripts-legacy/spec/common/discussion/recommendation.spec.js#L101) fails, as it falls into the `catch` callback before the class has been added. 

This is causing builds to [fail intermittently on CI](https://teamcity.gu-web.net/viewLog.html?buildId=31561&buildTypeId=dotcom_frontend&tab=buildLog)

## What is the value of this and can you measure success?

Allowing `unsetClicked` to resolve before throwing an error makes the code more deterministic.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
