### PR TITLE
Replace `lib/ajax` with `lib/fetch-json` in `avatar/api.js`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/avatar/api.js
+++ b/static/src/javascripts-legacy/projects/common/modules/avatar/api.js
@@ -1,8 +1,8 @@
 define([
-    'lib/ajax',
+    'lib/fetch-json',
     'lib/config'
 ], function (
-    ajax,
+    fetchJSON,
     config
 ) {
 
@@ -11,17 +11,12 @@ define([
     var Api = {};
 
     Api.request = function (method, path, data) {
-        var params = {
-            url: apiUrl + path,
-            type: 'json',
-            data: data || {},
-            processData : false,
+        return fetchJSON(apiUrl + path, {
+            body: data || {},
             method: method,
-            crossOrigin: true,
-            withCredentials: true
-        };
-
-        return ajax(params);
+            mode: 'cors',
+            credentials: 'include',
+        });
     };
 
     // A user's 'active' avatar is only available to signed-in users as it

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/user-avatars.js
@@ -33,10 +33,11 @@ define([
             avatarApi.getActive()
                 .then(function (response) {
                     avatar.attr('src', response.data.avatarUrl);
-                }, function () {
+                })
+                .catch(function () {
                     avatar.attr('src', avatarApi.deterministicUrl(avatarUserId));
                 })
-                .always(function () {
+                .then(function () {
                     updateCleanup();
                 });
         } else {

--- a/static/src/javascripts-legacy/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/account-profile.js
@@ -109,7 +109,8 @@ define([
         avatarApi.updateAvatar(formData)
             .then(function () {
                 self.prependSuccessMessage(self.messages.avatarUploadSuccess, avatarForm);
-            }, function (err) {
+            })
+            .catch(function (err) {
                 if (err.status >= 400 && err.status < 500) {
                     self.prependErrorMessage(
                         JSON.parse(err.responseText).message || self.messages.avatarUploadFailure,


### PR DESCRIPTION
## What does this change?

Replaces `lib/ajax` with `lib/fetch-json` in `avatar/api.js` take 2, after the [first PR](https://github.com/guardian/frontend/pull/16465) went wrong, because of the missing `credentials` property.

## What is the value of this and can you measure success?

Less dependencies (one day).

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
