### PR TITLE
Ensure advert exists before checking conditions

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/sticky-top-banner.js
@@ -84,7 +84,8 @@ define([
         .then(function (isRendered) {
             if (isRendered) {
                 var advert = getAdvertById(topSlotId);
-                if (advert.size &&
+                if (advert &&
+                    advert.size &&
                     // skip for Fabric creatives
                     advert.size[0] !== 88 &&
                     // skip for native ads


### PR DESCRIPTION
## What does this change?

Ensure an `advert` exists before checking its size.

## What is the value of this and can you measure success?

Removes a whole bunch of odd error messages that have been plaguing our builds and causing confusion

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 203](https://cloud.githubusercontent.com/assets/5931528/24160563/1e3e6452-0e5a-11e7-9df6-53f9bf9d70c3.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
