### PR TITLE
Update paywall copy in Epic tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
@@ -19,7 +19,7 @@ define([
     var defaultTemplateArgument = {
         // copy
         p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-            '<span class="contributions__paragraph--highlight">unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all</span>' +
+            '<span class="contributions__paragraph--highlight">unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can</span>' +
             '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
         p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
         p3: '',
@@ -105,20 +105,20 @@ define([
 
             buildVariant('highlight_perspective', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all' +
+                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. <span class="contributions__paragraph--highlight">But we do it because we believe our perspective matters – because it might well be your perspective, too.</span>'
             }),
 
             buildVariant('highlight_secure', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all' +
+                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.',
                 p2: '<span class="contributions__paragraph--highlight">If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.</span>'
             }),
 
             buildVariant('highlight_hard', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all' +
+                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. <span class="contributions__paragraph--highlight">The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.</span> But we do it because we believe our perspective matters – because it might well be your perspective, too.'
             }),
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
@@ -25,7 +25,7 @@ define([
                 linkUrl1: variant.membershipURLBuilder(appendSuffix),
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 title: 'Since you’re here …',
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -4,7 +4,7 @@
             Since you’re here …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike some other news organisations, we haven’t put up a paywall – we want to keep our journalism open to all</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.


### PR DESCRIPTION
The current versions are using an outdated version of the copy.