### PR TITLE
Add contributions link to footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -75,17 +75,17 @@
             <ul class="colophon__list">
                 @currentEdition match {
                     case Uk => {
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                            become a supporter</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
+                            make a contribution</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
                             Facebook</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
-                        </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.t+heguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
-                            become a supporter</a>
-                        </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
-                            make a contribution</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
                             jobs</a>
@@ -127,6 +127,12 @@
                     }
 
                     case Us => {
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_US_GU_MEMBERSHIP">
+                            become a supporter</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
+                            make a contribution</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
                             Facebook</a>
                         </li>
@@ -167,6 +173,12 @@
                     }
 
                     case Au => {
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_AU_GU_MEMBERSHIP">
+                            become a supporter</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
+                            make a contribution</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
                             Facebook</a>
                         </li>
@@ -216,16 +228,16 @@
                     }
 
                     case International => {
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_INT_GU_MEMBERSHIP">
+                            become a supporter</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
+                            make a contribution</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="international : footer : facebook" href="https://www.facebook.com/theguardian">
                             Facebook</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="international : footer : twitter" href="https://twitter.com/guardian">
-                            Twitter</a>
-                        </li>
-                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="international : footer : facebook" href="https://www.facebook.com/theguardian">
-                            Facebook</a>
-                        </li>
-                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="international : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="international : footer : all topics" href="@LinkTo {/index/subjects/a}">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -82,10 +82,10 @@
                             Twitter</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.t+heguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
-                            membership</a>
+                            become a supporter</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
-                            contribute</a>
+                            make a contribution</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
                             jobs</a>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -81,8 +81,11 @@
                         <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                             Twitter</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.t+heguardian.com/supporter?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
                             membership</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="https://contribute.theguardian.com?INTCMP=gdnwb_copts_memco_dotcom_footer">
+                            contribute</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
                             jobs</a>


### PR DESCRIPTION
## What does this change?
- Adds "make a contribution" and "become a supporter" links to footer (in the case of the UK the latter just means changing the link text from "membership" to "become a supporter")
- Puts those links at the top of the footer

## What is the value of this and can you measure success?
- The footer acquired 26 supporters over the past week - but during the US elections it drove 400 over the month of Nov. We think it could drive more, and contributions too
- All links have campaign codes so we can track their conversions (contributions codes aren't distinguished by country but we get that information elsewhere anyway)

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
## International
![picture 554](https://cloud.githubusercontent.com/assets/5122968/25853245/0d599d1a-34c4-11e7-937d-b4910dac6d23.png)
![picture 555](https://cloud.githubusercontent.com/assets/5122968/25853246/0d5bf204-34c4-11e7-8b00-e39a4f6a8d6b.png)

## Australia
![picture 551](https://cloud.githubusercontent.com/assets/5122968/25853263/216fd652-34c4-11e7-833f-d2b5b328820e.png)
![picture 552](https://cloud.githubusercontent.com/assets/5122968/25853262/216dcc7c-34c4-11e7-88d0-e175242886f5.png)

## US
![picture 556](https://cloud.githubusercontent.com/assets/5122968/25853305/462831ce-34c4-11e7-861e-d66c15063121.png)
![picture 557](https://cloud.githubusercontent.com/assets/5122968/25853304/46269fe4-34c4-11e7-94a3-e232f3b912c4.png)

## UK
![picture 558](https://cloud.githubusercontent.com/assets/5122968/25853362/6a0d63f2-34c4-11e7-8a7b-6f4f6662a0f3.png)
![picture 559](https://cloud.githubusercontent.com/assets/5122968/25853363/6a20ebe8-34c4-11e7-9b29-cd75680ef654.png)