### PR TITLE
Adding cartoon front, as well as the tag page to the new nav logic

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -289,6 +289,7 @@ object NewNavigation {
       SectionsLink("australia-news/indigenous-australians", indigenousAustralia, News),
 
       SectionsLink("commentisfree", opinion, Opinion),
+      SectionsLink("cartoons/archive", cartoons, Opinion),
       SectionsLink("type/cartoon", cartoons, Opinion),
       SectionsLink("index/contributors", columnists, Opinion),
       SectionsLink("commentisfree/series/comment-is-free-weekly", inMyOpinion, Opinion),
@@ -491,7 +492,8 @@ object NewNavigation {
       "football/competitions",
       "football/results",
       "football/fixtures",
-      "type/cartoon"
+      "type/cartoon",
+      "cartoons/archive"
     )
 
     def getSectionOrTagId(page: Page) = {

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -153,6 +153,7 @@ object NavLinks {
     "money/savings",
     "money/debt",
     "money/work-and-careers",
+    "cartoons/archive",
     "type/cartoon",
     "profile/editorial",
     "index/contributors",


### PR DESCRIPTION
## What does this change?
I made this change: https://github.com/guardian/frontend/pull/16128/commits/c90a29228d79a7fb0507d06131d2d736b5bc03c4

But it turns out cartoons locally (run by applications) has the page id of `type/cartoons`, but in PROD has the page id of `cartoons/archive`. This adds that page id back so the right Nav should show up on that page.

But when I run Facia and go to the cartoon page, I get nothing. Why is PROD and DEV different? 😕 

## What is the value of this and can you measure success?
Maybe this will work now?

## Does this affect other platforms - Amp, Apps, etc?
Nope


## Tested in CODE?
Nope