### PR TITLE
Expose short URLs on hosted page clientside

### DIFF
--- a/common/app/common/commercial/hosted/HostedMetadata.scala
+++ b/common/app/common/commercial/hosted/HostedMetadata.scala
@@ -33,7 +33,8 @@ object HostedMetadata {
       javascriptConfigOverrides = Map(
         "isHosted" -> JsBoolean(true),
         "toneIds" -> JsString(toneIds),
-        "tones" -> JsString(toneNames)
+        "tones" -> JsString(toneNames),
+        "shortUrl" -> JsString(item.fields.flatMap(_.shortUrl).getOrElse(""))
       ),
       opengraphPropertiesOverrides = Map(
         "og:url" -> s"${site.host}/${item.id}",


### PR DESCRIPTION
The merchandising team currently use short URLs to build traffic drivers.

/cc @guardian/commercial-dev 