### PR TITLE
Laundromat epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -220,6 +220,18 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+
+  Switch(
+    ABTests,
+    "ab-contributions-epic-laundromat",
+    "Display the Epic on Laundromat articles",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 4, 10),
+    exposeClientSide = true
+  )
+
+
   Switch(
     ABTests,
     "ab-acquisitions-epic-content-tailoring-environment",

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -33,6 +33,12 @@ define([
         variants: ['control']
     };
 
+    var ContributionsEpicLaundromat = {
+        name: 'ContributionsEpicLaundromat',
+        variants: ['control']
+    };
+
+
     var AcquisitionsContentTailoringEnvironment = {
         name: 'AcquisitionsEpicContentTailoringEnvironment',
         variants: ['control', 'impact', 'reference']

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -63,7 +63,8 @@ define([
         AcquisitionsEpicArticle50Trigger,
         AcquisitionsContentTailoringEnvironment,
         AcquisitionsContentTailoringCif,
-        AcquisitionsContentTailoringFootball
+        AcquisitionsContentTailoringFootball,
+        ContributionsEpicLaundromat
     ];
 
     var emailTests = [];

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -10,6 +10,7 @@ define([
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
     'common/modules/experiments/tests/contributions-epic-regulars-v2',
     'common/modules/experiments/tests/acquisitions-epic-article-50-trigger',
+    'common/modules/experiments/tests/acquisitions-epic-design-variations-v2',
     'common/modules/experiments/tests/contributions-epic-laundromat'
 ], function (
     segmentUtil,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -10,7 +10,7 @@ define([
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
     'common/modules/experiments/tests/contributions-epic-regulars-v2',
     'common/modules/experiments/tests/acquisitions-epic-article-50-trigger',
-    'common/modules/experiments/tests/acquisitions-epic-design-variations-v2'
+    'common/modules/experiments/tests/contributions-epic-laundromat'
 ], function (
     segmentUtil,
     testCanRunChecks,
@@ -23,13 +23,15 @@ define([
     askFourEarning,
     regularsV2,
     acquisitionsEpicArticle50Trigger,
-    acquisitionsEpicDesignVariationsV2
+    acquisitionsEpicDesignVariationsV2,
+    laundromat
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
     var tests = [
         alwaysAsk,
+        laundromat,
 		regularsV2,
         contentTailoringEnvironment,
         contentTailoringCif,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-laundromat.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-laundromat.js
@@ -1,0 +1,37 @@
+define([
+    'common/modules/commercial/contributions-utilities'
+], function (
+    contributionsUtilities
+) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'ContributionsEpicLaundromat',
+        campaignId: 'epic_laundromat',
+
+        start: '2017-03-20',
+        expiry: '2017-04-10',
+
+        author: 'Jonathan Rankin',
+        description: 'Run the epic on laundromat articles, ignoring the sensitive tag',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'The conversion rate is equal or above what we have observed on other campaigns',
+        showForSensitive: true,
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+        useTargetingTool: true,
+
+        variants: [
+            {
+                id: 'control',
+                maxViews: {
+                    days: 7,
+                    count: 6,
+                    minDaysBetweenViews: 1
+                },
+                insertBeforeSelector: '.submeta',
+                successOnView: true
+            }
+        ]
+    });
+});


### PR DESCRIPTION
## What does this change?

Adds the epic to laundromat tagged articles (targeting done using the targeting tool)

This was necessary because all the laundromat articles are tagged as isSensitive so we needed to create it's own test that ignores the sensitive flag. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
