### PR TITLE
Prevent Epic being inserted before multiple `.submeta` elements

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -194,7 +194,7 @@ define([
                     var sibling = $(selector);
 
                     if (sibling.length > 0) {
-                        component.insertBefore(sibling);
+                        component.insertBefore(sibling.first());
                         mediator.emit(test.insertEvent, component);
                         onInsert(component);
 


### PR DESCRIPTION
## What does this change?
Ensures the Epic is only inserted before the first `.submeta` element on the page. The new reader's questions feature adds a second instance of this class to the page, which currently means two Epics will be inserted.