### PR TITLE
Add control variant for inline ads test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
@@ -24,6 +24,10 @@ define([
             {
                 id: 'yes',
                 test: function () {}
+            },
+            {
+                id: 'no',
+                test: function () {}
             }
         ];
     };


### PR DESCRIPTION
Will allow @JamieKMorrison to measure the revenue uplift for people in the test.