### PR TITLE
Fix floating menu button on new recipe pages

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -83,7 +83,7 @@ final case class Content(
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
   lazy val hasRecipeAtom: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty)
-  lazy val showNewRecipeDesign: Boolean = hasRecipeAtom
+  lazy val showNewRecipeDesign: Boolean = hasRecipeAtom && ABNewRecipeDesign.switch.isSwitchedOn
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -452,7 +452,7 @@ object Article {
       opengraphPropertiesOverrides = opengraphProperties,
       shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && (content.elements.hasMainMedia || content.fields.main.nonEmpty))) && content.tags.isArticle,
       contentWithSlimHeader = (content.isImmersive && content.tags.isArticle),
-      isNewRecipe = content.showNewRecipeDesign
+      isNewRecipeDesign = content.showNewRecipeDesign
     )
   }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -83,7 +83,7 @@ final case class Content(
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
   lazy val hasRecipeAtom: Boolean = atoms.fold(false)(a => a.recipes.nonEmpty)
-  lazy val showNewRecipeDesign: Boolean = hasRecipeAtom && ABNewRecipeDesign.switch.isSwitchedOn
+  lazy val showNewRecipeDesign: Boolean = hasRecipeAtom
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -451,7 +451,8 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       shouldHideHeaderAndTopAds = (content.tags.isTheMinuteArticle || (content.isImmersive && (content.elements.hasMainMedia || content.fields.main.nonEmpty))) && content.tags.isArticle,
-      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle) || content.showNewRecipeDesign
+      contentWithSlimHeader = (content.isImmersive && content.tags.isArticle),
+      isNewRecipe = content.showNewRecipeDesign
     )
   }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -197,7 +197,7 @@ final case class MetaData (
   twitterPropertiesOverrides: Map[String, String] = Map(),
   contentWithSlimHeader: Boolean = false,
   commercial: Option[CommercialProperties],
-  isNewRecipe: Boolean = false
+  isNewRecipeDesign: Boolean = false
 ){
   val sectionId = section map (_.id) getOrElse ""
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -196,7 +196,8 @@ final case class MetaData (
   isHosted: Boolean = false,
   twitterPropertiesOverrides: Map[String, String] = Map(),
   contentWithSlimHeader: Boolean = false,
-  commercial: Option[CommercialProperties]
+  commercial: Option[CommercialProperties],
+  isNewRecipe: Boolean = false
 ){
   val sectionId = section map (_.id) getOrElse ""
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -27,6 +27,7 @@ object CommercialClientLoggingVariant extends TestDefinition(
   }
 }
 
+/** Watch out for "TODO: #new-recipe:" when removing the test */
 object ABNewRecipeDesign extends TestDefinition(
   name = "ab-new-recipe-design",
   description = "Users in the test will see the new design on articles with structured recipes",

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -6,8 +6,11 @@
 @* TODO: When implementing the desktop design, aim to consolidate the html *@
 @fragments.newHeader(page)
 
+@* TODO: #new-recipe - remove when removing the test *@
+@hasSlimHeader = @{page.metadata.hasSlimHeader || (page.metadata.isNewRecipe && mvt.ABNewRecipeDesign.isParticipating)}
+
 <header id="header"
-        class="l-header u-cf @if(page.metadata.hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header hide-on-mobile"
+        class="l-header u-cf @if(hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header hide-on-mobile"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">
@@ -75,7 +78,7 @@
             <div class="l-header-main">
                 @if((page.metadata.sectionId == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {
                     <a href="@LinkTo{@page.metadata.url}" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" data-component="logo">
-                        @if(page.metadata.hasSlimHeader) {
+                        @if(hasSlimHeader) {
                             @fragments.inlineSvg("observer-logo-160", "logo")
                         } else {
                             <span class="u-h">The Observer - Back to home</span>
@@ -85,7 +88,8 @@
                 } else {
                     <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" data-component="logo">
                         <span class="u-h">The Guardian - Back to home</span>
-                        @if(page.metadata.hasSlimHeader) {
+
+                        @if(hasSlimHeader) {
                             @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
                             <!--[if (gt IE 8)|(IEMobile)]><!-->
                                 @fragments.inlineSvg("guardian-logo-160", "logo")
@@ -103,11 +107,14 @@
                         }
                     </a>
                 }
-                @if(page.metadata.hasSlimHeader) {
+
+                @* #new-recipe *@
+                @if(hasSlimHeader) {
                     @fragments.nav.navigationToggle()
                 }
             </div>
         </div>
+
         @fragments.nav.navigation(page)
     </div>
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -7,7 +7,7 @@
 @fragments.newHeader(page)
 
 @* TODO: #new-recipe - remove when removing the test *@
-@hasSlimHeader = @{page.metadata.hasSlimHeader || (page.metadata.isNewRecipe && mvt.ABNewRecipeDesign.isParticipating)}
+@hasSlimHeader = @{page.metadata.hasSlimHeader || (page.metadata.isNewRecipeDesign && mvt.ABNewRecipeDesign.isParticipating)}
 
 <header id="header"
         class="l-header u-cf @if(hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header hide-on-mobile"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -108,7 +108,6 @@
                     </a>
                 }
 
-                @* #new-recipe *@
                 @if(hasSlimHeader) {
                     @fragments.nav.navigationToggle()
                 }


### PR DESCRIPTION
## What does this change?

Fixes floating menu button on new recipe pages, reported yesterday by @zeftilldeath. Seen here https://www.theguardian.com/books/little-library-cafe/2017/apr/06/novel-recipes-easter-fruitcake-from-84-charing-cross-road

## What is the value of this and can you measure success?

A proper navigation bar!

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** Before **

<img width="1280" alt="screen shot 2017-04-13 at 11 20 40" src="https://cloud.githubusercontent.com/assets/2244375/25000979/43088cac-203b-11e7-95d5-df0242b814fd.png">

** After **

<img width="1280" alt="screen shot 2017-04-13 at 11 20 19" src="https://cloud.githubusercontent.com/assets/2244375/25000980/430cd4ba-203b-11e7-9e1d-4e07e5e1170b.png">


## Tested in CODE?

No.
