### PR TITLE
Fix: useful error message when no cross account credentials

### DIFF
--- a/common/app/fronts/FrontsApi.scala
+++ b/common/app/fronts/FrontsApi.scala
@@ -7,7 +7,8 @@ import conf.Configuration
 import services.AwsEndpoints
 
 object FrontsApi extends ExecutionContexts {
-  val crossAccountClient: ApiClient = {
+
+  def crossAccountClient: ApiClient = {
     val client = new AmazonS3Client(Configuration.faciatool.crossAccountMandatoryCredentials)
     client.setEndpoint(AwsEndpoints.s3)
     ApiClient(Configuration.faciatool.crossAccountSourceBucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -25,9 +25,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
 
   def isLoaded() = configAgent.get().isDefined
 
-  def getClient: ApiClient = {
-    FrontsApi.crossAccountClient
-  }
+  def getClient: ApiClient = FrontsApi.crossAccountClient
 
   def refresh() = {
     val futureConfig = getClient.config


### PR DESCRIPTION
Making the cross account client a def so it doesn't throw an error
during the lifecycle initialization, which leads to an useless error
message

## What does this change?
Better error message when cross account credentials are not valid

```
[ERROR] [04/21/2017 00:23:41.583] [application-akka.actor.default-dispatcher-4] [TaskInvocation] AWS credentials for cross account are not configured
common.BadConfigurationException: AWS credentials for cross account are not configured
```
vs
```
Uncaught error from thread [application-akka.actor.default-dispatcher-5] shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[application]
java.lang.ExceptionInInitializerError
```

## What is the value of this and can you measure success?
Better error message. Less questions

## Tested in CODE?
No
