### PR TITLE
Add email front routes to dev-build

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -36,9 +36,9 @@ GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize
 GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()
 GET            /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
-# Email paths
-GET            /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
-GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
+# Email signup paths
+GET            /email/form/$emailType<article|footer|plain|plaindark|plaintone>/:listId                                          controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET            /email/$result<success|invalid|error>                                                                             controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()
 OPTIONS        /email                                                                                                            controllers.EmailSignupController.options()
 
@@ -388,6 +388,7 @@ GET            /                                                                
 GET            /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|world/asia|business/companies|football)>           controllers.FaciaController.renderFrontPressSpecial(path)
 GET            /rss                                                                                                              controllers.FaciaController.renderRootFrontRss()
 GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|business|money|travel|rss))?>                       controllers.FaciaController.renderFrontPress(path)
+GET            /$path<email/.*>                                                                                                  controllers.FaciaController.renderFrontPress(path)
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
 GET            /*path/deduped.json                                                                                               controllers.DedupedController.getDedupedForPath(path)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)


### PR DESCRIPTION
As far back as I can remember, I always wanted my email fronts to work on `dev-build`. But even when I added a line to the routes file it didn't seem to work. Why was this? Many sleepless nights were spent pondering this seemingly insoluble riddle.

Then one day, I decided to spend more than five seconds looking at the `routes` file, and miraculously found the answer. One of the email signup routes was matching my email front URLs and giving a 404.

Case closed.

@guardian/dotcom-platform 