### PR TITLE
Extend article badges switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -384,7 +384,7 @@ trait FeatureSwitches {
     "When ON, articles specified in the badges file will have visual elements added",
     owners = Seq(Owner.withGithub("superfrank")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 3, 28),
+    sellByDate = new LocalDate(2017, 8, 31),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Extending switch to avoid broken build

@guardian/dotcom-platform @superfrank 
