### PR TITLE
graduate poster image override MVT to feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -529,4 +529,14 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val YouTubePosterOverride = Switch(
+    SwitchGroup.Feature,
+    "youtube-poster-override",
+    "When ON show trail image on YouTube atom playable content cards instead of the poster image",
+    owners = Seq(Owner.withGithub("gidsg")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -534,7 +534,7 @@ trait FeatureSwitches {
     "youtube-poster-override",
     "When ON show trail image on YouTube atom playable content cards instead of the poster image",
     owners = Seq(Owner.withGithub("gidsg")),
-    safeState = On,
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = false
   )

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -27,17 +27,6 @@ object CommercialClientLoggingVariant extends TestDefinition(
   }
 }
 
-object YouTubePosterOverride extends TestDefinition(
-  name = "youtube-poster-override",
-  description = "Users in the test will always see the trail image on YouTube atom content cards instead of the poster image",
-  owners = Seq(Owner.withGithub("gidsg")),
-  sellByDate = new LocalDate(2017, 4, 3)
-  ) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-youtube-poster-override").contains("true")
-  }
-}
-
 object ABNewRecipeDesign extends TestDefinition(
   name = "ab-new-recipe-design",
   description = "Users in the test will see the new design on articles with structured recipes",
@@ -63,7 +52,6 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
-    YouTubePosterOverride,
     ABNewRecipeDesign
   )
 }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -8,10 +8,11 @@
 @import model.ImageMedia
 @import model.content.MediaWrapper._
 @import model.content.MediaWrapper
+@import conf.switches.Switches.YouTubePosterOverride
 @(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None)(implicit request: RequestHeader)
 
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
-@defining(playable && !posterImageOverride.exists(_ => mvt.YouTubePosterOverride.isParticipating)){sixteenByNine: Boolean =>
+@defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
 
 
     <div data-media-atom-id="@media.id" class="@RenderClasses(Map(
@@ -41,7 +42,7 @@
                 </iframe>
                 }
             }
-        @defining(posterImageOverride.filter(_ => !playable || mvt.YouTubePosterOverride.isParticipating) orElse media.posterImage) { bestPosterImage =>
+        @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">
 


### PR DESCRIPTION
## What does this change?
Converts the previous MVT test for poster image override into a feature switch (as editorial would like this turned on.)

## What is the value of this and can you measure success?
For background on this feature please see https://github.com/guardian/frontend/pull/15916

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
See https://github.com/guardian/frontend/pull/15916#issue-209442901 

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
