### PR TITLE
Replace `lib/ajax` with `lib/fetch-json` in `analytics/beacon`

### DIFF
--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -7,6 +7,7 @@ import model.diagnostics.csp.CSP
 import model.diagnostics.commercial.UserReport
 import model.TinyResponse
 import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json.JsObject
 
 class DiagnosticsController extends Controller with Logging {
   val r = scala.util.Random
@@ -31,7 +32,8 @@ class DiagnosticsController extends Controller with Logging {
   def commercialReport = Action(jsonParser) { implicit request =>
     UserReport.report(request.body)
 
-    TinyResponse.noContent()
+    /** An empty response isn't valid JSON, so we have to return an empty object */
+    JsonComponent(JsObject(Nil)).result
   }
 
   def commercialReports(dateTime: String) = Action { implicit request =>

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -7,7 +7,6 @@ import model.diagnostics.csp.CSP
 import model.diagnostics.commercial.UserReport
 import model.TinyResponse
 import org.joda.time.format.ISODateTimeFormat
-import play.api.libs.json.JsObject
 
 class DiagnosticsController extends Controller with Logging {
   val r = scala.util.Random
@@ -32,8 +31,7 @@ class DiagnosticsController extends Controller with Logging {
   def commercialReport = Action(jsonParser) { implicit request =>
     UserReport.report(request.body)
 
-    /** An empty response isn't valid JSON, so we have to return an empty object */
-    JsonComponent(JsObject(Nil)).result
+    TinyResponse.noContent()
   }
 
   def commercialReports(dateTime: String) = Action { implicit request =>

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/beacon.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/beacon.js
@@ -1,9 +1,9 @@
 define([
     'lib/config',
-    'lib/fetch-json',
+    'lib/fetch',
 ], function (
     config,
-    fetchJSON
+    fetch
 ) {
     return {
         fire: function (path) {
@@ -15,7 +15,7 @@ define([
         postJson: function (path, jsonString) {
             var url = (config.page.beaconUrl || '').replace(/^\/\//, window.location.protocol + '//') + path;
 
-            fetchJSON(url, {
+            fetch(url, {
                 method: 'post',
                 header: {
                     'Content-Type': 'application/json',

--- a/static/src/javascripts-legacy/projects/common/modules/analytics/beacon.js
+++ b/static/src/javascripts-legacy/projects/common/modules/analytics/beacon.js
@@ -1,9 +1,9 @@
 define([
     'lib/config',
-    'lib/ajax'
+    'lib/fetch-json',
 ], function (
     config,
-    ajax
+    fetchJSON
 ) {
     return {
         fire: function (path) {
@@ -15,14 +15,14 @@ define([
         postJson: function (path, jsonString) {
             var url = (config.page.beaconUrl || '').replace(/^\/\//, window.location.protocol + '//') + path;
 
-            ajax({
-                url: url,
-                type: 'json',
+            fetchJSON(url, {
                 method: 'post',
-                contentType: 'application/json',
-                data: jsonString,
-                crossOrigin: true
+                header: {
+                    'Content-Type': 'application/json',
+                },
+                body: jsonString,
+                mode: 'cors',
             });
-        }
+        },
     };
 });


### PR DESCRIPTION
## What does this change?

Replaces `lib/ajax` with `lib/fetch-json` in `analytics/beacon.js`. According to the `fetch` specs, the response body has to be valid JSON, so the response body can't be empty. Instead we have to return an empty object `{}`.

## What is the value of this and can you measure success?

Less dependencies (one day).

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
