### PR TITLE
Update deletion explanation text

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -32,7 +32,7 @@
             <h4><a href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
             <p class="identity-section__text">
                 Deleting your account removes personal information from our database. Your email address becomes
-                permanently reserved and the same email address cannot be re-used to register an new account.
+                permanently reserved and the same email address cannot be re-used to register a new account.
             </p>
 
             <h4><a href="https://www.theguardian.com/community-faqs">Comments</a></h4>

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -29,11 +29,19 @@
         </div>
 
         <div class="identity-section">
+            <h4><a href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
+            <p class="identity-section__text">
+                Deleting your account removes personal information from our database. Your email address becomes
+                permanently reserved and the same email address cannot be re-used to register an new account.
+            </p>
+
             <h4><a href="https://www.theguardian.com/community-faqs">Comments</a></h4>
             <p class="identity-section__text">
-                Deleting your account will anonymise the username under which you posted your coments, however it will not
-                automatically delete all your comments. If you wish for your comments to be deleted please contact the
-                <a href="mailto:moderation@@theguardian.com">Moderation Team</a>.
+                If you have posted comments your comment profile will be removed, however the posted comments will
+                remain underneath the articles. Comments are part of the historical record, but if want your comments to
+                be removed please contact the <a href="mailto:moderation@@theguardian.com">Moderation Team</a>.
+                Please note that requests are considered on a case-by-case basis and your comments will not be
+                automatically deleted.
             </p>
 
             <h4><a href="https://membership.theguardian.com/help">Membership</a></h4>

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -106,7 +106,7 @@
                 <div class="fieldset__fields">
                     <ul class="u-unstyled">
 
-                        @inputField(Password(accountDeletionForm("password"), '_label -> "Password", 'autofocus -> true, 'class -> "js-register-password js-password-strength",
+                        @inputField(Password(accountDeletionForm("password"), '_label -> "Password", 'class -> "js-register-password js-password-strength",
                             (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
 
                         <li>


### PR DESCRIPTION
Emails are now reserved on deletion. See PR https://github.com/guardian/identity/pull/635. This makes this fact explicit to the users on the deletion page.