### PR TITLE
Experiment - use selection for feedbak and explanations [do not merge]

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/selection-sharing.js
@@ -97,8 +97,8 @@ define([
             range,
             rect,
             top,
-            twitterMessage,
-            editHref,
+            //twitterMessage,
+            //editHref,
             disagreeHref;
 
         if (selection && selection.rangeCount > 0 && selection.toString()) {
@@ -114,7 +114,7 @@ define([
             // explainers http://internal.content.guardianapis.com/atoms?types=explainer&page-size=200&q=brexit&searchFields=data.title
             // question and answers 
 
-            twitterMessage = range.toString();
+            //twitterMessage = range.toString();
 
 
             if (!isValidSelection(range)) {

--- a/static/src/javascripts-legacy/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/selection-sharing.js
@@ -8,9 +8,11 @@ define([
     'lib/mediator',
     'lodash/utilities/template',
     'raw-loader!common/views/ui/selection-sharing.html',
+    'raw-loader!common/views/ui/selection-validate-edit.html',
     'common/views/svgs',
     'lodash/functions/debounce',
-    'lodash/collections/some'
+    'lodash/collections/some',
+    'ophan/ng'
 ], function (
     bean,
     bonzo,
@@ -21,27 +23,42 @@ define([
     mediator,
     template,
     sharingTemplate,
+    validateTemplate,
     svgs,
     debounce,
-    some
+    some,
+    ophan
 ) {
 
     var $body = bonzo(document.body),
-        twitterIcon = svgs('shareTwitter', ['icon', 'centered-icon']),
-        emailIcon = svgs('shareEmail', ['icon', 'centered-icon']),
+        editIcon = svgs('quoteIcon', ['icon', 'centered-icon']),
+        wrongIcon = svgs('crossIcon', ['icon', 'centered-icon']),
+        commentIcon = svgs('comment16icon', ['icon', 'centered-icon']),
+        exploreIcon = svgs('searchIcon', ['icon', 'centered-icon']),
+        validateIcon = svgs('tick', ['icon', 'centered-icon']),
+        cancelIcon = svgs('crossIcon', ['icon', 'centered-icon']),
         selectionSharing = template(sharingTemplate, {
-            twitterIcon: twitterIcon,
-            emailIcon: emailIcon
+            editIcon: editIcon,
+            wrongIcon: wrongIcon,
+            commentIcon: commentIcon,
+            exploreIcon: exploreIcon
         }),
         $selectionSharing = $.create(selectionSharing),
-        $twitterAction,
-        $emailAction,
-        twitterShortUrl = config.page.shortUrl + '/stw',
-        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=%E2%80%9C<%=text%>%E2%80%9D&url=<%=url%>',
-        twitterMessageLimit = 114, // 140 - t.co length - 3 chars for quotes and url spacing
+        selectionValidateEdit = template(validateTemplate, {
+            validateIcon: validateIcon,
+            cancelIcon: cancelIcon,
+        }),
+        $selectionValidateEdit = $.create(selectionValidateEdit),
+        $editAction,
+        $disagreeAction,
+        $validateEditAction,
+        $cancelEditAction,
         emailShortUrl = config.page.shortUrl + '/sbl',
         emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=%E2%80%9C<%=selection%>%E2%80%9D <%=url%>',
         validAncestors = ['js-article__body', 'content__standfirst', 'block', 'caption--main', 'content__headline'],
+        selectionNode,
+        selectionNodeCopy,
+        selectionRect,
 
     isValidSelection = function (range) {
         // commonAncestorContainer is buggy, can't use it here.
@@ -62,6 +79,18 @@ define([
         }
     },
 
+    hideValidate = function () {
+        if ($selectionValidateEdit.hasClass('selection-sharing--active')) {
+            $selectionValidateEdit.removeClass('selection-sharing--active');
+        }
+    },
+
+    showValidate = function () {
+        if (!$selectionValidateEdit.hasClass('selection-sharing--active')) {
+            $selectionValidateEdit.addClass('selection-sharing--active');
+        }
+    },
+
     updateSelection = function () {
 
         var selection = window.getSelection && document.createRange && window.getSelection(),
@@ -69,14 +98,24 @@ define([
             rect,
             top,
             twitterMessage,
-            twitterHref,
-            emailHref;
+            editHref,
+            disagreeHref;
 
         if (selection && selection.rangeCount > 0 && selection.toString()) {
             range = selection.getRangeAt(0);
             rect = clientRects.getBoundingClientRect(range);
-            top = $body.scrollTop() + rect.top;
+
+
+            selectionNode = selection.anchorNode.parentNode;
+            selectionNodeCopy = selectionNode && selectionNode.cloneNode(true);
+            selectionRect = rect;
+            
+            //TODO extract from the range entities and find related questions 
+            // explainers http://internal.content.guardianapis.com/atoms?types=explainer&page-size=200&q=brexit&searchFields=data.title
+            // question and answers 
+
             twitterMessage = range.toString();
+
 
             if (!isValidSelection(range)) {
                 hideSelection();
@@ -84,23 +123,20 @@ define([
             }
 
             // Truncate the twitter message.
-            if (twitterMessage.length > twitterMessageLimit) {
-                twitterMessage = twitterMessage.slice(0, twitterMessageLimit - 1) + '…';
-            }
+            //if (twitterMessage.length > twitterMessageLimit) {
+            //    twitterMessage = twitterMessage.slice(0, twitterMessageLimit - 1) + '…';
+            //}
 
-            twitterHref = template(twitterHrefTemplate, {
-                text: encodeURIComponent(twitterMessage),
-                url: encodeURI(twitterShortUrl)
-            });
-            emailHref = template(emailHrefTemplate, {
+            disagreeHref = template(emailHrefTemplate, {
                 subject: encodeURI(config.page.webTitle),
                 selection: encodeURI(range.toString()),
                 url: encodeURI(emailShortUrl)
             });
 
-            $twitterAction.attr('href', twitterHref);
-            $emailAction.attr('href', emailHref);
+            //$editAction.attr('href', agreeHref);
+            $disagreeAction.attr('href', disagreeHref);
 
+            top = $body.scrollTop() + rect.top;
             $selectionSharing.css({
                 top: top + 'px',
                 left: rect.left + 'px'
@@ -118,13 +154,75 @@ define([
         }
     },
 
+
+    onEditStart = function (event) {
+        event.preventDefault();
+        if (selectionNode) {
+
+            //set content as editable
+            selectionNode.setAttribute("contenteditable", "true");
+            
+            //correctly position edition validation
+            var top = $body.scrollTop() + selectionRect.top;
+            var left = selectionRect.left;
+            $selectionValidateEdit.css({
+                top: top + 'px',
+                left:left + 'px'
+            });
+            
+            // hide selection UI by clearing selection range and display validation UI 
+            var selection = window.getSelection && window.getSelection();
+            if (selection) {
+                selection.removeAllRanges();
+            }
+            selectionNode.focus();
+            showValidate();
+        }
+    },
+
+    onEditValidate = function (event) {
+        event.preventDefault();
+        if (selectionNode) {
+            selectionNode.setAttribute("contenteditable", "false");
+            hideValidate();
+            selectionNode.parentNode.replaceChild(selectionNodeCopy, selectionNode)
+            selectionNode = null;
+             ophan.record({
+                component: 'feedback',
+                value: selectionNode.innerText
+            });
+        }
+    },
+
+    onEditCancel = function (event) {
+        event.preventDefault();
+        if (selectionNode) {
+            selectionNode.setAttribute("contenteditable", "false");
+            hideValidate();
+            selectionNode.parent.replaceChild(selectionNodeCopy, selectionNode)
+            selectionNode = null;
+        }
+    },
+
+
     initSelectionSharing = function () {
         // The current mobile Safari returns absolute Rect co-ordinates (instead of viewport-relative),
         // and the UI is generally fiddly on touch.
         if (!detect.hasTouchScreen()) {
             $body.append($selectionSharing);
-            $twitterAction = $('.js-selection-twitter');
-            $emailAction = $('.js-selection-email');
+            $body.append($selectionValidateEdit);
+            $editAction = $('.js-selection-edit');
+            $disagreeAction = $('.js-selection-wrong');
+
+            $validateEditAction =$('.js-selection-edit-validate');
+            $cancelEditAction =$('.js-selection-edit-cancel');
+            
+
+            bean.on($editAction[0], 'click', onEditStart);
+            bean.on($validateEditAction[0], 'click', onEditValidate);
+            bean.on($cancelEditAction[0], 'click', onEditCancel);
+
+
             // Set timeout ensures that any existing selection has been cleared.
             bean.on(document.body, 'keypress keydown keyup', debounce(updateSelection, 50));
             bean.on(document.body, 'mouseup', debounce(updateSelection, 200));

--- a/static/src/javascripts-legacy/projects/common/views/svgs.js
+++ b/static/src/javascripts-legacy/projects/common/views/svgs.js
@@ -21,6 +21,7 @@ define([
     'svg-loader!svgs/icon/arrow-right.svg',
     'svg-loader!svgs/icon/bookmark.svg',
     'svg-loader!svgs/icon/dropdown-mask.svg',
+    'svg-loader!svgs/icon/comment-16.svg',
     'svg-loader!svgs/icon/comment-anchor.svg',
     'svg-loader!svgs/icon/reply.svg',
     'svg-loader!svgs/icon/expand-image.svg',
@@ -45,6 +46,8 @@ define([
     'svg-loader!svgs/commercial/adblock-coins-us.svg',
     'svg-loader!svgs/icon/star.svg',
     'svg-loader!svgs/icon/chevron-right.svg',
+    'svg-loader!svgs/icon/information.svg',
+    'svg-loader!svgs/icon/search-36.svg',
     'common/views/svg'
 ], function (
     commentCount16icon,
@@ -65,6 +68,7 @@ define([
     arrowRight,
     bookmark,
     dropdownMask,
+    comment16icon,
     commentAnchor,
     reply,
     expandImage,
@@ -89,6 +93,8 @@ define([
     adblockCoinsUS,
     star,
     chevronRight,
+    informationIcon,
+    searchIcon,
     svg
 ) {
     var svgs = {
@@ -110,6 +116,7 @@ define([
         arrowRight: arrowRight,
         bookmark: bookmark,
         dropdownMask: dropdownMask,
+        comment16icon: comment16icon,
         commentAnchor: commentAnchor,
         reply: reply,
         expandImage: expandImage,
@@ -133,7 +140,9 @@ define([
         notificationsExplainerMobile: notificationsExplainerMobile,
         star: star,
         chevronRight: chevronRight,
-        logomembershipwhite: membershipLogoWhite
+        logomembershipwhite: membershipLogoWhite,
+        informationIcon: informationIcon,
+        searchIcon: searchIcon
     };
 
     return function (name, classes, title) {

--- a/static/src/javascripts/projects/common/views/ui/selection-sharing.html
+++ b/static/src/javascripts/projects/common/views/ui/selection-sharing.html
@@ -1,21 +1,39 @@
 <div class="selection-sharing">
     <ul class="social u-unstyled u-cf" data-component="social-selection">
-        <li class="social__item" data-link-name="twitter">
-            <a  class="rounded-icon social-icon social-icon--twitter js-selection-twitter"
+        <li class="social__item" data-link-name="edit">
+            <a  class="rounded-icon social-icon social-icon--edit js-selection-edit"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">
-                <span class="u-h">Share on Twitter</span>
-                <%= twitterIcon %>
+                <span class="u-h">Edit</span>
+                <%= editIcon %>
             </a>
         </li>
-        <li class="social__item" data-link-name="email">
-            <a  class="rounded-icon social-icon social-icon--email js-selection-email"
+        <li class="social__item" data-link-name="wrong">
+            <a  class="rounded-icon social-icon social-icon--wrong js-selection-wrong"
                 data-link-name="social-selection"
                 target="_blank"
                 href="#">
-                <span class="u-h">Share via Email</span>
-                <%= emailIcon %>
+                <span class="u-h">This is wrong!</span>
+                <%= wrongIcon %>
+            </a>
+        </li>
+        <li class="social__item" data-link-name="">
+            <a  class="rounded-icon social-icon social-icon--comment js-selection-comment"
+                data-link-name="social-selection"
+                target="_blank"
+                href="#">
+                <span class="u-h">Comment</span>
+                <%= commentIcon %>
+            </a>
+        </li>
+        <li class="social__item" data-link-name="explore">
+            <a  class="rounded-icon social-icon social-icon--explore js-selection-explore"
+                data-link-name="social-selection"
+                target="_blank"
+                href="#">
+                <span class="u-h">Explore</span>
+                <%= exploreIcon %>
             </a>
         </li>
     </ul>

--- a/static/src/javascripts/projects/common/views/ui/selection-validate-edit.html
+++ b/static/src/javascripts/projects/common/views/ui/selection-validate-edit.html
@@ -1,0 +1,22 @@
+<div class="selection-sharing">
+    <ul class="social u-unstyled u-cf" data-component="social-selection">
+        <li class="social__item" data-link-name="validate">
+            <a  class="rounded-icon social-icon social-icon--edit-validate js-selection-edit-validate"
+                data-link-name="social-selection"
+                target="_blank"
+                href="#">
+                <span class="u-h">Validate</span>
+                <%= validateIcon %>
+            </a>
+        </li>
+        <li class="social__item" data-link-name="cancel">
+            <a  class="rounded-icon social-icon social-icon--edit-cancel js-selection-edit-cancel"
+                data-link-name="social-selection"
+                target="_blank"
+                href="#">
+                <span class="u-h">Cancel</span>
+                <%= cancelIcon %>
+            </a>
+        </li>
+    </ul>
+</div>

--- a/static/src/stylesheets/module/_social-icons.scss
+++ b/static/src/stylesheets/module/_social-icons.scss
@@ -36,3 +36,70 @@
 .social-icon--email {
     @include social-icon($social-email);
 }
+
+.social-icon--edit {
+    background-color: #005689;
+    &:hover {
+        background-color: darken(#005689, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}
+
+
+.social-icon--edit-validate {
+    background-color: green;
+    &:hover {
+        background-color: darken(green, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}
+
+.social-icon--edit-cancel {
+    background-color: red;
+    &:hover {
+        background-color: darken(red, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}
+
+.social-icon--wrong {
+    background-color: #005689;
+    &:hover {
+        background-color: darken(#005689, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}
+
+.social-icon--comment {
+    background-color: #005689;
+    &:hover {
+        background-color: darken(#005689, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}
+
+.social-icon--explore {
+    background-color: #005689;
+    &:hover {
+        background-color: darken(#005689, 10%);
+    }
+    svg {
+        height: 40%;
+        width: 40%;
+    }
+}


### PR DESCRIPTION

![hackweek-mini](https://cloud.githubusercontent.com/assets/615085/24418534/28d210fa-13e4-11e7-97bd-42c14f75f513.png)

## What does this change?

This an experiment to leverage the user selection to provide more useful user interactions than the current social actions, more specifically allow a user of the website:
- edit typo errors as on wikipedia, using `contenteditable` feature
- report wrong facts 
- comment on a specific part of an articles
- search for related content in explainers and user questions.

The code currently tries to report `typo` and `wrong facts` directly in ophan, but one can imagine having an additional moderation layer,  such as moderation tools, before letting editorial people access the feedback.

Code is hacky and features are not fully implemented but one can see the general ideas.

## What is the value of this and can you measure success?

I think there are 2 things that will be interesting to measure to evaluate success:
- simplicity for user and latency for updating articles compared to current solutions with comments and feedback ml.
- how people stay on the page, if they find a way to navigate to our own content when they don't understand or want to know more about a subject

## Does this affect other platforms - Amp, Apps, etc?
no and does not work on mobile safari as well

## Screenshots

- 4 available actions on selection

<img width="645" alt="screen shot 2017-03-24 at 14 56 14" src="https://cloud.githubusercontent.com/assets/615085/24419423/f3f3f97c-13e6-11e7-8c92-e5cde085990d.png">

- correct a typo and send it to ophan

![hackweekdemo](https://cloud.githubusercontent.com/assets/615085/24419422/f3f3d406-13e6-11e7-952a-4d89df2bbc39.gif)


## Tested in CODE?
no 😃 