### PR TITLE
ab-test-clash fix check logic for contributions

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -21,7 +21,7 @@ define([
     function _testABClash(f, clashingTests) {
         if (clashingTests.length > 0) {
             return some(clashingTests, function (test) {
-                test.variants.filter(function (variant) {
+                return test.variants.filter(function (variant) {
                     return !variant.isOutbrainCompliant;
                 }).some(function (variant) {
                     return f(test, variant);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab-test-clash.js
@@ -21,7 +21,9 @@ define([
     function _testABClash(f, clashingTests) {
         if (clashingTests.length > 0) {
             return some(clashingTests, function (test) {
-                return some(test.variants, function (variant) {
+                test.variants.filter(function (variant) {
+                    return !variant.isOutbrainCompliant;
+                }).some(function (variant) {
                     return f(test, variant);
                 });
             });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -50,13 +50,7 @@ define([
     }, []);
 
     var abTestClashData = tests.map(function(test) {
-        var testInstance = new test();
-        return {
-            name: testInstance.id,
-            variants: testInstance.variants.filter(function (variant) {
-                return !variant.isOutbrainCompliant
-            })
-        }
+        return new test();
     });
 
     return {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
@@ -2,7 +2,7 @@ define([
     'lib/config'
 ], function(config) {
     function isTestSwitchedOn(test) {
-        return config.switches['ab' + test.id];
+        return config.switches['ab' + test];
     }
 
     function isExpired(testExpiry) {
@@ -16,8 +16,8 @@ define([
         var expired = isExpired(test.expiry),
             isSensitive = config.page.isSensitive;
 
-        return ((isSensitive ? test.showForSensitive : true)
-            && isTestSwitchedOn(test)) && !expired && test.canRun();
+        return ((isSensitive ? test.showForSensitive : true) && isTestSwitchedOn(test)) 
+                    && !expired && (!test.canRun || test.canRun());
     }
 
     return {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/test-can-run-checks.js
@@ -2,7 +2,7 @@ define([
     'lib/config'
 ], function(config) {
     function isTestSwitchedOn(test) {
-        return config.switches['ab' + test];
+        return config.switches['ab' + test.id];
     }
 
     function isExpired(testExpiry) {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/utils.js
@@ -71,7 +71,7 @@ define([
      */
     function isInVariant(test, variant) {
         return getParticipations()[test.name] &&
-            getParticipations()[test.name].variant === variant &&
+            getParticipations()[test.name].variant === variant.id &&
             testCanRunChecks.testCanBeRun(test.name);
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/utils.js
@@ -70,9 +70,9 @@ define([
      * @returns {*|boolean|Boolean}
      */
     function isInVariant(test, variant) {
-        return getParticipations()[test.name] &&
-            getParticipations()[test.name].variant === variant.id &&
-            testCanRunChecks.testCanBeRun(test.name);
+        return getParticipations()[test.id] &&
+            getParticipations()[test.id].variant === variant.id &&
+            testCanRunChecks.testCanBeRun(test);
     }
 
     return {

--- a/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
+++ b/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
@@ -1,21 +1,82 @@
 define([
-    'common/modules/experiments/ab-test-clash'
+    'helpers/injector'
 ], function (
-    Clash
+    Injector
 ) {
         describe('Clash', function () {
+            var Clash,
+                sandbox;
 
-            var contributionsEpicButtons = {name: 'ContributionsEpicButtons20160907', variants: ['control', 'buttons']};
-            var clashingTests = [contributionsEpicButtons];
+            beforeEach(function (done) {
+                var injector = new Injector();
+                
+                sandbox = sinon.sandbox.create();
 
-            it('test clash should be true with true function', function () {
-                var f = function () { return true; };
-                expect(Clash._testABClash(f, clashingTests)).toBeTruthy();
+                injector.require([
+                    'common/modules/experiments/ab-test-clash'
+                ], function (sut) {
+                    Clash = sut;
+
+                    done();
+                });
             });
 
-            it('test clash should be false with false function', function () {
-                var f = function () { return false; };
+            afterEach(function () {
+                sandbox.restore();
+            });
+
+            it('test clash should return false if test has only outbrain compliant variant', function () {
+                var f = sandbox.spy();
+                var test = {
+                    id: 'outbrainCompliantTest',
+                    variants: [{
+                        id: 'control',
+                        isOutbrainCompliant: true
+                    }]
+                };
+                var clashingTests = [test];
+
                 expect(Clash._testABClash(f, clashingTests)).toBeFalsy();
+                expect(f).not.toHaveBeenCalled();
+            });
+
+            it('test clash should return true if test has outbrain non compliant variant and f returns true', function () {
+                var f = sandbox.stub().returns(true);
+                var test = {
+                    id: 'outbrainCompliantTest',
+                    variants: [{
+                        id: 'control',
+                        isOutbrainCompliant: true
+                    }, {
+                        id: 'variant',
+                        isOutbrainCompliant: false
+                    }]
+                };
+                var clashingTests = [test];
+
+                expect(Clash._testABClash(f, clashingTests)).toBeTruthy();
+                expect(f).toHaveBeenCalledOnce();
+                expect(f).toHaveBeenCalledWith(test, test.variants[1]);
+
+            });
+
+            it('test clash should return false if test has outbrain non compliant variant and f returns true', function () {
+                var f = sandbox.stub().returns(false);
+                var test = {
+                    id: 'outbrainCompliantTest',
+                    variants: [{
+                        id: 'control',
+                        isOutbrainCompliant: true
+                    }, {
+                        id: 'variant',
+                        isOutbrainCompliant: false
+                    }]
+                };
+                var clashingTests = [test];
+
+                expect(Clash._testABClash(f, clashingTests)).toBeFalsy();
+                expect(f).toHaveBeenCalledOnce();
+                expect(f).toHaveBeenCalledWith(test, test.variants[1]);
             });
         });
 });


### PR DESCRIPTION
## What does this change?

We've had reports of compliant outbrain widgets being shown on pages with contributions epics. After looking into this I found there were some issues with the way we checked whether the user was in a clashing contributions test.

**experiments/acquistion-test-selector**
Issue: the  objects in the list exported as abTestClashData are eventually passed to test-can-run-checks.testCanBeRun, however they have a different definition to the objects passed elsewhere to testCanBeRun (eg. they have the property 'name' instead of 'id').

Fix: export a list of test() instances, so the object eventually passed to testCanBeRun has the correct definition.

**experiments/utils.isInVariant** 
Issue: checks whether argument 'variant' is equal to getParticipations()[test.name].variant. getParticipations()[test.name].variant is a string eg. 'control' and the argument variant is an object eg. {id:'control'}

Fix: check against variant.id not variant.

Issue: it passes test.name (a string) to test-can-run-checks.testCanBeRun which expects a test object.

Fix: pass test object to test-can-run-checks.testCanRun.

**experiments/test-can-run-checks.testCanBeRun**
Issue: attempts to run test.canRun(), test.canRun isn't always defined on some ab.test objects, if it's not defined this will never return true.

Fix: If test.canRun isn't defined assume test can run.

## What is the value of this and can you measure success?

Should mean we only show non-compliant widgets if a user is in a clashing ab.test

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

N/A