### PR TITLE
use isOutbrainDisabled when evaluating if email-sign up can run

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -109,7 +109,9 @@ define([
 
     function init() {
         return checkMediator.waitForCheck('isOutbrainDisabled').then(function (outbrainDisabled) {
-            if (!outbrainDisabled) {
+            if (outbrainDisabled) {
+                return Promise.resolve();
+            } else {
                 // if there is no merch component, load the outbrain widget right away
                 return loadInstantly().then(function(shouldLoadInstantly) {
                     if (shouldLoadInstantly) {
@@ -119,11 +121,14 @@ define([
                     } else {
                         // if a high priority merch component and low priority merch component on page block outbrain
                         return checkMediator.waitForCheck('isOutbrainBlockedByAds').then(function(outbrainBlockedByAds) {
-                            if (!outbrainBlockedByAds) {
+                            if (outbrainBlockedByAds) {
+                                return Promise.resolve();
+                            } else {
                                 // if only a high priority merch component on page then outbrain is merchandise compliant
                                 return checkMediator.waitForCheck('isOutbrainMerchandiseCompliant').then(function (outbrainMerchandiseCompliant) {
                                     if (outbrainMerchandiseCompliant) {
                                         module.load('merchandising');
+                                        return Promise.resolve();
                                     } else {
                                         return checkMediator.waitForCheck('isUserInNonCompliantAbTest').then(function (userInNonCompliantAbTest) {
                                             userInNonCompliantAbTest ? module.load('nonCompliant') : module.load();

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -109,9 +109,7 @@ define([
 
     function init() {
         return checkMediator.waitForCheck('isOutbrainDisabled').then(function (outbrainDisabled) {
-            if (outbrainDisabled) {
-                return Promise.resolve();
-            } else {
+            if (!outbrainDisabled) {
                 // if there is no merch component, load the outbrain widget right away
                 return loadInstantly().then(function(shouldLoadInstantly) {
                     if (shouldLoadInstantly) {
@@ -121,14 +119,11 @@ define([
                     } else {
                         // if a high priority merch component and low priority merch component on page block outbrain
                         return checkMediator.waitForCheck('isOutbrainBlockedByAds').then(function(outbrainBlockedByAds) {
-                            if (outbrainBlockedByAds) {
-                                return Promise.resolve();
-                            } else {
+                            if (!outbrainBlockedByAds) {
                                 // if only a high priority merch component on page then outbrain is merchandise compliant
                                 return checkMediator.waitForCheck('isOutbrainMerchandiseCompliant').then(function (outbrainMerchandiseCompliant) {
                                     if (outbrainMerchandiseCompliant) {
                                         module.load('merchandising');
-                                        return Promise.resolve();
                                     } else {
                                         return checkMediator.waitForCheck('isUserInNonCompliantAbTest').then(function (userInNonCompliantAbTest) {
                                             userInNonCompliantAbTest ? module.load('nonCompliant') : module.load();
@@ -140,6 +135,8 @@ define([
                     }
                 });
             }
+        }).then(function () {
+            return Promise.resolve(true);
         });
     }
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -6,7 +6,6 @@ define([
     'lib/detect',
     'lodash/utilities/template',
     'lib/steady-page',
-    'commercial/modules/commercial-features',
     'commercial/modules/third-party-tags/outbrain-codes',
     'raw-loader!commercial/views/outbrain.html',
     'lib/load-script',
@@ -20,7 +19,6 @@ define([
     detect,
     template,
     steadyPage,
-    commercialFeatures,
     getCode,
     outbrainStr,
     loadScript,
@@ -110,7 +108,7 @@ define([
     }
 
     function init() {
-        checkMediator.waitForCheck('isOutbrainDisabled').then(function (outbrainDisabled) {
+        return checkMediator.waitForCheck('isOutbrainDisabled').then(function (outbrainDisabled) {
             if (!outbrainDisabled) {
                 // if there is no merch component, load the outbrain widget right away
                 return loadInstantly().then(function(shouldLoadInstantly) {
@@ -123,11 +121,11 @@ define([
                         return checkMediator.waitForCheck('isOutbrainBlockedByAds').then(function(outbrainBlockedByAds) {
                             if (!outbrainBlockedByAds) {
                                 // if only a high priority merch component on page then outbrain is merchandise compliant
-                                checkMediator.waitForCheck('isOutbrainMerchandiseCompliant').then(function (outbrainMerchandiseCompliant) {
+                                return checkMediator.waitForCheck('isOutbrainMerchandiseCompliant').then(function (outbrainMerchandiseCompliant) {
                                     if (outbrainMerchandiseCompliant) {
                                         module.load('merchandising');
                                     } else {
-                                        checkMediator.waitForCheck('isUserInNonCompliantAbTest').then(function (userInNonCompliantAbTest) {
+                                        return checkMediator.waitForCheck('isUserInNonCompliantAbTest').then(function (userInNonCompliantAbTest) {
                                             userInNonCompliantAbTest ? module.load('nonCompliant') : module.load();
                                         });
                                     }
@@ -138,8 +136,6 @@ define([
                 });
             }
         });
-
-        return Promise.resolve(true);
     }
 
     return module;

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -80,17 +80,17 @@ define([
                 $container.append(widgetHtml);
                 $outbrain.css('display', 'block');
             }).then(function () {
-                module.tracking(widgetCodes.code || widgetCodes.image);
+                module.tracking({
+                    widgetId: widgetCodes.code || widgetCodes.image
+                });
                 loadScript(outbrainUrl);
             });
         }
     }
 
-    function tracking(widgetCode) {
+    function tracking(trackingObj) {
         ophan.record({
-            outbrain: {
-                widgetId: widgetCode
-            }
+            outbrain: trackingObj
         });
     }
 
@@ -109,6 +109,9 @@ define([
 
     function onIsOutbrainDisabled(outbrainDisabled) {
         if (outbrainDisabled) {
+            module.tracking({
+                state: 'outbrainDisabled'
+            });
             return Promise.resolve();
         } else {
             return canLoadInstantly().then(onCanLoadInstantly);
@@ -124,12 +127,18 @@ define([
     }
 
     function onIsUserInNonCompliantAbTest(userInNonCompliantAbTest) {
-        userInNonCompliantAbTest ? module.load('nonCompliant') : module.load();
+        userInNonCompliantAbTest ? module.load('nonCompliant') : module.load();        
+        module.tracking({
+            state: userInNonCompliantAbTest ? 'userInNonCompliantAbTest' : 'compliant'
+        });
         return Promise.resolve();
     }
 
     function onIsOutbrainBlockedByAds(outbrainBlockedByAds) {
         if (outbrainBlockedByAds) {
+            module.tracking({
+                state: 'outbrainBlockedByAds'
+            });
             return Promise.resolve();
         } else {
             return checkMediator.waitForCheck('isOutbrainMerchandiseCompliant').then(onIsOutbrainMerchandiseCompliant);
@@ -139,6 +148,9 @@ define([
     function onIsOutbrainMerchandiseCompliant(outbrainMerchandiseCompliant) {
         if (outbrainMerchandiseCompliant) {
             module.load('merchandising');
+            module.tracking({
+                state: 'outbrainMerchandiseCompliant'
+            });
             return Promise.resolve();
         } else {
             return checkMediator.waitForCheck('isUserInNonCompliantAbTest').then(onIsUserInNonCompliantAbTest); 

--- a/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
@@ -22,9 +22,6 @@ define([
         isOutbrainDisabled: function () {
             return !commercialFeatures.outbrain;
         },
-        thirdPartyTagsDisabled: function () {
-            return !commercialFeatures.thirdPartyTags;
-        },
         isUserInContributionsAbTest: function() {
             return clash.userIsInAClashingAbTest(clash.contributionsTests);
         },
@@ -46,34 +43,30 @@ define([
             return config.switches.emailInArticleOutbrain;
         },
         hasHighPriorityAdLoaded: function() {
-            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
-                // if thirdPartyTagsDisabled no external ads are loaded
-                if (thirdPartyTagsDisabled) {
-                    return false;
-                } else {
-                    return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
-                        return highPriorityAdLoaded;
-                    });
-                }
-            });
+            // if thirdPartyTags false no external ads are loaded
+            if (commercialFeatures.thirdPartyTags) {
+                return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
+                    return highPriorityAdLoaded;
+                });
+            } else {
+                return false;
+            }
         },
         hasLowPriorityAdLoaded: function() {
-            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
-                // if thirdPartyTagsDisabled no external ads are loaded
-                if (thirdPartyTagsDisabled) {
-                    return false;
-                } else {
-                    return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
-                        if (highPriorityAdLoaded) {
-                            return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
-                                return lowPriorityAdLoaded;
-                            });
-                        } else {          
-                            return true;
-                        }
-                    });     
-                }
-            });
+            // if thirdPartyTags false no external ads are loaded
+            if (commercialFeatures.thirdPartyTags) {
+                return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
+                    if (highPriorityAdLoaded) {
+                        return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
+                            return lowPriorityAdLoaded;
+                        });
+                    } else {    
+                        return true;
+                    }
+                });
+            } else {
+                return false;
+            }
         },
         hasLowPriorityAdNotLoaded: function() {
             return checkMediator.waitForCheck('hasLowPriorityAdLoaded').then(function (lowPriorityAdLoaded) {

--- a/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
@@ -22,6 +22,9 @@ define([
         isOutbrainDisabled: function () {
             return !commercialFeatures.outbrain;
         },
+        thirdPartyTagsDisabled: function () {
+            return !commercialFeatures.thirdPartyTags;
+        },
         isUserInContributionsAbTest: function() {
             return clash.userIsInAClashingAbTest(clash.contributionsTests);
         },
@@ -43,18 +46,32 @@ define([
             return config.switches.emailInArticleOutbrain;
         },
         hasHighPriorityAdLoaded: function() {
-            return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
-                return highPriorityAdLoaded;
+            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
+                // if thirdPartyTagsDisabled no external ads are loaded
+                if (thirdPartyTagsDisabled) {
+                    return false;
+                } else {
+                    return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
+                        return highPriorityAdLoaded;
+                    });
+                }
             });
         },
         hasLowPriorityAdLoaded: function() {
-            return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
-                if (highPriorityAdLoaded) {
-                    return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
-                        return lowPriorityAdLoaded;
-                    });
-                } else {    
-                    return true;
+            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
+                // if thirdPartyTagsDisabled no external ads are loaded
+                if (thirdPartyTagsDisabled) {
+                    return false;
+                } else {
+                    return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
+                        if (highPriorityAdLoaded) {
+                            return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
+                                return lowPriorityAdLoaded;
+                            });
+                        } else {          
+                            return true;
+                        }
+                    });     
                 }
             });
         },

--- a/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
@@ -44,10 +44,8 @@ define([
         },
         hasHighPriorityAdLoaded: function() {
             // if thirdPartyTags false no external ads are loaded
-            if (commercialFeatures.thirdPartyTags) {
-                return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
-                    return highPriorityAdLoaded;
-                });
+            if (commercialFeatures.thirdPartyTags && commercialFeatures.highMerch) {
+                return trackAdRender('dfp-ad--merchandising-high');
             } else {
                 return false;
             }
@@ -57,9 +55,7 @@ define([
             if (commercialFeatures.thirdPartyTags) {
                 return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
                     if (highPriorityAdLoaded) {
-                        return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
-                            return lowPriorityAdLoaded;
-                        });
+                        return trackAdRender('dfp-ad--merchandising');
                     } else {    
                         return true;
                     }

--- a/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-dispatcher.js
@@ -19,8 +19,8 @@ define([
 ) {
 
     var checksToDispatch = {
-        thirdPartyTagsDisabled: function () {
-            return !commercialFeatures.thirdPartyTags;
+        isOutbrainDisabled: function () {
+            return !commercialFeatures.outbrain;
         },
         isUserInContributionsAbTest: function() {
             return clash.userIsInAClashingAbTest(clash.contributionsTests);
@@ -43,32 +43,18 @@ define([
             return config.switches.emailInArticleOutbrain;
         },
         hasHighPriorityAdLoaded: function() {
-            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
-                // if thirdPartyTagsDisabled no external ads are loaded
-                if (thirdPartyTagsDisabled) {
-                    return false;
-                } else {
-                    return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
-                        return highPriorityAdLoaded;
-                    });
-                }
+            return trackAdRender('dfp-ad--merchandising-high').then(function(highPriorityAdLoaded) {
+                return highPriorityAdLoaded;
             });
         },
         hasLowPriorityAdLoaded: function() {
-            return checkMediator.waitForCheck('thirdPartyTagsDisabled').then(function (thirdPartyTagsDisabled) {
-                // if thirdPartyTagsDisabled no external ads are loaded
-                if (thirdPartyTagsDisabled) {
-                    return false;
-                } else {
-                    return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
-                        if (highPriorityAdLoaded) {
-                            return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
-                                return lowPriorityAdLoaded;
-                            });
-                        } else {          
-                            return true;
-                        }
-                    });     
+            return checkMediator.waitForCheck('hasHighPriorityAdLoaded').then(function (highPriorityAdLoaded) {
+                if (highPriorityAdLoaded) {
+                    return trackAdRender('dfp-ad--merchandising').then(function(lowPriorityAdLoaded) {
+                        return lowPriorityAdLoaded;
+                    });
+                } else {    
+                    return true;
                 }
             });
         },

--- a/static/src/javascripts-legacy/projects/common/modules/check-mediator.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-mediator.js
@@ -89,7 +89,7 @@ define([
         }, {
             id: 'isOutbrainMerchandiseCompliantOrBlockedByAds'
         }, {
-            id: 'thirdPartyTagsDisabled'
+            id: 'isOutbrainDisabled'
         }]
     }];
 

--- a/static/src/javascripts-legacy/projects/common/modules/check-mediator.js
+++ b/static/src/javascripts-legacy/projects/common/modules/check-mediator.js
@@ -101,7 +101,6 @@ define([
 
         if (dependentCheckPromises) {
             Promise.all(dependentCheckPromises).then(function(results) {
-
                 var hasPassed = function(result) {
                     return result;
                 };

--- a/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
@@ -75,6 +75,7 @@ define([
         describe('Init', function () {
             beforeEach(function () {
                 spyOn(sut, 'load');
+                spyOn(sut, 'tracking');
             });
 
             it('should not load if outbrain disabled', function (done) {
@@ -91,6 +92,10 @@ define([
 
                 sut.init().then(function () {
                     expect(sut.load).not.toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        state: 'outbrainDisabled'
+                    });    
                     done();
                 });
             });
@@ -110,6 +115,10 @@ define([
                 sut.init().then(function () {
                     expect(sut.load).toHaveBeenCalled();
                     expect(sut.load).toHaveBeenCalledWith('nonCompliant');
+                    expect(sut.tracking).toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        state: 'userInNonCompliantAbTest'
+                    });
                     done();
                 });
             });
@@ -125,6 +134,10 @@ define([
                 sut.init().then(function () {
                     expect(sut.load).toHaveBeenCalled();
                     expect(sut.load).toHaveBeenCalledWith('merchandising');
+                    expect(sut.tracking).toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        state: 'outbrainMerchandiseCompliant'
+                    });
                     done();
                 });
             });
@@ -138,6 +151,10 @@ define([
 
                 sut.init().then(function () {
                     expect(sut.load).not.toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        state: 'outbrainBlockedByAds'
+                    });
                     done();
                 });
             });
@@ -161,6 +178,10 @@ define([
                     expect(sut.load).toHaveBeenCalled();
                     expect(sut.load).not.toHaveBeenCalledWith('nonCompliant');
                     expect(sut.load).not.toHaveBeenCalledWith('merchandising');
+                    expect(sut.tracking).toHaveBeenCalled();
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        state: 'compliant'
+                    });
                     done();
                 });
             });
@@ -340,7 +361,9 @@ define([
                 spyOn(sut, 'tracking');
 
                 sut.load().then(function () {
-                    expect(sut.tracking).toHaveBeenCalledWith('AR_13');
+                    expect(sut.tracking).toHaveBeenCalledWith({
+                        widgetId: 'AR_13'
+                    });
                     done();
                 });
             });


### PR DESCRIPTION
## What does this change?

- add isOutbrainDisabled to check dispatcher and mediator
- use isOutbrainDisabled check when evaluating whether email-sign up form can run
- use isOutbrainDisabled check in outbrain.js

## What is the value of this and can you measure success?

isOutbrainDisabled is a more appropriate check than thirdPartyTagsDisabled when deciding whether to show email sign-ups.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
