### PR TITLE
Remove AB test events

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -399,25 +399,6 @@ define([
             getActiveTests().filter(defersImpression).forEach(registerCompleteEvent(false));
         },
 
-        isEventApplicableToAnActiveTest: function (event) {
-            return Object.keys(getParticipations()).some(function (id) {
-                var listOfEventStrings = getTest(id).events;
-                return listOfEventStrings.some(function (ev) {
-                    return event.indexOf(ev) === 0;
-                });
-            });
-        },
-
-        getActiveTestsEventIsApplicableTo: function (event) {
-            var eventTag = event.tag;
-            return eventTag && getActiveTests().filter(function (test) {
-                    var testEvents = test.events;
-                    return testEvents && testEvents.some(function (testEvent) {
-                            return eventTag.indexOf(testEvent) === 0;
-                        });
-                }).map(getId);
-        },
-
         getAbLoggableObject: getAbLoggableObject,
         getParticipations: getParticipations,
         isParticipating: isParticipating,

--- a/static/src/javascripts-legacy/projects/common/modules/ui/clickstream.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/clickstream.js
@@ -1,15 +1,11 @@
 define([
     'bean',
     'lib/mediator',
-    'common/modules/experiments/ab',
-    'lodash/objects/merge',
-    'lodash/collections/map'
+    'lodash/objects/merge'
 ], function (
     bean,
     mediator,
-    ab,
-    merge,
-    map
+    merge
 ) {
 
     var Clickstream = function (opts) {
@@ -101,25 +97,13 @@ define([
         // delegate, emit the derived tag
         if (opts.addListener !== false) {
             bean.add(document.body, 'click', function (event) {
-                var applicableTests,
-                    clickSpec = {
-                        el: event.target,
-                        tag: []
-                    };
+                var clickSpec = {
+                    el: event.target,
+                    tag: []
+                };
 
                 clickSpec.target = event.target;
-
                 clickSpec = getClickSpec(clickSpec);
-
-                // prefix ab tests to the click spec
-                applicableTests = ab.getActiveTestsEventIsApplicableTo(clickSpec);
-                if (applicableTests !== undefined && applicableTests.length > 0) {
-                    clickSpec.tag = map(applicableTests, function (test) {
-                        var variant = ab.getTestVariantId(test);
-                        return 'AB,' + test + ',' + variant + ',' + clickSpec.tag;
-                    }).join(',');
-                }
-
                 mediator.emit('module:clickstream:click', clickSpec);
             });
         }

--- a/static/test/javascripts-legacy/fixtures/ab-test.js
+++ b/static/test/javascripts-legacy/fixtures/ab-test.js
@@ -10,7 +10,6 @@ define([], function () {
         this.canRun = function () {
             return true;
         };
-        this.events = ['most popular | The Guardian | trail ', 'most popular | Section | trail '];
         this.variants = [
             {
                 id: 'control',

--- a/static/test/javascripts-legacy/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts-legacy/spec/common/experiments/ab.spec.js
@@ -213,31 +213,6 @@ define([
 
         describe('Analytics', function () {
 
-            it('should tell me if an event is applicable to a test that I belong to', function () {
-                ab.addTest(test.one);
-                ab.segment();
-
-                expect(ab.isEventApplicableToAnActiveTest('most popular | The Guardian | trail | 1 | text')).toBeTruthy();
-
-            });
-
-            it('should tell me if an event is applicable to a test with multiple event strings that I belong to', function () {
-                ab.addTest(test.one);
-                ab.segment();
-
-                expect(ab.isEventApplicableToAnActiveTest('most popular | Section | trail | 1 | text')).toBeTruthy();
-            });
-
-            it('should return a list of test names that are relevant to the event', function () {
-                ab.addTest(test.one);
-                ab.addTest(test.two);
-                ab.segment();
-                var event = {};
-                event.tag = 'most popular | The Guardian | trail | 1 | text';
-
-                expect(ab.getActiveTestsEventIsApplicableTo(event)).toEqual(['DummyTest', 'DummyTest2']);
-            });
-
             it('should return the variant of a test that current user is participating in', function () {
                 mvtCookie.overwriteMvtCookie(2);
 


### PR DESCRIPTION
## What does this change?

The `events` property is no longer needed, used or documented on AB Tests. It was introduced in #1698, and then removed from the docs in #3065. No existing AB Test has an `events` property, so the `getActiveTestsEventIsApplicableTo` and `isEventApplicableToAnActiveTest` always return falsey values.

## What is the value of this and can you measure success?

- Less code to maintain
- Clickstream no longer dependent on AB tests
- Less head scratching, more time to enjoy life

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
