### PR TITLE
engagement banner copy test extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,7 +26,7 @@ trait ABTestSwitches {
     "Test copy for the engagement banner in all countries aside from the US and Australia",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 17),
+    sellByDate = new LocalDate(2017, 3, 24),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -172,7 +172,7 @@ define([
     var CopyTest = function() {
         this.id = 'MembershipEngagementBannerCopyTest';
         this.start = '2017-02-27';
-        this.expiry = '2017-03-17';
+        this.expiry = '2017-03-24';
         this.author = 'Guy Dawson';
         this.description = 'Test different copy for the engagement banner.';
         this.audience = 0.5;


### PR DESCRIPTION
@jfsoul 

## What does this change?

Extends the expiry test for the Engagement Banner copy test.

## What is the value of this and can you measure success?

Allows the test to reach statistical significance, and prevent the frontend build from failing tomorrow!

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No
