### PR TITLE
Ensure that Viewability tracker scripts are executed when added to the DOM.

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
@@ -9,6 +9,7 @@ define(function () {
       */
       var range = document.createRange();
       range.setStart(adSlot, 0);
+      range.setEnd(adSlot, 0);
       adSlot.appendChild(range.createContextualFragment(viewabilityTracker.replace('INSERT_UNIQUE_ID', creativeId)));
     }
 })

--- a/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js
@@ -2,6 +2,13 @@ define(function () {
     return addViewabilityTracker;
 
     function addViewabilityTracker(adSlot, creativeId, viewabilityTracker) {
-        adSlot.insertAdjacentHTML('beforeend', viewabilityTracker.replace('INSERT_UNIQUE_ID', creativeId));
+
+      /*
+        we need to ensure that any scripts in the viewabilityTracker are parsed
+        and executed; this can be done with a Range and ContextualFragment
+      */
+      var range = document.createRange();
+      range.setStart(adSlot, 0);
+      adSlot.appendChild(range.createContextualFragment(viewabilityTracker.replace('INSERT_UNIQUE_ID', creativeId)));
     }
 })


### PR DESCRIPTION
## What does this change?
When creating a Fabric-V1 creative in DFP, there is an option to add a `viewabilityTracker`, which can can either be an `<img>` or a `<script>`.

However it seems that this doesn't actually work; when adding a script to the DOM [here](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/commercial/modules/creatives/add-viewability-tracker.js#L5) the script isn't actually requested by the browser.

This change forces the browser to reparse and process the Node in question, and thus load the script.

**Note:**
The `Range.createContextualFragment` method has [good coverage apart from IE 9/10](https://developer.mozilla.org/en-US/docs/Web/API/Range/createContextualFragment#Browser_compatibility).

Can anyone help me check that this is covered by our current polyfill service and, if not, add it in?

@guardian/commercial-dev 