### PR TITLE
ArticleBody refactor take two

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -12,6 +12,17 @@
     if (page.article.tags.isReview) "reviewBody" else "articleBody"
 }
 
+@secondaryColumn(isPaidForContent: Boolean) = {
+    <div class="content__secondary-column js-secondary-column" aria-hidden="true">
+
+        @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes)
+
+        @if(!isPaidForContent){
+            <div class="js-components-container"></div>
+        }
+    </div>
+}
+
 @defining(model.article) { article =>
   @defining(isPaidContent(model)) { isPaidContent =>
 
@@ -36,24 +47,40 @@
             }
 
             @if(amp) {
+
+                @fragments.mainMedia(article, amp)
+
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
-                @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                    @fragments.mainMedia(article, amp)
-                }
             } else {
-                <div class="hide-on-mobile">
-                    @fragments.headTonal(article, model, isPaidContent, amp = amp)
+                @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
 
-                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                        @fragments.mainMedia(article, amp)
-                    }
-                </div>
-                <div class="mobile-only">
-                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                        @fragments.mainMedia(article, amp)
-                    }
-                </div>
+                    <div class="content__header-container">
+                        @fragments.headTonal(article, model, isPaidContent)
+
+                        <div class="content__main-media-full-width-mobile">
+                            @fragments.mainMedia(article)
+                        </div>
+                    </div>
+
+                } else {
+                    <div class="content__header-container">
+                        @fragments.headTonal(article, model, isPaidContent)
+
+                        <div class="content__main-media-wrapper content__main-media-full-width-mobile">
+                            <div class="content__main-media">
+
+                                @fragments.mainMedia(article)
+                            </div>
+
+                            <div class="hide-on-mobile">
+                                @fragments.contentMeta(article, model)
+                            </div>
+
+                            @secondaryColumn(isPaidContent)
+                        </div>
+                    </div>
+                }
             }
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
@@ -62,19 +89,15 @@
                         <div class="js-score"></div>
                         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
 
-                        @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
-                            @fragments.mainMedia(article, amp)
-                        }
-
-                        @if(!amp) {
+                        @if((article.tags.isFeature && article.elements.hasShowcaseMainElement) || amp) {
+                            @fragments.contentMeta(article, model, amp = amp)
+                        } else {
                             <div class="mobile-only">
-                                @fragments.headTonal(article, model, isPaidContent, amp = amp)
+                                @fragments.contentMeta(article, model, amp = amp)
                             </div>
                         }
 
                         @fragments.witnessCallToAction(article.content)
-
-                        @fragments.contentMeta(article, model, amp = amp)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
@@ -103,14 +126,9 @@
                         <div class="after-article js-after-article"></div>
                     </div>
 
-                    <div class="content__secondary-column js-secondary-column" aria-hidden="true">
-
-                        @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes)
-
-                        @if(!isPaidContent){
-                        <div class="js-components-container"></div>
-                        }
-                    </div>
+                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
+                        @secondaryColumn(isPaidContent)
+                    }
                 </div>
             </div>
         </article>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -69,7 +69,7 @@ import collection.JavaConversions._
 
         Then("I should see the names of the authors")
         $("[itemprop=author]")(0).getText should be("Ben Arnold")
