### PR TITLE
Extended the remind-me ab-test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -226,7 +226,7 @@ define([
     };
 
     return [
-        new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-03-20', 'remind_me_later')
+        new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-04-07', 'remind_me_later')
             .addMembershipVariant('control', {})
             .addMembershipVariant('remind_me', {showRemindMe : true}),
 


### PR DESCRIPTION
## What does this change?

We want to extend this test until Friday 7th of April.

## Screenshots
<img width="1234" alt="picture 217" src="https://cloud.githubusercontent.com/assets/825398/24146891/ac48aa94-0e2f-11e7-8a96-28b6d966a490.png">


## Tested in CODE?

Yes
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
