### PR TITLE
Add weekend crossword type.

### DIFF
--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -48,7 +48,8 @@ final case class CrosswordSearchPage(override val metadata: MetaData) extends St
     "genius",
     "speedy",
     "everyman",
-    "azed"
+    "azed",
+    "weekend"
   )
 
   val setters: Seq[String] = Seq(

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -18,10 +18,10 @@ GET        /survey/thankyou                                                     
 GET        /surveys/*file                                                       controllers.Assets.at(path="/public/surveys", file)
 
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy>/:id/print          controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
-GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy|weekend>/:id/print          controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
 GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -218,6 +218,7 @@ trait Navigation {
   val genius = SectionLink("crosswords", "genius", "Genius", "/crosswords/series/genius")
   val speedy = SectionLink("crosswords", "speedy", "Speedy", "/crosswords/series/speedy")
   val everyman = SectionLink("crosswords", "everyman", "Everyman", "/crosswords/series/everyman")
+  val weekendSectionLink = SectionLink("crosswords", "weekend", "Weekend", "/crosswords/series/weekend-crossword")
 
   // R1 Azeds have been re-created as NGW content with a new landing page
   val azed = SectionLink("crosswords", "azed", "Azed", "/crosswords/series/azed")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -446,7 +446,8 @@ object NewNavigation {
         NavLink("editor", "/crosswords/series/crossword-editor-update"),
         NavLink("quick", "/crosswords/series/quick"),
         NavLink("cryptic", "/crosswords/series/cryptic"),
-        NavLink("prize", "/crosswords/series/prize")
+        NavLink("prize", "/crosswords/series/prize"),
+        NavLink("weekend", "/crosswords/series/weekend-crossword")
       ),
       List(
         NavLink("quiptic", "/crosswords/series/quiptic"),

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -87,7 +87,8 @@ object International extends Edition(
     genius,
     speedy,
     everyman,
-    azed
+    azed,
+    weekendSectionLink
   )
 
   override val navigation: Seq[NavItem] = {

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -3,6 +3,7 @@ package common.editions
 import java.util.Locale
 
 import common._
+import common.editions.International.weekendSectionLink
 import org.joda.time.DateTimeZone
 
 object Uk extends Edition(
@@ -87,7 +88,8 @@ object Uk extends Edition(
     genius,
     speedy,
     everyman,
-    azed
+    azed,
+    weekendSectionLink
   )
 
   override val navigation: Seq[NavItem] = {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -27,10 +27,10 @@ GET            /commercial-reports/:dateTime                                    
 
 # Crosswords
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy>/:id/print                  controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
-GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy|weekend>/:id/print                  controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
 GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -18,7 +18,7 @@ GET           /oauth2callback                                                   
 GET           /logout                                                                          controllers.OAuthLoginPreviewController.logout
 
 # Crossword
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy|weekend>/:id    controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
 
 
 # Commercial

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -18,5 +18,6 @@ $xword-grid-sizes: (
     quiptic: 15,
     genius: 15,
     speedy: 13,
-    everyman: 15
+    everyman: 15,
+    weekend: 13
 );


### PR DESCRIPTION
Weekend crosswords are now in CAPI. This change gets them to render on frontend. Currently there's only 1 published weekend crossword:

http://content.guardianapis.com/crosswords/weekend/327?api-key=test

but we're set up to publish one a week to the end of time.

The crossword series tag doesn't follow the convention of the other crossword tags - it's /crossword/series/weekend-crossword, but I guess that's fine.

This is what the new series page looks like:
<img width="1169" alt="screen shot 2017-04-12 at 17 56 48" src="https://cloud.githubusercontent.com/assets/3606555/24969683/7718bc3e-1fa9-11e7-8593-4299ffce3fcb.png">

And this is what our first weekend crossword will look like:
<img width="1023" alt="screen shot 2017-04-12 at 17 57 47" src="https://cloud.githubusercontent.com/assets/3606555/24969717/90fc0e58-1fa9-11e7-9943-57d8e92e0cc0.png">
