### PR TITLE
Fix immersive media atom template by using named parameter for mediaWrapper

### DIFF
--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -7,7 +7,7 @@
             case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
             case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
                 if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
-                else views.html.fragments.atoms.youtube(media, displayCaption, displayEndSlate, mediaWrapper)
+                else views.html.fragments.atoms.youtube(media, displayCaption, displayEndSlate, mediaWrapper = mediaWrapper)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }


### PR DESCRIPTION
## What does this change?
Previously we were passing unnamed parameters in the YouTube template. This meant the `mediaWrapper` wasn't being correctly set I think because the compiler thought it to be a different parameter.

## What is the value of this and can you measure success?
Fixes immersive template

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
### Before
![screen shot 2017-03-16 at 10 33 37](https://cloud.githubusercontent.com/assets/1764158/23992245/171ef30a-0a34-11e7-951b-a6e7c002cbe8.png)
### After
![screen shot 2017-03-16 at 10 35 50](https://cloud.githubusercontent.com/assets/1764158/23992330/5f44667e-0a34-11e7-9064-106cc4b54104.png)


## Tested in CODE?
No

CC @duarte 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
