### PR TITLE
Small tweaks to caption overlay and tones on paid-content

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -760,6 +760,9 @@ $caption-button-size: 32px;
 
         .caption--main.caption--img {
             position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 0;
             background: rgba($multimedia-support-5, .8);
             color: #ffffff;
             display: none;
@@ -772,11 +775,6 @@ $caption-button-size: 32px;
 
             a {
                 color: #ffffff;
-            }
-
-            &.caption--img {
-                bottom: 0;
-                padding-bottom: $gs-baseline;
             }
 
             &:before {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -828,7 +828,7 @@
         background-color: $paid-article;
 
         .inline-close {
-            background-color: $neutral-5;
+            background-color: $neutral-6;
         }
     }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -820,9 +820,16 @@
         }
     }
 
-    .meta__social,
-    .meta__numbers {
-        border-top-color: $paid-article-header;
+    .meta__extras {
+        border-color: $paid-article-header;
+    }
+
+    .social--expanded-top {
+        background-color: $paid-article;
+
+        .inline-close {
+            background-color: $neutral-5;
+        }
     }
 
     &.tonal--tone-media {

--- a/static/src/stylesheets/module/content/_tones-mixins.scss
+++ b/static/src/stylesheets/module/content/_tones-mixins.scss
@@ -111,7 +111,7 @@
         }
 
         .tonal__main {
-            @include mq(phablet) {
+            @include mq(tablet) {
                 padding-top: $gs-baseline * 2;
             }
 


### PR DESCRIPTION
The new caption overlays were behaving badly at certain breakpoints. 


# Look
At the space above the image, the space to the right of the caption. This simply will not do. What a nightmare.

<img width="732" alt="screen shot 2017-04-04 at 11 32 06" src="https://cloud.githubusercontent.com/assets/14570016/24652609/72cfe5f6-192a-11e7-85ba-089cff9c5143.png">

# Look
That's better.

<img width="734" alt="screen shot 2017-04-04 at 11 32 26" src="https://cloud.githubusercontent.com/assets/14570016/24652610/72d0f1b2-192a-11e7-8bc9-fc00a624eba1.png">

# Look
The tone is wrong and the meta-extras borders aren't visible.

<img width="374" alt="screen shot 2017-04-04 at 11 29 53" src="https://cloud.githubusercontent.com/assets/14570016/24652519/21f853ca-192a-11e7-867d-e81c651417b9.png">

# Look
Now the tone is right and there borders ARE visible.

<img width="373" alt="screen shot 2017-04-04 at 11 29 37" src="https://cloud.githubusercontent.com/assets/14570016/24652520/21f98876-192a-11e7-9ead-4d1f480dc948.png">
