### PR TITLE
Use full url instead of id for post references

### DIFF
--- a/common/app/views/support/structuredData/BlogPosting.scala
+++ b/common/app/views/support/structuredData/BlogPosting.scala
@@ -48,7 +48,7 @@ object BlogPosting {
       "headline" -> block.title.getOrElse[String](blog.trail.headline),
       "author" -> blockAuthor(blog, block),
       "publisher" -> Json.obj("@id" -> "https://www.theguardian.com#publisher"),
-      "url" -> LinkTo{blog.metadata.id+"?page=with:block-"+block.id+"#block-"+block.id},
+      "url" -> LinkTo{blog.metadata.url+"?page=with:block-"+block.id+"#block-"+block.id},
       "datePublished" -> blockDate(block),
       "articleBody" -> blockBody(block)
     )


### PR DESCRIPTION
## What does this change?

The structured data reference to the post url was using an invalid relative path instead of a full absolute uri, and because of this the Google indexing API was throwing a wobbly the resolved url was a 404.

This tiny fix uses the full blog post url instead of the capi id as the structured data "url" property

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
