### PR TITLE
Strip invalid XML characters from image credits

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -86,7 +86,7 @@ object TrailsToRss extends implicits.Collections {
         val imageMetadata = new Metadata()
         trailAsset.caption.foreach({ d => imageMetadata.setDescription(stripInvalidXMLCharacters(d)) })
         trailAsset.credit.foreach { creditName =>
-          val credit = new Credit(null, null, creditName)
+          val credit = new Credit(null, null, stripInvalidXMLCharacters(creditName))
           imageMetadata.setCredits(Seq(credit).toArray)
         }
         media.setMetadata(imageMetadata)
@@ -107,7 +107,7 @@ object TrailsToRss extends implicits.Collections {
       entry.setLink(trail.metadata.webUrl)
       /* set http intentionally to not break existing guid */
       entry.setUri("http://www.theguardian.com/" + trail.metadata.id)
-      
+
       entry.setDescription(description)
       entry.setCategories(categories)
       entry.setModules(new java.util.ArrayList(mediaModules ++ Seq(dc)))


### PR DESCRIPTION
## What does this change?
This fixes an unhandled exception when writing XML for our RSS feeds caused by invalid XML characters in the `media:credit` field.  This change strips invalid XML characters out from this field like we already do for the caption.

## What is the value of this and can you measure success?
Less 500s on facia/rss.

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v1V0p -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
