### PR TITLE
Revert article layout changes

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -12,17 +12,6 @@
     if (page.article.tags.isReview) "reviewBody" else "articleBody"
 }
 
-@secondaryColumn(isPaidForContent: Boolean) = {
-    <div class="content__secondary-column js-secondary-column" aria-hidden="true">
-
-        @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes)
-
-        @if(!isPaidForContent){
-            <div class="js-components-container"></div>
-        }
-    </div>
-}
-
 @defining(model.article) { article =>
   @defining(isPaidContent(model)) { isPaidContent =>
 
@@ -47,40 +36,24 @@
             }
 
             @if(amp) {
-
-                @fragments.mainMedia(article, amp)
-
                 @fragments.headTonal(article, model, isPaidContent, amp = amp)
 
-            } else {
                 @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-
-                    <div class="content__header-container">
-                        @fragments.headTonal(article, model, isPaidContent)
-
-                        <div class="content__main-media-full-width-mobile">
-                            @fragments.mainMedia(article)
-                        </div>
-                    </div>
-
-                } else {
-                    <div class="content__header-container">
-                        @fragments.headTonal(article, model, isPaidContent)
-
-                        <div class="content__main-media-wrapper content__main-media-full-width-mobile">
-                            <div class="content__main-media">
-
-                                @fragments.mainMedia(article)
-                            </div>
-
-                            <div class="hide-on-mobile">
-                                @fragments.contentMeta(article, model)
-                            </div>
-
-                            @secondaryColumn(isPaidContent)
-                        </div>
-                    </div>
+                    @fragments.mainMedia(article, amp)
                 }
+            } else {
+                <div class="hide-on-mobile">
+                    @fragments.headTonal(article, model, isPaidContent, amp = amp)
+
+                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
+                        @fragments.mainMedia(article, amp)
+                    }
+                </div>
+                <div class="mobile-only">
+                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
+                        @fragments.mainMedia(article, amp)
+                    }
+                </div>
             }
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">
@@ -89,15 +62,19 @@
                         <div class="js-score"></div>
                         <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
 
-                        @if((article.tags.isFeature && article.elements.hasShowcaseMainElement) || amp) {
-                            @fragments.contentMeta(article, model, amp = amp)
-                        } else {
+                        @if(!(article.tags.isFeature && article.elements.hasShowcaseMainElement)) {
+                            @fragments.mainMedia(article, amp)
+                        }
+
+                        @if(!amp) {
                             <div class="mobile-only">
-                                @fragments.contentMeta(article, model, amp = amp)
+                                @fragments.headTonal(article, model, isPaidContent, amp = amp)
                             </div>
                         }
 
                         @fragments.witnessCallToAction(article.content)
+
+                        @fragments.contentMeta(article, model, amp = amp)
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
@@ -126,9 +103,14 @@
                         <div class="after-article js-after-article"></div>
                     </div>
 
-                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                        @secondaryColumn(isPaidContent)
-                    }
+                    <div class="content__secondary-column js-secondary-column" aria-hidden="true">
+
+                        @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes)
+
+                        @if(!isPaidContent){
+                        <div class="js-components-container"></div>
+                        }
+                    </div>
                 </div>
             </div>
         </article>

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -69,7 +69,7 @@ import collection.JavaConversions._
 
         Then("I should see the names of the authors")
         $("[itemprop=author]")(0).getText should be("Ben Arnold")
-        $("[itemprop=author]")(1).getText should be("Andrew Mueller")
+        $("[itemprop=author]").last.getText should be("Phelim O'Neill")
 
         And("I should see a link to the author's page")
         $("[itemprop=author] a[itemprop='sameAs']")(0).getAttribute("href") should be(withHost("/profile/ben-arnold"))

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -68,7 +68,7 @@
 <div class="@RenderClasses(Map(
     ("content__meta-container--no-byline", item.trail.byline.isEmpty),
     ("content__meta-container--liveblog", item.tags.isLiveBlog),
