### PR TITLE
Cancel editing selection if user hits escape

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -16,6 +16,7 @@ const keyCodeMap = {
     '13': 'enter',
     '38': 'up',
     '40': 'down',
+    '27': 'escape',
 };
 
 export class SearchTool {
@@ -179,6 +180,8 @@ export class SearchTool {
         } else if (key === 'enter') {
             // enter
             this.pushData();
+        } else if (key === 'escape') {
+            this.toggleControls();
         } else {
             this.getListOfResults(e);
         }


### PR DESCRIPTION
## What does this change?
Dismisses the search mode and returns to the previously selected value if the user hit escape (see #7845.

## What is the value of this and can you measure success?
It might cheer up @paperboyo 

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No, just locally

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
