### PR TITLE
Force links to be correct colour in T-Online mail client

### DIFF
--- a/common/app/views/fragments/email/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/email/stylesheets/tones.scala.html
@@ -9,7 +9,8 @@
     .tone-news .facia-card__text {
         background-color: #f6f6f6;
     }
-    .tone-news .headline {
+    .tone-news .headline,
+    .tone-news .facia-link {
         color: #333333;
     }
     .tone-news .fc-item__kicker,
@@ -30,7 +31,8 @@
     .tone-feature .facia-card__text {
         background-color: #951c55;
     }
-    .tone-feature .headline {
+    .tone-feature .headline,
+    .tone-feature .facia-link {
         color: #fff;
     }
     .tone-feature .fc-item__kicker,
@@ -51,7 +53,8 @@
     .tone-media .facia-card__text {
         background-color: #333;
     }
-    .tone-media .headline {
+    .tone-media .headline,
+    .tone-media .facia-link {
         color: #fff;
     }
     .tone-media .fc-item__kicker,
@@ -72,7 +75,8 @@
     .tone-review .facia-card__text {
         background-color: #7d7569;
     }
-    .tone-review .headline {
+    .tone-review .headline,
+    .tone-review .facia-link {
         color: #fff;
     }
     .tone-review .fc-item__kicker,
@@ -93,7 +97,8 @@
     .tone-editorial .facia-card__text {
         background-color: #005689;
     }
-    .tone-editorial .headline {
+    .tone-editorial .headline,
+    .tone-editorial .facia-link {
         color: #fff;
     }
     .tone-editorial .fc-item__kicker,
@@ -121,7 +126,8 @@
      * !important is needed here and elsewhere because the base styles in the Ink CSS framework for email use
      * !important and we need to override them. (See the ink stylesheet for notes on why the base styles need !important)
      *@
-    .tone-external .headline {
+    .tone-external .headline,
+    .tone-external .facia-link {
         color: #333333;
         font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
         font-weight: normal;
@@ -146,7 +152,8 @@
     .tone-live .facia-card__text {
         background-color: #b51800;
     }
-    .tone-live .headline {
+    .tone-live .headline,
+    .tone-live .facia-link {
         color: #fff;
     }
     .tone-live .fc-item__kicker,
@@ -167,7 +174,8 @@
     .tone-analysis .facia-card__text {
         background-color: #f6f6f6;
     }
-    .tone-analysis .headline {
+    .tone-analysis .headline,
+    .tone-analysis .facia-link {
         color: #005689;
     }
     .tone-analysis .fc-item__kicker,
@@ -188,7 +196,8 @@
     .tone-special-report .facia-card__text {
         background-color: #63717a;
     }
-    .tone-special-report .headline {
+    .tone-special-report .headline,
+    .tone-special-report .facia-link {
         color: #fff;
     }
     .tone-special-report .fc-item__kicker,
@@ -209,7 +218,8 @@
     .tone-comment .facia-card__text {
         background-color: #e3e3de;
     }
-    .tone-comment .headline {
+    .tone-comment .headline,
+    .tone-comment .facia-link {
         color: #333333;
     }
     .tone-comment .fc-item__kicker,
@@ -230,7 +240,8 @@
     .tone-dead .facia-card__text {
         background-color: #f6f6f6;
     }
-    .tone-dead .headline {
+    .tone-dead .headline,
+    .tone-dead .facia-link {
         color: #333333;
     }
     .tone-dead .fc-item__kicker,


### PR DESCRIPTION
Fixes a user-reported issue with the way our emails render in the T-Online German mail client. Links weren't getting the right colour so on some backgrounds they were very hard to read.

# before
![picture 492](https://cloud.githubusercontent.com/assets/5122968/23997025/a022bae8-0a47-11e7-8e28-a337c630e18b.png)

# after
![picture 491](https://cloud.githubusercontent.com/assets/5122968/23997029/a216b91c-0a47-11e7-935b-39b076030fdf.png)