### PR TITLE
adds px to top value

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/sticky.js
@@ -47,7 +47,7 @@ define([
             var top = this.opts.containInParent && parentRect.bottom <= elementRect.height ?
                 Math.floor(parentRect.bottom - elementHeight - this.opts.top) :
                 this.opts.top;
-            css = { top: top };
+            css = { top: top + 'px' };
             message = 'fixed';
         }
 


### PR DESCRIPTION
## What does this change?
Adds `px` to top value so that values other than 0 are valid and can be assigned to element. Previously the value was assigned using Bonzo which takes care of the px for you (I believe) but this was [recently replaced](https://github.com/guardian/frontend/commit/8c00a940cd1f247152d7f6bd7f7acafcd6c34918#diff-69415db31ee4037bc5c777954b48c534L64). 

## What is the value of this and can you measure success?
Fixes the sticky polyfill for elements contained in parent - element scrolls off the screen once it reaches bottom of parent div by decreasing top value as the users scrolls. These negative values are currently not valid and not being set. Also fixes for elements fixed with a space above them (with positive top values).

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
NOW: 
![scroll-sticky](https://cloud.githubusercontent.com/assets/8484757/24557344/4392e94e-162f-11e7-9fcc-bc1e5ccc9595.gif)
Header scrolls away

BEFORE:
![scroll-sticky-broken](https://cloud.githubusercontent.com/assets/8484757/24557338/3eabd468-162f-11e7-8064-24379b902c1c.gif)
Header never disappears! 

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/dotcom-platform 
