### PR TITLE
Lint JS for putting exports last

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     extends: ['airbnb', 'prettier'],
 
     // eslint-plugin-prettier switches prettier on
-    plugins: ['prettier'],
+    plugins: ['guardian-frontend', 'prettier'],
     parserOptions: {
         sourceType: 'module',
         ecmaVersion: 6,
@@ -32,6 +32,10 @@ module.exports = {
         ],
         'no-extend-native': 'error',
         'func-style': ['error', 'expression', { allowArrowFunctions: true }],
+
+        // our own rules for frontend
+        // live in tools/eslint-plugin-guardian-frontend
+        'guardian-frontend/exports-last': 'error',
     },
     // don't look for eslintrcs above here
     root: true,

--- a/dev/eslint-plugin-guardian-frontend/__tests__/exports-last.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/exports-last.js
@@ -2,39 +2,22 @@ const { RuleTester } = require('eslint');
 const rule = require('../rules/exports-last');
 
 const ruleTester = new RuleTester({
+    parser: 'babel-eslint',
     parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
 });
 
 ruleTester.run('exports-last', rule, {
     valid: [
-        `
-        const foo = 'bar';
-        const bar = 'baz';
-      `,
-        `
-        const foo = 'bar';
-        export {foo};
-      `,
-        `
-        const foo = 'bar';
-        export default foo;
-      `,
-        `
-        const foo = 'bar';
-        export default foo;
-        export const bar = true;
-      `,
+        `const foo = 'bar'; const bar = 'baz';`,
+        `const foo = 'bar'; export {foo};`,
+        `const foo = 'bar'; export default foo;`,
+        `const foo = 'bar'; export default foo; export const bar = true;`,
+        `export type a = { a: string }; const foo = 'bar';`,
     ],
 
     invalid: [
-        `
-        export default 'bar';
-        const bar = true;
-      `,
-        `
-        export const foo = 'bar';
-        const bar = true;
-      `,
+        `export default 'bar'; const bar = true;`,
+        `export const foo = 'bar'; const bar = true;`,
     ].map(code => ({
         code,
         errors: ['Export statements should appear at the end of the file'],

--- a/dev/eslint-plugin-guardian-frontend/__tests__/exports-last.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/exports-last.js
@@ -1,0 +1,42 @@
+const { RuleTester } = require('eslint');
+const rule = require('../rules/exports-last');
+
+const ruleTester = new RuleTester({
+    parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
+
+ruleTester.run('exports-last', rule, {
+    valid: [
+        `
+        const foo = 'bar';
+        const bar = 'baz';
+      `,
+        `
+        const foo = 'bar';
+        export {foo};
+      `,
+        `
+        const foo = 'bar';
+        export default foo;
+      `,
+        `
+        const foo = 'bar';
+        export default foo;
+        export const bar = true;
+      `,
+    ],
+
+    invalid: [
+        `
+        export default 'bar';
+        const bar = true;
+      `,
+        `
+        export const foo = 'bar';
+        const bar = true;
+      `,
+    ].map(code => ({
+        code,
+        errors: ['Export statements should appear at the end of the file'],
+    })),
+});

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-guardian-frontend",
   "main": "index.js",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "scripts": {
     "test": "jest"
   }

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-guardian-frontend",
   "main": "index.js",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "scripts": {
     "test": "jest"
   }

--- a/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
@@ -2,11 +2,15 @@
 
 const isExportStatement = (node, context) => {
     if (
-        (node.type === 'ExportDefaultDeclaration' ||
-            node.type === 'ExportNamedDeclaration' ||
-            node.type === 'ExportAllDeclaration') &&
+        [
+            'ExportAllDeclaration',
+            'ExportNamedDeclaration',
+            'ExportDefaultDeclaration',
+        ].includes(node.type) &&
         // ignore flowtype exports
-        context.getSourceCode().getTokens(node)[1].value !== 'type'
+        !['type', 'interface'].includes(
+            context.getSourceCode().getTokens(node)[1].value
+        )
     ) {
         return true;
     }

--- a/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
@@ -1,0 +1,38 @@
+// cribbed from https://github.com/k15a/eslint-plugin-import/commit/84fd4f27eb537c9230196d6403aafd406e46e6e9
+
+const isExportStatement = ({ type }) => {
+    if (
+        type === 'ExportDefaultDeclaration' ||
+        type === 'ExportNamedDeclaration'
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
+module.exports = {
+    create(context) {
+        return {
+            Program({ body }) {
+                const lastNonExportStatement = body.reduce(
+                    (acc, node, index) =>
+                        isExportStatement(node) ? acc : index,
+                    0
+                );
+
+                body.forEach((node, index) => {
+                    if (
+                        isExportStatement(node) &&
+                        index < lastNonExportStatement
+                    ) {
+                        context.report({
+                            node,
+                            message: 'Export statements should appear at the end of the file',
+                        });
+                    }
+                });
+            },
+        };
+    },
+};

--- a/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/exports-last.js
@@ -1,9 +1,12 @@
 // cribbed from https://github.com/k15a/eslint-plugin-import/commit/84fd4f27eb537c9230196d6403aafd406e46e6e9
 
-const isExportStatement = ({ type }) => {
+const isExportStatement = (node, context) => {
     if (
-        type === 'ExportDefaultDeclaration' ||
-        type === 'ExportNamedDeclaration'
+        (node.type === 'ExportDefaultDeclaration' ||
+            node.type === 'ExportNamedDeclaration' ||
+            node.type === 'ExportAllDeclaration') &&
+        // ignore flowtype exports
+        context.getSourceCode().getTokens(node)[1].value !== 'type'
     ) {
         return true;
     }
@@ -17,13 +20,13 @@ module.exports = {
             Program({ body }) {
                 const lastNonExportStatement = body.reduce(
                     (acc, node, index) =>
-                        isExportStatement(node) ? acc : index,
+                        isExportStatement(node, context) ? acc : index,
                     0
                 );
 
                 body.forEach((node, index) => {
                     if (
-                        isExportStatement(node) &&
+                        isExportStatement(node, context) &&
                         index < lastNonExportStatement
                     ) {
                         context.report({

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
         'prettier/flowtype',
         'prettier/react',
     ],
-    plugins: ['guardian-frontend', 'flowtype', 'flow-header'],
+    plugins: ['flowtype', 'flow-header'],
     rules: {
         // require-specific overrides
         'import/no-extraneous-dependencies': 'off', // necessary while we use aliases

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,7 +2527,7 @@ eslint-plugin-flowtype@^2.30.0:
     lodash "^4.15.0"
 
 "eslint-plugin-guardian-frontend@file:dev/eslint-plugin-guardian-frontend":
-  version "2.0.0"
+  version "3.0.0"
 
 eslint-plugin-import@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What does this change?

adds a lint rule to require that module exports come last in the file.
ignore's flow type exports, since they need to be defined before they can be used.

## What is the value of this and can you measure success?

make exports easy to find
