### PR TITLE
Gallery content meta should be separate from other content meta

### DIFF
--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -3,23 +3,38 @@
 @import views.support.TrailCssClasses.toneClass
 
 <header class="content__head tonal__head tonal__head--@toneClass(gallery.item)">
-    @* Hidden because we visually show this data in the head, but needed
-    here for SEO. *@
+    @* Hidden because we visually show this data in the head, but needed here for SEO. *@
     <h1 class="is-hidden" itemprop="headline">@Html(gallery.item.trail.headline)</h1>
 
     <div class="gs-container">
-        @fragments.commercial.badge(gallery.item, gallery)
+        <div class="gallery__header">
 
-        @fragments.contentMeta(gallery.item, gallery)
-
-        @if(gallery.item.fields.standfirst.isDefined) {
-            <div class="tonal__standfirst">
-                @fragments.standfirst(gallery.item)
+            <div class="gallery__badge--container">
+                @fragments.commercial.badge(gallery.item, gallery)
             </div>
-        }
 
-            <div class="content__meta-container gallery__meta-container">
+            <div class="meta__extras--gallery">
+                <div class="meta__social meta__social--gallery" data-component="share">
+                    @fragments.social(gallery.item.sharelinks.pageShares, "top", iconModifier = List("social-icon-media"))
+                </div>
 
+                <div class="meta__numbers meta__numbers--gallery">
+                    <div class="u-h meta__number meta__number--gallery js-sharecount"></div>
+                    <div class="u-h meta__number meta__number--gallery"
+                         data-discussion-id="@gallery.item.content.discussionId"
+                         data-commentcount-format="content"
+                         data-discussion-closed="@{!gallery.item.trail.isCommentable}">
+                    </div>
+                </div>
+            </div>
+
+            @if(gallery.item.fields.standfirst.isDefined) {
+                <div class="tonal__standfirst">
+                    @fragments.standfirst(gallery.item)
+                </div>
+            }
+
+            <div class="gallery__meta-container">
                 @if(!gallery.item.content.hasTonalHeaderByline) {
                     @fragments.meta.byline(gallery.item.trail.byline, gallery.item.tags)
                 }
@@ -32,7 +47,7 @@
                 @if(!gallery.item.trail.shouldHidePublicationDate) {
                     @fragments.meta.dateline(gallery.item.trail.webPublicationDate, gallery.item.fields.lastModified, gallery.item.content.hasBeenModified, gallery.item.fields.firstPublicationDate, gallery.item.tags.isLiveBlog, gallery.item.fields.isLive)
                 }
-
             </div>
+        </div>
     </div>
 </header>

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,17 +1,14 @@
 @(item: model.ContentType, page: model.Page, showExtras: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
+
 @import model._
 @import views.support.Commercial.isPaidContent
-@import views.support.ContentOldAgeDescriber
+@import views.support.{ContentOldAgeDescriber, RenderClasses}
 
 @byline() = {
     @item match {
         case v: Video   => { @fragments.meta.byline(v.bylineWithSource, v.tags) }
         case c          => { @fragments.meta.byline(c.trail.byline, c.tags) }
     }
-}
-
-@iconModifier() = @{
-    if (item.content.isGallery) List("social-icon-media") else Nil
 }
 
 @ageNotice() = @{
@@ -22,7 +19,7 @@
     @if(showExtras) {
         <div class="meta__extras @if(!ageNotice.isEmpty){ meta__extras--notice }">
             <div class="meta__social" data-component="share">
-                @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier, amp = amp)
+                @fragments.social(item.sharelinks.pageShares, "top", amp = amp)
             </div>
             @if(item.content.tags.tags.exists(_.id == "tone/news")) {
                 @fragments.contentAgeNotice(ageNotice)
@@ -66,16 +63,16 @@
     }
 }
 
-<div class="content__meta-container js-content-meta js-football-meta u-cf
-    @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
-    @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
-    @if(item.elements.hasShowcaseMainElement){ content__meta-container--showcase}
-    @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
-    @item.content.contributorBio.map { bio => content__meta-container--bio}
-    @if(item.content.isExplore) {content__meta-container--explore}
-    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
-    @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">
-
+<div class="@RenderClasses(Map(
+    "content__meta-container--no-byline" -> item.trail.byline.isEmpty,
+    "content__meta-container--liveblog" -> item.tags.isLiveBlog,
+    "content__meta-container--showcase" -> item.elements.hasShowcaseMainElement,
+    "content__meta-container--tonal-header" -> item.content.hasTonalHeaderByline,
+    "content__meta-container--bio" -> item.content.contributorBio.nonEmpty,
+    "content__meta-container--explore" -> item.content.isExplore,
+    "content__meta-container--twitter" -> (item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)),
+    "content__meta-container--email" -> (item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty))
+), "content__meta-container", "js-content-meta", "js-football-meta", "u-cf")">
 
     @if(
         item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))

