### PR TITLE
In the subnav, opinion pieces should always be opinion pieces

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -499,7 +499,10 @@ object NewNavigation {
       val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && tagPages.contains(page.metadata.id)
       val isArticleInTagPageSection = commonKeywords.nonEmpty
 
-      if (isTagPage) {
+      // opinion pieces should always clearly be opinion pieces, regardless of other keywords
+      if (page.metadata.sectionId == "commentisfree") {
+        page.metadata.sectionId
+      } else if (isTagPage) {
         page.metadata.id
       } else if (isArticleInTagPageSection) {
         commonKeywords.head


### PR DESCRIPTION
## What does this change?
This makes opinion pieces behave consistently, and always show the opinion subnav if they are in the section opinion.

## What is the value of this and can you measure success?
* Keeping it clear that opinion is opinion
* Making sure opinion pieces behave in a consistent way

## Does this affect other platforms - Amp, Apps, etc?
Nope :)

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/23900698/1be2f1a8-08b2-11e7-9ec9-8dfb677110ec.png)

In this example it shows that the "pillar" is Opinion, but the subnav is for News

After:
![image](https://cloud.githubusercontent.com/assets/8774970/23900774/53e0dc6e-08b2-11e7-9340-ce9e8504d7a7.png)


## Tested in CODE?
nope


cc  @stephanfowler  @guardian/dotcom-platform 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
