### PR TITLE
move youtube atom duration rendering server side

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -10,6 +10,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import quiz._
 import enumeratum._
 import model.content.MediaAssetPlatform.findValues
+import org.joda.time.format.{DateTimeFormat, PeriodFormatter, PeriodFormatterBuilder}
 import views.support.{GoogleStructuredData, ImgSrc}
 
 final case class Atoms(
@@ -38,8 +39,29 @@ final case class MediaAtom(
   endSlatePath: Option[String],
   expired: Option[Boolean]
 ) extends Atom {
+
   def isoDuration: Option[String] = {
     duration.map(d => new Duration(Duration.standardSeconds(d)).toString)
+  }
+
+  def formattedDuration: Option[String] = {
+    val formatter = new PeriodFormatterBuilder()
+      .appendHours
+      .appendSuffix(":")
+      .appendMinutes
+      .appendSuffix(":")
+      .printZeroAlways
+      .minimumPrintedDigits(2)
+      .appendSeconds
+      .toFormatter
+
+    duration.map(d => {
+      val duration =  new Duration(Duration.standardSeconds(d))
+      duration match {
+        case lessThanOneMinute if duration.isShorterThan(new Duration(Duration.standardMinutes(1))) => "0:" + formatter.print(duration.toPeriod())
+        case _ => formatter.print(duration.toPeriod())
+      }
+    })
   }
 }
 

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -57,8 +57,7 @@ final case class MediaAtom(
       val durationMillis = jodaDuration.getMillis
 
       jodaDuration match {
-        case lessThanOneMinute if jodaDuration.isShorterThan(new Duration(Duration.standardMinutes(1))) => DurationFormatUtils.formatDuration(durationMillis, "m:ss", true)
-        case oneMinuteToOneHour if jodaDuration.isShorterThan(new Duration(Duration.standardHours(1))) => stripLeadingZero(DurationFormatUtils.formatDuration(durationMillis, "mm:ss", true))
+        case lessThanOneHour if jodaDuration.isShorterThan(new Duration(Duration.standardHours(1))) => stripLeadingZero(DurationFormatUtils.formatDuration(durationMillis, "mm:ss", true))
         case _ => stripLeadingZero(DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss", true))
       }
     }

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -44,7 +44,7 @@ final case class MediaAtom(
   }
 
   def formattedDuration: Option[String] = {
-    duration.map(d => {
+    duration.map { d =>
       val jodaDuration = new Duration(Duration.standardSeconds(d))
       val durationMillis = jodaDuration.getMillis
       val oneHour = new Duration(Duration.standardHours(1))
@@ -52,7 +52,6 @@ final case class MediaAtom(
       val formattedDuration = DurationFormatUtils.formatDuration(durationMillis, durationPattern, true)
       "^0".r.replaceFirstIn(formattedDuration, "") //strip leading zero
     }
-    )
   }
 }
 

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -46,10 +46,9 @@ final case class MediaAtom(
   def formattedDuration: Option[String] = {
     duration.map { d =>
       val jodaDuration = new Duration(Duration.standardSeconds(d))
-      val durationMillis = jodaDuration.getMillis
       val oneHour = new Duration(Duration.standardHours(1))
       val durationPattern = if(jodaDuration.isShorterThan(oneHour)) "mm:ss" else "HH:mm:ss"
-      val formattedDuration = DurationFormatUtils.formatDuration(durationMillis, durationPattern, true)
+      val formattedDuration = DurationFormatUtils.formatDuration(jodaDuration.getMillis, durationPattern, true)
       "^0".r.replaceFirstIn(formattedDuration, "") //strip leading zero
     }
   }

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -4,14 +4,12 @@ import com.gu.contentapi.client.model.v1.TagType
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.contentatom.thrift.atom.media.{Asset => AtomApiMediaAsset, MediaAtom => AtomApiMediaAtom}
 import com.gu.contentatom.thrift.{AtomData, Atom => AtomApiAtom, Image => AtomApiImage, ImageAsset => AtomApiImageAsset, atom => atomapi}
+import enumeratum._
 import model.{EndSlateComponents, ImageAsset, ImageMedia}
+import org.apache.commons.lang3.time.DurationFormatUtils
 import org.joda.time.{DateTime, DateTimeZone, Duration}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import quiz._
-import enumeratum._
-import model.content.MediaAssetPlatform.findValues
-import org.apache.commons.lang3.time.DurationFormatUtils
-import org.joda.time.format.{DateTimeFormat, PeriodFormatter, PeriodFormatterBuilder}
 import views.support.{GoogleStructuredData, ImgSrc}
 
 final case class Atoms(

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -44,20 +44,13 @@ final case class MediaAtom(
   }
 
   def formattedDuration: Option[String] = {
-
-    def stripLeadingZero(formattedString: String): String = {
-      val leadingZero = "^0".r
-      leadingZero.replaceFirstIn(formattedString, "")
-    }
-
     duration.map(d => {
       val jodaDuration = new Duration(Duration.standardSeconds(d))
       val durationMillis = jodaDuration.getMillis
-
-      jodaDuration match {
-        case lessThanOneHour if jodaDuration.isShorterThan(new Duration(Duration.standardHours(1))) => stripLeadingZero(DurationFormatUtils.formatDuration(durationMillis, "mm:ss", true))
-        case _ => stripLeadingZero(DurationFormatUtils.formatDuration(durationMillis, "HH:mm:ss", true))
-      }
+      val oneHour = new Duration(Duration.standardHours(1))
+      val durationPattern = if(jodaDuration.isShorterThan(oneHour)) "mm:ss" else "HH:mm:ss"
+      val formattedDuration = DurationFormatUtils.formatDuration(durationMillis, durationPattern, true)
+      "^0".r.replaceFirstIn(formattedDuration, "") //strip leading zero
     }
     )
   }

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -65,8 +65,7 @@
                                 <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
                             }
                         }
-                        @if(displayDuration) {
-                            @for(duration <- media.formattedDuration) {
+                            @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {
                                 <div class="youtube-media-atom__bottom-bar">
                                     <div class="youtube-media-atom__bottom-bar__icon">
                                     @fragments.inlineSvg("video-icon", "icon")
@@ -74,7 +73,6 @@
                                     <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
                                 </div>
                             }
-                        }
                     }
                 } else {
                     <div class="vjs-error-display vjs-modal-dialog">

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -66,12 +66,14 @@
                             }
                         }
                         @if(displayDuration) {
-                            <div class="youtube-media-atom__bottom-bar">
-                                <div class="youtube-media-atom__bottom-bar__icon">
+                            @for(duration <- media.formattedDuration) {
+                                <div class="youtube-media-atom__bottom-bar">
+                                    <div class="youtube-media-atom__bottom-bar__icon">
                                     @fragments.inlineSvg("video-icon", "icon")
+                                    </div>
+                                    <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
                                 </div>
-                                <div class="youtube-media-atom__bottom-bar__duration"></div>
-                            </div>
+                            }
                         }
                     }
                 } else {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -90,7 +90,6 @@ class AtomCleanerTest extends FlatSpec
     val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").html() should be("0:36")
-
   }
 
 

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -95,6 +95,7 @@ class AtomCleanerTest extends FlatSpec
   "Formatted duration" should "produce the expected format" in {
     youTubeAtom.map(_.media.head).get.copy(duration = Some(61)).formattedDuration should contain("1:01")
     youTubeAtom.map(_.media.head).get.copy(duration = Some(70)).formattedDuration should contain("1:10")
+    youTubeAtom.map(_.media.head).get.copy(duration = Some(660)).formattedDuration should contain("11:00")
     youTubeAtom.map(_.media.head).get.copy(duration = Some(1)).formattedDuration should contain("0:01")
     youTubeAtom.map(_.media.head).get.copy(duration = Some(3601)).formattedDuration should contain("1:00:01")
   }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -92,6 +92,13 @@ class AtomCleanerTest extends FlatSpec
     doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").html() should be("0:36")
   }
 
