### PR TITLE
Add new signup page to bookmarks a/b test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bookmarks-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bookmarks-email-variants.js
@@ -11,6 +11,7 @@ define([
             author: 'David Furey',
             audience: 0,
             audienceOffset: 0,
+            signupPage: 'info/ng-interactive/2017/mar/30/sign-up-for-the-bookmarks-email',
             canonicalListId: 3039,
             testIds: [
                 { variantId: 'Control', listId: 3867 },


### PR DESCRIPTION
## What does this change?

This will enable the bookmarks email a/b test for the interactive signup page

## What is the value of this and can you measure success?

Will allow us to test the performance of the container based bookmarks email

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
