### PR TITLE
add support for youtube atoms within the video container

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -76,6 +76,7 @@ object MediaWrapper extends Enum[MediaWrapper] with PlayJsonEnum[MediaWrapper] {
   case object MainMedia extends MediaWrapper
   case object ImmersiveMainMedia extends MediaWrapper
   case object EmbedPage extends MediaWrapper
+  case object VideoContainer extends MediaWrapper
 }
 
 final case class MediaAsset(

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -9,7 +9,10 @@
 @import model.content.MediaWrapper._
 @import model.content.MediaWrapper
 @import conf.switches.Switches.YouTubePosterOverride
-@(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None)(implicit request: RequestHeader)
+@import model.VideoFaciaProperties
+@import views.html.fragments.items.elements.facia_cards.title
+
+@(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
 
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
 @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
@@ -41,6 +44,22 @@
                         allowfullscreen="">
                 </iframe>
                 }
+            @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
+                <div class="video-overlay">
+                    <div class="video-overlay__headline">
+
+                    @for(f <- faciaHeaderProperties) {
+                        @title(f.header, 0, 0)
+                        @if(f.showByline) {
+                            <div class="fc-item__byline">@f.byline</div>
+                        }
+                    }
+                    </div>
+                    <span class="video-overlay__duration">
+                    @media.formattedDuration
+                    </span>
+                </div>
+            }
             }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -53,14 +53,16 @@
                         @if(f.showByline) {
                             <div class="fc-item__byline">@f.byline</div>
                         }
-                    }
+
                     </div>
                     <span class="video-overlay__duration">
                     @media.formattedDuration
                     </span>
                 </div>
+                <a href="@f.header.url.get(request)" class="video-container-overlay-link"></a>
             }
-            }
+          }
+        }
         @defining(posterImageOverride.filter(_ => !playable || YouTubePosterOverride.isSwitchedOn) orElse media.posterImage) { bestPosterImage =>
             @bestPosterImage.map { image =>
                 <div class="@RenderClasses(Map("youtube-media-atom__overlay" -> true, "vjs-big-play-button" -> !expired))" style="background-image: url(@Video700.bestFor(image))">

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -45,8 +45,10 @@
         @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
                 @item.properties.maybeContent.map { content =>
-                    @content.atoms.flatMap(_.media.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))).map { youTubeAtom =>
-                        @youtube(media = youTubeAtom, displayCaption = false, mediaWrapper = Some(VideoContainer), displayEndSlate = false, displayDuration = false, faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None),showByline = item.properties.showByline, item.properties.byline)))
+                    @defining(content.atoms.flatMap(_.media.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube)))) { youTubeAtom =>
+                        @youTubeAtom.map { youTubeAtom =>
+                            @youtube(media = youTubeAtom, displayCaption = false, mediaWrapper = Some(VideoContainer), displayEndSlate = false, displayDuration = false, faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None), showByline = item.properties.showByline, item.properties.byline)))
+                        }
                     }
 
 

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -1,8 +1,13 @@
 @import model.{InlineImage, VideoPlayer}
 @import views.html.fragments.media.video
 @import views.html.fragments.nav.treats
+@import views.html.fragments.atoms.youtube
 @import views.support.{RenderClasses, Video640, Video700}
 
+@import model.content.MediaAssetPlatform
+@import model.content.MediaWrapper.VideoContainer
+@import model.VideoFaciaProperties
+@import layout.FaciaCardHeader
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 
 <div class="fc-container__inner">
@@ -37,9 +42,14 @@
             @treats(containerDefinition, frontProperties)
         </li>
 
