### PR TITLE
Re-Add check for supporter to epic logic

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -87,7 +87,10 @@ define([
 
         var tagsMatch = doTagsMatch(testConfig);
 
+        var canReasonablyAskForMoney = commercialFeatures.canReasonablyAskForMoney;
+
         return enoughTimeSinceLastContribution &&
+            canReasonablyAskForMoney &&
             worksWellWithPageTemplate &&
             inCompatibleLocation &&
             locationCheck &&


### PR DESCRIPTION
## What does this change?

The canReasonablyAskForMoney check that we do when deciding whether to show someone the epic was mistakenly removed from the default checks on Friday. This PR fixes that. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 