### PR TITLE
Update sonobi switch expiry date

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -211,7 +211,7 @@ trait CommercialSwitches {
     description = "Turn on Sonobi header bidding",
     owners = Seq(Owner.withGithub("rich-nguyen"), Owner.withGithub("janua")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 28), //Friday
+    sellByDate = never,
     exposeClientSide = true
   )
 


### PR DESCRIPTION
This switch should be permanent now.