### PR TITLE
Fix reference to wrong node

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/render-advert.js
@@ -208,7 +208,7 @@ define([
 
         if (adSlotContent.length) {
             fastdom.write(function () {
-                adSlotContent.classList.add('ad-slot__content');
+                adSlotContent[0].classList.add('ad-slot__content');
             });
         }
     }


### PR DESCRIPTION
Small typo referencing an array instead of a node