### PR TITLE
Adding temp hack for interactives and crosswords to keep the padding

### DIFF
--- a/common/app/views/fragments/headDefault.scala.html
+++ b/common/app/views/fragments/headDefault.scala.html
@@ -1,6 +1,6 @@
 @(item: model.ContentType, page: model.Page, showBadge: Boolean = false)(implicit request: RequestHeader)
 
-<header class="content__head u-cf">
+<header class="content__head @if(item.tags.isInteractive) {content__head--interactive} u-cf">
     <div class="gs-container">
         <div class="content__main-column">
 

--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -4,7 +4,12 @@
 
 // When the image is at the top of the article, the headline and byline are moved into a div with margins. This counteracts that
 // TODO: If this change is kept after the test the template will have to be rewriten and these overrides won't be needed
-.content__head:not(.tonal__head--tone-dead, .tonal__head--tone-live, .tonal__head--tone-media) {
+.content__head:not(.tonal__head--tone-dead,
+    .tonal__head--tone-live,
+    .tonal__head--tone-media,
+    .content__head--crossword,
+    .content__head--interactive) {
+
     @include mq($until: mobileLandscape) {
         margin-right: -$gs-gutter / 2;
         margin-left: -$gs-gutter / 2;


### PR DESCRIPTION
## What does this change?
Name says it all

## What is the value of this and can you measure success?
Less visual bugs

## Does this affect other platforms - Amp, Apps, etc?
Nope 

## Screenshots
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/25533621/1fcc9dce-2c29-11e7-91ce-a5a6a043ff4c.png)

![image](https://cloud.githubusercontent.com/assets/8774970/25533637/2b3b407a-2c29-11e7-80f7-1e4cc03942e1.png)


After:
![image](https://cloud.githubusercontent.com/assets/8774970/25533589/0c4e58c8-2c29-11e7-8567-4c8a6f7044c9.png)

![image](https://cloud.githubusercontent.com/assets/8774970/25533601/171d3eea-2c29-11e7-8ad4-e89bb955cfcd.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
