### PR TITLE
update Observer links to new domain

### DIFF
--- a/article/app/views/fragments/recipeArticleBody.scala.html
+++ b/article/app/views/fragments/recipeArticleBody.scala.html
@@ -75,7 +75,7 @@
                         }.getOrElse {
                             @if(articleModel.item.content.isFromTheObserver) {
                                 <div class="content__series-label">
-                                    <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+                                    <a class="content__series-label__link" href="https://www.theguardian.com/observer">The Observer</a>
                                 </div>
                             }
                         }

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -50,7 +50,7 @@
     }.getOrElse {
         @if(item.content.isFromTheObserver) {
             <div class="content__series-label">
-                <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+                <a class="content__series-label__link" href="https://www.theguardian.com/observer">The Observer</a>
             </div>
         }
     }

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -47,7 +47,7 @@
                 @if(content.content.isFromTheObserver) {
                     <li class="submeta__link-item">
                         <a class="submeta__link"
-                           href="http://observer.theguardian.com">
+                           href="https://www.theguardian.com/observer">
                                The Observer
                         </a>
                     </li>


### PR DESCRIPTION
## What does this change?
 - The links to the observer in the metadata, subMetdata and new Recipe forms was going to an old address.
- This updates the link.
## What is the value of this and can you measure success?
- No need for user to be redirected

## Does this affect other platforms - Amp, Apps, etc?
- Shouldn't do

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
