### PR TITLE
Fix messenger/get-stylesheet.js

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/get-stylesheet.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/get-stylesheet.js
@@ -18,20 +18,14 @@ define([
         var result = [];
         while (i < ii) {
             var sheet = styleSheets[i++];
-            if (!sheet.ownerNode || !sheet.ownerNode.matches) {
-                continue;
-            }
-
-            if (!sheet.ownerNode.matches(specs.selector)) {
-                continue;
-            }
-
-            if (sheet.ownerNode.tagName === 'STYLE') {
-                result.push(sheet.ownerNode.textContent);
-            } else {
-                result.push(aProto.reduce.call(sheet.cssRules, function (res, input) {
-                    return res + input.cssText;
-                }, ''));
+            if (sheet.ownerNode && sheet.ownerNode.matches && sheet.ownerNode.matches(specs.selector)) {
+                if (sheet.ownerNode.tagName === 'STYLE') {
+                    result.push(sheet.ownerNode.textContent);
+                } else {
+                    result.push(aProto.reduce.call(sheet.cssRules || [], function (res, input) {
+                        return res + input.cssText;
+                    }, ''));
+                }
             }
         }
 


### PR DESCRIPTION
## What does this change?

ensure `sheet.cssRules` is an array

## What is the value of this and can you measure success?

this test was passing in phantom but failing in headless chrome., but i think headless chrome is right.
