### PR TITLE
Extend AB test, and change SimpleReach to run on all Editions

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -185,7 +185,7 @@ trait ABTestSwitches {
     "Use the fabulous AB framework to add a opt-in for SimpleReach tracking",
     owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 4, 26),
+    sellByDate = new LocalDate(2017, 5, 3),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/simple-reach.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/third-party-tags/simple-reach.js
@@ -7,7 +7,7 @@ define([
 ) {
 
   var shouldRun = !config.page.isFront && config.switches.simpleReach &&
-    config.page.edition === 'US' && config.page.isPaidContent;
+    config.page.isPaidContent;
 
   var simpleReachUrl = '';
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/simple-reach.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/simple-reach.js
@@ -4,7 +4,7 @@ define([
     return function () {
         this.id = 'SimpleReach';
         this.start = '2017-04-13';
-        this.expiry = '2017-04-21';
+        this.expiry = '2017-05-03';
         this.author = 'Kate Whalen';
         this.description = 'Add SimpleReach opt-in behind query param, so we can test it';
         this.audience = 0;


### PR DESCRIPTION
## What does this change?

- Extends the SimpleReach AB test into next week
- We will end up running it on all Editions, so removing the restriction to US Edition

## What is the value of this and can you measure success?

- No expiring Switch tomorrow!
- Can test scripts

## Does this affect other platforms - Amp, Apps, etc?

Nope


