### PR TITLE
Fixing comment share data link

### DIFF
--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -27,7 +27,7 @@
         <a href="@ShareLinks.createShareLinkForComment(platform = platform, href = permalink, text = text, quote = quote).href"
         target="_blank"
         class="social__action social-icon-wrapper"
-        data-link-name=s"social-comment : ${platform.css}">
+        data-link-name="social-comment : @{platform.css}">
             <span class="inline-icon__fallback button">
                 @platform.userMessage</span>
             @fragments.inlineSvg(s"share-${platform.css}", "icon", List("rounded-icon", "social-icon", "centered-icon", s"social-icon--${platform.css}", s"comment-${platform.css}-icon"))


### PR DESCRIPTION
## What does this change?
Fixing data link, as it is showing up wrong. Broken, it looks like this:

> el: comment social | s"social-comment


## What is the value of this and can you measure success?
Data which is more consistent across platforms 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
