### PR TITLE
Extend reading time test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -206,7 +206,7 @@ trait ABTestSwitches {
     "Test demand for getting suggested content based on how much time a reader has",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 4),
+    sellByDate = new LocalDate(2017, 4, 11),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/reading-time.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/reading-time.js
@@ -28,7 +28,7 @@ define([
     return function () {
         this.id = 'ReadingTime';
         this.start = '2017-03-15';
-        this.expiry = '2017-04-04';
+        this.expiry = '2017-04-11';
         this.author = 'Leigh-Anne Mathieson';
         this.description = 'Add a thrasher to the home front that gives users an option to indicate how much time they'
             + ' have to read, to determine demand for suggesting content based on the amount of time they have.';


### PR DESCRIPTION
## What does this change?
Extend the reading time test for a week while I confirm if it can be removed. 

## What is the value of this and can you measure success?
Ensuring we have enough data for the test. 

## Does this affect other platforms - Amp, Apps, etc?
No. 

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
