### PR TITLE
Newsletters front tweaks

### DIFF
--- a/applications/app/views/signup/newsletters.scala.html
+++ b/applications/app/views/signup/newsletters.scala.html
@@ -31,28 +31,13 @@
             } else { newsletter-card--tone-news }"
                 data-component="newsletter-card @emailListing.name">
 
-                <div class="newsletter-card__imagewrapper">
-                    @if(emailListing.imageFilename.isDefined) {
-                        @defining(emailListing.imageFilename.get) { imageFilename =>
-                            <img class="newsletter-image"
-                                src="@{ Static("images/email" + imageFilename) }"
-                                alt="cover image for @emailListing.name"
-                            />
-                        }
-                    } else {
-                        <div class="newsletter-image">
-                            @fragments.inlineSvg("email_placeholder", "illustration")
-                        </div>
-                    }
-                </div>
-
                 <div class="newsletter-card__content js-newsletter-content">
 
                     <div class="newsletter-card__name">@emailListing.name
                         @if(emailListing.subheading.isDefined){ @emailListing.subheading }
                     </div>
 
-                    <div class="">
+                    <div>
                         @emailListing.teaser
 
                         <div class="newsletter-card__frequency">

--- a/applications/app/views/signup/newsletters.scala.html
+++ b/applications/app/views/signup/newsletters.scala.html
@@ -39,22 +39,23 @@
 
                     <div>
                         @emailListing.teaser
-
-                        <div class="newsletter-card__frequency">
-                            @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
-                            @emailListing.frequency
-                        </div>
                     </div>
                 </div>
 
                 <div class="newsletter-card__meta js-newsletter-meta">
 
-                  <div class="signup-confirmation is-hidden js-signup-confirmation">
-                    @fragments.inlineSvg("tick", "icon")
-                    <div class="signup-confirmation__message">
-                        <h3 class="signup-confirmation--success">You've subscribed!</h3>
+                    <div class="newsletter-card__frequency">
+                        @fragments.inlineSvg("clock", "icon", List("old-article-message--clock"))
+                        @emailListing.frequency
                     </div>
-                  </div>
+
+
+                    <div class="signup-confirmation is-hidden js-signup-confirmation">
+                        @fragments.inlineSvg("tick", "icon")
+                        <div class="signup-confirmation__message">
+                            <h3 class="signup-confirmation--success">You've subscribed!</h3>
+                        </div>
+                    </div>
 
                     <form action="@LinkTo("/email")" method="post" target="magicframe" class="newsletter-card__signup">
                         <input class="newsletter-card__text-input js-newsletter-card__text-input"
@@ -69,6 +70,9 @@
                           <span>Sign up</span>
                         </button>
                     </form>
+
+                    @* This iframe is used for submitting the form without reloading the page *@
+                    <iframe class="u-h" width="0" height="0" border="0" name="magicframe" id="magicframe"></iframe>
 
                     <div class="newsletter-card__example js-newsletter-preview is-hidden">
                         @if(emailListing.exampleUrl.isDefined){
@@ -119,7 +123,5 @@
         </div>
     </div>
   </div>
-
-  <iframe width="0" height="0" border="0" name="magicframe" id="magicframe"></iframe>
 
 }

--- a/docs/03-dev-howtos/17-working-with-emails.md
+++ b/docs/03-dev-howtos/17-working-with-emails.md
@@ -48,7 +48,6 @@ When adding a new `EmailSubscription`:
 - frequency >> Text that appears next to the clock icon
 - subheading >> Currently used for the region specific emails (UK, AUS, US)
 - tone >> Determines the tone colours of the card on the newsletters page
-- imageFilename >> Placeholder for when we add an image to each card (WIP)
 
 
 ## Adding colour and tones to the email sign up forms
