### PR TITLE
Remove football-specific right slot rules

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-aside-adverts.js
@@ -18,7 +18,6 @@ define([
     commercialFeatures
 ) {
     var minArticleHeight = 1300;
-    var minFootballArticleHeight = 2200;
     var minImmersiveArticleHeight = 600;
 
     var mainColumnSelector = '.js-content-main-column';
@@ -54,9 +53,9 @@ define([
                         'right' :
                         'right-small';
             } else {
-                adType = (config.page.section !== 'football' && mainColHeight >= minArticleHeight) ||
-                         (config.page.section === 'football' && mainColHeight >= minFootballArticleHeight)
-                         ? 'right-sticky' : 'right-small';
+                adType = mainColHeight >= minArticleHeight ?
+                    'right-sticky' :
+                    'right-small';
             }
 
             $adSlot = createSlot(adType, { classes: 'mpu-banner-ad' });


### PR DESCRIPTION
## What does this change?

It removes the specific length an article should have in the football section. This rule was probably there because of match reports, where there needs more space for the match stats component. The right slot is [completely disabled](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js#L82) on those pages, so this test does not make sense anymore.

## What is the value of this and can you measure success?

The DMPU unit has more value, as does the Portrait size (300x1050) in the US.

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

Before:
![picture 3](https://cloud.githubusercontent.com/assets/629976/23896983/68009392-08a3-11e7-8a34-13932dc0a165.jpg)

After:
![picture 4](https://cloud.githubusercontent.com/assets/629976/23897017/85e7cc7c-08a3-11e7-9063-b3cb7e5a6d1e.jpg)

White-space in the bottom-right shows we make space for larger units.