### PR TITLE
Force display of the inline merch slot

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -197,7 +197,7 @@ define([
             para.parentNode.insertBefore(ad, para);
         })
         .then(function () {
-            addSlot(ad);
+            addSlot(ad, name === 'im');
         });
     }
 });


### PR DESCRIPTION
It should not happen often, but to be on the safe side, we want to make sure the inline merch slot triggers a display as soon as it is added in the article.