### PR TITLE
Fix inline ads redux redux

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -21,11 +21,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-increase-inline-ads-redux",
+    "ab-increase-inline-ads-redux-redux",
     "Displays more inline ads in articles on desktop",
     owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 17),
+    sellByDate = new LocalDate(2017, 5, 29),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -25,7 +25,7 @@ define([
     trackAdRender,
     createSlot,
     commercialFeatures,
-    increaseInlineAdsRedux
+    increaseInlineAds
 ) {
 
     /* bodyAds is a counter that keeps track of the number of inline MPUs
@@ -34,7 +34,7 @@ define([
     var replaceTopSlot;
     var getSlotName;
     var getSlotType;
-    var isOffsetingAds = abUtils.testCanBeRun(new increaseInlineAdsRedux()) && abUtils.getTestVariantId('IncreaseInlineAdsReduxRedux') === 'yes';
+    var isOffsetingAds = abUtils.testCanBeRun(new increaseInlineAds()) && abUtils.getTestVariantId('IncreaseInlineAdsReduxRedux') === 'yes';
 
     function init() {
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -34,7 +34,7 @@ define([
     var replaceTopSlot;
     var getSlotName;
     var getSlotType;
-    var isOffsetingAds = abUtils.testCanBeRun(new increaseInlineAdsRedux());
+    var isOffsetingAds = abUtils.testCanBeRun(new increaseInlineAdsRedux()) && abUtils.getTestVariantId('IncreaseInlineAdsReduxRedux') === 'yes';
 
     function init() {
 

--- a/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/article-body-adverts.js
@@ -10,7 +10,8 @@ define([
     'commercial/modules/dfp/add-slot',
     'commercial/modules/dfp/track-ad-render',
     'commercial/modules/dfp/create-slot',
-    'commercial/modules/commercial-features'
+    'commercial/modules/commercial-features',
+    'common/modules/experiments/tests/increase-inline-ads'
 ], function (
     Promise,
     qwery,
@@ -23,7 +24,8 @@ define([
     addSlot,
     trackAdRender,
     createSlot,
-    commercialFeatures
+    commercialFeatures,
+    increaseInlineAdsRedux
 ) {
 
     /* bodyAds is a counter that keeps track of the number of inline MPUs
@@ -32,8 +34,7 @@ define([
     var replaceTopSlot;
     var getSlotName;
     var getSlotType;
-    var isOffsetingAds = abUtils.testCanBeRun('IncreaseInlineAdsRedux') &&
-        abUtils.getTestVariantId('IncreaseInlineAdsRedux') === 'yes';
+    var isOffsetingAds = abUtils.testCanBeRun(new increaseInlineAdsRedux());
 
     function init() {
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/increase-inline-ads.js
@@ -3,9 +3,9 @@ define([
     'lib/detect'
 ], function (config, detect) {
     return function () {
-        this.id = 'IncreaseInlineAdsRedux';
-        this.start = '2017-04-12';
-        this.expiry = '2017-05-17';
+        this.id = 'IncreaseInlineAdsReduxRedux';
+        this.start = '2017-05-05';
+        this.expiry = '2017-05-29';
         this.author = 'Gideon Goldberg';
         this.description = 'Displays more inline ads in articles on desktop';
         this.audience = .05;


### PR DESCRIPTION
## What does this change?
Fixes A/B test (previous added in #16442).  The `testCanBeRun` function expects a function argument but we were previously passing in a string so the check to see the changed behaviour always evaluated to `undefined`. 

## What is the value of this and can you measure success?
Allows us to run A/B test as originally intended

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