--- a/static/src/stylesheets/module/content/_gallery.head.scss
+++ b/static/src/stylesheets/module/content/_gallery.head.scss
@@ -1,22 +1,68 @@
 .content__labels--gallery,
-.l-side-margins--gallery .content__meta-container,
 .content__headline--gallery,
-.content__standfirst--gallery {
+.gallery__header {
     @include mq(desktop) {
         margin-left: gs-span(3) + $gs-gutter;
         max-width: gs-span(8);
     }
 }
 
-.l-side-margins--gallery {
-    .content__meta-container {
-        position: relative;
-        width: auto;
+.gallery__meta-container {
+    margin-bottom: $gs-baseline;
+
+    &:before {
+        content: '';
+        border-top: 1px solid $media-mute;
+        padding-top: $gs-baseline / 4;
+        display: block;
+        width: gs-span(1);
     }
 
-    .meta__extras {
-        display: flex;
-        justify-content: space-between;
+    .byline,
+    .content__dateline {
+        border: 0;
+        min-height: 0;
+        padding: 0;
+    }
+}
+
+.meta__extras--gallery {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px dotted $media-mute;
+    border-bottom: 1px dotted $media-mute;
+    position: relative;
+    clear: both;
+    min-height: 45px;
+    margin-bottom: $gs-baseline;
+}
+
+.meta__social--gallery {
+    border: 0;
+}
+
+.meta__numbers--gallery {
+    position: relative;
+    border: 0 none;
+    height: auto;
+    padding: $gs-baseline/2 0 0;
+}
+
+.meta__number--gallery {
+    text-align: right;
+}
+
+.gallery__badge--container {
+    @include mq($from: desktop) {
+        position: absolute;
+        width: gs-span(3);
+        margin-left: ($left-column-wide + $gs-gutter) * -1;
+    }
+
+    .badge--alt {
+        margin-top: 0;
+        margin-bottom: $gs-baseline;
+        border-top: 1px dotted $neutral-1;
     }
 }
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -8,21 +8,6 @@
     left: 0;
 }
 
-.gallery__meta-container {
-    &:before {
-        content: '';
-        border-top: 1px solid $media-mute;
-        padding-top: $gs-baseline / 4;
-        display: block;
-        width: gs-span(1);
-    }
-
-    .meta__twitter .button,
-    .meta__email .button {
-        margin-top: -$gs-baseline/2;
-    }
-}
-
 .gallery__divider {
     border-top: 1px solid $media-mute;
     margin-top: $gs-baseline;
@@ -189,22 +174,7 @@
     width: 100%;
 }
 
-.gallery__meta-container {
-    .byline,
-    .content__dateline {
-        border: 0;
-        min-height: 0;
-        padding: 0;
-    }
-}
-
 .l-side-margins--gallery {
-    .content__meta-container {
-        border: 0;
-        min-height: auto;
-        margin-bottom: $gs-baseline;
-    }
-
     .meta__comment-count--top {
         display: none;
     }
@@ -226,39 +196,6 @@
     .witness-cta {
         border: 0;
     }
-
-    .meta__extras {
-        border-top: 1px dotted $media-mute;
-        border-bottom: 1px dotted $media-mute;
-    }
-
-    // Reset the styles from _content.scss
-    .meta__numbers {
-        position: relative;
-        border: 0 none;
-        height: auto;
-        padding: $gs-baseline/2 0 0;
-    }
-
-    .meta__number {
-        text-align: right;
-    }
-
-    .meta__social {
-        border: 0;
-    }
-
-    .badge--alt {
-        margin-top: 0;
-        margin-bottom: $gs-baseline;
-        border-top: 1px dotted $neutral-1;
-
-        @include mq(desktop) {
-            position: absolute;
-            width: gs-span(3);
-        }
-    }
-
 }
 
 .gallery__fullscreen,


### PR DESCRIPTION
## What does this change?
This is step one for https://trello.com/c/SoAfcLjD/11-article-template-refactor-rewriting-the-meta-template.

Rewriting and hopefully simplifying the content meta in galleries. In more details this PR:
* Takes galleries out of `contentMeta.scala.html` because it made that template look very different, when they actually didn't share that much of the same styling. 
* In some places were were overriding a lot of styles, so I have opted to not use the same class names in this case. Please look for comments in my PR for more details on this. Naming is hard, so I would love some help coming up with better names here.

## What is the value of this and can you measure success?
* Hopefully this is a step in the right direction for simplifying content meta

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
It doesn't look any differnt

## Tested in CODE?
No
