### PR TITLE
Copy assets after watched sass recompile

### DIFF
--- a/dev/watch.js
+++ b/dev/watch.js
@@ -69,6 +69,7 @@ const sassGraph = require('sass-graph').parseDir(sassDir, {
 });
 
 const compileSass = require('../tools/compile-css');
+const copyFiles = require('../tools/__tasks__/compile/conf/copy');
 
 // when we detect a change in a sass file, we look up the tree of imports
 // and only compile what we need to. anything matching this regex, we can just ignore in dev.
@@ -95,6 +96,9 @@ chokidar.watch(`${sassDir}/**/*.scss`).on('change', changedFile => {
             browserSync.reload(
                 filesToCompile.map(file => file.replace('scss', 'css'))
             );
+        })
+        .then(() => {
+            copyFiles.task();
         })
         .catch(e => {
             // send editing errors to console and browser


### PR DESCRIPTION
I've been converting some inline styles which were raw CSS into Sass, and I found that while the watch task sees my changes and rebuilds the CSS, I don't see the changes in the browser. I figured out that this is because the assets aren't getting to a place where [this code](https://github.com/guardian/frontend/blob/master/common/app/assets/assets.scala#L69-L76) can find them.

I hacked this into the `watch` task to solve the issue and speed up my own workflow, but haven't spent enough time analysing the build scripts to know if this is actually a sensible thing to do. So I thought I'd raise a PR for some feedback.

A nice improvement would be to only do this extra step when it knows it's recompiling some inline styles, and in that case make the browser reload the main page. (As things stand I still have to do a manual refresh)

@guardian/dotcom-platform 