### PR TITLE
Extend LiveBlogChromeNotifications switch to end of June

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -483,7 +483,7 @@ trait FeatureSwitches {
     "Live blog chrome notifications - prod",
     owners = Seq(Owner.withGithub("janua")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 5),
+    sellByDate = new LocalDate(2017, 6, 30), //Friday
     exposeClientSide = true
   )
 


### PR DESCRIPTION
This extends the switch around liveblog notifications to the end of June, which is a Friday.

@NataliaLKB @DiegoVazquezNanini @jfsoul 