### PR TITLE
Remove legacy ajax dependency in `tests/epic-to-support-landing-page`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-to-support-landing-page.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-to-support-landing-page.js
@@ -1,7 +1,6 @@
 define([
     'commercial/modules/commercial-features',
     'common/modules/commercial/contributions-utilities',
-    'lib/ajax',
     'lib/config',
     'lib/cookies',
     'lib/storage',
@@ -10,7 +9,6 @@ define([
 ], function (
     commercialFeatures,
     contributionsUtilities,
-    ajax,
     config,
     cookies,
     store,


### PR DESCRIPTION
## What does this change?

Removes a legacy `lib/ajax` dependency from `tests/epic-to-support-landing-page.js`.

## What is the value of this and can you measure success?

Less dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
