### PR TITLE
Modify AB test to change thrasher copy

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
@@ -22,7 +22,7 @@ define([
         this.description = 'Test digital subs price points via thrasher';
         this.showForSensitive = true;
         this.audience = 0.25;
-        this.audienceOffset = 0;
+        this.audienceOffset = 0.5;
         this.successMeasure = '';
         this.audienceCriteria = 'Non-paying UK network front users - tablet resolution and above';
         this.dataLinkNames = '';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
@@ -51,7 +51,7 @@ define([
             if (this.thrasher()) {
                 var subTitleEl = document.querySelector('.membership-ab-thrasher_header .sub_title');
                 if (subTitleEl) {
-                    subTitleEl.innerHTML = '<p>We\'re introducing <strong>new ways</strong> to support' + (detect.isBreakpoint({min: 'desktop'}) ? '<br>' : ' ') + 'the Guardian\'s quality journalism and independent voice. Choose your new digital or print subscription today.</p>';
+                    subTitleEl.innerHTML = '<p>We\'re introducing <strong>new ways</strong> to support' + (detect.isBreakpoint({min: 'desktop'}) ? '<br>' : ' ') + 'the Guardian\'s quality journalism and independent voice. Choose to subscribe or contribute today.</p>';
                 }
             }
         };


### PR DESCRIPTION
## What does this change?
Change the up-coming bundle pricing AB test so that the thrasher copy better reflects the content offered by the test (we don't highlight print options)
  
## What is the value of this and can you measure success?
Don't mislead test participants

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
![screen shot 2017-05-04 at 11 47 33](https://cloud.githubusercontent.com/assets/690395/25700464/c3b8c09e-30bf-11e7-98e6-eeefca153d24.png)

## Tested in CODE?
Yes

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @Ap0c 
