### PR TITLE
Fix tag list in footer

### DIFF
--- a/common/app/views/support/MostPopularTags.scala
+++ b/common/app/views/support/MostPopularTags.scala
@@ -5,7 +5,8 @@ import model.Tag
 import model.pressed.PressedContent
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 
-object MostPopularTags {
+object MostPopularTags extends implicits.Collections {
+
   /** A descending list of the tags that occur most frequently within the given items of content and how frequently
     * they occur
     */
@@ -19,5 +20,5 @@ object MostPopularTags {
       .sortBy(-_._2)
 
   /** The top n tags that occur for the given items of content */
-  def topTags(items: Seq[PressedContent]) = apply(items).map(_._1)
+  def topTags(items: Seq[PressedContent]) = apply(items).map(_._1).distinctBy(_.id)
 }


### PR DESCRIPTION
This fixes a bug where if a front contains content with the same tag it appears multiple times in the footer.

For example:
Before:
![image](https://cloud.githubusercontent.com/assets/1722550/25235923/734be564-25de-11e7-928a-95ab96032f83.png)

After:
![image](https://cloud.githubusercontent.com/assets/1722550/25235945/83e0c4e4-25de-11e7-8389-bf38df9ecb36.png)
