### PR TITLE
Fix epic in liveblog campaign code

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -134,6 +134,7 @@ define([
         this.audienceCriteria = options.audienceCriteria;
         this.dataLinkNames = options.dataLinkNames || '';
         this.campaignPrefix = options.campaignPrefix || 'gdnwb_copts_memco';
+        this.campaignSuffix = options.campaignSuffix || '';
         this.insertEvent = this.makeEvent('insert');
         this.viewEvent = this.makeEvent('view');
         this.isEngagementBannerTest = options.isEngagementBannerTest || false;
@@ -175,7 +176,7 @@ define([
         this.isUnlimited = options.isUnlimited || false;
 
         this.pageviewId = (config.ophan && config.ophan.pageViewId) || 'not_found';
-        this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id);
+        this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id, test.campaignSuffix);
         this.campaignCodes = [this.campaignCode];
 
         this.contributeURL = options.contributeURL || this.makeURL(contributionsBaseURL, this.campaignCode);
@@ -244,8 +245,9 @@ define([
         this.registerListener('success', 'successOnView', test.viewEvent, options);
     }
 
-    function getCampaignCode(campaignCodePrefix, campaignID, id) {
-        return campaignCodePrefix + '_' + campaignID + '_' + id;
+    function getCampaignCode(campaignCodePrefix, campaignID, id, campaignCodeSuffix) {
+        var suffix = campaignCodeSuffix ? ('_' + campaignCodeSuffix) : '';
+        return campaignCodePrefix + '_' + campaignID + '_' + id + suffix;
     }
 
     ContributionsABTestVariant.prototype.makeURL = function(base, campaignCode) {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -11,13 +11,11 @@ define([
     config,
     liveblogEpicTemplate
 ) {
-    function addPageIdToCampaignCode(code) {
-        return code + '_' + config.page.pageId.replace(/[/-]/g, '_');
-    }
 
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicLiveblog',
         campaignId: 'epic_liveblog',
+        campaignSuffix: config.page.pageId.replace(/-/g, '_').replace(/\//g, '__'),
 
         start: '2017-04-01',
         expiry: '2018-04-01',
@@ -45,13 +43,12 @@ define([
                 },
                 insertBeforeSelector: '.js-liveblog-epic-placeholder',
                 insertMultiple: true,
-
                 successOnView: true,
 
                 template: function (variant) {
                     return template(liveblogEpicTemplate, {
-                        membershipUrl: variant.membershipURLBuilder(addPageIdToCampaignCode),
-                        contributionUrl: variant.contributionsURLBuilder(addPageIdToCampaignCode),
+                        membershipUrl: variant.membershipURL,
+                        contributionUrl: variant.contributeURL,
                         componentName: variant.componentName
                     });
                 },

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -11,11 +11,12 @@ define([
     config,
     liveblogEpicTemplate
 ) {
+    var pageId = config.page.pageId || '';
 
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicLiveblog',
         campaignId: 'epic_liveblog',
-        campaignSuffix: config.page.pageId.replace(/-/g, '_').replace(/\//g, '__'),
+        campaignSuffix: pageId.replace(/-/g, '_').replace(/\//g, '__'),
 
         start: '2017-04-01',
         expiry: '2018-04-01',


### PR DESCRIPTION
This is what I did in #16570 and reverted in #16572.

I've now found the cause of the test error. In the test environment, `config.page` is an [empty object](https://github.com/guardian/frontend/blob/fix-epic-in-liveblog-campaign-code/static/test/javascripts-legacy/setup.js#L32) meaning `pageId` is not a string so calling `.replace()` throws an error. So in my code I now make sure that `pageId` is defaulted to an empty string.

Why was this code even getting run when there's no test for it? Because `ab.js` has hard dependencies on all the test modules - really these should be passed in and then it could be tested independently of every single test module.

What I said in #16570 still applies:

- When converting page id to a campaign code, turn `/` into `__` and `-` into `_`, rather than both into `_`)
  - **Why?** So we can programatically get a liveblog URL from a campaign code. This will be useful for dashboards later
- Append this to the variant campaign code rather than just transforming it for the links
  - **Why?** So the full campaign code with page id will be sent to Ophan for impressions tracking as well as put into the link for conversion tracking

cc @alexduf
