### PR TITLE
use higher res meta image on video page

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -79,7 +79,7 @@
                                                 <meta itemprop="width" content="@mv.videos.width" />
                                             }
                                             <meta itemprop="requiresSubscription" content="false" />
-                                            <meta itemprop="image" content="@Html(video.content.signedArticleImage)" />
+                                            <meta itemprop="image" content="@Html(video.content.rawOpenGraphImage)" />
 
                                             @defining(video.elements.thumbnail.map(_.images) orElse video.mediaAtom.flatMap(_.posterImage)) {bestThumbnail =>
                                                 @bestThumbnail.map { thumbnail =>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -79,7 +79,7 @@
                                                 <meta itemprop="width" content="@mv.videos.width" />
                                             }
                                             <meta itemprop="requiresSubscription" content="false" />
-                                            <meta itemprop="image" content="@Html(video.content.rawOpenGraphImage)" />
+                                            <meta itemprop="image" content="@Html(video.content.signedArticleImage)" />
 
                                             @defining(video.elements.thumbnail.map(_.images) orElse video.mediaAtom.flatMap(_.posterImage)) {bestThumbnail =>
                                                 @bestThumbnail.map { thumbnail =>

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -107,7 +107,7 @@ final case class Content(
     cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1 && !tags.isInteractive
 
   lazy val signedArticleImage: String = {
-    ImgSrc(rawOpenGraphImage, EmailImage)
+    ImgSrc(rawOpenGraphImage, Item1200)
   }
 
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
@@ -367,8 +367,8 @@ object Content {
       paFootballTeams = apiContent.references.filter(ref => ref.id.contains("pa-football-team")).map(ref => ref.id.split("/").last).distinct,
       javascriptReferences = apiContent.references.map(ref => Reference.toJavaScript(ref.id)),
       wordCount = Jsoup.clean(fields.body, Whitelist.none()).split("\\s+").length,
-      hasStoryPackage = apifields.flatMap(_.hasStoryPackage).getOrElse(false),
       showByline = fapiutils.ResolvedMetaData.fromContentAndTrailMetaData(apiContent, TrailMetaData.empty, cardStyle).showByline,
+      hasStoryPackage = apifields.flatMap(_.hasStoryPackage).getOrElse(false),
       rawOpenGraphImage = {
         val bestOpenGraphImage = if (FacebookShareUseTrailPicFirstSwitch.isSwitchedOn) {
           trail.trailPicture.flatMap(_.largestImageUrl)

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -98,6 +98,7 @@ object Item460 extends Profile(width = Some(460))
 object Item620 extends Profile(width = Some(620))
 object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
+object Item1200 extends Profile(width = Some(1200))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
 


### PR DESCRIPTION
## What does this change?
I have noticed that currently Google is using the Open Graph image for video previews, rather than any of the others we provide. 
<img width="619" alt="screen shot 2017-04-10 at 14 48 55" src="https://cloud.githubusercontent.com/assets/1764158/24864674/e3db7d24-1dfc-11e7-9a35-c203a39f84f4.png">
My hypothesis is that this is because the OG image is much higher resolution than other meta images we provide.

This PR sets a higher res image as the `meta itemprop image`.

## What is the value of this and can you measure success?
Experiment to see if we can dislodge the OG image (which has an unwanted overlay)

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
