### PR TITLE
Convert to CommonMark

### DIFF
--- a/docs/01-start-here/02-guardian-visual-glossary.md
+++ b/docs/01-start-here/02-guardian-visual-glossary.md
@@ -1,4 +1,4 @@
-#Visual glossary of the Guardian.com
+# Visual glossary of the Guardian.com
 
 ## Content Types
 
@@ -6,12 +6,12 @@
 
 [A standard article](http://m.code.dev-theguardian.com/law/2012/jul/27/twitter-joke-trial-high-court) consists of a [headline](http://m.code.dev-theguardian.com/football/blog/2012/may/10/signing-of-season-premier-league), standfirst, date, main image + caption, body copy, contributor/byline + image
 
-![image](images/standard article.jpg)
+![image](images/standard%20article.jpg)
 
 - [Embedded images, quotes](http://m.code.dev-theguardian.com/crosswords/crossword-blog/2012/jul/26/top-10-crosswords-fiction-olivers-travels)
 - [Full width trail image](https://www.theguardian.com/travel/2016/aug/08/top-10-seawater-swimming-pools-in-europe)
 
-![image](images/full width trail.jpg)
+![image](images/full%20width%20trail.jpg)
 
 
 
@@ -19,11 +19,11 @@
 
 - [The Counted - Interactive map](http://www.theguardian.com/us-news/ng-interactive/2015/jun/01/the-counted-map-us-police-killings)
 
-![image](images/the counted.jpg)
+![image](images/the%20counted.jpg)
 
 - [How Katie Ledecky obliterated her own world record in the 400m freestyle](http://www.theguardian.com/sport/ng-interactive/2016/aug/08/how-katie-ledecky-obliterated-her-own-world-record-in-the-400m-freestyle)
 
-![image](images/katie ledecky.jpg)
+![image](images/katie%20ledecky.jpg)
 
 
 ### Immersives
@@ -66,13 +66,13 @@
 
 [Your next box set](http://m.code.dev-theguardian.com/tv-and-radio/2012/jul/26/john-adams-next-box-set)
 
-![image](images/box set.jpg)
+![image](images/box%20set.jpg)
 
 ### Blog Series
 
 [Blog Series](http://m.code.dev-theguardian.com/crosswords/crossword-blog/2012/jul/26/top-10-crosswords-fiction-olivers-travels)
 
-![image](images/blog series.jpg)
+![image](images/blog%20series.jpg)
 
 ### Related
 
@@ -86,7 +86,7 @@
 
 [List of fronts containing containers built from CAPI queries and no curation](https://docs.google.com/spreadsheets/d/1x5JcqR33tnFCjd83mzBxmQONH5xeDkmeQNEjT_MUz0I/edit#gid=374412710)
 
-## Rich Links
+## Rich Links
 
 [Lots of examples](http://preview.gutools.co.uk/info/developer-blog/2014/dec/12/rich-link-testing)
 

--- a/docs/01-start-here/07-faqs.md
+++ b/docs/01-start-here/07-faqs.md
@@ -1,4 +1,4 @@
-#FAQs
+# FAQs
 
 ## I can see mark-up in my response, but it's not in the application anywhere. Where is it coming from?
 

--- a/docs/02-architecture/04-archiving.md
+++ b/docs/02-architecture/04-archiving.md
@@ -10,7 +10,7 @@ We want to archive this content for safe keeping and remove the technical system
 
 This outlines the archival procedure for The Guardian website.
 
-# How
+# How
 
 Essentially, archiving parts of the website boils down to,
 

--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -162,7 +162,7 @@ define([
 Add #ab-<TestName>=<VariantName> to the end of your URL (in dev or prod) to force yourself into a test.
 e.g. www.theguardian.com/news#ab-MyGreatTest=GreenButton
 
-#### Firing complete events in dev mode
+#### Firing complete events in dev mode
 In prod, the completion events are fired based on the MVT ID cookie. This doesn't exist in dev, so if you need to test a complete event, force yourself into the test using the #ab-<TestName>=<VariantName> pattern described above.
 This way, the `success` function of the test and variant you specify will be run, so you can test your completion behaviour.
 

--- a/docs/03-dev-howtos/09-testing-externally-on-localhost.md
+++ b/docs/03-dev-howtos/09-testing-externally-on-localhost.md
@@ -1,10 +1,9 @@
 # Testing externally on your localhost
-====================================
 
 There are a number of tools on the market for this. The one we recommended is ngrok.
 
 
-#To use ngrok:
+# To use ngrok:
 
 Install ngrok via their website: https://ngrok.com/download or use homebrew :
 ```bash

--- a/docs/03-dev-howtos/12-Update-configuration-in-s3.md
+++ b/docs/03-dev-howtos/12-Update-configuration-in-s3.md
@@ -1,4 +1,4 @@
-#Update configuration in s3
+# Update configuration in s3
 
 We store all our configuration in a single file in `s3`
 This contains all the configuration for each application and for each stage.

--- a/docs/99-archives/website-benchmark-2013.md
+++ b/docs/99-archives/website-benchmark-2013.md
@@ -1,4 +1,4 @@
-#Website benchmark (July 2012)
+# Website benchmark (July 2012)
 
 Pig script :- https://gist.github.com/3415362
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
-#Table Of Content
+# Table Of Contents
 *(Do NOT edit manually. Generated automatically)*
 
-##[Start here](01-start-here/)
+## [Start here](01-start-here/)
 - [Quick start guide](01-start-here/01-installation-steps.md)
 - [Visual glossary of the Guardian.com](01-start-here/02-guardian-visual-glossary.md)
 - [How to deploy](01-start-here/03-how-to-deploy.md)
@@ -10,7 +10,7 @@
 - [Testing tips](01-start-here/06-testing-tips.md)
 - [FAQs](01-start-here/07-faqs.md)
 
-##[Architecture](02-architecture/)
+## [Architecture](02-architecture/)
 - [The different applications composing the Guardian website](02-architecture/01-applications-architecture.md)
 - [Fronts Architecture](02-architecture/02-fronts-architecture.md)
 - [Libraries we use](02-architecture/03-libraries-we-use.md)
@@ -18,7 +18,7 @@
 - [Architecture principles for CSS](02-architecture/05-architecture-principles-for-css.md)
 - [Javascript](02-architecture/06-client-side-architecture.md)
 
-##[Dev howtos](03-dev-howtos/)
+## [Dev howtos](03-dev-howtos/)
 - [How to setup and run A/B tests](03-dev-howtos/01-ab-testing.md)
 - [What to do when a deployment breaks](03-dev-howtos/02-deployment-errors.md)
 - [Guardian embeds](03-dev-howtos/03-embeds.md)
@@ -37,25 +37,25 @@
 - [Working with Google AMP](03-dev-howtos/16-working-with-amp.md)
 - [Working with emails](03-dev-howtos/17-working-with-emails.md)
 
-##[Quality](04-quality/)
+## [Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)
 - [Browser support principles](04-quality/02-browser-support-principles.md)
 
-##[Commercial](05-commercial/)
+## [Commercial](05-commercial/)
 - [How do DFP adverts work?](05-commercial/01-DFP-Advertising.md)
 - [Integration of commercial components](05-commercial/02-commercial-components.md)
 - [Commercial javascript](05-commercial/03-commercial-javascript.md)
 
-##[Features and components](06-features-and-components/)
+## [Features and components](06-features-and-components/)
 - [SteadyPage JS utility](06-features-and-components/01-steadypage-js-utility.md)
 - [How are trail pictures picked in Frontend?](06-features-and-components/02-trail-images.md)
 
-##[Performance](07-performance/)
+## [Performance](07-performance/)
 - [Performance reading list](07-performance/01-performance-reading.md)
 
-##[Design](08-design/)
+## [Design](08-design/)
 
-##[Archives](99-archives/)
+## [Archives](99-archives/)
 - [Recipe for Breton crêpes](99-archives/crepes.md)
 - [CSS guideline (out-of-date)](99-archives/css-guidelines.md)
 - [Javascript guidelines (Out of date)](99-archives/javascript-guidelines.md)

--- a/docs/generate-toc.sh
+++ b/docs/generate-toc.sh
@@ -32,12 +32,12 @@ root=$(git rev-parse --show-toplevel)
 docs="$root/docs"
 pushd $docs > /dev/null
 
-echo "#Table Of Content"
+echo "# Table Of Contents"
 echo "*(Do NOT edit manually. Generated automatically)*"
 echo ""
 for dir in */; do
     dirname=$(cleanDirectoryName $dir)
-    echo "##[$dirname]($dir)"
+    echo "## [$dirname]($dir)"
     cd $dir > /dev/null
     for doc in *.md; do
         if [ "$doc" != "README.md" ]; then


### PR DESCRIPTION
## What does this change?

Minor documentation formatting.

GitHub switched everything over to the CommonMark specification recently so some things no longer render as intended. I tried to fix as many issues as I found but it was a manual operation so I probably missed some bits.

## What is the value of this and can you measure success?

Hopefully it will be easier to read.

