### PR TITLE
Fix messenger/get-stylesheet.js

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/get-stylesheet.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/get-stylesheet.js
@@ -28,7 +28,7 @@ define([
 
             if (sheet.ownerNode.tagName === 'STYLE') {
                 result.push(sheet.ownerNode.textContent);
-            } else {
+            } else if (sheet.cssRules.length) {
                 result.push(aProto.reduce.call(sheet.cssRules, function (res, input) {
                     return res + input.cssText;
                 }, ''));


### PR DESCRIPTION
## What does this change?

ensure `sheet.cssRules` is an array

## What is the value of this and can you measure success?

this test was passing in phantom but failing in headless chrome., but i think headless chrome is right.
