### PR TITLE
Fix AMP docs link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,5 @@
 ## Tested in CODE?
 
 <!-- AB test? https://git.io/v1V0x -->
-<!-- AMP question? https://git.io/v1V0p -->
+<!-- AMP question? https://git.io/v9zIE -->
 <!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->


### PR DESCRIPTION
Link was broken

(went to https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/17-working-with-amp.md, should be https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/16-working-with-amp.md)