### PR TITLE
Don't load polyfill fallback

### DIFF
--- a/common/app/templates/inlineJS/blocking/loadApp.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadApp.scala.js
@@ -8,87 +8,63 @@
 // for that, we use polyfill.io.
 //
 // since that's a possbile point of failure, we have a checked-in copy of
-// the pf.io response for *all* polyfills that we will serve to everyone
-// as a worst-case back up.
+// the pf.io response for *all* polyfills that we may serve to everyone
+// as a worst-case back up. This fallback will be loaded if the PolyfillIO
+// switch is off.
 //
 // in that situation, they're gated, meaning they won't patch if they don't
 // need to, but they're still downloaded (currently ~20 kB gzipped) and
 // the file is still parsed
 
 // this is a global that's called at the bottom of the pf.io response,
-// once the polyfills have run.
+// once the polyfills have run. This may be useful for debugging.
 function guardianPolyfilled() {
     try {
-        // boot.js uses one of these to kick the app off,
-        // depending on which js file loads first
         window.guardian.polyfilled = true;
-        window.guardian.onPolyfilled();
     } catch (e) {};
 }
 
 // Load the app and try to patch the env with polyfill.io
+// Adapted from https://www.html5rocks.com/en/tutorials/speed/script-loading/#toc-aggressive-optimisation
 (function (document, window) {
-    var ref = document.getElementsByTagName('script')[0];
-    var polyfillScript, fallbackScript;
+    var scripts = [];
+    var src;
+    var script;
+    var pendingScripts = [];
+    var firstScript = document.scripts[0];
 
-    // because we're potentially setting up a race condition (polyfill.io and fallback)
-    // we need a way to stop one of the scripts evaling if they both get requested
-    function disableScript(script) {
-        if(script) {
-            script.type = 'ignore-this-script';
+    @if(PolyfillIO.isSwitchedOn) {
+        scripts.push('@common.Assets.js.polyfillioUrl');
+    } else {
+        scripts.push('@Static("javascripts/vendor/polyfillio.fallback.js")');
+    }
+
+    scripts.push('@Static("javascripts/graun.standard.js")');
+
+    function stateChange() {
+        var pendingScript;
+        while (pendingScripts[0] && pendingScripts[0].readyState == 'loaded') {
+            pendingScript = pendingScripts.shift();
+            pendingScript.onreadystatechange = null;
+            firstScript.parentNode.insertBefore(pendingScript, firstScript);
         }
     }
 
-    // if polyfill.io fails or times out, we'll load our fallback
-    function loadFallback () {
-        fallbackScript = document.createElement('script');
-        fallbackScript.src = '@Static("javascripts/vendor/polyfillio.fallback.js")';
-        fallbackScript.onload = function () {
-            // if this ends up loading before polyfill.io, make sure
-            // polyfill.io response isn't also applied
-            disableScript(polyfillScript);
-        };
-        ref.parentNode.insertBefore(fallbackScript, appScript);
-    }
-
-    // load polyfills from polyfill.io
-    function loadPolyfillIO () {
-        polyfillScript = document.createElement('script');
-        polyfillScript.src = "@common.Assets.js.polyfillioUrl";
-        polyfillScript.onerror = function () { // if something goes wrong...
-            // 1. ignore this script
-            disableScript(polyfillScript);
-            // 2. try to cancel the timeout that would have loaded the fallback eventually
-            window.clearTimeout(window.guardian.loadPolyfillioFallback);
-            // 3. manually load the fallback
-            loadFallback();
-        };
-        polyfillScript.onload = function () { // once we get polyfills from polyfill.io...
-            // 1. try to cancel the timeout that would have loaded the fallback eventually
-            window.clearTimeout(window.guardian.loadPolyfillioFallback);
-            // 2. disable the fallback script
-            // why? it's possible this script took too long to arrive and the fallback
-            // was triggered, but then this actually arrived *before* the fallback did.
-            // in that case, we might as well use this instead of waiting, but we don't
-            // want to patch again with the fallback when *it* arrives.
-            disableScript(fallbackScript);
-        };
-        appScript.parentNode.insertBefore(polyfillScript, appScript);
-
-        // give pollyfill.io 3 seconds to arrive before we trigger the fallback
-        window.guardian.loadPolyfillioFallback = window.setTimeout(loadFallback, 3000);
-    }
-
-    // the app will probably take longest to load, so let's
-    // get it loading ASAP. it won't do anything till the polyfills
-    // have run anyway
-    var appScript = document.createElement('script');
-    appScript.src = '@Static("javascripts/graun.standard.js")';
-    ref.parentNode.insertBefore(appScript, ref);
-
-    @if(PolyfillIO.isSwitchedOn) {
-        loadPolyfillIO()
-    } else {
-        loadFallback();
+    while (src = scripts.shift()) {
+        if ('async' in firstScript) { // modern browsers
+            script = document.createElement('script');
+            script.async = false;
+            script.src = src;
+            document.head.appendChild(script);
+        }
+        else if (firstScript.readyState) { // IE<10
+            script = document.createElement('script');
+            pendingScripts.push(script);
+            script.onreadystatechange = stateChange;
+            script.src = src;
+        }
+        else { // fall back to defer
+            document.write('<script src="' + src + '" defer></'+'script>');
+        }
     }
 })(document, window);

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -1,101 +1,88 @@
 // @flow
 
+// es7 polyfills not provided by pollyfill.io
+import 'core-js/modules/es7.object.values';
+import 'core-js/modules/es7.object.get-own-property-descriptors';
+import 'core-js/modules/es7.string.pad-start';
+import 'core-js/modules/es7.string.pad-end';
+
+import domready from 'domready';
+import raven from 'lib/raven';
+import bootStandard from 'bootstraps/standard/main';
+import config from 'lib/config';
+import { markTime } from 'lib/user-timing';
+import { capturePerfTimings } from 'lib/capture-perf-timings';
+
 // let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
 // https://webpack.js.org/guides/public-path/#set-value-on-the-fly
-// eslint-disable-next-line camelcase,no-undef,guardian-frontend/global-config
-__webpack_public_path__ = `${window.guardian.config.page.assetsPath}javascripts/`;
+// eslint-disable-next-line camelcase,no-undef
+__webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
 // kick off the app
 const go = () => {
-    require.ensure(
-        [],
-        require => {
-            // es7 polyfills not provided by pollyfill.io
-            require('core-js/modules/es7.object.values');
-            require('core-js/modules/es7.object.get-own-property-descriptors');
-            require('core-js/modules/es7.string.pad-start');
-            require('core-js/modules/es7.string.pad-end');
+    domready(() => {
+        // 1. boot standard, always
+        markTime('standard boot');
+        bootStandard();
 
-            const domready = require('domready');
-            const raven = require('lib/raven');
-            const bootStandard = require('bootstraps/standard/main');
-            const config = require('lib/config');
-            const { markTime } = require('lib/user-timing');
-            const { capturePerfTimings } = require('lib/capture-perf-timings');
-
-            domready(() => {
-                // 1. boot standard, always
-                markTime('standard boot');
-                bootStandard();
-
-                // 2. once standard is done, next is commercial
-                if (config.page.isDev) {
-                    window.guardian.adBlockers.onDetect.push(isInUse => {
-                        const needsMessage =
-                            isInUse && window.console && window.console.warn;
-                        const message =
-                            'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
-                        if (needsMessage) {
-                            window.console.warn(message);
-                        }
-                    });
+        // 2. once standard is done, next is commercial
+        if (config.page.isDev) {
+            window.guardian.adBlockers.onDetect.push(isInUse => {
+                const needsMessage =
+                    isInUse && window.console && window.console.warn;
+                const message =
+                    'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
+                if (needsMessage) {
+                    window.console.warn(message);
                 }
+            });
+        }
 
-                markTime('commercial request');
-                require.ensure(
-                    [],
-                    // webpack needs the require function to be called 'require'
-                    // eslint-disable-next-line no-shadow
-                    require => {
-                        raven.context(
-                            { tags: { feature: 'commercial' } },
-                            () => {
-                                markTime('commercial boot');
-                                const commercialBoot = config.switches
-                                    .commercial
-                                    ? require('bootstraps/commercial')
-                                    : Promise.resolve;
+        markTime('commercial request');
+        require.ensure(
+            [],
+            // webpack needs the require function to be called 'require'
+            // eslint-disable-next-line no-shadow
+            require => {
+                raven.context({ tags: { feature: 'commercial' } }, () => {
+                    markTime('commercial boot');
+                    const commercialBoot = config.switches.commercial
+                        ? require('bootstraps/commercial')
+                        : Promise.resolve;
 
-                                commercialBoot().then(() => {
-                                    // 3. finally, try enhanced
-                                    // this is defined here so that webpack's code-splitting algo
-                                    // excludes all the modules bundled in the commercial chunk from this one
-                                    if (window.guardian.isEnhanced) {
-                                        markTime('enhanced request');
-                                        require.ensure(
-                                            [],
-                                            // webpack needs the require function to be called 'require'
-                                            // eslint-disable-next-line no-shadow
-                                            require => {
-                                                markTime('enhanced boot');
-                                                require('bootstraps/enhanced/main')();
+                    commercialBoot().then(() => {
+                        // 3. finally, try enhanced
+                        // this is defined here so that webpack's code-splitting algo
+                        // excludes all the modules bundled in the commercial chunk from this one
+                        if (window.guardian.isEnhanced) {
+                            markTime('enhanced request');
+                            require.ensure(
+                                [],
+                                // webpack needs the require function to be called 'require'
+                                // eslint-disable-next-line no-shadow
+                                require => {
+                                    markTime('enhanced boot');
+                                    require('bootstraps/enhanced/main')();
 
-                                                if (
-                                                    document.readyState ===
-                                                    'complete'
-                                                ) {
-                                                    capturePerfTimings();
-                                                } else {
-                                                    window.addEventListener(
-                                                        'load',
-                                                        capturePerfTimings
-                                                    );
-                                                }
-                                            },
-                                            'enhanced'
+                                    if (document.readyState === 'complete') {
+                                        capturePerfTimings();
+                                    } else {
+                                        window.addEventListener(
+                                            'load',
+                                            capturePerfTimings
                                         );
                                     }
-                                });
-                            }
-                        );
-                    },
-                    'commercial'
-                );
-            });
-        },
-        'standard'
-    );
+                                },
+                                'enhanced'
+                            );
+                        }
+                    });
+                });
+            },
+            'commercial'
+        );
+    });
 };
 
 // make sure we've patched the env before running the app


### PR DESCRIPTION
## What does this change?

Currently, if the request to polyfill.io fails, we load a backup checked-in version of the polyfill.io response. To ensure polyfills load before code is executed, `boot.js` is structured in such a way as to prevent if from importing dependencies until polyfills have been applied. This works, but locks us into Webpack and adds complexity to our JS application.

This change removes the request to the polyfill fallback if polyfill.io fails. If polyfill.io fails the application code will still execute, but on older browsers there will be unhandled errors and the JavaScript will likely stop working. In this situation, the only remedy will be to turn off the polyfill.io switch, at which point we will serve polyfills from our expensive checked-in fallback until the polyfill.io service is restored and the switch is turned back on. 

## What is the value of this and can you measure success?

⬇️  Reduces the complexity in our application bootstrapping.
✨  Restores JavaScript in IE9... was previously not being served at all 😱 

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

- [x] Test in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
