### PR TITLE
Remove lib/ajax from bootstraps

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
@@ -6,7 +6,7 @@ define([
     'lib/$',
     'lib/config',
     'lib/storage',
-    'lib/ajax',
+    'lib/fetch',
     'lodash/utilities/template',
     'lib/robust',
     'common/views/svgs',
@@ -28,7 +28,7 @@ define([
     $,
     config,
     storage,
-    ajax,
+    fetch,
     template,
     robust,
     svgs,
@@ -178,11 +178,13 @@ define([
             return modules.getSub().then(function (sub) {
                 var endpoint = sub && sub.endpoint;
                 if (endpoint) {
-                    return ajax({
-                        url: notificationsEndpoint,
+                    return fetch(notificationsEndpoint, {
                         method: 'POST',
                         contentType: 'application/x-www-form-urlencoded',
-                        data: {browserEndpoint: endpoint, notificationTopicId: config.page.pageId}
+                        body: {
+                            browserEndpoint: endpoint,
+                            notificationTopicId: config.page.pageId
+                        }
                     });
                 }
             });

--- a/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
@@ -180,11 +180,13 @@ define([
                 if (endpoint) {
                     return fetch(notificationsEndpoint, {
                         method: 'POST',
-                        contentType: 'application/x-www-form-urlencoded',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
                         body: {
                             browserEndpoint: endpoint,
-                            notificationTopicId: config.page.pageId
-                        }
+                            notificationTopicId: config.page.pageId,
+                        },
                     });
                 }
             });

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -94,7 +94,6 @@ const handleMembershipAccess = (): void => {
 
     if (identity.isUserLoggedIn()) {
         fetchJSON(`${membershipUrl}/user/me`, {
-            type: 'json',
             mode: 'cors',
             credentials: 'include',
         })

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -20,7 +20,7 @@ import raven from 'lib/raven';
 import userPrefs from 'common/modules/user-prefs';
 import images from 'common/modules/ui/images';
 import storage from 'lib/storage';
-import ajax from 'lib/ajax';
+import fetchJSON from 'lib/fetch-json';
 import mediator from 'lib/mediator';
 import checkMediator from 'common/modules/check-mediator';
 import addEventListener from 'lib/add-event-listener';
@@ -93,11 +93,10 @@ const handleMembershipAccess = (): void => {
     };
 
     if (identity.isUserLoggedIn()) {
-        ajax({
-            url: `${membershipUrl}/user/me`,
+        fetchJSON(`${membershipUrl}/user/me`, {
             type: 'json',
-            crossOrigin: true,
-            withCredentials: true,
+            mode: 'cors',
+            credentials: 'include',
         })
             .then(updateDOM)
             .catch(redirect);


### PR DESCRIPTION
## What does this change?

Part of the push to remove `lib/ajax`, replacing it with `lib/fetch` and `lib/fetch-json`

## What is the value of this and can you measure success?

Consistent fetch-compatible API for AJAX requests

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
