### PR TITLE
Username change in edit profile

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -26,7 +26,7 @@
         <p>Before you post, we’d like to thank you for joining the debate - we’re glad you’ve chosen to participate and we value your opinions and experiences.</p>
 
         <div class="d-comment-box__onboarding-username">
-            <p>Please choose your username under which you would like all your comments to show up:</p>
+            <p>Please choose your username under which you would like all your comments to show up. You can only set your username once.</p>
             <label class="d-comment-box__onboarding-username-label" for="usernameInput">Username: </label>
             <span>Must be 6-20 characters, letters and/or numbers only, no spaces.</span>
             <input type="text" id="usernameInput" class="d-comment-box__onboarding-username-input" placeholder="" value=""/>

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -96,10 +96,10 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
 }
 
 case class ProfileForms(
-                         publicForm: Form[ProfileFormData],
-                         accountForm: Form[AccountFormData],
-                         privacyForm: Form[PrivacyFormData],
-                         activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping) {
+    publicForm: Form[ProfileFormData],
+    accountForm: Form[AccountFormData],
+    privacyForm: Form[PrivacyFormData],
+    activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping) {
 
   lazy val activeForm = activePage match {
     case PublicEditProfilePage => publicForm

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -34,11 +34,11 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
 
   import authenticatedActions._
 
-  protected val accountPage = IdentityPage("/account/edit", "Edit Account Details")
-  protected val publicPage = IdentityPage("/public/edit", "Edit Public Profile")
-  protected val membershipPage = IdentityPage("/membership/edit", "Membership")
-  protected val digitalPackPage = IdentityPage("/digitalpack/edit", "Digital Pack")
-  protected val privacyPage = IdentityPage("/privacy/edit", "Privacy")
+  private val accountPage = IdentityPage("/account/edit", "Edit Account Details")
+  private val publicPage = IdentityPage("/public/edit", "Edit Public Profile")
+  private val membershipPage = IdentityPage("/membership/edit", "Membership")
+  private val digitalPackPage = IdentityPage("/digitalpack/edit", "Digital Pack")
+  private val privacyPage = IdentityPage("/privacy/edit", "Privacy")
 
   def displayPublicProfileForm = displayForm(publicPage)
   def displayAccountForm = displayForm(accountPage)
@@ -46,9 +46,9 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
   def displayDigitalPackForm = displayForm(digitalPackPage)
   def displayPrivacyForm = displayForm(privacyPage)
 
-  protected def displayForm(page: IdentityPage) = csrfAddToken {
+  private def displayForm(page: IdentityPage) = csrfAddToken {
     recentlyAuthenticated.async { implicit request =>
-      profileFormsView(page = page, forms = ProfileForms(request.user, PublicEditProfilePage))
+      Future(profileFormsView(page = page, forms = ProfileForms(request.user, PublicEditProfilePage), request.user))
     }
   }
 
@@ -57,57 +57,49 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
   def submitPrivacyForm() = submitForm(privacyPage)
 
   def identifyActiveSubmittedForm(page: IdentityPage): EditProfilePage =
-    if(page == publicPage)
-      PublicEditProfilePage
-    else if(page == accountPage)
-      AccountEditProfilePage
-    else
-      PrivacyEditProfilePage
+    page match {
+      case `publicPage` => PublicEditProfilePage
+      case `accountPage` => AccountEditProfilePage
+      case _ => PrivacyEditProfilePage
+    }
 
-  def submitForm(page: IdentityPage) = csrfCheck {
-    authActionWithUser.async {
-      implicit request =>
-        val activePage = identifyActiveSubmittedForm(page)
-        val idRequest = idRequestParser(request)
-        val user = request.user
-        val forms = ProfileForms(user, activePage).bindFromRequest(request)
-        val futureFormOpt = forms.activeForm.value map {
-          case data: AccountFormData if (data.deleteTelephone) => {
-            identityApiClient.deleteTelephone(user.auth) map {
-              case Left(errors) => forms.withErrors(errors)
-              case Right(_) => {
-                forms.bindForms(user.user.copy(privateFields = user.user.privateFields.copy(telephoneNumber = None)))
-              }
+  def submitForm(page: IdentityPage) = csrfCheck { authActionWithUser.async { implicit request =>
+      val activePage = identifyActiveSubmittedForm(page)
+      val user = request.user
+      val forms = ProfileForms(user, activePage).bindFromRequest(request)
+
+      forms.activeForm.value.map {
+        case data: AccountFormData if (data.deleteTelephone) => {
+          identityApiClient.deleteTelephone(user.auth) map {
+            case Left(errors) => profileFormsView(page, forms.withErrors(errors), user)
+
+            case Right(_) => {
+              val boundForms = forms.bindForms(user.user.copy(privateFields = user.user.privateFields.copy(telephoneNumber = None)))
+              profileFormsView(page, boundForms, user)
             }
           }
-          case data: UserFormData =>
-            identityApiClient.saveUser(user.id, data.toUserUpdate(user), user.auth) map {
-              case Left(errors) =>
-                forms.withErrors(errors)
-
-              case Right(user) => forms.bindForms(user)
-            }
         }
 
-        val futureForms = futureFormOpt getOrElse Future.successful(forms)
-        futureForms flatMap {
-          forms =>
-            profileFormsView(page = page,forms = forms)
-        }
+        case data: UserFormData =>
+          identityApiClient.saveUser(user.id, data.toUserUpdate(user), user.auth) map {
+            case Left(errors) => profileFormsView(page, forms.withErrors(errors), user)
+            case Right(updatedUser) =>
+              logger.info(s"$updatedUser")
+              profileFormsView(page, forms.bindForms(updatedUser), updatedUser)
+          }
+      }.getOrElse(Future(profileFormsView(page, forms.bindForms(user), user)))
     }
   }
 
-  def profileFormsView(page: IdentityPage, forms: ProfileForms)(implicit request: AuthRequest[AnyContent]) = {
-    val idRequest = idRequestParser(request)
-    val user = request.user
-
-    Future(NoCache(Ok(views.html.profileForms(
-           page,
-           user, forms, idRequest, idUrlBuilder))))
-  }
+  private def profileFormsView(page: IdentityPage, forms: ProfileForms, user: User)(implicit request: AuthRequest[AnyContent]) =
+    NoCache(Ok(views.html.profileForms(page, user, forms, idRequestParser(request), idUrlBuilder)))
 }
 
-case class ProfileForms(publicForm: Form[ProfileFormData], accountForm: Form[AccountFormData], privacyForm: Form[PrivacyFormData], activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping) {
+case class ProfileForms(
+                         publicForm: Form[ProfileFormData],
+                         accountForm: Form[AccountFormData],
+                         privacyForm: Form[PrivacyFormData],
+                         activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping) {
 
   lazy val activeForm = activePage match {
     case PublicEditProfilePage => publicForm

--- a/identity/app/form/ProfileMapping.scala
+++ b/identity/app/form/ProfileMapping.scala
@@ -10,7 +10,8 @@ class ProfileMapping(val messagesApi: MessagesApi) extends UserFormMapping[Profi
   protected lazy val formMapping = mapping(
     "location" -> textField,
     "aboutMe" -> textArea,
-    "interests" -> textField
+    "interests" -> textField,
+    "username" -> textField
   )(ProfileFormData.apply)(ProfileFormData.unapply)
 
   protected def fromUser(user: User) = ProfileFormData(user)
@@ -18,21 +19,25 @@ class ProfileMapping(val messagesApi: MessagesApi) extends UserFormMapping[Profi
   protected lazy val contextMap =  Map(
     "publicFields.location" -> "location",
     "publicFields.aboutMe" -> "aboutMe",
-    "publicFields.interests" -> "interests"
+    "publicFields.interests" -> "interests",
+    "publicFields.username" -> "username"
   )
 }
 
 case class ProfileFormData(
   location: String,
   aboutMe: String,
-  interests: String
+  interests: String,
+  username: String
 ) extends UserFormData{
 
   def toUserUpdate(currentUser: User): UserUpdate = UserUpdate(
     publicFields = Some(PublicFields(
       location = toUpdate(location, currentUser.publicFields.location),
       aboutMe = toUpdate(aboutMe, currentUser.publicFields.aboutMe),
-      interests = toUpdate(interests, currentUser.publicFields.interests)
+      interests = toUpdate(interests, currentUser.publicFields.interests),
+      username = toUpdate(username, currentUser.publicFields.username),
+      displayName = toUpdate(username, currentUser.publicFields.username) // displayName == username
     ))
   )
 
@@ -42,6 +47,7 @@ object ProfileFormData {
   def apply(user: User): ProfileFormData = ProfileFormData(
     location = user.publicFields.location getOrElse "",
     aboutMe = user.publicFields.aboutMe getOrElse "",
-    interests = user.publicFields.interests getOrElse ""
+    interests = user.publicFields.interests getOrElse "",
+    username = user.publicFields.username getOrElse ""
   )
 }

--- a/identity/app/views/fragments/profile/publicProfileForm.scala.html
+++ b/identity/app/views/fragments/profile/publicProfileForm.scala.html
@@ -10,25 +10,70 @@
 @import conf.switches.Switches
 @import views.html.fragments.registrationFooter
 
+@usernameIsSet = @{ user.publicFields.username.fold(false)(_ => true) }
+
 <fieldset class="fieldset">
-    <div class="fieldset__heading">
-        <h2 class="form__heading">Username</h2>
+    <div class="form__note">
+        These details will be publicly visible to everyone who sees your profile in the
+        <a href="https://www.theguardian.com/community-faqs">commenting</a> section
+        and the <a href="https://witness.theguardian.com/faq">GuardianWitness</a>.
     </div>
-    <div class="fieldset__fields">
-        <ul class="u-unstyled">
-            <li class="form-field">
-                @user.publicFields.displayName
-            </li>
-            <li>
-                <div class="form__note">
-                    If you have not posted any comments you will be prompted to create/change a username when you post
-                    a comment for the first time. After entering your comment and clicking on ‘post your comment’
-                    you will be asked to create a username. If you have posted comments or experience any difficulties,
-                    please email <a href="mailto:userhelp@@theguardian.com">Userhelp</a>.
-                </div>
-            </li>
-        </ul>
-    </div>
+</fieldset>
+
+@if(usernameIsSet) {
+    <fieldset class="fieldset">
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Username</h2>
+            <div class="form__note">
+            </div>
+        </div>
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li class="form-field">@user.publicFields.username</li>
+            </ul>
+        </div>
+    </fieldset>
+}
+
+<fieldset class="fieldset">
+    <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
+        @views.html.helper.CSRF.formField
+
+        @if(publicProfileForm.globalError.isDefined) {
+            <div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>
+        }
+
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Profile</h2>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+
+                @publicProfileForm.error("user.publicFields.username").map { error =>
+                    <div class="form__error">@error.message</div>
+                }
+
+                @if(!usernameIsSet) {
+                    @inputField(Input(publicProfileForm("username"), ('_label, "Username")))
+                    <div class="form-field__note">
+                        You can only set your username once. It must be 6-20 characters, letters and/or numbers only
+                        and have no spaces. If you do not set your username, then your full name will be used.
+                    </div>
+                } else {
+                    <input type="hidden" name="username" value=@user.publicFields.username>
+                }
+
+                @inputField(Input(publicProfileForm("location"), ('_label, "Location")))
+                @textareaField(Input(publicProfileForm("aboutMe"), ('_label, "About me"), ('class, "textarea--mid")))
+                @textareaField(Input(publicProfileForm("interests"), ('_label, "Interests"), ('class, "textarea--mid"), ('maxlength, "255")))
+
+                <li>
+                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
+                </li>
+            </ul>
+        </div>
+    </form>
 </fieldset>
 
 @if(Switches.IdentityAvatarUploadSwitch.isSwitchedOn) {
@@ -48,7 +93,7 @@
                         <input type="file" name="file" accept="image/gif, image/jpeg, image/png" />
                     </li>
                     <li>
-                        <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload</button>
+                        <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload image</button>
                     </li>
                 </ul>
             </div>
@@ -56,34 +101,5 @@
     </fieldset>
 }
 
-<form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/public/edit", idRequest)" role="main" method="post">
-    @views.html.helper.CSRF.formField
-
-    @if(publicProfileForm.globalError.isDefined) {
-        <div class="form__error">@publicProfileForm.globalErrors.map(_.message).mkString(", ")</div>
-    }
-
-    <fieldset class="fieldset">
-
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Public profile</h2>
-            <div class="form__note">These details will be visible to everyone who sees your profile.</div>
-        </div>
-
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
-
-                @inputField(Input(publicProfileForm("location"), ('_label, "Location")))
-                @textareaField(Input(publicProfileForm("aboutMe"), ('_label, "About me"), ('class, "textarea--long")))
-                @textareaField(Input(publicProfileForm("interests"), ('_label, "Interests"), ('class, "textarea--mid"), ('maxlength, "255")))
-
-                <li>
-                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
-                </li>
-            </ul>
-        </div>
-
-    </fieldset>
-</form>
 
 @registrationFooter(idRequest, idUrlBuilder)

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -68,6 +68,7 @@ import scala.concurrent.Future
       val location = "Test location"
       val aboutMe = "Interesting"
       val interests = "Other interesting things"
+      val username = "usernametest1"
 
       "save the user through the ID API" in new EditProfileFixture {
 
@@ -75,14 +76,17 @@ import scala.concurrent.Future
           .withFormUrlEncodedBody(
             "location" -> location,
             "aboutMe" -> aboutMe,
-            "interests" -> interests
+            "interests" -> interests,
+            "username" -> username
           )
 
         val updatedUser = user.copy(
           publicFields = PublicFields(
             location = Some(location),
             aboutMe = Some(aboutMe),
-            interests = Some(interests)
+            interests = Some(interests),
+            username = Some(username),
+            displayName = Some(username)
           )
         )
         when(api.saveUser(Matchers.any[String], Matchers.any[UserUpdate], Matchers.any[Auth]))

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
@@ -98,7 +98,7 @@ CommentBox.prototype.defaultOptions = {
     maxLength: 5000,
     premod: false,
     newCommenter: false,
-    newUsername: true,
+    hasUsername: true,
     focus: false,
     state: 'top-level',
     replyTo: null,
@@ -171,7 +171,7 @@ CommentBox.prototype.showOnboarding = function(e) {
 
     // Check if new commenter as they may have already commented on this article
     if (this.hasState('onboarding-visible') || !this.options.newCommenter) {
-        if (!this.options.newUsername) {
+        if (this.options.hasUsername) {
             this.removeState('onboarding-visible');
         }
         this.postComment();
@@ -179,6 +179,9 @@ CommentBox.prototype.showOnboarding = function(e) {
         this.getElem('onboarding-author').innerHTML = this.getUserData().displayName;
         this.setState('onboarding-visible');
         this.previewComment(this.onboardingPreviewSuccess);
+        if (this.options.hasUsername) {
+            this.getElem('onboarding-username').classList.add('is-hidden');
+        }
     }
 };
 
@@ -265,7 +268,6 @@ CommentBox.prototype.postComment = function() {
 
     var postCommentToDAPI = function () {
         self.removeState('onboarding-visible');
-        self.options.newUsername = false;
         comment.body = self.urlify(comment.body);
         self.setFormState(true);
         DiscussionApi
@@ -275,14 +277,13 @@ CommentBox.prototype.postComment = function() {
 
     var updateUsernameSuccess = function (resp) {
         mediator.emit('user:username:updated', resp.user.publicFields.username);
-        self.options.newUsername = false;
+        self.options.hasUsername = true;
         self.getElem('onboarding-username').classList.add('is-hidden');
         postCommentToDAPI();
     };
 
     var updateUsernameFailure = function (errorResponse) {
         var usernameField = self.getElem('onboarding-username-input');
-        self.options.newUsername = true;
         self.setState('onboarding-visible');
         usernameField.classList.add('d-comment-box__onboarding-username-error-border');
         var errorMessage = self.getElem('onboarding-username-error-message');
@@ -305,7 +306,7 @@ CommentBox.prototype.postComment = function() {
         }
 
         if (self.errors.length === 0) {
-            if (self.options.newCommenter && self.options.newUsername) {
+            if (self.options.newCommenter && !self.options.hasUsername) {
                 IdentityApi.updateUsername(self.getElem('onboarding-username-input').value).then(updateUsernameSuccess, updateUsernameFailure);
             } else {
                 postCommentToDAPI();

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
@@ -58,6 +58,7 @@ Loader.prototype.classes = { };
 Loader.prototype.componentClass = 'discussion';
 Loader.prototype.comments = null;
 Loader.prototype.user = null;
+Loader.prototype.username = null;
 
 Loader.prototype.initTopComments = function() {
 
@@ -291,11 +292,17 @@ Loader.prototype.ready = function() {
 };
 
 Loader.prototype.getUser = function() {
+    var self = this;
     if (Id.getUserFromCookie()) {
         DiscussionApi.getUser().then(function(resp) {
-            this.user = resp.userProfile;
-            this.emit('user:loaded');
-        }.bind(this));
+            self.user = resp.userProfile;
+            Id.getUserFromApiWithRefreshedCookie().then(function (response) {
+                if (response.user.publicFields.username) {
+                    self.username = response.user.publicFields.username;
+                }
+                self.emit('user:loaded');
+            });
+        }.bind(self));
     } else {
         this.emit('user:loaded');
     }
@@ -343,6 +350,7 @@ Loader.prototype.renderCommentBox = function(elem) {
         discussionId: this.getDiscussionId(),
         premod: this.user.privateFields.isPremoderated,
         newCommenter: !this.user.privateFields.hasCommented,
+        hasUsername: this.username !== null,
         shouldRenderMainAvatar: false,
         paymentRequired: isPaidCommenting,
         testVariant: testVariant


### PR DESCRIPTION
## What does this change?

Enables users to set their username within `Edit Profile`. They can do so only if they do not already have a username.

## What is the value of this and can you measure success?

Currently users can set their username during discussion on-boarding when they post their first comment. This PR adds another place where they can set their username, namely within the `Edit Profile`.  This should reduce further the load on our Userhelp regarding username changes requests.

## Screenshots

![edit_profile_username_change](https://cloud.githubusercontent.com/assets/13835317/25893645/7d4e0d16-3570-11e7-839e-7170f741af87.gif)

@andrewfindlay
