### PR TITLE
Adding a placeholder element for AMP

### DIFF
--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -198,11 +198,13 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
           val linkToInteractive = link.first().attr("href")
           val iframe = document.createElement("amp-iframe")
           val overflowElem = document.createElement("div")
+          val placeholderElem = document.createElement("amp-img")
+
           // In AMP, when using the layout `responsive`, width is 100%,
           // and height is decided by the ratio between width and height.
           // https://www.ampproject.org/docs/guides/responsive/control_layout.html
           iframe.attr("width", "5")
-          iframe.attr("height", "1")
+          iframe.attr("height", "3")
           iframe.attr("layout", "responsive")
           iframe.attr("resizable", "")
           iframe.attr("sandbox", "allow-scripts allow-same-origin")
@@ -213,8 +215,16 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
           overflowElem.addClass("cta cta--medium cta--show-more cta--show-more__unindent")
           overflowElem.text("See the full visual")
           overflowElem.attr("overflow", "")
-          overflowElem.attr("placeholder", "")
+
+          // This placeholder element will only show if the interactive is a main media, and then be replaced
+          // as the interactive loads. In this case the LinkToInteractive is not an image so nothing will load,
+          // but we need an https resource here, because the src cannot be empty
+          placeholderElem.attr("layout", "fill")
+          placeholderElem.attr("src", linkToInteractive)
+          placeholderElem.attr("placeholder", "")
+
           link.remove()
+          iframe.appendChild(placeholderElem)
           iframe.appendChild(overflowElem)
           interactive.appendChild(iframe)
         } else {


### PR DESCRIPTION
## What does this change?
This adds a placeholder element for interactive embeds. This is needed to make sure pages are still valid AMP when an embed is used as the main media.

cc @Jholder112233 @stephanfowler 

## What is the value of this and can you measure success?
Less invalid AMP pages, hopefully more exposure for those pages in the AMP carousal in Google search.

## Does this affect other platforms - Amp, Apps, etc?
This is AMP specific

## Screenshots
The placeholder actually shows nothing, its just to pass validation.

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
