### PR TITLE
exends new recipe design test by 10 days

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -31,7 +31,7 @@ object ABNewRecipeDesign extends TestDefinition(
   name = "ab-new-recipe-design",
   description = "Users in the test will see the new design on articles with structured recipes",
   owners = Seq(Owner.withGithub("tsop14")),
-  sellByDate = new LocalDate(2017, 4, 3)
+  sellByDate = new LocalDate(2017, 4, 13)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-recipe-design").contains("variant")


### PR DESCRIPTION
@NataliaLKB 

This test can go live if https://github.com/guardian/frontend/pull/16328 is approved and merged. 