### PR TITLE
LinkTo: Making editionalisation of a link optional

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -30,7 +30,7 @@ case class EditionalisedLink(
     LinkTo(baseUrl)(requestHeader)
 
   def hrefWithRel(implicit requestHeader: RequestHeader): String =
-    processUrl(baseUrl, Edition(requestHeader)) match {
+    processUrl(baseUrl, Some(Edition(requestHeader))) match {
       case ProcessedUrl(url, true) => s"""href="$url" rel="nofollow""""
       case ProcessedUrl(url, false) => s"""href="$url""""
     }

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -19,7 +19,7 @@
                     "tone-comment" -> isContributor,
                     "tone-colour" -> isContributor))">
                     @href.map { href =>
-                    <a data-link-name="section heading" href="@LinkTo {/@href}">
+                    <a data-link-name="section heading" href="/@LinkTo(href, None)">
                     @if(ArticleBadgesSwitch.isSwitchedOn){
                         @badgeFor(containerDefinition).map { badge =>
                             <div class="badge-slot">

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -66,7 +66,7 @@
     https://support.google.com/webmasters/answer/189077
 *@
 @Edition.otherPagesFor(request).map{ link =>
-    <link rel="alternate" href="@LinkTo(link.path, link.edition)" hreflang="@link.edition.locale.toLanguageTag" />
+    <link rel="alternate" href="@LinkTo(link.path, Some(link.edition))" hreflang="@link.edition.locale.toLanguageTag" />
 }
 
 @page.metadata.rssPath.map { path =>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -218,7 +218,7 @@ case class InBodyLinkCleaner(dataLinkName: String, amp: Boolean = false)(implici
 
     links.foreach { link =>
       if (link.tagName == "a") {
-        link.attr("href", LinkTo(link.attr("href"), edition))
+        link.attr("href", LinkTo(link.attr("href"), Some(edition)))
         link.attr("data-link-name", dataLinkName)
         link.addClass("u-underline")
       }
@@ -382,7 +382,7 @@ case class TagLinker(article: Article)(implicit val edition: Edition, implicit v
 
           paragraphsWithMatchers.foreach { case (matcher, p) =>
             val tagLink = doc.createElement("a")
-            tagLink.attr("href", LinkTo(keyword.metadata.url, edition))
+            tagLink.attr("href", LinkTo(keyword.metadata.url, Some(edition)))
             tagLink.text(keyword.name)
             tagLink.attr("data-link-name", "auto-linked-tag")
             tagLink.attr("data-component", "auto-linked-tag")

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -20,7 +20,7 @@ class NavigationController extends Controller {
       implicit val sectionLinkWrites = new Writes[SectionLinkAndEdition] {
         def writes(item: SectionLinkAndEdition) = Json.obj(
           "title" -> item.link.title,
-          "href" -> LinkTo(item.link.href, item.edition)
+          "href" -> LinkTo(item.link.href, Some(item.edition))
         )
       }
 


### PR DESCRIPTION
Section title returned by onward should not be editionalize because
onward requests are not cached per edition (no cookie is passed to
api.nextgen.guardianapps.com). Therefore all clients will get the same
content.
Not editionalizing the title link means the editionalization would be
taken care of by a redirect when the link is clicked
This patch is adding a way to explicitely tell `LinkTo` not to
editionalise a link.
