### PR TITLE
Article 50 Epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -189,4 +189,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 3, 17),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-article-50-trigger",
+    "Display the Epic on Article 50 articles for readers in Europe",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 4, 10),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/lib/geolocation.js
+++ b/static/src/javascripts-legacy/lib/geolocation.js
@@ -135,10 +135,16 @@ define([
         return 'INT';
     }
 
+    function isInEurope() {
+        var countryCode = getSync();
+        return europeCountryCodes.indexOf(countryCode) > -1 || countryCode === 'GB'
+    }
+
     return {
         get: get,
         getSupporterPaymentRegion: getSupporterPaymentRegion,
         getSync: getSync,
+        isInEurope: isInEurope,
         init: init
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -26,9 +26,15 @@ define([
         name: 'ContributionsEpicRegulars',
         variants: ['control', 'fairness_mild', 'fairness_strong', 'fairness_strong_alternate_hook', 'reliance']
 	};
+
     var AcquisitionsEpicDesignVariations = {
         name: 'AcquisitionsDesignVariations',
         variants: ['control', 'extra_paragraph', 'large_hook', 'subtle', 'prominent', 'highlight']
+    };
+
+    var AcquisitionsEpicArticle50Trigger = {
+        name: 'AcquisitionsEpicArticle50Trigger',
+        variants: ['control']
     };
 
     var contributionsTests = [
@@ -37,7 +43,8 @@ define([
         ContributionsEpicAskFourStagger,
         ContributionsEpicAskFourEarning,
         ContributionsEpicRegulars,
-        AcquisitionsEpicDesignVariations
+        AcquisitionsEpicDesignVariations,
+        AcquisitionsEpicArticle50Trigger
     ];
 
     var emailTests = [];

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -7,7 +7,8 @@ define([
     'common/modules/experiments/tests/contributions-epic-ask-four-stagger',
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
     'common/modules/experiments/tests/contributions-epic-regulars',
-    'common/modules/experiments/tests/acquisitions-epic-design-variations'
+    'common/modules/experiments/tests/acquisitions-epic-design-variations',
+    'common/modules/experiments/tests/acquisitions-epic-article-50-trigger'
 ], function (
     segmentUtil,
     testCanRunChecks,
@@ -17,7 +18,8 @@ define([
     askFourStagger,
     askFourEarning,
     regulars,
-    acquisitionsEpicDesignVariations
+    acquisitionsEpicDesignVariations,
+    acquisitionsEpicArticle50Trigger
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
@@ -27,6 +29,7 @@ define([
 		regulars,
         acquisitionsEpicDesignVariations,
         askFourEarning,
+        acquisitionsEpicArticle50Trigger,
         brexit,
         askFourStagger
     ];

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-article-50-trigger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-article-50-trigger.js
@@ -1,0 +1,43 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lib/geolocation'
+], function (
+    contributionsUtilities,
+    geolocation
+) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicArticle50Trigger',
+        campaignId: 'epic_article_50_trigger',
+
+        start: '2017-03-14',
+        expiry: '2017-04-10',
+
+        author: 'Guy Dawson',
+        description: '',
+        successMeasure: 'Member acquisition and contributions',
+        idealOutcome: 'Our wonderful readers will support The Guardian in this time of need!',
+
+        audienceCriteria: 'Europe',
+        audience: 1,
+        audienceOffset: 0,
+        useTargetingTool: true,
+
+        canRun: function() {
+          return geolocation.isInEurope();
+        },
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 7,
+                    count: 6,
+                    minDaysBetweenViews: 1
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});


### PR DESCRIPTION
__NB:__ _Only merge if Article 50 is triggered_

@guardian/contributions 

## What does this change?

Allows us to display the Epic on Article 50 related articles via the targeting tool to readers in Europe.

## What is the value of this and can you measure success?

Readers either become a Guardian member, or contribute to the Guardian, in response to Article 50 being triggered.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No, tested locally.
