### PR TITLE
Fix membership regression introduced in #16296

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -75,9 +75,7 @@ const handleMembershipAccess = (): void => {
 
     const updateDOM = (resp: Object): void => {
         const requireClass = 'has-membership-access-requirement';
-        const requiresPaidTier = !membershipAccess.includes(
-            'paid-members-only'
-        );
+        const requiresPaidTier = membershipAccess.includes('paid-members-only');
         // Check the users access matches the content
         const canViewContent = requiresPaidTier
             ? !!resp.tier && resp.isPaidTier


### PR DESCRIPTION
## What does this change?

Fixes a regression introduced in #16296 as part of the ES6 conversion. With the regression the membership tiers are inverted.

## What is the value of this and can you measure success?

Users see the content made for them.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
