### PR TITLE
remove youtube opt in

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -30,13 +30,11 @@ class OptInController extends Controller {
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
       case "headerseven" => headerSeven.opt(choice)
-      case "youtubeposter" => youtubePosterOverride.opt(choice)
       case "newrecipedesign" => newRecipeDesignOverride.opt(choice)
       case _ => NotFound
     }))
   }
 //cookies should correspond with those checked by fastly-edge-cache
   val headerSeven = OptInFeature("new_header_seven_opt_in")
-  val youtubePosterOverride = OptInFeature("you_tube_poster_override_opt_in")
   val newRecipeDesignOverride = OptInFeature("new_recipe_design_opt_in")
 }


### PR DESCRIPTION
## What does this change?
Removes youtube MVT opt in. This is something I forgot to remove in: https://github.com/guardian/frontend/pull/16303

## What is the value of this and can you measure success?
Remove unused code

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
