### PR TITLE
use prettier for flow and react

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -4,7 +4,11 @@ module.exports = {
     settings: {
         'import/resolver': 'webpack',
     },
-    extends: ['plugin:flowtype/recommended'],
+    extends: [
+        'plugin:flowtype/recommended',
+        'prettier/flowtype',
+        'prettier/react',
+    ],
     plugins: ['guardian-frontend', 'flowtype', 'flow-header'],
     rules: {
         // require-specific overrides


### PR DESCRIPTION
## What does this change?

missed some config options for [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier?files=1#installation)

## What is the value of this and can you measure success?

should avoid potential weird conflicts between lint plugins