### PR TITLE
Change ask on engagement banner to weekly rather than monthly price

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -35,7 +35,7 @@ define([
     var defaultParamsLookup = {
 
         UK: assign({}, membershipParams, {
-            messageText: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for £5 a month.',
+            messageText: 'For less than the price of a coffee a week, you could help secure the Guardian’s future. Support our journalism for 95p a week.',
             campaignCode: "mem_uk_banner"
         }),
 
@@ -45,12 +45,12 @@ define([
         }),
 
         AU: assign({}, membershipParams, {
-            messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $10 a month.',
+            messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia member for just $1.92 a week.',
             campaignCode: "mem_au_banner"
         }),
 
         INT: assign({}, membershipParams, {
-            messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for $7 / €5 a month.',
+            messageText: 'For less than the price of a coffee a week, you could help secure the Guardian\'s future. Support our journalism for $1.33 / €0.95 a week.',
             campaignCode: "mem_int_banner"
         })
     };


### PR DESCRIPTION
## What does this change?

Analysing the results of a previous test (https://github.com/guardian/frontend/pull/15955), we noticed that the variant that replaced the monthly price with a weekly price yielded significantly more conversions. 

For some reason, the control was never changed to reflect this. This PR makes this change:

@JustinPinner @guardian/contributions @rupertbates 
## Screenshots

International: 

![screenshot at apr 26 14-39-42](https://cloud.githubusercontent.com/assets/2844554/25437571/b86ac3c2-2a8e-11e7-89f6-83decf7fb2f0.png)

UK:

![screenshot at apr 26 14-40-23](https://cloud.githubusercontent.com/assets/2844554/25437569/b863f25e-2a8e-11e7-9582-87c86322fa12.png)

Australia:

![screenshot at apr 26 14-40-43](https://cloud.githubusercontent.com/assets/2844554/25437570/b8685010-2a8e-11e7-9a6c-8d19c805ba13.png)




## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
