### PR TITLE
Fix line height on story questions to prevent overlap.

### DIFF
--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -54,6 +54,7 @@
 
 .user__question-text {
     @include fs-headline(2);
+    line-height: 18px;
     font-weight: 900;
     display: block;
     max-width: 68%;
@@ -66,6 +67,7 @@
 
     @include mq($from: tablet) {
         @include fs-headline(3);
+        line-height: 27px;
         max-width: 80%;
         font-weight: 900;
     }


### PR DESCRIPTION
Correct line height on story questions so that the text does not overlap.