### PR TITLE
stop applying CSS to fc-container--thrasher

### DIFF
--- a/static/src/javascripts/projects/common/views/experiments/reading-time.html
+++ b/static/src/javascripts/projects/common/views/experiments/reading-time.html
@@ -1,4 +1,4 @@
-<section id="reading-time" class="fc-container fc-container--thrasher fc-container--has-toggle" data-link-name="reading-time" data-component="reading-time" aria-expanded="true">
+<section id="reading-time" class="fc-container fc-container--thrasher reading-time--thrasher fc-container--has-toggle" data-link-name="reading-time" data-component="reading-time" aria-expanded="true">
     <div class="fc-container__inner">
         <div class="fc-container__header js-container__header">
             <div class="fc-container__header__title">

--- a/static/src/stylesheets/module/experiments/_reading-time.scss
+++ b/static/src/stylesheets/module/experiments/_reading-time.scss
@@ -1,4 +1,4 @@
-.fc-container--thrasher {
+.reading-time--thrasher {
     background: $guardian-brand-dark;
     .fc-item {
         background: $guardian-brand;


### PR DESCRIPTION
## What does this change?
In my [reading time test PR](https://github.com/guardian/frontend/pull/16145), I've erroneously applied a style to the quite general class fc-container--thrasher, and this is affecting thrashers elsewhere when it shouldn't be. 

## What is the value of this and can you measure success?
Removing a CSS bug I introduced. 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/dotcom-platform 