### PR TITLE
Reduce performance log parsing issues

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/commercial.js
+++ b/static/src/javascripts-legacy/bootstraps/commercial.js
@@ -134,7 +134,6 @@ define([
                     ga.trackPerformance('Javascript Load', 'commercialEnd', 'Commercial end parse time');
                 }],
             ]);
-            performanceLogging.reportTrackingData();
         })
         .catch(function (err) {
             // Just in case something goes wrong, we don't want it to

--- a/static/src/javascripts-legacy/bootstraps/commercial.js
+++ b/static/src/javascripts-legacy/bootstraps/commercial.js
@@ -60,7 +60,7 @@ define([
         ['cm-prepare-switch-tag', prepareSwitchTag.init, true],
         ['cm-articleAsideAdverts', articleAsideAdverts.init, true],
         ['cm-prepare-googletag', prepareGoogletag.init, true],
-        ['cm-articleBodyAdverts', articleBodyAdverts.init, true],
+        ['cm-articleBodyAdverts', articleBodyAdverts.init],
         ['cm-liveblogAdverts', liveblogAdverts.init, true],
         ['cm-closeDisabledSlots', closeDisabledSlots.init],
         ['cm-stickyTopBanner', stickyTopBanner.init],
@@ -100,7 +100,7 @@ define([
                         performanceLogging.wrap(moduleName, moduleInit);
                     var result = wrapped();
                     modulePromises.push(result);
-                }],
+                }]
             ]);
         });
 
@@ -132,7 +132,7 @@ define([
             robust.context([
                 ['ga-user-timing-commercial-end', function () {
                     ga.trackPerformance('Javascript Load', 'commercialEnd', 'Commercial end parse time');
-                }],
+                }]
             ]);
         })
         .catch(function (err) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -35,11 +35,9 @@ define([
     var isOffsetingAds = abUtils.testCanBeRun('IncreaseInlineAds') &&
         abUtils.getTestVariantId('IncreaseInlineAds') === 'yes';
 
-    function init(start, stop) {
-        start();
+    function init() {
 
         if (!commercialFeatures.articleBodyAdverts) {
-            stop();
             return Promise.resolve(false);
         }
 
@@ -55,11 +53,11 @@ define([
             // we must wait for DFP to return, since if the merch
             // component is empty, it might completely change the
             // positions where we insert those MPUs.
-            im.then(waitForMerch).then(addInlineAds).then(stop);
+            im.then(waitForMerch).then(addInlineAds);
             return im;
         }
 
-        addInlineAds().then(stop);
+        addInlineAds();
         return Promise.resolve(true);
     }
 


### PR DESCRIPTION
After https://github.com/guardian/frontend/pull/16386, there are still ways that incomplete performance reports can be sent through. Mainly, I reckon this is around the `defer` system that's been introduced, which means that there isn't much need to send a log when the module promises have resolved (since these don't resolve after a module has called `stop`, in the defer scenario).

Modules with wildly diverging behaviour, like `article-body-adverts` are hard to capture, because the measurement system is really average time. I've demoted this `defer` module to a `wrap` one.