### PR TITLE
Extend sleevenotes email signup AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -116,7 +116,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the new email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 31),
+    sellByDate = new LocalDate(2017, 4, 10),
     exposeClientSide = true
   )
 
@@ -126,7 +126,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the old email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 3, 31),
+    sellByDate = new LocalDate(2017, 4, 10),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesLegacyEmailVariant',
             start: '2017-03-02',
-            end: '2017-03-31',
+            end: '2017-04-10',
             author: 'Leigh-Anne Mathieson',
             audience: 0.3,
             audienceOffset: 0.7,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesNewEmailVariant',
             start: '2017-03-02',
-            end: '2017-03-31',
+            end: '2017-04-10',
             author: 'Leigh-Anne Mathieson',
             audience: 0.7,
             audienceOffset: 0,


### PR DESCRIPTION
## What does this change?
We are running an AB test for new subscribers to the Sleevenotes email (see: [15996](https://github.com/guardian/frontend/pull/15996)). This just extends the expiry of the test. 

## What is the value of this and can you measure success?
MORE DATA. 😄 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
