### PR TITLE
Remove inline-source-map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const webpack = require('webpack');
 const bundlePrefix = 'graun.';
 
 module.exports = ({ env = 'dev', plugins = [] } = {}) => ({
-    devtool: env === 'dev' ? 'inline-source-map' : 'source-map',
+    devtool: 'source-map',
     entry: {
         standard: path.join(
             __dirname,


### PR DESCRIPTION
## What does this change?

This change ensures sourcemaps will always be generated using `source-map` rather than [the now undocumented](https://webpack.js.org/configuration/devtool/) `inline-source-map`.

## What is the value of this and can you measure success?

`inline-source-map` does not work in Firefox at all, making it very awkward to debug. `source-map` does produce usable sourcemaps in Firefox Developmer Edition, making it possible to add breakpoints in the debugger. However, errors in the console are still not mapped to the pristine source.

There is some very active investigation happening in Webpack-land around browser support for source maps (webpack/webpack#3165) so we may be able to start experimenting with the newer devtools soon.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
