### PR TITLE
Add Nic and Calum to platform team for ES6 conversion

### DIFF
--- a/tools/es5to6-files-per-user.js
+++ b/tools/es5to6-files-per-user.js
@@ -33,7 +33,7 @@ const platform = [
     'sndrs',
     'Gareth Trufitt',
     'Simon Adcock',
-    'Nic Long',
+    'Nicolas Long',
     'Calum Campbell',
     'GHaberis',
     'Gustav Pursche',

--- a/tools/es5to6-files-per-user.js
+++ b/tools/es5to6-files-per-user.js
@@ -33,10 +33,12 @@ const platform = [
     'sndrs',
     'Gareth Trufitt',
     'Simon Adcock',
-    // 'NataliaLKB',
+    'Nic Long',
+    'Calum Campbell',
     'GHaberis',
-    // 'stephanfowler',
     'Gustav Pursche',
+    // 'NataliaLKB',
+    // 'stephanfowler',
 ];
 const platformModules = files.filter(_ => _.includes('lib'));
 const platformFilesPerHuman = filesPerHuman(platformModules, platform);

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -17,7 +17,7 @@
     "lib/detect.js",
     "lib/element-inview.js"
   ],
-  "Nic Long": [
+  "Nicolas Long": [
     "lib/fastdom-errors.js",
     "lib/fastdom-promise.js",
     "lib/fetch.js",

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -3,39 +3,42 @@
     "lib/add-event-listener.js",
     "lib/ajax.js",
     "lib/atob.js",
-    "lib/capture-perf-timings.js",
-    "lib/chain.js",
-    "lib/clamp.js",
-    "lib/client-rects.js"
+    "lib/capture-perf-timings.js"
   ],
   "Gareth Trufitt": [
-    "lib/config.js",
+    "lib/chain.js",
+    "lib/clamp.js",
+    "lib/client-rects.js",
+    "lib/config.js"
+  ],
+  "Simon Adcock": [
     "lib/cookies.js",
     "lib/create-store.js",
     "lib/detect.js",
-    "lib/element-inview.js",
-    "lib/fastdom-errors.js",
-    "lib/fastdom-promise.js"
+    "lib/element-inview.js"
   ],
-  "Simon Adcock": [
+  "Nic Long": [
+    "lib/fastdom-errors.js",
+    "lib/fastdom-promise.js",
     "lib/fetch.js",
-    "lib/formatters.js",
+    "lib/formatters.js"
+  ],
+  "Calum Campbell": [
     "lib/formInlineLabels.js",
     "lib/fsm.js",
     "lib/geolocation.js",
-    "lib/load-css-promise.js",
-    "lib/load-script.js",
-    "lib/location.js"
+    "lib/load-css-promise.js"
   ],
   "GHaberis": [
+    "lib/load-script.js",
+    "lib/location.js",
     "lib/pad.js",
-    "lib/page.js",
+    "lib/page.js"
+  ],
+  "Gustav Pursche": [
     "lib/picturefill.js",
     "lib/proximity-loader.js",
     "lib/queue.js",
-    "lib/QueueAsync.js",
-  ],
-  "Gustav Pursche": [
-    "lib/steady-page.js",
+    "lib/steady-page.js"
   ]
 }


### PR DESCRIPTION
## What does this change?

- Add Nic and Calum to platform team for ES6 conversion
- Redistribute all libs (apologies to @gustavpursche)

## What is the value of this and can you measure success?

Share the ES6 conversion love

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
