### PR TITLE
Paid cards in editorial containers AB test

### DIFF
--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -13,7 +13,7 @@
 
 }
 
-<div class="fc-item fc-item--has-image js-fc-item fc-item--list-media-mobile fc-item--standard-tablet adverts--within-unbranded">
+<div class="fc-item fc-item--has-image js-fc-item fc-item--list-media-mobile fc-item--standard-tablet adverts--within-unbranded without-sponsor-logo">
     <div class="fc-item__container">
         @item.image.map(image => itemImage(
             image,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-card-logo.js
@@ -37,16 +37,16 @@ define([
         this.variants = [
             {
                 id: 'with-logo',
-                test: function () {},
+                test: function () {
+                    $('.adverts--within-unbranded').each(function(el){
+                        el.classList.remove('without-sponsor-logo');
+                    });
+                },
                 success: this.completeFunc
             },
             {
                 id: 'without-logo',
-                test: function () {
-                    $('.adverts--within-unbranded').each(function(el){
-                        el.classList.add('without-sponsor-logo');
-                    });
-                },
+                test: function () {},
                 success: this.completeFunc
             }
         ];


### PR DESCRIPTION
Should default to 'without logo' version so that the logo doesn't flash on/off.

## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
