### PR TITLE
explicitly set display duration to true for youtube atom embeds

### DIFF
--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -7,7 +7,7 @@
             case posterOnly if media.assets.isEmpty && media.posterImage.isDefined  => views.html.fragments.atoms.posterImage(mediaWrapper, amp, media.posterImage.get, media.title)
             case youtube if media.assets.headOption.filter(_.platform == MediaAssetPlatform.Youtube) =>
                 if(amp) views.html.fragments.atoms.ampYoutube(media, displayCaption, mediaWrapper)
-                else views.html.fragments.atoms.youtube(media, displayCaption, displayEndSlate, mediaWrapper = mediaWrapper)
+                else views.html.fragments.atoms.youtube(media, displayCaption, displayDuration = true, displayEndSlate, mediaWrapper = mediaWrapper)
             case genericAsset if media.assets.nonEmpty => views.html.fragments.atoms.genericMedia(media, displayCaption, amp)
             case _ =>
         }

--- a/common/app/views/fragments/atoms/media.scala.html
+++ b/common/app/views/fragments/atoms/media.scala.html
@@ -1,6 +1,6 @@
 @import model.content.MediaAssetPlatform
 @import model.content.MediaWrapper
-@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, displayEndSlate: Boolean = false, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(media: _root_.model.content.MediaAtom, amp: Boolean = false, displayCaption: Boolean, displayEndSlate: Boolean = false, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 
 @{
     media match {

--- a/common/app/views/fragments/atoms/posterImage.scala.html
+++ b/common/app/views/fragments/atoms/posterImage.scala.html
@@ -1,6 +1,6 @@
 @import model.content.MediaWrapper
 @import layout.ContentWidths.MainMedia
-@(mediaWrapper: Option[MediaWrapper], amp: Boolean, picture: model.ImageMedia, caption: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(mediaWrapper: Option[MediaWrapper], amp: Boolean, picture: model.ImageMedia, caption: String)(implicit request: RequestHeader)
 
     @defining(
         if(mediaWrapper.contains(MediaWrapper.MainMedia)) {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -21,7 +21,7 @@ class AtomCleanerTest extends FlatSpec
   val asset: Asset = Asset(
     AssetType.Image,
     Some("image/jpeg"),
-    Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"),
+    Some("https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"),
     None
   )
   val imageAsset: ImageAsset = ImageAsset.make(asset, 1)

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -1,5 +1,6 @@
 package views.support.cleaner
 
+import com.gu.contentapi.client.model.v1.{Asset, AssetType}
 import implicits.FakeRequests
 import model.content._
 import org.jsoup.Jsoup
@@ -8,11 +9,25 @@ import org.scalatest.{FlatSpec, Matchers}
 import test.{TestRequest, WithTestContext}
 import views.support.AtomsCleaner
 import conf.switches.Switches
+import model.{ImageAsset, ImageMedia}
+
+import scala.collection.JavaConverters._
 
 class AtomCleanerTest extends FlatSpec
   with Matchers
   with WithTestContext
   with FakeRequests {
+
+  val asset: Asset = Asset(
+    AssetType.Image,
+    Some("image/jpeg"),
+    Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"),
+    None
+  )
+  val imageAsset: ImageAsset = ImageAsset.make(asset, 1)
+
+  val image: ImageMedia = ImageMedia.apply(Seq(imageAsset))
+
   val youTubeAtom = Some(Atoms(quizzes = Nil,
     media = Seq(MediaAtom(id = "887fb7b4-b31d-4a38-9d1f-26df5878cf9c",
       defaultHtml = "<iframe width=\"420\" height=\"315\"\n src=\"https://www.youtube.com/embed/nQuN9CUsdVg\" frameborder=\"0\"\n allowfullscreen=\"\">\n</iframe>",
@@ -20,7 +35,7 @@ class AtomCleanerTest extends FlatSpec
       title = "Bird",
       duration = None,
       source = None,
-      posterImage = None,
+      posterImage = Some(image),
       endSlatePath = Some("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z"),
       expired = None)
     ),
@@ -68,6 +83,12 @@ class AtomCleanerTest extends FlatSpec
     val html = views.html.fragments.atoms.youtube(media = youTubeAtom.map(_.media.head).get, displayEndSlate = true, displayCaption = true, mediaWrapper = Some(MediaWrapper.MainMedia))(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.select("figcaption").hasClass("caption--main") should be(true)
+  }
+
+  "Youtube template" should "include duration" in {
+    val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+    doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").asScala.headOption should be(defined)
   }
 
 


### PR DESCRIPTION
## What does this change?
Explicitly sets display duration to true for embedded youtube atoms in articles.

This is intended to be the default but I think possibly regressed as part of the removal of named arguments in https://github.com/guardian/frontend/pull/16015.

## What is the value of this and can you measure success?
Fix regression spotted by @duarte 

## Does this affect other platforms - Amp, Apps, etc?
No, AMP uses the standard `amp-youtube` to render these.

## Screenshots
<img width="652" alt="screen shot 2017-03-30 at 14 41 34" src="https://cloud.githubusercontent.com/assets/1764158/24507177/ae289a52-1557-11e7-933e-7bfd27b873bf.png">

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
