### PR TITLE
Removed the remind-me banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -7,7 +7,6 @@ import org.joda.time.LocalDate
 trait ABTestSwitches {
 
   for ((edition, testId) <- Map(
-    Uk -> "ab-membership-engagement-banner-uk-remind-me-later",
     International -> "ab-membership-engagement-international-experiment-test12",
     Au -> "ab-au-memb-engagement-msg-copy-test8"
   )) Switch(

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -49,17 +49,6 @@ define([
         // messageCode is also consumed by .../test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
         var messageCode = 'engagement-banner-2017-03-30';
 
-        //Remind me form selectors
-        var SECONDARY_BUTTON = '.secondary';
-        var REMIND_ME_FORM = '.membership__remind-me-form';
-        var REMIND_ME_TEXT_FIELD = '.membership__engagement-text-field';
-        var REMIND_ME_CTA = '.membership__remind-me-form__cta';
-        var REMIND_ME_THANKS_MESSAGE = '.membership__remind-me-form__thanks-message';
-        var REMIND_ME_ERROR = '.membership__remind-me-form__error';
-
-        var LIST_ID = 3813;
-        var EMAIL_PATH = '/email';
-
         var DO_NOT_RENDER_ENGAGEMENT_BANNER = 'do no render engagement banner';
 
         function getUserTest() {
@@ -174,7 +163,6 @@ define([
                 buttonCaption: params.buttonCaption,
                 colourClass: colourClass,
                 arrowWhiteRight: svgs('arrowWhiteRight'),
-                showRemindMe: params.showRemindMe || false
             });
 
             var messageShown = new Message(
@@ -192,94 +180,9 @@ define([
                 recordInteraction(params.interactionOnMessageShown);
 
                 mediator.emit('membership-message:display');
-
-                if(params.showRemindMe) {
-                    setSecondaryButtonListener();
-
-                    trackGAEvent('display', 'engagement-banner', 'engagement-banner-remind-me');
-                }
             }
 
             mediator.emit('banner-message:complete');
-        }
-
-        function trackGAEvent(category, action, label) {
-            var gaTracker = null;
-
-            if(config.googleAnalytics) {
-                 gaTracker = config.googleAnalytics.trackers.editorial;
-            }
-
-            if(gaTracker && window.ga){
-                window.ga(gaTracker + '.send', 'event', category, action, label);
-            }
-
-        }
-
-        function emailIsValid(email) {
-            return typeof email === 'string' && email.indexOf('@') > -1;
-        }
-
-        function sendEmail(email){
-            submitForm(email, LIST_ID).then(showThankYouMessage, showErrorMessage)
-        }
-
-        function showThankYouMessage(){
-            hideElement($(REMIND_ME_TEXT_FIELD));
-            hideElement($(REMIND_ME_CTA));
-            hideElement($(REMIND_ME_ERROR));
-
-            showElement($(REMIND_ME_THANKS_MESSAGE));
-        }
-
-        function showErrorMessage(){
-            hideElement($(REMIND_ME_TEXT_FIELD));
-            hideElement($(REMIND_ME_CTA));
-            showElement($(REMIND_ME_ERROR));
-        }
-
-        function submitForm(email, listID) {
-            var formQueryString =
-                'email=' + encodeURI(email) + '&' +
-                'listId=' + listID;
-
-            return fetch(config.page.ajaxUrl + EMAIL_PATH,
-                {   method: 'post',
-                    body: formQueryString,
-                    headers: {
-                        'Accept': 'application/json'
-                    }
-                }
-            );
-        }
-
-        function showElement(element) {
-            element.removeClass('is-hidden');
-        }
-
-        function hideElement(element) {
-            element.addClass('is-hidden');
-        }
-
-        function setSecondaryButtonListener() {
-
-            bean.on($(SECONDARY_BUTTON)[0], 'click', function () {
-                hideElement($(SECONDARY_BUTTON));
-                showElement($(REMIND_ME_FORM));
-
-                trackGAEvent('click', 'engagement-banner', 'remind-me-button');
-            });
-
-            bean.on($(REMIND_ME_CTA)[0], 'click', function () {
-                var email = $(REMIND_ME_TEXT_FIELD)[0].value;
-
-                if(emailIsValid(email)){
-                    trackGAEvent('click', 'engagement-banner', 'send-email');
-                    sendEmail(email);
-                } else {
-                    showElement($(REMIND_ME_ERROR));
-                }
-            });
         }
 
         function init() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -27,7 +27,7 @@ define([
         this.author = 'Roberto Tyley';
         this.description = 'Show contributions/membership messages for the ' + edition + ' edition.';
         this.showForSensitive = false;
-        this.audience = 0.5;
+        this.audience = 1.0;
         this.audienceOffset = 0;
         this.successMeasure = 'Conversion';
         this.audienceCriteria = 'All users in the ' + edition + ' edition.';
@@ -78,9 +78,5 @@ define([
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
 
-    return [
-        new EditionTest('UK', 'MembershipEngagementBannerUkRemindMeLater', '2017-02-02', '2017-04-07', 'remind_me_later')
-            .addMembershipVariant('control', {})
-            .addMembershipVariant('remind_me', {showRemindMe : true})
-    ]
+    return []
 });

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -3,27 +3,10 @@
         <span id="membership__engagement-message-text">
             <%=messageText%>
         </span>
-        <span id="membership__engagement-message-button" class="message-button-rounded__cta primary <%=colourClass%>">
+        <span id="membership__engagement-message-button" class="message-button-rounded__cta <%=colourClass%>">
             <span id="membership__engagement-message-button-caption"><%=buttonCaption%></span><%=arrowWhiteRight%>
         </span>
-
-        <% if(showRemindMe) { %>
-            <span id="membership__engagement-message-button" class="message-button-rounded__cta secondary  <%=colourClass%>">
-                <span id="membership__engagement-message-button-caption">Remind me</span>
-            </span>
-        <% } %>
     </div>
     <a id="membership__engagement-message-link" class="u-faux-block-link__overlay" target="_blank" href="<%=linkHref%>" data-link-name="Read more link">
     </a>
-
-    <div id="membership__remind-me-form" class="membership__remind-me-form is-hidden">
-        <div class="membership__remind-me-form__fields">
-            <input type="text" id="membership__engagement-text-field" class="membership__engagement-text-field" />
-            <span id="membership__remind-me-form__error" class="membership__remind-me-form__error <%=colourClass%> is-hidden">Invalid email address; please try again<br></span>
-        </div>
-        <span id="membership__remind-me-form__cta" class="message-button-rounded__cta membership__remind-me-form__cta">
-            <span id="membership__engagement-message-button-caption">Send email reminder</span>
-        </span>
-        <span id="membership__remind-me-form__thanks-message" class="membership__remind-me-form__thanks-message is-hidden">Thanks, we will send you a reminder about becoming a Supporter</span>
-    </div>
 </div>

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -625,14 +625,14 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         margin-right: 16px;
     }
 
-    .message-button-rounded__cta.primary.yellow {
+    .message-button-rounded__cta.yellow {
         svg path {
             stroke: #000333;
             fill: #000333;
         }
         background-color: #ff9b0b;
     }
-    .message-button-rounded__cta.primary.purple {
+    .message-button-rounded__cta.purple {
 
         svg path {
             stroke: #ffffff;
@@ -641,7 +641,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         color: #ffffff;
         background-color: #dc2a7d;
     }
-    .message-button-rounded__cta.primary.dark-blue {
+    .message-button-rounded__cta.dark-blue {
         svg path {
             stroke: #000333;
             fill: #000333;
@@ -649,7 +649,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         color: #000333;
         background-color: #4bc6df;
     }
-    .message-button-rounded__cta.primary.bright-blue {
+    .message-button-rounded__cta.bright-blue {
         svg path {
             stroke: #ffffff;
             fill: #ffffff;
@@ -661,35 +661,6 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         display: block;
         float: right;
         height: $gs-column-width/2;
-    }
-
-    .message-button-rounded__cta.secondary {
-        //The secondary span is the only thing that is not overlap by the anchor
-        z-index: $zindex-popover + 1;
-        @include mq($from: mobile) {
-            padding-left: 9px;
-            padding-right: 9px;
-        }
-        border: 1px solid;
-        margin-left: 10px;
-
-    }
-    .message-button-rounded__cta.secondary.yellow {
-        border-color: #333333;
-    }
-
-    .message-button-rounded__cta.secondary.purple {
-        border-color: #ffffff;
-        color: #ffffff;
-    }
-
-    .message-button-rounded__cta.secondary.dark-blue {
-        border-color: #ffffff;
-        color: #ffffff;
-    }
-
-    .message-button-rounded__cta.secondary.bright-blue {
-        border-color: #333333;
     }
 }
 
@@ -717,11 +688,6 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message--membership-prominent.dark-blue {
     background-color: #005689;
-}
-
-
-.site-message--membership-secondary.bright-blue {
-    background: #ff0000;
 }
 
 /*
@@ -976,97 +942,5 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     height: 100%;
 }
 
-.membership__remind-me-form {
-    border-top: 1px dotted $neutral-1;
-    margin-top: $gs-baseline/2;
-    width: 100%;
-}
 
-.membership__engagement-text-field {
-    @include clearfix;
-    @include circular;
-    padding-left: $gs-gutter;
-    color: #000000;
-    @include mq($from: mobile) {
-        font-size: 12px;
-        line-height: 24px;
-        height: $gs-baseline * 3;
-        margin-top: $gs-baseline/2;
-    }
-    @include mq($from: tablet) {
-        font-size: 14px;
-        line-height: 28px;
-        height: $gs-baseline * 3;
-    }
-    @include mq($from: desktop) {
-        font-size: 14px;
-        line-height: $gs-baseline * 3;
-        height: $gs-baseline * 3;
-        width: 269px;
-    }
-    position: relative;
-    border: 0;
-    width: 100%;
-}
 
-.message-button-rounded__cta.membership__remind-me-form__cta {
-    color: #fffffb;
-    background-color: #333333;
-    top: 0px;
-    z-index: $zindex-popover + 1;
-    margin-top: $gs-baseline/2;
-
-    @include mq($from: desktop) {
-        margin-left: $gs-gutter/2;
-        margin-top: $gs-baseline;
-    }
-
-}
-
-.membership__remind-me-form {
-
-    .membership__remind-me-form__error {
-        @include fs-textSans(2);
-        font-size: 12px;
-        line-height: 16px;
-        position: relative;
-        margin-top: 4px;
-        display: block;
-    }
-
-    .membership__remind-me-form__error.yellow {
-        color: $live-main-1;
-    }
-
-    .membership__remind-me-form__error.bright-blue {
-        color: $live-main-1;
-    }
-
-    .membership__remind-me-form__error.purple,
-    .membership__remind-me-form__error.dark-blue {
-        color: #ffffff;
-    }
-
-    .membership__remind-me-form__error.hide-element,
-    .membership__remind-me-form__thanks-message.hide-element {
-        display: none;
-    }
-
-    .membership__remind-me-form__thanks-message {
-        margin-top: $gs-baseline;
-        margin-bottom: $gs-baseline;
-        position: relative;
-        display: block;
-
-        @include mq($from: desktop) {
-            margin-bottom: $gs-baseline/2;
-        }
-    }
-
-    .membership__remind-me-form__fields {
-        @include mq($from: desktop) {
-            float: left;
-            margin-bottom: $gs-baseline/2;
-        }
-    }
-}


### PR DESCRIPTION
## What does this change?
We are turning off the remind-me banner test. Therefore I am pulling off all the code related to it. 

PR were the test was introduced: https://github.com/guardian/frontend/pull/15740

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
How it looks in **DEV**, it keeps showing the old version (control) version of the banner.
<img width="1240" alt="picture 237" src="https://cloud.githubusercontent.com/assets/825398/24865905/99c92368-1e00-11e7-9e9e-827ed70a6da3.png">

## Tested in CODE?

<img width="1271" alt="picture 241" src="https://cloud.githubusercontent.com/assets/825398/24952042/3a34cd5c-1f6e-11e7-9800-4360d06e67e5.png">
