### PR TITLE
Disable branding for paid cards

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -210,7 +210,7 @@ object FaciaCard {
   ): FaciaCard = {
 
     val containerName: Option[String] = config.displayName
-    if (faciaContent.branding(defaultEdition).exists(_.isPaid)) {
+    if ((containerName.contains("Paid content in unbranded container") || containerName.contains("lifestyle")) && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
       PaidCard.fromPressedContent(faciaContent, Some(cardTypes))
     } else {
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -209,50 +209,46 @@ object FaciaCard {
     showSeriesAndBlogKickers: Boolean
   ): FaciaCard = {
 
-    if (false && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
-      PaidCard.fromPressedContent(faciaContent, Some(cardTypes))
-    } else {
 
-      val maybeKicker = faciaContent.header.kicker orElse {
-        if (showSeriesAndBlogKickers) {
-          faciaContent.header.seriesOrBlogKicker
-        } else {
-          None
-        }
+    val maybeKicker = faciaContent.header.kicker orElse {
+      if (showSeriesAndBlogKickers) {
+        faciaContent.header.seriesOrBlogKicker
+      } else {
+        None
       }
-
-      /** If the kicker contains the byline, don't display it */
-      val suppressByline = (
-                             for {
-                               kicker <- maybeKicker
-                               kickerText <- kicker.properties.kickerText
-                               byline <- faciaContent.properties.byline
-                             } yield kickerText contains byline
-                             ) getOrElse false
-
-      ContentCard(
-        faciaContent.properties.maybeContentId.orElse(Option(faciaContent.card.id)),
-        FaciaCardHeader.fromTrailAndKicker(faciaContent, maybeKicker, Some(config)),
-        getByline(faciaContent).filterNot(Function.const(suppressByline)),
-        FaciaDisplayElement.fromFaciaContentAndCardType(faciaContent, cardTypes),
-        CutOut.fromTrail(faciaContent),
-        faciaContent.card.cardStyle,
-        cardTypes,
-        Sublinks.takeSublinks(faciaContent.supporting, cardTypes).map(Sublink.fromFaciaContent),
-        faciaContent.card.starRating,
-        DiscussionSettings.fromTrail(faciaContent),
-        SnapStuff.fromTrail(faciaContent),
-        faciaContent.card.webPublicationDateOption.filterNot(const(faciaContent.shouldHidePublicationDate)),
-        faciaContent.card.trailText,
-        faciaContent.card.mediaType,
-        DisplaySettings.fromTrail(faciaContent),
-        faciaContent.card.isLive,
-        if (config.showTimestamps) Option(DateTimestamp) else None,
-        faciaContent.card.shortUrlPath,
-        useShortByline = false,
-        faciaContent.card.group
-      )
     }
+
+    /** If the kicker contains the byline, don't display it */
+    val suppressByline = (
+                           for {
+                             kicker <- maybeKicker
+                             kickerText <- kicker.properties.kickerText
+                             byline <- faciaContent.properties.byline
+                           } yield kickerText contains byline
+                           ) getOrElse false
+
+    ContentCard(
+      faciaContent.properties.maybeContentId.orElse(Option(faciaContent.card.id)),
+      FaciaCardHeader.fromTrailAndKicker(faciaContent, maybeKicker, Some(config)),
+      getByline(faciaContent).filterNot(Function.const(suppressByline)),
+      FaciaDisplayElement.fromFaciaContentAndCardType(faciaContent, cardTypes),
+      CutOut.fromTrail(faciaContent),
+      faciaContent.card.cardStyle,
+      cardTypes,
+      Sublinks.takeSublinks(faciaContent.supporting, cardTypes).map(Sublink.fromFaciaContent),
+      faciaContent.card.starRating,
+      DiscussionSettings.fromTrail(faciaContent),
+      SnapStuff.fromTrail(faciaContent),
+      faciaContent.card.webPublicationDateOption.filterNot(const(faciaContent.shouldHidePublicationDate)),
+      faciaContent.card.trailText,
+      faciaContent.card.mediaType,
+      DisplaySettings.fromTrail(faciaContent),
+      faciaContent.card.isLive,
+      if (config.showTimestamps) Option(DateTimestamp) else None,
+      faciaContent.card.shortUrlPath,
+      useShortByline = false,
+      faciaContent.card.group
+    )
   }
 }
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -209,8 +209,7 @@ object FaciaCard {
     showSeriesAndBlogKickers: Boolean
   ): FaciaCard = {
 
-    val containerName: Option[String] = config.displayName
-    if ((containerName.contains("Paid content in unbranded container") || containerName.contains("lifestyle")) && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
+    if (false && faciaContent.branding(defaultEdition).exists(_.isPaid)) {
       PaidCard.fromPressedContent(faciaContent, Some(cardTypes))
     } else {
 


### PR DESCRIPTION
## What does this change?
Switch off branding for paid cards in editorial containers, as they are appearing on tag pages when they shouldn't.

Will re-enable when we've figured out a sensible way to exclude these pages.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/6290008/25486962/b299750c-2b5a-11e7-972c-b91186bd8035.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
