### PR TITLE
update copy on email-newsletters page for bookmarks email

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -259,7 +259,7 @@ object EmailNewsletters {
   val bookmarks = EmailNewsletter(
     name = "Bookmarks",
     theme = "culture",
-    teaser = "Kick back on a Sunday with our weekly email full of literary delights. Expert reviews, author interviews and top 10s, plus highlights from our columnists and community",
+    teaser = "Kick back and relax on a Sunday with our weekly email full of literary delights. Expert reviews, author interviews and top 10s, plus highlights from our columnists and community",
     description = "Join us in the world of books. Discover new books with our expert reviews, author interviews and top 10s, plus enjoy highlights from our columnists and community. Kick back on a Sunday with our weekly email full of literary delights",
     frequency = "Every Thursday",
     listId = 3039,


### PR DESCRIPTION
## What does this change?
Updating the copy on the email-newsletter page as requested by the books desk.

## What is the value of this and can you measure success?
It's consistent with the copy required by the books desk. 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
