### PR TITLE
Tearup and teardown robust.spec explicitly

### DIFF
--- a/static/src/javascripts/lib/robust.spec.js
+++ b/static/src/javascripts/lib/robust.spec.js
@@ -6,6 +6,17 @@ import robust from './robust';
 jest.mock('lib/report-error', () => jest.fn());
 const reportErrorMock: any = require('lib/report-error');
 
+let origConsoleWarn;
+
+beforeEach(() => {
+    origConsoleWarn = window.console.warn;
+    window.console.warn = jest.fn();
+});
+
+afterEach(() => {
+    window.console.warn = origConsoleWarn;
+});
+
 describe('robust', () => {
     const ERROR = new Error('Something broke.');
     const META = { module: 'test' };
@@ -17,10 +28,6 @@ describe('robust', () => {
     };
 
     test('catchErrorsAndLog()', () => {
-        // mock window.console.warn, to check whether it was called
-        const origConsoleWarn = window.console.warn;
-        window.console.warn = jest.fn();
-
         expect(() => {
             robust.catchErrorsAndLog('test', noError);
         }).not.toThrowError();
@@ -30,9 +37,6 @@ describe('robust', () => {
         }).not.toThrowError(ERROR);
 
         expect(window.console.warn).toHaveBeenCalledTimes(1);
-
-        // reset window.console.warn
-        window.console.warn = origConsoleWarn;
     });
 
     test('catchErrorsAndLog() - default reporter', () => {


### PR DESCRIPTION
## What does this change?

ensures `window.console.log` is restored properly 

## What is the value of this and can you measure success?

mocks work, avoids this:

![screen shot 2017-04-10 at 15 05 23](https://cloud.githubusercontent.com/assets/867233/24865433/24bf4616-1dff-11e7-8f0c-887d87686251.png)