-    ("content__meta-container--float", item.elements.hasShowcaseMainElement),
+    ("content__meta-container--float", item.elements.hasShowcaseMainElement || isPaidContent(page)),
     ("content__meta-container--media-page", item.tags.isMedia),
     ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
     ("content__meta-container--explore", item.content.isExplore),

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,7 +1,7 @@
 @(item: model.ContentType, page: model.Page, showExtras: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 @import model._
 @import views.support.Commercial.isPaidContent
-@import views.support.{ContentOldAgeDescriber, RenderClasses}
+@import views.support.ContentOldAgeDescriber
 
 @byline() = {
     @item match {
@@ -66,18 +66,16 @@
     }
 }
 
-<div class="@RenderClasses(Map(
-    ("content__meta-container--no-byline", item.trail.byline.isEmpty),
-    ("content__meta-container--liveblog", item.tags.isLiveBlog),
-    ("content__meta-container--showcase", item.elements.hasShowcaseMainElement),
-    ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
-    ("content__meta-container--explore", item.content.isExplore),
-    ("content__meta-container--twitter", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)),
-    ("content__meta-container--email", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)),
-    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)
-    ), "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
-    
+<div class="content__meta-container js-content-meta js-football-meta u-cf
+    @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
+    @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
+    @if(item.elements.hasShowcaseMainElement){ content__meta-container--showcase}
+    @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
     @item.content.contributorBio.map { bio => content__meta-container--bio}
+    @if(item.content.isExplore) {content__meta-container--explore}
+    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
+    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">
+
 
     @if(
         item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -65,17 +65,19 @@
         }
     }
 }
+
 <div class="@RenderClasses(Map(
     ("content__meta-container--no-byline", item.trail.byline.isEmpty),
     ("content__meta-container--liveblog", item.tags.isLiveBlog),
-    ("content__meta-container--float", item.elements.hasShowcaseMainElement || isPaidContent(page)),
-    ("content__meta-container--media-page", item.tags.isMedia),
+    ("content__meta-container--showcase", item.elements.hasShowcaseMainElement),
     ("content__meta-container--tonal-header", item.content.hasTonalHeaderByline),
     ("content__meta-container--explore", item.content.isExplore),
     ("content__meta-container--twitter", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)),
     ("content__meta-container--email", item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)),
-    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)),
-    "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
+    ("content__meta-container--bio", item.content.contributorBio.nonEmpty)
+    ), "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
+    
+    @item.content.contributorBio.map { bio => content__meta-container--bio}
 
     @if(
         item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -102,7 +102,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     @if(showBadge && isPaidContent(page)) {
-                        <div class="content__meta-container content__meta-container--float js-content-meta js-football-meta u-cf">
+                        <div class="content__meta-container js-content-meta js-football-meta u-cf">
                             @fragments.commercial.badge(item, page)
                         </div>
                     }

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -70,7 +70,7 @@ object MetaDataMatcher extends Matchers  {
     status(result) should be(200)
 
     val elements = body.getElementsByClass("old-article-message")
-    elements.size() should be > 0
+    elements.size() should be(1)
   }
 
   def ensureNoOldArticleMessage(result: Future[Result], articleUrl: String) {

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -33,6 +33,7 @@
 
 @include grid-system;
 @import 'layout/_header';
+@import 'layout/_ab-new-header-test-variant';
 @import 'layout/_subnav';
 @import 'module/nav/_supporter-trapezoid';
 @import 'layout/_helpers';
@@ -56,7 +57,6 @@
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
 @import 'module/onward/_rich-links-default.head';
-@import 'module/_main-media-captions';
 
 /* ==========================================================================
    Facia

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -210,7 +210,11 @@
 }
 
 .media-primary {
-    position: relative;
+    margin: 0 (-$gs-gutter / 2);
+
+    @include mq(mobileLandscape) {
+        margin: 0 (-$gs-gutter);
+    }
 }
 
 // TODO: on amp, shouldn't have this. Or, use amp-lightbox

--- a/static/src/stylesheets/head.amp.scss
+++ b/static/src/stylesheets/head.amp.scss
@@ -1,3 +1,1 @@
 @import 'head.amp-common';
-
-@import 'module/_main-media-captions';

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -1,4 +1,30 @@
+/****************
+ * Changes to an Article Body
+ ****************/
+
 $caption-button-size: 32px;
+
+// When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
+// TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
+.content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live, .tonal__head--tone-media) {
+    @include mq($until: mobileLandscape) {
+        margin-right: -$gs-gutter / 2;
+        margin-left: -$gs-gutter / 2;
+    }
+
+    @include mq($from: mobileLandscape, $until: phablet) {
+        margin-right: -$gs-gutter;
+        margin-left: -$gs-gutter;
+    }
+}
+
+@include mq($from: phablet, $until: tablet) {
+    .media-primary,
+    .content__head {
+        margin-left: -$gs-gutter;
+        margin-right: -$gs-gutter;
+    }
+}
 
 @include mq($until: tablet) {
 
@@ -53,3 +79,10 @@ $caption-button-size: 32px;
         background-color: $multimedia-support-5;
     }
 }
