### PR TITLE
Removed inline-block from newsletters page

### DIFF
--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -198,7 +198,6 @@
 
 .newsletters-category {
     border-top: 2px solid $news-accent;
-    display: inline-block;
     margin-top: $gs-baseline * 2;
 
     @include mq(tablet) {


### PR DESCRIPTION
A rogue 'inline-block' escaped my notice resulted in the blue dividing lines not being full width.

Before:
<img width="1225" alt="screen shot 2017-05-11 at 10 26 04" src="https://cloud.githubusercontent.com/assets/14570016/25942303/667705a6-3634-11e7-8dc7-41f1dfe518c8.png">

After:
<img width="1224" alt="screen shot 2017-05-11 at 10 25 07" src="https://cloud.githubusercontent.com/assets/14570016/25942305/67ebfd1a-3634-11e7-9a72-7e815a87abaf.png">
