### PR TITLE
Move path logic into `fetch` since `fetch-json` only wraps it

### DIFF
--- a/static/src/javascripts-legacy/lib/fetch.js
+++ b/static/src/javascripts-legacy/lib/fetch.js
@@ -1,7 +1,9 @@
 define([
+    'lib/config',
     'reqwest',
     'Promise'
 ], function (
+    config,
     reqwest,
     Promise
 ) {
@@ -53,6 +55,11 @@ define([
         var withCredentials =
             (isCors && options.credentials === 'include') ||
             (!isCors && options.credentials === 'same-origin');
+
+        if (!path.match('^(https?:)?//')) {
+            path = (config.page.ajaxUrl || '') + path;
+            options.mode = 'cors';
+        }
 
         return {
             url: path,

--- a/static/src/javascripts/lib/fetch-json.js
+++ b/static/src/javascripts/lib/fetch-json.js
@@ -1,17 +1,11 @@
 // @flow
-import config from 'lib/config';
 import fetch from 'lib/fetch';
 
 const json = (input: string | Request, init: RequestOptions = {}) => {
     // #? we should use Object.assign for this assignment, but this currently breaks
     // Karma tests that depend on fetch-json.js and have not been stubbed
     const options = init;
-    let path = typeof input === 'string' ? input : input.url;
-
-    if (!path.match('^(https?:)?//')) {
-        path = (config.page.ajaxUrl || '') + path;
-        options.mode = 'cors';
-    }
+    const path = typeof input === 'string' ? input : input.url;
 
     return fetch(path, options).then(resp => {
         if (resp.ok) {


### PR DESCRIPTION
## What does this change?

Move path logic into `fetch` since `fetch-json` only wraps it

## What is the value of this and can you measure success?

We don't have to duplicate the magic.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
