### PR TITLE
Avoid the side swipe

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -263,6 +263,8 @@
 }
 
 .content__head--byline-pic {
+    overflow: hidden;
+
     .byline-img {
         float: right;
         height: $gs-baseline * 12.5;


### PR DESCRIPTION
## What does this change?

Byline image positioning was forcing the body wider than viewport, causing side swiping possible on mobile.

## What is the value of this and can you measure success?

NO SIDE SWIPES.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

### Before

SIDE SWIPE

![screen shot 2017-03-14 at 17 32 31](https://cloud.githubusercontent.com/assets/638051/23914395/be486a4c-08dd-11e7-8d16-a264e21bc012.jpg)

### After

NO SIDE SWIPE

![screen shot 2017-03-14 at 17 32 36](https://cloud.githubusercontent.com/assets/638051/23914416/cbdf1354-08dd-11e7-9fb6-5e9e03896007.jpg)

## Tested in CODE?

No sir.