### PR TITLE
New Engagement banner default

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -20,7 +20,13 @@ define([
         colourStrategy: function() {
             return 'membership-prominent yellow'
         },
-        campaignCode: 'gdnwb_copts_memco_banner' // Agreed with Jess and Jesse
+        // Agreed with Jess and Jesse
+        campaignCode: 'gdnwb_copts_memco_banner',
+        // Used for tracking the new implementation
+        interactionOnMessageShow: {
+            component: 'engagement_banner',
+            value: 'default_paypal_and_paywall'
+        }
     };
 
     function engagementBannerCopy(cta) {
@@ -61,7 +67,7 @@ define([
                 'SE'
             ];
 
-            return euroAfterCountryCodes.indexOf(location) > -1 ? amount + ' ' + euro : euro + amount;
+            return euroAfterCountryCodes.includes(location) ? amount + ' ' + euro : euro + amount;
 
         } else {
 
@@ -108,7 +114,7 @@ define([
     }
 
     return {
-        defaultParams: engagementBannerParams(geolocation.getSync()),
+        defaultParams: engagementBannerParams,
         offerings: offerings
     }
 });

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -15,16 +15,11 @@ define([
         contributions: 'contributions'
     };
 
-    function defaultColourStrategy() {
-        return 'membership-prominent yellow'
-    }
-
-    // TODO: campaign code by location and/or reader product?
-
     var baseParams = {
         minArticles: 3,
-        colourStrategy: defaultColourStrategy,
-        paypalClass: 'site-message__message--show-paypal',
+        colourStrategy: function() {
+            return 'membership-prominent yellow'
+        },
         campaignCode: 'gdnwb_copts_memco_banner' // Agreed with Jess and Jesse
     };
 
@@ -66,7 +61,7 @@ define([
                 'SE'
             ];
 
-            return euroAfterCountryCodes.includes(location) ? amount + ' ' + euro : euro + amount;
+            return euroAfterCountryCodes.indexOf(location) > -1 ? amount + ' ' + euro : euro + amount;
 
         } else {
 
@@ -78,7 +73,7 @@ define([
                 INT: '$6.99'
             }[region];
 
-            return payment ? payment : '£5'
+            return payment || '£5'
         }
     }
 
@@ -102,7 +97,7 @@ define([
     function contributionParams() {
         return assign({}, baseParams, {
             buttonCaption: 'Make a Contribution',
-            linkUrl: 'https://contribute.theguardian.com/',
+            linkUrl: 'https://contribute.theguardian.com',
             offering: offerings.contributions,
             messageText: contributionEngagementBannerCopy()
         });

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -20,9 +20,8 @@ define([
         colourStrategy: function() {
             return 'membership-prominent yellow'
         },
-        // Agreed with Jess and Jesse
         campaignCode: 'gdnwb_copts_memco_banner',
-        // Used for tracking the new implementation
+        // Used for tracking the new implementation by querying the interactions field.
         interactionOnMessageShow: {
             component: 'engagement_banner',
             value: 'default_paypal_and_paywall'
@@ -30,7 +29,7 @@ define([
     };
 
     function engagementBannerCopy(cta) {
-        return 'Unlike many others, we haven\'t put up a paywall - we want to keep our journalism as open as we can.' + ' ' + cta
+        return 'Unlike many others, we haven\'t put up a paywall - we want to keep our journalism as open as we can. ' + cta
     }
 
     // Prices taken from https://membership.theguardian.com/<region>/supporter

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -160,21 +160,13 @@ define([
 
             var messageText = Array.isArray(params.messageText)?selectSequentiallyFrom(params.messageText):params.messageText;
 
-            var paypalClass = params.paypalClass || '';
-
-            //the paypall variant only works with the yellow banner
-            if(paypalClass) {
-                colourClass = 'membership-prominent yellow';
-            }
-
             var renderedBanner = template(messageTemplate, {
                 linkHref: params.linkUrl + '?INTCMP=' + params.campaignCode,
                 messageText: messageText,
                 buttonCaption: params.buttonCaption,
                 colourClass: colourClass,
                 arrowWhiteRight: svgs.inlineSvg('arrowWhiteRight'),
-                paypalLogoSrc: paypalAndCreditCardImage,
-                paypalClass : paypalClass
+                paypalLogoSrc: paypalAndCreditCardImage
             });
 
             var messageShown = new Message(
@@ -199,7 +191,7 @@ define([
 
         function init() {
 
-            mediator.once(geolocation.geoLocationEstablishedEvent, function() {
+            mediator.once(geolocation.geolocationEstablishedEvent, function() {
 
                 var bannerParams = deriveBannerParams();
 

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -119,8 +119,8 @@ define([
          *  }
          *
          */
-        function deriveBannerParams() {
-            var defaultParams = membershipEngagementBannerUtils.defaultParams;
+        function deriveBannerParams(location) {
+            var defaultParams = membershipEngagementBannerUtils.defaultParams(location);
             var userTest = getUserTest();
             var campaignId = userTest ? userTest.campaignId : undefined;
             var userVariant = getUserVariant(userTest);
@@ -191,9 +191,9 @@ define([
 
         function init() {
 
-            mediator.once(geolocation.geolocationEstablishedEvent, function() {
+            return geolocation.get().then(function(location) {
 
-                var bannerParams = deriveBannerParams();
+                var bannerParams = deriveBannerParams(location);
 
                 if (bannerParams && (storage.local.get('gu.alreadyVisited') || 0) >= bannerParams.minArticles) {
                     return commercialFeatures.async.canDisplayMembershipEngagementBanner.then(function (canShow) {
@@ -212,8 +212,6 @@ define([
                     });
                 }
             });
-
-            return Promise.resolve();
         }
 
         function selectSequentiallyFrom(array) {

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -2,7 +2,6 @@
 import fetchJSON from 'lib/fetch-json';
 import config from 'lib/config';
 import { local as storage } from 'lib/storage';
-import mediator from 'lib/mediator';
 
 const storageKey = 'gu.geolocation';
 const editionToGeolocationMap = {
@@ -13,8 +12,6 @@ const editionToGeolocationMap = {
 const daysBeforeGeolocationRefresh = 10;
 
 const getFromStorage = (): string => storage.get(storageKey);
-
-const geolocationEstablishedEvent = 'geolocation:established';
 
 const get = (): Promise<string> =>
     new Promise((resolve, reject) => {
@@ -40,17 +37,17 @@ const get = (): Promise<string> =>
             .catch(reject);
     });
 
-const init = (): void => {
-    get().then(geolocation => {
-        const currentDate = new Date();
-        storage.set(storageKey, geolocation, {
-            expires: currentDate.setDate(
-                currentDate.getDate() + daysBeforeGeolocationRefresh
-            ),
-        });
-        // Allows application logic to wait until geolocation is set.
-        mediator.emit(geolocationEstablishedEvent);
+const setGeolocation = (geolocation: string): void => {
+    const currentDate = new Date();
+    storage.set(storageKey, geolocation, {
+        expires: currentDate.setDate(
+            currentDate.getDate() + daysBeforeGeolocationRefresh
+        ),
     });
+};
+
+const init = (): void => {
+    get().then(setGeolocation);
 };
 
 const editionToGeolocation = (editionKey: string = 'UK'): string =>
@@ -139,11 +136,12 @@ const isInEurope = (): boolean => {
     return europeCountryCodes.includes(countryCode) || countryCode === 'GB';
 };
 
+// Exposed for unit testing
 export {
     get,
     getSupporterPaymentRegion,
     getSync,
     isInEurope,
     init,
-    geolocationEstablishedEvent,
+    setGeolocation,
 };

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -14,6 +14,11 @@ const daysBeforeGeolocationRefresh = 10;
 
 const getFromStorage = (): string => storage.get(storageKey);
 
+const geoLocationEstablishedEvent = 'geolocation:established';
+
+const fireGeoLocationEstablishedEvent = () =>
+    mediator.emit(geoLocationEstablishedEvent);
+
 const get = (): Promise<string> =>
     new Promise((resolve, reject) => {
         const geolocationFromStorage = getFromStorage();
@@ -38,8 +43,6 @@ const get = (): Promise<string> =>
             .catch(reject);
     });
 
-const geoLocationSetEvent = 'geolocation:set';
-
 const init = (): void => {
     get().then(geolocation => {
         const currentDate = new Date();
@@ -49,7 +52,7 @@ const init = (): void => {
             ),
         });
         // Allows application logic to wait until geolocation is set.
-        mediator.emit(geoLocationSetEvent);
+        fireGeoLocationEstablishedEvent();
     });
 };
 
@@ -145,5 +148,5 @@ export {
     getSync,
     isInEurope,
     init,
-    geoLocationSetEvent,
+    geoLocationEstablishedEvent,
 };

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -14,10 +14,7 @@ const daysBeforeGeolocationRefresh = 10;
 
 const getFromStorage = (): string => storage.get(storageKey);
 
-const geoLocationEstablishedEvent = 'geolocation:established';
-
-const fireGeoLocationEstablishedEvent = () =>
-    mediator.emit(geoLocationEstablishedEvent);
+const geolocationEstablishedEvent = 'geolocation:established';
 
 const get = (): Promise<string> =>
     new Promise((resolve, reject) => {
@@ -52,7 +49,7 @@ const init = (): void => {
             ),
         });
         // Allows application logic to wait until geolocation is set.
-        fireGeoLocationEstablishedEvent();
+        mediator.emit(geolocationEstablishedEvent);
     });
 };
 
@@ -148,5 +145,5 @@ export {
     getSync,
     isInEurope,
     init,
-    geoLocationEstablishedEvent,
+    geolocationEstablishedEvent,
 };

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,5 +1,5 @@
 <div id="site-message__message">
-    <div class="site-message__message site-message__message--membership site-message__message--show-paypal">
+    <div class="site-message__message site-message__message--membership">
         <span class = "membership__message-text"><%=messageText%></span>
         <span class="membership__paypal-container">
             <img class="membership__paypal-logo" src="<%=paypalLogoSrc%>" alt="Paypal and credit card">

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,5 +1,5 @@
 <div id="site-message__message">
-    <div class="site-message__message site-message__message--membership <%=paypalClass%>">
+    <div class="site-message__message site-message__message--membership site-message__message--show-paypal">
         <span class = "membership__message-text"><%=messageText%></span>
         <span class="membership__paypal-container">
             <img class="membership__paypal-logo" src="<%=paypalLogoSrc%>" alt="Paypal and credit card">

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -110,6 +110,16 @@
 
 .site-message__message--membership {
     max-width: none;
+
+    .membership__paypal-logo {
+        display: inline-block;
+    }
+
+    .membership__message-text {
+        @include mq(desktop) {
+            font-size: 25px;
+        }
+    }
 }
 
 .site-message__message--tall {
@@ -520,18 +530,6 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     @include mq(tablet) {
         margin-top: 0;
         order: 1;
-    }
-}
-
-.site-message__message--show-paypal {
-    .membership__paypal-logo {
-        display: inline-block;
-    }
-
-    .membership__message-text {
-        @include mq(desktop) {
-            font-size: 25px;
-        }
     }
 }
 

--- a/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
@@ -14,7 +14,7 @@ define([
     config
 ) {
     var commercialFeatures, membershipMessages, mediator,
-        showMembershipMessages, alreadyVisited, storage, participations;
+        showMembershipMessages, alreadyVisited, storage, participations, geolocation;
 
     var injector = new Injector();
 
@@ -45,12 +45,14 @@ define([
                 'commercial/modules/commercial-features',
                 'common/modules/commercial/membership-engagement-banner',
                 'lib/storage',
-                'lib/mediator'
+                'lib/mediator',
+                'lib/geolocation'
             ], function () {
                 commercialFeatures = arguments[0];
                 membershipMessages = arguments[1];
                 storage = arguments[2];
                 mediator = arguments[3];
+                geolocation = arguments[4];
                 done();
             }, function () {
                 // woohoo
@@ -89,6 +91,7 @@ define([
                 commercialFeatures.async.canDisplayMembershipEngagementBanner = Promise.resolve(true);
                 fixtures.render(conf);
                 storage.local.set('gu.alreadyVisited', 10);
+                geolocation.setGeolocation('GB');
                 done();
             });
 
@@ -133,6 +136,7 @@ define([
                 fixtures.render(conf);
                 participations = storage.local.get('gu.ab.participations');
                 storage.local.remove('gu.ab.participations');
+                geolocation.setGeolocation('GB');
                 done();
             });
 
@@ -164,6 +168,7 @@ define([
                 commercialFeatures.async.canDisplayMembershipEngagementBanner = Promise.resolve(true);
                 fixtures.render(conf);
                 storage.local.set('gu.alreadyVisited', 10);
+                geolocation.setGeolocation('GB');
                 done();
             });
 


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Sets a new _Paypal and paywall_ default for the engagement banner with an amount (where applicable) which is dependant on the reader's geo-location.

## What is the value of this and can you measure success?

The test implemented in #16631 showed that the _Paypal and paywall_ variant performed significantly better than the previous (edition-dependent) default. Making this change will improve the conversion rate of the engagement banner.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

* __UK__

  <img width="1273" alt="uk" src="https://cloud.githubusercontent.com/assets/4085817/25863358/88411de0-34e3-11e7-8269-24a2d0412490.png">

* __US__

  _Note: contribution call-to-action used for US_
  <img width="1262" alt="us" src="https://cloud.githubusercontent.com/assets/4085817/25863379/9adfec38-34e3-11e7-935b-1212987b91a2.png">

* __Australia__

  <img width="1261" alt="au" src="https://cloud.githubusercontent.com/assets/4085817/25863404/b6052456-34e3-11e7-8bb4-66356738cf43.png">

* __Canada__

  <img width="1258" alt="ca" src="https://cloud.githubusercontent.com/assets/4085817/25863487/f0005e64-34e3-11e7-8757-62158bef97c3.png">

* __International__

  <img width="1265" alt="int" src="https://cloud.githubusercontent.com/assets/4085817/25863493/f6eba878-34e3-11e7-9be6-1e36198caf5e.png">

* __Europe - V1__

  _Note: the € sign is before the amount - displayed in e.g. Germany_
  <img width="1257" alt="nl" src="https://cloud.githubusercontent.com/assets/4085817/25863515/0aae640e-34e4-11e7-9e0e-c263d367d422.png">

* __Europe - V2__

  _Note: the € sign is after the amount - displayed in e.g. The Netherlands_
  <img width="1266" alt="de" src="https://cloud.githubusercontent.com/assets/4085817/25863582/4db07422-34e4-11e7-8318-fa60014017c1.png">

## Tested in CODE?

No, tested locally.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
