### PR TITLE
add ‘get’ method to config object

### DIFF
--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -3,7 +3,13 @@
 // This should be the only module accessing the window config object directly
 // because this is the one that gets imported to all other modules
 // eslint-disable-next-line guardian-frontend/global-config
-const config = window.guardian.config;
+const config: Object = window.guardian.config;
+
+const get = (path: string = '', defaultValue: any) =>
+    path
+        .replace(/\[(.+?)\]/g, '.$1')
+        .split('.')
+        .reduce((o, key) => o[key], config) || defaultValue;
 
 const hasTone = (name: string): boolean =>
     (config.page.tones || '').includes(name);
@@ -44,6 +50,7 @@ const isMedia: boolean = ['Video', 'Audio'].includes(config.page.contentType);
 
 export default Object.assign(
     {
+        get,
         hasTone,
         hasSeries,
         referencesOfType,

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -5,6 +5,8 @@
 // eslint-disable-next-line guardian-frontend/global-config
 const config: Object = window.guardian.config;
 
+// allows you to safely get items from config using a query of
+// dot or bracket notation, with optional default fallback
 const get = (path: string = '', defaultValue: any) =>
     path
         .replace(/\[(.+?)\]/g, '.$1')

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -8,6 +8,11 @@ Object.assign(window.guardian.config, {
         references: [{ baz: 'one' }, { baz: 'two' }],
         webPublicationDate: '2013-03-20T17:07:00.000Z',
         pageId: 'politics/2017/mar/14/ukip-donor-arron-banks-says-he-has-quit-party-to-set-up-ukip-20',
+        x: {
+            y: {
+                z: 'z',
+            },
+        },
     },
 });
 
@@ -42,6 +47,24 @@ describe('Config', () => {
     });
 
     it('should return the expected dateFromSlug', () => {
-        expect(config.dateFromSlug()).toBe('2017/mar/14');
+        expect(config.dateFromSlug()).toEqual('2017/mar/14');
+    });
+
+    it('`get` should return a value using dot notation', () => {
+        expect(config.get('page.x.y.z')).toEqual('z');
+    });
+
+    it('`get` should return a value using bracket notation', () => {
+        expect(config.get('page[x].y[z]')).toEqual('z');
+    });
+
+    it('`get` should return undefined for non-existing key', () => {
+        expect(config.get('page.qwert')).toBeUndefined();
+    });
+
+    it('`get` should return default value for non-existing key with a default', () => {
+        expect(config.get('page.qwert', ['I am the default'])).toEqual([
+            'I am the default',
+        ]);
     });
 });


### PR DESCRIPTION
## What does this change?

adds a method called `get` to config:

```js
const config = { a: { b: { c: 'c' } } };

// before
const c = config.a && config.a.b && config.a.b.c;

// now
const c = config.get('a.b.c'); // c
const c = config.get('a[b].c'); // c
const c = config.get('a[b][c]'); // c

const d = config.get('a.b.d'); // undefined
const hi = config.get('a.b.d', 'hi'); // 'hi'
```

## What is the value of this and can you measure success?

no more dancing down the tree