### PR TITLE
Hosted Gallery - layout fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -42,7 +42,7 @@
                         <div class="js-hosted-gallery-images hosted-gallery__images-container">
                             @guardianHostedGalleryImage(page.images.head, if(page.standfirst.trim.isEmpty) {""} else {
                                 <div class="hosted-gallery__meta js-hosted-gallery-meta">
-                                    <div class="content__main-column">
+                                    <div class="content__main-column--hosted">
                                         <h1 class="hosted-gallery__heading">{page.title}</h1>
                                         <h3 class="hosted-gallery__sub-heading">{page.standfirst}</h3>
                                     </div>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -3,6 +3,11 @@ $headerHeight: 58px;
 $footerHeight: 46px;
 $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
 
+$tabletHeight: #{map-get($mq-breakpoints, tablet) * 3/5 + $headerHeight + $footerHeight};
+$desktopHeight: #{map-get($mq-breakpoints, desktop) * 3/5 + $headerHeight + $footerHeight};
+$leftColHeight: #{map-get($mq-breakpoints, leftCol) * 3/5 + $headerHeight + $footerHeight};
+$wideHeight: #{map-get($mq-breakpoints, wide) * 3/5 + $headerHeight + $footerHeight};
+
 
 .hosted-gallery__scroll-container {
     overflow-x: hidden;
@@ -314,7 +319,7 @@ $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
     transition: opacity 300ms ease;
     background: linear-gradient(to top, rgba(51, 51, 51, .7) 0%, rgba(51, 51, 51, .5) 50%, transparent 100%);
     filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColor=0, endColorstr='#B4333333');
-    @include mq($until: tablet) {
+    @include mq($until: tablet, $and: '(max-height: #{$tabletHeight})') {
         padding: 20px 70px 10px 20px;
     }
 }
@@ -324,11 +329,11 @@ $approxGalleryWidth: calc(167vh - #{5/3 * ($headerHeight + $footerHeight)});
     margin-bottom: 5px;
     font-size: 26px;
     line-height: 28px;
-    @include mq(tablet) {
+    @include mq(tablet, $and: '(min-height: #{$tabletHeight})') {
         font-size: 30px;
         line-height: 32px;
     }
-    @include mq(desktop) {
+    @include mq(desktop, $and: '(min-height: #{$desktopHeight})') {
         font-size: 36px;
         line-height: 36px;
     }
@@ -698,4 +703,28 @@ $progressColor: #ffffff;
     .hosted-gallery__cta {
         padding-bottom: 20px;
     }
+}
+
+.content__main-column--hosted {
+    max-width: gs-span(8);
+    margin: auto;
+    position: relative;
+
+    @include mq(tablet, desktop, $and: '(min-height: #{$tabletHeight})') {
+        max-width: gs-span(9);
+    }
+
+    @include mq(desktop, $and: '(min-height: #{$desktopHeight})') {
+        margin-left: 0;
+        margin-right: $right-column + $gs-gutter;
+    }
+
+    @include mq(leftCol, $and: '(min-height: #{$leftColHeight})') {
+        margin-left: $left-column + $gs-gutter;
+    }
+
+    @include mq(wide, $and: '(min-height: #{$wideHeight})') {
+        margin-left: $left-column-wide + $gs-gutter;
+    }
+
 }


### PR DESCRIPTION
## What does this change?
Use some `min-height` media queries to properly align & size the title and standfirst text on the first slide across different breakpoints.

## What is the value of this and can you measure success?
The gallery images scale in terms of both height and width of the page in order to maintain their aspect ratio, so sizing text according to page width only doesn't make sense, and causes weird layout bugs.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
All taken at 'wide' breakpoint (bug appears on letterbox-shaped screen), but using mobile/tablet sizing/margins where appropriate.

Before:
![image](https://cloud.githubusercontent.com/assets/6290008/24515697/4c6aca06-1570-11e7-8091-e8da20cc1f54.png)

After:
![image](https://cloud.githubusercontent.com/assets/6290008/24515677/3c59403e-1570-11e7-9d82-31eec9c09fb0.png)


Before:
![image](https://cloud.githubusercontent.com/assets/6290008/24515755/7386db84-1570-11e7-831d-8defe69089e7.png)

After:
![image](https://cloud.githubusercontent.com/assets/6290008/24515775/814fcbb8-1570-11e7-9b8b-18c9cb0449d3.png)



