### PR TITLE
ab server side recipe test

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -31,12 +31,12 @@ class OptInController extends Controller {
     Cached(60)(WithoutRevalidationResult(feature match {
       case "headerseven" => headerSeven.opt(choice)
       case "youtubeposter" => youtubePosterOverride.opt(choice)
-      case "abnewrecipedesign" => ABNewRecipeDesignOverride.opt(choice)
+      case "newrecipedesign" => newRecipeDesignOverride.opt(choice)
       case _ => NotFound
     }))
   }
 //cookies should correspond with those checked by fastly-edge-cache
   val headerSeven = OptInFeature("new_header_seven_opt_in")
   val youtubePosterOverride = OptInFeature("you_tube_poster_override_opt_in")
-  val ABNewRecipeDesignOverride = OptInFeature("ab_new_recipe_design_opt_in")
+  val newRecipeDesignOverride = OptInFeature("new_recipe_design_opt_in")
 }

--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -31,10 +31,12 @@ class OptInController extends Controller {
     Cached(60)(WithoutRevalidationResult(feature match {
       case "headerseven" => headerSeven.opt(choice)
       case "youtubeposter" => youtubePosterOverride.opt(choice)
+      case "abnewrecipedesign" => ABNewRecipeDesignOverride.opt(choice)
       case _ => NotFound
     }))
   }
 //cookies should correspond with those checked by fastly-edge-cache
   val headerSeven = OptInFeature("new_header_seven_opt_in")
   val youtubePosterOverride = OptInFeature("you_tube_poster_override_opt_in")
+  val ABNewRecipeDesignOverride = OptInFeature("ab_new_recipe_design_opt_in")
 }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -122,7 +122,7 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit context: Ap
         else if (article.article.isExplore) views.html.articleExplore(article)
         else if (article.article.isImmersive) views.html.articleImmersive(article)
         else if (request.isAmp) views.html.articleAMP(article)
-        else if (article.article.isRecipeArticle) {
+        else if (article.article.showNewRecipeDesign && mvt.ABNewRecipeDesign.isParticipating) {
           val recipeAtoms = article.article.content.atoms.fold(Nil: Seq[RecipeAtom])(_.recipes)
           val maybeMainImage: Option[ImageMedia] = article.article.content.elements.mainPicture.map{ _.images}
           views.html.recipeArticle(article, recipeAtoms, maybeMainImage)

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -127,7 +127,7 @@ class ArticleController(contentApiClient: ContentApiClient)(implicit context: Ap
           val maybeMainImage: Option[ImageMedia] = article.article.content.elements.mainPicture.map{ _.images}
           views.html.recipeArticle(article, recipeAtoms, maybeMainImage)
         }
-        else views.html.article(article)
+        else views.html.article(article, recipePageNotInTest = article.article.showNewRecipeDesign)
       }
 
       val jsonResponse = () => views.html.fragments.articleBody(article)

--- a/article/app/views/article.scala.html
+++ b/article/app/views/article.scala.html
@@ -1,6 +1,6 @@
-@(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@(model: ArticlePage, recipePageNotInTest: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
-@main(model){
+@main(model, showNormalHeader = recipePageNotInTest){
 }{
     @fragments.articleBody(model)
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -486,16 +486,6 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 4, 5),
     exposeClientSide = true
   )
-  
-  val ArticleWithStructuredRecipe = Switch(
-    SwitchGroup.Feature,
-    "is-article-with-structured-recipe-data",
-    "changes design of articles with strucutred recipe data",
-    owners = Seq(Owner.withGithub("tsop14"), Owner.withGithub("blongden73")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 4),
-    exposeClientSide = true
-  )
 
   // Owner: George Haberis
   val TailorSurveyOverlay = Switch(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -13,6 +13,7 @@ import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, MediaAssetPlatform, MediaAtom, Quiz}
 import model.pressed._
+import mvt.ABNewRecipeDesign
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
 import org.scala_tools.time.Imports._
@@ -84,7 +85,8 @@ final case class Content(
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
   lazy val hasRecipeAtom: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty)
-  lazy val showNewRecipeDesign: Boolean = ArticleWithStructuredRecipe.isSwitchedOn && hasRecipeAtom
+  lazy val showNewRecipeDesign: Boolean =  hasRecipeAtom && ABNewRecipeDesign.switch.isSwitchedOn
+
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
       case (Some(t), Some(b)) => tags.contributors.length == 1 && t.name == b

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -83,8 +83,8 @@ final case class Content(
   lazy val isImmersive = fields.displayHint.contains("immersive") || isImmersiveGallery || tags.isTheMinuteArticle || isExplore || isPhotoEssay
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
-  lazy val isRecipeArticle: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty) && ArticleWithStructuredRecipe.isSwitchedOn
-
+  lazy val hasRecipeAtom: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty)
+  lazy val showNewRecipeDesign: Boolean = ArticleWithStructuredRecipe.isSwitchedOn && hasRecipeAtom
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
       case (Some(t), Some(b)) => tags.contributors.length == 1 && t.name == b
@@ -218,7 +218,7 @@ final case class Content(
     ("isExplore", JsBoolean(isExplore)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
-    ("newRecipeDesign", JsBoolean(isRecipeArticle))
+    ("newRecipeDesign", JsBoolean(showNewRecipeDesign))
 
   )
 
@@ -449,7 +449,7 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && (content.elements.hasMainMedia || content.fields.main.nonEmpty))) && content.tags.isArticle,
-      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle) || content.isRecipeArticle
+      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle) || content.showNewRecipeDesign
     )
   }
 
