### PR TITLE
Filter out incomplete commercial modules during logging

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
@@ -157,7 +157,6 @@ define([
         primaryBaseline : primaryBaseline,
         addTag: addTag,
         wrap: wrap,
-        defer: defer,
-        reportTrackingData: reportData
+        defer: defer
     };
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/dfp/performance-logging.js
@@ -91,8 +91,16 @@ define([
     // multiple times in a page view, so that partial data is captured, and then topped up as adverts load in.
     function reportTrackingData() {
         if (config.tests.commercialClientLogging) {
-            performanceLog.viewId = ophan.viewId;
-            beacon.postJson('/commercial-report', JSON.stringify(performanceLog));
+            var performanceReport = {
+                viewId: ophan.viewId,
+                tags: performanceLog.tags,
+                adverts: performanceLog.adverts,
+                baselines: performanceLog.baselines,
+                modules : (performanceLog.modules || []).filter(function (module){
+                    return !!module.duration;
+                })
+            };
+            beacon.postJson('/commercial-report', JSON.stringify(performanceReport));
         }
     }
 

--- a/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
@@ -8,9 +8,6 @@ define([
         var pubads = {
             addEventListener: jasmine.createSpy('addEventListener')
         };
-        var googletag = {
-            pubads: function () { return pubads; }
-        };
         var performanceLogging;
 
         beforeEach(function (done) {

--- a/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
@@ -22,11 +22,6 @@ define([
             });
         });
 
-        it('should register onSlotRender event listener', function () {
-            performanceLogging.setListeners(googletag);
-            expect(pubads.addEventListener).toHaveBeenCalledWith('slotRenderEnded', performanceLogging.reportTrackingData)
-        });
-
         describe('wrap', function () {
             it('should return the wrapped function return value', function () {
                 var randomVal = Math.random();

--- a/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/performance-logging.spec.js
@@ -5,9 +5,6 @@ define([
 ], function (Promise, fixtures, Injector) {
     describe('Performance Logging', function () {
         var injector = new Injector();
-        var pubads = {
-            addEventListener: jasmine.createSpy('addEventListener')
-        };
         var performanceLogging;
 
         beforeEach(function (done) {


### PR DESCRIPTION
Checking over the logs, most of the invalid reports are normal, it's just that there is no strict ordering between module loads and slot render events. So I'm happy to filter those, now that we know the cause.