### PR TITLE
Add email preferences link to privacy tab

### DIFF
--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -18,13 +18,13 @@
 
     <fieldset class="fieldset">
         <div class="fieldset__heading">
-            <h2 class="form__heading">News emails</h2>
+            <h2 class="form__heading">Guardian & Observer newsletters</h2>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">
-                    <label class="label">Click <a href=@idUrlBuilder.buildUrl("/email-prefs")>here</a> to manage your Guardian news related email subscriptions.</label>
+                    <label class="label">Click <a href=@idUrlBuilder.buildUrl("/email-prefs")>here</a> to manage your email subscriptions.</label>
                 </li>
             </ul>
         </div>
@@ -32,13 +32,13 @@
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
-            <h2 class="form__heading">Marketing emails</h2>
+            <h2 class="form__heading">Marketing</h2>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">
-                    <label class="label">Would you like to receive marketing emails from the Guardian and their partners?</label>
+                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -17,15 +17,28 @@
     }
 
     <fieldset class="fieldset">
-
         <div class="fieldset__heading">
-            <h2 class="form__heading">Marketing</h2>
+            <h2 class="form__heading">News emails</h2>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">
-                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
+                    <label class="label">Click <a href=@idUrlBuilder.buildUrl("/email-prefs")>here</a> to manage your Guardian news related email subscriptions.</label>
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+    <fieldset class="fieldset">
+
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Marketing emails</h2>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li class="form-field">
+                    <label class="label">Would you like to receive marketing emails from the Guardian and their partners?</label>
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">
@@ -37,7 +50,9 @@
         </div>
     </fieldset>
     <fieldset class="fieldset">
-        <div class="fieldset__heading"></div>
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Profiling</h2>
+        </div>
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">


### PR DESCRIPTION
## What does this change?

Adds a link to `/email-prefs` page to `Privacy` tab of `Edit Profile` page.
 
![image](https://cloud.githubusercontent.com/assets/13835317/25615964/0de3bdc0-2f32-11e7-9878-5657e4005615.png)


## What is the value of this and can you measure success?

In the last 3 months there were 500 userhelp requests related to email subscriptions.

Users often do not realise that they can manage their own news email subscriptions on the `/email-pref` page. This is because in `Edit Profile` they are able to manage only marketing email subscriptions, but not news related email subscritptions, and they do not realise the link to `/email-prefs` is in the drop down menu.

@andrewfindlay