### PR TITLE
control for Epic changed

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -12,7 +12,7 @@ define([
     'lib/storage',
     'lib/geolocation',
     'lodash/utilities/template',
-    'raw-loader!common/views/contributions-epic-equal-buttons.html'
+    'raw-loader!common/views/acquisitions-epic-control.html'
 ], function (
     uniq,
     commercialFeatures,
@@ -27,7 +27,7 @@ define([
     storage,
     geolocation,
     template,
-    contributionsEpicEqualButtons
+    acquisitionsEpicControlTemplate
 ) {
 
     var membershipBaseURL = 'https://membership.theguardian.com/supporter';
@@ -121,15 +121,9 @@ define([
     };
 
     function controlTemplate(variant) {
-        return template(contributionsEpicEqualButtons, {
-            linkUrl1: variant.membershipURL,
-            linkUrl2: variant.contributeURL,
-            title: 'Since you’re here …',
-            p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-            p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-            p3: '',
-            cta1: 'Become a Supporter',
-            cta2: 'Make a contribution'
+        return template(acquisitionsEpicControlTemplate, {
+            membershipUrl: variant.membershipURL,
+            contributionUrl: variant.contributeURL
         });
     }
 

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -1,0 +1,31 @@
+<div class="contributions__epic">
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Since you’re here …
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+        </p>
+    </div>
+
+    <div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
+               href="<%=membershipUrl%>"
+               target="_blank">
+                Become a supporter
+            </a>
+        </div>
+
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+               href="<%=contributionUrl%>"
+               target="_blank">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
__NB:__ _Do not merge until the design variations test has been removed, since this pull request would change the control for that test._

@guardian/contributions 

## What does this change?

Changes the control of the Epic to a better performing variant.

## What is the value of this and can you measure success?

A higher conversion rate for member acquisition and contributions.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![new-control-desktop](https://cloud.githubusercontent.com/assets/4085817/23903030/0b118390-08bb-11e7-9900-f0d2e04d2976.jpg)

## Tested in CODE?

No, tested locally.
