### PR TITLE
Add comment to complex regex for matching invalid XML

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -25,8 +25,8 @@ object TrailsToRss extends implicits.Collections {
     by specifying individual and ranges of valid ones in a negated set.  The final range \\u10000-\\u10FFFF
     is intended to match the supplementary character set, but I believe it is invalid java regex.
     It ought to be changed to \\x{10000}-\\x{10FFFF} but that produces unexpected behaviour which I suspect
-    is a bug.  For now, leaving this unchanged as the end result gives valid XML, although it may exclude 
-    supplementary characters.
+    is a bug (http://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8179668).  For now, leaving this 
+    unchanged as the end result gives valid XML, although it may exclude supplementary characters.
   */
   val pattern = Pattern.compile("[^\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]")
   private def stripInvalidXMLCharacters(s: String) = {

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -20,6 +20,14 @@ import scala.collection.JavaConverters._
 
 object TrailsToRss extends implicits.Collections {
 
+  /* 
+    This regex pattern matches all invalid XML characters (see https://www.w3.org/TR/xml/#charsets)
+    by specifying individual and ranges of valid ones in a negated set.  The final range \\u10000-\\u10FFFF
+    is intended to match the supplementary character set, but I believe it is invalid java regex.
+    It ought to be changed to \\x{10000}-\\x{10FFFF} but that produces unexpected behaviour which I suspect
+    is a bug.  For now, leaving this unchanged as the end result gives valid XML, although it may exclude 
+    supplementary characters.
+  */
   val pattern = Pattern.compile("[^\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]")
   private def stripInvalidXMLCharacters(s: String) = {
     pattern.matcher(s).replaceAll("")


### PR DESCRIPTION
## What does this change?
After using the `stripInvalidXMLCharacters` method and struggling to understand the regex, I have added a (very long 😰) comment to the pattern for clarity.  Too much?

## What is the value of this and can you measure success?
Easier to understand code.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
