### PR TITLE
Check for getEntriesByName() before calling it

### DIFF
--- a/static/src/javascripts-legacy/lib/user-timing.js
+++ b/static/src/javascripts-legacy/lib/user-timing.js
@@ -7,7 +7,6 @@ define(function () {
     var startDate = new Date().getTime();
 
     function mark(label) {
-
         if (perf && 'mark' in perf) {
             perf.mark(label);
         } else {
@@ -17,7 +16,7 @@ define(function () {
 
     // Returns the ms time when the mark was made.
     function getTiming(label) {
-        if (perf) {
+        if (perf && 'getEntriesByName' in perf) {
             var performanceMark = perf.getEntriesByName(label, 'mark')[0];
             if (performanceMark && 'startTime' in performanceMark) {
                 return performanceMark.startTime;


### PR DESCRIPTION
## What does this change?

Adds a check around `window.performance.getEntriesByName()` before calling it. I saw this while investigating scroll issues on iPhones on IOS9.

## What is the value of this and can you measure success?

Less JS errors, happier Sentry.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.