### PR TITLE
Some small nav tweaks

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -400,8 +400,8 @@ object NewNavigation {
     )
 
     val worldSubNav = NavLinkLists(
-      List(world, europe, usNews, americas, asia, australiaNews, middleEast),
-      List(africa, cities, globalDevelopment)
+      List(world, europe, usNews, americas, asia, australiaNews, middleEast, africa),
+      List(cities, globalDevelopment)
     )
 
     val moneySubNav = NavLinkLists(List(money, property, pensions, savings, borrowing, careers))

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -20,7 +20,7 @@ object NavLinks {
   var auPolitics = NavLink("AU politics", "/australia-news/australian-politics", "australia-news/australian-politics", longTitle = "australian politics")
   var auImmigration = NavLink("immigration", "/australia-news/australian-immigration-and-asylum", "australia-news/australian-immigration-and-asylum")
   var indigenousAustralia = NavLink("indigenous australia", "/australia-news/indigenous-australians", "australia-news/indigenous-australians")
-  var indigenousAustraliaOpinion = NavLink("Indigenous", "/australia-news/indigenous-australians+tone/comment", "commentisfree/series/indigenousx")
+  var indigenousAustraliaOpinion = NavLink("Indigenous", "/commentisfree/series/indigenousx", "commentisfree/series/indigenousx")
   var usNews = NavLink("US", "/us-news", "us-news", longTitle = "US news")
   var usPolitics = NavLink("US politics", "/us-news/us-politics", "us-news/us-politics", longTitle = "US politics")
   val education = NavLink("education", "/education", "education")

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -34,7 +34,8 @@
 .media-primary--showcase,
 .content__standfirst a,
 .content__standfirst br,
-figure {
+figure,
+.new-header {
     display: none !important;
 }
 


### PR DESCRIPTION
## What does this change?
This PR:
* adds `africa` to the world tertiary nav. It looks like this:
![image](https://cloud.githubusercontent.com/assets/8774970/24701995/b846659a-19f4-11e7-99fd-10bee12011c1.png)

* A request from editorial in AU to change the link to Indigenous opinion back to what it was before
* Hide the header on print

## What is the value of this and can you measure success?
Just some small improvements ⭐️ 

## Does this affect other platforms - Amp, Apps, etc?
Nope!

## Tested in CODE?
Nope

