### PR TITLE
update link to syndication to https

### DIFF
--- a/common/app/views/fragments/syndication.scala.html
+++ b/common/app/views/fragments/syndication.scala.html
@@ -6,7 +6,7 @@
             <li class="syndication__item">
                 <a class="syndication__action"
                 data-link-name="meta-syndication-@content.content.syndicationType"
-                href="http://syndication.theguardian.com/automation/?url=@URLEncode(content.metadata.webUrl)&type=@content.content.syndicationType&internalpagecode=@content.content.internalPageCode"
+                href="https://syndication.theguardian.com/automation/?url=@URLEncode(content.metadata.webUrl)&type=@content.content.syndicationType&internalpagecode=@content.content.internalPageCode"
                 target="_blank"
                 title="Reuse this content">
                     <span class="syndication__link button button--syndication-reprint button--small">Reuse this content</span>


### PR DESCRIPTION
## What does this change?

Since today `4.00` `pm`, syndication now works fine on `https` 🎉 

