### PR TITLE
Spacing tweaks and improved trailing slash mixin

### DIFF
--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -16,17 +16,17 @@
         </a>
 
         <nav class="header__nav">
-            <ul class="header__nav__primary-links">
-            @NewNavigation.PrimaryLinks.map { link =>
-                <li class="header__nav__link-item">
-                    <a class="header__nav__link"
-                        href="@LinkTo(link.url)"
-                        data-link-name="amp : nav : @link.title">
-                            @link.title
-                    </a>
-                </li>
-            }
-        </ul>
+            <ul class="header__nav-primary-links">
+                @NewNavigation.PrimaryLinks.map { link =>
+                    <li class="header__nav-link-item">
+                        <a class="header__nav-link"
+                            href="@LinkTo(link.url)"
+                            data-link-name="amp : nav : @link.title">
+                                @link.title
+                        </a>
+                    </li>
+                }
+            </ul>
 
             <button class="header__nav__menu-button" on='tap:sidebar1.toggle'
                 data-link-name="amp : nav : toggle-veggie-burger">

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -16,13 +16,17 @@
         </a>
 
         <nav class="header__nav">
+            <ul class="header__nav__primary-links">
             @NewNavigation.PrimaryLinks.map { link =>
-                <a class="header__nav__link"
-                    href="@LinkTo(link.url)"
-                    data-link-name="amp : nav : @link.title">
-                        @link.title
-                </a>
+                <li class="header__nav__link-item">
+                    <a class="header__nav__link"
+                        href="@LinkTo(link.url)"
+                        data-link-name="amp : nav : @link.title">
+                            @link.title
+                    </a>
+                </li>
             }
+        </ul>
 
             <button class="header__nav__menu-button" on='tap:sidebar1.toggle'
                 data-link-name="amp : nav : toggle-veggie-burger">

--- a/common/app/views/fragments/nav/subSectionNav.scala.html
+++ b/common/app/views/fragments/nav/subSectionNav.scala.html
@@ -3,18 +3,19 @@
 @import common.{NewNavigation, Edition, LinkTo}
 @import views.support.RenderClasses
 
-<div class="tertiary-navigation">
+<ul class="tertiary-navigation">
     @defining(NewNavigation.SubSectionLinks.getSectionOrTagId(page)) { id =>
 
         @NewNavigation.SubSectionLinks.getSubSectionNavLinks(id, Edition(request), page.metadata.isFront).map { link =>
-
-            <a class="@RenderClasses(Map(
-                    "tertiary-navigation__link" -> true,
-                    "tertiary-navigation__link--current-section" -> (id == link.uniqueSection)
-                ))"
-                href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
-                    @link.title
-            </a>
+            <li class="tertiary-navigation__link-item">
+                <a class="@RenderClasses(Map(
+                        "tertiary-navigation__link" -> true,
+                        "tertiary-navigation__link--current-section" -> (id == link.uniqueSection)
+                    ))"
+                    href="@LinkTo(link.url)" data-link-name="nav2 : tertiary : @{ if(link.longTitle.isEmpty) link.title else link.longTitle}">
+                        @link.title
+                </a>
+            </li>
         }
     }
-</div>
+</ul>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -27,13 +27,17 @@
                 }
 
                 <nav class="new-header__nav" data-component="nav2">
-                    @NewNavigation.PrimaryLinks.map { link =>
-                        <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
-                            href="@LinkTo(link.url)"
-                            data-link-name="nav2 : primary : @link.title">
-                                @link.title
-                        </a>
-                    }
+                    <ul class="new-header__nav__primary-links">
+                        @NewNavigation.PrimaryLinks.map { link =>
+                            <li class="new-header__nav__link-item">
+                                <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
+                                    href="@LinkTo(link.url)"
+                                    data-link-name="nav2 : primary : @link.title">
+                                        @link.title
+                                </a>
+                            </li>
+                        }
+                    </ul>
                     <label for="main-menu-toggle"
                         class="new-header__nav__menu-button js-change-link"
                         tabindex="0"

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -27,10 +27,10 @@
                 }
 
                 <nav class="new-header__nav" data-component="nav2">
