### PR TITLE
Remove lib/ajax from membership modules

### DIFF
--- a/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
@@ -1,11 +1,18 @@
 define([
     'bean',
     'lib/$',
-    'lib/ajax',
+    'lib/fetch',
     'lib/config',
     'membership/formatters',
     'membership/stripe'
-], function (bean, $, ajax, config, formatters, stripe) {
+], function (
+    bean,
+    $,
+    fetch,
+    config,
+    formatters,
+    stripe
+) {
 
     var PACKAGE_COST = '.js-dig-package-cost',
         PAYMENT_FORM = '.js-dig-card-details',
@@ -29,16 +36,15 @@ define([
         IS_HIDDEN_CLASSNAME = 'is-hidden';
 
     function fetchUserDetails() {
-        ajax({
-
-            url: config.page.userAttributesApiUrl + '/me/mma-digitalpack',
-            crossOrigin: true,
-            withCredentials: true,
-            method: 'get'
+        fetch(config.page.userAttributesApiUrl + '/me/mma-digitalpack', {
+            mode: 'cors',
+            credentials: 'include',
         }).then(function (resp) {
-            if (resp && resp.subscription) {
+            var body = resp && resp.text();
+
+            if (body && body.subscription) {
                 hideLoader();
-                populateUserDetails(resp);
+                populateUserDetails(body);
             } else {
                 hideLoader();
                 displayDigitalPackUpSell();

--- a/static/src/javascripts-legacy/projects/membership/membership-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/membership-tab.js
@@ -1,11 +1,18 @@
 define([
     'bean',
     'lib/$',
-    'lib/ajax',
+    'lib/fetch',
     'lib/config',
     'membership/formatters',
     'membership/stripe'
-], function (bean, $, ajax, config,  formatters, stripe) {
+], function (
+    bean,
+    $,
+    fetch,
+    config,
+    formatters,
+    stripe
+) {
 
     var CARD_DETAILS = '.js-mem-card-details',
         PAYPAL = '.js-mem-paypal',
@@ -38,15 +45,15 @@ define([
         IS_HIDDEN_CLASSNAME = 'is-hidden';
 
     function fetchUserDetails() {
-        ajax({
-            url: config.page.userAttributesApiUrl + '/me/mma-membership',
-            crossOrigin: true,
-            withCredentials: true,
-            method: 'get'
+        fetch(config.page.userAttributesApiUrl + '/me/mma-membership', {
+            mode: 'cors',
+            credentials: 'include',
         }).then(function (resp) {
-            if (resp && resp.subscription) {
+            var body = resp && resp.text();
+
+            if (body && body.subscription) {
                 hideLoader();
-                populateUserDetails(resp);
+                populateUserDetails(body);
             } else {
                 hideLoader();
                 displayMembershipUpSell();

--- a/static/src/javascripts-legacy/projects/membership/stripe.js
+++ b/static/src/javascripts-legacy/projects/membership/stripe.js
@@ -138,7 +138,9 @@ define([
                     body: {
                         stripeToken: token.id
                     },
-                }).then(function(card) {
+                }).then(function(resp) {
+                    var card = resp && resp.text();
+
                     display($parent, card);
                 }).catch(function() {
                     $parent.text('We have not been able to update your card details at this time.');

--- a/static/src/javascripts-legacy/projects/membership/stripe.js
+++ b/static/src/javascripts-legacy/projects/membership/stripe.js
@@ -2,10 +2,10 @@
 define([
     'lib/$',
     'bean',
-    'lib/ajax',
+    'lib/fetch',
     'lib/config',
     'fastdom'
-], function ($, bean, ajax, config, fastdom) {
+], function ($, bean, fetch, config, fastdom) {
 
     var checkoutHandler = StripeCheckout.configure({
         key: config.page.stripePublicToken,
@@ -128,20 +128,19 @@ define([
         function update(endpoint) {
             return function (token) {
                 loading.send();
-                ajax({
-                    url: endpoint,
-                    crossOrigin: true,
-                    withCredentials: true,
+                fetch(endpoint, {
+                    mode: 'cors',
+                    credentials: 'include',
                     method: 'post',
                     headers: {
                         'Csrf-Token': 'nocheck'
                     },
-                    data: {
+                    body: {
                         stripeToken: token.id
-                    }
-                }).then(function success(card) {
+                    },
+                }).then(function(card) {
                     display($parent, card);
-                }, function fail() {
+                }).catch(function() {
                     $parent.text('We have not been able to update your card details at this time.');
                 });
             };


### PR DESCRIPTION
## What does this change?

Part of the push to remove `lib/ajax`, replacing it with `lib/fetch` and `lib/fetch-json`

## What is the value of this and can you measure success?

Consistent fetch-compatible API for AJAX requests

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
