### PR TITLE
Adding women back as a section

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -345,6 +345,7 @@ object NewNavigation {
       SectionsLink("society", society, Life),
       SectionsLink("lifeandstyle/food-and-drink", food, Life),
       SectionsLink("tone/recipes", recipes, Life),
+      SectionsLink("lifeandstyle/women", women, Life),
       SectionsLink("lifeandstyle/health-and-wellbeing", health, Life),
       SectionsLink("lifeandstyle/family", family, Life),
       SectionsLink("lifeandstyle/home-and-garden", home, Life),


### PR DESCRIPTION
## What does this change?
Bug accidentally introduced in https://github.com/guardian/frontend/pull/16181.

The section women was taken out, and mostly put back in. It was just missed in one place. This puts it back.

## What is the value of this and can you measure success?
Fixes this problem:
(this section should be women)
![image](https://cloud.githubusercontent.com/assets/8774970/24197581/1702dd26-0efa-11e7-881d-4bc338552131.png)


## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
No

