### PR TITLE
fix for browsers which don't support position sticky

### DIFF
--- a/article/app/views/fragments/recipeArticleBody.scala.html
+++ b/article/app/views/fragments/recipeArticleBody.scala.html
@@ -55,6 +55,7 @@
                 </div>
             }
         </div>
+        <div class="flex-filler"></div>
         <div class="js-recipe__gutter-wrapper recipe__gutter-wrapper">
             @defining(articleModel.item.content.tags) { tags =>
                 @if(tags.hasLargeContributorImage && tags.contributors.length == 1) {

--- a/static/src/javascripts-legacy/bootstraps/enhanced/recipe-article.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/recipe-article.js
@@ -27,11 +27,10 @@ function init() {
     var nextRecipeText = $('.js-recipe__article--next-text');
     var nextRecipeKicker = $('.js-kicker');
     var nextButton = $('.js-recipe__article--next-button');
-    var readMoreButton;
-    var displayClass = 'recipe__image__wrapper--is-displayed';
-    var stickyGutter = $('.js-recipe__gutter-wrapper');
     var stickyImages = $('.js-recipes__images-wrapper');
     var contentFooter = $('.content-footer');
+    var displayClass = 'recipe__image__wrapper--is-displayed';
+    var readMoreButton;
     var contentFooterTop;
     var windowHeight = window.innerHeight;
 
@@ -133,9 +132,8 @@ function init() {
         resetAssets(focalRecipeInt);
         if (focalRecipeInt < 0) { nextButton.removeClass('top'); }
 
-        if(detect.isBreakpoint({ min: 'desktop' })) {
-          new Sticky(stickyGutter[0]).init();
-          new Sticky(stickyImages[0]).init();
+        if (detect.isBreakpoint({ min: 'desktop' })) {
+          new Sticky(stickyImages[0], {}).init();
         }
 
         readMoreWrapper.html(readMoreNoJS.html());

--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -72,7 +72,6 @@
     height: 50vh;
     top: 0;
     width: 100%;
-    position: relative;
     overflow: hidden;
 
     @include mq($from: desktop) {
@@ -80,9 +79,16 @@
         position: sticky;
         height: 100vh;
         min-height: 600px;
+
+        &.is-sticky {
+            width: 40%
+        }
     }
     @include mq($from: leftCol) {
         flex-basis: 50%;
+        &.is-sticky {
+            width: 50%
+        }
     }
 }
 
@@ -162,17 +168,23 @@
     padding-bottom: $gs-gutter * 4;
 }
 
+.flex-filler {
+    flex-shrink: 0;
+    flex-grow: 4;
+}
 .recipe__gutter-wrapper {
     display: none;
 
     @include mq($from: desktop) {
         display: flex;
         flex-basis: 5%;
-        position: sticky;
+        position: relative;
         top: 0;
         height: 100vh;
         min-height: 600px;
-        border-right: 1px solid $neutral-3;
+        @supports (position: sticky) {
+            position: sticky;
+        }
     }
 }
 
@@ -256,16 +268,19 @@
 }
 
 .recipe__article-wrapper {
-    margin-left: auto;
-    margin-right: auto;
+    @include mq($until: desktop) {
+        margin-left: auto;
+        margin-right: auto;
+    }
 
     @include mq($from: desktop) {
         flex-basis: 55%;
         float: right;
+        border-left: 1px solid $neutral-3;
     }
 
-    @include mq($from: wide) {
-        flex-basis: 55%;
+    @include mq($from: leftCol) {
+        flex-basis: 45%;
     }
 }
 
@@ -639,7 +654,6 @@
     margin-top: $gs-gutter * 2;
     padding-top: 0;
     padding-bottom: 0;
-    margin-left: -$gs-baseline;
 
     .ad-slot {
         margin-left: auto;


### PR DESCRIPTION
## What does this change?

- Adds a 'flex-filler' div which ensures when images-wrapper element taken out of the page flow (by the sticky polyfill) that the page layout remains the same. 
- Adds fall back widths for elements which are set to `position: fixed` by the polyfill.
- Only calls sticky polyfill on screens larger than desktop.

## What is the value of this and can you measure success?
New design now works on browsers which don't support `position: sticky`

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![chrome54](https://cloud.githubusercontent.com/assets/8484757/24605061/3786b090-185f-11e7-84ef-2cffdf565fb5.gif)

## Tested in CODE?
Tested on IE, Edge, Opera and Chrome v < 55

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
