### PR TITLE
enagement banner bug fix

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -16,7 +16,8 @@ define([
         'lodash/objects/defaults',
         'lodash/collections/find',
         'common/views/svgs',
-        'lib/fetch'
+        'lib/fetch',
+        'common/modules/experiments/segment-util'
     ], function (bean,
                  $,
                  config,
@@ -34,7 +35,8 @@ define([
                  defaults,
                  find,
                  svgs,
-                 fetch) {
+                 fetch,
+                 segmentUtil) {
 
 
         // change messageCode to force redisplay of the message to users who already closed it.
@@ -125,12 +127,10 @@ define([
             var paramsByOfferingForUserEdition = editionParams[config.page.edition];
 
             var engagementBannerTest = find(MembershipEngagementBannerTests, function(test) {
-                return ab.testCanBeRun(test)
+                return ab.testCanBeRun(test) && segmentUtil.isInTest(test)
             });
 
-            var userVariant = engagementBannerTest ? find(engagementBannerTest.variants, function(variant) {
-                return variant.id == ab.getTestVariantId(engagementBannerTest.id);
-            }) : undefined;
+            var userVariant = engagementBannerTest ? segmentUtil.variantFor(engagementBannerTest) : undefined;
 
             // If we have found a copy test variant, then defer building the banner params to the variant.
             if (engagementBannerTest && engagementBannerTest.id === 'MembershipEngagementBannerCopyTest' && userVariant) {


### PR DESCRIPTION
@guardian/contributions 
@guardian/membership-and-subscriptions 

## What does this change?

Ensures an engagement banner test is selected iff (1) the test can be run; and (2) the reader is in the test. This fixes a bug which allowed a test to be selected that the reader wasn't in over a test that the reader was in.

## What is the value of this and can you measure success?

Allows us to run concurrent engagement banner tests. As an immediate benefit, we will be able to evaluate the engagement banner copy tests sooner than we would otherwise.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No, tested locally.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
