### PR TITLE
Import cleanup

### DIFF
--- a/admin/app/views/admin_main.scala.html
+++ b/admin/app/views/admin_main.scala.html
@@ -4,6 +4,8 @@
 @import controllers.admin.routes.UncachedWebAssets
 @import templates.inlineJS.blocking.js._
 @import play.api.Mode.Dev
+@import conf.Static
+@import conf.Configuration
 
 <!DOCTYPE html>
 

--- a/admin/app/views/football/main.scala.html
+++ b/admin/app/views/football/main.scala.html
@@ -3,6 +3,7 @@
 @import controllers.admin.routes.UncachedAssets
 @import controllers.admin.routes.UncachedWebAssets
 @import play.api.Mode.Dev
+@import conf.Static
 
 <!DOCTYPE html>
 <html lang="en">

--- a/admin/app/views/football/player/cards/assist.scala.html
+++ b/admin/app/views/football/player/cards/assist.scala.html
@@ -1,5 +1,7 @@
 @(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
+@import conf.Configuration
+
 @views.html.football.main("Player card") {
 <hgroup class="page-header">
     <h1>Player card - assist</h1>

--- a/admin/app/views/football/player/cards/attack.scala.html
+++ b/admin/app/views/football/player/cards/attack.scala.html
@@ -1,5 +1,7 @@
 @(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
+@import conf.Configuration
+
 @views.html.football.main("Player card") {
 <hgroup class="page-header">
     <h1>Player card - attack</h1>

--- a/admin/app/views/football/player/cards/defence.scala.html
+++ b/admin/app/views/football/player/cards/defence.scala.html
@@ -1,5 +1,7 @@
 @(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
+@import conf.Configuration
+
 @views.html.football.main("Player card") {
 <hgroup class="page-header">
     <h1>Player card - defence</h1>

--- a/admin/app/views/football/player/cards/discipline.scala.html
+++ b/admin/app/views/football/player/cards/discipline.scala.html
@@ -1,5 +1,7 @@
 @(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
+@import conf.Configuration
+
 @views.html.football.main("Player card") {
 <hgroup class="page-header">
     <h1>Player card - discipline</h1>

--- a/admin/app/views/football/player/cards/goalkeeper.scala.html
+++ b/admin/app/views/football/player/cards/goalkeeper.scala.html
@@ -1,5 +1,7 @@
 @(playerId: String, player: pa.PlayerProfile, playerStats: pa.StatsSummary, playerAppearances: pa.PlayerAppearances)(implicit context: model.ApplicationContext)
 
+@import conf.Configuration
+
 @views.html.football.main("Player card") {
 <hgroup class="page-header">
     <h1>Player card - goalkeeper</h1>

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -1,5 +1,6 @@
 @()(implicit context: model.ApplicationContext)
 @import conf.Static
+@import conf.Configuration
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
 /*eslint quotes: [2, "single"], curly: [2, "multi-line"], strict: 0*/

--- a/applications/app/templates/webAppManifest.scala.js
+++ b/applications/app/templates/webAppManifest.scala.js
@@ -1,3 +1,5 @@
+@import conf.Static
+
 @()
 {
     "name":"The Guardian",

--- a/applications/app/views/signup/newsletters.scala.html
+++ b/applications/app/views/signup/newsletters.scala.html
@@ -3,6 +3,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 
 @import common.LinkTo
+@import conf.Static
 
 @(signupPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 

--- a/applications/app/views/signup/newsletters.scala.html
+++ b/applications/app/views/signup/newsletters.scala.html
@@ -1,6 +1,5 @@
 @import model.Page
 @import model.{EmailNewsletter, EmailNewsletters}
-@import views.support.RenderClasses
 @import views.support.`package`.Seq2zipWithRowInfo
 
 @import common.LinkTo

--- a/archive/app/views/notFound.scala.html
+++ b/archive/app/views/notFound.scala.html
@@ -1,5 +1,7 @@
 @()
 
+@import conf.Configuration
+
 <!DOCTYPE html>
 <!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if IE 7]>    <html class="lt-ie9 lt-ie8" lang="en"> <![endif]-->

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -1,6 +1,7 @@
 @(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import play.api.libs.json.{JsObject, Json}
+@import conf.Static
 
 @main(page){ }{
 

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -5,7 +5,7 @@ import conf.Configuration
 import model.ApplicationContext
 import org.apache.commons.io.IOUtils
 import play.api.libs.json._
-import play.api.{Mode, Play}
+import play.api.Mode
 
 import scala.collection.concurrent.{Map => ConcurrentMap, TrieMap}
 import scala.util.{Failure, Success, Try}

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -12,7 +12,7 @@ import play.twirl.api.Html
 
 import scala.collection.JavaConversions._
 import scala.collection.immutable.ListMap
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 case class CSSRule(selector: String, styles: ListMap[String, String]) {
   val canInline = !selector.contains(":")

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -10,7 +10,6 @@ import common.commercial.hosted.HostedUtils.getAndLog
 import common.commercial.hosted.HostedVideoPage.log
 import conf.Configuration.site
 import model.StandalonePage
-import play.api.libs.json.Json
 
 trait HostedPage extends StandalonePage {
   def id: String

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -2,7 +2,6 @@ package common
 
 import java.io.{File, FileInputStream}
 import java.util.Map.Entry
-import java.util.{Properties => JavaProperties}
 
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
@@ -12,7 +11,6 @@ import com.typesafe.config.ConfigException
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import org.apache.commons.io.IOUtils
-import play.api.Play
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -1,7 +1,6 @@
 package common.dfp
 
 import model.Tag
-import conf.switches.Switches._
 import common.Edition
 
 trait HighMerchandiseComponentAgent {

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -1,7 +1,6 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import org.joda.time.LocalDate
 
 trait PerformanceSwitches {
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -4,8 +4,7 @@ import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
 import com.gu.contentapi.client.ContentApiClientLogic
 import com.gu.contentapi.client.model._
-import com.gu.contentapi.client.model.v1.{AtomsResponse, ItemResponse}
-import com.gu.contentapi.client.thrift.ThriftDeserializer
+import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import common._
 import conf.Configuration

--- a/common/app/crosswords/CrosswordTreat.scala
+++ b/common/app/crosswords/CrosswordTreat.scala
@@ -1,6 +1,6 @@
 package crosswords
 
-import com.gu.contentapi.client.model.v1.{CrosswordPosition => Position, Crossword}
+import com.gu.contentapi.client.model.v1.{CrosswordPosition => Position}
 
 object CrosswordGrid {
   val DefaultTreat = CrosswordGrid(Set(

--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -11,7 +11,6 @@ import play.api.{Environment, Mode}
 import play.api.http.HttpEntity
 import play.api.libs.MimeTypes
 import play.api.mvc._
-import play.api.libs.iteratee.Enumerator
 
 class DevAssetsController(val environment: Environment) extends Controller with ExecutionContexts {
 

--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -1,6 +1,5 @@
 package implicits
 
-import com.gu.commercial.branding.PaidContent
 import common.Edition.defaultEdition
 import implicits.Dates._
 import model._

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -2,9 +2,7 @@ package layout
 
 import cards.{MediaList, Standard}
 import com.gu.commercial.branding.Branding
-import com.gu.contentapi.client.model.v1.{ContentType, TagType}
 import com.gu.contentapi.client.model.{v1 => contentapi}
-import com.gu.facia.api.{utils => fapiutils}
 import common.Edition.defaultEdition
 import common.{Edition, LinkTo}
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -5,7 +5,6 @@ import conf.switches.Switches
 import implicits.FaciaContentFrontendHelpers._
 import layout.ItemClasses
 import model.pressed.PressedContent
-import com.gu.contentapi.client.model.{v1 => contentapi}
 import model.content.MediaAtom
 
 object FaciaDisplayElement {

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -1,7 +1,6 @@
 package model
 
 import campaigns.PersonalInvestmentsCampaign
-import com.gu.commercial.branding.Branding
 import com.gu.facia.api.models._
 import common.Edition
 import conf.Configuration

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -1,7 +1,6 @@
 package model
 
 import com.gu.commercial.branding.Branding
-import common.Edition._
 import common.commercial.{CommercialProperties, EditionBranding}
 import common.{Edition, ExecutionContexts, Logging}
 import play.api.libs.json.Json

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -13,7 +13,6 @@ import com.amazonaws.util.StringInputStream
 import common.Logging
 import conf.Configuration
 import org.joda.time.{DateTime, DateTimeZone}
-import play.Play
 import play.api.libs.ws.{WSClient, WSRequest}
 import sun.misc.BASE64Encoder
 

--- a/common/app/services/TagIndexesS3.scala
+++ b/common/app/services/TagIndexesS3.scala
@@ -2,7 +2,6 @@ package services
 
 import conf.Configuration
 import model.{TagIndexListings, TagIndexPage}
-import play.api.Play
 import play.api.libs.json._
 
 sealed trait TagIndexError

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -1,6 +1,7 @@
 @(item: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, StringEncodings}
 @import conf.Static
+@import conf.Configuration
 @import play.api.libs.json.Json
 @import views.support.{CamelCase, JavaScriptPage, GoogleAnalyticsAccount}
 @import conf.Configuration.environment

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -4,6 +4,7 @@
 @import common.InlineJs
 @import templates.inlineJS.blocking.js._
 @import play.api.Mode.Dev
+@import conf.Static
 
 <!doctype html>
 <head>

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,6 +1,8 @@
 @(content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.GoogleAnalyticsAccount
+@import conf.Configuration
+
 @* TODO: Abstract this out so its shared with the main GA tracking *@
 <amp-analytics type="googleanalytics" id="google-analytics">
     <script type="application/json">

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -1,7 +1,9 @@
 @(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
+
 @import play.api.Mode.Dev
 @import views.support.Commercial.listSponsorLogosOnPage
 @import views.support.{Commercial, GoogleAnalyticsAccount}
+@import conf.Configuration
 
 <script id='google_analytics'>
 

--- a/common/app/views/fragments/fontDefinitions.scala.html
+++ b/common/app/views/fragments/fontDefinitions.scala.html
@@ -1,3 +1,5 @@
+@import conf.Static
+
 @List("GuardianEgyptianWeb", "GuardianTextEgyptianWeb", "GuardianSansWeb", "GuardianTextSansWeb").map { typeface =>
     <style class="webfont" data-cache-name="@typeface"
         @List("woff2", "woff", "ttf").map { font =>

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,7 +1,8 @@
 @(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
+
 @import model.Page.getContent
 @import conf.switches.Switches.{preflightServerSideAdCallSwitch, PolyfillIO}
-@import conf.Configuration
+@import conf.Static
 
 <meta charset="utf-8" />
 <!--

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,6 +1,5 @@
 @(page: model.Page, projectName: Option[String] = None, head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import model.Page.getContent
-@import play.api.Mode.Dev
 @import conf.switches.Switches.{preflightServerSideAdCallSwitch, PolyfillIO}
 @import conf.Configuration
 

--- a/common/app/views/fragments/stylesheetLink.scala.html
+++ b/common/app/views/fragments/stylesheetLink.scala.html
@@ -1,5 +1,7 @@
 @(stylesheet: String, isCrossword: Boolean = false)
+
 @import conf.switches.Switches._
+@import conf.Static
 
 @* temporarily disable async css on crossword pages so they're usable on safari 6 and below *@
 @if(AsyncCss.isSwitchedOn && !isCrossword) {

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -2,6 +2,7 @@
 
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
+@import conf.Static
 
 @* any images in head need to go here (or they'll be relative to the page)} *@
 <style class="js-loggable">

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import conf.Configuration.environment
-import model.{ApplicationContext, ApplicationIdentity}
+import model.ApplicationContext
 
 object GoogleAnalyticsAccount {
 

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -2,7 +2,7 @@ package views.support.cleaner
 
 import java.net.URLDecoder
 
-import model.{Elements, Article, VideoAsset}
+import model.{Article, VideoAsset}
 import org.jsoup.nodes.{Document, Element}
 import views.support.{AmpSrcCleaner, HtmlCleaner}
 

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -2,7 +2,7 @@ package views.support.cleaner
 
 import java.net.{URL, URLEncoder}
 
-import model.{Article, ShareLinks, VideoAsset, VideoElement}
+import model.{Article, ShareLinks, VideoElement}
 import org.jsoup.nodes.{Document, Element}
 import views.support.{HtmlCleaner, Item640}
 

--- a/discussion/app/views/fragments/commentBadges.scala.html
+++ b/discussion/app/views/fragments/commentBadges.scala.html
@@ -1,4 +1,4 @@
-@(comment: Comment)
+@(comment: discussion.model.Comment)
 @if(comment.profile.isStaff){
     <div class="d-comment__author-label">
         @fragments.inlineSvg("marque-36", "icon", Seq("d-comment__gu-icon")) Staff

--- a/discussion/app/views/fragments/ctaTopComments.scala.html
+++ b/discussion/app/views/fragments/ctaTopComments.scala.html
@@ -1,4 +1,4 @@
-@(comments: List[Comment], showMore: Boolean = false)(implicit request: RequestHeader)
+@(comments: List[discussion.model.Comment], showMore: Boolean = false)(implicit request: RequestHeader)
 <div class="open-cta__top-comments">
 @comments.map { comment =>
     @fragments.commentSchema(comment, showMore)

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -1,3 +1,5 @@
+@import conf.Configuration
+
 <div hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-rec-tooltip">
     <button
         class="tooltip-box__close js-rec-tooltip-close u-button-reset"

--- a/discussion/app/views/profileActivity/witnessActivity.scala.html
+++ b/discussion/app/views/profileActivity/witnessActivity.scala.html
@@ -1,4 +1,4 @@
-@(activity: List[WitnessActivity])(implicit request: RequestHeader)
+@(activity: List[discussion.model.WitnessActivity])(implicit request: RequestHeader)
 
 <div class="activity-stream__witness-contributions" data-link-name="User activity contributions">
 @if(activity.isEmpty){

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -1,6 +1,7 @@
 @(idUrlBuilder: services.IdentityUrlBuilder, idRequest: services.IdentityRequest,user: com.gu.identity.model.User)(implicit request: RequestHeader)
 
 @import views.html.fragments.registrationFooter
+@import conf.Static
 
 <div class="manage-account-tab js-mem-tab" data-sprite-url="@Static("stylesheets/membership-icons.css")">
     <div class="manage-account-loader js-mem-loader">

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -9,6 +9,7 @@
 @import views.html.fragments.form.{inputField, textareaField}
 @import views.html.fragments.registrationFooter
 @import views.html.fragments.socialSignin
+@import conf.Static
 
 @tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "") = {
     <li class="tabs__tab @if(hidden){is-hidden} @if(page.metadata.id == url){tabs__tab--selected tone-colour tone-accent-border} @optionalClass" role="tab" id="tabs-account-profile-@i-tab" aria-selected="@(page.metadata.id == url)" aria-controls="tabs-account-profile-@i">

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -3,7 +3,6 @@ package com.gu
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import play.sbt.Play.autoImport._
 import play.sbt.routes.RoutesKeys
-import play.twirl.sbt.Import._
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.typesafe.sbt.SbtNativePackager._
 import Dependencies._
@@ -88,17 +87,10 @@ object Frontend extends Build with Prototypes {
     libraryDependencies ++= Seq(
       paClient,
       akkaContrib
-    ),
-    TwirlKeys.templateImports ++= Seq(
-      "pa._",
-      "feed._",
-      "football.controllers._"
     )
   )
 
-  val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common).settings(
-    TwirlKeys.templateImports ++= Seq("discussion._", "discussion.model._")
-  )
+  val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common)
 
   val diagnostics = application("diagnostics").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -6,9 +6,7 @@ import sbt._
 import sbt.Keys._
 import com.gu.riffraff.artifact.RiffRaffArtifact
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
-import play.twirl.sbt.Import._
 import Dependencies._
-import play.sbt.routes.RoutesKeys._
 import play.sbt.PlayScala
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
@@ -68,10 +66,6 @@ trait Prototypes {
       .withWarnScalaVersionEviction(false)
   )
 
-  val frontendClientSideSettings = Seq(
-    TwirlKeys.templateImports ++= Seq("conf._")
-  )
-
   val frontendTestSettings = Seq(
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
     testOptions in Test := Nil,
@@ -129,7 +123,6 @@ trait Prototypes {
     Project(applicationName, file(applicationName)).enablePlugins(PlayScala, UniversalPlugin)
     .settings(frontendDependencyManagementSettings)
     .settings(frontendCompilationSettings)
-    .settings(frontendClientSideSettings)
     .settings(frontendTestSettings)
     .settings(VersionInfo.settings)
     .settings(libraryDependencies ++= Seq(macwire, commonsIo))
@@ -141,7 +134,6 @@ trait Prototypes {
     Project(applicationName, file(applicationName)).enablePlugins(PlayScala)
     .settings(frontendDependencyManagementSettings)
     .settings(frontendCompilationSettings)
-    .settings(frontendClientSideSettings)
     .settings(frontendTestSettings)
     .settings(VersionInfo.settings)
     .settings(libraryDependencies ++= Seq(commonsIo))

--- a/sport/app/cricket/views/cricketMatch.scala.html
+++ b/sport/app/cricket/views/cricketMatch.scala.html
@@ -3,7 +3,7 @@
 
 @(page: CricketMatchPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(page, "football"){ } {
+@main(page, Some("football")){ } {
     <div class="l-side-margins">
         <article id="article" class="content content--article  tonal tonal--tone-news" itemprop="mainContentOfPage" role="main">
             <div class="content__main tonal__main tonal__main--tone-news">

--- a/sport/app/football/views/competitions.scala.html
+++ b/sport/app/football/views/competitions.scala.html
@@ -3,7 +3,7 @@
 
 @(competitions: Map[String, Seq[CompetitionFilter]], page: Page, competitionList: List[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(page, "football"){
+@main(page, Some("football")){
 }{
 
     @football.views.html.fragments.competitionsBody(competitions, page, competitionList)

--- a/sport/app/football/views/fragments/componentStyles.scala.html
+++ b/sport/app/football/views/fragments/componentStyles.scala.html
@@ -1,5 +1,5 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <style>
-    @Html(common.Assets.css.head("footballSnaps"))
+    @Html(common.Assets.css.head(Some("footballSnaps")))
 </style>

--- a/sport/app/football/views/fragments/leagueSelector.scala.html
+++ b/sport/app/football/views/fragments/leagueSelector.scala.html
@@ -1,4 +1,4 @@
-@(filterGroups: Map[String, Seq[CompetitionFilter]], pageType: String, selectedCompetition: Option[model.Competition])(implicit request: RequestHeader)
+@(filterGroups: Map[String, Seq[football.controllers.CompetitionFilter]], pageType: String, selectedCompetition: Option[model.Competition])(implicit request: RequestHeader)
 
 @renderOpts(name: String) = {
     @filterGroups.get(name).map{ filter =>

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -3,6 +3,7 @@
 @import model.Competition
 @import pa.FootballMatch
 @import views.support.RenderClasses
+@import conf.Configuration
 
 @(theMatch: FootballMatch, competition: Option[Competition] = None, responsive: Boolean = false, link: Boolean = false)(implicit request: RequestHeader)
 

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -10,7 +10,7 @@
 @import common.LinkTo
 @import views.support.RenderClasses
 @import views.MatchStatus
-@import conf.switches.Switches
+@import conf.Configuration
 
 <table class="table table--football football-matches@if(responsiveFont){ table--responsive-font}">
     <thead hidden>

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -1,9 +1,9 @@
-@(page: model.Page, matchesList: football.model.MatchesList, filters: Map[String, Seq[CompetitionFilter]])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, matchesList: football.model.MatchesList, filters: Map[String, Seq[football.controllers.CompetitionFilter]])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches
 @import football.model._
 
-@main(page, "football"){
+@main(page, Some("football")){
 }{
 <div class="l-side-margins">
     <article id="article" class="content content--footballfixtures" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">

--- a/sport/app/football/views/matchStats/matchStatsPage.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsPage.scala.html
@@ -3,8 +3,7 @@
 @import implicits.Football._
 @import views.FootballHelpers._
 
-
-@(page: MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: football.controllers.MatchPage, competition: Option[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @team(players: Seq[LineUpPlayer]) = {
     <ul class="team-list u-unstyled">
@@ -24,7 +23,7 @@
     </ul>
 }
 
-@main(page, "football"){
+@main(page, Some("football")){
 } {
 
 <article class="content">

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -1,6 +1,7 @@
 @import model.{Competition, Group, TeamUrl}
 @import views.support.RenderClasses
 @import views.support.`package`.Seq2zipWithRowInfo
+@import conf.Configuration
 
 @(competition: Competition, group: Group,
     heading: Option[String] = None,

--- a/sport/app/football/views/tablesList/tablesPage.scala.html
+++ b/sport/app/football/views/tablesList/tablesPage.scala.html
@@ -3,7 +3,7 @@
 
 @(page: TablesPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(page.page, "football"){
+@main(page.page, Some("football")){
 }{
 <div class="l-side-margins">
     <article id="article" class="content content--article tonal tonal--tone-news" itemprop="mainContentOfPage" itemtype="http://schema.org/Article" role="main">

--- a/sport/app/football/views/teamlist.scala.html
+++ b/sport/app/football/views/teamlist.scala.html
@@ -1,6 +1,6 @@
-@(pageModel: TablesPage, comps: Seq[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(pageModel: football.controllers.TablesPage, comps: Seq[model.Competition])(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(pageModel.page, "football"){
+@main(pageModel.page, Some("football")){
 }{
 
     @football.views.html.fragments.teamlistBody(pageModel, comps)

--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -1,7 +1,7 @@
 @(fm: pa.FootballMatch, round: pa.Round)
 
 @import implicits.Football._
-
+@import conf.Configuration
 
 <div class="football-match" id="football-match-@fm.id">
     <div class="football-match__container">

--- a/sport/app/football/views/wallchart/page.scala.html
+++ b/sport/app/football/views/wallchart/page.scala.html
@@ -3,7 +3,7 @@
 
 @(page: Page, competition: Competition, competitionStages: List[CompetitionStageLike])(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(page, "football"){
+@main(page, Some("football")){
 }{
     @wallchart(competition, competitionStages)
 }

--- a/sport/app/rugby/views/fragments/matchSummary.scala.html
+++ b/sport/app/rugby/views/fragments/matchSummary.scala.html
@@ -2,6 +2,7 @@
 @import rugby.model.Match
 @import rugby.model.Status.{FirstHalf, HalfTime, Result, SecondHalf}
 @import views.support.RenderClasses
+@import conf.Configuration
 
 @(page: Page, theMatch: Match)
 

--- a/sport/app/rugby/views/matchSummary.scala.html
+++ b/sport/app/rugby/views/matchSummary.scala.html
@@ -3,7 +3,7 @@
 
 @(page: Page, theMatch: Match, homeTeamScorers: Seq[ScoreEvent], awayTeamScorers: Seq[ScoreEvent])(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@main(page, "football") { } {
+@main(page, Some("football")) { } {
     <div class="l-side-margins">
         <article class="content">
             <header class="content__main">


### PR DESCRIPTION
## What does this change?
This patch:
- removes some unused imports
- removes template auto import using `TwirlKeys.templateImports` setting: It makes templates dependencies hard to follow. Instead importing the necessary dependencies in each templates.

Example: `football` templates were automatically importing `pa._` which provides an implicit `StringToOption` function. It was not clear to me why passing a `String` to a fragment that was expecting an `Option[String]` argument was compiling successfully

I wanted to enable the `-Ywarn-unused-import` compiler option but it doesn't play well with Twirl templates: https://github.com/playframework/twirl/issues/105

## What is the value of this and can you measure success?
More explicit dependencies, less hidden magic

## Tested in CODE?
yes
