### PR TITLE
Fix docs links

### DIFF
--- a/docs/01-start-here/06-testing-tips.md
+++ b/docs/01-start-here/06-testing-tips.md
@@ -1,9 +1,9 @@
 # Testing tips
 
-1. [Running localhost] (#running-localhost)
-2. [Testing AMP] (#testing-amp)
+1. [Running localhost](#running-localhost)
+2. [Testing AMP](#testing-amp)
 3. [Device Testing](#device-testing)
-4. [Testing local on CODE] (#testing-your-local-on-code)
+4. [Testing local on CODE](#testing-your-local-on-code)
 
 
 # Running localhost


### PR DESCRIPTION
## What does this change?
Remove some white space which breaks the links formatting [here](https://github.com/guardian/frontend/blob/master/docs/01-start-here/06-testing-tips.md)

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/24252742/428fa1a4-0fd6-11e7-89aa-19fdaa3ad8d9.png)