### PR TITLE
Change failing variants on design variantions v2 epic test to show control

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-design-variations-v2.js
@@ -62,7 +62,7 @@ define([
 
     function buildVariant(variantId, templateArgs) {
         var args = { id: variantId };
-        if (variantId !== 'control') {
+        if (templateArgs) {
             args.template = function(variant) {
                 return buildHtml(variant, templateArgs)
             }
@@ -104,24 +104,11 @@ define([
                 p1Class: 'contributions__paragraph--subtle'
             }),
 
-            buildVariant('highlight_perspective', {
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
-                    '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. <span class="contributions__paragraph--highlight">But we do it because we believe our perspective matters – because it might well be your perspective, too.</span>'
-            }),
+            buildVariant('highlight_perspective_dead'),
 
-            buildVariant('highlight_secure', {
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
-                    '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.',
-                p2: '<span class="contributions__paragraph--highlight">If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.</span>'
-            }),
+            buildVariant('highlight_secure_dead'),
 
-            buildVariant('highlight_hard', {
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                    'unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can' +
-                    '. So you can see why we need to ask for your help. <span class="contributions__paragraph--highlight">The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.</span> But we do it because we believe our perspective matters – because it might well be your perspective, too.'
-            }),
+            buildVariant('highlight_hard_dead'), 
 
             buildVariant('paypal', {
                 epicClass: 'contributions__epic--paypal',


### PR DESCRIPTION
## What does this change?
Out of the 5 variants other than the control in this test, 3 are already clearly not going to beat the control. To ensure we don't lose money over the weekend, we are reverting these variants to show the control 

## What is the value of this and can you measure success?
We save 💰 


## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