+  "Formatted duration" should "produce the expected format" in {
+    youTubeAtom.map(_.media.head).get.copy(duration = Some(61)).formattedDuration should contain("1:01")
+    youTubeAtom.map(_.media.head).get.copy(duration = Some(70)).formattedDuration should contain("1:10")
+    youTubeAtom.map(_.media.head).get.copy(duration = Some(1)).formattedDuration should contain("0:01")
+    youTubeAtom.map(_.media.head).get.copy(duration = Some(3601)).formattedDuration should contain("1:00:01")
+  }
+
 
 
 }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -33,7 +33,7 @@ class AtomCleanerTest extends FlatSpec
       defaultHtml = "<iframe width=\"420\" height=\"315\"\n src=\"https://www.youtube.com/embed/nQuN9CUsdVg\" frameborder=\"0\"\n allowfullscreen=\"\">\n</iframe>",
       assets = Seq(MediaAsset(id = "nQuN9CUsdVg", version = 1L, platform = MediaAssetPlatform.Youtube, mimeType = None)),
       title = "Bird",
-      duration = None,
+      duration = Some(36),
       source = None,
       posterImage = Some(image),
       endSlatePath = Some("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z"),
@@ -89,7 +89,8 @@ class AtomCleanerTest extends FlatSpec
   "Youtube template" should "include duration" in {
     val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None)(TestRequest())
     val doc = Jsoup.parse(html.toString())
