### PR TITLE
⚡ Disable documentation generation - faster compilation

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -20,6 +20,8 @@ trait Prototypes {
     javacOptions := Seq("-g","-encoding", "utf8"),
     scalacOptions := Seq("-unchecked", "-deprecation", "-target:jvm-1.8",
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
+    publishArtifact in (Compile, packageDoc) := false,
+    sources in (Compile,doc) := Seq.empty,
     doc in Compile := target.map(_ / "none").value,
     incOptions := incOptions.value.withNameHashing(true),
     scalaVersion := "2.11.8",


### PR DESCRIPTION
## What does this change?

Reduce compilation time by [disabling documentation generation and avoiding publishing the documentation artifact](https://www.playframework.com/documentation/2.5.x/SBTCookbook), that [can be seen in current builds](https://teamcity.gu-web.net/viewLog.html?buildId=33587&buildTypeId=dotcom_frontend&tab=buildLog#_state=17103,17096,5727&focus=15792):

```
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/rss/target/scala-2.11/rss_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/applications/target/scala-2.11/applications_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/facia/target/scala-2.11/facia_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/discussion/target/scala-2.11/discussion_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/archive/target/scala-2.11/archive_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/identity/target/scala-2.11/identity_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/diagnostics/target/scala-2.11/diagnostics_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/discussion/target/scala-2.11/discussion_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/sport/target/scala-2.11/sport_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/applications/target/scala-2.11/applications_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/preview/target/scala-2.11/preview_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/diagnostics/target/scala-2.11/diagnostics_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/archive/target/scala-2.11/archive_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/facia-press/target/scala-2.11/facia-press_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/diagnostics/target/scala-2.11/diagnostics_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/commercial/target/scala-2.11/commercial_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/identity/target/scala-2.11/identity_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/facia-press/target/scala-2.11/facia-press_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/archive/target/scala-2.11/archive_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/preview/target/scala-2.11/preview_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/commercial/target/scala-2.11/commercial_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/facia/target/scala-2.11/facia_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/article/target/scala-2.11/article_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/applications/target/scala-2.11/applications_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/facia/target/scala-2.11/facia_2.11-0.1-SNAPSHOT-sources.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/sport/target/scala-2.11/sport_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/onward/target/scala-2.11/onward_2.11-0.1-SNAPSHOT-web-assets.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/discussion/target/scala-2.11/discussion_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/commercial/target/scala-2.11/commercial_2.11-0.1-SNAPSHOT.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/commercial/target/scala-2.11/commercial_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Packaging /home/ubuntu/buildAgent/work/2494dc0f8c736a58/archive/target/scala-2.11/archive_2.11-0.1-SNAPSHOT-javadoc.jar ...
[14:51:02][Step 4/5] [info] Done packaging.
[14:51:02][Step 4/5] [info] Done packaging.
[14:51:02][Step 4/5] [info] Done packaging.
[14:51:02][Step 4/5] [info] Done packaging.
[14:51:02][Step 4/5] [info] Done packaging.
[14:51:02][Step 4/5] [info] Done packaging.
```

@rtyley [did that in the past](https://github.com/guardian/gu-who/commit/340d42acdef8f0b1a085026d9fb5276976ac0607) to the same purpose.

## What is the value of this and can you measure success?

reduce compilation times.
