### PR TITLE
Live blogs should have an article-aside-slot

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -10,7 +10,7 @@
 @import conf.switches.Switches._
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
-@import views.support.Commercial.isPaidContent
+@import views.support.Commercial.{isPaidContent, articleAsideOptionalSizes, shouldShowAds}
 @import views.support.TrailCssClasses.toneClass
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
@@ -128,7 +128,9 @@
                 </div>
 
                 <div class="content__secondary-column js-secondary-column" aria-hidden="true">
-                    <div class="ad-slot-container js-ad-slot-container"></div>
+
+                    @fragments.articleAsideSlot(shouldShowAds(model), articleAsideOptionalSizes)
+
                     @if(model.related.hasStoryPackage && !amp) {
                         <aside role="complementary" class="blog__related">
                             <h3 class="blog__related__head">More on this story</h3>

--- a/static/test/javascripts-legacy/spec/commercial/article-aside-adverts.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/article-aside-adverts.spec.js
@@ -25,7 +25,7 @@ define([
             fixtures: [
                 '<div class="js-content-main-column" style="height:90000px;min-height:90000px;max-height:90000px;"></div>' +
                 '<div class="content__secondary-column js-secondary-column">' +
-                '<div class="js-ad-slot-container">' +
+                '<div class="ad-slot-container">' +
                 '<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right ad-slot--mpu-banner-ad js-sticky-mpu ad-slot--rendered" data-link-name="ad slot right" data-name="right" data-mobile="1,1|2,2|300,250|300,600|fluid">' +
                 '</div></div></div>'
             ]


### PR DESCRIPTION
## What does this change?

- Putting ads back in the RHS MPU of live blogs (adding them to the liveblog template)
- Removing remaining occurrences of `js-ad-slot-container` (because it should be unused)

## What is the value of this and can you measure success?

$CASH

# Screenshots

#### Before:

<img width="1175" alt="picture 713" src="https://cloud.githubusercontent.com/assets/8607683/25177387/a2d37a4e-24f9-11e7-9010-fd2993ff4fdf.png">


#### After:

<img width="1034" alt="picture 712" src="https://cloud.githubusercontent.com/assets/8607683/25177331/61b25bfc-24f9-11e7-9cf7-c1516a6b33f2.png">

<img width="1051" alt="picture 714" src="https://cloud.githubusercontent.com/assets/8607683/25178971/d8dfe5fe-24ff-11e7-9f6f-306150d3eaaf.png">
