### PR TITLE
Remove "we are hiring" comment

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -7,16 +7,6 @@
 @import views.support.JavaScriptPage.getMap
 
 <meta charset="utf-8" />
-<!--
- __        __                      _     _      _
- \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
-  \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
-   \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
-    \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
-                                                        |___/
-Ever thought about joining us?
-http://developers.theguardian.com/join-the-team.html
--->
 <title>@views.support.Title(page)</title>
 
 @fragments.metaData(page)


### PR DESCRIPTION
## What does this change?

Removes the "we are hiring" comment from the HTML as we are not currently hiring devs.

## What is the value of this and can you measure success?

Prevents us from misleading job hunters

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

😭 

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
