### PR TITLE
Track when story questions component enters the users viewport.

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -1,7 +1,7 @@
 @(storyquestions: model.content.StoryQuestionsAtom, isAmp: Boolean)(implicit request: RequestHeader)
 
 @if(!isAmp) {
-    <div class="submeta user__question">
+    <div class="js-view-tracking-component submeta user__question">
         <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
         <h2 class="user__question-title">Finished this article but want to know more? <span class="user__question-title--secondary">Let us know what questions you want answered.</span></h2>
         @for(questions <- storyquestions.data.editorialQuestions) {
@@ -29,6 +29,6 @@
                     }
                 </p>
             }
-        </div>
+    </div>
 }
 }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -1,8 +1,12 @@
 define([
+    'lib/mediator',
+    'lib/detect',
     'lib/$',
     'bean',
     'ophan/ng'
 ], function (
+    mediator,
+    detect,
     $,
     bean,
     ophan
@@ -35,6 +39,29 @@ define([
                     bean.on(el, 'click', askQuestion);
                 });
             }
+
+            var storyQuestionsComponent = document.querySelector('.js-view-tracking-component');
+    
+            mediator.on('window:throttledScroll', function onScroll() {
+                var height = detect.getViewport().height;
+                var coords = storyQuestionsComponent.getBoundingClientRect();
+                var isStoryQuestionsInView = 0 <= coords.top && coords.bottom <= height;
+                
+                if( isStoryQuestionsInView ) {
+                    var atomId = $('.js-storyquestion-atom-id').attr('id');
+
+                    if (atomId) {
+                        ophan.record({
+                            atomId: atomId,
+                            component: atomId,
+                            value: 'question_component_in_view'
+                        });
+                    }
+
+                    mediator.off('window:throttledScroll', onScroll);
+                }
+            });
+
         }
     };
 


### PR DESCRIPTION
## What does this change?
Provides the ability to track in Ophan when story questions component has been seen by a user (exists in the users viewport).

## What is the value of this and can you measure success?
This allows us to track in Ophan the amount of people whom have seen the story questions component compared to how many have interacted with it.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
No.

## Tested in CODE?
No.
