### PR TITLE
Fix switch exception

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -85,7 +85,7 @@ const pushAdUnit = (dfpDivId: string, sizeMapping: any) => {
     const promises = [];
 
     if (__switch_zero) {
-        const adUnitIds = findAdUnitIds(sizeMapping.size);
+        const adUnitIds = findAdUnitIds(sizeMapping.sizes);
 
         adUnitIds.forEach(adUnitId => {
             if (adUnitId) {


### PR DESCRIPTION
Art and design doesn't have any loaded ads because of an api change in `define-slot`