### PR TITLE
remove locale timezones and fix bug when more button clicked

### DIFF
--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -36,8 +36,8 @@
                 ))">
                 <td class="football-match__status football-match__status--@MatchStatus(theMatch.matchStatus).toString.toLowerCase table-column--sub">
                     @if(theMatch.isFixture){
-                        <time datetime="@theMatch.date.toString("yyyy-MM-dd'T'HH:mm:ssZ")" data-timestamp="@theMatch.date.getMillis" data-show-timezone
-                            class="js-locale-timestamp">
+                        <time datetime="@theMatch.date.toString("yyyy-MM-dd'T'HH:mm:ssZ")" data-timestamp="@theMatch.date.getMillis" 
+                        class="js-locale-timestamp">
                             @theMatch.date.toString("HH:mm")</time>
                     }else{
                         @MatchStatus(theMatch.matchStatus)

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -30,7 +30,7 @@
                     <div class="football-matches__container" data-show-more-contains="football-matches">
                         @matchesList.matchesGroupedByDateAndCompetition.map { case (date, competitionMatches) =>
                             <div class="football-matches__day">
-                                <div class="date-divider">@date.toString("EEEE d MMMM yyyy") GMT</div>
+                                <div class="date-divider">@date.toString("EEEE d MMMM yyyy")</div>
                                 @competitionMatches.map { case (competition, matches) =>
                                     <div class="football-table__container">
                                         <div class="u-cf">

--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -14,7 +14,8 @@ define([
     'common/modules/sport/football/match-list-live',
     'common/modules/sport/football/tag-page-stats',
     'common/modules/sport/score-board',
-    'common/modules/ui/rhc'
+    'common/modules/ui/rhc',
+    'common/modules/ui/relativedates'
 ], function (
     bean,
     bonzo,
@@ -31,7 +32,8 @@ define([
     MatchListLive,
     tagPageStats,
     ScoreBoard,
-    rhc
+    rhc,
+    relativeDates
 ) {
 
     function renderNav(match, callback) {
@@ -257,10 +259,15 @@ define([
             fetchJson(el.getAttribute('href') + '.json')
             .then(function (resp) {
                 $.create(resp.html).each(function (html) {
-                    $('[data-show-more-contains="' + el.getAttribute('data-puts-more-into') + '"]')
-                        .append($(el.getAttribute('data-shows-more'), html));
+                    var htmlContainer = document.querySelector('[data-show-more-contains="' + el.getAttribute('data-puts-more-into') + '"]');
+
+                    if (htmlContainer) {
+                        relativeDates.replaceLocaleTimestamps(html);
+                        htmlContainer.appendChild(html);
+                    }
 
                     var nurl = resp[el.getAttribute('data-new-url')];
+
                     if (nurl) {
                         bonzo(el).attr('href', nurl);
                     } else {

--- a/static/src/javascripts-legacy/projects/common/modules/ui/relativedates.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/relativedates.js
@@ -200,7 +200,7 @@ define([
 
     function init(opts) {
         replaceValidTimestamps(opts);
-        replaceLocaleTimestamps(opts);
+        replaceLocaleTimestamps();
     }
 
     return {

--- a/static/src/javascripts-legacy/projects/common/modules/ui/relativedates.js
+++ b/static/src/javascripts-legacy/projects/common/modules/ui/relativedates.js
@@ -147,33 +147,21 @@ define([
         return $('.js-timestamp, .js-item__timestamp');
     }
 
-    function replaceLocaleTimestamps() {
+    function replaceLocaleTimestamps(html) {
         var cls = 'js-locale-timestamp';
-        $('.' + cls).each(function (el) {
+        var context = html || document;
+
+        $('.' + cls, context).each(function (el) {
             var datetime,
                 $el = bonzo(el),
-                timestamp = parseInt($el.attr('data-timestamp'), 10),
-                timezone,
-                html;
+                timestamp = parseInt($el.attr('data-timestamp'), 10);
 
             if (timestamp) {
                 datetime = new Date(timestamp);
-                html = pad(datetime.getHours()) + ':' + pad(datetime.getMinutes());
-                if (el.hasAttribute('data-show-timezone')) {
-                    timezone = getLocaleTimezone(datetime);
-                    if (timezone !== 'GMT') {
-                        html += ' ' + timezone;
-                    }
-                }
-                el.innerHTML = html;
+                el.innerHTML = pad(datetime.getHours()) + ':' + pad(datetime.getMinutes());
                 $el.removeClass(cls);
             }
         });
-    }
-
-    function getLocaleTimezone(datetime) {
-        // extracts timezone from datetime, eg. EST from Fri Mar 03 2017 09:57:25 GMT-0500 (EST)
-        return datetime.toString().match(/\(([^)]+)\)/)[1];
     }
 
     function replaceValidTimestamps(opts) {
@@ -216,6 +204,7 @@ define([
     }
 
     return {
+        replaceLocaleTimestamps: replaceLocaleTimestamps,
         makeRelativeDate: makeRelativeDate,
         isWithinSeconds: isWithinSeconds,
         init: init

--- a/static/src/stylesheets/module/football/_tables.scss
+++ b/static/src/stylesheets/module/football/_tables.scss
@@ -126,25 +126,3 @@
         float: right;
     }
 }
-
-/* ==========================================================================
-   Fixtures list
-   ========================================================================== */
-
-.table--football tr.football-match--fixture {
-    td {
-        padding: $gs-baseline/3 $table-gutter;
-    }
-
-    time {
-        display: block;
-        
-        @include mq($from: phablet) {
-            min-width: 5rem;
-        }
-
-        @include mq($until: phablet) {
-            min-height: $gs-baseline*3;
-        }
-    }
-}

--- a/static/test/javascripts-legacy/spec/common/ui/relativedates.spec.js
+++ b/static/test/javascripts-legacy/spec/common/ui/relativedates.spec.js
@@ -6,8 +6,7 @@ function (RelativeDates, fixtures) {
         fixtures: [
                     '<time id="time-valid" class="js-timestamp" datetime="2012-08-12T18:43:00.000Z">12th August</time>',
                     '<time id="time-invalid" class="js-timestamp" datetime="201-08-12agd18:43:00.000Z">Last Tuesday</time>',
-                    '<time id="time-locale" class="js-locale-timestamp" datetime="2014-06-13T17:00:00+0100" data-timestamp="1402675200000">17:00</time>',
-                    '<time id="time-with-timezone" class="js-locale-timestamp" datetime="2017-03-24T16:00:00+0000" data-timestamp="1490371200000" data-show-timezone>16:00</time>'
+                    '<time id="time-locale" class="js-locale-timestamp" datetime="2014-06-13T17:00:00+0100" data-timestamp="1402675200000">17:00</time>'
                    ]
     },
     // make the date static so tests are stable
@@ -164,28 +163,6 @@ function (RelativeDates, fixtures) {
         it('Should convert timestamps to users locale', function () {
             RelativeDates.init();
             expect(document.getElementById('time-locale').innerHTML).toBe('17:00');
-        });
-
-        it('Converts valid timestamps in the HTML document into their expected output without timezone appended if GMT', function () {
-            var toStringStub = sinon.stub(window.Date.prototype, 'toString').returns('Fri Mar 24 2017 16:00:00 GMT+0000 (GMT)');
-            
-            RelativeDates.init();
-
-            expect(toStringStub).toHaveBeenCalled();
-            expect(document.getElementById('time-with-timezone').innerHTML).toBe('16:00');
-
-            toStringStub.restore();
-        })
-
-        it('Converts valid timestamps in the HTML document into their expected output with timezone appended if not GMT', function () {
-            var toStringStub = sinon.stub(window.Date.prototype, 'toString').returns('Fri Mar 24 2017 16:00:00 GMT-0400 (EST)');
-
-            RelativeDates.init();
-
-            expect(toStringStub).toHaveBeenCalled();
-            expect(document.getElementById('time-with-timezone').innerHTML).toBe('16:00 EST');
-
-            toStringStub.restore();
         });
     });
 });

--- a/static/test/javascripts-legacy/spec/common/ui/relativedates.spec.js
+++ b/static/test/javascripts-legacy/spec/common/ui/relativedates.spec.js
@@ -6,7 +6,7 @@ function (RelativeDates, fixtures) {
         fixtures: [
                     '<time id="time-valid" class="js-timestamp" datetime="2012-08-12T18:43:00.000Z">12th August</time>',
                     '<time id="time-invalid" class="js-timestamp" datetime="201-08-12agd18:43:00.000Z">Last Tuesday</time>',
-                    '<time id="time-locale" class="js-locale-timestamp" datetime="2014-06-13T17:00:00+0100" data-timestamp="1402675200000">17:00</time>'
+                    '<time id="time-locale" class="js-locale-timestamp" datetime="2014-06-13T17:00:00+0100" data-timestamp="1402675200000">16:00</time>'
                    ]
     },
     // make the date static so tests are stable
@@ -160,9 +160,20 @@ function (RelativeDates, fixtures) {
             expect(document.getElementById('time-invalid').innerHTML).toBe('Last Tuesday');
         });
 
-        it('Should convert timestamps to users locale', function () {
-            RelativeDates.init();
+        it('Should convert timestamps in document to users locale', function () {
+            RelativeDates.replaceLocaleTimestamps();
+
             expect(document.getElementById('time-locale').innerHTML).toBe('17:00');
+        });
+
+        it('Should convert timestamps in HTML element to users locale', function () {
+            var elem = document.createElement('div');
+
+            elem.innerHTML = conf.fixtures[2];
+
+            RelativeDates.replaceLocaleTimestamps(elem);
+
+            expect(elem.querySelector('#time-locale').innerHTML).toBe('17:00');
         });
     });
 });


### PR DESCRIPTION
## What does this change?

- Reverts this PR https://github.com/guardian/frontend/pull/16033 so we no longer show users locale timezone abbreviation beside the match time because of bug on Windows.

- Fixes unrelated issue that occurs when a user taps the 'more' button. Currently if a user is in another timezone the kickoff times are updated on page load, however if they tap 'more' to view more matches the HTML returned from the server has additional kickoff times listed as GMT and we never update them to the user's locale timezone. This fix updates the times before adding them to the page.

## What is the value of this and can you measure success?

- Fixes bug on windows
- Ensures users always see kickoff times in their locale timezone

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Remove timezone (before)
![picture 54](https://cloud.githubusercontent.com/assets/1590704/25174459/56252e2c-24ef-11e7-9ef2-5f7d771f6793.png)

Remove timezone (after)
![picture 55](https://cloud.githubusercontent.com/assets/1590704/25174482/65d8d832-24ef-11e7-8652-ef92f972bfd7.png)

More button fix (before) - AFC Bournemouth v Middlesborough incorrectly has 15:00 k/o time
![footy-fixtures-before](https://cloud.githubusercontent.com/assets/1590704/25174736/383c8c06-24f0-11e7-803c-576a4d1b42bf.gif)

More button fix (after) - AFC Bournemouth v Middlesborough correctly has 10:00 k/o time
![footy-fixtures-after](https://cloud.githubusercontent.com/assets/1590704/25174751/41dfbada-24f0-11e7-9c1f-e025858e6ecb.gif)

## Tested in CODE?

N/A
