### PR TITLE
[Discuss?] Preload standard, polyfill and commercial instead of prefetch

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -23,12 +23,13 @@ http://developers.theguardian.com/join-the-team.html
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
 @fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
 
-<link rel="prefetch" href="@Static("javascripts/graun.standard.js")">
+<link rel="preload" as="script" href="@Static("javascripts/graun.standard.js")">
 @if(PolyfillIO.isSwitchedOn) {
-    <link rel="prefetch" href="@common.Assets.js.polyfillioUrl">
+    <link rel="preload" as="script" href="@common.Assets.js.polyfillioUrl">
 } else {
-    <link rel="prefetch" href="@Static("javascripts/vendor/polyfillio.fallback.js")">
+    <link rel="preload" as="script" href="@Static("javascripts/vendor/polyfillio.fallback.js")">
 }
+<link rel="preload" as="script" href="@Static("javascripts/graun.commercial.js")">
 
 @*
 Protect against ReferenceErrors in IE:


### PR DESCRIPTION
Reading the [spec for preload](https://w3c.github.io/preload/#h-link-type-preload), it describes the use case for `prefetch` and `preload` as so:

> Both prefetch ([RESOURCE-HINTS]) and preload declare a resource and its fetch properties, but differ in how and when the resource is fetched by the user agent: prefetch is an optional and low-priority fetch for a resource **that might be used by a subsequent navigation**; preload is a mandatory and **high-priority fetch for a resource that is necessary for the current navigation**. Developers should use each one accordingly to minimize resource contention and optimize load performance.


We currently use a `prefetch` rel for `standard` and `polyfill` but this gives the standard `prefetch` fetch a low priority so, the `prefetch` fetch actually ends up happening around the same time as the async script insertion fetch Both yellow blogs are `graun.standard`:

![screen shot 2017-03-29 at 08 59 50](https://cloud.githubusercontent.com/assets/638051/24451394/88676f0a-1476-11e7-965e-8ba3e40ce714.jpg)

This results in a double download of standard:

![screen shot 2017-03-29 at 10 09 27](https://cloud.githubusercontent.com/assets/638051/24451301/23c9b490-1476-11e7-9068-a88409d8d352.jpg)

![screen shot 2017-03-29 at 10 08 29](https://cloud.githubusercontent.com/assets/638051/24451314/3500ea58-1476-11e7-83f8-0523a422d40f.jpg)

If we switch to using `preload` a non-blocking 'high' priority request is kicked off immediately for standard:

![screen shot 2017-03-29 at 10 15 09](https://cloud.githubusercontent.com/assets/638051/24451349/5ca1e17a-1476-11e7-875e-18d6d9c0277f.jpg)

Resulting in a single `standard.js` download:

![screen shot 2017-03-29 at 10 15 39](https://cloud.githubusercontent.com/assets/638051/24451362/68bf38a4-1476-11e7-9f18-dcd8072aa2e8.jpg)

![screen shot 2017-03-29 at 10 05 05](https://cloud.githubusercontent.com/assets/638051/24451365/6e8d56a8-1476-11e7-8ea2-3a5941ca6143.jpg)

This seems to suggest that the desired behaviour is seen when using `preload`.

To test this I also added a `preload` link for `commercial` (not enhanced because it's not always fetched) and refreshed my localhost 5 times with an average result for commercial parse end time of:

- 7.93s for preload
- 9.92 for current setup

Obviously, locally, the server response is slow but probably matches latency of 3/4G networks.

Finally, a downside of using `preload` instead of `prefetch` is that our current analytics show that support for `prefetch` is 56.72% and support for `preload` is 39.48% (but it seems prefetch might not be working as expected anyway, so maybe that's ok?).

@guardian/dotcom-platform 

