### PR TITLE
Bump fapi client version for new special report tag

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -81,6 +81,7 @@ object CardStyle {
     case fapiutils.Review => Review
     case fapiutils.Letters => Letters
     case fapiutils.ExternalLink => ExternalLink
+    case fapiutils.Paid => DefaultCardstyle // Default style for now until a tone is added for paid
     case fapiutils.DefaultCardstyle  => DefaultCardstyle
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
-  val faciaVersion = "2.0.13"
+  val faciaVersion = "2.0.15"
   val capiVersion = "11.12"
   val dispatchVersion = "0.11.3"
   val configurationMagicVersion = "1.2.2"


### PR DESCRIPTION
## What does this change?
Bumps the fapi client version to include the new special report tag.  A previous release added a `Paid` card style - which I have put a placeholder tone in for (the default news tone).  Let me know what you think @marialivia16 - was there a plan for adding this card style to frontend?

## What is the value of this and can you measure success?
Allows new special report tag to be used

## Does this affect other platforms - Amp, Apps, etc?
No, also being added in MAPI

## Screenshots
N/A

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
