### PR TITLE
acquisition test selector typo fix

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,7 +13,7 @@ define([
     viewLog,
     alwaysAsk,
     askFourEarning,
-    acquisitionsEpicLivelog
+    acquisitionsEpicLiveBlog
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
@@ -21,7 +21,7 @@ define([
     var tests = [
         alwaysAsk,
         askFourEarning,
-        acquisitionsEpicLivelog
+        acquisitionsEpicLiveBlog
     ];
 
     var epicEngagementBannerTests = reduce(tests, function(out, test) {


### PR DESCRIPTION
cc @joelochlann 

## What does this change?

Fixes a typo for a variable name.