### PR TITLE
Replace table bottom captions with tfoot elements

### DIFF
--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -54,9 +54,13 @@
             <caption class="table__caption table__caption--top" itemprop="name">
                 @theMatch.competitionName, @theMatch.venueName
             </caption>
-            <caption class="table__caption table__caption--bottom" >
-                <a class="table__caption--bottom-link" href=@LinkTo(matchUrl)>View full scorecard</a>
-            </caption>
+            <tfoot class="table__caption table__caption--bottom" >
+                <tr>
+                    <td colspan="2">
+                        <a class="table__caption--bottom-link" href="@LinkTo(matchUrl)">View full scorecard</a>
+                    </td>
+                </tr>
+            </tfoot>
         </table>
     </div>
 

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -85,8 +85,25 @@
         }
         <span class="football-matches__date">@date.toString("E d MMMM")</span>
     </caption>
-    @if(linkToCompetition && link == None){<caption class="table__caption table__caption--bottom"><a href="@competition.url@if(matchType!=""){/@matchType}" data-link-name="view @competition.fullName matches" class="full-table-link">Show more <span class="competition-name">@competition.fullName</span> @matchType</a></caption>}
+    @if(linkToCompetition && link == None){
+        <tfoot class="table__caption table__caption--bottom" >
+            <tr>
+                <td colspan="4">
+                    <a href="@competition.url@if(matchType!=""){/@matchType}" data-link-name="view @competition.fullName matches" class="full-table-link">
+                        Show more <span class="competition-name">@competition.fullName</span> @matchType
+                    </a>
+                </td>
+            </tr>
+        </tfoot>
+    }
+
     @link.map{ case (text, href) =>
-            <caption class="table__caption table__caption--bottom"><a href="@href" data-link-name="view matches" class="full-table-link">@text</a></caption>
+        <tfoot class="table__caption table__caption--bottom" >
+            <tr>
+                <td colspan="4">
+                    <a href="@href" data-link-name="view matches" class="full-table-link">@text</a>
+                </td>
+            </tr>
+        </tfoot>
     }
 </table>

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -70,6 +70,14 @@
                 <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
             </caption>
         }
-        @if(linkToCompetition){<caption class="table__caption table__caption--bottom"><a href="@{competition.url + "/table"}" data-link-name="full table" class="full-table-link">View full <span class="competition-name">@competition.fullName</span> table</a></caption>}
+        @if(linkToCompetition){
+            <tfoot class="table__caption table__caption--bottom" >
+                <tr>
+                    <td colspan="11">
+                        <a href="@{competition.url + "/table"}" data-link-name="full table" class="full-table-link">View full <span class="competition-name">@competition.fullName</span> table</a>
+                    </td>
+                </tr>
+            </tfoot>
+        }
     </table>
 </div>


### PR DESCRIPTION
## What does this change?

Fixes [bug](https://trello.com/c/4d3NxZeU/239-cricket-view-scorecard-link-missing-on-firefox) on Firefox where the 'View full scorecard' doesn't show. This was because Firefox only shows the first caption in a table.

The fix was to use the correct element for these links in tables `<tfoot>` which is slightly more semantically correct (though you could argue which shouldn't be using tables for some of these 'tables' in the first place but that's another issue.)

## What is the value of this and can you measure success?

Show's the links properly.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![screen shot 2017-03-27 at 15 40 17](https://cloud.githubusercontent.com/assets/638051/24362603/31739790-1305-11e7-8a5e-6373048b8741.jpg)


## Tested in CODE?
No.