### PR TITLE
Refactor hosted gallery init to remove mediator

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/commercial.js
+++ b/static/src/javascripts-legacy/bootstraps/commercial.js
@@ -73,7 +73,7 @@ define([
         commercialModules.push(
             ['cm-hostedAbout', hostedAbout.init],
             ['cm-hostedVideo', hostedVideo.init, true],
-            ['cm-hostedGallery', hostedGallery.init, true],
+            ['cm-hostedGallery', hostedGallery.init],
             ['cm-hostedOnward', hostedOnward.init, true],
             ['cm-hostedOJCarousel', hostedOJCarousel.init]
         );

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/gallery.js
@@ -446,9 +446,7 @@ define([
         }
     };
 
-    function init(start, stop) {
-        start();
-
+    function init() {
         if (qwery('.js-hosted-gallery-container').length) {
             return loadCssPromise
                 .then(function () {
@@ -467,12 +465,10 @@ define([
                             gallery.loadAtIndex(parseInt(res[1], 10));
                         }
                     }
-                    stop();
 
                     return gallery;
                 });
         }
-        stop();
 
         return Promise.resolve();
     }

--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/gallery.js
@@ -450,32 +450,29 @@ define([
         start();
 
         if (qwery('.js-hosted-gallery-container').length) {
-            loadCssPromise
-            .then(function () {
-                var gallery,
-                    match,
-                    galleryHash = window.location.hash,
-                    res;
+            return loadCssPromise
+                .then(function () {
+                    var gallery,
+                        match,
+                        galleryHash = window.location.hash,
+                        res;
 
-                gallery = new HostedGallery();
-                match = /\?index=(\d+)/.exec(document.location.href);
-                if (match) { // index specified so launch gallery at that index
-                    gallery.loadAtIndex(parseInt(match[1], 10));
-                } else {
-                    res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
-                    if (res) {
-                        gallery.loadAtIndex(parseInt(res[1], 10));
+                    gallery = new HostedGallery();
+                    match = /\?index=(\d+)/.exec(document.location.href);
+                    if (match) { // index specified so launch gallery at that index
+                        gallery.loadAtIndex(parseInt(match[1], 10));
+                    } else {
+                        res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
+                        if (res) {
+                            gallery.loadAtIndex(parseInt(res[1], 10));
+                        }
                     }
-                }
-                return gallery;
-            })
-            .then(function (gallery) {
-                stop();
-                mediator.emit('page:hosted:gallery', gallery);
-            });
-        } else {
-            stop();
+                    stop();
+
+                    return gallery;
+                });
         }
+        stop();
 
         return Promise.resolve();
     }

--- a/static/test/javascripts-legacy/spec/commercial/hosted/gallery.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/hosted/gallery.spec.js
@@ -1,6 +1,5 @@
 define([
     'lib/$',
-    'lib/mediator',
     'helpers/fixtures',
     'Promise',
     'fastdom',
@@ -8,7 +7,6 @@ define([
     'helpers/injector'
 ], function (
     $,
-    mediator,
     fixtures,
     Promise,
     fastdom,
@@ -37,11 +35,12 @@ define([
                 'commercial/modules/hosted/gallery'
             ], function (galleryModule) {
                 $fixturesContainer = fixtures.render(fixturesConfig);
-                galleryModule.init(noop, noop);
-                mediator.on('page:hosted:gallery', function(instance) {
-                    gallery = instance;
-                    done();
-                });
+                galleryModule
+                    .init(noop, noop)
+                    .then(function (galleryInstance) {
+                        gallery = galleryInstance;
+                        done();
+                    });
             });
         });
 


### PR DESCRIPTION
## What does this change?

The hosted gallery init utilises a very interesting pattern of behaviour that is unnecessarily complicated and difficult to test. 

This refactor returns the `loadCssPromise` directly, and dispenses with the redundant `mediator.emit` call.

## What is the value of this and can you measure success?

Code that is easier to understand and test.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
