### PR TITLE
We are no longer website of the year

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -111,12 +111,6 @@
                                 <span class="inline-logo inline-guardian-logo-320"></span>
                             <![endif]-->
                         }
-                        @if(Edition(request) == Uk) {
-                            @* This is an object because of this: https://github.com/guardian/frontend/pull/12345#discussion_r57301347 *@
-                        <object class="logo-tagline hide-on-mobile hide-on-slim-header">
-                            <a class="logo-tagline__link" href="/culture/2016/mar/22/the-guardian-named-website-of-the-year-at-press-awards" data-link-name="website of the year">website of the year</a>
-                        </object>
-                        }
                     </a>
                 }
                 @if(page.metadata.hasSlimHeader) {


### PR DESCRIPTION
## What does this change?

Removes the misinformation

## What is the value of this and can you measure success?

We'll work harder so we win again next year.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
Before.
![image](https://cloud.githubusercontent.com/assets/638051/23942588/b00a4838-0964-11e7-8623-65c568cb1bc5.png)

After.
![image](https://cloud.githubusercontent.com/assets/638051/23942578/a556dca8-0964-11e7-8320-8b2a6da71505.png)

## Tested in CODE?
No

@guardian/dotcom-platform 