### PR TITLE
Up the target audience to 25pc

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -37,7 +37,7 @@ define([
         this.expiry = '2017-04-28';
         this.author = 'Manlio & Mahana';
         this.description = 'Testing Tailor surveys';
-        this.audience = 0.01;
+        this.audience = 0.25;
         this.audienceOffset = 0.7;
         this.successMeasure = 'We can show a survey on Frontend as decided by Tailor';
         this.audienceCriteria = 'All users';


### PR DESCRIPTION
It turned out that targeting 1pc of our audience isn't working, because we don't have enough top users in such a small segment, so I'm upping the targeting to 25pc 🙈 

Please note that this doesn't actually mean the surveys will be showed to 25pc of the audience, as the final decision wether to show a survey or not will be taken by Tailor.

@SiAdcock 


