### PR TITLE
Refactor membership engagement banner tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -207,8 +207,12 @@ define([
                         mediator.on('modules:onwards:breaking-news:ready', function (breakingShown) {
                             if (!breakingShown) {
                                 showBanner(bannerParams);
+                            } else {
+                                mediator.emit('banner-message:complete');
                             }
                         });
+                    } else {
+                        mediator.emit('banner-message:complete');
                     }
                 });
             }

--- a/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
@@ -4,17 +4,19 @@ define([
     'helpers/fixtures',
     'helpers/injector',
     'Promise',
-    'common/modules/ui/message'
+    'common/modules/ui/message',
+    'lib/config'
 ], function (
     $,
     userPrefs,
     fixtures,
     Injector,
     Promise,
-    Message
+    Message,
+    config
 ) {
     var commercialFeatures, membershipMessages, mediator,
-        showMembershipMessages, alreadyVisited, storage, config, participations;
+        showMembershipMessages, alreadyVisited, storage, participations;
 
     var injector = new Injector();
 
@@ -35,18 +37,22 @@ define([
     describe('Membership engagement banner', function () {
 
         beforeEach(function (done) {
+            config.page.edition = 'UK';
+            injector.mock('common/views/svgs', {
+                inlineSvg: function() {
+                    return '';
+                }
+            });
             injector.require([
                 'commercial/modules/commercial-features',
                 'common/modules/commercial/membership-engagement-banner',
-                'lib/config',
                 'lib/storage',
                 'lib/mediator'
             ], function () {
                 commercialFeatures = arguments[0];
                 membershipMessages = arguments[1];
-                storage = arguments[3];
-                config = arguments[2];
-                mediator = arguments[4];
+                storage = arguments[2];
+                mediator = arguments[3];
                 done();
             }, function () {
                 // woohoo
@@ -62,31 +68,20 @@ define([
             expect(getMessageContent()).toBeNull();
         }
 
-        function expectMessageToBeShown(done) {
-            membershipMessages.init().then(function () {
-                mediator.emit('modules:onwards:breaking-news:ready', false);
-                var message = document.querySelector('.js-site-message');
-                var messageContent = getMessageContent();
-                expect(messageContent).not.toBeNull();
-                expect(message.className).toContain('membership-prominent');
-                expect(message.className).not.toContain('is-hidden');
-            }).then(done);
+        function expectMessageToBeShown() {
+            var message = document.querySelector('.js-site-message');
+            var messageContent = getMessageContent();
+
+            expect(messageContent).not.toBeNull();
+            expect(message.className).toContain('membership-prominent');
+            expect(message.className).not.toContain('is-hidden');
         }
 
-        function expectMessageNotToBeShown(done) {
-            membershipMessages.init().then(function () {
-                mediator.emit('modules:onwards:breaking-news:ready', false);
-                expectMessageContentNotToBeShown();
-            }).then(done);
-        }
+        function expectMessageNotToBeVisible() {
+            var message = document.querySelector('.js-site-message');
 
-        function expectMessageNotToBeVisible(done) {
-            membershipMessages.init().then(function () {
-                mediator.emit('modules:onwards:breaking-news:ready', false);
-                var message = document.querySelector('.js-site-message');
-                expect(message.className).toContain('is-hidden');
-                expect(message.className).not.toContain('membership-message');
-            }).then(done);
+            expect(message.className).toContain('is-hidden');
+            expect(message.className).not.toContain('membership-message');
         }
 
         describe('If breaking news banner', function () {
@@ -106,19 +101,28 @@ define([
                 mediator.removeAllListeners();
             });
 
-            describe('has shown', function () {
-                it('should not show the membership engagement banner', function (done) {
-                    membershipMessages.init().then(function () {
-                        mediator.emit('modules:onwards:breaking-news:ready', true);
-                        expectMessageContentNotToBeShown();
-                    }).then(done);
+            it('has shown, should not show the membership engagement banner', function (done) {
+                mediator.on('banner-message:complete', function() {
+                    expectMessageContentNotToBeShown();
+                    done();
                 });
+                membershipMessages
+                    .init()
+                    .then(function () {
+                        mediator.emit('modules:onwards:breaking-news:ready', true);
+                    });
             });
 
-            describe('has not shown', function () {
-                it('should show the membership engagement banner', function (done) {
-                    expectMessageToBeShown(done);
+            it('has not shown, should show the membership engagement banner', function (done) {
+                mediator.on('banner-message:complete', function() {
+                    expectMessageToBeShown();
+                    done();
                 });
+                membershipMessages
+                    .init()
+                    .then(function () {
+                        mediator.emit('modules:onwards:breaking-news:ready', false);
+                    });
             });
         });
 
@@ -139,9 +143,20 @@ define([
                 storage.local.set('gu.alreadyVisited', alreadyVisited);
                 storage.local.set('gu.ab.participations', participations);
                 fixtures.clean(conf.id);
+                mediator.removeAllListeners();
             });
 
-            it('should not show any messages even to engaged readers', expectMessageNotToBeShown);
+            it('should not show any messages even to engaged readers', function(done) {
+                mediator.on('banner-message:complete', function() {
+                    expectMessageContentNotToBeShown();
+                    done();
+                });
+                membershipMessages
+                    .init()
+                    .then(function () {
+                        mediator.emit('modules:onwards:breaking-news:ready', false);
+                    });
+            });
         });
 
         describe('If user not member', function () {
@@ -164,32 +179,63 @@ define([
             describe('of the UK edition', function () {
                 it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'UK' };
-                    expectMessageToBeShown(done);
+                    mediator.on('banner-message:complete', function() {
+                        expectMessageToBeShown();
+                        done();
+                    });
+                    membershipMessages
+                        .init()
+                        .then(function () {
+                            mediator.emit('modules:onwards:breaking-news:ready', false);
+                        });
                 });
             });
 
             describe('of the US edition', function () {
                 it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'US' };
-                    expectMessageToBeShown(done);
+                    mediator.on('banner-message:complete', function() {
+                        expectMessageToBeShown();
+                        done();
+                    });
+                    membershipMessages
+                        .init()
+                        .then(function () {
+                            mediator.emit('modules:onwards:breaking-news:ready', false);
+                        });
                 });
             });
 
             describe('of the International edition', function () {
                 it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'INT' };
-                    expectMessageToBeShown(done);
+                    mediator.on('banner-message:complete', function() {
+                        expectMessageToBeShown();
+                        done();
+                    });
+                    membershipMessages
+                        .init()
+                        .then(function () {
+                            mediator.emit('modules:onwards:breaking-news:ready', false);
+                        });
                 });
             });
 
             describe('but has already closed a message', function () {
                 it('should not redisplay that message', function (done) {
                     var message = new Message(membershipMessages.messageCode);
+
                     message.acknowledge();
-
                     config.page = { edition: 'UK' };
-
-                    expectMessageNotToBeVisible(done);
+                    mediator.on('banner-message:complete', function() {
+                        expectMessageNotToBeVisible();
+                        done();
+                    });
+                    membershipMessages
+                        .init()
+                        .then(function () {
+                            mediator.emit('modules:onwards:breaking-news:ready', false);
+                        });
                 });
             });
         });


### PR DESCRIPTION
## What does this change?

Some of the membership engagement banner tests are passing erroneously as the expectations were executing before the code had finished running.

The module now emits an event when the banner code has finished running and is ready to be tested. Previously this event was only fired on one particular code branch.

The test always waits for this event before testing expectations.

## What is the value of this and can you measure success?

Tests are now correctly being executed and are passing

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