-                    <ul class="new-header__nav__primary-links">
+                    <ul class="new-header__nav-primary-links">
                         @NewNavigation.PrimaryLinks.map { link =>
-                            <li class="new-header__nav__link-item">
-                                <a class="new-header__nav__link @if(link.title == currentTopLevelSection) {section-indicator}"
+                            <li class="new-header__nav-link-item">
+                                <a class="new-header__nav-link @if(link.title == currentTopLevelSection) {section-indicator}"
                                     href="@LinkTo(link.url)"
                                     data-link-name="nav2 : primary : @link.title">
                                         @link.title

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -247,19 +247,30 @@
     }
 }
 
-// Nav Mixins
+// Trailing slash mixins
+// Please note the container of the trailing-slash-items must contain font-size: 0;
+// to ensure there's no missalignment between inline-block items
+@mixin trailing-slash-item {
+    display: inline-block;
 
-@mixin nav-links {
+    &:last-of-type > a:after {
+        content: '';
+    }
+}
+
+@mixin trailing-slash-link {
     position: relative;
+    display: block;
     padding-left: .3em;
     padding-right: .35em;
-    float: left;
 }
 
 @mixin trailing-slash {
+    content: '/';
+    font-size: 1em;
     position: absolute;
     pointer-events: none;
-    content: '/';
+
     //optically aligns slashes
     top: 0;
     right: -.19em;

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -19,7 +19,7 @@
     line-height: 32px;
     font-weight: 400;
     letter-spacing: -.02rem;
-    padding-top: $gs-baseline/6;
+    padding-top: $gs-baseline/2;
     padding-bottom: $gs-baseline*2;
 
     a {

--- a/static/src/stylesheets/amp/_fonts.scss
+++ b/static/src/stylesheets/amp/_fonts.scss
@@ -65,7 +65,7 @@
 .guardian-text-sans-loaded {
     .hosted-page,
     .hosted__header,
-    .header__nav__link,
+    .header__nav-link,
     .caption,
     .content__dateline,
     .ad-slot--paid-for-badge__header,

--- a/static/src/stylesheets/amp/_fonts.scss
+++ b/static/src/stylesheets/amp/_fonts.scss
@@ -84,7 +84,8 @@
     .d2-body,
     .meta__contact-header,
     .back-to-top__text,
-    .submeta2 {
+    .submeta__label,
+    .submeta__link {
         font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
     }
 }

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -52,8 +52,6 @@ $veggie-burger-medium: 52px;
 }
 
 .header__nav {
-    font-size: 16px;
-    line-height: $gs-baseline * 2.5;
     width: 100%;
     overflow: hidden;
 
@@ -63,17 +61,7 @@ $veggie-burger-medium: 52px;
         margin-right: $gutter-small + $veggie-burger-small + $gs-gutter / 3;
     }
 
-    @include mq($from: mobile, $until: mobileLandscape) {
-        font-size: 5.1vw;
-    }
-
-    @include mq($from: mobileMedium, $until: mobileLandscape) {
-        line-height: $gs-baseline * 3;
-    }
-
     @include mq(mobileLandscape) {
-        font-size: 24px;
-        line-height: $gs-baseline * 3.5;
         margin-left: 0;
     }
 }
@@ -140,34 +128,50 @@ $veggie-burger-medium: 52px;
     }
 }
 
+.header__nav__primary-links {
+    font-size: 0;
+    margin: 0;
+}
+
+.header__nav__link-item {
+    @include trailing-slash-item;
+}
+
 .header__nav__link {
-    // Override a from _lists.scss
+    font-size: 16px;
+    line-height: $gs-baseline * 2.5;
+    @include trailing-slash-link;
     color: #ffffff;
-    position: relative;
-    padding-left: .3em;
-    padding-right: .35em;
-    float: left;
     cursor: pointer;
+
+    @include mq($from: mobile, $until: mobileLandscape) {
+        font-size: 5.1vw;
+    }
+
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
+        line-height: $gs-baseline * 3;
+    }
+
+    @include mq(mobileLandscape) {
+        font-size: 24px;
+        line-height: $gs-baseline * 3.5;
+    }
 
     &:focus,
     &:hover {
         text-decoration: none;
     }
 
