### PR TITLE
Add make test-watch task

### DIFF
--- a/makefile
+++ b/makefile
@@ -87,6 +87,10 @@ pasteup: install # PRIVATE
 test: install
 	@./tools/task-runner/runner test/javascript --verbose
 
+# Run the modern JS test suite in watch mode.
+test-watch: install
+	@yarn test -- --watch
+
 # Check the JS test suite coverage.
 coverage: install
 	@./tools/task-runner/runner test/javascript/coverage --stdout

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ test: install
 
 # Run the modern JS test suite in watch mode.
 test-watch: install
-	@yarn test -- --watch
+	@yarn test -- --watch --coverage
 
 # Check the JS test suite coverage.
 coverage: install


### PR DESCRIPTION
## What does this change?

adds `make test-watch` task.

## What is the value of this and can you measure success?

shortcut to easily run jest tests in watch mode

## Screenshots

![screen shot 2017-04-19 at 12 36 03](https://cloud.githubusercontent.com/assets/867233/25178216/c8e24776-24fc-11e7-8fe5-44e8d165d49e.png)
