### PR TITLE
Remove job ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 [![Gitter](https://badges.gitter.im/guardian/frontend.svg)](https://gitter.im/guardian/frontend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-## We're hiring!
-Ever thought about joining us?<br/>
-http://developers.theguardian.com/join-the-team.html
-
 # Frontend
 [The Guardian](http://www.theguardian.com) website frontend.
 

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -45,27 +45,6 @@ const setAdTestCookie = (): void => {
     }
 };
 
-const showHiringMessage = (): void => {
-    try {
-        if (!config.page.isDev) {
-            window.console.log(
-                '\n' +
-                    '%cHello.\n' +
-                    '\n' +
-                    '%cWe are hiring – ever thought about joining us? \n' +
-                    '%chttp://developers.theguardian.com/join-the-team.html%c \n' +
-                    '\n',
-                'font-family: Georgia, serif; font-size: 32px; color: #005689',
-                'font-family: Georgia, serif; font-size: 16px; color: #767676',
-                'font-family: Helvetica Neue, sans-serif; font-size: 11px; text-decoration: underline; line-height: 1.2rem; color: #767676',
-                ''
-            );
-        }
-    } catch (e) {
-        /* do nothing */
-    }
-};
-
 const handleMembershipAccess = (): void => {
     const { membershipUrl, membershipAccess, contentId } = config.page;
 
@@ -236,8 +215,6 @@ const init = (): void => {
     identity.init();
 
     newHeaderNavigation();
-
-    showHiringMessage();
 
     markTime('standard end');
 


### PR DESCRIPTION
## What does this change?

Removes the links to the recruitment page from the readme and the browser console.

## What is the value of this and can you measure success?

We are not currently hiring developers. Removing the links avoids misleading prospective applications.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
