### PR TITLE
Add --no-verify to the es6 make command

### DIFF
--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -54,7 +54,7 @@ git
         const steps = {
             'Create a branch for the conversion': `git checkout -b "${branchName}" || git checkout -b "${branchName}-${unique}"`,
             'Move the legacy module to the new location': `mkdir -p ${path.dirname(es6Module)}; mv ${es5Module} ${path.dirname(es6Module)}; node ./tools/es5to6-remove-module.js ${moduleId}`,
-            'Commit the move': `git add .; git commit -m "move ${moduleId} from legacy to standard JS"`,
+            'Commit the move': `git add .; git commit --no-verify -m "move ${moduleId} from legacy to standard JS"`,
             'Convert module to ES6': `npm run -s amdtoes6 -- -d ${path.dirname(es6Module)} -o ${path.dirname(es6Module)} -g **/${path.basename(es6Module)} `,
             'Commit the module tranform': `git add .; git commit -m "transform ${moduleId} to ES6 module"`,
             'Convert contents to ES6': `npm run -s lebab -- ${es6Module}`,


### PR DESCRIPTION
The hooks added in https://github.com/guardian/frontend/pull/16599 seem to clash with the `make es6` command; forcing a check and lint on the code.

This adds `--no-verify` to the `git commit` commands in the `es5to6` module so that we don't run the pre and post commit hooks.

@sndrs 