### PR TITLE
Refactor tailor

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -14,7 +14,7 @@ define([
     'ophan/ng',
     'lodash/utilities/template',
     'common/modules/article/space-filler',
-    'common/modules/tailor/tailor'
+    'common/modules/tailor/fetch-data'
 ], function (
     bean,
     bonzo,
@@ -31,7 +31,7 @@ define([
     ophan,
     template,
     spaceFiller,
-    tailor
+    fetchData
 ) {
     return function () {
         this.id = 'TailorSurvey';
@@ -168,7 +168,7 @@ define([
                 queryParams.surveysNotToShow = surveysNotToShow;
             }
 
-            return tailor.fetchData('suggestions', true, queryParams).then(function (suggestions) {
+            return fetchData('suggestions', true, queryParams).then(function (suggestions) {
                 // get the survey to show
                 var surveySuggestionToShow = getSurveySuggestionToShow(suggestions);
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/tailor-survey.js
@@ -155,7 +155,7 @@ define([
                 queryParams.surveysNotToShow = surveysNotToShow;
             }
 
-            return tailor.getSuggestion(queryParams).then(function(suggestion) {
+            return tailor.getSuggestedSurvey(queryParams).then(function(suggestion) {
                 if (suggestion) {
                     storeSurveyShowedInCookie(suggestion.data);
 

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/fetch-data.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/fetch-data.js
@@ -1,0 +1,85 @@
+define([
+    'Promise',
+    'lib/fetch-json',
+    'lib/cookies',
+    'lib/storage',
+    'lib/report-error',
+    'lib/config'
+], function(
+    Promise,
+    fetchJson,
+    cookies,
+    storage,
+    reportError,
+    config
+) {
+
+    var URLS = {
+        suggestions: 'https://tailor.guardianapis.com/suggestions?browserId='
+    };
+
+    var browserId = cookies.getCookie('bwid');
+
+    function getURL(type, queryParams) {
+        var baseURL = URLS[type];
+
+        if (!browserId || !baseURL) return;
+
+        baseURL += browserId;
+
+        if (queryParams) {
+            Object.keys(queryParams).forEach(function (key) {
+                baseURL += '&' + key + '=' + queryParams[key];
+            });
+        }
+
+        return baseURL;
+    }
+
+    /**
+     * type (required) is a string which should match a key in the URLS object
+     * bypassStorage a boolean, if true don't retrieve data from local storage
+     * queryParams an object literal, each key/value will be query string parameter
+     * eg. {foo:'bar', hello:'world'} translates to ?foo=bar&hello=world
+     *
+     **/
+    function fetchData(type, bypassStorage, queryParams) {
+        var url = getURL(type, queryParams);
+
+        // exit if no valid url end point, or tailor switch is off
+        if (!url || !config.switches.useTailorEndpoints) {
+            return Promise.resolve({});
+        }
+
+        var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
+
+        // if data in local storage, resolve with this
+        if (tailorData && tailorData[url]) {
+            return Promise.resolve(tailorData[url]);
+        }
+
+        return fetchJson(url, { method: 'get' })
+            .then(handleResponse.bind(null, url))
+            .catch(handleError.bind(null, url));
+    }
+
+    function handleResponse(url, data) {
+        var tailorData = storage.local.get('gu.tailor') || {};
+        var hour = 1000 * 60 * 60;
+
+        tailorData[url] = data;
+
+        storage.local.set('gu.tailor', tailorData, {expires: Date.now() + hour});
+
+        return Promise.resolve(data);
+    }
+
+    function handleError(url, error) {
+        reportError(error, {
+            feature: 'tailor',
+            url: url
+        });
+    }
+
+    return fetchData;
+});

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/fetch-data.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/fetch-data.js
@@ -58,7 +58,7 @@ define([
             return Promise.resolve(tailorData[url]);
         }
 
-        return fetchJson(url, { method: 'get' })
+        return fetchJson(url)
             .then(handleResponse.bind(null, url))
             .catch(handleError.bind(null, url));
     }

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -1,8 +1,28 @@
 define([
-    'common/modules/tailor/tailor'
+    'common/modules/tailor/fetch-data'
 ], function(
     fetchData
 ) {
+
+    /**
+     * Given a response from tailor, we see if the response has a survey suggestion, and if so return the first
+     * survey suggestion (there should only ever be one, but just in case).
+     *
+     * @returns {Promise.<Boolean>}
+     */
+    function getSuggestion(queryParams) {
+        return fetchData('suggestions', false, queryParams).then(function(response) {
+            if (response.suggestions) {
+                var surveySuggestions = response.suggestions.filter(function (suggestion) {
+                    return suggestion.class === 'SurveySuggestion';
+                });
+
+                if (surveySuggestions.length > 0) {
+                    return surveySuggestions[0];
+                }
+            }
+        });
+    }
 
     /**
      * Query the user's regular status
@@ -22,6 +42,7 @@ define([
     }
 
     return {
-        isRegular: isRegular
+        isRegular: isRegular,
+        getSuggestion: getSuggestion,
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -46,21 +46,22 @@ define([
     function fetchData(type, bypassStorage, queryParams) {
         var url = getURL(type, queryParams);
 
-        return new Promise(function(resolve, reject) {
-            // if no valid url end point, or tailor switch is off, reject
-            if (!url || !config.switches.useTailorEndpoints) return reject();
+        // exit if no valid url end point, or tailor switch is off
+        if (!url || !config.switches.useTailorEndpoints) {
+            return Promise.resolve({});
+        }
 
-            var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
+        var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
 
-            // if data in local storage return this
-            if (tailorData && tailorData[url]) {
-                return resolve(tailorData[url]);
-            }
+        // if data in local storage, resolve with this
+        if (tailorData && tailorData[url]) {
+            return Promise.resolve(tailorData[url]);
+        }
 
-            return resolve(fetchJson(url, { method: 'get' }));
-        }).then(handleResponse.bind(null, url))
-          .catch(handleError.bind(null, url));
-    }
+        return fetchJson(url, { method: 'get' })
+            .then(handleResponse.bind(null, url))
+            .catch(handleError.bind(null, url));
+}
 
     function handleResponse(url, data) {
         var tailorData = storage.local.get('gu.tailor') || {};

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -1,85 +1,8 @@
 define([
-    'Promise',
-    'lib/fetch-json',
-    'lib/cookies',
-    'lib/storage',
-    'lib/report-error',
-    'lib/config'
+    'common/modules/tailor/tailor'
 ], function(
-    Promise,
-    fetchJson,
-    cookies,
-    storage,
-    reportError,
-    config
+    fetchData
 ) {
-
-    var URLS = {
-        suggestions: 'https://tailor.guardianapis.com/suggestions?browserId='
-    };
-
-    var browserId = cookies.getCookie('bwid');
-
-    function getURL(type, queryParams) {
-        var baseURL = URLS[type];
-
-        if (!browserId || !baseURL) return;
-
-        baseURL += browserId;
-
-        if (queryParams) {
-            Object.keys(queryParams).forEach(function (key) {
-                baseURL += '&' + key + '=' + queryParams[key];
-            });
-        }
-
-        return baseURL;
-    }
-
-    /**
-     * type (required) is a string which should match a key in the URLS object
-     * bypassStorage a boolean, if true don't retrieve data from local storage
-     * queryParams an object literal, each key/value will be query string parameter
-     * eg. {foo:'bar', hello:'world'} translates to ?foo=bar&hello=world
-     *
-    **/
-    function fetchData(type, bypassStorage, queryParams) {
-        var url = getURL(type, queryParams);
-
-        // exit if no valid url end point, or tailor switch is off
-        if (!url || !config.switches.useTailorEndpoints) {
-            return Promise.resolve({});
-        }
-
-        var tailorData = bypassStorage ? null : storage.local.get('gu.tailor');
-
-        // if data in local storage, resolve with this
-        if (tailorData && tailorData[url]) {
-            return Promise.resolve(tailorData[url]);
-        }
-
-        return fetchJson(url, { method: 'get' })
-            .then(handleResponse.bind(null, url))
-            .catch(handleError.bind(null, url));
-}
-
-    function handleResponse(url, data) {
-        var tailorData = storage.local.get('gu.tailor') || {};
-        var hour = 1000 * 60 * 60;
-
-        tailorData[url] = data;
-
-        storage.local.set('gu.tailor', tailorData, {expires: Date.now() + hour});
-
-        return Promise.resolve(data);
-    }
-
-    function handleError(url, error) {
-        reportError(error, {
-            feature: 'tailor',
-            url: url
-        });
-    }
 
     /**
      * Query the user's regular status
@@ -99,7 +22,6 @@ define([
     }
 
     return {
-        fetchData: fetchData,
         isRegular: isRegular
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
+++ b/static/src/javascripts-legacy/projects/common/modules/tailor/tailor.js
@@ -10,7 +10,7 @@ define([
      *
      * @returns {Promise.<Boolean>}
      */
-    function getSuggestion(queryParams) {
+    function getSuggestedSurvey(queryParams) {
         return fetchData('suggestions', false, queryParams).then(function(response) {
             if (response.suggestions) {
                 var surveySuggestions = response.suggestions.filter(function (suggestion) {
@@ -43,6 +43,6 @@ define([
 
     return {
         isRegular: isRegular,
-        getSuggestion: getSuggestion,
+        getSuggestedSurvey: getSuggestedSurvey,
     };
 });


### PR DESCRIPTION
## What does this change?

- Moves the data fetching call and localStorage caching out of the tailor module and into a separate module
- The `tailor` module exposes an API that executes `fetch-data` and returns data in a way it can be easily consumed.

## What is the value of this and can you measure success?

- More consistent way of consuming data from tailor
- Hides the complexity of the fetching and caching logic

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

Non

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
