### PR TITLE
use 16x9 image for video page meta itemprop image

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -4,7 +4,7 @@
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}
 @import views.support.Commercial.isPaidContent
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640}
+@import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640, Video1280}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }) { case (media, mediaType) =>
     @defining(isPaidContent(page)) { isPaidContent =>
@@ -79,7 +79,11 @@
                                                 <meta itemprop="width" content="@mv.videos.width" />
                                             }
                                             <meta itemprop="requiresSubscription" content="false" />
-                                            <meta itemprop="image" content="@Html(video.content.signedArticleImage)" />
+                                            @defining(video.mediaAtom.flatMap(_.posterImage) orElse video.elements.thumbnail.map(_.images)) {sixteenByNineImage =>
+                                                @sixteenByNineImage.map {i =>
+                                                    <meta itemprop="image" content="@Video1280.bestFor(i)" />
+                                                }
+                                            }
 
                                             @defining(video.elements.thumbnail.map(_.images) orElse video.mediaAtom.flatMap(_.posterImage)) {bestThumbnail =>
                                                 @bestThumbnail.map { thumbnail =>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -79,11 +79,9 @@
                                                 <meta itemprop="width" content="@mv.videos.width" />
                                             }
                                             <meta itemprop="requiresSubscription" content="false" />
-                                            @defining(video.mediaAtom.flatMap(_.posterImage) orElse video.elements.thumbnail.map(_.images)) {sixteenByNineImage =>
-                                                @sixteenByNineImage.map {i =>
-                                                    <meta itemprop="image" content="@Video1280.bestFor(i)" />
+                                            @video.sixteenByNineMetaImage.map{ i =>
+                                                    <meta itemprop="image" content="@i" />
                                                 }
-                                            }
 
                                             @defining(video.elements.thumbnail.map(_.images) orElse video.mediaAtom.flatMap(_.posterImage)) {bestThumbnail =>
                                                 @bestThumbnail.map { thumbnail =>

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -633,6 +633,12 @@ final case class Video (
     suffixVariations.fold(trail.headline.trim) { (str, suffix) => str.stripSuffix(suffix) }
   }
   def endSlatePath = EndSlateComponents.fromContent(content).toUriPath
+
+  def sixteenByNineMetaImage: Option[String] = {
+    (for {
+      imageMedia <- mediaAtom.flatMap(_.posterImage) orElse content.elements.thumbnail.map(_.images)
+    } yield Video1280.bestFor(imageMedia)).flatten
+  }
 }
 
 object Gallery {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -632,13 +632,12 @@ final case class Video (
         " - video interviews"," – video interviews" )
     suffixVariations.fold(trail.headline.trim) { (str, suffix) => str.stripSuffix(suffix) }
   }
-  def endSlatePath = EndSlateComponents.fromContent(content).toUriPath
+  def endSlatePath: String = EndSlateComponents.fromContent(content).toUriPath
 
-  def sixteenByNineMetaImage: Option[String] = {
-    (for {
-      imageMedia <- mediaAtom.flatMap(_.posterImage) orElse content.elements.thumbnail.map(_.images)
-    } yield Video1280.bestFor(imageMedia)).flatten
-  }
+  def sixteenByNineMetaImage: Option[String] = for {
+    imageMedia <- mediaAtom.flatMap(_.posterImage) orElse content.elements.thumbnail.map(_.images)
+    videoProfile <- Video1280.bestFor(imageMedia)
+  } yield videoProfile
 }
 
 object Gallery {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -106,10 +106,6 @@ final case class Content(
   lazy val showCircularBylinePicAtSide: Boolean =
     cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1 && !tags.isInteractive
 
-  lazy val signedArticleImage: String = {
-    ImgSrc(rawOpenGraphImage, Item1200)
-  }
-
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImage: String = {
     if (isPaidContent && FacebookShareImageLogoOverlay.isSwitchedOn) {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -101,6 +101,8 @@ object Item700 extends Profile(width = Some(700))
 object Item1200 extends Profile(width = Some(1200))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
+object Video1280 extends VideoProfile(width = Some(1280), height = Some(720)) // 16:9
+
 
 object GoogleStructuredData extends Profile(width = Some(300), height = Some(300)) // 1:1
 


### PR DESCRIPTION
## What does this change?
Currently we are using a 5x3 image as the meta itemprop image on video pages. I noticed in some video container views within Google SERPs the images are being either 'black boxed' or cropped.

<img width="678" alt="cropped" src="https://cloud.githubusercontent.com/assets/1764158/25135387/2884da76-244a-11e7-9178-3257d9bbfd51.png">

This PR changes video pages to use a 16x9 meta image, so they should now fit correctly into these components.  

## What is the value of this and can you measure success?
Experiment to see if appearance of video pages is improved in SERPs.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
