### PR TITLE
Extend sleeve notes ab test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -106,7 +106,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the new email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 10),
+    sellByDate = new LocalDate(2017, 5, 19),
     exposeClientSide = true
   )
 
@@ -116,7 +116,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the old email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 10),
+    sellByDate = new LocalDate(2017, 5, 19),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesLegacyEmailVariant',
             start: '2017-03-02',
-            end: '2017-04-10',
+            end: '2017-05-19',
             author: 'Leigh-Anne Mathieson',
             audience: 0.3,
             audienceOffset: 0.7,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesNewEmailVariant',
             start: '2017-03-02',
-            end: '2017-04-10',
+            end: '2017-05-19',
             author: 'Leigh-Anne Mathieson',
             audience: 0.7,
             audienceOffset: 0,


### PR DESCRIPTION
## What does this change?
Extends the AB test for the sleeve notes email (added in PR [15996](https://github.com/guardian/frontend/pull/15996))

## What is the value of this and can you measure success?
We are going to assess the results of several tests in mid-May including this one, and this means the test can keep running until then. 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
