### PR TITLE
Centre the button text on frame creative

### DIFF
--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -147,11 +147,13 @@ $mobile-max-container-width: gs-span(8);
 
 .frame__cta {
     color: #ffffff;
+    line-height: $gs-baseline * 2.5;
 }
 
 .frame__external-link-icon svg {
-    width: 20px;
+    width: 14px;
     height: 10px;
+    padding-left: 4px;
 }
 
 .has-no-flex {


### PR DESCRIPTION
Before:
![screenshot 2017-03-31 at 14 17 26](https://cloud.githubusercontent.com/assets/6290008/24552031/d55874d8-161c-11e7-806f-0a0ac8b9a45e.png)

After:
![screenshot 2017-03-31 at 14 16 18](https://cloud.githubusercontent.com/assets/6290008/24552004/b26871ee-161c-11e7-8fbb-d35bf58bc006.png)
