### PR TITLE
Put epic ask4 earning test to 100%

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -17,8 +17,8 @@ define([
         idealOutcome: 'Acquires many Supporters',
 
         audienceCriteria: 'All',
-        audience: 0.88,
-        audienceOffset: 0.12,
+        audience: 1,
+        audienceOffset: 0,
 
         variants: [
             {


### PR DESCRIPTION
## What does this change?
After turning off the stagger test that was on 0-12%, we need the earning test to be put to 100%;

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
