### PR TITLE
Quick meta content fix

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -65,19 +65,17 @@
         }
     }
 }
-
 <div class="@RenderClasses(Map(
     ("content__meta-container--no-byline", item.trail.byline.isEmpty),
     ("content__meta-container--liveblog", item.tags.isLiveBlog),
-    ("content__meta-container--showcase", item.elements.hasShowcaseMainElement),
+    ("content__meta-container--float", item.elements.hasShowcaseMainElement || isPaidContent(page)),
+    ("content__meta-container--media-page", item.tags.isMedia),
     ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
     ("content__meta-container--explore", item.content.isExplore),
     ("content__meta-container--twitter", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)),
     ("content__meta-container--email", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)),
-    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)
-    ), "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
-    
-    @item.content.contributorBio.map { bio => content__meta-container--bio}
+    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)),
+    "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
 
     @if(
         item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -68,7 +68,7 @@
 <div class="@RenderClasses(Map(
     ("content__meta-container--no-byline", item.trail.byline.isEmpty),
     ("content__meta-container--liveblog", item.tags.isLiveBlog),
-    ("content__meta-container--float", item.elements.hasShowcaseMainElement || isPaidContent(page)),
+    ("content__meta-container--float", item.elements.hasShowcaseMainElement),
     ("content__meta-container--media-page", item.tags.isMedia),
     ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
     ("content__meta-container--explore", item.content.isExplore),

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,7 +1,7 @@
 @(item: model.ContentType, page: model.Page, showExtras: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 @import model._
 @import views.support.Commercial.isPaidContent
-@import views.support.ContentOldAgeDescriber
+@import views.support.{ContentOldAgeDescriber, RenderClasses}
 
 @byline() = {
     @item match {
@@ -66,16 +66,18 @@
     }
 }
 
-<div class="content__meta-container js-content-meta js-football-meta u-cf
-    @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
-    @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
-    @if(item.elements.hasShowcaseMainElement){ content__meta-container--showcase}
-    @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
+<div class="@RenderClasses(Map(
+    ("content__meta-container--no-byline", item.trail.byline.isEmpty),
+    ("content__meta-container--liveblog", item.tags.isLiveBlog),
+    ("content__meta-container--showcase", item.elements.hasShowcaseMainElement),
+    ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
+    ("content__meta-container--explore", item.content.isExplore),
+    ("content__meta-container--twitter", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)),
+    ("content__meta-container--email", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)),
+    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)
+    ), "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
+    
     @item.content.contributorBio.map { bio => content__meta-container--bio}
-    @if(item.content.isExplore) {content__meta-container--explore}
-    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
-    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">
-
 
     @if(
         item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -102,7 +102,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     @if(showBadge && isPaidContent(page)) {
-                        <div class="content__meta-container js-content-meta js-football-meta u-cf">
+                        <div class="content__meta-container content__meta-container--float js-content-meta js-football-meta u-cf">
                             @fragments.commercial.badge(item, page)
                         </div>
                     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -557,10 +557,16 @@
     }
 }
 
-.content__meta-container.content__meta-container--showcase {
+.content__meta-container--float {
     @include mq(leftCol) {
         float: left;
         position: static;
+        margin-left: ($left-column + $gs-gutter) * -1;
+    }
+}
+
+.content__meta-container--media-page {
+    @include mq(leftCol) {
         margin-left: ($left-column + $gs-gutter) * -1;
     }
 }


### PR DESCRIPTION
## What does this change?

Fixing this bug:
![image](https://cloud.githubusercontent.com/assets/8774970/25011291/c6dfc90e-2064-11e7-9550-94b78f179d72.png)


So that it looks like this:
![image](https://cloud.githubusercontent.com/assets/8774970/25011302/cf2cb838-2064-11e7-8104-a2cbf6674a11.png)


## What is the value of this and can you measure success?
Media pages look good again on desktop

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Tested in CODE?
Nope

