### PR TITLE
Paid-content vs outbrain test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -161,6 +161,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-paid-content-vs-outbrain",
+    "Displays a paid content widget instead of Outbrain",
+    owners = Seq(Owner.withGithub("lps88")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 5, 10),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-epic-to-support-landing-page",
     "Use AB framework to divert traffic from epic to new support landing page",
     owners = Seq(Owner.withGithub("JustinPinner")),

--- a/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js
@@ -2,12 +2,20 @@ define([
     'Promise',
     'lib/config',
     'lib/fastdom-promise',
+    'common/modules/experiments/ab',
+    'commercial/modules/dfp/add-slot',
     'commercial/modules/dfp/create-slot',
+    'commercial/modules/dfp/track-ad-render',
     'commercial/modules/commercial-features'
-], function (Promise, config, fastdom, createSlot, commercialFeatures) {
+], function (Promise, config, fastdom, ab, addSlot, createSlot, trackAdRender, commercialFeatures) {
     return {
         init: init
     };
+
+    function isLuckyBastard() {
+        var testName = 'PaidContentVsOutbrain2';
+        return ab.testCanBeRun(testName) && ab.getTestVariantId(testName) === 'paid-content';
+    }
 
     function init() {
         if (commercialFeatures.highMerch) {
@@ -17,14 +25,41 @@ define([
 
             container.className = 'fc-container fc-container--commercial';
             container.appendChild(createSlot(config.page.isPaidContent ? 'high-merch-paid' : 'high-merch'));
-
+            
+            if (commercialFeatures.outbrain && isLuckyBastard()) {
+                trackAdRender('dfp-ad--merchandising-high')
+                    .then(insertAlternativeSlot);
+            }
+            
             return fastdom.write(function () {
                 if (anchor && anchor.parentNode) {
                     anchor.parentNode.insertBefore(container, anchor);
                 }
             });
+        } else if (commercialFeatures.outbrain && isLuckyBastard()) {
+            insertAlternativeSlot(false);
         }
 
         return Promise.resolve();
+    }
+
+    function insertAlternativeSlot(isHiResLoaded) {
+        if (isHiResLoaded) {
+            return;
+        }
+
+        var container = document.querySelector(
+            !(config.page.seriesId || config.page.blogIds) ?
+            '.js-related, .js-outbrain-anchor' :
+            '.js-outbrain-anchor'
+        );
+        var slot = createSlot('high-merch-lucky');
+
+        fastdom.write(function () {
+            container.parentNode.insertBefore(slot, container.nextSibling);
+        })
+        .then(function () {
+            addSlot(slot, true);
+        });
     }
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags.js
@@ -7,6 +7,7 @@ define([
     'lib/config',
     'lib/fastdom-promise',
     'lodash/utilities/template',
+    'common/modules/experiments/ab',
     'commercial/modules/commercial-features',
     'commercial/modules/third-party-tags/audience-science-gateway',
     'commercial/modules/third-party-tags/audience-science-pql',
@@ -25,6 +26,7 @@ define([
     config,
     fastdom,
     template,
+    ab,
     commercialFeatures,
     audienceScienceGateway,
     audienceSciencePql,
@@ -76,11 +78,18 @@ define([
         }
 
         // Outbrain/Plista needs to be loaded before first ad as it is checking for presence of high relevance component on page
-        loadExternalContentWidget();
+        if (!isLuckyBastard()) {
+            loadExternalContentWidget();
+        }
 
         loadOther();
 
         return Promise.resolve(true);
+    }
+
+    function isLuckyBastard() {
+        var testName = 'PaidContentVsOutbrain2';
+        return ab.testCanBeRun(testName) && ab.getTestVariantId(testName) === 'paid-content';
     }
 
     function loadOther() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/ab.js
@@ -13,6 +13,7 @@ define([
     'common/modules/experiments/tests/editorial-email-variants',
     'common/modules/experiments/tests/opinion-email-variants',
     'common/modules/experiments/tests/membership-engagement-banner-tests',
+    'common/modules/experiments/tests/paid-content-vs-outbrain',
     'common/modules/experiments/tests/tailor-survey',
     'common/modules/experiments/tests/the-long-read-email-variants',
     'common/modules/experiments/tests/fashion-statement-email-variants',
@@ -39,6 +40,7 @@ define([
              EditorialEmailVariants,
              OpinionEmailVariants,
              MembershipEngagementBannerTests,
+             PaidContentVsOutbrain2,
              TailorSurvey,
              TheLongReadEmailVariants,
              FashionStatementEmailVariants,
@@ -55,6 +57,7 @@ define([
     var TESTS = compact([
         new EditorialEmailVariants(),
         new OpinionEmailVariants(),
+        new PaidContentVsOutbrain2,
         acquisitionTestSelector.getTest(),
         new TailorSurvey(),
         TheLongReadEmailVariants,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-content-vs-outbrain.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-content-vs-outbrain.js
@@ -1,0 +1,35 @@
+define([
+    'lib/config'
+], function (config) {
+    return function () {
+        this.id = 'PaidContentVsOutbrain2';
+        this.start = '2017-04-24';
+        this.expiry = '2017-05-10';
+        this.author = 'Regis Kuckaertz / Lydia Shepherd';
+        this.description = 'Measure the revenue generated (or lost) by replacing the Outbrain widget with a paid content widget';
+        this.audience = .05;
+        this.audienceOffset = 0;
+        this.successMeasure = 'The paid content widget allows to release enough inventory to cover up for the lost revenue from Outbrain';
+        this.audienceCriteria = '';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'We generate more revenue *without* Outbrain and the brand image gets its shiny back';
+        this.showForSensitive = true;
+
+        this.canRun = function () {
+            return config.page.edition === 'UK';
+        };
+
+        this.variants = [
+            {
+                id: 'paid-content',
+                test: function () {
+                }
+            },
+            {
+                id: 'outbrain',
+                test: function () {
+                }
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?
Reinstate the test which replaces outbrain with a paid content container.

## What is the value of this and can you measure success?
We want to find out whether we can make/save as much money as we make from outbrain by using the space for paid content containers, and hence freeing up other inventory.

The first time we ran the test we didn't get as many impressions as expected, so trying this again.

## Does this affect other platforms - Amp, Apps, etc?
No
