### PR TITLE
Acquisition tests: fix comma and test name

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -24,7 +24,7 @@ define([
 	};
 
     var AcquisitionsEpicDesignVariationsV2 = {
-        name: 'AcquisitionsDesignVariations',
+        name: 'AcquisitionsEpicDesignVariationsV2',
         variants: ['control', 'highlight_subtle', 'highlight_perspective', 'highlight_secure', 'highlight_hard', 'paypal']
     };
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-cif.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-cif.js
@@ -24,7 +24,7 @@ define([
 
     var defaultEpicValues = {
         p1Intro: "… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ",
-        p1Highlight: "unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can.",
+        p1Highlight: "unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can.",
         p1End: "So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.",
         p2: "If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure."
     };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-environment.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-environment.js
@@ -24,7 +24,7 @@ define([
 
     var defaultEpicValues = {
         p1Intro: "… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ",
-        p1Highlight: "unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can.",
+        p1Highlight: "unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can.",
         p1End: "So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.",
         p2: "If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure."
     };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-football.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-content-tailoring-football.js
@@ -24,7 +24,7 @@ define([
 
     var defaultEpicValues = {
         p1Intro: "… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ",
-        p1Highlight: "unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can.",
+        p1Highlight: "unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can.",
         p1End: "So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.",
         p2: "If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure."
     };

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
@@ -19,7 +19,7 @@ define([
     var defaultTemplateArgument = {
         // copy
         p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-            '<span class="contributions__paragraph--highlight">unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can</span>' +
+            '<span class="contributions__paragraph--highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>' +
             '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
         p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
         p3: '',
@@ -106,20 +106,20 @@ define([
 
             buildVariant('highlight_perspective', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
+                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. <span class="contributions__paragraph--highlight">But we do it because we believe our perspective matters – because it might well be your perspective, too.</span>'
             }),
 
             buildVariant('highlight_secure', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
+                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.',
                 p2: '<span class="contributions__paragraph--highlight">If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.</span>'
             }),
 
             buildVariant('highlight_hard', {
                 p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can' +
+                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
                     '. So you can see why we need to ask for your help. <span class="contributions__paragraph--highlight">The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.</span> But we do it because we believe our perspective matters – because it might well be your perspective, too.'
             }),
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars.js
@@ -26,7 +26,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Since you’re here …',
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -4,7 +4,7 @@
             Since you’re here …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike many news organisations we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.


### PR DESCRIPTION
## What does this change?
This fixes a missing comma in the copy of our tests, and fixes the name of one of our tests in order to be outbrain compliance.

## What is the value of this and can you measure success?
A better copy

## Does this affect other platforms - Amp, Apps, etc?
no

## Screenshots
Can you spot the comma?
![screenshot from 2017-03-17 11-18-56](https://cloud.githubusercontent.com/assets/3389563/24041174/1c06ac48-0b04-11e7-9c79-ed7b6fd2d432.png)

The working test, after renaming its id:
![screenshot from 2017-03-17 11-19-33](https://cloud.githubusercontent.com/assets/3389563/24041183/27e72b46-0b04-11e7-834a-381fa1473c84.png)



## Tested in CODE?
No, but tested locally

cc @GHaberis @guardian/contributions 
