### PR TITLE
New header switch

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -5,6 +5,7 @@
 @import views.support.Commercial.isPaidContent
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
+@import conf.switches.Switches.NewHeader
 
 @schemaType(page: ArticlePage) = @{page.article.metadata.schemaType}
 
@@ -35,7 +36,7 @@
                 @fragments.guBand()
             }
 
-            @if(!mvt.ABNewNavVariantSeven.isParticipating || amp) {
+            @if(!NewHeader.isSwitchedOn || amp) {
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
                 @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
@@ -66,7 +67,7 @@
                             @fragments.mainMedia(article, amp)
                         }
 
-                        @if(mvt.ABNewNavVariantSeven.isParticipating && !amp) {
+                        @if(NewHeader.isSwitchedOn && !amp) {
                             <div class="mobile-only">
                                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
                             </div>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -498,4 +498,13 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val NewHeader = Switch(
+    SwitchGroup.Feature,
+    "new-header",
+    "New header switch, just in case anything is really wrong with it",
+    owners = Seq(Owner.withGithub("natalialkb")),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 4, 12),
+    exposeClientSide = false
+  )
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -16,29 +16,6 @@ import conf.switches.Switches.ServerSideTests
 //    val tests = List(ExampleTest)
 // }
 
-
-object ABNewNavVariantSeven extends TestDefinition(
-  name = "ab-new-nav-variant-seven",
-  description = "users in this test will see the new header seventh variant",
-  owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2017, 3, 23)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variantseven")
-  }
-}
-
-object ABNewNavControl extends TestDefinition(
-  name = "ab-new-nav-control",
-  description = "control for the new header test",
-  owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2017, 3, 23)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("control")
-  }
-}
-
 object CommercialClientLoggingVariant extends TestDefinition(
   name = "commercial-client-logging",
   description = "A slice of the audience who will post their commercial js performance data",
@@ -96,8 +73,6 @@ trait ServerSideABTests {
 
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
-    ABNewNavVariantSeven,
-    ABNewNavControl,
     CommercialClientLoggingVariant,
     YouTubePosterOverride,
     ABNewRecipeDesign,

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -11,7 +11,7 @@
         </a>
 
         <a href="@LinkTo{/}" class="header__logo-wrapper" tabindex="0" data-link-name="amp : nav : logo">
-            <h1 class="u-h">The Guardian</h1>
+            <span class="u-h">The Guardian - Back to home</span>
             @fragments.inlineSvg("guardian-logo-160", "logo", List("header__logo"))
         </a>
 

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -8,7 +8,7 @@
 @import conf.switches.Switches._
 
 <footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
-    <div class="l-footer__primary @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}">
+    <div class="l-footer__primary @if(NewHeader.isSwitchedOn) {hide-on-mobile}">
         <div id="footer-nav" class="gs-container">
             <div class="brand-bar modern-visible u-cf">
                 <a href="@LinkTo {/}" data-link-name="site logo" class="guardian-logo-footer hide-on-mobile">
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-    @if(mvt.ABNewNavVariantSeven.isParticipating) {
+    @if(NewHeader.isSwitchedOn) {
         <div class="mobile-only footer__primary">
             <a data-link-name="back to top" href="#top">
                 <div class="footer__back-to-top__container">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,5 +1,4 @@
 @(page: model.Page, showNormalHeader: Boolean = false)(implicit request: RequestHeader)
-@import common.editions._
 @import common.{Edition, LinkTo, SubscribeLink}
 @import conf.Configuration
 @import conf.switches.Switches._

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,12 +3,12 @@
 @import conf.Configuration
 @import conf.switches.Switches._
 
-@if(mvt.ABNewNavVariantSeven.isParticipating) {
+@if(NewHeader.isSwitchedOn) {
     @fragments.newHeader(page)
 }
 
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header @if(mvt.ABNewNavVariantSeven.isParticipating) {hide-on-mobile}"
+        class="l-header u-cf @if(page.metadata.hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header @if(NewHeader.isSwitchedOn) {hide-on-mobile}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -1,6 +1,7 @@
 @import layout.ContentWidths.MainMedia
 @import model.ImageAsset
 @import views.support.{ImgSrc, Item700}
+@import conf.switches.Switches.NewHeader
 
 @(
     picture: model.ImageMedia,
@@ -107,7 +108,7 @@
 @caption(picture: model.ImageMedia, imageOption: Option[ImageAsset], isMain: Boolean) = {
     @imageOption.map { img =>
         @if(img.showCaption) {
-            @if(isMain && mvt.ABNewNavVariantSeven.isParticipating) {
+            @if(isMain && NewHeader.isSwitchedOn) {
 
                 <input type="checkbox" id="show-caption" class="mobile-only u-h">
 

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -132,7 +132,7 @@
 
         <div class="new-header-feedback">
             @fragments.inlineSvg("information-circle", "icon", List("main-menu__icon", "main-menu__icon--information"))
-            This navigation is new. We'd appreciate your feedback. <a href="https://goo.gl/forms/yZQtbFVli8ABMYJF2">Share your thoughts here.</a>
+            This navigation is new. We'd appreciate your feedback. <a href="https://goo.gl/forms/yZQtbFVli8ABMYJF2" data-link-name="nav2: survey">Share your thoughts here.</a>
         </div>
     </div>
 </div>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -11,7 +11,7 @@
         ) { case (currentTopLevelSection) =>
             <div class="new-header__inner gs-container">
                 <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="nav2 : logo">
-                    <span class="u-h">The Guardian</span>
+                    <span class="u-h">The Guardian - Back to home</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
                 </a>
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -27,7 +27,7 @@
                     </a>
                 }
 
-                <nav class="new-header__nav" data-component="nav2">
+                <nav class="new-header__nav" data-component="nav2" role="navigation">
                     <ul class="new-header__nav-primary-links">
                         @NewNavigation.PrimaryLinks.map { link =>
                             <li class="new-header__nav-link-item">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -11,7 +11,7 @@
         ) { case (currentTopLevelSection) =>
             <div class="new-header__inner gs-container">
                 <a href="@LinkTo{/}" class="new-header__logo-wrapper" tabindex="0" data-link-name="nav2 : logo">
-                    <h1 class="u-h">The Guardian</h1>
+                    <span class="u-h">The Guardian</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", List("new-header__logo"))
                 </a>
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -27,7 +27,7 @@
                     </a>
                 }
 
-                <nav class="new-header__nav" data-component="nav2" role="navigation">
+                <nav class="new-header__nav" data-component="nav2" role="navigation" aria-label="Guardian sections">
                     <ul class="new-header__nav-primary-links">
                         @NewNavigation.PrimaryLinks.map { link =>
                             <li class="new-header__nav-link-item">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @(page: model.Page, projectName: Option[String] = None, showNormalHeader: Boolean = false)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, Navigation, commercial}
-@import conf.switches.Switches.{BreakingNewsSwitch}
+@import conf.switches.Switches.{BreakingNewsSwitch, NewHeader}
 @import model.Page.getContent
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
@@ -42,7 +42,7 @@
             ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
-            ("has-new-header", mvt.ABNewNavVariantSeven.isParticipating),
+            ("has-new-header", NewHeader.isSwitchedOn),
             ("has-super-sticky-banner", content.exists(_.tags.hasSuperStickyBanner)),
             ("is-immersive", content.exists(_.content.isImmersive)),
             ("is-immersive-interactive", content.exists(content => content.tags.isInteractive && content.content.isImmersive))))"


### PR DESCRIPTION
## What does this change?
To merge tomorrow. 

This makes the new header permanent on mobile! To be safe (as we haven't received any serious complaints yet), rather than just removing the test, I am making it a switch for a short time. 

## What is the value of this and can you measure success?
Both in user testing and in our a/b test, this change was proved successful. Pending any serious complaints from editorial, this change should go to 100% tomorrow. 🎉 

## Does this affect other platforms - Amp, Apps, etc?
Nope. The new header is already on AMP.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/8774970/24193548/8dc9e428-0eea-11e7-9991-cb678829efa0.png)


## Tested in CODE?
Nope
