### PR TITLE
Upgrade to raven-js v3.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash-amd": "~2.4.1",
     "ophan-tracker-js": "^1.3.6",
     "qwery": "3.4.2",
-    "raven-js": "~1.1.16",
+    "raven-js": "^3.14.0",
     "react": "0.13.2",
     "reqwest": "2.0.5",
     "tcp-ping": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,17 +463,7 @@ babel-helper-explode-assignable-expression@^6.18.0:
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
 
-babel-helper-function-name@^6.18.0, babel-helper-function-name@^6.8.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz#68ec71aeba1f3e28b2a6f0730190b754a9bf30e6"
-  dependencies:
-    babel-helper-get-function-arity "^6.18.0"
-    babel-runtime "^6.0.0"
-    babel-template "^6.8.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-
-babel-helper-function-name@^6.23.0:
+babel-helper-function-name@^6.18.0, babel-helper-function-name@^6.23.0, babel-helper-function-name@^6.8.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
   dependencies:
@@ -483,14 +473,7 @@ babel-helper-function-name@^6.23.0:
     babel-traverse "^6.23.0"
     babel-types "^6.23.0"
 
-babel-helper-get-function-arity@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz#a5b19695fd3f9cdfc328398b47dafcd7094f9f24"
-  dependencies:
-    babel-runtime "^6.0.0"
-    babel-types "^6.18.0"
-
-babel-helper-get-function-arity@^6.22.0:
+babel-helper-get-function-arity@^6.18.0, babel-helper-get-function-arity@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz#0beb464ad69dc7347410ac6ade9f03a50634f5ce"
   dependencies:
@@ -4336,7 +4319,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -6099,9 +6082,11 @@ range-parser@^1.2.0, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@~1.1.16:
-  version "1.1.22"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-1.1.22.tgz#1a9d13621c5ec4d02981e1e4654359dad4104c8a"
+raven-js@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.14.0.tgz#94dda81d975fdc4a42f193db437cf70021d654e0"
+  dependencies:
+    json-stringify-safe "^5.0.1"
 
 raw-body@~2.1.7:
   version "2.1.7"


### PR DESCRIPTION
## What does this change?

A [recent blog](https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise.html) posted by the Sentry team recommended upgrading to the latest version of Raven in order to reduce the amount of noise that gets generated in Sentry. We tried this last November (#14982) and subsequently had to revert the change (#15190) due to a large amount of mysterious Windows phone errors that were generated as a result.

After some [brief discussion](https://twitter.com/SiAdcock/status/847131315849904128) with the blog author, it was suggested that these errors may still be in our app, just not reported by the ancient version of Raven we are currently using.

If these errors are still surfacing, we could probably look at ignoring those particular errors, as it is likely to be caused by something untraceable, internal to the browser.

## What is the value of this and can you measure success?

- Less noise in Sentry
- More reliable error reporting

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

I'd like to do further testing in CODE before merging to ensure the Raven API has not changed. Please don't merge until this is confirmed 😄 

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