+
+
+
+
+//TODO: captions
+//TODO: headline + main
+//TODO: AMP <- image always first if possible?

--- a/static/src/stylesheets/layout/_helpers.scss
+++ b/static/src/stylesheets/layout/_helpers.scss
@@ -58,8 +58,7 @@
 }
 
 /* Override default .gs-container breakpoints */
-.gs-container,
-.content__main-media-wrapper {
+.gs-container {
     @include mq(tablet) {
         max-width: gs-span(9) + $gs-gutter * 2;
     }

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -1,5 +1,15 @@
 .media-primary {
+    margin: 0 $gs-gutter * -.5;
     position: relative;
+
+    @include mq(mobileLandscape) {
+        margin-left: $gs-gutter / -1;
+        margin-right: $gs-gutter / -1;
+    }
+    @include mq(phablet) {
+        margin-left: 0;
+        margin-right: 0;
+    }
 }
 
 .content__main-column--article {

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -563,20 +563,11 @@
         position: static;
         margin-left: ($left-column + $gs-gutter) * -1;
     }
-
-    @include mq(wide) {
-        margin-left: ($left-column-wide + $gs-gutter) * -1;
-    }
 }
 
-.content__meta-container--media-page,
-.content__meta-container--immersive {
+.content__meta-container--media-page {
     @include mq(leftCol) {
         margin-left: ($left-column + $gs-gutter) * -1;
-    }
-
-    @include mq(wide) {
-        margin-left: ($left-column-wide + $gs-gutter) * -1;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -557,16 +557,10 @@
     }
 }
 
-.content__meta-container--float {
+.content__meta-container.content__meta-container--showcase {
     @include mq(leftCol) {
         float: left;
         position: static;
-        margin-left: ($left-column + $gs-gutter) * -1;
-    }
-}
-
-.content__meta-container--media-page {
-    @include mq(leftCol) {
         margin-left: ($left-column + $gs-gutter) * -1;
     }
 }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -561,7 +561,7 @@
     @include mq(leftCol) {
         float: left;
         position: static;
-        margin-left: ($left-column + $gs-gutter) * -1;
+        margin-left: ($left-column + $gs-gutter)*-1;
     }
 }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -22,58 +22,6 @@
     box-sizing: border-box;
 }
 
-.content__header-container {
-    @include mq($until: tablet) {
-        // on desktop, the headline is first, on mobile the image is first
-        display: flex;
-        flex-wrap: wrap-reverse;
-    }
-}
-
-.content__head,
-.content__main-media-full-width-mobile {
-    @include mq($until: tablet) {
-        // Even when using flex, the main media should be 100% of it's container
-        width: 100%;
-        flex-grow: 1;
-    }
-}
-
-.content__main-media-wrapper {
-    position: relative;
-    margin: 0 auto;
-
-    @include mq(tablet) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
-        box-sizing: border-box;
-    }
-}
-
-.content__main-media {
-    max-width: gs-span(8);
-    margin: auto;
-    position: relative;
-
-    @include mq(tablet, desktop) {
-        max-width: gs-span(9);
-    }
-
-    @include mq(desktop) {
-        margin-left: 0;
-        margin-right: $right-column + $gs-gutter;
-    }
-
-    @include mq(leftCol) {
-        margin-left: $left-column + $gs-gutter;
-    }
-
-    @include mq(wide) {
-        margin-left: $left-column-wide + $gs-gutter;
-    }
-}
-
-
 .content__main-column {
     max-width: gs-span(8);
     margin: auto;
@@ -510,11 +458,13 @@
     @include mq(leftCol) {
         position: absolute;
         top: 0;
+        margin-left: ($left-column + $gs-gutter)*-1;
         margin-bottom: ($gs-baseline/3)*4;
         width: $left-column;
     }
 
     @include mq(wide) {
+        margin-left: ($left-column-wide + $gs-gutter)*-1;
         width: $left-column-wide;
     }
 
@@ -557,11 +507,17 @@
     }
 }
 
+.content__meta-container--float {
+    @include mq(leftCol) {
+        float: left;
+        position: static;
+    }
+}
+
 .content__meta-container.content__meta-container--showcase {
     @include mq(leftCol) {
         float: left;
         position: static;
-        margin-left: ($left-column + $gs-gutter)*-1;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Reverting https://github.com/guardian/frontend/pull/16461, https://github.com/guardian/frontend/pull/16457, https://github.com/guardian/frontend/pull/16449

The things that are outstanding to fix if I attempt this again are:
* Showcase images on non feature tones don't work, they push the meta content off the screen
* Not all tonal colours picked up by the meta content
