### PR TITLE
classList.add Multiple Classes Denied

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/fabric-v1.js
@@ -97,7 +97,10 @@ define([
                 this.scrollingBg.style.backgroundAttachment = 'fixed';
             }
 
-            this.adSlot.classList.add('ad-slot--fabric-v1', 'ad-slot--fabric', 'content__mobile-full-width');
+            this.adSlot.classList.add('ad-slot--fabric-v1');
+            this.adSlot.classList.add('ad-slot--fabric');
+            this.adSlot.classList.add('content__mobile-full-width');
+
             if( this.adSlot.parentNode.classList.contains('top-banner-ad-container') ) {
                 this.adSlot.parentNode.classList.add('top-banner-ad-container--fabric');
             }


### PR DESCRIPTION
This is a code refactoring that takes account of the fact that in Internet Explorer 11, the code 

```
this.adSlot.classList.add('ad-slot--fabric-v1', 'ad-slot--fabric', 'content__mobile-full-width');
```

Doesn't work as intended because `classList.add` only adds one class. This is a documented problem ( https://social.msdn.microsoft.com/Forums/en-US/b408eab5-0bb8-4c35-9eba-3c94d900d4d8/classlistadd-multiple-classes-denied?forum=iewebdevelopment )

Before the change class `ad-slot--fabric` wasn't applied and the display was as the following screenshot

![image001](https://cloud.githubusercontent.com/assets/6035518/25815911/4a82ad94-341a-11e7-8549-e9189e14ecda.jpg)

After the change the display was correct.

Note that you need to use Browserstack with Windows 7, Explorer 11 and a high resolution to see both the problem and the resolution. 


