### PR TITLE
Hide arrow when fixed

### DIFF
--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -74,11 +74,17 @@
     width: 100%;
     overflow: hidden;
 
+    @include mq($until: desktop) {
+        position: relative;
+    }
+
     @include mq($from: desktop) {
         flex-basis: 40%;
-        position: sticky;
         height: 100vh;
         min-height: 600px;
+        @supports (position: sticky) {
+            position: sticky;
+        }
         &.is-sticky {
             width: 40%
         }

--- a/static/src/stylesheets/module/content/_recipe-article.scss
+++ b/static/src/stylesheets/module/content/_recipe-article.scss
@@ -79,7 +79,6 @@
         position: sticky;
         height: 100vh;
         min-height: 600px;
-
         &.is-sticky {
             width: 40%
         }
@@ -262,8 +261,13 @@
         transform: rotate(270deg);
     }
 
-    &.visible, &.hide-on-desktop {
+    &.hide-on-desktop {
         opacity: 1;
+    }
+    @supports (position: sticky) {
+        &.visible {
+            opacity: 1;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?
Puts position sticky behind `@supports` check. 
Hides arrow on browsers running sticky polyfill.

## What is the value of this and can you measure success?
Better visual experience across all browsers. 🖌

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
