### PR TITLE
Make `easing.create()` test more robust

### DIFF
--- a/static/src/javascripts/lib/easing.spec.js
+++ b/static/src/javascripts/lib/easing.spec.js
@@ -36,15 +36,16 @@ describe('easing', () => {
 
     test('create()', () => {
         const OriginalDate = global.Date;
-        const ELAPSED = chance.integer({ min: 0, max: 80 });
+        const ELAPSED = chance.integer({ min: 0, max: 100 });
         const DURATION = chance.integer({ min: ELAPSED, max: 300 });
-        const ELAPSED_DATE = `1970-01-01T00:00:00.0${ELAPSED}Z`;
         global.Date = jest.fn(() => new OriginalDate(0));
 
         const ease = easing.create('linear', DURATION);
         expect(ease()).toBe(0);
 
-        global.Date = jest.fn(() => new OriginalDate(ELAPSED_DATE));
+        global.Date = jest.fn(
+            () => new OriginalDate((1970, 1, 1, 0, 0, 0, ELAPSED))
+        );
         expect(ease()).toBe(ELAPSED / DURATION);
 
         global.Date = OriginalDate;


### PR DESCRIPTION
## What does this change?

Makes `easing.create()` test more robust by removing a flaky Date construction.

## What is the value of this and can you measure success?

Relieable tests.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

<img width="537" alt="screen shot 2017-03-29 at 17 28 18" src="https://cloud.githubusercontent.com/assets/2244375/24465506/25487656-14a5-11e7-848e-58a2fed39dd2.png">


## Tested in CODE?

No.