@@ -493,7 +493,7 @@ final case class Article (
   val isImmersive: Boolean = content.isImmersive
   var isPhotoEssay : Boolean = content.isPhotoEssay
   val isExplore: Boolean = content.isExplore
-  val isRecipeArticle: Boolean = content.isRecipeArticle
+  val showNewRecipeDesign: Boolean = content.showNewRecipeDesign
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -218,7 +218,7 @@ final case class Content(
     ("isExplore", JsBoolean(isExplore)),
     ("isPaidContent", JsBoolean(isPaidContent)),
     ("campaigns", JsArray(campaigns.map(Campaign.toJson))),
-    ("newRecipeDesign", JsBoolean(showNewRecipeDesign))
+    ("showNewRecipeDesign", JsBoolean(showNewRecipeDesign))
 
   )
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -61,6 +61,17 @@ object YouTubePosterOverride extends TestDefinition(
   }
 }
 
+object ABNewRecipeDesign extends TestDefinition(
+  name = "ab-new-recipe-design",
+  description = "Users in the test will see the new design on articles with structured recipes",
+  owners = Seq(Owner.withGithub("tsop14")),
+  sellByDate = new LocalDate(2017, 4, 3)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-recipe-design").contains("true")
+  }
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -77,7 +88,8 @@ object ActiveTests extends ServerSideABTests {
     ABNewNavVariantSeven,
     ABNewNavControl,
     CommercialClientLoggingVariant,
-    YouTubePosterOverride
+    YouTubePosterOverride,
+    ABNewRecipeDesign
   )
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -68,7 +68,7 @@ object ABNewRecipeDesign extends TestDefinition(
   sellByDate = new LocalDate(2017, 4, 3)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-recipe-design").contains("true")
+    request.headers.get("X-GU-ab-new-recipe-design").contains("variant")
   }
 }
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(implicit request: RequestHeader)
+@(page: model.Page, showNormalHeader: Boolean = false)(implicit request: RequestHeader)
 @import common.editions._
 @import common.{Edition, LinkTo, SubscribeLink}
 @import conf.Configuration
@@ -7,8 +7,9 @@
 @if(mvt.ABNewNavVariantSeven.isParticipating) {
     @fragments.newHeader(page)
 }
+
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,11 +1,11 @@
-@(page: model.Page, projectName: Option[String] = None)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, projectName: Option[String] = None, showNormalHeader: Boolean = false)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, Navigation, commercial}
 @import conf.switches.Switches.{BreakingNewsSwitch}
 @import model.Page.getContent
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
 
