### PR TITLE
Require ensure everything

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -48,40 +48,47 @@ const go = () => {
                     // webpack needs the require function to be called 'require'
                     // eslint-disable-next-line no-shadow
                     require => {
-                        raven.context({ tags: { feature: 'commercial' } }, () => {
-                            markTime('commercial boot');
-                            const commercialBoot = config.switches.commercial
-                                ? require('bootstraps/commercial')
-                                : Promise.resolve;
+                        raven.context(
+                            { tags: { feature: 'commercial' } },
+                            () => {
+                                markTime('commercial boot');
+                                const commercialBoot = config.switches
+                                    .commercial
+                                    ? require('bootstraps/commercial')
+                                    : Promise.resolve;
 
-                            commercialBoot().then(() => {
-                                // 3. finally, try enhanced
-                                // this is defined here so that webpack's code-splitting algo
-                                // excludes all the modules bundled in the commercial chunk from this one
-                                if (window.guardian.isEnhanced) {
-                                    markTime('enhanced request');
-                                    require.ensure(
-                                        [],
-                                        // webpack needs the require function to be called 'require'
-                                        // eslint-disable-next-line no-shadow
-                                        require => {
-                                            markTime('enhanced boot');
-                                            require('bootstraps/enhanced/main')();
+                                commercialBoot().then(() => {
+                                    // 3. finally, try enhanced
+                                    // this is defined here so that webpack's code-splitting algo
+                                    // excludes all the modules bundled in the commercial chunk from this one
+                                    if (window.guardian.isEnhanced) {
+                                        markTime('enhanced request');
+                                        require.ensure(
+                                            [],
+                                            // webpack needs the require function to be called 'require'
+                                            // eslint-disable-next-line no-shadow
+                                            require => {
+                                                markTime('enhanced boot');
+                                                require('bootstraps/enhanced/main')();
 
-                                            if (document.readyState === 'complete') {
-                                                capturePerfTimings();
-                                            } else {
-                                                window.addEventListener(
-                                                    'load',
-                                                    capturePerfTimings
-                                                );
-                                            }
-                                        },
-                                        'enhanced'
-                                    );
-                                }
-                            });
-                        });
+                                                if (
+                                                    document.readyState ===
+                                                    'complete'
+                                                ) {
+                                                    capturePerfTimings();
+                                                } else {
+                                                    window.addEventListener(
+                                                        'load',
+                                                        capturePerfTimings
+                                                    );
+                                                }
+                                            },
+                                            'enhanced'
+                                        );
+                                    }
+                                });
+                            }
+                        );
                     },
                     'commercial'
                 );

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -1,86 +1,94 @@
 // @flow
 
-// es7 polyfills not provided by pollyfill.io
-import 'core-js/modules/es7.object.values';
-import 'core-js/modules/es7.object.get-own-property-descriptors';
-import 'core-js/modules/es7.string.pad-start';
-import 'core-js/modules/es7.string.pad-end';
-
-import domready from 'domready';
-import raven from 'lib/raven';
-import bootStandard from 'bootstraps/standard/main';
-import config from 'lib/config';
-import { markTime } from 'lib/user-timing';
-import capturePerfTimings from 'lib/capture-perf-timings';
-
 // let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
 // https://webpack.js.org/guides/public-path/#set-value-on-the-fly
