### PR TITLE
Add audience percentage for reading time test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -268,7 +268,7 @@ trait ABTestSwitches {
     "Test demand for getting suggested content based on how much time a reader has",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 31),
+    sellByDate = new LocalDate(2017, 4, 4),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/reading-time.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/reading-time.js
@@ -28,11 +28,11 @@ define([
     return function () {
         this.id = 'ReadingTime';
         this.start = '2017-03-15';
-        this.expiry = '2017-03-31'; //to be set to run for a week when audience > 0 change is merged
+        this.expiry = '2017-04-04';
         this.author = 'Leigh-Anne Mathieson';
         this.description = 'Add a thrasher to the home front that gives users an option to indicate how much time they'
             + ' have to read, to determine demand for suggesting content based on the amount of time they have.';
-        this.audience = 0; // to be 0.029
+        this.audience = 0.029; // 1.45% of users on the home front will see reading time thrasher
         this.audienceOffset = 0; //just needs to not clash with recommended for you, which is offset 0.2
         this.successMeasure = 'Number of clicks';
         this.audienceCriteria = 'All users';


### PR DESCRIPTION
Add audience percentage so that 1.45% of users on the home front will see the reading time test. 

Also amends the expiry of the switch to a day when I'm in the office to remove the test.

## What does this change?
Actually add the audience for the test added in [16145](https://github.com/guardian/frontend/pull/16145).

## What is the value of this and can you measure success?
If enough users click the test to tell us how much time they have, we will know if we should try more sophisticated ways to use reading time to suggest content to users.

Measure of success = number of clicks

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
