### PR TITLE
Remove more-toggle tests & make element permanent

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -29,12 +29,11 @@ class OptInController extends Controller {
 
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
-      case "navigationmoretoggle" => navigationMoreToggle.opt(choice)
       case "newrecipedesign" => newRecipeDesignOverride.opt(choice)
       case _ => NotFound
     }))
   }
-//cookies should correspond with those checked by fastly-edge-cache
-  val navigationMoreToggle = OptInFeature("ab_navigation_more_toggle")
+
+  //cookies should correspond with those checked by fastly-edge-cache
   val newRecipeDesignOverride = OptInFeature("new_recipe_design_opt_in")
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -39,28 +39,6 @@ object ABNewRecipeDesign extends TestDefinition(
   }
 }
 
-object ABNavigationMoreToggleControl extends TestDefinition(
-  name = "ab-navigation-more-toggle-control",
-  description = "Users in the test will see a more link in the navigation subnav",
-  owners = Seq(Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 5, 8)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-navigation-more-toggle").contains("control")
-  }
-}
-
-object ABNavigationMoreToggleVariant extends TestDefinition(
-  name = "ab-navigation-more-toggle-variant",
-  description = "Users in the test will see a more link in the navigation subnav",
-  owners = Seq(Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 5, 8)
-) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-navigation-more-toggle").contains("variant")
-  }
-}
-
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -75,9 +53,7 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
-    ABNewRecipeDesign,
-    ABNavigationMoreToggleControl,
-    ABNavigationMoreToggleVariant
+    ABNewRecipeDesign
   )
 }
 

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -20,16 +20,14 @@
             </li>
         }
 
-        @if(mvt.ABNavigationMoreToggleVariant.isParticipating) {
-            <li class="subnav__link-item">
-                <button class="
-                    subnav__link
-                    subnav__link--toggle-more
-                    js-toggle-nav-section"
-                    data-link-name="nav2 : subnav-toggle">
-                    more
-                </button>
-            </li>
-        }
+        <li class="subnav__link-item">
+            <button class="
+                subnav__link
+                subnav__link--toggle-more
+                js-toggle-nav-section"
+                data-link-name="nav2 : subnav-toggle">
+                more
+            </button>
+        </li>
     </ul>
 }


### PR DESCRIPTION
## What does this change?

Make navigation more toggle permanent.

## What is the value of this and can you measure success?

No breaking tests. Users seem to engange with it.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![screen shot 2017-05-08 at 16 38 34](https://cloud.githubusercontent.com/assets/2244375/25811993/d24350b6-340c-11e7-9556-71f8569c1e57.png)


## Tested in CODE?

No.