-// eslint-disable-next-line camelcase,no-undef
-__webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
+// eslint-disable-next-line camelcase,no-undef,guardian-frontend/global-config
+__webpack_public_path__ = `${window.guardian.config.page.assetsPath}javascripts/`;
 
 // kick off the app
 const go = () => {
-    domready(() => {
-        // 1. boot standard, always
-        markTime('standard boot');
-        bootStandard();
+    require.ensure(
+        [],
+        require => {
+            // es7 polyfills not provided by pollyfill.io
+            require('core-js/modules/es7.object.values');
+            require('core-js/modules/es7.object.get-own-property-descriptors');
+            require('core-js/modules/es7.string.pad-start');
+            require('core-js/modules/es7.string.pad-end');
 
-        // 2. once standard is done, next is commercial
-        if (config.page.isDev) {
-            window.guardian.adBlockers.onDetect.push(isInUse => {
-                const needsMessage =
-                    isInUse && window.console && window.console.warn;
-                const message =
-                    'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
-                if (needsMessage) {
-                    window.console.warn(message);
-                }
-            });
-        }
+            const domready = require('domready');
+            const raven = require('lib/raven');
+            const bootStandard = require('bootstraps/standard/main');
+            const config = require('lib/config');
+            const { markTime } = require('lib/user-timing');
+            const capturePerfTimings = require('lib/capture-perf-timings');
 
-        markTime('commercial request');
-        require.ensure(
-            [],
-            require => {
-                raven.context({ tags: { feature: 'commercial' } }, () => {
-                    markTime('commercial boot');
-                    const commercialBoot = config.switches.commercial
-                        ? require('bootstraps/commercial')
-                        : Promise.resolve;
+            domready(() => {
+                // 1. boot standard, always
+                markTime('standard boot');
+                bootStandard();
 
-                    commercialBoot().then(() => {
-                        // 3. finally, try enhanced
-                        // this is defined here so that webpack's code-splitting algo
-                        // excludes all the modules bundled in the commercial chunk from this one
-                        if (window.guardian.isEnhanced) {
-                            markTime('enhanced request');
-                            require.ensure(
-                                [],
-                                // webpack needs the require function to be called 'require'
-                                // eslint-disable-next-line no-shadow
-                                require => {
-                                    markTime('enhanced boot');
-                                    require('bootstraps/enhanced/main')();
-
-                                    if (document.readyState === 'complete') {
-                                        capturePerfTimings();
-                                    } else {
-                                        window.addEventListener(
-                                            'load',
-                                            capturePerfTimings
-                                        );
-                                    }
-                                },
-                                'enhanced'
-                            );
+                // 2. once standard is done, next is commercial
+                if (config.page.isDev) {
+                    window.guardian.adBlockers.onDetect.push(isInUse => {
+                        const needsMessage =
+                            isInUse && window.console && window.console.warn;
+                        const message =
+                            'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
+                        if (needsMessage) {
+                            window.console.warn(message);
                         }
                     });
-                });
-            },
-            'commercial'
-        );
-    });
+                }
+
+                markTime('commercial request');
+                require.ensure(
+                    [],
+                    // webpack needs the require function to be called 'require'
+                    // eslint-disable-next-line no-shadow
+                    require => {
+                        raven.context({ tags: { feature: 'commercial' } }, () => {
+                            markTime('commercial boot');
+                            const commercialBoot = config.switches.commercial
+                                ? require('bootstraps/commercial')
+                                : Promise.resolve;
+
+                            commercialBoot().then(() => {
+                                // 3. finally, try enhanced
+                                // this is defined here so that webpack's code-splitting algo
+                                // excludes all the modules bundled in the commercial chunk from this one
+                                if (window.guardian.isEnhanced) {
+                                    markTime('enhanced request');
+                                    require.ensure(
+                                        [],
+                                        // webpack needs the require function to be called 'require'
+                                        // eslint-disable-next-line no-shadow
+                                        require => {
+                                            markTime('enhanced boot');
+                                            require('bootstraps/enhanced/main')();
+
+                                            if (document.readyState === 'complete') {
+                                                capturePerfTimings();
+                                            } else {
+                                                window.addEventListener(
+                                                    'load',
+                                                    capturePerfTimings
+                                                );
+                                            }
+                                        },
+                                        'enhanced'
+                                    );
+                                }
+                            });
+                        });
+                    },
+                    'commercial'
+                );
+            });
+        },
+        'standard'
+    );
 };
 
 // make sure we've patched the env before running the app


### PR DESCRIPTION
## What does this change?

Side effect code in dependencies imported by `boot.js` are being executed before polyfills have loaded. This is a race condition so is not 100% reproducable, and is highly dependant on browser version. Users with modern browsers will suffer no impact. The older the browser, the more likely
some side effect code will blow up.

To solve this problem, I have moved all dependencies of `boot.js` into a `require.ensure` callback, to ensure the side effects of importing modules, or any Webpack bootstrap code (which depends on `Promise`) is not executed until polyfills have been loaded.

## What is the value of this and can you measure success?

Less break in older browsers

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
