### PR TITLE
Fix another floating navigation toggle with slim header

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -3,6 +3,9 @@
 @import common._
 @import views.support.RenderClasses
 
+@* TODO: #new-recipe - remove when removing the test *@
+@hasSlimHeader = @{page.metadata.hasSlimHeader || (page.metadata.isNewRecipeDesign && mvt.ABNewRecipeDesign.isParticipating)}
+
 @defining(Edition(request).navigation) { navigation =>
     <div class="@RenderClasses(Map(
                     ("navigation", true),
@@ -34,10 +37,11 @@
                         @fragments.nav.topNavigation(page, navigation)
                     </nav>
                 </div>
-                @* Don't show navigation toggle if slimHeader, or participating in the gallery redesign test*@
-                @if(!page.metadata.hasSlimHeader) {
+
+                @if(!hasSlimHeader) {
                     @fragments.nav.navigationToggle()
                 }
+
             </div>
             <div id="all-sections-popup" class="navigation__expandable js-mega-nav-placeholder" data-component="all-nav"></div>
         </div>


### PR DESCRIPTION
## What does this change?

Followup of #16450. This time the floating toggle was rendered twice on new recipes with slim header.

## What is the value of this and can you measure success?

Proper navigation.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** Before **

<img width="1280" alt="screen shot 2017-04-13 at 15 14 23" src="https://cloud.githubusercontent.com/assets/2244375/25008535/f2267350-205b-11e7-8605-debfa71cbd10.png">

** After **

<img width="1280" alt="screen shot 2017-04-13 at 15 14 35" src="https://cloud.githubusercontent.com/assets/2244375/25008534/f200e432-205b-11e7-8197-a9cbfc12a730.png">


## Tested in CODE?

No.
