### PR TITLE
AB: check for existence of campaignCodes before access

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -183,9 +183,10 @@ define([
                 .forEach(function (test) {
                     var variantId = getTestVariantId(test.id);
                     var variant = getVariant(test, variantId);
+                    var campaingCodes = (variant && variant.campaignCodes) ? variant.campaignCodes : undefined;
 
                     if (variantId && segmentUtil.isInTest(test)) {
-                        log[test.id] = abData(variantId, 'false', variant.campaignCodes);
+                        log[test.id] = abData(variantId, 'false', campaingCodes);
                     }
                 });
 


### PR DESCRIPTION
## What does this change?

Add a check around `campaignCodes` property to avoid null reference errors. `abData()` is prepared to receive `undefined` instead of `campaignCodes` anyway.

Hopefully fixes this Sentry issue: https://sentry.io/the-guardian/client-side-prod/issues/230497094/

## What is the value of this and can you measure success?

Less Sentry issues.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.