### PR TITLE
Replace `ajax` call with `fetch-json`

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
@@ -306,7 +306,11 @@ CommentBox.prototype.postComment = function() {
 
         if (self.errors.length === 0) {
             if (self.options.newCommenter && self.options.newUsername) {
-                IdentityApi.updateUsername(self.getElem('onboarding-username-input').value).then(updateUsernameSuccess, updateUsernameFailure);
+                var username = self.getElem('onboarding-username-input').value;
+
+                IdentityApi.updateUsername(username)
+                    .then(updateUsernameSuccess)
+                    .catch(updateUsernameFailure);
             } else {
                 postCommentToDAPI();
             }

--- a/static/src/javascripts-legacy/projects/common/modules/identity/api.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/api.js
@@ -1,6 +1,7 @@
 /*global escape:true */
 define([
     'lib/ajax',
+    'lib/fetch-json',
     'lib/atob',
     'lib/config',
     'lib/cookies',
@@ -10,6 +11,7 @@ define([
     'Promise'
 ], function (
     ajax,
+    fetchJSON,
     utilAtob,
     config,
     cookies,
@@ -246,22 +248,24 @@ define([
     };
 
     Id.updateUsername = function (username) {
-        var endpoint = '/user/me',
-            data = {'publicFields': {'username': username, 'displayName': username}},
-            request = ajax({
-                url: Id.idApiRoot + endpoint,
-                type: 'json',
-                crossOrigin: true,
-                method: 'POST',
-                contentType: 'application/json; charset=utf-8',
-                data: JSON.stringify(data),
-                withCredentials: true,
-                headers: {
-                    'X-GU-ID-Client-Access-Token':  'Bearer ' + config.page.idApiJsClientToken
+        var endpoint = Id.idApiRoot + '/user/me',
+            data = {
+                publicFields: {
+                    username: username,
+                    displayName: username
                 }
-            });
+            };
 
-        return request;
+        return fetchJSON(endpoint, {
+            mode: 'cors',
+            method: 'POST',
+            body: JSON.stringify(data),
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'X-GU-ID-Client-Access-Token':  'Bearer ' + config.page.idApiJsClientToken
+            },
+        });
     };
 
     return Id;


### PR DESCRIPTION
## What does this change?

Replace at least one occurence of `ajax` in `identity/api.js`. The rest will follow next week, but requires some refactoring of the response, because at the moment this is `jsonp` which is not supported by `fetch`.

## What is the value of this and can you measure success?

Less dependencies (one day).

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
