### PR TITLE
Paid card AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -250,4 +250,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 3, 30),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-paid-card-logo",
+    "Trialling paid cards in editorial containers",
+    owners = Seq(Owner.withGithub("lps88")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 5, 3),
+    exposeClientSide = true
+  )
 }

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -5,7 +5,7 @@
 @import views.html.fragments.commercial.cardLogo
 
 @badgeNoImage(branding: Branding) = {
-    <div class="badge badge--branded badge--no-image">
+    <div class="badge badge--no-image">
         <div class="badge__label">
             Paid for by @branding.sponsorName
         </div>
@@ -26,13 +26,13 @@
                     @item.headline
                 </div>
             </div>
+
+            @item.branding.map(badgeNoImage)
+
+            @item.branding.map(branding =>
+                cardLogo(branding, isStandardSizeCard = false)
+            )
         </div>
-
-        @item.branding.map(badgeNoImage)
-
-        @item.branding.map(branding =>
-            cardLogo(branding, isStandardSizeCard = true)
-        )
 
         <a href="@item.targetUrl" class="u-faux-block-link__overlay js-headline-text" data-link-name="Labs paid card | @omnitureId" tabindex="-1"></a>
     </div>

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -24,6 +24,7 @@ define([
     'common/modules/experiments/tests/sleeve-notes-legacy-email-variant',
     'common/modules/experiments/tests/increase-inline-ads',
     'common/modules/experiments/tests/reading-time',
+    'common/modules/experiments/tests/paid-card-logo',
     'ophan/ng',
     'common/modules/experiments/tests/paid-commenting'
 ], function (reportError,
@@ -51,6 +52,7 @@ define([
              SleevenotesLegacyEmailVariant,
              IncreaseInlineAds,
              ReadingTime,
+             PaidCardLogo,
              ophan,
              PaidCommenting
     ) {
@@ -70,6 +72,7 @@ define([
         SleevenotesLegacyEmailVariant,
         new IncreaseInlineAds(),
         new ReadingTime(),
+        new PaidCardLogo(),
         new PaidCommenting()
     ].concat(MembershipEngagementBannerTests));
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
@@ -11,7 +11,7 @@ define([
 ) {
     return function () {
         this.id = 'PaidCardLogo';
-        this.start = '2017-03-22';
+        this.start = '2017-03-29';
         this.expiry = '2017-03-31';
         this.author = 'Lydia Shepherd';
         this.description = 'Paid cards in editorial containers - trial with and without logo';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
@@ -1,0 +1,54 @@
+define([
+    'bean',
+    'qwery',
+    'lib/$',
+    'lib/config'
+], function (
+    bean,
+    qwery,
+    $,
+    config
+) {
+    return function () {
+        this.id = 'PaidCardLogo';
+        this.start = '2017-03-22';
+        this.expiry = '2017-03-31';
+        this.author = 'Lydia Shepherd';
+        this.description = 'Paid cards in editorial containers - trial with and without logo';
+        this.showForSensitive = true;
+        this.audience = 0;  // wait until we know where the test will run
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = '';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'One or both versions of this card perform measurably better than an MPU';
+        this.hypothesis = '';
+
+        this.canRun = function () {
+            return config.page.pageId === "commercial-containers" && qwery(".adverts--within-unbranded").length;
+        };
+
+        this.completeFunc = function(complete) {
+            $('.adverts--within-unbranded').each(function(el){
+                el.addEventListener('click', complete);
+            });
+        };
+
+        this.variants = [
+            {
+                id: 'with-logo',
+                test: function () {},
+                success: this.completeFunc
+            },
+            {
+                id: 'without-logo',
+                test: function () {
+                    $('.adverts--within-unbranded').each(function(el){
+                        el.classList.add('without-sponsor-logo');
+                    });
+                },
+                success: this.completeFunc
+            }
+        ];
+    };
+});

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -385,29 +385,39 @@
     .fc-item__title {
         @include f-headlineSans;
     }
-    @include mq(tablet) {
-        .fc-item__content {
-            padding-bottom: $gs-baseline * 8;
+
+    .fc-item__content {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        flex: 1;
+        @include mq(mobileLandscape, tablet) {
+            flex-direction: row;
         }
     }
 
-    @include mq($until: tablet) {
-        .fc-item__content {
-            padding-right: $gs-gutter * 5;
-        }
-        .badge {
-            display: flex;
-            flex-direction: column;
-            width: $gs-gutter * 3;
-        }
-    }
     .badge {
+        display: flex;
+        align-self: flex-end;
+        justify-content: flex-end;
         pointer-events: none;
-        right: 0;
+        flex-shrink: 0;
+        padding-left: $gs-gutter;
+        @include mq(mobileLandscape) {
+            flex-direction: column;
+        }
     }
     .badge__label {
         text-align: center;
-        width: 100%;
+        align-self: center;
+    }
+    .badge__link {
+        @include mq($until: mobileLandscape) {
+            margin-left: $gs-gutter;
+        }
+        @include mq($until: tablet) {
+            width: $gs-gutter * 3;
+        }
     }
     .badge__logo {
         max-width: 100%;
@@ -425,13 +435,9 @@
     }
 
     &.without-sponsor-logo {
-        @include mq(tablet) {
-            .fc-item__content {
-                padding-bottom: $gs-baseline * 3;
-            }
-        }
         .badge--no-image {
             display: block;
+            margin-bottom: $gs-baseline/2;
             + .badge {
                 display: none;
             }


### PR DESCRIPTION
## What does this change?
New AB test to measure clicks on two variants of the new paid cards in editorial containers. Also improve the card layout with some flexbox magic.

## Does this affect other platforms - Amp, Apps, etc?
We will need to exclude the card from Apps fronts as there isn't proper styling in place for those.

## Screenshots
With sponsor logos:
![image](https://cloud.githubusercontent.com/assets/6290008/24255847/77e0e7fc-0fde-11e7-9aaa-cb7f28a23bf6.png)
Without logos:
![image](https://cloud.githubusercontent.com/assets/6290008/24255910/ad8d5778-0fde-11e7-8f74-50550b7b99f7.png)
 
Mobile size:
![image](https://cloud.githubusercontent.com/assets/6290008/24255995/eef4796c-0fde-11e7-94c9-a0492a412cec.png)


