### PR TITLE
Putting back some css I hastily removed

### DIFF
--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -94,6 +94,10 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
     list-style: none;
     margin: 0;
 
+    @include mq($until: tablet) {
+        @include columns(2, $gs-gutter);
+    }
+
     @include mq(tablet) {
         box-sizing: border-box;
         padding-left: $gs-gutter / 2;


### PR DESCRIPTION
## What does this change?
Sorry! I broke the footer in this commit: https://github.com/guardian/frontend/pull/16347/commits/a3a73d1cb5c868914bb60e3a4102a1f67696ef0a

## What is the value of this and can you measure success?
Makes the footer look like its supposed to again

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before:**
![image](https://cloud.githubusercontent.com/assets/8774970/24758680/f9a288de-1ada-11e7-87d3-22dc2bc3812d.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/24758693/05b04a1c-1adb-11e7-9f2d-2dfedab5734c.png)


## Tested in CODE?
Nope
