### PR TITLE
Disable account deletion for unvalidated users

### DIFF
--- a/identity/app/controllers/AccountDeletionController.scala
+++ b/identity/app/controllers/AccountDeletionController.scala
@@ -52,7 +52,7 @@ class AccountDeletionController(
   def renderAccountDeletionForm = csrfAddToken {
     authActionWithUser.async { implicit request =>
       val form = accountDeletionForm.bindFromFlash.getOrElse(accountDeletionForm)
-      Future(NoCache(Ok(views.html.profile.deletion.accountDeletion(page, idRequestParser(request), idUrlBuilder, form, Nil))))
+      Future(NoCache(Ok(views.html.profile.deletion.accountDeletion(page, idRequestParser(request), idUrlBuilder, form, Nil, request.user))))
     }
   }
 

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -3,7 +3,8 @@
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     accountDeletionForm: Form[(String, Option[String])],
-    errors: List[client.Error]
+    errors: List[client.Error],
+    user: com.gu.identity.model.User
 )(implicit
     request: RequestHeader,
     messages: play.api.i18n.Messages,
@@ -14,83 +15,86 @@
 @import views.html.fragments.form.radioField
 @import views.html.fragments.registrationFooter
 
+@emailIsValidated = @{ user.statusFields.userEmailValidated.fold(false)(_ => true) }
+
 @main(page, projectName = Option("identity")){
 }{
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Are you sure you want to delete your account?</h1>
 
-        <div class="identity-section">
-            <p class="identity-section__text">
-                Please read the following paragraphs carefully to understand how account
-                deletion affects any Guardian products you may have. If at any point you require further clarification please
-                email our <a href="mailto:userhelp@@theguardian.com" data-link-name="Email Userhelp">Userhelp</a> who will
-                be happy to help.
-            </p>
-        </div>
-
-        <div class="identity-section">
-            <h4><a href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
-            <p class="identity-section__text">
-                Deleting your account removes personal information from our database. Your email address becomes
-                permanently reserved and the same email address cannot be re-used to register a new account.
-            </p>
-
-            <h4><a href="https://www.theguardian.com/community-faqs">Comments</a></h4>
-            <p class="identity-section__text">
-                If you have posted comments your comment profile will be removed, however the posted comments will
-                remain underneath the articles. Comments are part of the historical record, but if want your comments to
-                be removed please contact the <a href="mailto:moderation@@theguardian.com">Moderation Team</a>.
-                Please note that requests are considered on a case-by-case basis and your comments will not be
-                automatically deleted.
-            </p>
-
-            <h4><a href="https://membership.theguardian.com/help">Membership</a></h4>
-            <p class="identity-section__text">
-                Deleting your account does not cancel paid Membership. If you would like to cancel your membership
-                please <a href="https://membership.theguardian.com/tier/cancel">click here.</a>
-            </p>
-
-            <h4><a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">Digital/Paper Subscriptions</a></h4>
-            <p class="identity-section__text">
-                Deleting your account does not cancel paid Subscriptions. If you would like to cancel your subscription,
-                please email the <a href="mailto:subscriptions@@theguardian.com">Subscriptions Team.</a>
-            </p>
-
-            <h4><a href="https://www.theguardian.com/info/2013/aug/12/1">Guardian in-app purchases via App Stores</a></h4>
-            <p class="identity-section__text">
-                Deleting your account does not cancel Guardian in-app purchases made through Google, Apple or Amazon
-                app stores. For further queries please contact respective App Store.
-            </p>
-
-            <h4><a href="https://jobs.theguardian.com/article/faq">Guardian Jobs</a></h4>
-            <p class="identity-section__text">
-                Deleting your account does not delete your Jobs account. If you would like to delete your Jobs account,
-                please <a href="https://jobs.theguardian.com/deletemyaccount">click here.</a>
-            </p>
-
-            <h4><a href="https://witness.theguardian.com/faq">Guardian Witness</a></h4>
-            <p class="identity-section__text">
-                Deleting your account will not delete your Witness contributions. If you would like to delete your
-                contributions please email the <a href="mailto:witness@@theguardian.com">Witness Team.</a>
-            </p>
-
-            <h4><a href="https://www.theguardian.com/help/problems-with-your-email-subscriptions">Email Subscriptions</a></h4>
-            <p class="identity-section__text">
-                Deleting your account will unsubscribe you from all mailing lists.
-            </p>
-
-            <h4><a href="https://www.theguardian.com/help/insideguardian/2015/jul/21/introducing-save-for-later">Saved for Later Articles</a></h4>
-            <p class="identity-section__text">
-                Deleting your account will delete your Saved Articles links.
-            </p>
-        </div>
-
-        <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post">
-            @views.html.helper.CSRF.formField
-
+        @if(emailIsValidated) {
             <div class="identity-section">
                 <p class="identity-section__text">
-                    <p><b>Please take a moment to tell us why you wish to delete your account:</b></p>
+                    Please read the following paragraphs carefully to understand how account
+                    deletion affects any Guardian products you may have. If at any point you require further clarification please
+                    email our <a href="mailto:userhelp@@theguardian.com" data-link-name="Email Userhelp">Userhelp</a> who will
+                    be happy to help.
+                </p>
+            </div>
+
+            <div class="identity-section">
+                <h4><a href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account removes personal information from our database. Your email address becomes
+                    permanently reserved and the same email address cannot be re-used to register a new account.
+                </p>
+
+                <h4><a href="https://www.theguardian.com/community-faqs">Comments</a></h4>
+                <p class="identity-section__text">
+                    If you have posted comments your comment profile will be removed, however the posted comments will
+                    remain underneath the articles. Comments are part of the historical record, but if want your comments to
+                    be removed please contact the <a href="mailto:moderation@@theguardian.com">Moderation Team</a>.
+                    Please note that requests are considered on a case-by-case basis and your comments will not be
+                    automatically deleted.
+                </p>
+
+                <h4><a href="https://membership.theguardian.com/help">Membership</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account does not cancel paid Membership. If you would like to cancel your membership
+                    please <a href="https://membership.theguardian.com/tier/cancel">click here.</a>
+                </p>
+
+                <h4><a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">Digital/Paper Subscriptions</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account does not cancel paid Subscriptions. If you would like to cancel your subscription,
+                    please email the <a href="mailto:subscriptions@@theguardian.com">Subscriptions Team.</a>
+                </p>
+
+                <h4><a href="https://www.theguardian.com/info/2013/aug/12/1">Guardian in-app purchases via App Stores</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account does not cancel Guardian in-app purchases made through Google, Apple or Amazon
+                    app stores. For further queries please contact respective App Store.
+                </p>
+
+                <h4><a href="https://jobs.theguardian.com/article/faq">Guardian Jobs</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account does not delete your Jobs account. If you would like to delete your Jobs account,
+                    please <a href="https://jobs.theguardian.com/deletemyaccount">click here.</a>
+                </p>
+
+                <h4><a href="https://witness.theguardian.com/faq">Guardian Witness</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account will not delete your Witness contributions. If you would like to delete your
+                    contributions please email the <a href="mailto:witness@@theguardian.com">Witness Team.</a>
+                </p>
+
+                <h4><a href="https://www.theguardian.com/help/problems-with-your-email-subscriptions">Email Subscriptions</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account will unsubscribe you from all mailing lists.
+                </p>
+
+                <h4><a href="https://www.theguardian.com/help/insideguardian/2015/jul/21/introducing-save-for-later">Saved for Later Articles</a></h4>
+                <p class="identity-section__text">
+                    Deleting your account will delete your Saved Articles links.
+                </p>
+            </div>
+
+            <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post">
+                @views.html.helper.CSRF.formField
+
+                <div class="identity-section">
+                    <p class="identity-section__text">
+                <p><b>Please take a moment to tell us why you wish to delete your account:</b></p>
 
                     @radioField(accountDeletionForm("reason"), List(
                         "accident"      -> "I have created an account by accident",
@@ -101,32 +105,43 @@
                         "membership"    -> "I was asked to create an account in order to become member/subscriber",
                         "other"         -> "Other")
                     )(nonInputFields, messages)
+                    </p>
+                </div>
+
+
+                <fieldset class="fieldset">
+
+                    <div class="fieldset__heading">
+                        <h2 class="form__heading">Confirm account deletion</h2>
+                        <div class="form__note">Please re-enter password to confirm the you have understood the conditions and would like to proceed with account deletion.</div>
+                    </div>
+
+                    <div class="fieldset__fields">
+                        <ul class="u-unstyled">
+
+                            @inputField(Password(accountDeletionForm("password"), '_label -> "Password", 'class -> "js-register-password js-password-strength",
+                                (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
+
+                            <li>
+                                <button type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
+                            </li>
+                        </ul>
+                    </div>
+                </fieldset>
+            </form>
+
+            @if(accountDeletionForm.globalError.isDefined) {
+                <div class="form__error">@accountDeletionForm.globalErrors.map(_.message).mkString(", ")</div>
+            }
+        } else {
+            <div class="identity-section">
+                <p class="identity-section__text">
+                    Before you can delete your account you need to validate your email address.
+                    Once you have validated, please reload this page and you will be able to delete
+                    your account.
                 </p>
+                <a class="js-id-send-validation-email" data-link-name="Resend verification email">Send validation email</a>
             </div>
-
-            <fieldset class="fieldset">
-
-                <div class="fieldset__heading">
-                    <h2 class="form__heading">Confirm account deletion</h2>
-                    <div class="form__note">Please re-enter password to confirm the you have understood the conditions and would like to proceed with account deletion.</div>
-                </div>
-
-                <div class="fieldset__fields">
-                    <ul class="u-unstyled">
-
-                        @inputField(Password(accountDeletionForm("password"), '_label -> "Password", 'class -> "js-register-password js-password-strength",
-                            (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
-
-                        <li>
-                            <button type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
-                        </li>
-                    </ul>
-                </div>
-            </fieldset>
-        </form>
-
-        @if(accountDeletionForm.globalError.isDefined) {
-            <div class="form__error">@accountDeletionForm.globalErrors.map(_.message).mkString(", ")</div>
         }
 
         @registrationFooter(idRequest, idUrlBuilder)


### PR DESCRIPTION
## What does this change?

If users' email address is not validated, then they need to validate before they can delete their account.

## What is the value of this and can you measure success?

Moderation asked for this to help combat trolls. Decreases load on Userhelp which had to manually handle unvalidated user account deletions. 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/25951958/399af3d0-3657-11e7-8afe-9441decad15a.png)
