### PR TITLE
fix the poster image not hiding when video is playing in Chrome

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -134,6 +134,17 @@
     pointer-events: none;
 }
 
+.youtube__video-buffering,
+.youtube__video-playing,
+.youtube__video-paused {
+    ~ .hosted__youtube-poster-image {
+        // HACK! "hide" the poster image (with a 0 height) when video is playing
+        // but position static for hosted__youtube-play-button's absolute positioning to work
+        height: 0;
+        position: static;
+    }
+}
+
 .youtube__video-ended,
 .hosted__youtube-video:not(.youtube__video-started) {
     ~ .hosted__youtube-poster-image {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -104,7 +104,7 @@
     width: 100%;
     height: 100%;
     position: absolute;
-    background-size: 0;
+    background-size: cover;
 }
 
 .hosted__youtube-play-button {
@@ -142,13 +142,6 @@
         // but position static for hosted__youtube-play-button's absolute positioning to work
         height: 0;
         position: static;
-    }
-}
-
-.youtube__video-ended,
-.hosted__youtube-video:not(.youtube__video-started) {
-    ~ .hosted__youtube-poster-image {
-        background-size: cover;
     }
 }
 


### PR DESCRIPTION
## What does this change?
For some reason, Chrome 57 doesn't like the current css, I think its to do with the background-size property but can't confirm.

As a really hacky fix, lets make the height of the poster 0 to "hide" it when the video is playing/paused.

Removing background-size wasn't an option because the poster image needs to stretch to fill its container (background-size: cover).

Using opacity also wasn't an option as this effects child elements and made the "Watch now" button transparent.

## What is the value of this and can you measure success?
Hosted video pages with a youtube video works again.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
Before
![before](https://cloud.githubusercontent.com/assets/836140/24402285/b63168a4-13af-11e7-9804-93c225e75d28.gif)

After
![after](https://cloud.githubusercontent.com/assets/836140/24402261/a05a3448-13af-11e7-8ff9-23c8f0b7416e.gif)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
