### PR TITLE
Ad call targeting variables for Switch

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -48,7 +48,7 @@ Example: http://output.jsbin.com/jodureg/1
     @defining(getMap(page)
         .filter( { case (key: String, _) => key == "sharedAdTargeting"} )
         .map( { case (key, value) => (key, value.toString)}) ) { (params: Map[String, String]) =>
-        <!--esi <esi:include src=@{"/esi/ad-call".appendQueryParams(params)}" /> -->
+        <!--esi <esi:include src="@{"/esi/ad-call".appendQueryParams(params)}" /> -->
     }
 }
 

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -3,6 +3,8 @@
 @import model.Page.getContent
 @import conf.switches.Switches.{preflightServerSideAdCallSwitch, PolyfillIO}
 @import conf.Static
+@import implicits.Strings.String2Uri
+@import views.support.JavaScriptPage.getMap
 
 <meta charset="utf-8" />
 <!--
@@ -43,7 +45,11 @@ Example: http://output.jsbin.com/jodureg/1
 </script>
 
 @if(preflightServerSideAdCallSwitch.isSwitchedOn) {
-    <!--esi <esi:include src="/esi/ad-call" /> -->
+    @defining(getMap(page)
+        .filter( { case (key: String, _) => key == "sharedAdTargeting"} )
+        .map( { case (key, value) => (key, value.toString)}) ) { (params: Map[String, String]) =>
+        <!--esi <esi:include src=@{"/esi/ad-call".appendQueryParams(params)}" /> -->
+    }
 }
 
 @* inline JS - blocking *@

--- a/diagnostics/app/controllers/CommercialPreflightController.scala
+++ b/diagnostics/app/controllers/CommercialPreflightController.scala
@@ -26,7 +26,7 @@ case class AdRequest(
   browser_dimensions: Option[String],
   switch_user_id: Option[String],       // switch_user_id, SWID cookie
   floor_price: Option[String],
-  targeting_variables: Option[String]
+  targeting_variables: Option[AppNexusTargeting]
 )
 
 case class AdTargeting(
@@ -46,8 +46,8 @@ case class AdTargeting(
       pt2 = edition,
       pt3 = ct,
       pt4 = p,
-      pt5 = k,
-      pt6 = su,
+      pt5 = k.mkString(","),
+      pt6 = su.mkString(","),
       pt9 = (co ++ tn).mkString("|")
     )
   }
@@ -59,12 +59,13 @@ case class AppNexusTargeting(
   pt2: String,
   pt3: String,
   pt4: String,
-  pt5: List[String],
-  pt6: List[String],
+  pt5: String,
+  pt6: String,
   pt9: String
-){
-  def toOpenRTBString: String = {
-  }
+)
+
+object AppNexusTargeting {
+  implicit val appNexusTargeting = Json.writes[AppNexusTargeting]
 }
 
 object AdRequest {
@@ -117,7 +118,7 @@ class CommercialPreflightController(wsClient: WSClient) extends Controller with 
         browser_dimensions = None,
         switch_user_id = switchId,
         floor_price = None,
-        targeting_variables = maybeTargeting.map(_.toAppNexusTargeting.toOpenRTBString)
+        targeting_variables = maybeTargeting.map(_.toAppNexusTargeting)
       ))
 
       wsClient.url(Configuration.switch.switchAdHubUrl)


### PR DESCRIPTION
Switch needs to receive `targeting_variables` to do page targeting for AppNexus. This has to be passed through the ad call, which is initiated by Fastly. So the Fastly ESI is extended to pass request generic parameters, which are formatted for AppNexus.