### PR TITLE
various acquisition tests extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -45,7 +45,7 @@ trait ABTestSwitches {
     "Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles",
     owners = Seq(Owner.withGithub("alexduf")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 13),
+    sellByDate = new LocalDate(2017, 4, 19),
     exposeClientSide = true
   )
 
@@ -155,7 +155,7 @@ trait ABTestSwitches {
     "Display the Epic on Article 50 articles for readers in Europe",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 13),
+    sellByDate = new LocalDate(2017, 4, 19),
     exposeClientSide = true
   )
 
@@ -165,7 +165,7 @@ trait ABTestSwitches {
     "Display the Epic on Laundromat articles",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 13),
+    sellByDate = new LocalDate(2017, 4, 19),
     exposeClientSide = true
   )
 
@@ -205,7 +205,7 @@ trait ABTestSwitches {
     "Test displaying the Epic only vs the Epic and Engagement Banner",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 13),
+    sellByDate = new LocalDate(2017, 4, 19),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-article-50-trigger.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-article-50-trigger.js
@@ -11,7 +11,7 @@ define([
         campaignId: 'epic_article_50_trigger',
 
         start: '2017-03-14',
-        expiry: '2017-04-13',
+        expiry: '2017-04-19',
 
         author: 'Guy Dawson',
         description: '',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-vs-epic-and-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-vs-epic-and-engagement-banner.js
@@ -37,7 +37,7 @@ define([
         campaignId: campaignId,
 
         start: '2017-03-24',
-        expiry: '2017-04-13',
+        expiry: '2017-04-19',
 
         author: 'Guy Dawson',
         description: 'Epic and engagement banner vs the epic only',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-brexit.js
@@ -9,7 +9,7 @@ define([
         campaignId: 'epic_brexit_2017_01',
 
         start: '2017-01-06',
-        expiry: '2017-04-13',
+        expiry: '2017-04-19',
 
         author: 'Alex Dufournet',
         description: 'Test whether we get a positive effect on membership/contribution by targeting the latest brexit articles',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-laundromat.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-laundromat.js
@@ -9,7 +9,7 @@ define([
         campaignId: 'epic_laundromat',
 
         start: '2017-03-20',
-        expiry: '2017-04-13',
+        expiry: '2017-04-19',
 
         author: 'Jonathan Rankin',
         description: 'Run the epic on laundromat articles, ignoring the sensitive tag',


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Extends the expiry date of various acquisition tests.

## What is the value of this and can you measure success?

Stops the front-end build from breaking. Gives us additional time to decide which tests should be removed, and which tests should be extended indefinitely.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No
