### PR TITLE
Homogenise epic campaign codes for supporter and contributor links

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -133,8 +133,7 @@ define([
         this.successMeasure = options.successMeasure;
         this.audienceCriteria = options.audienceCriteria;
         this.dataLinkNames = options.dataLinkNames || '';
-        this.membershipCampaignPrefix = options.membershipCampaignPrefix || 'gdnwb_copts_mem';
-        this.contributionsCampaignPrefix = options.contributionsCampaignPrefix || 'co_global';
+        this.campaignPrefix = options.campaignPrefix || 'gdnwb_copts_memco';
         this.insertEvent = this.makeEvent('insert');
         this.viewEvent = this.makeEvent('view');
         this.isEngagementBannerTest = options.isEngagementBannerTest || false;
@@ -176,12 +175,11 @@ define([
         this.isUnlimited = options.isUnlimited || false;
 
         this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'not_found';
-        this.contributeCampaignCode = getCampaignCode(test.contributionsCampaignPrefix, this.campaignId, this.id);
-        this.membershipCampaignCode = getCampaignCode(test.membershipCampaignPrefix, this.campaignId, this.id);
-        this.campaignCodes = uniq([this.contributeCampaignCode, this.membershipCampaignCode]);
+        this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id);
+        this.campaignCodes = [this.campaignCode];
 
-        this.contributeURL = options.contributeURL || this.makeURL(contributionsBaseURL, this.contributeCampaignCode);
-        this.membershipURL = options.membershipURL || this.makeURL(membershipBaseURL, this.membershipCampaignCode);
+        this.contributeURL = options.contributeURL || this.makeURL(contributionsBaseURL, this.campaignCode);
+        this.membershipURL = options.membershipURL || this.makeURL(membershipBaseURL, this.campaignCode);
 
         this.componentName = 'mem_acquisition_' + trackingCampaignId + '_' + this.id;
 
@@ -260,11 +258,11 @@ define([
     };
 
     ContributionsABTestVariant.prototype.contributionsURLBuilder = function(codeModifier) {
-        return this.makeURL(contributionsBaseURL, codeModifier(this.contributeCampaignCode));
+        return this.makeURL(contributionsBaseURL, codeModifier(this.campaignCode));
     };
 
     ContributionsABTestVariant.prototype.membershipURLBuilder = function(codeModifier) {
-        return this.makeURL(membershipBaseURL, codeModifier(this.membershipCampaignCode));
+        return this.makeURL(membershipBaseURL, codeModifier(this.campaignCode));
     };
 
     ContributionsABTestVariant.prototype.registerListener = function (type, defaultFlag, event, options) {


### PR DESCRIPTION
## What does this change?
For no real reason, we have always prefixed contributions and supporter codes with different prefixes.

This causes unneeded headaches further down the line and needs to be stopped!

From now on, both contributions and supporter campaign codes will start with "gdnwb_copts_mem"

## What is the value of this and can you measure success?
Less headaches when analysing epic tests 

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 