### PR TITLE
Fix icon sizing of Frame creative

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/frame.js
@@ -28,7 +28,7 @@ define([
     };
 
     Frame.prototype.create = function () {
-        this.params.externalLinkIcon = svg(externalLink.markup, ['gu-external-icon']);
+        this.params.externalLinkIcon = svg(externalLink.markup, ['frame__external-link-icon']);
         this.params.target = this.params.newWindow === 'yes' ? '_blank' : '_self';
         this.params.id = 'frame-' + (Math.random() * 10000 | 0).toString(16);
 

--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -149,6 +149,11 @@ $mobile-max-container-width: gs-span(8);
     color: #ffffff;
 }
 
+.frame__external-link-icon svg {
+    width: 20px;
+    height: 10px;
+}
+
 .has-no-flex {
     .frame__logo,
     .frame__content,


### PR DESCRIPTION
## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/6290008/24359651/da6ec4f4-12fc-11e7-978b-1fe5ff82bc12.png)

After:
![image](https://cloud.githubusercontent.com/assets/6290008/24359592/b05e50a8-12fc-11e7-8cd5-8f25d49908e6.png)

## Tested in CODE?
Yes
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
