### PR TITLE
Extend habit forming email tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,7 +26,7 @@ trait ABTestSwitches {
     "Assign users to variants of our editorial emails",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 12),
+    sellByDate = new LocalDate(2017, 5, 30),
     exposeClientSide = true
   )
 
@@ -36,7 +36,7 @@ trait ABTestSwitches {
     "Assign users to variants of opinion emails",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 12),
+    sellByDate = new LocalDate(2017, 5, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/editorial-email-variants.js
@@ -14,7 +14,7 @@ define([
     return function () {
         this.id = 'EditorialEmailVariants';
         this.start = '2016-12-01';
-        this.expiry = '2017-04-12';
+        this.expiry = '2017-05-30';
         this.author = 'Kate Whalen';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB function in ExactTarget re-randomises all recipients on each send, and we need users to receive their variant for several weeks. This test will ensure users are added to the corresponding email list (listId) in ExactTarget';
         this.audience = 1;

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/opinion-email-variants.js
@@ -14,7 +14,7 @@ define([
     return function () {
         this.id = 'OpinionEmailVariants';
         this.start = '2017-01-12';
-        this.expiry = '2017-04-12';
+        this.expiry = '2017-05-30';
         this.author = 'David Furey';
         this.description = 'Using the wonderful frontend AB testing framework to AB test emails, since the AB ' +
             'function in ExactTarget re-randomises all recipients on each send, and we need users to receive their ' +


### PR DESCRIPTION
## What does this change?

Extends habit forming a/b tests

## What is the value of this and can you measure success?

We haven’t finished the exact target migration for these lists yet

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
