### PR TITLE
Old header sans-splosion

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -76,12 +76,12 @@ $c-guardian-services-action: #ffffff;
     }
 
     @include mq(tablet) {
-        margin-top: $gs-baseline * .5;
+        margin-top: -$gs-baseline / 2;
         margin-bottom: $gs-baseline * .5;
 
         svg {
-            width: 320px;
-            height: 60px;
+            width: 360px;
+            height: auto;
         }
     }
 

--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -81,7 +81,7 @@ $c-guardian-services-action: #ffffff;
 
         svg {
             width: 360px;
-            height: auto;
+            height: 68px;
         }
     }
 

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -18,7 +18,7 @@
 // to context matching).
 
 .brand-bar__item {
-    @include fs-bodyHeading(1);
+    @include fs-textSans(3);
     user-select: none;
     float: left;
     color: $c-guardian-services-action;

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -90,9 +90,9 @@ $c-navigation-expandable-background: $neutral-1;
 .local-navigation,
 .global-navigation,
 .signposting {
-    @include fs-headline(2);
+    @include fs-textSans(5);
     line-height: $navigation-height;
-    font-weight: 500;
+    font-weight: 600;
 
     // Restore opentype kerning settings in WebKit / Blink
     -webkit-font-feature-settings: 'kern' 1;
@@ -637,7 +637,8 @@ $c-navigation-expandable-background: $neutral-1;
 
 // TODO: Move
 .navigation-toggle {
-    @include fs-header(1);
+    @include fs-textSans(5);
+    font-weight: 600;
     z-index: 4; /* ensure it is higher than .top-navigation__action */
     position: absolute;
     right: 0;


### PR DESCRIPTION
## What does this change?
Subtle, but important. The desktop header will have a bit more in common visually with the new mobile header.

<img width="1380" alt="screen shot 2017-03-22 at 16 00 35" src="https://cloud.githubusercontent.com/assets/14570016/24207467/d6edc36c-0f18-11e7-91db-1de5ac38232d.png">

<img width="1499" alt="screen shot 2017-03-22 at 16 00 57" src="https://cloud.githubusercontent.com/assets/14570016/24207468/d7ce3b86-0f18-11e7-84bf-9e6437e86e27.png">

To be merged Thurs 23rd March. 
