### PR TITLE
Enable a/b test of bookmarks email

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bookmarks-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bookmarks-email-variants.js
@@ -6,10 +6,10 @@ define([
     return new genericEmailTest(
         {
             id: 'BookmarksEmailVariants',
-            start: '2017-03-14',
-            end: '2017-03-31',
+            start: '2017-03-31',
+            end: '2017-05-30',
             author: 'David Furey',
-            audience: 0,
+            audience: 1,
             audienceOffset: 0,
             canonicalListId: 3039,
             testIds: [


### PR DESCRIPTION
## What does this change?

Enables test of bookmarks email. 50% of new users will receive facia version, 50% will receive R2 version.

## What is the value of this and can you measure success?

Allows us to measure the impact of changing the bookmarks email from R2 to facia cards design

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
