### PR TITLE
Australian edition nav updates

### DIFF
--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -42,7 +42,7 @@ object Au extends Edition(
       NavItem(sport, Seq(australiaSport, afl, nrl, aLeague, football, cricket, rugbyunion, tennis, cycling, boxing)),
       NavItem(football, aLeague :: footballNav.toList),
       NavItem(culture, cultureLocalNav),
-      NavItem(lifeandstyle, Seq(australiaFoodAndDrink, australiaRelationships, australiaFashion, recipes, australiaHealthAndWellbeing, women)),
+      NavItem(lifeandstyle, Seq(australiaFoodAndDrink, recipes, australiaRelationships, australiaFashion, australiaHealthAndWellbeing, women)),
       NavItem(environment, Seq(cities, globalDevelopment, ausustainablebusiness)),
       NavItem(economy, economyLocalNav),
       NavItem(media),

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -20,7 +20,7 @@ object NavLinks {
   var auPolitics = NavLink("AU politics", "/australia-news/australian-politics", "australia-news/australian-politics", longTitle = "australian politics")
   var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum", "australia-news/australian-immigration-and-asylum")
   var indigenousAustralia = NavLink("indigenous australia", "/australia-news/indigenous-australians", "australia-news/indigenous-australians")
-  var indigenousAustraliaOpinion = NavLink("indigenous", "commentisfree/series/indigenousx", "commentisfree/series/indigenousx")
+  var indigenousAustraliaOpinion = NavLink("Indigenous", "/australia-news/indigenous-australians+tone/comment", "commentisfree/series/indigenousx")
   var usNews = NavLink("US", "/us-news", "us-news", longTitle = "US news")
   var usPolitics = NavLink("US politics", "/us-news/us-politics", "us-news/us-politics", longTitle = "US politics")
   val education = NavLink("education", "/education", "education")


### PR DESCRIPTION
## What does this change?
Some more Australian edition tweaks to the nav requested from editorial. 

cc @guardian/dotcom-platform

## What is the value of this and can you measure success?
Hopefully they are the correct links now

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope
