### PR TITLE
Replace `Cookie.get` with `Cookie.getCookies`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
@@ -23,7 +23,7 @@ define([
             hasForcedOptIn = /forceForesee/.test(location.hash);
 
         // the Foresee code is large, we only want to load it in when necessary.
-        if (!Cookie.get('GU_TEST') && !isNetworkFront && !isProfilePage && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
+        if (!Cookie.getCookie('GU_TEST') && !isNetworkFront && !isProfilePage && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
             openForesee();
         }
 

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
@@ -5,7 +5,7 @@ define([
     'lib/load-script'
 ], function (
     config,
-    Cookie,
+    cookie,
     detect,
     loadScript
     ) {
@@ -23,7 +23,7 @@ define([
             hasForcedOptIn = /forceForesee/.test(location.hash);
 
         // the Foresee code is large, we only want to load it in when necessary.
-        if (!Cookie.getCookie('GU_TEST') && !isNetworkFront && !isProfilePage && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
+        if (!cookie.getCookie('GU_TEST') && !isNetworkFront && !isProfilePage && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
             openForesee();
         }
 


### PR DESCRIPTION
## What does this change?

Replaces `Cookie.get` with `Cookie.getCookies`. It's a leftover from a recent conversion of ES6 modules.

## What is the value of this and can you measure success?

The module is not broken anymore. Less JS errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
