### PR TITLE
Nav link changes

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -246,7 +246,7 @@ object NewNavigation {
 
     val au = NavLinkLists(List(
       jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
-      auMasterClasses,
+      auEvents,
       apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
       podcasts,
       video,

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -238,6 +238,7 @@ object NewNavigation {
       podcasts,
       video,
       pictures,
+      newsletters,
       todaysPaper,
       observer,
       crosswords
@@ -250,6 +251,7 @@ object NewNavigation {
       podcasts,
       video,
       pictures,
+      newsletters,
       crosswords
     ))
 
@@ -259,6 +261,7 @@ object NewNavigation {
       podcasts,
       video,
       pictures,
+      newsletters,
       crosswords
     ))
 
@@ -269,6 +272,7 @@ object NewNavigation {
       podcasts,
       video,
       pictures,
+      newsletters,
       todaysPaper,
       observer,
       crosswords

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -123,6 +123,7 @@ object NavLinks {
   val video =  NavLink("video", "/video")
   val podcasts =  NavLink("podcasts", "/podcasts")
   val pictures =  NavLink("pictures", "/inpictures")
+  val newsletters =  NavLink("newsletters", "/email-newsletters")
   val jobs = NavLink("jobs", "https://jobs.theguardian.com")
   val dating = NavLink("dating", "https://soulmates.theguardian.com")
   val apps = NavLink("the guardian app", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -128,7 +128,7 @@ object NavLinks {
   val dating = NavLink("dating", "https://soulmates.theguardian.com")
   val apps = NavLink("the guardian app", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
   val ukMasterClasses = NavLink("masterclasses", "/guardian-masterclasses?INTCMP=masterclasses_uk_web_newheader")
-  val auMasterClasses = NavLink("masterclasses", "/guardian-masterclasses-australia?INTCMP=masterclasses_au_web_newheader")
+  val auEvents = NavLink("events", "/guardian-live-australia")
 
   val tagPages = List(
     "technology/games",

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -59,6 +59,8 @@
     background-color: $guardian-brand;
     height: 0;
     padding-bottom: 60%;
+    // Temporarily hiding until there are numerous images, to prevent repetition of icon
+    display: none;
 
     svg {
         display: block;

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -59,8 +59,6 @@
     background-color: $guardian-brand;
     height: 0;
     padding-bottom: 60%;
-    // Temporarily hiding until there are numerous images, to prevent repetition of icon
-    display: none;
 
     svg {
         display: block;


### PR DESCRIPTION
A couple of changes to the new nav links.

'Newsletters' makes a grand return to the nav, now the newsletters landing page is ready. Alongside that, the images on the newsletters landing page have been temporarily hidden to prevent the repetition of the large grey space and icon.

Futhermore, due to Australian masterclasses ending, the auMasterclasses link has been replaced with auEvents. 