### PR TITLE
Restore styles for highlighted sentence in epic

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-to-support-landing-page.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-to-support-landing-page.js
@@ -48,7 +48,7 @@ define([
                         componentName: variant.componentName,
                         title: 'Since you’re here…',
                         p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
-                        '<span class="contributions__paragraph--highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>' +
+                        '<span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>' +
                         '. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.',
                         p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
                         p3: '',

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control-regulars.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control-regulars.html
@@ -4,7 +4,7 @@
             Hello again …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
+            … today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And <span class="contributions__highlight"> unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.'
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -4,7 +4,7 @@
             Since you’re here …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__paragraph--highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -35,6 +35,13 @@
     margin-bottom: 0;
 }
 
+.contributions__paragraph--highlight {
+    background-color: #ffe399;
+    padding: 4px 2px;
+    margin-left: -2px;
+    margin-right: -2px;
+}
+
 .contributions__hidden {
     display: none;
 }

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -35,7 +35,7 @@
     margin-bottom: 0;
 }
 
-.contributions__paragraph--highlight {
+.contributions__highlight {
     background-color: #ffe399;
     padding: 4px 2px;
     margin-left: -2px;


### PR DESCRIPTION
In #16377 some styles were deleted that we actually wanted to preserve - specifically the styles for highlighting text in the epic which had caused a large increase in conversion rate.

This re-instates the style. It also renames the class from `contributions__paragraph--highlight` to `contributions__highlight` since the original name gave the false impression that it was a modifier class for `contributions__paragraph` when in fact it's applied to a `<span>` within the paragraph