### PR TITLE
Force engagement banner re-display

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -47,7 +47,7 @@ define([
 
         // change messageCode to force redisplay of the message to users who already closed it.
         // messageCode is also consumed by .../test/javascripts/spec/common/commercial/membership-engagement-banner.spec.js
-        var messageCode = 'engagement-banner-2017-03-30';
+        var messageCode = 'engagement-banner-2017-05-11';
 
         var DO_NOT_RENDER_ENGAGEMENT_BANNER = 'do no render engagement banner';
 


### PR DESCRIPTION
## What does this change?

Forces re-display of the engagement banner to users that have closed it.

## What is the value of this and can you measure success?

The re-display will increase the number of impressions of the engagement banner, which will lead to more conversions.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

<img width="1267" alt="eb" src="https://cloud.githubusercontent.com/assets/4085817/25947411/3c045356-3647-11e7-877e-c766d412a28e.png">

## Tested in CODE?

No, tested locally.
