### PR TITLE
Add account deletion reason survey form

### DIFF
--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -160,11 +160,11 @@ abstract class IdApi(http: Http, jsonBodyParser: JsonBodyParser, conf: IdentityC
     post(urlJoin("user", "me", "group", groupCode), Some(auth)) map extractUnit
   }
 
-  def executeAccountDeletionStepFunction(userId: String, email: String, auth: Auth) = {
-    case class DeletionBody(identityId: String, email: String)
+  def executeAccountDeletionStepFunction(userId: String, email: String, reason: Option[String], auth: Auth) = {
+    case class DeletionBody(identityId: String, email: String, reason: Option[String])
     http.POST(
         s"${conf.id.accountDeletionApiRoot}/delete",
-        Some(write(DeletionBody(userId, email))),
+        Some(write(DeletionBody(userId, email, reason))),
         headers = buildHeaders(Some(auth), extra = Seq(("x-api-key", conf.id.accountDeletionApiKey)))
     ) map extract[AccountDeletionResult](identity)
   }

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -2,7 +2,7 @@
     page: model.Page,
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
-    accountDeletionForm: Form[(String)],
+    accountDeletionForm: Form[(String, Option[String])],
     errors: List[client.Error]
 )(implicit
     request: RequestHeader,
@@ -11,9 +11,8 @@
 
 @import form.IdFormHelpers._
 @import views.html.fragments.form.inputField
+@import views.html.fragments.form.radioField
 @import views.html.fragments.registrationFooter
-@import client.Error
-@import form.Input
 
 @main(page, projectName = Option("identity")){
 }{
@@ -23,7 +22,7 @@
         <div class="identity-section">
             <p class="identity-section__text">
                 Please read the following paragraphs carefully to understand how account
-                deletion affects any Guardian products you may have. If at any point require further clarification please
+                deletion affects any Guardian products you may have. If at any point you require further clarification please
                 email our <a href="mailto:userhelp@@theguardian.com" data-link-name="Email Userhelp">Userhelp</a> who will
                 be happy to help.
             </p>
@@ -80,6 +79,24 @@
 
         <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
+
+            <div class="identity-section">
+                <p class="identity-section__text">
+                    <p><b>Do you mind telling us why you wish to delete your account?</b></p>
+
+                    @radioField(accountDeletionForm("reason"), List(
+                        "accident"      -> "I have created an account by accident",
+                        "password"      -> "I accidentally entered my password as the username",
+                        "emails"        -> "I want to stop receiving emails",
+                        "trolls"        -> "I have been trolled in the comments section",
+                        "comments"      -> "I no longer want to comment",
+                        "privacy"       -> "I am concerned about my privacy on the Internet",
+                        "membership"    -> "I was asked to create an account in order to become member/subscriber",
+                        "other"         -> "Other")
+                    )(nonInputFields, messages)
+                </p>
+            </div>
+
             <fieldset class="fieldset">
 
                 <div class="fieldset__heading">

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -82,13 +82,13 @@
 
             <div class="identity-section">
                 <p class="identity-section__text">
-                    <p><b>Do you mind telling us why you wish to delete your account?</b></p>
+                    <p><b>Please take a moment to tell us why you wish to delete your account:</b></p>
 
                     @radioField(accountDeletionForm("reason"), List(
                         "accident"      -> "I have created an account by accident",
                         "password"      -> "I accidentally entered my password as the username",
                         "emails"        -> "I want to stop receiving emails",
-                        "trolls"        -> "I have been trolled in the comments section",
+                        "abuse"         -> "I have been exposed to abuse in the comments section",
                         "comments"      -> "I no longer want to comment",
                         "privacy"       -> "I am concerned about my privacy on the Internet",
                         "membership"    -> "I was asked to create an account in order to become member/subscriber",

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -88,7 +88,6 @@
                         "accident"      -> "I have created an account by accident",
                         "password"      -> "I accidentally entered my password as the username",
                         "emails"        -> "I want to stop receiving emails",
-                        "abuse"         -> "I have been exposed to abuse in the comments section",
                         "comments"      -> "I no longer want to comment",
                         "privacy"       -> "I am concerned about my privacy online",
                         "membership"    -> "I was asked to create an account in order to become member/subscriber",

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -90,7 +90,7 @@
                         "emails"        -> "I want to stop receiving emails",
                         "abuse"         -> "I have been exposed to abuse in the comments section",
                         "comments"      -> "I no longer want to comment",
-                        "privacy"       -> "I am concerned about my privacy on the Internet",
+                        "privacy"       -> "I am concerned about my privacy online",
                         "membership"    -> "I was asked to create an account in order to become member/subscriber",
                         "other"         -> "Other")
                     )(nonInputFields, messages)


### PR DESCRIPTION
## What does this change?

It enables users to tell us the reason why they wish to delete their account.

## What is the value of this and can you measure success?

Knowing the reason will help us improve user service.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/24551729/8100802a-161b-11e7-90a2-d86cb70775e2.png)

Could you please recommend options to provide to users. The current ones are what Userhelp sees as the most common reason.

@sallygoble @andrewfindlay 