### PR TITLE
remove rendundant youtube parameters

### DIFF
--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -4,7 +4,7 @@
     <amp-youtube
     data-videoid="@media.assets.head.id"
     layout="responsive"
-    width="16" height="9" data-param-modestbranding="1" data-param-rel="0" data-param-showinfo="1">
+    width="16" height="9" data-param-rel="0">
     </amp-youtube>
 
 @if(displayCaption) {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -30,10 +30,8 @@
             @defining(s"https://www.youtube.com/embed${
                 media.assets.head.id
                 .addParams(List(
-                "modestbranding" -> 1,
                 "enablejsapi" -> 1,
                 "rel" -> 0,
-                "showinfo" -> 1,
                 "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>


### PR DESCRIPTION
## What does this change?
Removes redundant parameters from YouTube player. This is as per the following updates from YouTube:

> A minimum branding requirement is fulfilled by the YouTube logo being in the bottom right of the player, as such 'modestbranding' no longer has any effect.
> The 'showinfo' parameter is not available when the PfP player is in use.


## What is the value of this and can you measure success?
Remove redundant code

## Does this affect other platforms - Amp, Apps, etc?
Yes, same change is applied to AMP template

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