-        @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo && i.header.hasMainVideoElement.exists(identity)).zipWithIndex.map { case (item, index) =>
+        @containerDefinition.collectionEssentials.items.filter(i => i.header.isVideo).zipWithIndex.map { case (item, index) =>
            <li class="video-playlist__item js-video-playlist-item-@index @if(index == 0){video-playlist__item--active video-playlist__item--first}">
                 @item.properties.maybeContent.map { content =>
+                    @content.atoms.flatMap(_.media.find(_.assets.exists(_.platform == MediaAssetPlatform.Youtube))).map { youTubeAtom =>
+                        @youtube(media = youTubeAtom, displayCaption = false, mediaWrapper = Some(VideoContainer), displayEndSlate = false, displayDuration = false, faciaHeaderProperties = Some(VideoFaciaProperties(header = FaciaCardHeader.fromTrail(item, None),showByline = item.properties.showByline, item.properties.byline)))
+                    }
+
+
                     @content.elements.mainVideo.map { mainVideo =>
                         @defining(VideoPlayer(
                             mainVideo,

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -26,6 +26,13 @@ define([
         'PAUSED': onPlayerPaused
     };
 
+    function onVideoContainerNavigation(atomId) {
+        var player = players[atomId];
+        if(player){
+            player.player.pauseVideo();
+        }
+    }
+
     function checkState(atomId, state, status) {
         if (state === window.YT.PlayerState[status] && STATES[status]) {
             STATES[status](atomId);
@@ -184,6 +191,8 @@ define([
 
                 // append index of atom as atomId must be unique
                 var atomId = el.getAttribute('data-media-atom-id') + '/' + index;
+                //need data attribute with index for unique lookup
+                el.setAttribute('data-unique-atom-id', atomId);
                 var overlay = el.querySelector('.youtube-media-atom__overlay');
 
                 tracking.init(getTrackingId(atomId));
@@ -211,6 +220,7 @@ define([
     }
 
     return {
-        checkElemsForVideos: checkElemsForVideos
+        checkElemsForVideos: checkElemsForVideos,
+        onVideoContainerNavigation: onVideoContainerNavigation
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
@@ -5,7 +5,8 @@ define([
     'lib/element-inview',
     'bootstraps/enhanced/media/video-player',
     'lodash/objects/assign',
-    'lib/create-store'
+    'lib/create-store',
+    'common/modules/atoms/youtube'
 ], function (
     bean,
     fastdom,
@@ -13,17 +14,30 @@ define([
     ElementInview,
     videojs,
     assign,
-    createStore
-) {
+    createStore,
+    youtube
+)
+{
+
+
+
+    function updateYouTubeVideo(currentItem){
+        var youTubeAtom = currentItem.querySelector('.youtube-media-atom');
+        if(youTubeAtom) {
+         return youtube.onVideoContainerNavigation(youTubeAtom.dataset.uniqueAtomId);
+        }
+    }
 
     var reducers = {
         NEXT: function next(previousState) {
             var position = previousState.position >= previousState.length ? previousState.position : previousState.position + 1;
+            updateYouTubeVideo(document.querySelector('.js-video-playlist-item-'+ (position-1)));
             return assign({}, previousState, getPositionState(position, previousState.length));
         },
 
         PREV: function prev(previousState) {
             var position = previousState.position <= 0 ? 0 : previousState.position - 1;
+            updateYouTubeVideo(document.querySelector('.js-video-playlist-item-'+ (position+1)));
             return assign({}, previousState, getPositionState(position, previousState.length));
         },
 

--- a/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
@@ -23,7 +23,7 @@ define([
     function updateYouTubeVideo(currentItem){
         var youTubeAtom = currentItem.querySelector('.youtube-media-atom');
         if(youTubeAtom) {
-            return youtube.onVideoContainerNavigation(youTubeAtom.dataset.uniqueAtomId);
+            return youtube.onVideoContainerNavigation(youTubeAtom.getAttribute("data-unique-atom-id"));
         }
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
@@ -6,7 +6,8 @@ define([
     'bootstraps/enhanced/media/video-player',
     'lodash/objects/assign',
     'lib/create-store',
-    'common/modules/atoms/youtube'
+    'common/modules/atoms/youtube',
+    'lib/detect'
 ], function (
     bean,
     fastdom,
@@ -15,12 +16,10 @@ define([
     videojs,
     assign,
     createStore,
-    youtube
+    youtube,
+    detect
 )
 {
-
-
-
     function updateYouTubeVideo(currentItem){
         var youTubeAtom = currentItem.querySelector('.youtube-media-atom');
         if(youTubeAtom) {
@@ -42,6 +41,25 @@ define([
         },
 
         INIT: function init(previousState) {
+            function makeYouTubeNonPlayableAtSmallBreakpoint(previousState) {
+                if(detect.isBreakpoint({max: 'desktop'})){
+                 var youTubeIframes = previousState.container.querySelectorAll('.youtube-media-atom iframe');
+                 youTubeIframes.forEach(function(el){
+                     el.remove();
+                 });
+                 var overlayLinks = previousState.container.querySelectorAll('.video-container-overlay-link');
+                 overlayLinks.forEach(function(el){
+                     el.classList.add('u-faux-block-link__overlay');
+                 });
+
+                 var atomWrapper = previousState.container.querySelectorAll('.youtube-media-atom');
+                 atomWrapper.forEach(function(el){
+                     el.classList.add('no-player');
+                 })
+                }
+            }
+            makeYouTubeNonPlayableAtSmallBreakpoint(previousState);
+
             fastdom.read(function() {
                 // Lazy load images on scroll for mobile
                 $('.js-video-playlist-image', previousState.container).each(function(el) {

--- a/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts-legacy/projects/common/modules/video/video-container.js
@@ -23,7 +23,7 @@ define([
     function updateYouTubeVideo(currentItem){
         var youTubeAtom = currentItem.querySelector('.youtube-media-atom');
         if(youTubeAtom) {
-         return youtube.onVideoContainerNavigation(youTubeAtom.dataset.uniqueAtomId);
+            return youtube.onVideoContainerNavigation(youTubeAtom.dataset.uniqueAtomId);
         }
     }
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -29,6 +29,14 @@
                 display: block;
             }
         }
+        @include mq($until: desktop) {
+            iframe,
+            .vjs-big-play-button {
+                top: gs-height(3) - (get-line-height(textSans, 3) + 4px);
+                bottom: 0;
+                height: auto;
+            }
+        }
     }
 
 

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -87,9 +87,6 @@
             ~ .video-overlay {
                 @include hide;
             }
-        }
-
-        &.youtube__video-started:not(.youtube__video-ended) {
             ~ .youtube-media-atom__overlay {
                 @include fade-out;
                 transition-delay: 500ms;

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -20,6 +20,29 @@
     transition: opacity 1s linear, visibility 1s;
 }
 
+.video-playlist__item {
+    .youtube-media-atom {
+        @include mq(desktop) {
+            opacity: .3;
+            transition: opacity .4s ease-out;
+            .vjs-big-play-button {
+                display: block;
+            }
+        }
+    }
+
+
+    &--active {
+        .youtube-media-atom {
+            opacity: 1;
+            .vjs-big-play-button {
+                display: block;
+            }
+        }
+    }
+
+}
+
 .youtube-media-atom {
     position: relative;
 
@@ -55,6 +78,12 @@
         }
 
         &.youtube__video-started:not(.youtube__video-ended) {
+            ~ .video-overlay {
+                @include hide;
+            }
+        }
+
+        &.youtube__video-started:not(.youtube__video-ended) {
             ~ .youtube-media-atom__overlay {
                 @include fade-out;
                 transition-delay: 500ms;
@@ -79,6 +108,8 @@
         pointer-events: none;
     }
 
+
+
     .youtube-media-atom__overlay {
         background-size: cover;
         /**
@@ -90,6 +121,10 @@
         background-repeat: no-repeat;
         z-index: 1;
         text-align: center;
+    }
+
+    .youtube-media-atom__overlay .video-overlay {
+        text-align: initial;
     }
 
     .youtube-media-atom__play-button.vjs-control-text {

--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -39,7 +39,6 @@
         }
     }
 
-
     &--active {
         .youtube-media-atom {
             opacity: 1;
@@ -48,7 +47,6 @@
             }
         }
     }
-
 }
 
 .youtube-media-atom {
@@ -110,13 +108,11 @@
                 }
             }
         }
-	}
+    }
 
     .youtube-media-atom__overlay.vjs-big-play-button {
         pointer-events: none;
     }
-
-
 
     .youtube-media-atom__overlay {
         background-size: cover;

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -439,7 +439,7 @@ $video-width-desktop: 700px;
 
     .youtube-media-atom__iframe:not(.youtube__video-ready) {
         ~ .youtube-media-atom__overlay {
-            visibility: hidden;      
+            visibility: hidden;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
Add support for youtube atoms within the video container.
Note, there are some differences in behaviour due to constraints of the youtube player:

- On Navigation event we pause the video and do not restore the poster image or overlay
- At <desktop breakpoints we revert to a non-playable card which links through to the video page in order to comply with PFP rules regarding minimum size and overlaying content on the player

*H/T to all reviewers for their help with the client-side part of this work*

## What is the value of this and can you measure success?
Creates parity within video container between video JS and youtube atoms

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
### Mobile view
![mobile-view](https://cloud.githubusercontent.com/assets/1764158/24798880/5ed9b032-1b90-11e7-8294-e9e17d081c8c.gif)
### Desktop view
![desktop-view](https://cloud.githubusercontent.com/assets/1764158/24798897/6d43d26a-1b90-11e7-9dbd-06bd8c2285c6.gif)

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
