### PR TITLE
remove default keyword from loadscript module export

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
@@ -387,7 +387,7 @@ define([
 
         if (config.switches.enhancedMediaPlayer) {
             if (shouldPreroll) {
-                loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js').then(function () {
+                loadScript.loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js').then(function () {
                     initWithRaven(true);
                 }).catch(function (e) {
                     raven.captureException(e, { tags: { feature: 'media', action: 'ads', ignored: true } });

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-googletag.js
@@ -55,7 +55,7 @@ define([
             );
 
             // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.
-            return loadScript(config.libs.googletag, { async: false });
+            return loadScript.loadScript(config.libs.googletag, { async: false });
         }
 
         if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -19,7 +19,7 @@ define([
 
         // Setting the async property to false will _still_ load the script in
         // a non-blocking fashion but will ensure it is executed before googletag
-        loadScript(config.libs.sonobi, { async: false }).then(catchPolyfillErrors).then(stop);
+        loadScript.loadScript(config.libs.sonobi, { async: false }).then(catchPolyfillErrors).then(stop);
     }
 
     // Wrap the native implementation of getOwnPropertyNames in a try-catch. If any polyfill attempts

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -28,7 +28,7 @@ define([
 
         // Setting the async property to false will _still_ load the script in
         // a non-blocking fashion but will ensure it is executed before googletag
-        loadScript(config.libs.switch, { async: false }).then(setupLoadId).then(stop);
+        loadScript.loadScript(config.libs.switch, { async: false }).then(setupLoadId).then(stop);
     }
 
     // Set Switch's load id to the value of the ophan page view id. This id links the js

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/outbrain.js
@@ -83,7 +83,7 @@ define([
                 module.tracking({
                     widgetId: widgetCodes.code || widgetCodes.image
                 });
-                loadScript(outbrainUrl);
+                loadScript.loadScript(outbrainUrl);
             });
         }
     }

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/plista.js
@@ -50,7 +50,7 @@ define([
                 categories: categories,
                 dataMode: 'data-display'
             };
-            loadScript('//static-au.plista.com/async/' + name + '.js');
+            loadScript.loadScript('//static-au.plista.com/async/' + name + '.js');
         } else {
             lib.widgets.push({name: widgetName, pre: u});
         }

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/foresee-survey.js
@@ -11,7 +11,7 @@ define([
     ) {
 
     function openForesee() {
-        loadScript(config.libs.foresee);
+        loadScript.loadScript(config.libs.foresee);
     }
 
     function load() {

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube-player.js
@@ -19,7 +19,7 @@ define([
     });
 
     function loadYoutubeJs() {
-        loadScript(scriptSrc);
+        loadScript.loadScript(scriptSrc);
     }
 
     function _onPlayerStateChange(event, handlers, el) {

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/discussion-frontend.js
@@ -59,7 +59,7 @@ define([
         //   modify discussion-frontend to remove `fetch` polyfill and pass, if needed,
         //   opts.net = { json: fetchJson }
 
-        return loadScript(config.page.discussionFrontendUrl)
+        return loadScript.loadScript(config.page.discussionFrontendUrl)
             .then(function() {
                 init(window.guardian.app.discussion);
             })

--- a/static/src/javascripts-legacy/projects/common/modules/social/pinterest.js
+++ b/static/src/javascripts-legacy/projects/common/modules/social/pinterest.js
@@ -21,7 +21,7 @@ define([
             });
         });
 
-        loadScript('https://assets.pinterest.com/js/pinmarklet.js?r=' + new Date().getTime());
+        loadScript.loadScript('https://assets.pinterest.com/js/pinmarklet.js?r=' + new Date().getTime());
     }
 
     return function () {

--- a/static/src/javascripts/lib/load-script.js
+++ b/static/src/javascripts/lib/load-script.js
@@ -24,4 +24,4 @@ const loadScript = (src: string, props: Object): Promise<any> => {
     });
 };
 
-export default loadScript;
+export { loadScript };

--- a/static/src/javascripts/lib/load-script.spec.js
+++ b/static/src/javascripts/lib/load-script.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import loadScript from './load-script';
+import { loadScript } from './load-script';
 
 describe('loadScript', () => {
     const script = document.createElement('script');

--- a/static/test/javascripts-legacy/spec/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/dfp/dfp-api.spec.js
@@ -59,8 +59,10 @@ define([
                 return Promise.resolve();
             });
 
-            injector.mock('lib/load-script', function () {
-                return Promise.resolve();
+            injector.mock('lib/load-script', {
+                loadScript: function () {
+                    return Promise.resolve();
+                }
             });
 
             injector.require([

--- a/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/third-party-tags/outbrain.spec.js
@@ -29,8 +29,12 @@ define([
 
     describe('Outbrain', function () {
         var loadScript = jasmine.createSpy('loadScript');
+        
         beforeEach(function (done) {
-            injector.mock('lib/load-script', loadScript);
+            injector.mock('lib/load-script', {
+                loadScript: loadScript
+            });
+
             injector.mock('ophan/ng', { record: function () {} });
 
             injector.require([


### PR DESCRIPTION
## What does this change?

Removes export default from load-script module and updates all modules which import load-script to use the named export.

## What is the value of this and can you measure success?

Standardised exports

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No