### PR TITLE
Remove high-merch from Crosswords footer; covered by high-merch.js.

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
@@ -9,10 +9,4 @@
 
     @fragments.onwardPlaceholder(isPaidContent = false)
 
-    @if(!crosswordPage.content.content.shouldHideAdverts) {
-        <div class="fc-container fc-container--commercial">
-            @fragments.commercial.commercialComponentHigh(false)
-        </div>
-    }
-
 </div>


### PR DESCRIPTION
## What does this change?
Crossword pages are not showing ads
this is because the GPT library is throwing an exception and bottoming out;
_this_ is because we are attempting to define the same ad slot twice;
_**this**_ is because there are two high-merch slots in the page;
_**THIS**_ is because it is added via both [crosswordFooter.scala.html](https://github.com/guardian/frontend/blob/master/applications/app/views/fragments/crosswords/crosswordFooter.scala.html#L14) and [high-merch.js](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/commercial/modules/high-merch.js#L20).

Since the high merch slot is always covered by `high-merch.js` I'm removing it from the crossword footer.

## What is the value of this and can you measure success?
Ads will now work on crossword pages: $$$

## Does this affect other platforms - Amp, Apps, etc?
No

@guardian/commercial-dev 