### PR TITLE
extends acquisition tests whose expiry dates fall on bank holiday Monday

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -45,7 +45,7 @@ trait ABTestSwitches {
     "Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 1),
+    sellByDate = new LocalDate(2017, 6, 1),
     exposeClientSide = true
   )
 
@@ -55,7 +55,7 @@ trait ABTestSwitches {
     "This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 1),
+    sellByDate = new LocalDate(2017, 6, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -30,7 +30,7 @@ define([
         campaignId: 'epic_always_ask_strategy',
 
         start: '2016-12-06',
-        expiry: '2017-05-01',
+        expiry: '2017-06-01',
 
         author: 'Guy Dawson',
         description: 'Test to assess the effects of always asking readers to contribute via the Epic over a prolonged period.',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -18,7 +18,7 @@ define([
         campaignId: 'kr1_epic_ask_four_earning',
 
         start: '2017-01-24',
-        expiry: '2017-05-01',
+        expiry: '2017-06-01',
 
         author: 'Jonathan Rankin',
         description: 'This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days',
@@ -47,7 +47,7 @@ define([
                                 contributionUrl: variant.contributeURL,
                                 componentName: variant.componentName
                             });
-                        });                    
+                        });
                     });
                 },
                 insertBeforeSelector: '.submeta',


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Extends acquisitions tests whose expiry dates fall on bank holiday Monday.

## What is the value of this and can you measure success?

Avoids front-end build complications. Allows us to gather more data and make more money.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No
