### PR TITLE
Darkened them dotted lines (Media tones)

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -74,6 +74,9 @@
     .commentcount,
     .meta__numbers,
     .meta__social,
+    .meta__extras,
+    .submeta,
+    .submeta__keywords,
     .meta__save-for-later,
     .meta__number:not(u-h) + .meta__number {
         border-color: $media-mute;
@@ -102,11 +105,6 @@
 
     .submeta__section-labels .submeta__link {
         color: $neutral-6;
-    }
-
-    .submeta,
-    .submeta__keywords {
-        border-color: $neutral-2;
     }
 
     .submeta__keywords .submeta__link {


### PR DESCRIPTION
Media tones pages were starting to look to zingy again.

BEFORE
<img width="402" alt="screen shot 2017-03-17 at 14 18 02" src="https://cloud.githubusercontent.com/assets/14570016/24047561/02565cca-0b1e-11e7-9032-ea3e5fd11e89.png">

AFTER
<img width="409" alt="screen shot 2017-03-17 at 14 18 12" src="https://cloud.githubusercontent.com/assets/14570016/24047562/026772da-0b1e-11e7-854b-d4f4901de6f2.png">
