### PR TITLE
Replace `lib/ajax` with `lib/fetch-json` in `modules/social/share-count`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts-legacy/projects/common/modules/social/share-count.js
@@ -2,7 +2,7 @@ define([
     'fastdom',
     'lib/report-error',
     'lib/$',
-    'lib/ajax',
+    'lib/fetch-json',
     'lib/detect',
     'lib/config',
     'lib/formatters',
@@ -14,7 +14,7 @@ define([
     fastdom,
     reportError,
     $,
-    ajax,
+    fetchJSON,
     detect,
     config,
     formatters,
@@ -69,13 +69,12 @@ define([
     }
 
     function fetch() {
-        ajax({
-            url: config.page.ajaxUrl + '/sharecount/' + config.page.pageId + '.json',
-            type: 'json',
-            method: 'get',
-            crossOrigin: true
-        }).then(function (resp) {
-            var count = resp.share_count || 0;
+        var url = config.page.ajaxUrl + '/sharecount/' + config.page.pageId + '.json';
+
+        fetchJSON(url, {
+            mode: 'cors',
+        }).then(function (res) {
+            var count = res.share_count || 0;
             counts.facebook = count;
             addToShareCount(count);
             updateTooltip();


### PR DESCRIPTION
## What does this change?

Replaces `lib/ajax` with `lib/fetch-json` in `modules/social/share-count`.

## What is the value of this and can you measure success?

Less dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No

## Tested in CODE?

No.
