### PR TITLE
Added the info icon to main media captions

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -115,6 +115,7 @@
                 </label>
 
                 <figcaption class="caption caption--main caption--img" itemprop="description">
+                    @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))

--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -139,7 +139,7 @@
     color: $neutral-2;
 
     a {
-        color: $neutral-2;
+        color: inherit;
     }
 
     .inline-information {

--- a/static/src/stylesheets/amp/_from-content-api.scss
+++ b/static/src/stylesheets/amp/_from-content-api.scss
@@ -138,12 +138,16 @@
     line-height: 16px;
     color: $neutral-2;
 
+    a {
+        color: $neutral-2;
+    }
+
     .inline-information {
         margin-right: $gs-gutter/10;
         margin-top: -$gs-baseline/4;
         width: 14px;
         height: 14px;
-        background-color: $neutral-2;
+        background-color: $neutral-3;
 
         .inline-information__svg {
             width: 4px;

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -169,7 +169,7 @@
     color: $neutral-2;
 
     a {
-        color: $neutral-2;
+        color: inherit;
     }
 
     .inline-information {

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -168,12 +168,16 @@
     @include fs-textSans(1);
     color: $neutral-2;
 
+    a {
+        color: $neutral-2;
+    }
+
     .inline-information {
         margin-right: $gs-gutter/10;
         margin-top: -$gs-baseline/4;
         width: 14px;
         height: 14px;
-        background-color: $neutral-2;
+        background-color: $neutral-3;
 
         .inline-information__svg {
             width: 4px;


### PR DESCRIPTION
This has been bugging me for ages.
Main media captions for images were showing up without the info icon.

Before:
<img width="1295" alt="screen shot 2017-05-11 at 14 31 28" src="https://cloud.githubusercontent.com/assets/14570016/25951843/d7710e2e-3656-11e7-8526-d642238a2c8a.png">

After:
<img width="1289" alt="screen shot 2017-05-11 at 14 31 02" src="https://cloud.githubusercontent.com/assets/14570016/25951849/d96fc5b2-3656-11e7-9b6c-ac06056fa156.png">

I've also toned back the icon colour and the link colour of captions. Easier on the 👀.

Before:
<img width="648" alt="screen shot 2017-05-11 at 14 31 34" src="https://cloud.githubusercontent.com/assets/14570016/25951902/0245dd14-3657-11e7-9397-2577046a31a3.png">

After:
<img width="651" alt="screen shot 2017-05-11 at 14 31 09" src="https://cloud.githubusercontent.com/assets/14570016/25951909/056b5d48-3657-11e7-8aad-7936db6516e3.png">

