### PR TITLE
Make the mostPop MPU behave, across browsers

### DIFF
--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -205,23 +205,6 @@ Hence why a greater depth of selector specificity is needed.
     }
 }
 
-.popular-trails__mpu {
-    margin: $gs-baseline auto 0;
-
-    @include mq(desktop) {
-        min-width: $mpu-original-width;
-        border-top: 1px solid $neutral-5;
-        padding: $gs-baseline 0 0 $gs-gutter;
-        margin-top: 39px; // magic number: unavoidable to match the tab headings
-    }
-
-    .fc-slice__item--no-mpu {
-        @include mq($until: desktop) {
-            min-height: 0;
-        }
-    }
-}
-
 .fc-slice--popular {
     .fc-slice__item:before {
         display: none;
@@ -245,25 +228,38 @@ Hence why a greater depth of selector specificity is needed.
 }
 
 .fc-slice__popular-mpu {
-    width: $mpu-original-width + 20px;
-    margin: 0 auto;
+    width: $mpu-original-width + $gs-gutter;
+    min-width: $mpu-original-width;
+    margin: $gs-baseline auto 0;
 
     .ad-slot {
         min-height: $mpu-original-height + $mpu-ad-label-height;
+        margin: 0;
     }
 
     @include mq(desktop) {
         width: auto;
         margin-left: auto;
+        border-top: 1px solid $neutral-5;
+        padding: $gs-baseline 0 0 $gs-gutter;
+        margin-top: 39px; // magic number: unavoidable to match the tab headings
 
-        .ad-slot {
-            margin: 0;
+        .tabs__content & {
+            border-top: 0;
+            margin-top: 0;
+            padding-top: 0;
         }
 
         .has-no-flex & {
             position: absolute;
             top: $gs-baseline;
             right: -($gs-gutter / 2);
+        }
+    }
+
+    .fc-slice__item--no-mpu {
+        @include mq($until: desktop) {
+            min-height: 0;
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Targeting MostPop (AKA 'most viewed') container on fronts

Firefox reserves MPU space with an adblocker enabled, Chrome and Opera **do not**. Safari has gone wild and suddenly decided the MPU should be pushed all the way over, to give the tabs all the space.

...CSS  (╯°□°）╯︵ ┻━┻)

## What is the value of this and can you measure success?

- Fix idiopathic CSS breakage on Safari where the MPU was running off the page
- Make MostPop look and behave the same across various browsers
- Makes the fronts MostPop behave the **same** as the article trail MostPop; MostPop should reserve space for the MPU and the list should not flow to fill if the MPU is blocked or gone
- Amalgamate css of `popular-trails__mpu` and `fc-slice__popular-mpu` to dedupe efforts

Success? Ideally, nothing looks broken in MostPop, anywhere.

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

##### Safari BEFORE:

<img width="1164" alt="picture 653" src="https://cloud.githubusercontent.com/assets/8607683/24658659/462d56ec-1942-11e7-818e-5ffdfc21d67d.png">

##### Safari AFTER:

<img width="1162" alt="picture 652" src="https://cloud.githubusercontent.com/assets/8607683/24658674/517a3c72-1942-11e7-958e-204f8154bb14.png">


##### Opera (blocks by default) and with adBlock enabled in Chrome BEFORE:

<img width="999" alt="picture 654" src="https://cloud.githubusercontent.com/assets/8607683/24658567/fc1a92f4-1941-11e7-922d-afa548e5ba7b.png">

##### Opera (blocks by default) and with adBlock enabled in Chrome AFTER:

<img width="1192" alt="picture 655" src="https://cloud.githubusercontent.com/assets/8607683/24658628/2c3047ea-1942-11e7-98cc-453779dda41b.png">


## Tested in CODE?

- [x] Chrome
- [x] Opera
- [x] Safari
- [x] Firefox
- [x] IE 11
- [x] Edge 14