### PR TITLE
Add custom fields page

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -1,9 +1,9 @@
 package controllers.admin
 
-import common.dfp.{GuCreativeTemplate, GuLineItem}
+import common.dfp.{GuCreativeTemplate, GuCustomField, GuLineItem}
 import common.{ExecutionContexts, JsonComponent, Logging}
 import conf.Configuration
-import dfp.{AdvertiserAgent, CreativeTemplateAgent, DfpApi, DfpDataExtractor, OrderAgent}
+import dfp.{AdvertiserAgent, CreativeTemplateAgent, CustomFieldAgent, DfpApi, DfpDataExtractor, OrderAgent}
 import model._
 import ophan.SurgingContentAgent
 import play.api.libs.json.{Format, JsString, JsValue, Json}
@@ -66,6 +66,13 @@ class CommercialController(implicit context: ApplicationContext) extends Control
       soFar :+ template.copy(creatives = creatives.filter(_.templateId.get == template.id).sortBy(_.name))
     }.sortBy(_.name)
     NoCache(Ok(views.html.commercial.templates(templates)))
+  }
+
+  def renderCustomFields = Action { implicit request =>
+
+    val fields: Seq[GuCustomField] = CustomFieldAgent.get.data.values.toSeq
+    NoCache(Ok(views.html.commercial.customFields(fields)))
+
   }
 
   def renderAdTests = Action { implicit request =>

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -13,6 +13,11 @@ object DataMapper {
     GuAdUnit(dfpAdUnit.getId, ancestorNames :+ dfpAdUnit.getName, dfpAdUnit.getStatus.getValue)
   }
 
+  def toGuCustomField(dfpCustomField: CustomField) =
+    GuCustomField(dfpCustomField.getId, dfpCustomField.getName, dfpCustomField.getDescription,
+      dfpCustomField.getIsActive, dfpCustomField.getEntityType.getValue, dfpCustomField.getDataType.getValue,
+      dfpCustomField.getVisibility.getValue)
+
   private def toGuTargeting(session: SessionWrapper)(dfpTargeting: Targeting): GuTargeting = {
 
     def toIncludedGuAdUnits(inventoryTargeting: InventoryTargeting): Seq[GuAdUnit] = {

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -13,10 +13,22 @@ object DataMapper {
     GuAdUnit(dfpAdUnit.getId, ancestorNames :+ dfpAdUnit.getName, dfpAdUnit.getStatus.getValue)
   }
 
-  def toGuCustomField(dfpCustomField: CustomField) =
+  def toGuCustomFieldOption(option: CustomFieldOption): GuCustomFieldOption =
+    GuCustomFieldOption(option.getId, option.getDisplayName)
+
+  def toGuCustomField(dfpCustomField: CustomField): GuCustomField = {
+
+    val options: List[GuCustomFieldOption] = {
+      dfpCustomField match {
+        case dropdown: DropDownCustomField => dropdown.getOptions.toList
+        case _ => Nil
+        }
+      } map toGuCustomFieldOption
+
     GuCustomField(dfpCustomField.getId, dfpCustomField.getName, dfpCustomField.getDescription,
       dfpCustomField.getIsActive, dfpCustomField.getEntityType.getValue, dfpCustomField.getDataType.getValue,
-      dfpCustomField.getVisibility.getValue)
+      dfpCustomField.getVisibility.getValue, options)
+  }
 
   private def toGuTargeting(session: SessionWrapper)(dfpTargeting: Targeting): GuTargeting = {
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -31,18 +31,12 @@ object DfpApi extends Logging {
 
   def getAllOrders: Seq[GuOrder] = {
     val stmtBuilder = new StatementBuilder()
-
-    withDfpSession( session => {
-      session.orders(stmtBuilder).map(toGuOrder)
-    })
+    withDfpSession(_.orders(stmtBuilder).map(toGuOrder))
   }
 
   def getAllCustomFields: Seq[GuCustomField] = {
     val stmtBuilder = new StatementBuilder()
-
-    withDfpSession( session => {
-      session.customFields(stmtBuilder).map(toGuCustomField)
-    })
+    withDfpSession(_.customFields(stmtBuilder).map(toGuCustomField))
   }
 
   def getAllAdvertisers: Seq[GuAdvertiser] = {
@@ -51,9 +45,7 @@ object DfpApi extends Logging {
                       .withBindVariableValue("type", CompanyType.ADVERTISER.toString)
                       .orderBy("id ASC")
 
-    withDfpSession( session => {
-      session.companies(stmtBuilder).map(toGuAdvertiser)
-    })
+    withDfpSession(_.companies(stmtBuilder).map(toGuAdvertiser))
   }
 
   def readCurrentLineItems: DfpLineItems = {

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -4,7 +4,7 @@ import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder
 import com.google.api.ads.dfp.axis.v201608._
 import common.Logging
 import common.dfp._
-import dfp.DataMapper.{toGuAdUnit, toGuCreativeTemplate, toGuLineItem, toGuTemplateCreative, toGuAdvertiser, toGuOrder}
+import dfp.DataMapper.{toGuAdUnit, toGuCreativeTemplate, toGuCustomField, toGuLineItem, toGuTemplateCreative, toGuAdvertiser, toGuOrder}
 import org.joda.time.DateTime
 
 object DfpApi extends Logging {
@@ -34,6 +34,14 @@ object DfpApi extends Logging {
 
     withDfpSession( session => {
       session.orders(stmtBuilder).map(toGuOrder)
+    })
+  }
+
+  def getAllCustomFields: Seq[GuCustomField] = {
+    val stmtBuilder = new StatementBuilder()
+
+    withDfpSession( session => {
+      session.customFields(stmtBuilder).map(toGuCustomField)
     })
   }
 

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import app.LifecycleComponent
-import common.dfp.{GuAdUnit, GuCreativeTemplate}
+import common.dfp.{GuAdUnit, GuCreativeTemplate, GuCustomField}
 import common._
 import play.api.inject.ApplicationLifecycle
 
@@ -32,7 +32,7 @@ class DfpDataCacheLifecycle(
       def run() = AdUnitAgent.refresh()
     },
 
-    new Job[DataCache[String, Long]] {
+    new Job[DataCache[String, GuCustomField]] {
       val name = "DFP-CustomFields-Update"
       val interval = 30
       def run() = CustomFieldAgent.refresh()
@@ -105,7 +105,6 @@ class DfpDataCacheLifecycle(
         Future.sequence(Seq(AdvertiserAgent.refresh(), OrderAgent.refresh())).map(_ => ())
       }
     }
-
   )
 
   override def start() = {
@@ -123,6 +122,7 @@ class DfpDataCacheLifecycle(
       CustomTargetingKeyValueJob.run()
       AdvertiserAgent.refresh()
       OrderAgent.refresh()
+      CustomFieldAgent.refresh()
     }
   }
 }

--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -38,6 +38,7 @@
                         <li><a href="@controllers.admin.routes.CommercialController.renderKeyValues()">Key Values</a></li>
                         <li><a href="@controllers.admin.commercial.routes.DfpDataController.renderCacheFlushPage()">Refresh all cached DFP data</a></li>
                         <li><a href="@controllers.admin.routes.CommercialController.renderInvalidItems()">Invalid Line Items</a></li>
+                        <li><a href="@controllers.admin.routes.CommercialController.renderCustomFields()">Custom Fields</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/commercial/customFields.scala.html
+++ b/admin/app/views/commercial/customFields.scala.html
@@ -1,0 +1,35 @@
+@import common.dfp.GuCustomField
+
+@(fields: Seq[GuCustomField])(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@admin_main("Custom Fields", isAuthed = true) {
+
+<link rel="stylesheet" type="text/css" href="@controllers.admin.routes.UncachedAssets.at("css/commercial.css")" />
+
+<h1>DFP CustomFields</h1>
+
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Is Active</th>
+            <th>Entity Type</th>
+            <th>Visibility</th>
+        </tr>
+    </thead>
+    <tbody>
+    @for(field <- fields) {
+        <tr id="field-@field.id">
+            <td>@field.id</td>
+            <td>@field.name</td>
+            <td>@field.description</td>
+            <td>@field.isActive</td>
+            <td>@field.entityType</td>
+            <td>@field.visibility</td>
+        </tr>
+    }
+    </tbody>
+</table>
+}

--- a/admin/app/views/commercial/customFields.scala.html
+++ b/admin/app/views/commercial/customFields.scala.html
@@ -8,26 +8,32 @@
 
 <h1>DFP CustomFields</h1>
 
-<table>
+<table class="table table-striped table-bordered table-condensed table-hover">
     <thead>
         <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Description</th>
-            <th>Is Active</th>
-            <th>Entity Type</th>
-            <th>Visibility</th>
+            <th class="col-md-1">ID</th>
+            <th class="col-md-2">Name</th>
+            <th class="col-md-3">Description</th>
+            <th class="col-md-1">Is Active</th>
+            <th class="col-md-1">Entity Type</th>
+            <th class="col-md-1">Visibility</th>
+            <th class="col-md-6">Options</th>
         </tr>
     </thead>
     <tbody>
     @for(field <- fields) {
         <tr id="field-@field.id">
-            <td>@field.id</td>
+            <td><a href="https://www.google.com/dfp/59666047#admin/editCustomField/id=@field.id">@field.id</a></td>
             <td>@field.name</td>
             <td>@field.description</td>
             <td>@field.isActive</td>
             <td>@field.entityType</td>
             <td>@field.visibility</td>
+            <td>
+                @for(option <- field.options) {
+                    <div>@option.name (@option.id)</div>
+                }
+            </td>
         </tr>
     }
     </tbody>

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -93,6 +93,7 @@ GET         /commercial/adops/takeovers-empty-mpus/create                       
 POST        /commercial/adops/takeovers-empty-mpus/create                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.create()
 POST        /commercial/adops/takeovers-empty-mpus/remove                                           controllers.admin.commercial.TakeoverWithEmptyMPUsController.remove(t)
 GET         /commercial/invalid-lineitems                                                           controllers.admin.CommercialController.renderInvalidItems()
+GET         /commercial/custom-fields                                                               controllers.admin.CommercialController.renderCustomFields()
 GET         /commercial/adgrabber/order/:orderId                                                    controllers.admin.CommercialController.getLineItemsForOrder(orderId: String)
 GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -81,6 +81,19 @@ object GeoTarget {
 
 }
 
+case class GuCustomField(id: Long,
+                         name: String,
+                         description: String,
+                         isActive: Boolean,
+                         entityType: String,
+                         dataType: String,
+                         visibility: String)
+
+object GuCustomField {
+
+  implicit val customFieldFormats: Format[GuCustomField] = Json.format[GuCustomField]
+}
+
 case class GuAdUnit(id: String, path: Seq[String], status: String) {
   val fullPath = path.mkString("/")
 

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -87,11 +87,16 @@ case class GuCustomField(id: Long,
                          isActive: Boolean,
                          entityType: String,
                          dataType: String,
-                         visibility: String)
+                         visibility: String,
+                         options: List[GuCustomFieldOption])
+
+case class GuCustomFieldOption(id: Long, name: String)
 
 object GuCustomField {
 
+  implicit val customFieldOptionFormats: Format[GuCustomFieldOption] = Json.format[GuCustomFieldOption]
   implicit val customFieldFormats: Format[GuCustomField] = Json.format[GuCustomField]
+
 }
 
 case class GuAdUnit(id: String, path: Seq[String], status: String) {


### PR DESCRIPTION
## What does this change?
This adds a commercial admin page that displays all of the [Custom Fields](https://support.google.com/dfp_premium/answer/2694303?hl=en) currently in use in DFP.

I could cache the results in S3 as we do with some other jobs, but I don't think this is high priority / risk enough to warrant adding that in. I have the code ready to do so if anyone disagrees :)

## What is the value of this and can you measure success?
Visibility of what were are doing in DFP - useful for Tom Duffett

## Does this affect other platforms - Amp, Apps, etc?
Nope.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1821099/24807431/0d87ff5c-1bb0-11e7-9bb8-d64c63737a2e.png)
(I didn't really do any of that UX/Styling thing that people talk about)

@guardian/commercial-dev 