### PR TITLE
Extend Explore test

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -21,7 +21,7 @@ trait FeatureSwitches {
     "If this switch is on, Explore template will be applied to explore articles. This template is part of a Membership Explore test",
     owners = Seq(Owner.withGithub("siadcock")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 3),
+    sellByDate = new LocalDate(2017, 7, 3),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

The Explore template is being used as part of our General Election coverage, so I'll extend this switch until July

## What is the value of this and can you measure success?

Test extension

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
