### PR TITLE
Howto apply the special report tone to a tag

### DIFF
--- a/docs/03-dev-howtos/18-apply-the-special-report-tone.md
+++ b/docs/03-dev-howtos/18-apply-the-special-report-tone.md
@@ -17,7 +17,7 @@ https://github.com/guardian/facia-scala-client/blame/48f90b6173c6409507a58e80468
 
 5. Merge the PR and release the library to Maven using sbt.
 
-6. Update facia-scala-client library on Frontend and MAPI. Merge adn deploy the PRs.
+6. Update facia-scala-client library on Frontend and MAPI. Merge and deploy the PRs.
 On Frontend - https://github.com/guardian/frontend/pull/15842/commits/3c6a598a0340fc9f4bd4e774d1466a5806f67c67
 On MAPI - https://github.com/guardian/mobile-apps-api/pull/900/commits/99012625a0b9e4bbab61d224768ca31bf36fcf46
 

--- a/docs/03-dev-howtos/18-apply-the-special-report-tone.md
+++ b/docs/03-dev-howtos/18-apply-the-special-report-tone.md
@@ -4,7 +4,7 @@ Sometimes CP or someone from Editorial will ask us to apply the special report t
 The following doc explains how to make that happen.
 
 1. Find out the id of the tag where we need the special report tone. For example "news/series/panama-papers".
-2. Replace <NEW-SPECIAL-TAG> with the string of the special tag and run this code on a python REPL:
+2. Replace <NEW-SPECIAL-TAG> with the id of the special tag and run this code on a python REPL:
 ```
 import hashlib
 tag = "<NEW-SPECIAL-TAG>"

--- a/docs/03-dev-howtos/18-apply-the-special-report-tone.md
+++ b/docs/03-dev-howtos/18-apply-the-special-report-tone.md
@@ -1,0 +1,24 @@
+# Apply the special report tone
+
+Sometimes CP or someone from Editorial will ask us to apply the special report treatment to a tag.
+The following doc explains how to make that happen.
+
+1. Find out the id of the tag where we need the special report tone. For example "news/series/panama-papers".
+2. Replace <NEW-SPECIAL-TAG> with the string of the special tag and run this code on a python REPL:
+```
+import hashlib
+tag = "<NEW-SPECIAL-TAG>"
+m = hashlib.md5()
+m.update("a-public-salt3W#ywHav!p+?r+W2$E6="+tag)
+print m.hexdigest()
+```
+3. Add the generated hash to the facia-scala-client on this file and raise a PR against master
+https://github.com/guardian/facia-scala-client/blame/48f90b6173c6409507a58e8046868f0d9e93ca06/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala#L52
+
+5. Merge the PR and release the library to Maven using sbt.
+
+6. Update facia-scala-client library on Frontend and MAPI. Merge adn deploy the PRs.
+On Frontend - https://github.com/guardian/frontend/pull/15842/commits/3c6a598a0340fc9f4bd4e774d1466a5806f67c67
+On MAPI - https://github.com/guardian/mobile-apps-api/pull/900/commits/99012625a0b9e4bbab61d224768ca31bf36fcf46
+
+7. Profit! This will make Frontend and MAPI give this tone tag the special report treatment

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
 - [Updating the test database](03-dev-howtos/15-updating-test-database.md)
 - [Working with Google AMP](03-dev-howtos/16-working-with-amp.md)
 - [Working with emails](03-dev-howtos/17-working-with-emails.md)
+- [Apply the special report tone](03-dev-howtos/18-apply-the-special-report-tone.md)
 
 ## [Quality](04-quality/)
 - [Browsers support](04-quality/01-browser-support.md)


### PR DESCRIPTION
## What does this change?
Adds documentation on how to apply the special report tone to a tag.

@guardian/guardian-frontend 