### PR TITLE
Add Webpack Bundle Analyzer plugin to Webpack config

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,6 +3,9 @@
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const Visualizer = require('webpack-visualizer-plugin');
+const BundleAnalyzerPlugin = require(
+    'webpack-bundle-analyzer'
+).BundleAnalyzerPlugin;
 
 const config = require('./webpack.config.js');
 
@@ -20,6 +23,11 @@ module.exports = webpackMerge.smart(config, {
         }),
         new Visualizer({
             filename: './webpack-stats.html',
+        }),
+        new BundleAnalyzerPlugin({
+            reportFilename: './bundle-analyzer-report.html',
+            analyzerMode: 'static',
+            openAnalyzer: false,
         }),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),


### PR DESCRIPTION
## What does this change?

This plugin was accidentally removed by the Webpack config refactor in #16176. This change reinstates it to its former glory

## What is the value of this and can you measure success?

We can analyse Webpack bundles in a neo-maxi-zoom-awesome way

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
