### PR TITLE
Main media captions on AMP

### DIFF
--- a/common/app/views/fragments/amp/customStyles.scala.html
+++ b/common/app/views/fragments/amp/customStyles.scala.html
@@ -1,8 +1,7 @@
 @(page: model.Page, mainPicture: String, ctaImage: Option[String], brandColour: String)(implicit request: RequestHeader, context: model.ApplicationContext)
-@import common.Edition
+
 @import conf.Static
 @import play.api.Mode.Dev
-@import com.gu.commercial.branding.PaidContent
 
 <style amp-custom>
     @* TODO: these two stylesheets should be refactored into SCSS *@

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -108,7 +108,7 @@
     @imageOption.map { img =>
         @if(img.showCaption) {
             @if(isMain) {
-                <input type="checkbox" id="show-caption" class="mobile-only u-h">
+                <input type="checkbox" id="show-caption" class="mobile-only u-h reveal-caption__checkbox">
 
                 <label class="mobile-only reveal-caption reveal-caption--img" for="show-caption">
                     @fragments.inlineSvg("information", "icon", List("reveal-caption-icon", "centered-icon"))

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -57,6 +57,7 @@
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
 @import 'module/onward/_rich-links-default.head';
+@import 'module/_main-media-captions';
 
 /* ==========================================================================
    Facia

--- a/static/src/stylesheets/amp/_content.scss
+++ b/static/src/stylesheets/amp/_content.scss
@@ -210,11 +210,7 @@
 }
 
 .media-primary {
-    margin: 0 (-$gs-gutter / 2);
-
-    @include mq(mobileLandscape) {
-        margin: 0 (-$gs-gutter);
-    }
+    position: relative;
 }
 
 // TODO: on amp, shouldn't have this. Or, use amp-lightbox
@@ -234,4 +230,10 @@
     float: left;
     margin-top: 2px;
     margin-right: 5px;
+}
+
+.reveal-caption {
+    @include mq($from: tablet) {
+        display: none;
+    }
 }

--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -160,15 +160,6 @@
     }
 }
 
-.caption--main {
-    padding: ($gs-baseline/3)*2 $gs-gutter/2 $gs-baseline*2;
-
-    @include mq(mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
-    }
-}
-
 
 /* Figures */
 

--- a/static/src/stylesheets/head.amp.scss
+++ b/static/src/stylesheets/head.amp.scss
@@ -1,1 +1,3 @@
 @import 'head.amp-common';
+
+@import 'module/_main-media-captions';

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -2,8 +2,6 @@
  * Changes to an Article Body
  ****************/
 
-$caption-button-size: 32px;
-
 // When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
 // TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
 .content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live, .tonal__head--tone-media) {
@@ -26,63 +24,5 @@ $caption-button-size: 32px;
     }
 }
 
-@include mq($until: tablet) {
-
-    .reveal-caption {
-        position: absolute;
-        right: $gs-gutter / 4;
-        width: $caption-button-size;
-        height: $caption-button-size;
-        z-index: 1;
-        background-color: rgba($neutral-1, .4);
-        border-radius: 50%;
-    }
-
-    .reveal-caption--img {
-        bottom: $gs-baseline/2;
-    }
-
-    .caption--main.caption--video {
-        padding-bottom: 0;
-    }
-
-    .caption--main.caption--img {
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba($multimedia-support-5, .8);
-        color: #ffffff;
-        display: none;
-        padding: $gs-baseline / 2 $gs-gutter * 2 $gs-baseline $gs-gutter / 2;
-        max-width: 100%;
-
-
-        @include mq($from: mobileLandscape) {
-            padding-left: $gs-gutter;
-        }
-
-        a {
-            color: #ffffff;
-        }
-
-        &:before {
-            content: none;
-        }
-    }
-
-    input[id='show-caption']:checked ~ .caption--main {
-        display: block;
-    }
-
-    input[id='show-caption']:checked ~ .reveal-caption {
-        background-color: $multimedia-support-5;
-    }
-}
-
-
-
-
-//TODO: captions
 //TODO: headline + main
 //TODO: AMP <- image always first if possible?

--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -47,7 +47,7 @@ $caption-button-size: 32px;
             max-width: 100%;
 
             a {
-                color: #ffffff;
+                color: currentColor;
             }
 
             &:before {

--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -8,7 +8,12 @@ $caption-button-size: 32px;
     z-index: 1;
     background-color: rgba($neutral-1, .4);
     border-radius: 50%;
+
+    &:hover {
+        background-color: rgba($neutral-1, 1);
+    }
 }
+
 
 .reveal-caption--img {
     bottom: $gs-baseline/2;
@@ -60,11 +65,20 @@ $caption-button-size: 32px;
 }
 
 @include mq($until: tablet) {
-    input[id='show-caption']:checked ~ .caption--main {
+    .reveal-caption__checkbox:checked ~ .caption--main {
         display: block;
     }
 
-    input[id='show-caption']:checked ~ .reveal-caption {
+    .reveal-caption__checkbox:checked ~ .reveal-caption {
         background-color: $multimedia-support-5;
+
+        &:hover {
+            background-color: rgba($neutral-1, 1);
+        }
     }
+
+    .reveal-caption__checkbox:focus ~ .reveal-caption {
+        background-color: rgba($neutral-1, 1);
+    }
+
 }

--- a/static/src/stylesheets/module/_main-media-captions.scss
+++ b/static/src/stylesheets/module/_main-media-captions.scss
@@ -1,0 +1,70 @@
+$caption-button-size: 32px;
+
+.reveal-caption {
+    position: absolute;
+    right: $gs-gutter / 4;
+    width: $caption-button-size;
+    height: $caption-button-size;
+    z-index: 1;
+    background-color: rgba($neutral-1, .4);
+    border-radius: 50%;
+}
+
+.reveal-caption--img {
+    bottom: $gs-baseline/2;
+}
+
+.caption--main {
+    min-height: ($gs-baseline / 3) * 7;
+    max-width: gs-span(7);
+    padding: ($gs-baseline / 3) * 2 $gs-gutter / 2 $gs-baseline * 2;
+
+    @include mq($from: tablet) {
+        max-width: gs-span(8);
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    @include mq($from: desktop) {
+        max-width: none;
+    }
+
+    &.caption--img {
+        @include mq($until: tablet) {
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba($multimedia-support-5, .8);
+            color: #ffffff;
+            display: none;
+            padding: $gs-baseline / 2 $gs-gutter * 2 $gs-baseline $gs-gutter / 2;
+            max-width: 100%;
+
+            a {
+                color: #ffffff;
+            }
+
+            &:before {
+                content: none;
+            }
+        }
+    }
+
+    &.caption--video,
+    .content__main-column--image & {
+        @include mq($until: tablet) {
+            padding-bottom: 0;
+        }
+    }
+}
+
+@include mq($until: tablet) {
+    input[id='show-caption']:checked ~ .caption--main {
+        display: block;
+    }
+
+    input[id='show-caption']:checked ~ .reveal-caption {
+        background-color: $multimedia-support-5;
+    }
+}

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -16,23 +16,6 @@
     min-height: gs-height(6);
 }
 
-.caption--main {
-    min-height: ($gs-baseline / 3) * 7;
-    max-width: gs-span(7);
-
-    @include mq(tablet) {
-        max-width: gs-span(8);
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-    }
-    @include mq(desktop) {
-        max-width: none;
-    }
-    .content__main-column--image & {
-        padding-bottom: 0;
-    }
-}
-
 .article-elongator {
     position: relative;
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -190,20 +190,6 @@
     }
 }
 
-.caption--main {
-    padding: ($gs-baseline/3)*2 $gs-gutter/2 $gs-baseline*2;
-
-    @include mq(mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
-    }
-    @include mq(phablet) {
-        padding-left: 0;
-        padding-right: 0;
-    }
-}
-
-
 /* Figures
    ========================================================================== */
 


### PR DESCRIPTION
## What does this change?

On our website mobile main media captions look like this:

![mobile main media](https://cloud.githubusercontent.com/assets/8774970/25381559/2e99c2d4-29ac-11e7-8d02-4245092d01cd.gif)

I thought it was time to make sure AMP was uniform. 

## What is the value of this and can you measure success?
Updated design for main media captions on mobile for AMP.

## Does this affect other platforms - Amp, Apps, etc?
This affects AMP

## Screenshots
**before:**
![image](https://cloud.githubusercontent.com/assets/8774970/25381707/b29cc61c-29ac-11e7-9c68-d8cf5849b7b9.png)

**after:**
![image](https://cloud.githubusercontent.com/assets/8774970/25381680/9d3337fc-29ac-11e7-80be-9f518b935faa.png)

![image](https://cloud.githubusercontent.com/assets/8774970/25381691/a722ff5e-29ac-11e7-9c96-16c335102be2.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
