### PR TITLE
Immersive dateline fix

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -580,7 +580,6 @@
 
     @include mq(wide) {
         margin-left: ($left-column-wide + $gs-gutter)*-1;
-        width: $left-column-wide;
     }
 }
 


### PR DESCRIPTION
Dateline and meta area was odd at the wide breakpoint. 

Before:
<img width="1127" alt="screen shot 2017-04-26 at 14 00 35" src="https://cloud.githubusercontent.com/assets/14570016/25435690/cdd5e31e-2a88-11e7-9bed-dec45293dc2e.png">

After:
<img width="1113" alt="screen shot 2017-04-26 at 14 00 25" src="https://cloud.githubusercontent.com/assets/14570016/25435689/cdc2b208-2a88-11e7-9da0-cf9d6c5f098b.png">

Spotted by @blongden73 