### PR TITLE
Force into AB test before common init

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -48,8 +48,6 @@ define([
             ga.trackPerformance('Javascript Load', 'enhancedStart', 'Enhanced start parse time');
         });
 
-        bootstrapContext('common', common);
-
         //
         // A/B tests
         //
@@ -63,6 +61,8 @@ define([
 
             ab.trackEvent();
         });
+
+        bootstrapContext('common', common);
 
         // geolocation
         robust.catchErrorsAndLog('geolocation', geolocation.init);


### PR DESCRIPTION
## What does this change?

Previously, the enhanced bootstrap was forcing users into AB tests (using [`segmentUser`](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js#L370)) after most of the page JavaScript had been initialised. This meant that when opting into a particular variant using the URL hash approach, the developer had to refresh the page a second time in order to see the result of opting in.

Running `segmentUser` before common module initialisation ensures that the developer is opted into the variant for this session, and does not have to reload the page.

## What is the value of this and can you measure success?

A smoother developer experience for opting into AB test variants.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
