### PR TITLE
fix end date of regulars epic test v2

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
@@ -101,7 +101,7 @@ define([
         campaignId: 'kr1_epic_regulars_v2',
 
         start: '2017-03-07',
-        expiry: '2017-03-21',
+        expiry: '2017-05-01',
 
         author: 'Jonathan Rankin',
         description: 'Test messages aimed at our regular readers',


### PR DESCRIPTION
## What does this change?

The date of expiry in the regulars test had expired, hence why it wasn't working. 

This fixes that bug.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 
@lindseydew 