### PR TITLE
Tests: Wait for ConfigAgent.refreshWith() to complete in BeforeAll

### DIFF
--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -10,6 +10,8 @@ import common.ExecutionContexts
 import services.ConfigAgent
 import org.scalatest._
 import controllers.FaciaControllerImpl
+import scala.concurrent.duration._
+import scala.concurrent.Await
 
 @DoNotDiscover class FaciaControllerTest extends FlatSpec
   with Matchers
@@ -30,12 +32,13 @@ import controllers.FaciaControllerImpl
   val responsiveRequest = FakeRequest().withHeaders("host" -> "www.theguardian.com")
 
   override def beforeAll() {
-    ConfigAgent.refreshWith(
+    val refresh = ConfigAgent.refreshWith(
       ConfigJson(
         fronts = Map("music" -> frontJson, "inline-embeds" -> frontJson, "uk" -> frontJson, "au/media" -> frontJson),
         collections = Map.empty)
     )
     conf.switches.Switches.FaciaInlineEmbeds.switchOn()
+    Await.result(refresh, 3.seconds)
   }
 
   it should "serve an X-Accel-Redirect for something it doesn't know about" in {

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -8,6 +8,8 @@ import play.api.libs.json._
 import play.api.test.Helpers._
 import services.ConfigAgent
 import test._
+import scala.concurrent.duration._
+import scala.concurrent.Await
 
 @DoNotDiscover class FaciaMetaDataTest extends FlatSpec
   with Matchers
@@ -18,11 +20,12 @@ import test._
   with WithTestWsClient {
 
   override def beforeAll() {
-    ConfigAgent.refreshWith(
+    val refresh = ConfigAgent.refreshWith(
       ConfigJson(
         fronts = Map("music" -> FrontJson(Nil, None, None, None, None, None, None, None, None, None, None, None, None, None)),
         collections = Map.empty)
     )
+    Await.result(refresh, 3.seconds)
   }
 
   lazy val faciaController = new FaciaControllerImpl(new TestFrontJsonFapi(wsClient))


### PR DESCRIPTION
## What is the value of this and can you measure success?
Avoid race conditions and better code consistency in tests

## Does this affect other platforms - Amp, Apps, etc?
Just tests
