### PR TITLE
Amp outbrain compliancy

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -307,6 +307,8 @@ final case class Content(
 
   val quizzes: Seq[Quiz] = atoms.map(_.quizzes).getOrElse(Nil)
   val media: Seq[MediaAtom] = atoms.map(_.media).getOrElse(Nil)
+
+  val nonCompliantOutbrainAmp = (hasStoryPackage && tags.series.nonEmpty) || (tags.series.length > 1)
 }
 
 object Content {

--- a/common/app/views/fragments/amp/onwardJourneys.scala.html
+++ b/common/app/views/fragments/amp/onwardJourneys.scala.html
@@ -1,14 +1,15 @@
 @(page: model.Page, related: model.RelatedContent, content: model.Content)(implicit context: model.ApplicationContext)
 
 @if(content.metadata.sectionId != "childrens-books-site") {
+
     @if(related.hasStoryPackage) {
         @fragments.amp.storyPackageAmp(related)
     }
-    @if(content.tags.series.nonEmpty) {
-        @content.tags.series.map { tag =>
-            @fragments.amp.onwardTemplateAmp("series-mf2/" + tag.id + ".json")
-        }
+
+    @content.tags.series.map { tag =>
+        @fragments.amp.onwardTemplateAmp("series-mf2/" + tag.id + ".json")
     }
+
     @if(content.showInRelated
         && !related.hasStoryPackage
         && content.tags.series.isEmpty) {
@@ -16,7 +17,7 @@
     }
 
     @if(!content.shouldHideAdverts) {
-        @fragments.amp.outbrain(page)
+        @fragments.amp.outbrain(page, nonCompliant = content.nonCompliantOutbrainAmp)
     }
 
     @defining({

--- a/common/app/views/fragments/amp/outbrain.scala.html
+++ b/common/app/views/fragments/amp/outbrain.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)
+@(page: model.Page, nonCompliant: Boolean)
 @import conf.switches.Switches.OutbrainSwitch
 @import views.support.URLEncode
 
@@ -8,7 +8,7 @@
         sandbox="allow-scripts allow-same-origin allow-popups"
         layout="fixed-height"
         frameborder="0"
-        src="https://widgets.outbrain.com/hub/amp.html#widgetIds=AMP_1&amp;htmlURL=@URLEncode(htmlUrl)&amp;ampURL=@URLEncode(s"$htmlUrl?amp")"
+        src="https://widgets.outbrain.com/hub/amp.html#widgetIds=@if(nonCompliant){AMP_2}else{AMP_1}&amp;htmlURL=@URLEncode(htmlUrl)&amp;ampURL=@URLEncode(s"$htmlUrl?amp")"
         class="fc-container__outbrain">
             <div overflow class="cta cta--medium cta--show-more">
                 @fragments.inlineSvg("plus", "icon")

--- a/common/app/views/fragments/amp/outbrain.scala.html
+++ b/common/app/views/fragments/amp/outbrain.scala.html
@@ -4,11 +4,10 @@
 
 @if(OutbrainSwitch.isSwitchedOn) {
     @defining(page.metadata.webUrl) { htmlUrl =>
-        <amp-iframe height=175
+        <amp-iframe height=456
         sandbox="allow-scripts allow-same-origin allow-popups"
         layout="fixed-height"
         frameborder="0"
-        resizable
         src="https://widgets.outbrain.com/hub/amp.html#widgetIds=AMP_1&amp;htmlURL=@URLEncode(htmlUrl)&amp;ampURL=@URLEncode(s"$htmlUrl?amp")"
         class="fc-container__outbrain">
             <div overflow class="cta cta--medium cta--show-more">


### PR DESCRIPTION
## What does this change?
https://trello.com/c/9jdCKTqA/253-outbrain-compliancy-on-amp

Sometimes there might be two containers above outbrain, which makes those views noncompliant. If there are two series containers like this article: 

https://amp.theguardian.com/cities/2017/mar/23/dalian-china-russian-city-heritage-demolition-in-pictures

Or there is a story package, and a series container this might happen. 

This change makes it so that non compliant outbrain views request `AMP_2` instad of `AMP_1`, as requested by outbrain. Also, outbrain is always the same height, so we can just use that height instead of making it a responsive iframe.

@guardian/commercial-dev 

## What is the value of this and can you measure success?
Properly marked outbrain views.

## Does this affect other platforms - Amp, Apps, etc?
This should only affect AMP

## Screenshots
![image](https://cloud.githubusercontent.com/assets/8774970/24293703/06540634-108b-11e7-85f4-65b3264c5a57.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
