### PR TITLE
Refactor tailor module and update regulars test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-regulars-v2.js
@@ -11,9 +11,6 @@ define([
     contributionsEpicEqualButtons,
     tailor
 ) {
-
-    var bwidCookie = cookies.get('bwid') || '';
-
     function controlTemplate(regular) {
         var suffix = regular ? '_regular' : '_non_regular';
         return function(variant) {
@@ -72,28 +69,14 @@ define([
         }
     }
 
-    function isRegular() {
-        return tailor.fetchData('suggestions', false).then(function (suggestions) {
-            try {
-                return suggestions.userDataForClient.regular;
-            } catch (e) {
-                return false;
+    function renderTemplate(render, template) {
+        return tailor.isRegular().then(function (regular) {
+            if (regular) {
+                render(template(true));
+            } else {
+                render(controlTemplate(false));
             }
         });
-    }
-
-    function renderTemplate(render, template) {
-        if (bwidCookie) {
-            isRegular().then(function (regular) {
-                if (regular) {
-                    render(template(true));
-                } else {
-                    render(controlTemplate(false));
-                }
-            });
-        } else {
-            render(controlTemplate(false));
-        }
     }
 
     return contributionsUtilities.makeABTest({

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -23,9 +23,7 @@ define([
     function getURL(type, queryParams) {
         var baseURL = URLS[type];
 
-        if (!browserId || !baseURL) {
-            return '';
-        }
+        if (!browserId || !baseURL) return;
 
         baseURL += browserId;
 
@@ -48,28 +46,20 @@ define([
     function fetchData(type, bypassStorage, queryParams) {
         var url = getURL(type, queryParams);
 
-        // if no valid url end point return empty object
-        if (!url) {
-            return Promise.resolve({});
-        }
+        return new Promise(function(resolve, reject) {
+            // if no valid url end point, or tailor switch is off, reject
+            if (!url || !config.switches.useTailorEndpoints) return reject();
 
-        var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
+            var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
 
-        // if data in local storage return this
-        if (tailorData && tailorData[url]) {
-            return Promise.resolve(tailorData[url]);
-        }
+            // if data in local storage return this
+            if (tailorData && tailorData[url]) {
+                return resolve(tailorData[url]);
+            }
 
-        // if use tailor switch is off then return an empty object
-        if (!config.switches.useTailorEndpoints) {
-            return Promise.resolve({});
-        }
-
-        return fetchJson(url, {
-                    method: 'get'
-                })
-                .then(handleResponse.bind(null, url))
-                .catch(handleError.bind(null, url))
+            return resolve(fetchJson(url, { method: 'get' }));
+        }).then(handleResponse.bind(null, url))
+          .catch(handleError.bind(null, url));
     }
 
     function handleResponse(url, data) {
@@ -90,7 +80,25 @@ define([
         });
     }
 
+    /**
+     * Query the user's regular status
+     *
+     * @returns {Promise.<Boolean>}
+     */
+    function isRegular() {
+        return fetchData('suggestions', false).then(function(suggestions) {
+            try {
+                return suggestions.userDataForClient.regular;
+            } catch (e) {
+                return false;
+            }
+        }).catch(function() {
+            return false;
+        });
+    }
+
     return {
-        fetchData: fetchData
+        fetchData: fetchData,
+        isRegular: isRegular
     };
 });


### PR DESCRIPTION
## What does this change?
This moves the `isRegular` check (which we'll need to use in a few other places
soon) to the tailor module and slightly tidies the `fetchData` function.

## What is the value of this and can you measure success?
The `tailor` module providers a more user-friendly API over the ajax calls, so users of the module don't have to implement their own browserID cookie checks and code around the structure of tailor responses.

## Tested in CODE?
Only locally 