### PR TITLE
Paid cards AB test setup

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -211,8 +211,8 @@ object FaciaCard {
     showSeriesAndBlogKickers: Boolean
   ): FaciaCard = {
 
-    val isTestContainer = config.displayName.contains("Paid content in unbranded container")
-    if (isTestContainer && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
+    val containerName: Option[String] = config.displayName
+    if ((containerName.contains("Paid content in unbranded container") || containerName.contains("lifestyle")) && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
       PaidCard.fromPressedContent(faciaContent)
     } else {
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
@@ -11,12 +11,12 @@ define([
 ) {
     return function () {
         this.id = 'PaidCardLogo';
-        this.start = '2017-03-29';
-        this.expiry = '2017-03-31';
+        this.start = '2017-04-03';
+        this.expiry = '2017-05-05';
         this.author = 'Lydia Shepherd';
         this.description = 'Paid cards in editorial containers - trial with and without logo';
         this.showForSensitive = true;
-        this.audience = 0;  // wait until we know where the test will run
+        this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = '';
@@ -25,7 +25,7 @@ define([
         this.hypothesis = '';
 
         this.canRun = function () {
-            return config.page.pageId === "commercial-containers" && qwery(".adverts--within-unbranded").length;
+            return config.page.pageId === "uk/lifeandstyle" && !!qwery(".adverts--within-unbranded").length;
         };
 
         this.completeFunc = function(complete) {


### PR DESCRIPTION
## What does this change?
The AB test for paid cards in editorial containers should have the correct parameters. See https://github.com/guardian/frontend/pull/16232

## What is the value of this and can you measure success?
Test will be able to start soon! 

## Does this affect other platforms - Amp, Apps, etc?
We will block the paid card from appearing in apps for now, as it won't show up as branded there.

## Screenshots
With sponsor logos:
![image](https://cloud.githubusercontent.com/assets/6290008/24255847/77e0e7fc-0fde-11e7-9aaa-cb7f28a23bf6.png)
Without logos:
![image](https://cloud.githubusercontent.com/assets/6290008/24255910/ad8d5778-0fde-11e7-8f74-50550b7b99f7.png)
 
Mobile size:
![image](https://cloud.githubusercontent.com/assets/6290008/24255995/eef4796c-0fde-11e7-94c9-a0492a412cec.png)