### PR TITLE
Don't stub require in Outbrain tests

### DIFF
--- a/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
@@ -1,4 +1,3 @@
-define('ophan/ng', [], function () { return { record: function () {} }; });
 define([
     'fastdom',
     'helpers/injector',
@@ -33,7 +32,8 @@ define([
         var loadScript = jasmine.createSpy('loadScript');
         beforeEach(function (done) {
             injector.mock('lib/load-script', loadScript);
-            
+            injector.mock('ophan/ng', { record: function () {} });
+
             injector.require([
                 'commercial/modules/third-party-tags/outbrain',
                 'commercial/modules/third-party-tags/outbrain-sections',
@@ -165,15 +165,6 @@ define([
         });
 
         describe('Load', function () {
-            var requireStub;
-            beforeEach(function () {
-                requireStub = sinon.stub(window, 'require');
-            });
-
-            afterEach(function () {
-                requireStub.restore();
-            });
-
             it('should create two containers for desktop with correct IDs for slot 1', function (done) {
                 detect.getBreakpoint = function () {
                     return 'desktop';
@@ -307,9 +298,6 @@ define([
 
         describe('Tracking', function () {
             it('should call tracking method', function (done) {
-                // We don't care about the require for this test, so stub it
-                sinon.stub(window, 'require');
-
                 detect.getBreakpoint = function () {
                     return 'wide';
                 };


### PR DESCRIPTION
## What does this change?

Since [Ophan was defined as an explicit dependency](https://github.com/guardian/frontend/pull/16048) of the Outbrain module, there has been no need to stub `window.require` in the Outbrain tests. This change injects an Ophan mock and removes the stubbing and restoring of Ophan from these tests. 

## What is the value of this and can you measure success?

Stubing require was causing [intermittent build failures](https://teamcity.gu-web.net/viewLog.html?buildId=32162&buildTypeId=dotcom_frontend&tab=buildLog#_state=961,1664,1672,1662,1615&focus=1615), which should now go away.

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
