### PR TITLE
do not try to throw an undefined or set a property on it

### DIFF
--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -24,8 +24,10 @@ const reportError = (
     if (shouldThrow) {
         // Flag to ensure it is not reported to Sentry again via global handlers
         const error = err;
-        error.reported = true;
-        throw error;
+        if (typeof error !== undefined) {
+            error.reported = true;
+            throw error;
+        }
     }
 };
 

--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -24,7 +24,7 @@ const reportError = (
     if (shouldThrow) {
         // Flag to ensure it is not reported to Sentry again via global handlers
         const error = err;
-        if (typeof error !== undefined) {
+        if (typeof error !== "undefined") {
             error.reported = true;
             throw error;
         }


### PR DESCRIPTION
## What does this change?

<img width="1660" alt="screen shot 2017-04-18 at 13 39 34" src="https://cloud.githubusercontent.com/assets/615085/25131262/fb101be4-243c-11e7-9a43-bc3b7cbfc618.png">

```
graun.standard.js:formatted:4228 Potentially unhandled rejection [2] TypeError: Cannot set property 'reported' of undefined
    at i (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:20:12145)
    at u (https://assets.guim.co.uk/javascripts/2113f9594674cd6cef97/graun.commercial.js:12:9710)
    at B (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:14:3076)
    at U (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:14:2708)
    at C.when (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:14:6557)
    at A.run (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:14:7459)
    at t._drain (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:10:542)
    at drain (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:10:196)
    at MutationObserver.e (https://assets.guim.co.uk/javascripts/cc32e5f2636e8920c1cb/graun.standard.js:12:322)
```
Caught when visiting https://www.theguardian.com/society/2017/apr/11/confessions-gentrification-race-rogers-park-chicago

## What is the value of this and can you measure success?

not filling error in the console

## Does this affect other platforms - Amp, Apps, etc?

not sure
