### PR TITLE
Add username instructions to edit profile

### DIFF
--- a/identity/app/views/fragments/profile/publicProfileForm.scala.html
+++ b/identity/app/views/fragments/profile/publicProfileForm.scala.html
@@ -12,13 +12,22 @@
 
 <fieldset class="fieldset">
     <div class="fieldset__heading">
-        <div class="user-avatar" data-userid="@user.id"></div>
-        <h2 class="form__heading">
-            @user.publicFields.displayName
-        </h2>
-        @user.dates.accountCreatedDate.map { joinDate =>
-            <p class="form-field__note">Joined: @joinDate.toString("d MMM yyyy")</p>
-        }
+        <h2 class="form__heading">Username</h2>
+    </div>
+    <div class="fieldset__fields">
+        <ul class="u-unstyled">
+            <li class="form-field">
+                @user.publicFields.displayName
+            </li>
+            <li>
+                <div class="form__note">
+                    If you have not posted any comments you will be prompted to create/change a username when you post
+                    a comment for the first time. After entering your comment and clicking on ‘post your comment’
+                    you will be asked to create a username. If you have posted comments or experience any difficulties,
+                    please email <a href="mailto:userhelp@@theguardian.com">Userhelp</a>.
+                </div>
+            </li>
+        </ul>
     </div>
 </fieldset>
 
@@ -32,6 +41,9 @@
 
             <div class="fieldset__fields">
                 <ul class="u-unstyled">
+                    <li class="form-field">
+                        <div class="user-avatar" style="float:none"  data-userid="@user.id"></div>
+                    </li>
                     <li class="form-field">
                         <input type="file" name="file" accept="image/gif, image/jpeg, image/png" />
                     </li>


### PR DESCRIPTION
## What does this change?

Add username changes blurb from the [FAQ](https://www.theguardian.com/help/users/faq) to `Edit Profile`. 

## What is the value of this and can you measure success?

This should take a bit of load of userhelp as it makes it easier for users to find the relevant information themselves.




## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/25705801/761c9d62-30d6-11e7-82e7-2154ff094949.png)

@andrewfindlay