### PR TITLE
Remove devtools default export

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -31,11 +31,7 @@ define([
 ) {
     return function () {
         var bootstrapContext = function (featureName, bootstrap) {
-            raven.context(
-                { tags: { feature: featureName } },
-                bootstrap.init,
-                []
-            );
+            raven.context({ tags: { feature: featureName } }, bootstrap, []);
         };
 
 
@@ -63,7 +59,7 @@ define([
             }]
         ]);
 
-        bootstrapContext('common', common);
+        bootstrapContext('common', common.init);
 
         // geolocation
         robust.catchErrorsWithContext([
@@ -73,93 +69,89 @@ define([
         // Front
         if (config.page.isFront) {
             require.ensure([], function (require) {
-                bootstrapContext('facia', require('bootstraps/enhanced/facia'));
+                bootstrapContext('facia', require('bootstraps/enhanced/facia').init);
             }, 'facia');
         }
 
         if (config.page.contentType === 'Article' && !config.page.isMinuteArticle) {
             require.ensure([], function (require) {
-                bootstrapContext('article', require('bootstraps/enhanced/article'));
-                bootstrapContext('article : image-content', require('bootstraps/enhanced/image-content'));
+                bootstrapContext('article', require('bootstraps/enhanced/article').init);
+                bootstrapContext('article : image-content', require('bootstraps/enhanced/image-content').init);
             }, 'article');
         }
 
         if (config.page.contentType === 'Crossword') {
             require.ensure([], function (require) {
-                bootstrapContext('crosswords', require('bootstraps/enhanced/crosswords'));
+                bootstrapContext('crosswords', require('bootstraps/enhanced/crosswords').init);
             }, 'crosswords');
         }
 
         if (config.page.contentType === 'LiveBlog') {
             require.ensure([], function (require) {
-                bootstrapContext('liveBlog', require('bootstraps/enhanced/liveblog'));
-                bootstrapContext('liveBlog : image-content', require('bootstraps/enhanced/image-content'));
+                bootstrapContext('liveBlog', require('bootstraps/enhanced/liveblog').init);
+                bootstrapContext('liveBlog : image-content', require('bootstraps/enhanced/image-content').init);
             }, 'live-blog');
         }
 
         if (config.page.isMinuteArticle) {
             require.ensure([], function (require) {
-                bootstrapContext('articleMinute', require('bootstraps/enhanced/article-minute'));
-                bootstrapContext('article : image-content', require('bootstraps/enhanced/image-content'));
+                bootstrapContext('articleMinute', require('bootstraps/enhanced/article-minute').init);
+                bootstrapContext('article : image-content', require('bootstraps/enhanced/image-content').init);
             }, 'article-minute');
         }
 
         if (config.isMedia || config.page.contentType === 'Interactive') {
             require.ensure([], function (require) {
-                bootstrapContext('media : trail', {
-                    init: require('bootstraps/enhanced/trail')
-                });
+                bootstrapContext('media : trail', require('bootstraps/enhanced/trail'));
             }, 'trail');
         }
 
         if ((config.isMedia || qwery('video, audio').length) && !config.page.isHosted) {
             require.ensure([], function (require) {
-                bootstrapContext('media', require('bootstraps/enhanced/media/main'));
+                bootstrapContext('media', require('bootstraps/enhanced/media/main').init);
             }, 'media');
         }
 
         if (config.page.contentType === 'Gallery') {
             require.ensure([], function (require) {
-                bootstrapContext('gallery', require('bootstraps/enhanced/gallery'));
-                bootstrapContext('gallery : image-content', require('bootstraps/enhanced/image-content'));
+                bootstrapContext('gallery', require('bootstraps/enhanced/gallery').init);
+                bootstrapContext('gallery : image-content', require('bootstraps/enhanced/image-content').init);
             }, 'gallery');
         }
 
         if (config.page.contentType === 'ImageContent') {
             require.ensure([], function (require) {
-                bootstrapContext('image-content', require('bootstraps/enhanced/image-content'));
-                bootstrapContext('image-content : trail', {
-                    init: require('bootstraps/enhanced/trail')
-                });
+                bootstrapContext('image-content', require('bootstraps/enhanced/image-content').init);
+                bootstrapContext('image-content : trail', require('bootstraps/enhanced/trail'));
             }, 'image-content');
         }
 
         if (config.page.section === 'football') {
             require.ensure([], function (require) {
-                bootstrapContext('football', require('bootstraps/enhanced/football'));
+                bootstrapContext('football', require('bootstraps/enhanced/football').init);
             }, 'football');
         }
 
         if (config.page.section === 'sport') {
             // Leaving this here for now as it's a tiny bootstrap.
-            bootstrapContext('sport', sport);
+            bootstrapContext('sport', sport.init);
         }
 
         if (config.page.section === 'identity') {
             require.ensure([], function (require) {
-                bootstrapContext('profile', require('bootstraps/enhanced/profile'));
+                bootstrapContext('profile', require('bootstraps/enhanced/profile').init);
             }, 'profile');
         }
 
         if (config.page.isPreferencesPage) {
             require.ensure([], function (require) {
-                bootstrapContext('preferences', require('bootstraps/enhanced/preferences'));
+                bootstrapContext('preferences', require('bootstraps/enhanced/preferences').init);
             }, 'preferences');
         }
 
         if (config.page.section === 'newsletter-signup-page') {
             require.ensure([], function (require) {
-                bootstrapContext('newsletters', require('bootstraps/enhanced/newsletters'));
+                bootstrapContext('newsletters', require('bootstraps/enhanced/newsletters').init);
             }, 'newsletters');
         }
 
@@ -173,7 +165,7 @@ define([
 
         if (config.page.pageId === 'help/accessibility-help') {
             require.ensure([], function (require) {
-                bootstrapContext('accessibility', require('bootstraps/enhanced/accessibility'));
+                bootstrapContext('accessibility', require('bootstraps/enhanced/accessibility').init);
             }, 'accessibility');
         }
 
@@ -181,7 +173,7 @@ define([
             //below is for during testing
             if (config.tests.abNewRecipeDesign) {
                 require.ensure([], function (require) {
-                    bootstrapContext('recipes', require('bootstraps/enhanced/recipe-article'));
+                    bootstrapContext('recipes', require('bootstraps/enhanced/recipe-article').init);
                 }, 'recipes');
             }
         }
@@ -189,19 +181,19 @@ define([
         fastdom.read(function() {
             if ( $('.youtube-media-atom').length > 0) {
                 require.ensure([], function (require) {
-                    bootstrapContext('youtube', require('bootstraps/enhanced/youtube'));
+                    bootstrapContext('youtube', require('bootstraps/enhanced/youtube').init);
                 }, 'youtube');
             }
         });
 
         if (window.location.hash.indexOf('devtools') !== -1) {
             require.ensure([], function(require) {
-                bootstrapContext('devtools', require('bootstraps/enhanced/devtools'));
+                bootstrapContext('devtools', require('bootstraps/enhanced/devtools').init);
             }, 'devtools');
         }
 
         // initialise email/outbrain check dispatcher
-        bootstrapContext('checkDispatcher', checkDispatcher);
+        bootstrapContext('checkDispatcher', checkDispatcher.init);
 
         // Mark the end of synchronous execution.
         userTiming.markTime('App End');

--- a/static/src/javascripts-legacy/bootstraps/enhanced/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/main.js
@@ -188,7 +188,7 @@ define([
 
         if (window.location.hash.indexOf('devtools') !== -1) {
             require.ensure([], function(require) {
-                bootstrapContext('devtools', require('bootstraps/enhanced/devtools').init);
+                bootstrapContext('devtools', require('common/modules/devtools').showDevTools);
             }, 'devtools');
         }
 

--- a/static/src/javascripts/bootstraps/enhanced/devtools.js
+++ b/static/src/javascripts/bootstraps/enhanced/devtools.js
@@ -1,9 +1,0 @@
-// @flow
-
-import showDevTools from 'common/modules/devtools';
-
-export default {
-    init() {
-        showDevTools();
-    },
-};

--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -76,9 +76,9 @@ const appendOverlay = () => {
     $('body').prepend(template(overlay, data));
 };
 
-export default function showDevTools() {
+export const showDevTools = () => {
     appendOverlay();
     bindEvents();
     selectRadios();
     applyCss();
-}
+};


### PR DESCRIPTION
## What does this change?

- give devtools a named export
- removes devtools bootstrap, since it just loads the module
- updates `bootstrapContext` method to not default to `init`

## What is the value of this and can you measure success?

move towards lifting against `export default`