-        $("[itemprop=author]").last.getText should be("Phelim O'Neill")
+        $("[itemprop=author]")(1).getText should be("Andrew Mueller")
 
         And("I should see a link to the author's page")
         $("[itemprop=author] a[itemprop='sameAs']")(0).getAttribute("href") should be(withHost("/profile/ben-arnold"))

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -70,7 +70,7 @@ object MetaDataMatcher extends Matchers  {
     status(result) should be(200)
 
     val elements = body.getElementsByClass("old-article-message")
-    elements.size() should be(1)
+    elements.size() should be > 0
   }
 
   def ensureNoOldArticleMessage(result: Future[Result], articleUrl: String) {

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -33,7 +33,6 @@
 
 @include grid-system;
 @import 'layout/_header';
-@import 'layout/_ab-new-header-test-variant';
 @import 'layout/_subnav';
 @import 'module/nav/_supporter-trapezoid';
 @import 'layout/_helpers';
@@ -57,6 +56,7 @@
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
 @import 'module/onward/_rich-links-default.head';
+@import 'module/_main-media-captions';
 
 /* ==========================================================================
    Facia

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -210,11 +210,7 @@
 }
 
 .media-primary {
-    margin: 0 (-$gs-gutter / 2);
-
-    @include mq(mobileLandscape) {
-        margin: 0 (-$gs-gutter);
-    }
+    position: relative;
 }
 
 // TODO: on amp, shouldn't have this. Or, use amp-lightbox

--- a/static/src/stylesheets/head.amp.scss
+++ b/static/src/stylesheets/head.amp.scss
@@ -1,1 +1,3 @@
 @import 'head.amp-common';
+
+@import 'module/_main-media-captions';

--- a/static/src/stylesheets/layout/_helpers.scss
+++ b/static/src/stylesheets/layout/_helpers.scss
@@ -58,7 +58,8 @@
 }
 
 /* Override default .gs-container breakpoints */
-.gs-container {
+.gs-container,
+.content__main-media-wrapper {
     @include mq(tablet) {
         max-width: gs-span(9) + $gs-gutter * 2;
     }

--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -1,30 +1,4 @@
-/****************
- * Changes to an Article Body
- ****************/
-
 $caption-button-size: 32px;
-
-// When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
-// TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
-.content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live, .tonal__head--tone-media) {
-    @include mq($until: mobileLandscape) {
-        margin-right: -$gs-gutter / 2;
-        margin-left: -$gs-gutter / 2;
-    }
-
-    @include mq($from: mobileLandscape, $until: phablet) {
-        margin-right: -$gs-gutter;
-        margin-left: -$gs-gutter;
-    }
-}
-
-@include mq($from: phablet, $until: tablet) {
-    .media-primary,
-    .content__head {
-        margin-left: -$gs-gutter;
-        margin-right: -$gs-gutter;
-    }
-}
 
 @include mq($until: tablet) {
 
@@ -79,10 +53,3 @@ $caption-button-size: 32px;
         background-color: $multimedia-support-5;
     }
 }
-
-
-
-
-//TODO: captions
-//TODO: headline + main
-//TODO: AMP <- image always first if possible?

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -1,15 +1,5 @@
 .media-primary {
-    margin: 0 $gs-gutter * -.5;
     position: relative;
-
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter / -1;
-        margin-right: $gs-gutter / -1;
-    }
-    @include mq(phablet) {
-        margin-left: 0;
-        margin-right: 0;
-    }
 }
 
 .content__main-column--article {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -561,7 +561,7 @@
     @include mq(leftCol) {
         float: left;
         position: static;
-        margin-left: ($left-column + $gs-gutter)*-1;
+        margin-left: ($left-column + $gs-gutter) * -1;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -22,6 +22,58 @@
     box-sizing: border-box;
 }
 
+.content__header-container {
+    @include mq($until: tablet) {
+        // on desktop, the headline is first, on mobile the image is first
+        display: flex;
+        flex-wrap: wrap-reverse;
+    }
+}
+
+.content__head,
+.content__main-media-full-width-mobile {
+    @include mq($until: tablet) {
+        // Even when using flex, the main media should be 100% of it's container
+        width: 100%;
+        flex-grow: 1;
+    }
+}
+
+.content__main-media-wrapper {
+    position: relative;
+    margin: 0 auto;
+
+    @include mq(tablet) {
+        padding-left: $gs-gutter;
+        padding-right: $gs-gutter;
+        box-sizing: border-box;
+    }
+}
+
+.content__main-media {
+    max-width: gs-span(8);
+    margin: auto;
+    position: relative;
+
+    @include mq(tablet, desktop) {
+        max-width: gs-span(9);
+    }
+
+    @include mq(desktop) {
+        margin-left: 0;
+        margin-right: $right-column + $gs-gutter;
+    }
+
+    @include mq(leftCol) {
+        margin-left: $left-column + $gs-gutter;
+    }
+
+    @include mq(wide) {
+        margin-left: $left-column-wide + $gs-gutter;
+    }
+}
+
+
 .content__main-column {
     max-width: gs-span(8);
     margin: auto;
@@ -458,13 +510,11 @@
     @include mq(leftCol) {
         position: absolute;
         top: 0;
-        margin-left: ($left-column + $gs-gutter)*-1;
         margin-bottom: ($gs-baseline/3)*4;
         width: $left-column;
     }
 
     @include mq(wide) {
-        margin-left: ($left-column-wide + $gs-gutter)*-1;
         width: $left-column-wide;
     }
 
@@ -507,17 +557,11 @@
     }
 }
 
-.content__meta-container--float {
-    @include mq(leftCol) {
-        float: left;
-        position: static;
-    }
-}
-
 .content__meta-container.content__meta-container--showcase {
     @include mq(leftCol) {
         float: left;
         position: static;
+        margin-left: ($left-column + $gs-gutter)*-1;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Take two of https://github.com/guardian/frontend/pull/16435

For the new header/article refresh test we are serving more html than we actually need to. We basically [show something different for mobile, than we do for desktop](https://github.com/guardian/frontend/blob/master/article/app/views/fragments/articleBody.scala.html#L45).

This is a go at serving less html, but still enabling things to visually look as we want them to.


## What is the value of this and can you measure success?
Less html served? Maybe more readable?

## Does this affect other platforms - Amp, Apps, etc?
It does affect AMP, but it validates and looks just fine.

Visually, the image will now go first on AMP.

## Screenshots

### AMP:
**before:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998573/7a897cb2-2032-11e7-81e1-6a4d2b8375ac.png)

**after:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998560/6fd1a27c-2032-11e7-958c-43d20292b076.png)

### Feature Showcase article:

**mobile:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998530/527d5f2c-2032-11e7-9bab-cc1cb449975f.png)

**desktop:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998514/45b3acce-2032-11e7-8a02-0b1788d0d3f9.png)


### Article with video main Media:
**mobile:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998644/c2ff8040-2032-11e7-8b70-f21a2f8115ea.png)

**desktop:**
![image](https://cloud.githubusercontent.com/assets/8774970/24998627/bb5aa450-2032-11e7-8916-2583553a5347.png)


## Tested in CODE?
Yes!