### PR TITLE
Paid content in rich links

### DIFF
--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -1,4 +1,5 @@
 @import model.ContentType
+@import common.Edition
 @import model.pressed.{Comment, DefaultCardstyle, Feature, Media, SpecialReport}
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{BulletCleaner, ImgSrc, Item460, RenderClasses, RichLinkContributor}
@@ -55,6 +56,13 @@
             }
             @content.content.starRating.map { stars => @fragments.items.elements.starRating(stars) }
         </div>
+
+        @if(content.tags.isPaidContent){
+            <div class="rich-link__branding">
+                Paid for by
+                @content.metadata.commercial.flatMap(_.branding(Edition(request))).map(_.sponsorName)
+            </div>
+        }
 
         @if(!content.tags.isGallery && !content.tags.isVideo) {
             <div class="rich-link__standfirst u-cf">

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -22,6 +22,7 @@
     "rich-link--video" -> content.tags.isVideo,
     "rich-link--gallery" -> content.tags.isGallery,
     "rich-link--audio" -> content.tags.isAudio,
+    "rich-link--paidfor" -> content.tags.isPaidContent,
     "rich-link--has-byline-pic" -> (content.content.hasTonalHeaderByline && content.tags.hasLargeContributorImage)
     ))">
 

--- a/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
@@ -215,8 +215,8 @@
             }
             .rich-link__header,
             .rich-link__read-more-text {
-                color: $neutral-1;
                 @include f-headlineSans;
+                color: $neutral-1;
             }
             .rich-link__arrow-icon {
                 fill: $paid-article-brand;

--- a/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
@@ -200,3 +200,30 @@
     float: none;
     width: auto;
 }
+
+.rich-link--paidfor {
+    &.tone-media--item,
+    & {
+        .rich-link__container {
+            background-color: $paid-article-card-bg;
+            &:hover,
+            &.u-faux-block-link--hover {
+                background: darken($paid-article-subheader, 7%);
+            }
+            &:before {
+                background-color: $paid-article-brand;
+            }
+            .rich-link__header,
+            .rich-link__read-more-text {
+                color: $neutral-1;
+                @include f-headlineSans;
+            }
+            .rich-link__arrow-icon {
+                fill: $paid-article-brand;
+            }
+        }
+    }
+    .rich-link__title {
+        color: $neutral-1;
+    }
+}

--- a/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
@@ -227,3 +227,9 @@
         color: $neutral-1;
     }
 }
+.rich-link__branding {
+    @include fs-textSans(1);
+    color: $neutral-2;
+    font-weight: bold;
+    margin: -$gs-baseline / 2 $gs-gutter / 4 $gs-baseline;
+}


### PR DESCRIPTION
## What does this change?
Add styling for paid-for articles in rich links.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/25438519/b586fbe6-2a91-11e7-8447-63e28a1d2fa6.png)

as compared to editorial content:
![image](https://cloud.githubusercontent.com/assets/6290008/25435751/fdeb0836-2a88-11e7-8482-a5d6a553166d.png)

## Tested in CODE?
No
