### PR TITLE
Make epic in liveblog pass AMP validation

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -11,7 +11,7 @@
     <div
         id="block-@block.id"
         data-sort-time="@block.publishedCreatedTimestamp()"
-        class="block block--content@block.eventClass"
+        class="block block--content@block.eventClass@block.attributes.membershipPlaceholder.map { _ => js-insert-epic-after}"
     >
         <p class="block-time published-time">
             @if(amp){
@@ -42,7 +42,4 @@
         }
         @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
     </div>
-    @block.attributes.membershipPlaceholder.map { _ =>
-        <div class="js-liveblog-epic-placeholder"></div>
-    }
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -75,11 +75,11 @@ define([
     }
 
     // Returns an array containing:
-    // - the first element matching insertBeforeSelector, if isMultiple is false or not supplied
-    // - all elements matching insertBeforeSelector, if isMultiple is true
+    // - the first element matching insertAtSelector, if isMultiple is false or not supplied
+    // - all elements matching insertAtSelector, if isMultiple is true
     // - or an empty array if the selector doesn't match anything on the page
-    function getTargets(insertBeforeSelector, isMultiple) {
-        var els = document.querySelectorAll(insertBeforeSelector);
+    function getTargets(insertAtSelector, isMultiple) {
+        var els = document.querySelectorAll(insertAtSelector);
 
         if (isMultiple) {
             return toArray(els);
@@ -211,14 +211,18 @@ define([
                 return fastdom.write(function () {
                     var targets = [];
 
-                    if (!options.insertBeforeSelector) {
+                    if (!options.insertAtSelector) {
                         targets = getTargets('.submeta', false);
                     } else {
-                        targets = getTargets(options.insertBeforeSelector, options.insertMultiple);
+                        targets = getTargets(options.insertAtSelector, options.insertMultiple);
                     }
 
                     if (targets.length > 0) {
-                        component.insertBefore(targets);
+                        if (options.insertAfter) {
+                            component.insertAfter(targets);
+                        } else {
+                            component.insertBefore(targets);
+                        }
 
                         mediator.emit(test.insertEvent, component);
                         onInsert(component);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -42,7 +42,8 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                insertBeforeSelector: '.js-liveblog-epic-placeholder',
+                insertAtSelector: '.js-insert-epic-after',
+                insertAfter: true,
                 insertMultiple: true,
                 successOnView: true,
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -72,7 +72,7 @@ define([
                     });
                 },
 
-                insertBeforeSelector: '.submeta',
+                insertAtSelector: '.submeta',
 
                 test: function (render) {
                     if (canBeDisplayed()) render();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -50,7 +50,7 @@ define([
                         });
                     });
                 },
-                insertBeforeSelector: '.submeta',
+                insertAtSelector: '.submeta',
                 successOnView: true
             }
         ]


### PR DESCRIPTION
Fixes an AMP validation issue in #16519.

Items in an `amp-live-list` are required to have an `id` and `data-sort-time`.
https://www.ampproject.org/docs/reference/components/amp-live-list#items

I was inserting a placeholder element for the epic which didn't have these. So I've opted to ditch the placeholder element and instead add a class to the block itself, then insert the epic after that selector.

cc @Mullefa @dominickendrick 
