### PR TITLE
[WIP] Interactive atoms do work in AMP!

### DIFF
--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -7,7 +7,7 @@
     model match {
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, ShareLinkMeta(Nil, Nil))
         case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
-        case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
+        case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence, isAmp = amp)
         case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp)
         case _ =>
     }

--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -2,7 +2,7 @@
 @import model.content.InteractiveAtom
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
 
-@(interactive: InteractiveAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
+@(interactive: InteractiveAtom, shouldFence: Boolean, isAmp: Boolean)(implicit context: model.ApplicationContext)
 
 @iframeBody = {
     <!DOCTYPE html>
@@ -33,7 +33,26 @@
 }
 
 @if(shouldFence) {
-    <iframe class="interactive-atom-fence" srcdoc="@iframeBody.toString"></iframe>
+    @if(isAmp) {
+        <amp-iframe class="interactive-atom-fence"
+                    srcdoc="@iframeBody.toString"
+                    layout="responsive"
+                    sandbox="allow-scripts allow-popups"
+                    width="500"
+                    height="200"
+                    resizable
+                    placeholder="">
+            <div class="cta cta--medium cta--show-more cta--show-more__unindent"
+                 overflow
+                 tabindex=0
+                 role=button
+                 aria-label="See the full visual">
+                See the full visual
+            </div>
+        </amp-iframe>
+    } else {
+        <iframe class="interactive-atom-fence" srcdoc="@iframeBody.toString"></iframe>
+    }
 } else {
     <figure class="interactive interactive-atom">
         <style>


### PR DESCRIPTION
## What does this change?
This PR demonstrates how Interactive atoms could work in amp.

Caveats:
- Only "fenced" (iframed) interactive atoms can be used in AMP
- Atoms use srcdoc, and that means we can't make cross origin requests from within the iframe

Blockers for this PR
- The iframe needs to make a resize request as specified here: https://github.com/ampproject/amphtml/blob/master/extensions/amp-iframe/amp-iframe.md#iframe-resizing. @Jholder112233 is it possible for every interactive atom to have this resize request, or are they all just completely different? 

Things we might want to add to this PR:
- Do we need a placeholder element for this? (The answer is yes if we want the main media to be an interactive atom)


cc @stephanfowler @Jholder112233 @gustavpursche @TBonnin 

## What is the value of this and can you measure success?
Less invalid AMP pages. Those pages can show up in the AMP carousal

## Does this affect other platforms - Amp, Apps, etc?
This only affects AMP

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
