### PR TITLE
Support international takeovers

### DIFF
--- a/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
+++ b/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
@@ -1,34 +1,34 @@
 package controllers.admin.commercial
 
 import common.dfp.TakeoverWithEmptyMPUs
-import model.ApplicationContext
+import model.{ApplicationContext, NoCache}
 import play.api.i18n.Messages
 import play.api.mvc.{Action, Controller}
 
 class TakeoverWithEmptyMPUsController(implicit val messages: Messages, context: ApplicationContext) extends Controller {
 
   def viewList() = Action { implicit request =>
-    Ok(views.html.commercial.takeoverWithEmptyMPUs(TakeoverWithEmptyMPUs.fetchSorted()))
+    NoCache(Ok(views.html.commercial.takeoverWithEmptyMPUs(TakeoverWithEmptyMPUs.fetchSorted())))
   }
 
   def viewForm() = Action { implicit request =>
-    Ok(views.html.commercial.takeoverWithEmptyMPUsCreate(TakeoverWithEmptyMPUs.form))
+    NoCache(Ok(views.html.commercial.takeoverWithEmptyMPUsCreate(TakeoverWithEmptyMPUs.form)))
   }
 
   def create() = Action { implicit request =>
     TakeoverWithEmptyMPUs.form.bindFromRequest.fold(
       formWithErrors => {
-        BadRequest(views.html.commercial.takeoverWithEmptyMPUsCreate(formWithErrors))
+        NoCache(BadRequest(views.html.commercial.takeoverWithEmptyMPUsCreate(formWithErrors)))
       },
       takeover => {
         TakeoverWithEmptyMPUs.create(takeover)
-        Redirect(routes.TakeoverWithEmptyMPUsController.viewList())
+        NoCache(Redirect(routes.TakeoverWithEmptyMPUsController.viewList()))
       }
     )
   }
 
   def remove(url: String) = Action { implicit request =>
     TakeoverWithEmptyMPUs.remove(url)
-    Redirect(routes.TakeoverWithEmptyMPUsController.viewList())
+    NoCache(Redirect(routes.TakeoverWithEmptyMPUsController.viewList()))
   }
 }

--- a/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
@@ -1,14 +1,31 @@
+@import common.Edition
 @import common.dfp.TakeoverWithEmptyMPUs
-@(takeoverForm: Form[TakeoverWithEmptyMPUs])(implicit messages: Messages, request: RequestHeader, context: model.ApplicationContext)
 @import helper._
+@(takeoverForm: Form[TakeoverWithEmptyMPUs])(
+  implicit messages: Messages,
+  request: RequestHeader,
+  context: model.ApplicationContext
+)
 
 @admin_main("Create takeover with Empty MPUs", isAuthed = true) {
     <link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")">
     <h1>New Takeover with Empty MPUs</h1>
     @form(action = controllers.admin.commercial.routes.TakeoverWithEmptyMPUsController.create()) {
         <p>Fill in the details of a front takeover in which MPUs should not appear on the page.</p>
+        @if(takeoverForm.hasGlobalErrors) {
+            <ul>
+            @for(error <- takeoverForm.globalErrors) {
+                <li>@Messages(error.messages, error.args)</li>
+            }
+            </ul>
+        }
         @inputText(takeoverForm("url"), '_label -> "Paste URL here:", 'size -> 100, '_help -> "")
-        @select(takeoverForm("editions"), options = List("UK" -> "UK", "US" -> "US", "AU" -> "AU"), 'multiple -> true, '_label -> "Editions this applies to (one or multiple):")
+        @select(
+            takeoverForm("editions"),
+            options = for(e <- Edition.all) yield { e.id -> e.displayName },
+            'multiple -> true,
+            '_label -> "Editions this applies to (one or multiple):"
+        )
         @input(takeoverForm("startTime"), '_label -> "Takeover starts (UTC):", '_help -> "") { (id, name, value, args) =>
             <input type="datetime-local" name="@name" id="@id" @toHtmlArgs(args)>
         }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -91,7 +91,7 @@ GET         /commercial/slot/:slotName                                          
 GET         /commercial/adops/takeovers-empty-mpus                                                  controllers.admin.commercial.TakeoverWithEmptyMPUsController.viewList()
 GET         /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.viewForm()
 POST        /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.create()
-POST        /commercial/adops/takeovers-empty-mpus/remove                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(takeoverStr)
+POST        /commercial/adops/takeovers-empty-mpus/remove                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(t)
 GET         /commercial/invalid-lineitems                                                           controllers.admin.CommercialController.renderInvalidItems()
 GET         /commercial/adgrabber/order/:orderId                                                    controllers.admin.CommercialController.getLineItemsForOrder(orderId: String)
 GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -306,7 +306,7 @@ GET            /commercial/slot/:slotName                                       
 GET            /commercial/adops/takeovers-empty-mpus                                                                            controllers.admin.commercial.TakeoverWithEmptyMPUsController.viewList()
 GET            /commercial/adops/takeovers-empty-mpus/create                                                                     controllers.admin.commercial.TakeoverWithEmptyMPUsController.viewForm()
 POST           /commercial/adops/takeovers-empty-mpus/create                                                                     controllers.admin.commercial.TakeoverWithEmptyMPUsController.create()
-POST           /commercial/adops/takeovers-empty-mpus/remove                                                                     controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(takeoverStr)
+POST           /commercial/adops/takeovers-empty-mpus/remove                                                                     controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(t)
 
 # Breaking News
 GET            /news-alert/alerts                                                                                                controllers.NewsAlertController.alerts()


### PR DESCRIPTION
This adds all editions to the takeover form, including the international edition.

/cc @guardian/commercial-dev 