-    doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").asScala.headOption should be(defined)
+    doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").html() should be("0:36")
+
   }
 
 

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -136,8 +136,6 @@ define([
         }
 
         if (overlay) {
-            showDuration(atomId, overlay);
-
             players[atomId].overlay = overlay;
 
             if (!!config.page.section && detect.isBreakpoint({ min: 'desktop' })) {
@@ -148,35 +146,6 @@ define([
         if (iframe && iframe.closest('.immersive-main-media__media')) {
             updateImmersiveButtonPos();
             window.addEventListener('resize', debounce(updateImmersiveButtonPos.bind(null), 200));
-        }
-    }
-
-    function getFormattedDuration(durationInSeconds) {
-        var times = [];
-        var hours = Math.floor(durationInSeconds / 3600);
-        var minutes = Math.floor((durationInSeconds - hours * 3600) / 60);
-        var seconds = (durationInSeconds - hours * 3600) - (minutes * 60);
-
-        if (hours) {
-            times.push(hours);
-            times.push(formatTime(minutes));
-        } else {
-            times.push(minutes);
-        }
-        times.push(formatTime(seconds));
-
-        return times.join(':');
-    }
-
-    function formatTime(time) {
-        return ('0' + time).slice(-2);
-    }
-
-    function showDuration(atomId, overlay) {
-        var durationElem = overlay.querySelector('.youtube-media-atom__bottom-bar__duration');
-
-        if (durationElem) {
-           durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
         }
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -176,7 +176,7 @@ define([
         var durationElem = overlay.querySelector('.youtube-media-atom__bottom-bar__duration');
 
         if (durationElem) {
-            durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
+           durationElem.innerText = getFormattedDuration(players[atomId].player.getDuration());
         }
     }
 


### PR DESCRIPTION
## What does this change?
Moves the formatted duration on the youtube player overlay server side based on the Atom data.
Previously this was done client side using the YouTube iframe API. 

## What is the value of this and can you measure success?
Less DOM mutation, entirety of poster rendered server side.

## Does this affect other platforms - Amp, Apps, etc?
No, AMP uses the standard `amp-youtube` tag.

## Screenshots
N/A 
this is a refactor

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
