### PR TITLE
Homogenise epic campaign codes

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -134,7 +134,7 @@ define([
         this.audienceCriteria = options.audienceCriteria;
         this.dataLinkNames = options.dataLinkNames || '';
         this.membershipCampaignPrefix = options.membershipCampaignPrefix || 'gdnwb_copts_mem';
-        this.contributionsCampaignPrefix = options.contributionsCampaignPrefix || 'co_global';
+        this.contributionsCampaignPrefix = options.contributionsCampaignPrefix || 'gdnwb_copts_mem';
         this.insertEvent = this.makeEvent('insert');
         this.viewEvent = this.makeEvent('view');
         this.isEngagementBannerTest = options.isEngagementBannerTest || false;


### PR DESCRIPTION
## What does this change?

For no real reason, we have always prefixed contributions and supporter codes with different prefixes. 

This causes unneeded headaches further down the line and needs to be stopped!

Because there may be instances in the future where they do need to be different, the ability to make them different is kept intact. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
