### PR TITLE
Fix queryparams construction on Tailor's module

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -39,8 +39,8 @@ define([
         this.expiry = '2017-04-28';
         this.author = 'Manlio & Mahana';
         this.description = 'Testing Tailor surveys';
-        this.audience = 0.25;
-        this.audienceOffset = 0.7;
+        this.audience = 1;
+        this.audienceOffset = 0;
         this.successMeasure = 'We can show a survey on Frontend as decided by Tailor';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = 'Tailor survey';

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -32,7 +32,7 @@ define([
         if (queryParams) {
             var queryParamList = Object.keys(queryParams);
 
-            baseURL += '?';
+            baseURL += '&';
 
             queryParamList.forEach(function (queryParam, i) {
                 baseURL += queryParam + '=' + queryParams[queryParam];


### PR DESCRIPTION
The `baseURL` already contains `suggestions?browserId=`, so when we attach the query parameters to it  they must come after an `&` and not a `?`.

Also target 100pc of our audience because the filtering is done by Tailor.

@GHaberis @MahanaC 