### PR TITLE
Fix tracking of navigation more toggle test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -39,11 +39,22 @@ object ABNewRecipeDesign extends TestDefinition(
   }
 }
 
-object ABNavigationMoreToggle extends TestDefinition(
-  name = "ab-navigation-more-toggle",
+object ABNavigationMoreToggleControl extends TestDefinition(
+  name = "ab-navigation-more-toggle-control",
   description = "Users in the test will see a more link in the navigation subnav",
   owners = Seq(Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 4, 28)
+  sellByDate = new LocalDate(2017, 5, 4)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-navigation-more-toggle").contains("control")
+  }
+}
+
+object ABNavigationMoreToggleVariant extends TestDefinition(
+  name = "ab-navigation-more-toggle-variant",
+  description = "Users in the test will see a more link in the navigation subnav",
+  owners = Seq(Owner.withGithub("gustavpursche")),
+  sellByDate = new LocalDate(2017, 5, 4)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-navigation-more-toggle").contains("variant")
@@ -65,7 +76,8 @@ object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
     ABNewRecipeDesign,
-    ABNavigationMoreToggle
+    ABNavigationMoreToggleControl,
+    ABNavigationMoreToggleVariant
   )
 }
 

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -20,12 +20,13 @@
             </li>
         }
 
-        @if(mvt.ABNavigationMoreToggle.isParticipating) {
+        @if(mvt.ABNavigationMoreToggleVariant.isParticipating) {
             <li class="subnav__link-item">
                 <button class="
                     subnav__link
                     subnav__link--toggle-more
-                    js-toggle-nav-section">
+                    js-toggle-nav-section"
+                    data-link-name="nav2 : subnav-toggle">
                     more
                 </button>
             </li>

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -1,7 +1,6 @@
 // @flow
 
 import fastdom from 'fastdom';
-import ophan from 'ophan/ng';
 import { scrollToElement } from 'lib/scroller';
 import userAccount from 'common/modules/navigation/user-account';
 
@@ -106,6 +105,7 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
             button.addEventListener('click', () => toggleSidebar());
             button.setAttribute('id', checkboxId);
             button.setAttribute('aria-expanded', 'false');
+            button.setAttribute('data-link-name', 'nav2 : toggle');
 
             if (checkboxControls) {
                 button.setAttribute('aria-controls', checkboxControls);
@@ -138,11 +138,6 @@ const enhanceSidebarToggle = (): void => {
         };
 
         checkbox.addEventListener('click', closeMenuHandler);
-
-        ophan.record({
-            component: 'main-navigation',
-            value: 'is fully expanded',
-        });
     }
 };
 
@@ -158,11 +153,6 @@ const toggleSidebarWithOpenSection = () => {
     }
 
     toggleSidebar();
-
-    ophan.record({
-        component: 'main-navigation',
-        value: `more toggle: ${pillarTitle}`,
-    });
 };
 
 const addEventHandler = (): void => {


### PR DESCRIPTION
## What does this change?

Fixes the tracking of the navigation "more" toggle test. Previously it was very hard to distinguish users which aren't part of the test from user who a part of the control group. With two tests this becomes better trackable.

It also converts the `ophan.record` calls into pure dom attributes, since they were broken anyways.

## What is the value of this and can you measure success?

We are able to analyze the test.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
