### PR TITLE
engagement banner copy test removed

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,16 +22,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-engagement-banner-copy-test",
-    "Test copy for the engagement banner in all countries aside from the US and Australia",
-    owners = Seq(Owner.withGithub("Mullefa")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 24),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-increase-inline-ads",
     "Displays more inline ads in articles on desktop",
     owners = Seq(Owner.withGithub("regiskuckaertz")),

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -132,11 +132,6 @@ define([
 
             var userVariant = engagementBannerTest ? segmentUtil.variantFor(engagementBannerTest) : undefined;
 
-            // If we have found a copy test variant, then defer building the banner params to the variant.
-            if (engagementBannerTest && engagementBannerTest.id === 'MembershipEngagementBannerCopyTest' && userVariant) {
-                return userVariant.deriveBannerParams()
-            }
-
             // offering = 'membership' or 'contributions'
             var offering = Object.keys(userVariant?userVariant.params:paramsByOfferingForUserEdition)[0];
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -2,7 +2,6 @@ define([
     'bean',
     'qwery',
     'lib/config',
-    'lib/geolocation',
     'lib/storage',
     'lodash/utilities/template',
     'commercial/modules/commercial-features',
@@ -12,7 +11,6 @@ define([
     bean,
     qwery,
     config,
-    geolocation,
     storage,
     template,
     commercialFeatures,
@@ -80,177 +78,10 @@ define([
 
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
-    // Below are the 6 messages that are being tested, modulo the currency/amount which is dependent on the user's geolocation.
-    // The reader's geolocation is also used on the membership website to determine the currency/amount,
-    // therefore, the pricing should remain consistent between the engagement banner and the membership website.
-    //
-    // CONTROL
-    // For less than the price of a coffee a week, you could help secure the Guardian's future.
-    // Support our journalism for £5 a month.
-    //
-    // WEEKLY PRICE
-    // For less than the price of a coffee a week, you could help secure the Guardian's future.
-    // Support our journalism from 95p a week.
-    //
-    // SOCIAL PROOF
-    // Join hundreds of thousands of Guardian readers and help secure our future.
-    // Support our journalism today for just £5 a month.
-    //
-    // OPPORTUNITY
-    // If you’ve been thinking about supporting us, we’ve never needed you more.
-    // Support our journalism today for just £5 a month.
-    //
-    // SPEED
-    // It only takes two minutes to play your part in helping to secure the Guardian’s future.
-    // Support our journalism today for just £5 a month.
-    //
-    // LOW COST / BIG IMPACT
-    // From helping us hold power to account, to giving a voice to the voiceless, your money can do a lot of good.
-    // Support our journalism for just £5 a month.
-
-    // We don't want to run these tests on the US or Australia audience, as this would delay releasing them by ~ week.
-    function isNotInUSOrAU() {
-        var countryCode = geolocation.getSync();
-        return countryCode !== 'US' && countryCode !== 'AU'
-    }
-
-    // Prices taken from https://membership.theguardian.com/<region>/supporter
-    var monthlySupporterCost = {
-        GB:  '£5',
-        US:  'US$6.99',
-        AU:  'AU$10',
-        CA:  'CA$6.99',
-        EU:  '€4.99',
-        INT: 'US$6.99'
-    };
-
-    // today boolean argument accounts for the fact that some monthly CTA's contain the word 'today', and others don't
-    function monthlySupporterCta(today) {
-        var prefix;
-        if (today) {
-            prefix = 'Support our journalism today for just'
-        }
-        else {
-            prefix = 'Support our journalism for just'
-        }
-        return function() {
-            var region = geolocation.getSupporterPaymentRegion();
-            var cost = monthlySupporterCost[region];
-            return prefix + ' ' + cost + ' a month.'
-        }
-    }
-
-    var monthlySupporterCtaWithToday = monthlySupporterCta(true);
-
-    var monthlySupporterCtaWithoutToday = monthlySupporterCta(false);
-
-    // Prices based on https://membership.theguardian.com/<region>/supporter
-    var weeklySupporterCost = {
-        GB:  '95p',
-        US:  'US$1.33',
-        AU:  'AU$1.92',
-        CA:  'CA$1.33',
-        EU:  '€0.95',
-        INT: 'US$1.33'
-    };
-
-    function weeklySupporterCta() {
-        var region = geolocation.getSupporterPaymentRegion();
-        var cost = weeklySupporterCost[region];
-        return 'Support our journalism today from ' + cost + ' a week.'
-    }
-
-    function completer(complete) {
-        mediator.on('membership-message:display', function () {
-            // When the button link is clicked, call the function that indicates the A/B test is 'complete'
-            // ...note that for Membership & Contributions this completion is only the start of a longer
-            // journey that will hopefully end pages later with the user giving us money.
-            bean.on(qwery('#membership__engagement-message-link')[0], 'click', complete);
-        });
-    }
-
-    var CopyTest = function() {
-        this.id = 'MembershipEngagementBannerCopyTest';
-        this.start = '2017-02-27';
-        this.expiry = '2017-03-24';
-        this.author = 'Guy Dawson';
-        this.description = 'Test different copy for the engagement banner.';
-        this.audience = 0.5;
-        this.audienceOffset = 0.5;
-        this.successMeasure = 'Supporter click-through rate and/or acquisition rate';
-        this.audienceCriteria = 'All readers.';
-        this.idealOutcome = 'We are able to establish which copy is best, with statistical significance';
-
-        this.canRun = function() {
-            return commercialFeatures.canReasonablyAskForMoney && isNotInUSOrAU();
-        };
-
-        this.variants = [];
-    };
-
-    // cta should be a function which returns the call-to-action which is placed after the message text.
-    CopyTest.prototype.addVariant = function(variantId, messageText, cta) {
-
-        function createCampaignCode(variantId) {
-            // Campaign code follows convention. Talk to Alex for more information.
-            return 'gdnwb_copts_mem_kr3_learn_banner_copy_' + variantId;
-        }
-
-        this.variants.push({
-            id: variantId,
-
-            // We don't want to run any 'code' in this test, we just want a variant to be selected.
-            // All message display is performed in membership-engagement-banner.js,
-            // modifying the banner using the data in variantParams.
-            test: function () {},
-
-            success: completer,
-
-            // This allows a lot of the deriveBannerParams() logic (in membership-engagement-banner.js) to be by-passed.
-            // If that function has picked up a variant from the CopyTest test, call this method and be done with it.
-            deriveBannerParams: function() {
-                return {
-                    minArticles: 3,
-                    messageText: messageText + ' ' + cta(),
-                    colourStrategy: function() {
-                        return 'membership-prominent dark-blue'
-                    },
-                    linkUrl: 'https://membership.theguardian.com/supporter',
-                    buttonCaption: 'Become a Supporter',
-                    campaignCode: createCampaignCode(variantId)
-                }
-            }
-        });
-
-        return this;
-    };
 
     return [
         new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-04-07', 'remind_me_later')
             .addMembershipVariant('control', {})
-            .addMembershipVariant('remind_me', {showRemindMe : true}),
-
-        // Release the first 3 variants. The remaining 2 will be released when the 'Remind Me Later' test is complete.
-        new CopyTest()
-            .addVariant(
-                'control',
-                'For less than the price of a coffee a week, you could help secure the Guardian’s future.',
-                monthlySupporterCtaWithoutToday
-            )
-            .addVariant(
-                'weekly_price',
-                'For less than the price of a coffee a week, you could help secure the Guardian’s future.',
-                weeklySupporterCta
-            )
-            .addVariant(
-                'social_proof',
-                'Join hundreds of thousands of Guardian readers and help secure our future.',
-                monthlySupporterCtaWithToday
-            )
-            .addVariant(
-                'opportunity',
-                'If you’ve been thinking about supporting us, we’ve never needed you more.',
-                monthlySupporterCtaWithToday
-            )
+            .addMembershipVariant('remind_me', {showRemindMe : true})
     ]
 });


### PR DESCRIPTION
@guardian/contributions 
@guardian/membership-and-subscriptions 

## What does this change?

Remove the engagement banner copy test.

## What is the value of this and can you measure success?

Frees up audience share so the (prioritised) epic vs epic and engagement banner test can be run. The copy test which is being removed has not reached statistical significance, but has still provided data which will influence the next iteration of the copy test.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No, tested locally.
