### PR TITLE
Fix edit profile 'email in use' error

### DIFF
--- a/identity/app/views/fragments/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/accountDetailsForm.scala.html
@@ -29,6 +29,10 @@
         <div class="fieldset__fields">
             <ul class="u-unstyled">
 
+                @accountDetailsForm.error("user.primaryEmailAddress").map { error =>
+                    <div class="form__error">@error.message</div>
+                }
+
                 @inputField(Input(accountDetailsForm("primaryEmailAddress"), ('_label, "Email address"),
                     Symbol("data-test-id") -> "email-address"))
 


### PR DESCRIPTION
## What does this change?

When users try to change their email address via 'Edit Profile' page there is no error shown if the email is already in use. This fix shows the error next to the email input field.

## What is the value of this and can you measure success?

Less confusion for users, as well as less load on Userhelp, as this is a frequent userhelp case.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/24510845/39c21f20-1562-11e7-8afc-c98422c014a5.png)

@andrewfindlay
