### PR TITLE
Add path to logged message when capi request in AllIndexController fails

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -112,7 +112,7 @@ class AllIndexController(contentApiClient: ContentApiClient, sectionsLookUp: Sec
     }
 
     result.recover{ case e: Exception =>
-      log.error(e.getMessage, e)
+      log.error(s"Cannot fetch content for path '$path'", e)
       None
     }
   }
@@ -127,7 +127,7 @@ class AllIndexController(contentApiClient: ContentApiClient, sectionsLookUp: Sec
       item.results.getOrElse(Nil).headOption.flatMap(_.webPublicationDate).map(_.toJodaDateTime.withZone(DateTimeZone.UTC))
     }
     result.recover{ case e: Exception =>
-      log.error(e.getMessage, e)
+      log.error(s"Cannot fetch content for path '$path'", e)
       None
     }
   }


### PR DESCRIPTION
## What does this change?
Kibana shows lot of CAPI `Not Found` errors in `applications.AllIndexController`. 
Adding the path in the log message to better understand what's going on. 

## What is the value of this and can you measure success?
More info for debugging
