### PR TITLE
Don't lint deleted files on commit

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 
 const path = require('path');
-
+const fs = require('fs');
 const execa = require('execa');
 const chalk = require('chalk');
 
@@ -11,7 +11,9 @@ execa
     .then(staged => staged.split('\n'))
     // lint and commit any lint fixes
     .then(staged => {
-        const jsFiles = staged.filter(file => file.endsWith('.js'));
+        const jsFiles = staged
+            .filter(file => file.endsWith('.js'))
+            .filter(file => fs.existsSync(file));
         if (jsFiles.length) {
             return execa('eslint', ['--fix', ...jsFiles], {
                 stdio: 'inherit',


### PR DESCRIPTION
## What does this change?

The pre-commit hook that lints JS files currently does not ensure files exist before attempting to lint them. Therefore it gets a bit crashy.

This change filters out deleted files from the list of staged files before attempting to lint them

## What is the value of this and can you measure success?

No more break

## Does this affect other platforms - Amp, Apps, etc?

Nein

## Screenshots

Non

## Tested in CODE?

OXI

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
