### PR TITLE
Add Mx title to profile

### DIFF
--- a/identity/app/model/Titles.scala
+++ b/identity/app/model/Titles.scala
@@ -2,6 +2,6 @@ package model
 
 object Titles {
 
-  val titles = List("Mr", "Mrs", "Ms", "Miss", "Dr", "Prof", "Rev")
+  val titles = List("Mr", "Mrs", "Ms", "Mx", "Miss", "Dr", "Prof", "Rev")
 
 }


### PR DESCRIPTION
## What does this change?
Allows users to select the Mx title in their profile. 

## What is the value of this and can you measure success?
Mx is a valid title, and we should support it. 

## Does this affect other platforms - Amp, Apps, etc?
Yes, see: https://github.com/guardian/identity/pull/634

## Screenshots

## Tested in CODE?
Tested in CODE.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
