### PR TITLE
Add switch for email style inlining

### DIFF
--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -6,6 +6,7 @@ import akka.pattern.CircuitBreakerOpenException
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
+import conf.switches.Switches.InlineEmailStyles
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
@@ -66,7 +67,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       if (request.isJson)
         JsonComponent(jsonResponse())
       else if (request.isEmail)
-        RevalidatableResult.Ok(InlineStyles(htmlResponse()))
+        RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse()) else htmlResponse())
       else
         RevalidatableResult.Ok(htmlResponse())
     }
@@ -76,7 +77,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       if (request.isJson)
         JsonComponent(page, jsonResponse())
       else if (request.isEmail)
-        RevalidatableResult.Ok(InlineStyles(htmlResponse()))
+        RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse()) else htmlResponse())
       else
         RevalidatableResult.Ok(htmlResponse())
     }
@@ -86,7 +87,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       if (request.isJson)
         JsonComponent(jsonResponse())
       else if (request.isEmail)
-        RevalidatableResult.Ok(InlineStyles(htmlResponse()))
+        RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse()) else htmlResponse())
       else
         RevalidatableResult.Ok(htmlResponse())
     }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -507,4 +507,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 4, 12),
     exposeClientSide = false
   )
+
+  val InlineEmailStyles = Switch(
+    SwitchGroup.Feature,
+    "inline-email-styles",
+    "When ON, email styles will be stripped from the <head> and inlined into HTML style attributes",
+    owners = Seq(Owner.withGithub("joelochlann")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 4, 28),
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -514,7 +514,7 @@ trait FeatureSwitches {
     "When ON, email styles will be stripped from the <head> and inlined into HTML style attributes",
     owners = Seq(Owner.withGithub("joelochlann")),
     safeState = On,
-    sellByDate = new LocalDate(2018, 4, 28),
+    sellByDate = never,
     exposeClientSide = false
   )
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -14,6 +14,7 @@ import services.{CollectionConfigWithId, ConfigAgent}
 import slices._
 import views.html.fragments.containers.facia_cards.container
 import views.support.FaciaToMicroFormat2Helpers.getCollection
+import conf.switches.Switches.InlineEmailStyles
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -119,8 +120,9 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           else if (request.isJson)
             Cached(CacheTime.Facia)(JsonFront(faciaPage))
           else if (request.isEmail || ConfigAgent.isEmailFront(path)) {
+            val htmlResponse = views.html.frontEmail(faciaPage)
             Cached(CacheTime.Facia) {
-              RevalidatableResult.Ok(InlineStyles(views.html.frontEmail(faciaPage)))
+              RevalidatableResult.Ok(if (InlineEmailStyles.isSwitchedOn) InlineStyles(htmlResponse) else htmlResponse)
             }
           }
           else {


### PR DESCRIPTION
A common workflow when making changes to emails is make changes in the browser first, then put them through https://litmus.com to see how they look in mail clients. Gmail and Outlook require styles to be inlined into style attributes, so in Litmus we want the styles inlined. But in the browser it's much easier to see what's going on without all that noise. So we need an easy to way to switch this on and off.

A further reason for having a switch is that Gmail recently started supporting styles in the `<head>`. Ideally at some point we would switch to not inlining styles (which would significantly reduce the size of the email), if we can [meet all the conditions Gmail imposes](https://www.emailonacid.com/blog/article/email-development/12_things_you_must_know_when_developing_for_gmail_and_gmail_mobile_apps). This will be a fiddly and error-prone task so we'd definitely want the ability to switch the inlining on & off while working through any issues.

@guardian/dotcom-platform 