### PR TITLE
ES6 module swapping

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -118,6 +118,7 @@
     "bootstraps/enhanced/gallery.js"
   ],
   "Simon Adcock": [
+    "projects/common/modules/experiments/tests/tailor-survey.js",
     "projects/common/modules/tailor/tailor.js",
     "lib/ajax.js",
     "bootstraps/enhanced/identity-common.js",
@@ -127,8 +128,7 @@
     "bootstraps/enhanced/media/main.js",
     "bootstraps/enhanced/media/video-player.js",
     "bootstraps/enhanced/membership.js",
-    "bootstraps/enhanced/newsletters.js",
-    "bootstraps/enhanced/notifications.js"
+    "bootstraps/enhanced/newsletters.js"
   ],
   "Nicolas Long": [
     "lib/atob.js",
@@ -268,14 +268,14 @@
     "projects/common/modules/experiments/tests/simple-reach.js",
     "projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js",
     "projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js",
-    "projects/common/modules/experiments/tests/tailor-survey.js",
     "projects/common/modules/experiments/tests/the-long-read-email-variants.js",
     "projects/common/modules/experiments/utils.js",
     "projects/common/modules/gallery/lightbox.js",
     "projects/common/modules/identity/account-profile.js",
     "projects/common/modules/identity/api.js",
     "projects/common/modules/identity/cookierefresh.js",
-    "projects/common/modules/identity/email-preferences.js"
+    "projects/common/modules/identity/email-preferences.js",
+    "bootstraps/enhanced/notifications.js"
   ],
   "ShaunYearStrong": [
     "projects/common/modules/identity/forms.js",

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -118,6 +118,7 @@
     "bootstraps/enhanced/gallery.js"
   ],
   "Simon Adcock": [
+    "projects/common/modules/tailor/tailor.js",
     "lib/ajax.js",
     "bootstraps/enhanced/identity-common.js",
     "bootstraps/enhanced/image-content.js",
@@ -127,8 +128,7 @@
     "bootstraps/enhanced/media/video-player.js",
     "bootstraps/enhanced/membership.js",
     "bootstraps/enhanced/newsletters.js",
-    "bootstraps/enhanced/notifications.js",
-    "bootstraps/enhanced/preferences.js"
+    "bootstraps/enhanced/notifications.js"
   ],
   "Nicolas Long": [
     "lib/atob.js",
@@ -177,9 +177,9 @@
     "projects/common/modules/sport/football/tag-page-stats.js",
     "projects/common/modules/sport/score-board.js",
     "projects/common/modules/tailor/fetch-data.js",
-    "projects/common/modules/tailor/tailor.js",
     "projects/common/modules/ui/accessibility-prefs.js",
-    "projects/common/modules/ui/autoupdate.js"
+    "projects/common/modules/ui/autoupdate.js",
+    "bootstraps/enhanced/preferences.js"
   ],
   "NataliaLKB": [
     "lib/client-rects.js",


### PR DESCRIPTION
## What does this change?

I'd like to prioritise converting the tailor module to ES6, as @oilnam has a genuine need to use a ES6 `Set`.

I've given @gustavpursche and @jranks123 a couple of my bootstraps in a fair exchange. 

## What is the value of this and can you measure success?

Moar ES6

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
