### PR TITLE
ESLint rule: disallow multiple parameters to classList.add

### DIFF
--- a/dev/eslint-plugin-guardian-frontend/__tests__/no-multiple-classlist-parameter.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/no-multiple-classlist-parameter.js
@@ -1,0 +1,17 @@
+const { RuleTester } = require('eslint');
+const rule = require('../rules/no-multiple-classlist-parameters');
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+ruleTester.run('no-multiple-classlist-parameter', rule, {
+    valid: ['element.classList.add("class1")'],
+
+    invalid: ['element.classList.add("class1", "class2")'].map(code => ({
+        code,
+        errors: [
+            {
+                type: 'Identifier',
+            },
+        ],
+    })),
+});

--- a/dev/eslint-plugin-guardian-frontend/__tests__/no-multiple-classlist-parameter.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/no-multiple-classlist-parameter.js
@@ -4,9 +4,15 @@ const rule = require('../rules/no-multiple-classlist-parameters');
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 
 ruleTester.run('no-multiple-classlist-parameter', rule, {
-    valid: ['element.classList.add("class1")'],
+    valid: [
+        'element.classList.add("class1")',
+        'element.classList.remove("class1")',
+    ],
 
-    invalid: ['element.classList.add("class1", "class2")'].map(code => ({
+    invalid: [
+        'element.classList.add("class1", "class2")',
+        'element.classList.add("class1", "class2", "class3")',
+    ].map(code => ({
         code,
         errors: [
             {

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -4,8 +4,5 @@
   "version": "3.1.0",
   "scripts": {
     "test": "jest"
-  },
-  "devDependencies": {
-    "jest": "^20.0.0"
   }
 }

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-guardian-frontend",
   "main": "index.js",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "scripts": {
     "test": "jest"
   }

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -4,5 +4,8 @@
   "version": "3.1.0",
   "scripts": {
     "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^20.0.0"
   }
 }

--- a/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
@@ -1,0 +1,14 @@
+module.exports = {
+    create(context) {
+        return {
+            Identifier: node => {
+                if (node.name === 'classList') {
+                    context.report({
+                        node,
+                        message: 'You are using a classlist',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
@@ -11,27 +11,27 @@ module.exports = {
             Identifier: node => {
                 if (node.name === 'add') {
                     const [
-                        dot1,
+                        dot,
                         parent,
                     ] = context
                         .getSourceCode()
                         .getTokensBefore(node, 2)
                         .reverse();
-
                     const [
                         ,
                         ,
-                        nextToken,
+                        maybeComma,
                     ] = context.getSourceCode().getTokensAfter(node, 3);
 
                     if (
-                        isDot(dot1) &&
+                        isDot(dot) &&
                         isIdentifierOf('classList', parent) &&
-                        isComma(nextToken)
+                        isComma(maybeComma)
                     ) {
                         context.report({
                             node,
-                            message: 'You are using a classList.add',
+                            message: `Only one class name can be passed to classList.add
+                                See: https://github.com/Financial-Times/polyfill-service/issues/268`,
                         });
                     }
                 }

--- a/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
@@ -1,12 +1,39 @@
 module.exports = {
     create(context) {
+        const isDot = token =>
+            token && token.type === 'Punctuator' && token.value === '.';
+        const isComma = token =>
+            token && token.type === 'Punctuator' && token.value === ',';
+        const isIdentifierOf = (prop, token) =>
+            token && token.type === 'Identifier' && token.value === prop;
+
         return {
             Identifier: node => {
-                if (node.name === 'classList') {
-                    context.report({
-                        node,
-                        message: 'You are using a classlist',
-                    });
+                if (node.name === 'add') {
+                    const [
+                        dot1,
+                        parent,
+                    ] = context
+                        .getSourceCode()
+                        .getTokensBefore(node, 2)
+                        .reverse();
+
+                    const [
+                        ,
+                        ,
+                        nextToken,
+                    ] = context.getSourceCode().getTokensAfter(node, 3);
+
+                    if (
+                        isDot(dot1) &&
+                        isIdentifierOf('classList', parent) &&
+                        isComma(nextToken)
+                    ) {
+                        context.report({
+                            node,
+                            message: 'You are using a classList.add',
+                        });
+                    }
                 }
             },
         };

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -69,6 +69,7 @@ module.exports = {
         // our own rules for frontend
         // live in tools/eslint-plugin-guardian-frontend
         'guardian-frontend/global-config': 'error',
+        'guardian-frontend/no-multiple-classlist-parameters': 'error',
         'guardian-frontend/no-default-export': 'warn',
         'import/prefer-default-export': 'off',
 


### PR DESCRIPTION
## What does this change?

Adds a custom ESLint rule disallowing from passing multiple parameters to `classList.add`. This is because IE10 and IE11 do not support multiple class names being passed, even with polyfills provided by polyfill.io (see #16673)

The ideal solution would actually be to not use this Lint rule and instead help to fix the real issue (Financial-Times/polyfill-service#1167)

## What is the value of this and can you measure success?

Reminds developer to implement manual workaround (multiple calls to `classList.add` 😭 )

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
