### PR TITLE
Removing the feedback form in the new header

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -129,10 +129,5 @@
                 </a>
             </li>
         </ul>
-
-        <div class="new-header-feedback">
-            @fragments.inlineSvg("information-circle", "icon", List("main-menu__icon", "main-menu__icon--information"))
-            This navigation is new. We'd appreciate your feedback. <a href="https://goo.gl/forms/yZQtbFVli8ABMYJF2" data-link-name="nav2: survey">Share your thoughts here.</a>
-        </div>
     </div>
 </div>

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -556,33 +556,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     height: 18px;
 }
 
-// Feedback prompt
-.new-header-feedback {
-    color: $news-support-1;
-    font-size: 15px;
-    line-height: 18px;
-    text-transform: none;
-    margin-top: $gs-baseline * 2;
-    padding: $gs-baseline $gs-gutter $gs-baseline * 2 $navigation-horizontal-padding;
-    background-color: rgba(0, 0, 0, .2);
-
-    .main-menu__icon__svg {
-        width: 1.3em;
-        height: 1.3em;
-    }
-
-    a {
-        color: #ffffff;
-        border-bottom: 1px solid rgba(255, 255, 255, .3);
-
-        &:hover,
-        &:focus {
-            text-decoration: none;
-            border-color: #ffffff;
-        }
-    }
-}
-
 .navigation-group__item--user-account {
     .user-account__signed-in {
         display: none;


### PR DESCRIPTION
## What does this change?

This is the feedback form:
![image](https://cloud.githubusercontent.com/assets/8774970/24508332/fb7ce918-155a-11e7-81b4-33bf9900c86e.png)

We have collected enough responses so now we can remove it.

## What is the value of this and can you measure success?
Removing some unneeded code

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
