### PR TITLE
Fix A/B clash 

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -22,7 +22,7 @@ define([
         if (clashingTests.length > 0) {
             return some(clashingTests, function (test) {
                 return some(test.variants, function (variant) {
-                    return f(test.name, variant);
+                    return f(test, variant);
                 });
             });
         }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -52,20 +52,13 @@ define([
         return out;
     }, []);
 
-    function nonOutbrainCompliantVariantIds(testInstance) {
-        return reduce(testInstance.variants, function(out, variant) {
-            if (!variant.isOutbrainCompliant) {
-                out.push(variant.id)
-            }
-            return out;
-        }, [])
-    }
-
     var abTestClashData = tests.map(function(test) {
         var testInstance = new test();
         return {
             name: testInstance.id,
-            variants: nonOutbrainCompliantVariantIds(testInstance)
+            variants: testInstance.variants.filter(function (variant) {
+                return !variant.isOutbrainCompliant
+            })
         }
     });
 


### PR DESCRIPTION
## What does this change?
A nice bit of housekeeping by @regiskuckaertz recently changed the signature of `ab.isInVariant` – but the call to that in the A/B test clash module is still using the old form. This fixes that.

## What is the value of this and can you measure success?
ヾ(｡･ω･)ｼ     ＯＵＴＢＲＡＩＮ      ＣＯＭＰＬＩＡＮＣＥ    ⤴︎ ε=ε=(ง ˃̶͈̀ᗨ˂̶͈́)۶ ⤴︎

## Does this affect other platforms - Amp, Apps, etc?
No 

## Screenshots
No

## Tested in CODE?
No 
