### PR TITLE
Add campaign code suffix to ophan events as well

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -134,6 +134,7 @@ define([
         this.audienceCriteria = options.audienceCriteria;
         this.dataLinkNames = options.dataLinkNames || '';
         this.campaignPrefix = options.campaignPrefix || 'gdnwb_copts_memco';
+        this.campaignSuffix = options.campaignSuffix || '';
         this.insertEvent = this.makeEvent('insert');
         this.viewEvent = this.makeEvent('view');
         this.isEngagementBannerTest = options.isEngagementBannerTest || false;
@@ -175,7 +176,7 @@ define([
         this.isUnlimited = options.isUnlimited || false;
 
         this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'not_found';
-        this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id);
+        this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id, test.campaignSuffix);
         this.campaignCodes = [this.campaignCode];
 
         this.contributeURL = options.contributeURL || this.makeURL(contributionsBaseURL, this.campaignCode);
@@ -244,8 +245,9 @@ define([
         this.registerListener('success', 'successOnView', test.viewEvent, options);
     }
 
-    function getCampaignCode(campaignCodePrefix, campaignID, id) {
-        return campaignCodePrefix + '_' + campaignID + '_' + id;
+    function getCampaignCode(campaignCodePrefix, campaignID, id, campaignCodeSuffix) {
+        var suffix = campaignCodeSuffix ? ('_' + campaignCodeSuffix) : '';
+        return campaignCodePrefix + '_' + campaignID + '_' + id + suffix;
     }
 
     ContributionsABTestVariant.prototype.makeURL = function(base, campaignCode) {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -11,13 +11,11 @@ define([
     config,
     liveblogEpicTemplate
 ) {
-    function addPageIdToCampaignCode(code) {
-        return code + '_' + config.page.pageId.replace(/[/-]/g, '_');
-    }
 
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicLiveblog',
         campaignId: 'epic_liveblog',
+        campaignSuffix: config.page.pageId.replace(/-/g, '_').replace(/\//g, '__'),
 
         start: '2017-04-01',
         expiry: '2018-04-01',
@@ -45,13 +43,12 @@ define([
                 },
                 insertBeforeSelector: '.js-liveblog-epic-placeholder',
                 insertMultiple: true,
-
                 successOnView: true,
 
                 template: function (variant) {
                     return template(liveblogEpicTemplate, {
-                        membershipUrl: variant.membershipURLBuilder(addPageIdToCampaignCode),
-                        contributionUrl: variant.contributionsURLBuilder(addPageIdToCampaignCode),
+                        membershipUrl: variant.membershipURL,
+                        contributionUrl: variant.contributeURL,
                         componentName: variant.componentName
                     });
                 },


### PR DESCRIPTION
- When converting page id to a campaign code, turn `/` into `__` and `-` into `_`, rather than both into `_`)
  - **Why?** So we can programatically get a liveblog URL from a campaign code. This will be useful for dashboards later
- Append this to the variant campaign code rather than just transforming it for the links
  - **Why?** So the full campaign code with page id will be sent to Ophan for impressions tracking as well as put into the link for conversion tracking

@alexduf 
@jranks123 
