### PR TITLE
re-run inline ads AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -21,6 +21,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-increase-inline-ads",
+    "Displays more inline ads in articles on desktop",
+    owners = Seq(Owner.withGithub("regiskuckaertz")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 4, 10),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-editorial-email-variants",
     "Assign users to variants of our editorial emails",
     owners = Seq(Owner.withGithub("davidfurey")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -21,11 +21,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-increase-inline-ads",
+    "ab-increase-inline-ads-redux",
     "Displays more inline ads in articles on desktop",
-    owners = Seq(Owner.withGithub("regiskuckaertz")),
+    owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 10),
+    sellByDate = new LocalDate(2017, 5, 17),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -32,8 +32,8 @@ define([
     var replaceTopSlot;
     var getSlotName;
     var getSlotType;
-    var isOffsetingAds = abUtils.testCanBeRun('IncreaseInlineAds') &&
-        abUtils.getTestVariantId('IncreaseInlineAds') === 'yes';
+    var isOffsetingAds = abUtils.testCanBeRun('IncreaseInlineAdsRedux') &&
+        abUtils.getTestVariantId('IncreaseInlineAdsRedux') === 'yes';
 
     function init() {
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -20,6 +20,7 @@ define([
     'common/modules/experiments/tests/film-today-email-variants',
     'common/modules/experiments/tests/sleeve-notes-new-email-variant',
     'common/modules/experiments/tests/sleeve-notes-legacy-email-variant',
+    'common/modules/experiments/tests/increase-inline-ads',
     'common/modules/experiments/tests/email-demand-tests',
     'common/modules/experiments/tests/paid-card-logo',
     'ophan/ng',
@@ -45,6 +46,7 @@ define([
              FilmTodayEmailVariants,
              SleevenotesNewEmailVariant,
              SleevenotesLegacyEmailVariant,
+             IncreaseInlineAds,
              EmailDemandTests,
              PaidCardLogo,
              ophan,
@@ -61,6 +63,7 @@ define([
         FilmTodayEmailVariants,
         SleevenotesNewEmailVariant,
         SleevenotesLegacyEmailVariant,
+        new IncreaseInlineAds(),
         new EmailDemandTests(),
         new PaidCardLogo(),
         new PaidCommenting()

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -46,7 +46,7 @@ define([
              FilmTodayEmailVariants,
              SleevenotesNewEmailVariant,
              SleevenotesLegacyEmailVariant,
-             IncreaseInlineAds,
+             increaseInlineAdsRedux,
              EmailDemandTests,
              PaidCardLogo,
              ophan,
@@ -63,7 +63,7 @@ define([
         FilmTodayEmailVariants,
         SleevenotesNewEmailVariant,
         SleevenotesLegacyEmailVariant,
-        new IncreaseInlineAds(),
+        new increaseInlineAdsRedux(),
         new EmailDemandTests(),
         new PaidCardLogo(),
         new PaidCommenting()

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
@@ -1,0 +1,34 @@
+define([
+    'lib/config',
+    'lib/detect'
+], function (config, detect) {
+    return function () {
+        this.id = 'IncreaseInlineAds';
+        this.start = '2017-03-10';
+        this.expiry = '2017-03-24';
+        this.author = 'Regis Kuckaertz';
+        this.description = 'Displays more inline ads in articles on desktop';
+        this.audience = .05;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Our inventory has increased';
+        this.audienceCriteria = '';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Viewability and user engagement has not been impacted';
+        this.showForSensitive = true;
+
+        this.canRun = function () {
+          return !config.page.isImmersive && detect.isBreakpoint({ min: 'desktop' });
+        };
+
+        this.variants = [
+            {
+                id: 'yes',
+                test: function () {}
+            },
+            {
+                id: 'no',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
@@ -3,10 +3,10 @@ define([
     'lib/detect'
 ], function (config, detect) {
     return function () {
-        this.id = 'IncreaseInlineAds';
-        this.start = '2017-03-10';
-        this.expiry = '2017-03-24';
-        this.author = 'Regis Kuckaertz';
+        this.id = 'IncreaseInlineAdsRedux';
+        this.start = '2017-04-12';
+        this.expiry = '2017-05-17';
+        this.author = 'Gideon Goldberg';
         this.description = 'Displays more inline ads in articles on desktop';
         this.audience = .05;
         this.audienceOffset = 0;


### PR DESCRIPTION
## What does this change?
Re-introduces the inline ads AB tests. (The previous results weren't valid as a variant was added after the test had started.)

## What is the value of this and can you measure success?
Allows us to measure the impact of this change

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
CC @guardian/commercial-dev 