### PR TITLE
Use regular function expression to bind 'this' correctly in FastDom.

### DIFF
--- a/static/src/javascripts/lib/fastdom-promise.js
+++ b/static/src/javascripts/lib/fastdom-promise.js
@@ -5,7 +5,11 @@ const promisify = fdaction =>
     (fn: Function, ctx: Object) =>
         new Promise((resolve, reject) =>
             fdaction(
-                () => {
+                /* this function needs to be bound to ctx - it therefore cannot
+                   be an arrow function as this will be bound with the current
+                   context and cannot be rebound.
+                */
+                function() {
                     try {
                         resolve(fn.call(this));
                     } catch (e) {


### PR DESCRIPTION
## What does this change?
This uses a regular function declaration to promisify fastdom calls, as commented in the code:

>this function needs to be bound to ctx - it therefore cannot be an arrow function as this will be bound with the current context and cannot be rebound.

## What is the value of this and can you measure success?

Stops all of the commercial components that are using fastdom promises from failing!
## Does this affect other platforms - Amp, Apps, etc?

@guardian/commercial-dev 