### PR TITLE
Bump fapi client version for new special report

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
-  val faciaVersion = "2.0.15"
+  val faciaVersion = "2.0.16"
   val capiVersion = "11.12"
   val dispatchVersion = "0.11.3"
   val configurationMagicVersion = "1.2.2"


### PR DESCRIPTION
Bumps fapi version because the hash was wrong previously.