### PR TITLE
Fix indexedDB InvalidStateError occurring in FF

### DIFF
--- a/static/src/javascripts-legacy/lib/private-browsing.js
+++ b/static/src/javascripts-legacy/lib/private-browsing.js
@@ -4,14 +4,13 @@ define([
     Promise
 ) {
     var browserCheck = new Promise(function (resolve) {
-        var db;
         var on = function () {
             resolve(true);
         };
         var off = function () {
              resolve(false);
         };
-        var tryLocalStorage = function () {
+        var tryLocalStorage = function() {
             try {
                 localStorage.length ? off() : (localStorage.x = 1, localStorage.removeItem('x'), off());
             } catch (e) {
@@ -19,22 +18,38 @@ define([
             }
         };
 
+        var tryIndexedDB = function() {
+            var db;
+
+            try {
+                db = indexedDB.open('test');
+                db.onerror = on;
+                db.onsuccess = off;
+            } catch(err) {
+                on();
+            }
+        };
+
         // Blink
-        window.webkitRequestFileSystem ?
-            window.webkitRequestFileSystem(window.TEMPORARY, 1, off, on)
+        if (window.webkitRequestFileSystem) {
+            window.webkitRequestFileSystem(window.TEMPORARY, 1, off, on);
 
         // Firefox
-        : 'MozAppearance' in document.documentElement.style ?
-            (db = indexedDB.open('test'), db.onerror = on, db.onsuccess = off)
+        } else if ('MozAppearance' in document.documentElement.style) {
+            tryIndexedDB();
 
         // Safari
-        : /constructor/i.test(window.HTMLElement) ? tryLocalStorage()
+        } else if (/constructor/i.test(window.HTMLElement)) {
+            tryLocalStorage();
 
         // IE10+ and edge
-        : !window.indexedDB && (window.PointerEvent || window.MSPointerEvent) ? on()
+        } else if (!window.indexedDB && (window.PointerEvent || window.MSPointerEvent)) {
+            on();
 
         // Rest
-        : off();
+        } else {
+            off();
+        }
     });
 
     return browserCheck;


### PR DESCRIPTION
## What does this change?

As part of my "a sentry error a day" I looked into https://sentry.io/the-guardian/client-side-prod/issues/228307682/.

This Pr should not change the indended behavoir, but improve the code readability. It also adds a `try{} catch` around the indexedDB open call.

## What is the value of this and can you measure success?

Less sentry errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.