### PR TITLE
Generate pressed ad targeting for non-tag or section fronts

### DIFF
--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -31,6 +31,8 @@ object CommercialProperties {
 
   implicit val commercialPropertiesFormat = Json.format[CommercialProperties]
 
+  val empty = CommercialProperties(editionBrandings = Nil, editionAdTargetings = Nil)
+
   def fromContent(item: Content): CommercialProperties = CommercialProperties(
     editionBrandings = EditionBranding.fromContent(item),
     editionAdTargetings = EditionAdTargeting.fromContent(item)
@@ -44,5 +46,21 @@ object CommercialProperties {
   def fromTag(tag: Tag): CommercialProperties = CommercialProperties(
     editionBrandings = EditionBranding.fromTag(tag),
     editionAdTargetings = EditionAdTargeting.fromTag(tag)
+  )
+
+  private def isNetworkFront(frontId: String): Boolean = Edition.all.map(_.networkFrontId).contains(frontId)
+
+  def forNetworkFront(frontId: String): Option[CommercialProperties] = {
+    if (isNetworkFront(frontId)) {
+      Some(CommercialProperties(
+        editionBrandings = Nil,
+        editionAdTargetings = EditionAdTargeting.forNetworkFront(frontId)
+      ))
+    } else None
+  }
+
+  def forFrontUnknownToCapi(frontId: String): CommercialProperties = CommercialProperties(
+    editionBrandings = Nil,
+    editionAdTargetings = EditionAdTargeting.forFrontUnknownToCapi(frontId)
   )
 }

--- a/common/app/common/commercial/EditionAdTargeting.scala
+++ b/common/app/common/commercial/EditionAdTargeting.scala
@@ -36,11 +36,9 @@ object EditionAdTargeting {
   def fromSection(section: Section): Seq[EditionAdTargeting] =
     editionTargeting(edition => adCall.pageLevelContextTargeting(section, edition.id))
 
-  def targeting(adContextTargetings: Option[Seq[EditionAdTargeting]], edition: Edition): Map[String, String] = {
-    val params = for {
-      targetings <- adContextTargetings
-      targeting <- targetings.find(_.edition == edition)
-    } yield targeting.params
-    params getOrElse Map.empty
-  }
+  def forNetworkFront(frontId: String): Seq[EditionAdTargeting] =
+    editionTargeting(edition => adCall.pageLevelContextTargeting(networkFrontPath = s"/$frontId", edition.id))
+
+  def forFrontUnknownToCapi(frontId: String): Seq[EditionAdTargeting] =
+    editionTargeting(edition => adCall.pageLevelTargetingForFrontUnknownToCapi(frontId, edition.id))
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -7,9 +7,9 @@ import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuer
 import com.gu.facia.api.models.{Collection, Front}
 import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.client.ApiClient
-import com.gu.facia.client.models.{Breaking, ConfigJson, Special, Metadata}
+import com.gu.facia.client.models.{Breaking, ConfigJson, Metadata, Special}
 import common._
-import common.commercial.{CommercialProperties, EditionAdTargeting, EditionBranding}
+import common.commercial.CommercialProperties
 import conf.Configuration
 import conf.switches.Switches.FaciaInlineEmbeds
 import contentapi.{CapiHttpClient, CircuitBreakingContentApiClient, ContentApiClient, QueryDefaults}
@@ -254,12 +254,10 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
         commercial = {
           val tag = itemResp flatMap (_.tag)
           val section = itemResp flatMap (_.section)
-          Some(CommercialProperties(
-            editionBrandings =
-              tag.map(EditionBranding.fromTag) orElse section.map(EditionBranding.fromSection) getOrElse Nil,
-            editionAdTargetings =
-              tag.map(EditionAdTargeting.fromTag) orElse section.map(EditionAdTargeting.fromSection) getOrElse Nil
-          ))
+          tag.map(CommercialProperties.fromTag) orElse
+            section.map(CommercialProperties.fromSection) orElse
+            CommercialProperties.forNetworkFront(path) orElse
+            Some(CommercialProperties.forFrontUnknownToCapi(path))
         }
       )
 

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -251,6 +251,11 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
 
       val frontProperties: FrontProperties = ConfigAgent.fetchFrontProperties(path).copy(
         editorialType = itemResp.flatMap(_.tag).map(_.`type`.name),
+        /*
+         * We expect the capi response for a front to have exclusively either a tag or a section or neither,
+         * according to whether it is a section front, a tag page or a page unknown to capi respectively.
+         * Thus the order in which tag and section are processed is unimportant.
+         */
         commercial = {
           val tag = itemResp flatMap (_.tag)
           val section = itemResp flatMap (_.section)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   val targetingClient = "com.gu" %% "targeting-client" % "0.11.0"
   val scanamo = "com.gu" %% "scanamo" % "0.8.3"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.6"
-  val commercialShared = "com.gu" %% "commercial-shared" % "2.0.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "2.0.2"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"


### PR DESCRIPTION
This adds the remaining cases to make the clientside value `sharedAdTargeting` complete.

Eg. for a network front:
`{ct: "network-front", url: "/uk", edition: "uk", p: "ng", k: "uk"}`
and for a front that's only known to the fronts tool:
`{ct: "section", url: "/guardian-masterclasses/journalism", edition: "uk", p: "ng", k: "journalism"}`

The next step is to replace most of the existing ad-call parameters with these new ones.

/cc @guardian/commercial-dev 
