### PR TITLE
Content meta explore template rewrite

### DIFF
--- a/article/app/views/fragments/articleBodyExplore.scala.html
+++ b/article/app/views/fragments/articleBodyExplore.scala.html
@@ -43,7 +43,12 @@
             <div class="content__main">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column">
-                        @fragments.contentMeta(article, model)
+
+                        <div class="content__meta-container--explore u-cf">
+                            <div class="meta__social" data-component="share">
+                                @fragments.social(article.sharelinks.pageShares, "top")
+                            </div>
+                        </div>
 
                         <div class="content__article-body from-content-api js-article__body" itemprop="articleBody">
                             @BodyCleaner(article, article.fields.body, amp = amp)

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -27,7 +27,7 @@
             @if(item.content.tags.tags.exists(_.id == "tone/news")) {
                 @fragments.contentAgeNotice(ageNotice)
             }
-            @if(!item.content.isExplore & !amp) {
+            @if(!amp) {
                 <div class="meta__numbers">
                     <div class="u-h meta__number js-sharecount">
                     </div>
@@ -46,7 +46,7 @@
         </div>
     }
 
-    @if(!item.content.isGallery && !item.content.isExplore) {
+    @if(!item.content.isGallery) {
         @if(!item.content.hasTonalHeaderByline) {
             @byline()
         }
@@ -72,7 +72,6 @@
     @if(item.elements.hasShowcaseMainElement){ content__meta-container--showcase}
     @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
     @item.content.contributorBio.map { bio => content__meta-container--bio}
-    @if(item.content.isExplore) {content__meta-container--explore}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">
 

--- a/static/src/stylesheets/inline/article-explore.scss
+++ b/static/src/stylesheets/inline/article-explore.scss
@@ -416,22 +416,6 @@ $explore-series-header-element-opacity: .85;
     }
 }
 
-.content__meta-container--explore {
-    margin: 7px;
-    border: 0;
-
-    .meta__social {
-        border-top: 1px dotted $neutral-4;
-    }
-
-    @include mq($from: desktop) {
-        position: absolute;
-        margin-left: 0;
-        margin-right: -240px;
-        right: 0;
-    }
-}
-
 .content__article-body {
     figure {
         //these styles need to overide the styles coming from Layout Hint
@@ -519,5 +503,25 @@ $explore-series-header-element-opacity: .85;
 
     @include mq($from: desktop) {
         width: 980px;
+    }
+}
+
+.content__meta-container--explore {
+    margin: 7px;
+    border-top: 1px dotted $neutral-4;
+
+    @include mq($until: leftCol) {
+        border-bottom: 1px dotted $neutral-4;
+    }
+
+    @include mq($from: desktop) {
+        position: absolute;
+        margin-left: 0;
+        margin-right: -240px;
+        right: 0;
+    }
+
+    @include mq($from: wide) {
+        width: $left-column-wide;
     }
 }


### PR DESCRIPTION
## What does this change?
Given that the explore template is very different than our others, it doesn't really make sense that it has a shared template just excluded most of it.

This is just cleans it up a bit

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?
Nope. These pages are not Ampified

## Screenshots
Looks the same, except I took away the double line here:
![image](https://cloud.githubusercontent.com/assets/8774970/25532174/3e43dbd2-2c24-11e7-829f-cd1be06dae5b.png)


so it looks like this:

![image](https://cloud.githubusercontent.com/assets/8774970/25532177/45a11886-2c24-11e7-85c5-c7bb14d09c4f.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
