### PR TITLE
Fix async ShouldServeFrontTest

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -38,8 +38,8 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
     futureConfig.map(Option.apply).map(configAgent.send)
   }
 
-  def refreshWith(config: ConfigJson): Unit = {
-    configAgent.send(Option(config))
+  def refreshWith(config: ConfigJson): Future[Option[ConfigJson]] = {
+    configAgent.alter(Option(config))
   }
 
   def refreshAndReturn(): Future[Option[ConfigJson]] =

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -2,11 +2,12 @@ package services
 
 import com.gu.facia.client.models.{Branded, CollectionConfigJson, ConfigJson, FrontJson}
 import model.{ApplicationContext, ApplicationIdentity}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.Environment
 import test.WithTestContext
 
-class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
+class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext with ScalaFutures {
 
   val fronts = ConfigJson(
     Map(
@@ -66,18 +67,20 @@ class ShouldServeFrontTest extends FlatSpec with Matchers with WithTestContext {
     )
   )
 
-  ConfigAgent.refreshWith(fronts)
+  whenReady(ConfigAgent.refreshWith(fronts)) { config =>
 
-  "shouldServeFront" should "not serve the front if the front is not in the config JSON" in {
-    ConfigAgent.shouldServeFront("nonexistent-front") should be(false)
-  }
+    "shouldServeFront" should "not serve the front if the front is not in the config JSON" in {
+      ConfigAgent.shouldServeFront("nonexistent-front") should be(false)
+    }
 
-  it should "not serve a hidden editorial front" in {
-    ConfigAgent.shouldServeFront("hidden-editorial-front") should be(false)
-  }
+    it should "not serve a hidden editorial front" in {
+      ConfigAgent.shouldServeFront("hidden-editorial-front") should be(false)
+    }
 
-  it should "serve a hidden front in preview mode" in {
-    val previewContext = ApplicationContext(Environment.simple(), ApplicationIdentity("preview"))
-    ConfigAgent.shouldServeFront("editorial-front")(previewContext) should be(true)
+    it should "serve a hidden front in preview mode" in {
+      val previewContext = ApplicationContext(Environment.simple(), ApplicationIdentity("preview"))
+      ConfigAgent.shouldServeFront("hidden-editorial-front")(previewContext) should be(true)
+    }
+
   }
 }


### PR DESCRIPTION
## What does this change?
Attempts to fix an intermittently failing test.  It's possible that the test was being run before the `ConfigAgent` was updated with the mock values because `refreshWith` is async.  This is an attempt to wait for the config refresh to complete.

## What is the value of this and can you measure success?
TC tests pass.

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No, but waiting for build to go green in TC (will re-run once for good measure).

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
