### PR TITLE
Set default border colour in front emails

### DIFF
--- a/static/src/stylesheets/email/_front.scss
+++ b/static/src/stylesheets/email/_front.scss
@@ -121,6 +121,14 @@ $email-tones: (
     sleeve-notes: #ffbb00
 );
 
+// Defaults
+.container-title.has-top-border {
+    border-top: 3px solid #46bcdf;
+}
+.tone-external {
+    border-top: 1px solid #46bcdf;
+}
+
 @each $email, $tone-color in $email-tones {
     .#{$email} {
         .container-title.has-top-border {


### PR DESCRIPTION
The default border colour got lost in the big refactor of #16244 

## before
![picture 495](https://cloud.githubusercontent.com/assets/5122968/24361908/20c6fa88-1303-11e7-9bd9-a94ff34e2ded.png)

## after
![picture 494](https://cloud.githubusercontent.com/assets/5122968/24361909/226b70d0-1303-11e7-8c55-9f16d54c338d.png)