### PR TITLE
Fix wrong css deletion

### DIFF
--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -26,7 +26,9 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__standfirst,
+    .rich-link__standfirst {
+        color: $news-support-6;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $analysis-background, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -19,7 +19,10 @@
     .rich-link__kicker,
     .fc-item__byline,
     .rich-link__byline,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $comment-default;
+    }
+
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $comment-background, 10%);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -15,7 +15,10 @@
     }
 
     .fc-item__kicker,
-    .fc-item__byline,
+    .fc-item__byline {
+        color: $live-accent;
+    }
+
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $neutral-7, 10%);
     }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -35,7 +35,9 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__standfirst,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $editorial-accent;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $editorial-default, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -2,7 +2,9 @@
     background-color: $neutral-6;
 
     .fc-item__kicker,
-    .fc-item__byline,
+    .fc-item__byline {
+        color: $external-main-1;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $neutral-6, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -35,7 +35,9 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $feature-mute;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $feature-default, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -32,7 +32,9 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $live-mute;
+    }
 
     .rich-link__arrow-icon {
         fill: $live-mute;

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -36,7 +36,9 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $media-default;
+    }
 
     .fc-item__kicker:after,
     .rich-link__kicker:after,

--- a/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
@@ -11,7 +11,9 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $news-default;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $neutral-8, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -31,7 +31,9 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $review-accent;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $review-background, 10%);

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -35,7 +35,9 @@
     .rich-link__kicker,
     .fc-item__byline,
     .rich-link__byline,
-    .rich-link__read-more-text,
+    .rich-link__read-more-text {
+        color: $special-report-accent;
+    }
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, $news-support-6, 10%);


### PR DESCRIPTION
Overzealous deletion in #16423 lead to deleting css that should have not
been deleted

cc @guardian/dotcom-platform 

## What does this change?
Fixing ugly highlight of story title on fronts

## Tested in CODE?
I am about to. 😁 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
