### PR TITLE
New Header: cartoon should be in opinion

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -289,7 +289,7 @@ object NewNavigation {
       SectionsLink("australia-news/indigenous-australians", indigenousAustralia, News),
 
       SectionsLink("commentisfree", opinion, Opinion),
-      SectionsLink("cartoons", cartoons, Opinion),
+      SectionsLink("type/cartoon", cartoons, Opinion),
       SectionsLink("index/contributors", columnists, Opinion),
       SectionsLink("commentisfree/series/comment-is-free-weekly", inMyOpinion, Opinion),
       SectionsLink("profile/editorial", theGuardianView, Opinion),
@@ -490,7 +490,8 @@ object NewNavigation {
       "football/tables",
       "football/competitions",
       "football/results",
-      "football/fixtures"
+      "football/fixtures",
+      "type/cartoon"
     )
 
     def getSectionOrTagId(page: Page) = {

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -358,9 +358,9 @@ object NewNavigation {
       }
     }
 
-    def getTopLevelSection(sectionName: String) = {
+    def getTopLevelSection(id: String) = {
       val sectionList = sectionLinks.filter { item =>
-        item.pageId == sectionName
+        item.pageId == id
       }
 
       if (sectionList.isEmpty) {

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -153,7 +153,7 @@ object NavLinks {
     "money/savings",
     "money/debt",
     "money/work-and-careers",
-    "cartoons/archive",
+    "type/cartoon",
     "profile/editorial",
     "index/contributors",
     "commentisfree/series/comment-is-free-weekly",

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -19,7 +19,7 @@
                 ) { editionId =>
                     <a class="header__supporter-cta"
                         data-link-name="nav2 : supporter-cta"
-                        data-edition=@{editionId}
+                        data-edition="@{editionId}"
                         href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
 
                         Become a <span>Supporter</span>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,48 +4,50 @@
 @import common.{LinkTo, NewNavigation, Edition}
 
 <header class="new-header" role="banner">
-    @defining(
-        NewNavigation.SectionLinks.getTopLevelSection(page.metadata.sectionId)
-    ) { case (currentTopLevelSection) =>
-        <div class="new-header__inner gs-container">
-            <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="nav2 : logo">
-                <h1 class="u-h">The Guardian</h1>
-                @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
-            </a>
-
-            @defining(
-                Edition(request).id.toLowerCase()
-            ) { editionId =>
-                <a class="header__supporter-cta"
-                    data-link-name="nav2 : supporter-cta"
-                    data-edition=@{editionId}
-                    href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
-
-                    Become a <span>Supporter</span>
+    @defining(NewNavigation.SubSectionLinks.getSectionOrTagId(page)) { id =>
+        @defining(
+            NewNavigation.SectionLinks.getTopLevelSection(id)
+        ) { case (currentTopLevelSection) =>
+            <div class="new-header__inner gs-container">
+                <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="nav2 : logo">
+                    <h1 class="u-h">The Guardian</h1>
+                    @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
                 </a>
-            }
 
-            <nav class="new-header__nav" data-component="nav2">
-                @NewNavigation.PrimaryLinks.map { link =>
-                    <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
-                        href="@LinkTo(link.url)"
-                        data-link-name="nav2 : primary : @link.title">
-                            @link.title
+                @defining(
+                    Edition(request).id.toLowerCase()
+                ) { editionId =>
+                    <a class="header__supporter-cta"
+                        data-link-name="nav2 : supporter-cta"
+                        data-edition=@{editionId}
+                        href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
+
+                        Become a <span>Supporter</span>
                     </a>
                 }
-                <label for="main-menu-toggle"
-                    class="new-header__nav__menu-button js-change-link"
-                    tabindex="0"
-                    data-link-name="nav2 : veggie-burger : show">
-                        <span class="new-header__veggie-burger-icon"></span>
-                        <span class="u-h">Menu</span>
-                </label>
-                <input type="checkbox" id="main-menu-toggle" class="new-header__nav__button js-enhance-checkbox" aria-controls="main-menu">
 
-                @fragments.nav.newHeaderMenu()
-            </nav>
-        </div>
+                <nav class="new-header__nav" data-component="nav2">
+                    @NewNavigation.PrimaryLinks.map { link =>
+                        <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
+                            href="@LinkTo(link.url)"
+                            data-link-name="nav2 : primary : @link.title">
+                                @link.title
+                        </a>
+                    }
+                    <label for="main-menu-toggle"
+                        class="new-header__nav__menu-button js-change-link"
+                        tabindex="0"
+                        data-link-name="nav2 : veggie-burger : show">
+                            <span class="new-header__veggie-burger-icon"></span>
+                            <span class="u-h">Menu</span>
+                    </label>
+                    <input type="checkbox" id="main-menu-toggle" class="new-header__nav__button js-enhance-checkbox" aria-controls="main-menu">
 
-        @fragments.nav.subSectionNav(page)
+                    @fragments.nav.newHeaderMenu()
+                </nav>
+            </div>
+
+            @fragments.nav.subSectionNav(page)
+        }
     }
 </header>


### PR DESCRIPTION
## What does this change?
This does two things to solve the problem that cartoon doesn't fit within opinion.

First, the page id was wrong! Not sure how I missed that, but it is changed now.

The second, the blue part of the new header (news, opinion, sport, life, arts) was using slightly different logic to find the parent "pillar" than the subnav leading to inconsistencies. Those should be fixed now.

## What is the value of this and can you measure success?
More consistent and more expected behaviour 🐛 🐛 

## Does this affect other platforms - Amp, Apps, etc?
Nope!

## Screenshots
**Before:**
![image](https://cloud.githubusercontent.com/assets/8774970/23904160/cbf7f5b4-08be-11e7-9f6f-3fe5d06cb76a.png)
cartoon should show in opinion, and show the opinion subnav. This doesn't seem to be happening which is a problem.

![image](https://cloud.githubusercontent.com/assets/8774970/23904196/e30b47b0-08be-11e7-9ff8-d39e9d933611.png)
This is an issue because women isn't actually a section, but just a keyword or tag page. We treat it like a section though which is why this problem is highlighted.

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/23904296/3f285c9a-08bf-11e7-86bc-fd17ba32a0c4.png)


![image](https://cloud.githubusercontent.com/assets/8774970/23904215/f0530c1e-08be-11e7-9b55-6b9b555b437d.png)

## Tested in CODE?
Nope


cc @stephanfowler @guardian/dotcom-platform 