### PR TITLE
Show epic even on sensitive liveblogs

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -30,6 +30,8 @@ define([
         audience: 1,
         audienceOffset: 0,
 
+        showForSensitive: true,
+
         pageCheck: function(page) {
             return page.contentType === 'LiveBlog';
         },


### PR DESCRIPTION
We missed out on some supporters & contributors from the French election liveblog, since it was marked sensitive. This will ensure we never make the same mistake again!

@desbo 