### PR TITLE
Hide menu on opera mini

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -913,4 +913,10 @@ $caption-button-size: 32px;
     }
 }
 
+// Don't show menu on opera mini: https://wp-mix.com/css-target-opera/
+x:-o-prefocus, .main-menu-container,
+x:-o-prefocus, .new-header__nav__menu-button {
+    display: none;
+}
+
 @import '../module/nav/_supporter-trapezoid';

--- a/static/src/stylesheets/module/nav/_supporter-trapezoid.scss
+++ b/static/src/stylesheets/module/nav/_supporter-trapezoid.scss
@@ -51,3 +51,8 @@
         left: $gs-gutter/2;
     }
 }
+
+// Don't show trapezoid on opera mini: https://wp-mix.com/css-target-opera/
+x:-o-prefocus, .header__supporter-cta {
+    display: none;
+}


### PR DESCRIPTION
## What does this change?
When the new header went out to 100% of the mobile audience, it was revealed how bad it looks on opera mini! 

This is how it looks:
![screenshot_20170327-151420](https://cloud.githubusercontent.com/assets/8774970/24361638/5288897a-1302-11e7-84ca-96b84b1dde52.png)

To keep the site usable, I think the best thing to do is just to hide the menu on opera mini in extreme data savings mode. The subnav and pillars are still visible so users can still navigate. 

This is what it looks like: 

![screenshot_20170327-151344](https://cloud.githubusercontent.com/assets/8774970/24361642/5444c3a0-1302-11e7-906a-2399ccc66245.png)

For your interest @ScottPainterGNM @stephanfowler 

## What is the value of this and can you measure success?
Users hopefully can still use the site on opera mini in extreme data savings mode

## Does this affect other platforms - Amp, Apps, etc?
The menu doesn't work in AMP either, but AMP doesn't actively support opera mini (in extreme data savings mode), just the normal opera browser. 

Given AMP pages are unlikely to surface in opera mini right now, I don't think there is a point in fixing it there.

## Tested in CODE?
Yep! Works as expected

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
