### PR TITLE
Update cities email demand test and remove the others

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -173,7 +173,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-email-demand-tests",
-    "Test demand for food, business, and cities emails",
+    "Test demand for a cities email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 4, 21),

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/email-demand-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/email-demand-tests.js
@@ -42,28 +42,11 @@ define([
         this.successMeasure = 'Number of clicks';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'People will demonstrate their interest in food, business and/or cities emails';
+        this.idealOutcome = 'People will demonstrate their interest a cities email';
 
         var articleBody = '.js-article__body';
 
         var listConfigs = {
-            food: {
-                listName: 'food',
-                displayName: {
-                    normalText: 'food',
-                    accentedText: 'weekly'
-                },
-                tone: 'feature',
-                headline: "What's for dinner?",
-                description: "Sign-up for our new weekly food email and you’ll get recipes, restaurant reviews and the best" +
-                " of all things culinary. Whether you’re a full-on foodie or a budding gastronaut, we’ve something to sate your appetite",
-                linkOnClick: "https://docs.google.com/forms/d/e/1FAIpQLSeGAacgwIRrUFxKPRSUG-imlqEwUKgVYFhOnJP4__avevZEHw/viewform?usp=sf_link",
-                canRun: function () {
-                    var tags = config.page.keywordIds.concat(config.page.nonKeywordTagIds);
-
-                    return (tags.indexOf('lifeandstyle/food-and-drink') > -1) || (tags.indexOf('tone/recipes') > -1)
-                }
-            },
             cities: {
                 listName: 'cities',
                 displayName: {
@@ -75,22 +58,9 @@ define([
                 "over the world – from gentrification and climate change to cycling and urban history",
                 linkOnClick: "https://docs.google.com/forms/d/e/1FAIpQLScUfA4BZ8RtDGJaM9NSVc7YxDRg_SB9-bLtdJG-Gml837cayQ/viewform?usp=sf_link",
                 canRun: function () {
-                    return config.page.section === 'cities';
-                }
-            },
-            business: {
-                listName: 'business',
-                displayName: {
-                    normalText: 'business',
-                    accentedText: 'today'
-                },
-                tone: 'news',
-                headline: "Business updates, direct to your inbox",
-                description: "Sign up to our daily email for an at-a-glance guide to the biggest stories, smartest " +
-                "analysis and hottest topics in the world of business and economics",
-                linkOnClick: "https://docs.google.com/forms/d/e/1FAIpQLSclNwg8nkuwYrApRnnVkhGsdIIb85Uk0_DTEoCRiMDdgqIBFQ/viewform?usp=sf_link",
-                canRun: function () {
-                    return config.page.section === 'business';
+                    var tags = config.page.keywordIds.concat(config.page.nonKeywordTagIds);
+
+                    return (config.page.section === 'cities' || (tags.indexOf('cities/cities') > -1));
                 }
             }
         };


### PR DESCRIPTION
## What does this change?
Re: the email demand tests added in [16311](https://github.com/guardian/frontend/pull/16311)
* Remove food and business email demand tests
* Change criteria for the cities email demand test so that it can appear on articles outside the cities section if the article has tag 'cities/cities'

## What is the value of this and can you measure success?
We already have enough data for the food and business email tests, and we should stop running them.

If the cities demand test can also appear on articles tagged 'cities/cities', then this should help us get enough data from the test sooner. 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
