### PR TITLE
Fix js enhanced split points

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -175,9 +175,9 @@ define([
         if (config.page.showNewRecipeDesign === true) {
             //below is for during testing
             if (config.tests.abNewRecipeDesign) {
-                require(['bootstraps/enhanced/recipe-article'], function (recipes) {
-                    bootstrapContext('recipes', recipes);
-                });
+                require.ensure([], function (require) {
+                    bootstrapContext('recipes', require('bootstraps/enhanced/recipe-article'));
+                }, 'recipes');
             }
         }
 

--- a/tools/__tasks__/compile/javascript/webpack.js
+++ b/tools/__tasks__/compile/javascript/webpack.js
@@ -14,6 +14,11 @@ module.exports = {
         const config = require('../../../../webpack.config.js')({
             env: 'production',
             plugins: [
+                new webpack.optimize.AggressiveMergingPlugin({
+                    // delicate number: stops enhanced-no-commercial and enhanced
+                    // being merged into one
+                    minSizeReduce: 1.6,
+                }),
                 new Visualizer({
                     filename: './webpack-stats.html',
                 }),

--- a/tools/__tasks__/compile/javascript/webpack.js
+++ b/tools/__tasks__/compile/javascript/webpack.js
@@ -14,7 +14,6 @@ module.exports = {
         const config = require('../../../../webpack.config.js')({
             env: 'production',
             plugins: [
-                new webpack.optimize.AggressiveMergingPlugin(),
                 new Visualizer({
                     filename: './webpack-stats.html',
                 }),


### PR DESCRIPTION
## What does this change?

increases the saving required for `AggressiveMergingPlugin` to kick in

## What is the value of this and can you measure success?

stops it merging `enhanced` and `enhanced-no-commercial`, which are really pseudo-entry points, not code-split points.

we should probably do this more cleverly

## Tested in CODE?

- [x] check on code