### PR TITLE
Enforce flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,7 +14,7 @@ module.name_mapper='^common' -> 'projects/common'
 module.name_mapper='^facia' -> 'projects/facia'
 module.name_mapper='^membership' -> 'projects/membership'
 module.name_mapper='^commercial' -> 'projects/commercial'
-module.name_mapper='^lodash(.*)$' -> 'lodash-amd/compat$1'
+module.name_mapper='^lodash\(.*\)$' -> 'lodash-amd/compat\1'
 module.name_mapper='^picturefill' -> 'projects/common/utils/picturefill'
 module.name_mapper='^Promise' -> 'when/es6-shim/Promise'
 module.name_mapper='^raven' -> 'raven-js'
@@ -24,6 +24,7 @@ module.name_mapper='^stripe' -> 'stripe/stripe.min'
 module.name_mapper='^svgs' -> '<PROJECT_ROOT>/static/src/inline-svgs'
 module.name_mapper='^ophan/ng' -> 'ophan-tracker-js'
 module.name_mapper='^ophan/embed' -> 'ophan-tracker-js/build/ophan.embed'
+module.name_mapper='^raw-loader!.*$' -> '<PROJECT_ROOT>/dev/flow-asset-stub'
 
 module.file_ext=.js
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -25,6 +25,7 @@ module.name_mapper='^svgs' -> '<PROJECT_ROOT>/static/src/inline-svgs'
 module.name_mapper='^ophan/ng' -> 'ophan-tracker-js'
 module.name_mapper='^ophan/embed' -> 'ophan-tracker-js/build/ophan.embed'
 module.name_mapper='^raw-loader!.*$' -> '<PROJECT_ROOT>/dev/flow-asset-stub'
+module.name_mapper='^inlineSvg!.*$' -> '<PROJECT_ROOT>/dev/flow-asset-stub'
 
 module.file_ext=.js
 

--- a/dev/flow-asset-stub.js
+++ b/dev/flow-asset-stub.js
@@ -1,0 +1,1 @@
+export default '';

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -1,10 +1,11 @@
+// @flow
 module.exports = {
     parser: 'babel-eslint',
     settings: {
         'import/resolver': 'webpack',
     },
     extends: ['plugin:flowtype/recommended'],
-    plugins: ['guardian-frontend', 'flowtype'],
+    plugins: ['guardian-frontend', 'flowtype', 'flow-header'],
     rules: {
         // require-specific overrides
         'import/no-extraneous-dependencies': 'off', // necessary while we use aliases
@@ -54,6 +55,8 @@ module.exports = {
                 patterns: ['!lodash/*'],
             },
         ],
+
+        'flow-header/flow-header': 2,
 
         // our own rules for frontend
         // live in tools/eslint-plugin-guardian-frontend

--- a/static/src/javascripts/bootstraps/enhanced/devtools.js
+++ b/static/src/javascripts/bootstraps/enhanced/devtools.js
@@ -1,3 +1,5 @@
+// @flow
+
 import showDevTools from 'common/modules/devtools';
 
 export default {

--- a/static/src/javascripts/lib/.eslintrc.js
+++ b/static/src/javascripts/lib/.eslintrc.js
@@ -1,8 +1,0 @@
-// @flow
-module.exports = {
-    parser: 'babel-eslint',
-    plugins: ['flow-header'],
-    rules: {
-        'flow-header/flow-header': 2,
-    },
-};

--- a/static/src/javascripts/projects/common/modules/commercial/temp.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/temp.spec.js
@@ -1,5 +1,0 @@
-// #karma-jest temporary test to make sure jest is working
-
-test('temporary fake test', () => {
-    expect(1 + 2).toBe(3);
-});

--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -1,3 +1,4 @@
+// @flow
 import template from 'lodash/utilities/template';
 import storage from 'lib/storage';
 import $ from 'lib/$';

--- a/static/src/javascripts/temp.spec.js
+++ b/static/src/javascripts/temp.spec.js
@@ -1,5 +1,0 @@
-// #karma-jest temporary test to make sure jest is working
-
-test('temporary fake test', () => {
-    expect(1 + 2).toBe(3);
-});


### PR DESCRIPTION
## What does this change?

enforces flow-type in modern JS

## What is the value of this and can you measure success?

- no reason no to – explicit typing is not mandatory
- should help catch implicit errors (I think?)