@@ -93,10 +92,10 @@ function validate(form) {
 ## Email rendering
 
 Fronts and articles can be rendered in email-friendly HTML by appending the URL parameter `format=email`. The response from these endpoints can be put into an email body and will render well in a wide variety of email clients.
- 
+
 For curating emails, you'll normally want to set up a custom front rather than co-opting an existing front. For
 this purpose, we have a notion of "Email fronts" (in addition to Commercial, Editorial, and Training). Content can
-be placed into email fronts in the same way as for web fronts, via the [fronts tool](https://fronts.gutools.co.uk/email). 
+be placed into email fronts in the same way as for web fronts, via the [fronts tool](https://fronts.gutools.co.uk/email).
 
 As for web fronts, other properties of email fronts can be configured via the [fronts config tool](https://fronts.gutools.co.uk/email/config).
 This includes creating containers and choosing their layout types.
@@ -139,5 +138,3 @@ medium | 1st    | big      | yes         | big
 fast   | 1st    | small    | no          | small
        | others | none     | no          | small
 ```
-
-

--- a/static/src/inline-svgs/illustration/email_placeholder.svg
+++ b/static/src/inline-svgs/illustration/email_placeholder.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 60 60"><title>Group</title><circle fill="#46BCDF" cx="30" cy="30" r="30"/><path fill="#005689" d="M42.955 19.5h-25.91L15 21.6v16.8l2.045 2.1h25.91L45 38.4V21.6l-2.045-2.1zm-2.975 2.8l-10.058 9.468-9.937-9.468H39.98zm2.29 9.8v5.6H17.73V24.26l10.91 10.64h2.726L42.27 24.26v7.84z"/></svg>

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -51,36 +51,6 @@
     }
 }
 
-.newsletter-card__header {
-
-}
-
-.newsletter-card__imagewrapper {
-    background-color: $guardian-brand;
-    height: 0;
-    padding-bottom: 60%;
-
-    svg {
-        display: block;
-        margin: auto;
-        padding-top: 15%;
-        height: 80%;
-        width: 80px;
-
-        @include mq(desktop) {
-            width: 60px;
-        }
-    }
-
-
-}
-
-.newsletter-image {
-    position: relative;
-    width: 100%;
-
-}
-
 .newsletter-card__name {
     @include fs-header(5);
     font-weight: 900;
@@ -267,19 +237,6 @@
 .newsletter-card--tone-feature {
     border-top-color: $features-support-3;
 
-    .newsletter-card__imagewrapper {
-        background-color: $features-support-1;
-    }
-
-    .newsletter-image {
-        circle {
-            fill: $features-support-3;
-        }
-        path {
-            fill:  $features-support-1;
-        }
-    }
-
     .newsletter-card__signup {
         .newsletter-card__lozenge {
             border-color: $features-support-1;
@@ -313,20 +270,6 @@
 .newsletter-card--tone-comment {
     border-top-color: $comment-support-4;
 
-    .newsletter-card__imagewrapper {
-        background-color: $comment-support-4;
-    }
-
-    .newsletter-image {
-        circle {
-            fill: $comment-support-2;
-        }
-
-        path {
-            fill: $comment-support-4;
-        }
-    }
-
     .newsletter-card__signup {
         .newsletter-card__lozenge {
             border-color: $comment-support-4;
@@ -359,20 +302,6 @@
 // TONE SPECIFIC MODS - MEDIA
 .newsletter-card--tone-media {
     border-top-color: $multimedia-main-2;
-
-    .newsletter-card__imagewrapper {
-        background-color: $multimedia-main-1;
-    }
-
-    .newsletter-image {
-        circle {
-            fill: $multimedia-main-2;
-        }
-
-        path {
-            fill: $multimedia-main-1;
-        }
-    }
 
     .newsletter-card__signup {
         .newsletter-card__lozenge {
@@ -409,20 +338,6 @@
     $brexit-main-2: #ff0ff0;
 
     border-top-color: $brexit-main-2;
-
-    .newsletter-card__imagewrapper {
-        background-color: $brexit-main-1;
-    }
-
-    .newsletter-image {
-        circle {
-            fill: $brexit-main-2;
-        }
-
-        path {
-            fill: $brexit-main-1;
-        }
-    }
 
     .newsletter-card__signup {
         .newsletter-card__lozenge {

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -20,34 +20,44 @@
 
 .newsletter-card__wrapper {
     position: relative;
+    display: flex;
+    flex-wrap: wrap;
+
+    @include mq(tablet) {
+        margin-right: -$gs-gutter;
+    }
 
     @include mq(leftCol) {
+        margin-left: gs-span(2) + $gs-gutter;
+    }
+
+    @include mq(wide) {
         margin-left: gs-span(3) + $gs-gutter;
     }
 }
 
 .newsletter-card {
-    display: inline-block;
-    float: left;
     margin-bottom: $gs-baseline;
     border-top: 2px solid $news-accent;
+    border-bottom: 1px solid $neutral-3;
+    background-color: $comment-support-2;
+    padding: $gs-baseline / 2 $gs-gutter / 2 $gs-baseline;
+    box-sizing: border-box;
     width: 100%;
+    display: flex;
+    flex-wrap: wrap;
 
     @include mq(tablet) {
-        width: gs-span(4);
+        width: (gs-span(4)) + ($gs-gutter * 2);
         margin-right: $gs-gutter;
     }
 
     @include mq(desktop) {
-        width: 30%;
+        width: gs-span(3);
     }
 
     @include mq(leftCol) {
         margin-top: $gs-baseline;
-    }
-
-    @include mq(wide) {
-        width: gs-span(3);
     }
 }
 
@@ -55,44 +65,25 @@
     @include fs-header(5);
     font-weight: 900;
     line-height: 24px;
-    padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline / 2;
 }
 
 .newsletter-card__content {
     @include fs-textSans(3);
     line-height: 18px;
-    background-color: $comment-support-2;
-    height: 9em;
-    padding: 0 $gs-gutter / 2 0 $gs-gutter / 2;
-
-
-    @include mq(tablet) {
-        height: 12em;
-    }
-
-    @include mq(desktop) {
-        height: 12em;
-    }
 }
 
 .newsletter-card__meta {
-    background-color: $comment-support-2;
-    border-bottom: 1px solid $neutral-3;
-    padding: $gs-gutter / 2;
-    padding-bottom: $gs-baseline;
-    height: gs-height(1);
+    padding-top: $gs-baseline;
+    margin-top: auto;
+    width: 100%;
 
     * {
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
         box-sizing: border-box;
     }
 
-
     .newsletter-card__text-input {
         @include fs-textSans(2);
-        -webkit-border-radius: 1000px 0 0 1000px;
         border-radius: 1000px 0 0 1000px;
         border: 1px solid $neutral-3;
         border-right: 0;
@@ -107,7 +98,6 @@
         color: #ffffff;
         border: 1px solid $news-main-1;
         background-color: $news-main-1;
-        -webkit-border-radius: 1000px;
         border-radius: 1000px;
         border-width: 1px;
         height: 3em;
@@ -123,7 +113,6 @@
     }
 
     .newsletter-card__lozenge--submit {
-        -webkit-border-radius: 0 1000px 1000px 0;
         border-radius: 0 1000px 1000px 0;
         border-left: 0;
         margin-right: 0;
@@ -161,7 +150,7 @@
 .newsletter-card__frequency {
     @include fs-textSans(1);
     color: $neutral-2;
-    padding: $gs-baseline 0 0;
+    padding-bottom: $gs-baseline / 2;
 
     .inline-icon {
         fill: $neutral-3;
@@ -186,7 +175,6 @@
 
     .inline-icon {
         background-color: $neutral-3;
-        -webkit-border-radius: 1000px;
         border-radius: 1000px;
         fill: $neutral-1;
         height: $gs-baseline * 3;
@@ -211,26 +199,29 @@
 .newsletters-category {
     border-top: 2px solid $news-accent;
     display: inline-block;
-    clear: both;
-    width: 100%;
     margin-top: $gs-baseline * 2;
+
+    @include mq(tablet) {
+        margin-left: -$gs-gutter;
+        margin-right: -$gs-gutter;
+        padding: 0 $gs-gutter;
+    }
 }
 
 .newsletters-category__heading {
     @include fs-header(5);
     color: $neutral-1;
     position: relative;
-    margin: 0;
-    margin-top: $gs-baseline / 2;
-    margin-bottom: $gs-baseline;
-
-    @include mq(desktop) {
-        width: gs-span(4);
-  }
+    margin: ($gs-baseline / 2) 0 $gs-baseline;
 
     @include mq(leftCol) {
         position: absolute;
-  }
+        width: gs-span(2);
+    }
+
+    @include mq(wide) {
+        width: gs-span(3);
+    }
 }
 
 // TONE SPECIFIC MODS - FEATURE


### PR DESCRIPTION
## What does this change?
Primarily this PR is to remove the functionality and appearance of thumbnail images on the newsletters page. 

A few other tweaks:

- Switched to flexbox for layout - resulting in a cleaner design eg frequency can all be vertically matching, and regardless of the amount of copy the cards will remain equal in size to each other. 
- Changed breakpoints to reflect the grid on other pages
- Hidden the sneaky iframe that was causing a gap in the page layout
- Blue borders now edge to edge as they are on fronts
- Various other css refactors

Here's how it was:
<img width="1401" alt="screen shot 2017-05-10 at 15 22 04" src="https://cloud.githubusercontent.com/assets/14570016/25905751/b5d2fcee-359a-11e7-97f1-b6d59c30284d.png">

Here's how it's looking now:
<img width="1343" alt="screen shot 2017-05-10 at 15 21 42" src="https://cloud.githubusercontent.com/assets/14570016/25905914/1b840e98-359b-11e7-941b-093c8e9498f2.png">

![demonstration](https://cloud.githubusercontent.com/assets/14570016/25905630/7bc79564-359a-11e7-97ee-fbe07ed6472a.gif)