### PR TITLE
Epic regulars version 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -122,7 +122,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-regulars",
+    "ab-contributions-epic-regulars-v2",
     "Test messages aimed at our regular readers",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -18,9 +18,9 @@ define([
         variants: ['control']
     };
 
-    var ContributionsEpicRegulars = {
-        name: 'ContributionsEpicRegulars',
-        variants: ['control', 'fairness_mild', 'fairness_strong', 'fairness_strong_alternate_hook', 'reliance']
+    var ContributionsEpicRegularsV2 = {
+        name: 'ContributionsEpicRegularsV2',
+        variants: ['control', 'fairness_strong', 'fairness_strong_alternate_hook']
 	};
 
     var AcquisitionsEpicDesignVariationsV2 = {
@@ -52,7 +52,7 @@ define([
         ContributionsEpicAlwaysAskStrategy,
         ContributionsEpicBrexit,
         ContributionsEpicAskFourEarning,
-        ContributionsEpicRegulars,
+        ContributionsEpicRegularsV2,
         AcquisitionsEpicDesignVariationsV2,
         AcquisitionsEpicArticle50Trigger,
         AcquisitionsContentTailoringEnvironment,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -8,7 +8,7 @@ define([
     'common/modules/experiments/tests/acquisitions-epic-content-tailoring-football',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
-    'common/modules/experiments/tests/contributions-epic-regulars',
+    'common/modules/experiments/tests/contributions-epic-regulars-v2',
     'common/modules/experiments/tests/acquisitions-epic-article-50-trigger',
     'common/modules/experiments/tests/acquisitions-epic-design-variations-v2'
 ], function (
@@ -21,7 +21,7 @@ define([
     contentTailoringFootball,
     alwaysAsk,
     askFourEarning,
-    regulars,
+    regularsV2,
     acquisitionsEpicArticle50Trigger,
     acquisitionsEpicDesignVariationsV2
 ) {
@@ -30,10 +30,10 @@ define([
      */
     var tests = [
         alwaysAsk,
+		regularsV2,
         contentTailoringEnvironment,
         contentTailoringCif,
         contentTailoringFootball,
-        regulars,
         acquisitionsEpicDesignVariationsV2,
         askFourEarning,
         acquisitionsEpicArticle50Trigger,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
@@ -3,16 +3,13 @@ define([
     'lodash/utilities/template',
     'lib/cookies',
     'raw-loader!common/views/contributions-epic-equal-buttons.html',
-    'common/modules/tailor/tailor',
-    'raw-loader!common/views/acquisitions-epic-control.html'
-
+    'common/modules/tailor/tailor'
 ], function (
     contributionsUtilities,
     template,
     cookies,
     contributionsEpicEqualButtons,
-    tailor,
-    acquisitionsEpicControlTemplate
+    tailor
 ) {
 
 
@@ -29,7 +26,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Since you’re here …',
-                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',
@@ -49,7 +46,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And \<\span class=\"contributions__paragraph--highlight\"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can\</\span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And <span class=\"contributions__paragraph--highlight\"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If you regularly read and value our reporting, support us now and help make our future much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',
@@ -68,7 +65,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Hello again …',
-                p1: '… today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And \<\span class=\"contributions__paragraph--highlight\"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can\</\span>. . So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If you regularly read and value our reporting, support us now and help make our future much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',
@@ -90,7 +87,7 @@ define([
         idealOutcome: 'Establish which variant has the highest conversion rate',
 
         audienceCriteria: 'All',
-        audience: 1,
+        audience: 0.5,
         audienceOffset: 0,
 
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
@@ -3,13 +3,16 @@ define([
     'lodash/utilities/template',
     'lib/cookies',
     'raw-loader!common/views/contributions-epic-equal-buttons.html',
-    'common/modules/tailor/tailor'
+    'common/modules/tailor/tailor',
+    'raw-loader!common/views/acquisitions-epic-control.html'
+
 ], function (
     contributionsUtilities,
     template,
     cookies,
     contributionsEpicEqualButtons,
-    tailor
+    tailor,
+    acquisitionsEpicControlTemplate
 ) {
 
 
@@ -46,7 +49,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And \<\span class=\"contributions__paragraph--highlight\"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can\</\span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If you regularly read and value our reporting, support us now and help make our future much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',
@@ -65,7 +68,7 @@ define([
                 linkUrl2: variant.contributionsURLBuilder(appendSuffix),
                 componentName: variant.componentName,
                 title: 'Hello again …',
-                p1: '… today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
+                p1: '… today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And \<\span class=\"contributions__paragraph--highlight\"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can\</\span>. . So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                 p2: 'If you regularly read and value our reporting, support us now and help make our future much more secure.',
                 p3: '',
                 cta1: 'Become a Supporter',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
@@ -35,25 +35,6 @@ define([
         }
     }
 
-    function fairnessMildTemplate(regular) {
-        var suffix = regular ? '_regular' : '_non_regular';
-        return function(variant) {
-            function appendSuffix(code) { return code + suffix; }
-
-            return template(contributionsEpicEqualButtons, {
-                linkUrl1: variant.membershipURLBuilder(appendSuffix),
-                linkUrl2: variant.contributionsURLBuilder(appendSuffix),
-                componentName: variant.componentName,
-                title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If you regularly read and value our reporting, support us now and help make our future much more secure.',
-                p3: '',
-                cta1: 'Become a Supporter',
-                cta2: 'Make a contribution'
-            });
-        }
-    }
-
     function fairnessStrongTemplate(regular) {
         var suffix = regular ? '_regular' : '_non_regular';
 
@@ -93,28 +74,9 @@ define([
         }
     }
 
-    function relianceTemplate(regular) {
-        var suffix = regular ? '_regular' : '_non_regular';
-        return function(variant) {
-            function appendSuffix(code) { return code + suffix; }
-
-            return template(contributionsEpicEqualButtons, {
-                linkUrl1: variant.membershipURLBuilder(appendSuffix),
-                linkUrl2: variant.contributionsURLBuilder(appendSuffix),
-                componentName: variant.componentName,
-                title: 'Since you’re here …',
-                p1: '… we have a small favour to ask. More people than ever rely on the Guardian to keep them up-to-date, but far fewer are paying for our journalism. Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
-                p2: 'If you depend on our reporting to stay informed, support us now and help make our future much more secure.',
-                p3: '',
-                cta1: 'Become a Supporter',
-                cta2: 'Make a contribution'
-            });
-        }
-    }
-
     return contributionsUtilities.makeABTest({
-        id: 'ContributionsEpicRegulars',
-        campaignId: 'kr1_epic_regulars',
+        id: 'ContributionsEpicRegularsV2',
+        campaignId: 'kr1_epic_regulars_v2',
 
         start: '2017-03-07',
         expiry: '2017-03-21',
@@ -125,7 +87,7 @@ define([
         idealOutcome: 'Establish which variant has the highest conversion rate',
 
         audienceCriteria: 'All',
-        audience: 0.5,
+        audience: 1,
         audienceOffset: 0,
 
 
@@ -150,25 +112,6 @@ define([
                 successOnView: true
             },
             {
-                id: 'fairness_mild',
-                maxViews: {
-                    days: 30,
-                    count: 4,
-                    minDaysBetweenViews: 0
-                },
-                test: function(render) {
-                    if (bwidCookie) {
-                        tailor.getRegularStatus(bwidCookie).then(function (regular) {
-                            render(fairnessMildTemplate(regular));
-                        });
-                    } else {
-                        render(fairnessMildTemplate(false));
-                    }
-                },
-                insertBeforeSelector: '.submeta',
-                successOnView: true
-            },
-            {
                 id: 'fairness_strong',
                 maxViews: {
                     days: 30,
@@ -178,10 +121,14 @@ define([
                 test: function(render) {
                     if (bwidCookie) {
                         tailor.getRegularStatus(bwidCookie).then(function (regular) {
-                            render(fairnessStrongTemplate(regular));
+                            if(regular) {
+                                render(fairnessStrongTemplate(true));
+                            } else {
+                                render(controlTemplate(false));
+                            }
                         });
                     } else {
-                        render(fairnessStrongTemplate(false));
+                        render(controlTemplate(false));
                     }
                 },
                 insertBeforeSelector: '.submeta',
@@ -197,29 +144,14 @@ define([
                 test: function(render) {
                     if (bwidCookie) {
                         tailor.getRegularStatus(bwidCookie).then(function (regular) {
-                            render(fairnessStrongAlternateHookTemplate(regular));
+                            if(regular) {
+                                render(fairnessStrongAlternateHookTemplate(true));
+                            } else {
+                                render(controlTemplate(false));
+                            }
                         });
                     } else {
-                        render(fairnessStrongAlternateHookTemplate(false));
-                    }
-                },
-                insertBeforeSelector: '.submeta',
-                successOnView: true
-            },
-            {
-                id: 'reliance',
-                maxViews: {
-                    days: 30,
-                    count: 4,
-                    minDaysBetweenViews: 0
-                },
-                test: function(render) {
-                    if (bwidCookie) {
-                        tailor.getRegularStatus(bwidCookie).then(function (regular) {
-                            render(relianceTemplate(regular));
-                        });
-                    } else {
-                        render(relianceTemplate(false));
+                        render(controlTemplate(false));
                     }
                 },
                 insertBeforeSelector: '.submeta',


### PR DESCRIPTION
## What does this change?

Version 2 of our regulars test. This test has 3 variants. The control, and 2 message variants. Only regulars will see the new message in the 2 competing variants. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

![screenshot at mar 20 17-13-46](https://cloud.githubusercontent.com/assets/2844554/24112575/e5d30dca-0d91-11e7-97f2-c7451f361d0c.png)
![screenshot at mar 20 17-14-17](https://cloud.githubusercontent.com/assets/2844554/24112574/e5d17870-0d91-11e7-9c8f-4da3f05ccc5e.png)
![screenshot at mar 20 17-15-25](https://cloud.githubusercontent.com/assets/2844554/24112573/e5d14544-0d91-11e7-99ca-a5d4f0d76df0.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
