### PR TITLE
Engagement banner paypal and paywall test round 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -171,8 +171,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-engagement-banner-paywall-and-paypal-test",
-    "test new paywall and Paypal variants on the engagement banner",
+    "ab-membership-engagement-banner-paywall-and-paypal-test-round-two",
+    "Test variant with paywall message and paypal logo on the engagement banner",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 5, 25),

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -95,19 +95,19 @@ define([
     function weeklySupporterCta() {
         var edition = config.page.edition;
         if(edition === 'US'){
-            return 'Support us with a one-off contribution'
+            return 'Support us with a one-off contribution';
         }
         var cost = monthlySupporterCost[config.page.edition];
-        return 'Support us for ' + cost + ' a month.'
+        return 'Support us for ' + cost + ' a month.';
     }
 
 
-    var MembershipEngagementBannerPaywallAndPaypalTest = function() {
-        this.id = 'MembershipEngagementBannerPaywallAndPaypalTest';
-        this.start = '2017-02-27';
+    var MembershipEngagementBannerPaywallAndPaypalTestRoundTwo = function() {
+        this.id = 'MembershipEngagementBannerPaywallAndPaypalTestRoundTwo';
+        this.start = '2017-05-04';
         this.expiry = '2017-05-25';
         this.author = 'Jonathan Rankin';
-        this.description = 'Test different copy for the engagement banner.';
+        this.description = 'Test a combination of the paywall message and paypal for the engagement banner.';
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Supporter click-through rate and/or acquisition rate';
@@ -122,7 +122,7 @@ define([
     };
 
     // cta should be a function which returns the call-to-action which is placed after the message text.
-    MembershipEngagementBannerPaywallAndPaypalTest.prototype.addVariant = function(variantId, messageText, cta, paypalClass) {
+    MembershipEngagementBannerPaywallAndPaypalTestRoundTwo.prototype.addVariant = function(variantId, messageText, cta, paypalClass) {
 
         function createCampaignCode(variantId) {
             // Campaign code follows convention. Talk to Alex for more information.
@@ -170,21 +170,15 @@ define([
 
 
     return [
-        new MembershipEngagementBannerPaywallAndPaypalTest()
+        new MembershipEngagementBannerPaywallAndPaypalTestRoundTwo()
             .addVariant(
                 'control'
             )
             .addVariant(
-                'paywall',
+                'paypalPaywall',
                 'Unlike many others, we haven\'t put up a paywall - we want to keep our journalism as open as we can.',
-                weeklySupporterCta
+                weeklySupporterCta,
+                'show-paypal'
             )
-            .addVariant(
-                'paypal',
-                '',
-                '',
-                'showPaypal'
-            )
-
     ]
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -178,7 +178,7 @@ define([
                 'paypalPaywall',
                 'Unlike many others, we haven\'t put up a paywall - we want to keep our journalism as open as we can.',
                 weeklySupporterCta,
-                'show-paypal'
+                'site-message__message--show-paypal'
             )
     ]
 });

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,6 +1,6 @@
 <div id="site-message__message">
     <div class="site-message__message site-message__message--membership">
-        <span class = "membership__message-text"><%=messageText%></span>
+        <span class = "membership__message-text <%=paypalClass%>-message-text"><%=messageText%></span>
         <span class="membership__paypal-container">
             <img class="membership__paypal-logo <%=paypalClass%>" src="<%=paypalLogoSrc%>" alt="Paypal and credit card">
             <span class="membership__support-button"><a class="message-button-rounded__cta <%=colourClass%>" href="<%=linkHref%>"><%=buttonCaption%><%=arrowWhiteRight%></a></span>

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,8 +1,8 @@
 <div id="site-message__message">
-    <div class="site-message__message site-message__message--membership">
-        <span class = "membership__message-text <%=paypalClass%>-message-text"><%=messageText%></span>
+    <div class="site-message__message site-message__message--membership <%=paypalClass%>">
+        <span class = "membership__message-text"><%=messageText%></span>
         <span class="membership__paypal-container">
-            <img class="membership__paypal-logo <%=paypalClass%>" src="<%=paypalLogoSrc%>" alt="Paypal and credit card">
+            <img class="membership__paypal-logo" src="<%=paypalLogoSrc%>" alt="Paypal and credit card">
             <span class="membership__support-button"><a class="message-button-rounded__cta <%=colourClass%>" href="<%=linkHref%>"><%=buttonCaption%><%=arrowWhiteRight%></a></span>
         </span>
     </div>

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -523,16 +523,17 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     }
 }
 
-.show-paypal {
-    display: inline-block;
-}
+.site-message__message--show-paypal {
+    .membership__paypal-logo {
+        display: inline-block;
+    }
 
-.show-paypal-message-text {
-    @include mq(desktop) {
-        font-size: 25px;
+    .membership__message-text {
+        @include mq(desktop) {
+            font-size: 25px;
+        }
     }
 }
-
 
 .membership__paypal-container a {
     text-decoration: none;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -523,8 +523,14 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     }
 }
 
-.showPaypal {
+.show-paypal {
     display: inline-block;
+}
+
+.show-paypal-message-text {
+    @include mq(desktop) {
+        font-size: 25px;
+    }
 }
 
 


### PR DESCRIPTION
## What does this change?

This test tries out a combination of new paywall message and the paypal logo on the engagement banner. The previous test showed that both the paywall message and the paypal logo by themselves resulted in a large improvement, so this test puts them together.

New variant for ROW, AU and GB
![screenshot at may 04 15-29-34](https://cloud.githubusercontent.com/assets/2844554/25709476/60ac539a-30e1-11e7-9c0c-91d5647be4ae.png)


Control for ROW, AU and GB
![screenshot at may 04 15-29-55](https://cloud.githubusercontent.com/assets/2844554/25709477/60ae07d0-30e1-11e7-8fab-3287c06be382.png)

New variant for US
![screenshot at may 04 15-36-41](https://cloud.githubusercontent.com/assets/2844554/25709478/60af8588-30e1-11e7-84d1-f16ccc5ee24f.png)

Control for US
![screenshot at may 04 15-36-22](https://cloud.githubusercontent.com/assets/2844554/25709479/60b014b2-30e1-11e7-8b1e-16423b4b49cb.png)

@guardian/contributions 




## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
