### PR TITLE
Hide poster image when playing

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/video.js
@@ -125,6 +125,8 @@ define([
             return Promise.resolve();
         }
 
+        var posterImage = document.querySelector('.hosted__youtube-poster-image');
+
         // Return a promise that resolves after the async work is done.
         new Promise(function(resolve){
             require.ensure([], function (require) {
@@ -143,7 +145,9 @@ define([
                 setupVideo(el, videojs);
             });
 
-            $youtubeIframe.each(hostedYoutube.init);
+            $youtubeIframe.each(function (el) {
+                hostedYoutube.init(el, posterImage);
+            });
         })
         .then(stop, stop);
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
@@ -83,8 +83,6 @@ define([
                 if (posterImage) {
                     if (event.data === -1 || event.data === window.YT.PlayerState.PLAYING) {
                         posterImage.style.backgroundImage = null;
-                    } else if (event.data === window.YT.PlayerState.PAUSED) {
-                        posterImage.style.backgroundImage = posterImageSrc;
                     }
                 }
             },

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
@@ -40,10 +40,11 @@ define([
         });
     }
 
-    function init(el) {
+    function init(el, posterImage) {
         var atomId = $(el).data('media-id');
         var duration = $(el).data('duration');
         var $currentTime = $('.js-youtube-current-time');
+        var posterImageSrc = posterImage ? posterImage.style.backgroundImage : null;
         var playTimer;
 
         tracking.init(atomId);
@@ -77,6 +78,14 @@ define([
                     }, 1000);
                 } else {
                     clearTimeout(playTimer);
+                }
+
+                if (posterImage) {
+                    if (event.data === -1 || event.data === window.YT.PlayerState.PLAYING) {
+                        posterImage.style.backgroundImage = null;
+                    } else if (event.data === window.YT.PlayerState.PAUSED) {
+                        posterImage.style.backgroundImage = posterImageSrc;
+                    }
                 }
             },
             onPlayerReady: function (event) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
@@ -44,7 +44,6 @@ define([
         var atomId = $(el).data('media-id');
         var duration = $(el).data('duration');
         var $currentTime = $('.js-youtube-current-time');
-        var posterImageSrc = posterImage ? posterImage.style.backgroundImage : null;
         var playTimer;
 
         tracking.init(atomId);


### PR DESCRIPTION
Fixes a bug where the poster image would overlay the youtube player while playing and jam the display.

(you'll have to trust me on this as my GIF recorder does not work with youtube videos)

I don't know if we should put the background back when the video has ended.