### PR TITLE
Epic testimonials

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -185,7 +185,7 @@ trait ABTestSwitches {
     "ab-acquisitions-epic-testimonials",
     "Test placing reader testimonials in the Epic",
     owners = Seq(Owner.withGithub("Mullefa")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2017, 5, 4),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -180,4 +180,16 @@ trait ABTestSwitches {
   )
 
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-testimonials",
+    "Test placing reader testimonials in the Epic",
+    owners = Seq(
+      Owner.withGithub("Mullefa"),
+      Owner.withGithub("joelochlann")
+    ),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 5, 4),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -184,11 +184,8 @@ trait ABTestSwitches {
     ABTests,
     "ab-acquisitions-epic-testimonials",
     "Test placing reader testimonials in the Epic",
-    owners = Seq(
-      Owner.withGithub("Mullefa"),
-      Owner.withGithub("joelochlann")
-    ),
-    safeState = On,
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = Off,
     sellByDate = new LocalDate(2017, 5, 4),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -186,7 +186,7 @@ trait ABTestSwitches {
     "Test placing reader testimonials in the Epic",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 5, 4),
+    sellByDate = new LocalDate(2017, 5, 10),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/acquisition-test-selector.js
@@ -5,7 +5,8 @@ define([
     'common/modules/commercial/acquisitions-view-log',
     'common/modules/experiments/tests/contributions-epic-always-ask-strategy',
     'common/modules/experiments/tests/contributions-epic-ask-four-earning',
-    'common/modules/experiments/tests/acquisitions-epic-liveblog'
+    'common/modules/experiments/tests/acquisitions-epic-liveblog',
+    'common/modules/experiments/tests/acquisitions-epic-testimonials'
 ], function (
     reduce,
     segmentUtil,
@@ -13,12 +14,14 @@ define([
     viewLog,
     alwaysAsk,
     askFourEarning,
-    acquisitionsEpicLiveBlog
+    acquisitionsEpicLiveBlog,
+    acquisitionsEpicTestimonials
 ) {
     /**
      * acquisition tests in priority order (highest to lowest)
      */
     var tests = [
+        acquisitionsEpicTestimonials,
         alwaysAsk,
         askFourEarning,
         acquisitionsEpicLiveBlog

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -1,12 +1,26 @@
 define([
     'lodash/utilities/template',
     'common/modules/commercial/contributions-utilities',
-    'raw-loader!common/views/acquisitions-epic-testimonials-prominent.html'
+    'raw-loader!common/views/acquisitions-epic-testimonials-prominent.html',
+    'raw-loader!common/views/acquisitions-epic-testimonials-subtle.html',
+    'raw-loader!common/views/acquisitions-epic-testimonials-testimonial-only.html'
 ], function (
     template,
     contributionsUtilities,
-    acquisitionsEpicTestimonialsProminent
+    acquisitionsEpicTestimonialsProminent,
+    acquisitionsEpicTestimonialsSubtle,
+    acquisitionsEpicTestimonialsOnly
 ) {
+
+    function createVariantTemplate(epicTemplate) {
+        return function(variant) {
+            return template(epicTemplate, {
+                membershipUrl: variant.membershipURL,
+                contributionUrl: variant.contributeURL,
+                componentName: variant.componentName
+            })
+        }
+    }
 
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicTestimonials',
@@ -21,10 +35,8 @@ define([
         idealOutcome: 'We are able to determine which testimonial design is the best',
 
         audienceCriteria: 'All',
-        // TODO: confirm
         audience: 0.9,
         audienceOffset: 0,
-        // END TODO
 
         variants: [
             {
@@ -32,16 +44,15 @@ define([
             },
             {
                 id: 'prominent',
-                template: function (variant) {
-                    return template(acquisitionsEpicTestimonialsProminent, {
-                        membershipUrl: variant.membershipURL,
-                        contributionUrl: variant.contributeURL,
-                        componentName: variant.componentName
-                    });
-                }
+                template: createVariantTemplate(acquisitionsEpicTestimonialsProminent)
             },
             {
-                id: 'subtle'
+                id: 'subtle',
+                template: createVariantTemplate(acquisitionsEpicTestimonialsSubtle)
+            },
+            {
+                id: 'testimonial_only',
+                template: createVariantTemplate(acquisitionsEpicTestimonialsOnly)
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -26,8 +26,8 @@ define([
         id: 'AcquisitionsEpicTestimonials',
         campaignId: 'kr1_epic_testimonials',
 
-        start: '2017-04-28',
-        expiry: '2017-05-03',
+        start: '2017-05-02',
+        expiry: '2017-05-10', // Wednesday
 
         author: 'Guy Dawson',
         description: 'Test placing reader testimonials in the Epic',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -26,10 +26,10 @@ define([
         id: 'AcquisitionsEpicTestimonials',
         campaignId: 'kr1_epic_testimonials',
 
-        start: '2017-04-27',
+        start: '2017-04-28',
         expiry: '2017-05-03',
 
-        author: 'Guy Dawson and Joe Smith',
+        author: 'Guy Dawson',
         description: 'Test placing reader testimonials in the Epic',
         successMeasure: 'Conversion rate',
         idealOutcome: 'We are able to determine which testimonial design is the best',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -1,0 +1,48 @@
+define([
+    'lodash/utilities/template',
+    'common/modules/commercial/contributions-utilities',
+    'raw-loader!common/views/acquisitions-epic-testimonials-prominent.html'
+], function (
+    template,
+    contributionsUtilities,
+    acquisitionsEpicTestimonialsProminent
+) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicTestimonials',
+        campaignId: 'kr1_epic_testimonials',
+
+        start: '2017-04-27',
+        expiry: '2017-05-03',
+
+        author: 'Guy Dawson and Joe Smith',
+        description: 'Test placing reader testimonials in the Epic',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'We are able to determine which testimonial design is the best',
+
+        audienceCriteria: 'All',
+        // TODO: confirm
+        audience: 0.9,
+        audienceOffset: 0,
+        // END TODO
+
+        variants: [
+            {
+                id: 'control'
+            },
+            {
+                id: 'prominent',
+                template: function (variant) {
+                    return template(acquisitionsEpicTestimonialsProminent, {
+                        membershipUrl: variant.membershipURL,
+                        contributionUrl: variant.contributeURL,
+                        componentName: variant.componentName
+                    });
+                }
+            },
+            {
+                id: 'subtle'
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -29,7 +29,7 @@ define([
         id: 'AcquisitionsEpicTestimonials',
         campaignId: 'kr1_epic_testimonials',
 
-        start: '2017-05-02',
+        start: '2017-05-03',
         expiry: '2017-05-10', // Wednesday
 
         author: 'Guy Dawson',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-testimonials.js
@@ -3,13 +3,15 @@ define([
     'common/modules/commercial/contributions-utilities',
     'raw-loader!common/views/acquisitions-epic-testimonials-prominent.html',
     'raw-loader!common/views/acquisitions-epic-testimonials-subtle.html',
-    'raw-loader!common/views/acquisitions-epic-testimonials-testimonial-only.html'
+    'raw-loader!common/views/acquisitions-epic-testimonials-testimonial-only.html',
+    'svg-loader!svgs/icon/quote.svg'
 ], function (
     template,
     contributionsUtilities,
     acquisitionsEpicTestimonialsProminent,
     acquisitionsEpicTestimonialsSubtle,
-    acquisitionsEpicTestimonialsOnly
+    acquisitionsEpicTestimonialsOnly,
+    quoteSvg
 ) {
 
     function createVariantTemplate(epicTemplate) {
@@ -17,7 +19,8 @@ define([
             return template(epicTemplate, {
                 membershipUrl: variant.membershipURL,
                 contributionUrl: variant.contributeURL,
-                componentName: variant.componentName
+                componentName: variant.componentName,
+                quoteSvg: quoteSvg.markup
             })
         }
     }

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -3,16 +3,16 @@
         <h2 class="contributions__title contributions__title--epic">
             Why readers support us &hellip;
         </h2>
-        <div class="epic__testimonial__container">
-            <div class="epic__testimonial__quote">
+        <div class="epic__testimonial-container">
+            <div class="epic__testimonial-quote">
                 <%=quoteSvg%>
             </div>
-            <blockquote class="epic__testimonial__text">
+            <blockquote class="epic__testimonial-text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
                 <br>
-                <cite class="epic__testimonial__name">
+                <cite class="epic__testimonial-name">
                     Mike L
                 </cite>
             </blockquote>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -1,7 +1,7 @@
 <div class="contributions__epic" data-component="<%=componentName%>">
     <div>
         <h2 class="contributions__title contributions__title--epic">
-            Why our readers are supporting us:
+            Why readers support us &hellip;
         </h2>
         <div class="epic__testimonial__container">
             <div class="epic__testimonial__quote">

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -11,7 +11,7 @@
             </p>
         </div>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+            More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -1,0 +1,40 @@
+<div class="contributions__epic" data-component="<%=componentName%>">
+
+    <div>
+        <p>
+            I read it fairly often and enjoy the variety of news and entertainment content.
+            It never occurred to me that you wanted contributions, but I'd like you to stick around.
+            Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
+        </p>
+    </div>
+
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Why our readers are supporting us:
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+        </p>
+    </div>
+
+    <div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
+               href="<%=membershipUrl%>"
+               target="_blank">
+                Become a supporter
+            </a>
+        </div>
+
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+               href="<%=contributionUrl%>"
+               target="_blank">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -4,12 +4,15 @@
             Why our readers are supporting us:
         </h2>
         <div class="epic__testimonial__container">
+            <div class="epic__testimonial__quote">
+                <%=quoteSvg%>
+            </div>
             <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
             </blockquote>
-            <cite class="epic__testimonial__name">
+            <cite class="epic__testimonial__text epic__testimonial__name">
                 Mike L
             </cite>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -4,10 +4,13 @@
             Why our readers are supporting us:
         </h2>
         <div class="epic__testimonial__container">
-            <p class="epic__testimonial__text epic__testimonial__text--prominent">
+            <p class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
-                Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
+                Sometimes you actually have to pay for stuff you like. Go figure.
+            </p>
+            <p class="epic__testimonial__name">
+                Mike L
             </p>
         </div>
         <p class="contributions__paragraph contributions__paragraph--epic">

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -3,8 +3,8 @@
         <h2 class="contributions__title contributions__title--epic">
             Why our readers are supporting us:
         </h2>
-        <div class="epic__testimonial__container--prominent">
-            <p class="epic__testimonial__text--prominent">
+        <div class="epic__testimonial__container">
+            <p class="epic__testimonial__text epic__testimonial__text--prominent">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure. - Mike L

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -4,14 +4,14 @@
             Why our readers are supporting us:
         </h2>
         <div class="epic__testimonial__container">
-            <p class="epic__testimonial__text">
+            <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
-            </p>
-            <p class="epic__testimonial__name">
+            </blockquote>
+            <cite class="epic__testimonial__name">
                 Mike L
-            </p>
+            </cite>
         </div>
         <p class="contributions__paragraph contributions__paragraph--epic">
             More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
@@ -25,7 +25,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
                href="<%=membershipUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Become a supporter
             </a>
         </div>
@@ -33,7 +34,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
                href="<%=contributionUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Make a contribution
             </a>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -11,10 +11,12 @@
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
+                <br>
+                <cite class="epic__testimonial__name">
+                    Mike L
+                </cite>
             </blockquote>
-            <cite class="epic__testimonial__text epic__testimonial__name">
-                Mike L
-            </cite>
+
         </div>
         <p class="contributions__paragraph contributions__paragraph--epic">
             More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-prominent.html
@@ -1,17 +1,15 @@
 <div class="contributions__epic" data-component="<%=componentName%>">
-
-    <div>
-        <p>
-            I read it fairly often and enjoy the variety of news and entertainment content.
-            It never occurred to me that you wanted contributions, but I'd like you to stick around.
-            Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
-        </p>
-    </div>
-
     <div>
         <h2 class="contributions__title contributions__title--epic">
             Why our readers are supporting us:
         </h2>
+        <div class="epic__testimonial__container--prominent">
+            <p class="epic__testimonial__text--prominent">
+                I read it fairly often and enjoy the variety of news and entertainment content.
+                It never occurred to me that you wanted contributions, but I'd like you to stick around.
+                Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
+            </p>
+        </div>
         <p class="contributions__paragraph contributions__paragraph--epic">
             … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -15,10 +15,11 @@
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
+                <br>
+                <cite class="epic__testimonial__name">
+                    Mike L
+                </cite>
             </blockquote>
-            <cite class="epic__testimonial__text epic__testimonial__name">
-                Mike L
-            </cite>
         </div>
 
         <p class="contributions__paragraph contributions__paragraph--epic">

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -1,19 +1,22 @@
 <div class="contributions__epic" data-component="<%=componentName%>">
     <div>
         <h2 class="contributions__title contributions__title--epic">
-            Since you’re here …
+            Since you’re here &hellip;
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+            &hellip; we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
 
         <div class="epic__testimonial__container epic__testimonial__container--subtle">
+            <div class="epic__testimonial__quote epic__testimonial__quote--subtle">
+                <%=quoteSvg%>
+            </div>
             <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
             </blockquote>
-            <cite class="epic__testimonial__name">
+            <cite class="epic__testimonial__text epic__testimonial__name">
                 Mike L
             </cite>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -8,14 +8,14 @@
         </p>
 
         <div class="epic__testimonial__container epic__testimonial__container--subtle">
-            <p class="epic__testimonial__text">
+            <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
-            </p>
-            <p class="epic__testimonial__name">
+            </blockquote>
+            <cite class="epic__testimonial__name">
                 Mike L
-            </p>
+            </cite>
         </div>
 
         <p class="contributions__paragraph contributions__paragraph--epic">
@@ -27,7 +27,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
                href="<%=membershipUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Become a supporter
             </a>
         </div>
@@ -35,7 +36,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
                href="<%=contributionUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Make a contribution
             </a>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -7,11 +7,13 @@
             … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
 
-        <p>
-            I read it fairly often and enjoy the variety of news and entertainment content.
-            It never occurred to me that you wanted contributions, but I'd like you to stick around.
-            Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
-        </p>
+        <div class="epic__testimonial__container">
+            <p class="epic__testimonial__text">
+                I read it fairly often and enjoy the variety of news and entertainment content.
+                It never occurred to me that you wanted contributions, but I'd like you to stick around.
+                Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
+            </p>
+        </div>
 
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -1,0 +1,31 @@
+<div class="contributions__epic" data-component="<%=componentName%>">
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Since you’re here …
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+        </p>
+    </div>
+
+    <div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
+               href="<%=membershipUrl%>"
+               target="_blank">
+                Become a supporter
+            </a>
+        </div>
+
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+               href="<%=contributionUrl%>"
+               target="_blank">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -7,7 +7,7 @@
             … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
 
-        <div class="epic__testimonial__container">
+        <div class="epic__testimonial__container epic__testimonial__container--subtle">
             <p class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -11,7 +11,10 @@
             <p class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
-                Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
+                Sometimes you actually have to pay for stuff you like. Go figure.
+            </p>
+            <p class="epic__testimonial__name">
+                Mike L
             </p>
         </div>
 

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-subtle.html
@@ -7,16 +7,16 @@
             &hellip; we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
         </p>
 
-        <div class="epic__testimonial__container epic__testimonial__container--subtle">
-            <div class="epic__testimonial__quote epic__testimonial__quote--subtle">
+        <div class="epic__testimonial-container epic__testimonial-container--subtle">
+            <div class="epic__testimonial-quote epic__testimonial-quote--subtle">
                 <%=quoteSvg%>
             </div>
-            <blockquote class="epic__testimonial__text">
+            <blockquote class="epic__testimonial-text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
                 <br>
-                <cite class="epic__testimonial__name">
+                <cite class="epic__testimonial-name">
                     Mike L
                 </cite>
             </blockquote>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -12,10 +12,11 @@
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
+                <br>
+                <cite class="epic__testimonial__name epic__testimonial__name--testimonial-only">
+                    Mike L
+                </cite>
             </blockquote>
-            <cite class="epic__testimonial__text epic__testimonial__name epic__testimonial__name--testimonial-only">
-                Mike L
-            </cite>
         </div>
 
         <div class="epic__testimonial__info__container">

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -5,6 +5,7 @@
         </h2>
 
         <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">
+
             <p class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -1,20 +1,27 @@
-<div class="contributions__epic" data-component="<%=componentName%>">
+<div class="contributions__epic contributions__epic--subtle" data-component="<%=componentName%>">
     <div>
-        <h2 class="contributions__title contributions__title--epic">
+        <h2 class="contributions__title contributions__title--epic contributions__title--epic--subtle">
             Why our readers support us:
         </h2>
 
-        <p>
-            I read it fairly often and enjoy the variety of news and entertainment content.
-            It never occurred to me that you wanted contributions, but I'd like you to stick around.
-            Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
-        </p>
+        <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">
+            <p class="epic__testimonial__text">
+                I read it fairly often and enjoy the variety of news and entertainment content.
+                It never occurred to me that you wanted contributions, but I'd like you to stick around.
+                Sometimes you actually have to pay for stuff you like. Go figure.
+            </p>
+            <p class="epic__testimonial__name--testimonial-only">
+                Mike L
+            </p>
+        </div>
 
-        <p>
-            Our reporting takes a lot of time,
-            hard work and money to produce and is increasingly funded by readers like Mike.
-            Support the Guardian and help us keep our journalism open to everyone.
-        </p>
+        <div class="epic__testimonial__info__container">
+            <p class="epic__testimonial__info">
+                Our reporting takes a lot of time,
+                hard work and money to produce and is increasingly funded by readers like Mike.
+                Support the Guardian and help us keep our journalism open to everyone.
+            </p>
+        </div>
     </div>
 
     <div class="contributions__amount-field">

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -6,14 +6,14 @@
 
         <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">
 
-            <p class="epic__testimonial__text">
+            <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
-            </p>
-            <p class="epic__testimonial__name--testimonial-only">
+            </blockquote>
+            <cite class="epic__testimonial__name epic__testimonial__name--testimonial-only">
                 Mike L
-            </p>
+            </cite>
         </div>
 
         <div class="epic__testimonial__info__container">
@@ -29,7 +29,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
                href="<%=membershipUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Become a supporter
             </a>
         </div>
@@ -37,7 +38,8 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
                href="<%=contributionUrl%>"
-               target="_blank">
+               target="_blank"
+               rel="noopener noreferrer">
                 Make a contribution
             </a>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -4,23 +4,23 @@
             Why readers support us &hellip;
         </h2>
 
-        <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">
-            <div class="epic__testimonial__quote">
+        <div class="epic__testimonial-container epic__testimonial-container--testimonial-only">
+            <div class="epic__testimonial-quote">
                 <%=quoteSvg%>
             </div>
-            <blockquote class="epic__testimonial__text">
+            <blockquote class="epic__testimonial-text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
                 <br>
-                <cite class="epic__testimonial__name epic__testimonial__name--testimonial-only">
+                <cite class="epic__testimonial-name epic__testimonial-name--testimonial-only">
                     Mike L
                 </cite>
             </blockquote>
         </div>
 
-        <div class="epic__testimonial__info__container">
-            <p class="epic__testimonial__info">
+        <div class="epic__testimonial-info-container">
+            <p class="epic__testimonial-info">
                 Our reporting takes a lot of time,
                 hard work and money to produce and is increasingly funded by readers like Mike.
                 Support the Guardian and help us keep our journalism open to everyone.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -5,13 +5,15 @@
         </h2>
 
         <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">
-
+            <div class="epic__testimonial__quote">
+                <%=quoteSvg%>
+            </div>
             <blockquote class="epic__testimonial__text">
                 I read it fairly often and enjoy the variety of news and entertainment content.
                 It never occurred to me that you wanted contributions, but I'd like you to stick around.
                 Sometimes you actually have to pay for stuff you like. Go figure.
             </blockquote>
-            <cite class="epic__testimonial__name epic__testimonial__name--testimonial-only">
+            <cite class="epic__testimonial__text epic__testimonial__name epic__testimonial__name--testimonial-only">
                 Mike L
             </cite>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -1,11 +1,8 @@
 <div class="contributions__epic" data-component="<%=componentName%>">
     <div>
         <h2 class="contributions__title contributions__title--epic">
-            Since you’re here …
+            Why our readers support us:
         </h2>
-        <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters – because it might well be your perspective, too.
-        </p>
 
         <p>
             I read it fairly often and enjoy the variety of news and entertainment content.
@@ -13,8 +10,10 @@
             Sometimes you actually have to pay for stuff you like. Go figure. - Mike L
         </p>
 
-        <p class="contributions__paragraph contributions__paragraph--epic">
-            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+        <p>
+            Our reporting takes a lot of time,
+            hard work and money to produce and is increasingly funded by readers like Mike.
+            Support the Guardian and help us keep our journalism open to everyone.
         </p>
     </div>
 

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials-testimonial-only.html
@@ -1,7 +1,7 @@
 <div class="contributions__epic contributions__epic--subtle" data-component="<%=componentName%>">
     <div>
         <h2 class="contributions__title contributions__title--epic contributions__title--epic--subtle">
-            Why our readers support us:
+            Why readers support us &hellip;
         </h2>
 
         <div class="epic__testimonial__container epic__testimonial__container--testimonial-only">

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -27,4 +27,5 @@
 @import 'module/experiments/embed';
 @import 'module/experiments/svg';
 @import 'module/experiments/_ab-acquisitions-love-boat';
+@import 'module/experiments/_acquisitions-epic-testimonials';
 

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -7,18 +7,28 @@
 .epic__testimonial__container {
     margin-top: $gs-gutter;
     margin-bottom: $gs-gutter;
+}
 
-    padding-left: 2 * $gs-gutter;
+.epic__testimonial__quote {
+    position: relative;
+}
 
-    background-repeat: no-repeat;
-    background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="17" height="10" stroke="#ffbb00" fill="#ffbb00" viewBox="0 0 33 20"><path d="M9.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553C4.064 2.97 7.414.937 11.003 1l-1-1C3.98 0 .098 4.447.002 10.006c-.097 5.557 3.35 9.892 9 9.994zM26.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553.063-3.53 3.413-5.563 7.002-5.5l-1-1c-6.022 0-9.904 4.447-10 10.006-.097 5.557 3.35 9.892 9 9.994z"/></svg>');
-    background-size: 30px 30px;
+.epic__testimonial__quote span {
+    position: absolute;
+}
+
+.epic__testimonial__quote svg {
+    fill: #ffbb00;
+    stroke: #ffbb00;
+    width: 1.5 * $gs-gutter;
+    height: 1.5 * $gs-gutter;
 }
 
 .epic__testimonial__text {
     margin-bottom: 0;
     font-family: $f-sans-serif-text;
     font-style: italic;
+    padding-left: 2 * $gs-gutter;
 }
 
 .epic__testimonial__name {
@@ -33,8 +43,9 @@
 
 // Variant 3 - subtle
 
-.epic__testimonial__container--subtle {
-    background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="17" height="10" stroke="#bdbdbd" fill="#bdbdbd" viewBox="0 0 33 20"><path d="M9.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553C4.064 2.97 7.414.937 11.003 1l-1-1C3.98 0 .098 4.447.002 10.006c-.097 5.557 3.35 9.892 9 9.994zM26.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553.063-3.53 3.413-5.563 7.002-5.5l-1-1c-6.022 0-9.904 4.447-10 10.006-.097 5.557 3.35 9.892 9 9.994z"/></svg>');
+.epic__testimonial__quote--subtle svg {
+    fill: #bdbdbd;
+    stroke: #bdbdbd;
 }
 
 // Variant 4 - testimonial only
@@ -42,9 +53,6 @@
 .epic__testimonial__container--testimonial-only {
     margin-top: $gs-gutter;
     margin-bottom: $gs-gutter / 2;
-
-    padding-left: 0;
-    padding-top: $gs-gutter * 1.5;
 }
 
 .epic__testimonial__name--testimonial-only {

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,4 +1,4 @@
-@import "svg";
+@import 'svg';
 
 // CSS used for the Epic testimonials test
 
@@ -16,8 +16,15 @@
 }
 
 .epic__testimonial__text {
+    margin-bottom: 0;
+    font-family: $f-sans-serif-text;
     font-style: italic;
 }
+
+.epic__testimonial__name {
+    font-family: $f-sans-serif-text;
+}
+
 
 // Variant 1 - control
 
@@ -63,9 +70,9 @@
 }
 
 .contributions__title--epic--subtle {
+    @include fs-header(3);
     display: inline;
     border-top: 1px solid $multimedia-main-2;
-    @include fs-header(3);
     padding-top: $gs-baseline / 3;
 }
 

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,0 +1,15 @@
+// CSS used for the Epic testimonials test
+
+
+// Variant 1 - control
+
+// Variant 2 - prominent
+
+.epic__testimonial__container--prominent {
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+//.epic__testimonial__text--prominent {
+//    font-style: italic;
+//}

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,3 +1,5 @@
+@import "svg";
+
 // CSS used for the Epic testimonials test
 
 // Common classes
@@ -5,6 +7,12 @@
 .epic__testimonial__container {
     margin-top: 20px;
     margin-bottom: 20px;
+
+    padding-left: 40px;
+
+    background-repeat: no-repeat;
+    background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="17" height="10" stroke="#ffbb00" fill="#ffbb00" viewBox="0 0 33 20"><path d="M9.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553C4.064 2.97 7.414.937 11.003 1l-1-1C3.98 0 .098 4.447.002 10.006c-.097 5.557 3.35 9.892 9 9.994zM26.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553.063-3.53 3.413-5.563 7.002-5.5l-1-1c-6.022 0-9.904 4.447-10 10.006-.097 5.557 3.35 9.892 9 9.994z"/></svg>');
+    background-size: 30px 30px;
 }
 
 .epic__testimonial__text {
@@ -17,10 +25,18 @@
 
 // Variant 3 - subtle
 
+.epic__testimonial__container--subtle {
+    background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="17" height="10" stroke="#bdbdbd" fill="#bdbdbd" viewBox="0 0 33 20"><path d="M9.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553C4.064 2.97 7.414.937 11.003 1l-1-1C3.98 0 .098 4.447.002 10.006c-.097 5.557 3.35 9.892 9 9.994zM26.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553.063-3.53 3.413-5.563 7.002-5.5l-1-1c-6.022 0-9.904 4.447-10 10.006-.097 5.557 3.35 9.892 9 9.994z"/></svg>');
+}
+
 // Variant 4 - testimonial only
 
 .epic__testimonial__container--testimonial-only {
+    margin-top: 20px;
     margin-bottom: 10px;
+
+    padding-left: 0;
+    padding-top: 30px;
 }
 
 .epic__testimonial__name--testimonial-only {

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -2,33 +2,33 @@
 
 // Common classes
 
-.epic__testimonial__container {
+.epic__testimonial-container {
     margin-top: $gs-gutter;
     margin-bottom: $gs-gutter;
 }
 
-.epic__testimonial__quote {
+.epic__testimonial-quote {
     position: relative;
 }
 
-.epic__testimonial__quote span {
+.epic__testimonial-quote span {
     position: absolute;
 }
 
-.epic__testimonial__quote svg {
+.epic__testimonial-quote svg {
     fill: $multimedia-main-2;
     width: 1.5 * $gs-gutter;
     height: 1.5 * $gs-gutter;
 }
 
-.epic__testimonial__text {
+.epic__testimonial-text {
     margin-bottom: 0;
     font-family: $f-sans-serif-text;
     font-style: italic;
     padding-left: 2 * $gs-gutter;
 }
 
-.epic__testimonial__name {
+.epic__testimonial-name {
     font-family: $f-sans-serif-text;
     font-style: normal;
 }
@@ -40,27 +40,27 @@
 
 // Variant 3 - subtle
 
-.epic__testimonial__quote--subtle svg {
+.epic__testimonial-quote--subtle svg {
     fill: $neutral-3;
 }
 
 // Variant 4 - testimonial only
 
-.epic__testimonial__container--testimonial-only {
+.epic__testimonial-container--testimonial-only {
     margin-top: $gs-gutter;
     margin-bottom: $gs-gutter / 2;
 }
 
-.epic__testimonial__name--testimonial-only {
+.epic__testimonial-name--testimonial-only {
     margin-top: $gs-baseline;
 }
 
-.epic__testimonial__info__container {
+.epic__testimonial-info-container {
     margin-top: $gs-gutter / 2;
     margin-bottom: $gs-gutter / 2;
 }
 
-.epic__testimonial__info {
+.epic__testimonial-info {
     font-family: $f-sans-serif-text;
     font-size: 14px;
 }

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -63,6 +63,7 @@
 }
 
 .epic__testimonial__info {
+    font-family: $f-sans-serif-text;
     font-size: 14px;
 }
 

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,5 +1,3 @@
-@import 'svg';
-
 // CSS used for the Epic testimonials test
 
 // Common classes

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -1,15 +1,58 @@
 // CSS used for the Epic testimonials test
 
+// Common classes
+
+.epic__testimonial__container {
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.epic__testimonial__text {
+    font-style: italic;
+}
 
 // Variant 1 - control
 
 // Variant 2 - prominent
 
-.epic__testimonial__container--prominent {
-    margin-top: 20px;
-    margin-bottom: 20px;
+// Variant 3 - subtle
+
+// Variant 4 - testimonial only
+
+.epic__testimonial__container--testimonial-only {
+    margin-bottom: 10px;
 }
 
-//.epic__testimonial__text--prominent {
-//    font-style: italic;
-//}
+.epic__testimonial__name--testimonial-only {
+    margin-top: 13px;
+}
+
+.epic__testimonial__info__container {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.epic__testimonial__info {
+    font-size: 14px;
+}
+
+// Remaining classes taken from previous pull request
+
+.contributions__epic--subtle {
+    // Unset border top as it will be set for the inline header element
+    border-top: 0;
+    background-color: #ffffff;
+    margin-top: $gs-baseline * 4;
+    margin-bottom: $gs-baseline * 4;
+}
+
+.contributions__title--epic--subtle {
+    display: inline;
+    border-top: 1px solid $multimedia-main-2;
+    @include fs-header(3);
+    padding-top: $gs-baseline / 3;
+}
+
+.contributions__paragraph--subtle {
+    margin-top: 0;
+}

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -5,10 +5,10 @@
 // Common classes
 
 .epic__testimonial__container {
-    margin-top: 20px;
-    margin-bottom: 20px;
+    margin-top: $gs-gutter;
+    margin-bottom: $gs-gutter;
 
-    padding-left: 40px;
+    padding-left: 2 * $gs-gutter;
 
     background-repeat: no-repeat;
     background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="17" height="10" stroke="#ffbb00" fill="#ffbb00" viewBox="0 0 33 20"><path d="M9.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553C4.064 2.97 7.414.937 11.003 1l-1-1C3.98 0 .098 4.447.002 10.006c-.097 5.557 3.35 9.892 9 9.994zM26.002 20c3.85.068 6.932-3.104 7-6.994.068-3.892-3.15-6.937-7-7.006-2.016-.036-3.59.694-4.888 2.053-.07-.48-.122-1.04-.113-1.553.063-3.53 3.413-5.563 7.002-5.5l-1-1c-6.022 0-9.904 4.447-10 10.006-.097 5.557 3.35 9.892 9 9.994z"/></svg>');
@@ -23,6 +23,7 @@
 
 .epic__testimonial__name {
     font-family: $f-sans-serif-text;
+    font-style: normal;
 }
 
 
@@ -39,20 +40,20 @@
 // Variant 4 - testimonial only
 
 .epic__testimonial__container--testimonial-only {
-    margin-top: 20px;
-    margin-bottom: 10px;
+    margin-top: $gs-gutter;
+    margin-bottom: $gs-gutter / 2;
 
     padding-left: 0;
-    padding-top: 30px;
+    padding-top: $gs-gutter * 1.5;
 }
 
 .epic__testimonial__name--testimonial-only {
-    margin-top: 13px;
+    margin-top: $gs-baseline;
 }
 
 .epic__testimonial__info__container {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin-top: $gs-gutter / 2;
+    margin-bottom: $gs-gutter / 2;
 }
 
 .epic__testimonial__info {

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-testimonials.scss
@@ -16,8 +16,7 @@
 }
 
 .epic__testimonial__quote svg {
-    fill: #ffbb00;
-    stroke: #ffbb00;
+    fill: $multimedia-main-2;
     width: 1.5 * $gs-gutter;
     height: 1.5 * $gs-gutter;
 }
@@ -42,8 +41,7 @@
 // Variant 3 - subtle
 
 .epic__testimonial__quote--subtle svg {
-    fill: #bdbdbd;
-    stroke: #bdbdbd;
+    fill: $neutral-3;
 }
 
 // Variant 4 - testimonial only


### PR DESCRIPTION
# What does this change?

Adds a test which includes testimonials in the Epic.

## What is the value of this and can you measure success?

We find a variant which beats the control and/or gain more information regarding where testimonials should be placed within the Epic.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

- __control__
<img width="639" alt="control" src="https://cloud.githubusercontent.com/assets/4085817/25657468/e5827af0-2ff5-11e7-924b-6ded0e89efae.png">

- __prominent__
<img width="638" alt="prominent" src="https://cloud.githubusercontent.com/assets/4085817/25657478/ef11ce18-2ff5-11e7-9ad8-31c6e07b927a.png">

- __subtle__
<img width="633" alt="subtle" src="https://cloud.githubusercontent.com/assets/4085817/25657488/f8552218-2ff5-11e7-89eb-abd85724b8f9.png">

- __testimonial only__
<img width="648" alt="testimonial_only" src="https://cloud.githubusercontent.com/assets/4085817/25657492/ffd0a7f6-2ff5-11e7-985d-5792dc901f47.png">


## Tested in CODE?

No, tested locally.
