### PR TITLE
Relax eslints `consistent-return` rule, now that we have flow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
         ],
         'no-extend-native': 'error',
         'func-style': ['error', 'expression', { allowArrowFunctions: true }],
+        'consistent-return': 0,
     },
     // don't look for eslintrcs above here
     root: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
         ],
         'no-extend-native': 'error',
         'func-style': ['error', 'expression', { allowArrowFunctions: true }],
-        'consistent-return': 0,
     },
     // don't look for eslintrcs above here
     root: true,

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -61,5 +61,8 @@ module.exports = {
         // our own rules for frontend
         // live in tools/eslint-plugin-guardian-frontend
         'guardian-frontend/global-config': 2,
+
+        // flow should take care of our return values
+        'consistent-return': 'off',
     },
 };

--- a/static/src/javascripts/lib/sha1.js
+++ b/static/src/javascripts/lib/sha1.js
@@ -1,6 +1,6 @@
 // @flow
 
-/* eslint no-bitwise: 0, no-plusplus: 0, default-case: 0, consistent-return: 0 */
+/* eslint no-bitwise: 0, no-plusplus: 0, default-case: 0 */
 
 /**
  * SHA-1 hash function reference implementation.


### PR DESCRIPTION
## What does this change?

Relaxs eslints `consistent-return` rule, now that we have flow. @SiAdcock proposed it as part of [his review in another PR](https://github.com/guardian/frontend/pull/16326#pullrequestreview-30633076).

## What is the value of this and can you measure success?

Less `return undefined` weirdos in our code.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![tumblr_inline_odd2lpiw7j1raprkq_500](https://cloud.githubusercontent.com/assets/2244375/24704028/c9b1e062-19fd-11e7-8f77-1173e1a272e5.gif)


## Tested in CODE?

No.