-@headerAndTopAds(showAdverts: Boolean, edition: Edition, content: Option[model.ContentType]) = {
+@headerAndTopAds(showAdverts: Boolean, edition: Edition, content: Option[model.ContentType], showNormalHeader: Boolean = false) = {
   @if(!page.metadata.shouldHideHeaderAndTopAds) {
     @defining(showAdverts && !content.exists(_.tags.isTheMinuteArticle)) { showTopSlot =>
       @if(content.exists(_.tags.hasSuperStickyBanner)) {
@@ -18,7 +18,7 @@
               @if(showTopSlot) {
                 @fragments.commercial.topBanner(page.metadata)
               }
-              @fragments.header(page)
+              @fragments.header(page, showNormalHeader)
           </div>
       }
       <div id="maincontent" tabindex="0"></div>
@@ -93,7 +93,7 @@
             }
             case _: commercial.hosted.HostedPage => {}
             case _ => {
-                @headerAndTopAds(showAdverts, edition, content)
+                @headerAndTopAds(showAdverts, edition, content, showNormalHeader)
             }
         }
 

--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -178,7 +178,7 @@ define([
 
         if (config.page.showNewRecipeDesign === true) {
             //below is for during testing
-            if (config.tests.abNewRecipeDesign != undefined && config.tests.abNewRecipeDesign === true) {
+            if (config.tests.abNewRecipeDesign) {
                 require(['bootstraps/enhanced/recipe-article'], function (recipes) {
                     bootstrapContext('recipes', recipes);
                 });

--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -176,10 +176,13 @@ define([
             }, 'accessibility');
         }
 
-        if (config.page.nonKeywordTagIds && contains(config.page.nonKeywordTagIds.split(','), 'tone/recipes')) {
-            require(['bootstraps/enhanced/recipe-article'], function (recipes) {
-                bootstrapContext('recipes', recipes);
-            });
+        if (config.page.showNewRecipeDesign === true) {
+            //below is for during testing
+            if (config.tests.abNewRecipeDesign != undefined && config.tests.abNewRecipeDesign === true) {
+                require(['bootstraps/enhanced/recipe-article'], function (recipes) {
+                    bootstrapContext('recipes', recipes);
+                });
+            }
         }
 
         fastdom.read(function() {

--- a/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
@@ -52,7 +52,7 @@ define([
 
         var supportsSticky = document.documentElement.classList.contains('has-sticky');
 
-        var newRecipeDesign = config.page.showNewRecipeDesign && (config.tests.abNewRecipeDesign != undefined && config.tests.abNewRecipeDesign === true);
+        var newRecipeDesign = config.page.showNewRecipeDesign && config.tests.abNewRecipeDesign;
 
         // Feature switches
 
@@ -71,25 +71,14 @@ define([
             isArticle &&
             !isLiveBlog &&
             !isHosted &&
-            !newRecipeDesign &&
-            switches.commercial;
+            !newRecipeDesign;
 
         this.articleAsideAdverts =
             this.dfpAdvertising &&
             !isMinuteArticle &&
             !isMatchReport &&
             !!(isArticle || isLiveBlog) &&
-            !newRecipeDesign &&
-            switches.commercial;
-
-        this.sliceAdverts =
-            this.dfpAdvertising &&
-            config.page.isFront &&
-            switches.commercial;
-
-        this.popularContentMPU =
-            this.dfpAdvertising &&
-            !isMinuteArticle;
+            !newRecipeDesign;
 
         this.videoPreRolls =
             this.dfpAdvertising;
@@ -100,8 +89,7 @@ define([
             !isHosted &&
             !isInteractive &&
             !config.page.isFront &&
-            !newRecipeDesign &&
-            switches.commercial;
+            !newRecipeDesign;
 
         this.thirdPartyTags =
             externalAdvertising &&

--- a/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
@@ -5,7 +5,8 @@ define([
     'lib/robust',
     'commercial/modules/user-features',
     'common/modules/identity/api',
-    'common/modules/user-prefs'
+    'common/modules/user-prefs',
+    'lib/cookies'
 ], function (
     location,
     config,
@@ -13,7 +14,8 @@ define([
     robust,
     userFeatures,
     identityApi,
-    userPrefs
+    userPrefs,
+    cookies
 ) {
     // Having a constructor means we can easily re-instantiate the object in a test
     function CommercialFeatures() {
@@ -52,6 +54,8 @@ define([
 
         var supportsSticky = document.documentElement.classList.contains('has-sticky');
 
+        var newRecipeDesign = config.page.showNewRecipeDesign && cookies.get("X-GU-ab-new-recipe-design");
+
         // Feature switches
 
         this.dfpAdvertising =
@@ -69,14 +73,25 @@ define([
             isArticle &&
             !isLiveBlog &&
             !isHosted &&
-            !config.page.newRecipeDesign;
+            !newRecipeDesign &&
+            switches.commercial;
 
         this.articleAsideAdverts =
             this.dfpAdvertising &&
             !isMinuteArticle &&
             !isMatchReport &&
             !!(isArticle || isLiveBlog) &&
-            !config.page.newRecipeDesign;
+            !newRecipeDesign &&
+            switches.commercial;
+
+        this.sliceAdverts =
+            this.dfpAdvertising &&
+            config.page.isFront &&
+            switches.commercial;
+
+        this.popularContentMPU =
+            this.dfpAdvertising &&
+            !isMinuteArticle;
 
         this.videoPreRolls =
             this.dfpAdvertising;
@@ -87,7 +102,8 @@ define([
             !isHosted &&
             !isInteractive &&
             !config.page.isFront &&
-            !config.page.newRecipeDesign;
+            !newRecipeDesign &&
+            switches.commercial;
 
         this.thirdPartyTags =
             externalAdvertising &&

--- a/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
@@ -5,8 +5,7 @@ define([
     'lib/robust',
     'commercial/modules/user-features',
     'common/modules/identity/api',
-    'common/modules/user-prefs',
-    'lib/cookies'
+    'common/modules/user-prefs'
 ], function (
     location,
     config,
@@ -14,8 +13,7 @@ define([
     robust,
     userFeatures,
     identityApi,
-    userPrefs,
-    cookies
+    userPrefs
 ) {
     // Having a constructor means we can easily re-instantiate the object in a test
     function CommercialFeatures() {
@@ -54,7 +52,7 @@ define([
 
         var supportsSticky = document.documentElement.classList.contains('has-sticky');
 
-        var newRecipeDesign = config.page.showNewRecipeDesign && cookies.get("X-GU-ab-new-recipe-design");
+        var newRecipeDesign = config.page.showNewRecipeDesign && (config.tests.abNewRecipeDesign != undefined && config.tests.abNewRecipeDesign === true);
 
         // Feature switches
 


### PR DESCRIPTION
## What does this change?
- Adds mvt for new recipe design
- Adds ability to opt in to test
- Sets `showNewRecipeDesign` to true if an article has recipe atoms (is eligible) and the feature is enabled.
- If `showNewRecipeDesign` and user is participating in test - shows the new recipe template.

While running the test, for articles which are eligible for new design but requested by users in the control group:
- Sets argument `recipePageNotInTest` on article template to true. This is used to set `displayNormalHeader` to ensure correct header (not slim) is displayed.
- Sets same js-features as normal article.

## What is the value of this and can you measure success?
Work towards running server-side ab test on new recipe design. 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
Here is a video of page without "X-GU-ab-new-recipe-design" set and then ⚡️⚡️⚡️ I set it to "variant" and 💥 hello shiny new recipe design. 
![ab-test](https://cloud.githubusercontent.com/assets/8484757/23963891/a12ea746-09aa-11e7-8b07-8dc3d117a230.gif)


## Tested in CODE?
No

To see new design:

1. Enable feature switch
2. Enable ab server side test
3. Set `X-GU-ab-new-recipe-design` header to true

TODO
- [x] test with fastly
- [x] Add 50:50 buckets on fastly

Thanks @gidsg for the help!