-    &:first-child {
-        padding-left: 0;
-    }
-
-    &:before {
-        position: absolute;
-        pointer-events: none;
-        content: '/';
-        //optically aligns slashes
-        left: -.19em;
+    &:after {
+        @include trailing-slash;
         color: $news-main-2;
     }
 
-    &:first-of-type:before {
+    .header__nav__link-item:first-child & {
+        padding-left: 0;
+    }
+
+    .header__nav__link-item:last-of-type &:after {
         content: none;
     }
 }

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -138,9 +138,9 @@ $veggie-burger-medium: 52px;
 }
 
 .header__nav__link {
+    @include trailing-slash-link;
     font-size: 16px;
     line-height: $gs-baseline * 2.5;
-    @include trailing-slash-link;
     color: #ffffff;
     cursor: pointer;
 

--- a/static/src/stylesheets/amp/_header.scss
+++ b/static/src/stylesheets/amp/_header.scss
@@ -128,16 +128,16 @@ $veggie-burger-medium: 52px;
     }
 }
 
-.header__nav__primary-links {
+.header__nav-primary-links {
     font-size: 0;
     margin: 0;
 }
 
-.header__nav__link-item {
+.header__nav-link-item {
     @include trailing-slash-item;
 }
 
-.header__nav__link {
+.header__nav-link {
     @include trailing-slash-link;
     font-size: 16px;
     line-height: $gs-baseline * 2.5;
@@ -167,11 +167,11 @@ $veggie-burger-medium: 52px;
         color: $news-main-2;
     }
 
-    .header__nav__link-item:first-child & {
+    .header__nav-link-item:first-child & {
         padding-left: 0;
     }
 
-    .header__nav__link-item:last-of-type &:after {
+    .header__nav-link-item:last-of-type &:after {
         content: none;
     }
 }

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -10,7 +10,8 @@
 }
 
 .submeta__label {
-    @include fs-textSans(1);
+    font-size: 12px;
+    line-height: 16px;
     color: $neutral-2;
     display: block;
     margin-bottom: -($gs-baseline / 4);
@@ -52,7 +53,8 @@
     }
 
     .submeta__section-labels & {
-        @include fs-textSans(5);
+        font-size: 16px;
+        line-height: 22px;
     }
 }
 

--- a/static/src/stylesheets/amp/_submeta.scss
+++ b/static/src/stylesheets/amp/_submeta.scss
@@ -17,7 +17,6 @@
 }
 
 .submeta__keywords {
-    font-size: 15px;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
     border-bottom: 1px dotted $neutral-5;
@@ -25,32 +24,35 @@
 }
 
 .submeta__links {
+    font-size: 0;
     list-style: none;
     overflow: hidden;
     margin-bottom: 0;
-    margin-left: -.3em;
+    margin-left: -$gs-gutter / 4;
     margin-top: 0;
 }
 
 .submeta__link-item {
-    @include nav-links;
+    @include trailing-slash-item;
+}
+
+.submeta__link {
+    @include trailing-slash-link;
+    font-weight: 500;
+    line-height: 22px;
 
     &:after {
         @include trailing-slash;
         color: $neutral-5;
     }
 
-    &:last-of-type:after {
-        content: none;
-    }
-}
-
-.submeta__link {
-    font-weight: 500;
-    line-height: 22px;
-
     .submeta__keywords & {
+        font-size: 15px;
         color: $neutral-2;
+    }
+
+    .submeta__section-labels & {
+        @include fs-textSans(5);
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -186,9 +186,8 @@ $gutter-large: 55px;
 
 .new-header__nav__link {
     @include fs-textSans(5);
-    line-height: $gs-baseline * 2.5;
-
     @include trailing-slash-link;
+    line-height: $gs-baseline * 2.5;
 
     // Override a from _lists.scss
     color: $news-support-1;

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -176,15 +176,15 @@ $gutter-large: 55px;
     }
 }
 
-.new-header__nav__primary-links {
+.new-header__nav-primary-links {
     margin: 0;
 }
 
-.new-header__nav__link-item {
+.new-header__nav-link-item {
     @include trailing-slash-item;
 }
 
-.new-header__nav__link {
+.new-header__nav-link {
     @include fs-textSans(5);
     @include trailing-slash-link;
     line-height: $gs-baseline * 2.5;
@@ -212,7 +212,7 @@ $gutter-large: 55px;
         text-decoration: none;
     }
 
-    .new-header__nav__link-item:first-child & {
+    .new-header__nav-link-item:first-child & {
         padding-left: $gs-gutter / 2;
     }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -58,8 +58,7 @@ $gutter-large: 55px;
 }
 
 .new-header__nav {
-    @include fs-textSans(5);
-    line-height: $gs-baseline * 2.5;
+    font-size: 0;
     width: 100%;
     overflow: hidden;
 
@@ -69,17 +68,7 @@ $gutter-large: 55px;
         margin-right: $gutter-small + $veggie-burger-small + $gs-gutter / 3;
     }
 
-    @include mq($from: mobile, $until: mobileLandscape) {
-        font-size: 5.1vw;
-    }
-
-    @include mq($from: mobileMedium, $until: mobileLandscape) {
-        line-height: $gs-baseline * 3;
-    }
-
     @include mq(mobileLandscape) {
-        font-size: 24px;
-        line-height: $gs-baseline * 3.5;
         margin-left: $gs-gutter / 2;
     }
 }
@@ -187,28 +176,50 @@ $gutter-large: 55px;
     }
 }
 
+.new-header__nav__primary-links {
+    margin: 0;
+}
+
+.new-header__nav__link-item {
+    @include trailing-slash-item;
+}
+
 .new-header__nav__link {
-    @include nav-links;
+    @include fs-textSans(5);
+    line-height: $gs-baseline * 2.5;
+
+    @include trailing-slash-link;
+
     // Override a from _lists.scss
     color: $news-support-1;
     cursor: pointer;
+
+    @include mq($from: mobile, $until: mobileLandscape) {
+        font-size: 16px;
+        font-size: 5.1vw;
+    }
+
+    @include mq($from: mobileMedium, $until: mobileLandscape) {
+        line-height: $gs-baseline * 3;
+    }
+
+    @include mq(mobileLandscape) {
+        font-size: 24px;
+        line-height: $gs-baseline * 3.5;
+    }
 
     &:focus,
     &:hover {
         text-decoration: none;
     }
 
-    &:first-child {
+    .new-header__nav__link-item:first-child & {
         padding-left: $gs-gutter / 2;
     }
 
     &:after {
         @include trailing-slash;
         color: $news-main-2;
-    }
-
-    &:last-of-type:after {
-        content: none;
     }
 }
 
@@ -641,11 +652,11 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
  * Tertiary Nav
  ****************/
 .tertiary-navigation {
+    font-size: 0;
     background-color: #747a81;
     padding-top: $gs-baseline / 3;
     padding-left: $gs-gutter / 2;
-    // Spacer that prevents links flowing beneath the veggie burger
-    padding-right: $gutter-medium + $veggie-burger-medium;
+    padding-right: $gs-gutter / 2;
     margin-left: -4px;
     border-bottom: $gs-baseline / 3 solid #747a81;
     max-height: $gs-baseline * 3.4;
@@ -653,30 +664,45 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     z-index: 1;
     position: relative;
 
-    @include mq($from: mobile, $until: mobileLandscape) {
-        max-height: $gs-baseline * 3.5;
-        max-height: 13vw;
-        margin-left: -.3em;
+    // Spacer to prevent text from sitting directly beneath the veggie burger
+    &:before {
+        content: '';
+        float: right;
+        width: $gutter-small + $veggie-burger-small - ($gs-gutter / 2);
+        height: 1px;
     }
 
-    @include mq($from: mobileLandscape) {
-        max-height: $gs-baseline * 4.8;
+    @include mq(mobile) {
+        max-height: $gs-baseline * 3.5;
+        max-height: 13vw;
+    }
+
+    @include mq(mobileMedium) {
+        &:before {
+            width: $gutter-medium + $veggie-burger-medium - ($gs-gutter / 2);
+        }
+    }
+
+    @include mq(mobileLandscape) {
         padding-left: $gs-gutter;
         margin-left: -5px;
-        padding-right: $gutter-large + $veggie-burger-medium;
+
+        &:before {
+            width: $gutter-large + $veggie-burger-medium - ($gs-gutter / 2);
+        }
     }
+}
+
+.tertiary-navigation__link-item {
+    @include trailing-slash-item;
 }
 
 .tertiary-navigation__link {
     @include fs-textSans(5);
-    @include nav-links
+    @include trailing-slash-link;
+
     color: $neutral-4;
     line-height: 1.3em;
-
-    &:hover,
-    &:focus {
-        text-decoration: none;
-    }
 
     @include mq($from: mobile, $until: mobileLandscape) {
         font-size: 16px;
@@ -685,15 +711,17 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
         font-size: 22px;
+        max-height: $gs-baseline * 4.8;
+    }
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
     }
 
     &:after {
         @include trailing-slash;
         color: rgba(255, 255, 255, .3);
-    }
-
-    &:last-of-type:after {
-        content: none;
     }
 }
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -562,6 +562,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     font-size: 15px;
     line-height: 18px;
     text-transform: none;
+    margin-top: $gs-baseline * 2;
     padding: $gs-baseline $gs-gutter $gs-baseline * 2 $navigation-horizontal-padding;
     background-color: rgba(0, 0, 0, .2);
 

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -15,12 +15,7 @@
     margin-bottom: -($gs-baseline / 4);
 }
 
-.submeta__section-labels {
-    @include fs-textSans(5);
-}
-
 .submeta__keywords {
-    @include fs-textSans(4);
     border-bottom: 1px dotted $neutral-5;
     padding-bottom: $gs-baseline;
     min-height: $gs-baseline * 2;
@@ -28,32 +23,34 @@
 }
 
 .submeta__links {
+    font-size: 0;
     list-style: none;
     overflow: hidden;
     margin-bottom: 0;
-    margin-left: -.3em;
+    margin-left: -$gs-gutter / 4;
     margin-top: 0;
 }
 
 .submeta__link-item {
-    @include nav-links;
+    @include trailing-slash-item;
+}
+
+.submeta__link {
+    @include trailing-slash-link;
+    font-weight: bold;
+
+    .submeta__keywords & {
+        @include fs-textSans(4);
+        color: $neutral-2;
+    }
+
+    .submeta__section-labels & {
+        @include fs-textSans(5);
+    }
 
     &:after {
         @include trailing-slash;
         color: $neutral-5;
-    }
-
-    &:last-of-type:after,
-    &.more-tags:after {
-        content: none;
-    }
-}
-
-.submeta__link {
-    font-weight: bold;
-
-    .submeta__keywords & {
-        color: $neutral-2;
     }
 }
 


### PR DESCRIPTION
## What does this change?
On the new header sub-menu it looks aesthetically better if words don't appear directly beneath the veggie burger. Currently to achieve that there is a right-margin: 

<img width="375" alt="screen shot 2017-03-14 at 16 54 32" src="https://cloud.githubusercontent.com/assets/14570016/23952721/358b12ce-098a-11e7-9bb8-58d69d982cda.png">

The problem with that, is when there are more links like 'clubs' in this example they wrap, despite there being room on the second row for them to be show.

To sort this out I've changed all links with trailing slashes to be inline-block with the font-size: 0; fix which allows for correct alignment when they wrap. They are no longer floats.

To further standardise all elements with trailing slashes I have made the menu unordered lists just like page tags and improved the logic of the trailing slash mixin to incorporate that.

## Does this affect other platforms - Amp, Apps, etc?
Yep, updated amp to use this logic also.

## Screenshots
This illustrates the tap targets and the pink line illustrates the spacer than knocks the links onto a new line.

<img width="374" alt="screen shot 2017-03-15 at 14 07 25" src="https://cloud.githubusercontent.com/assets/14570016/23952724/3b5ddc40-098a-11e7-9586-b3079a624fa5.png">

<img width="375" alt="screen shot 2017-03-15 at 14 28 56" src="https://cloud.githubusercontent.com/assets/14570016/23953202/cb6afd08-098b-11e7-92d3-8dea5e611ea2.png">



