### PR TITLE
Stub SVGs for flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -24,7 +24,7 @@ module.name_mapper='^svgs' -> '<PROJECT_ROOT>/static/src/inline-svgs'
 module.name_mapper='^ophan/ng' -> 'ophan-tracker-js'
 module.name_mapper='^ophan/embed' -> 'ophan-tracker-js/build/ophan.embed'
 module.name_mapper='^raw-loader!.*$' -> '<PROJECT_ROOT>/dev/flow-asset-stub'
-module.name_mapper='^inlineSvg!.*$' -> '<PROJECT_ROOT>/dev/flow-asset-stub'
+module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/dev/flow-svg-stub'
 
 module.file_ext=.js
 

--- a/dev/flow-svg-stub.js
+++ b/dev/flow-svg-stub.js
@@ -1,0 +1,3 @@
+export default {
+    markup: '',
+};

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -2,7 +2,7 @@
 import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/utilities/template';
 import popupTemplate from 'raw-loader!commercial/views/ad-feedback-popup.html';
-import tick from 'svg-loader!svgs/icon/tick.svg';
+import tick from 'svgs/icon/tick.svg';
 import config from 'lib/config';
 
 const shouldRenderLabel = adSlotNode =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/measure-understanding.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/measure-understanding.js
@@ -10,7 +10,7 @@ import template from 'lodash/utilities/template';
 import ophan from 'ophan/ng';
 import measureUnderstandingStr
     from 'raw-loader!common/views/experiments/measure-understanding.html';
-import { markup as thumb } from 'svg-loader!svgs/icon/thumb.svg';
+import { markup as thumb } from 'svgs/icon/thumb.svg';
 
 const MeasureUnderstanding = () => {
     // Test id

--- a/static/test/javascripts-legacy/spec/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/dfp/dfp-api.spec.js
@@ -48,21 +48,22 @@ define([
         }
 
         beforeEach(function (done) {
-
-            injector.mock('common/modules/analytics/google', function noop() {
-                // No implementation
-            });
-
-            injector.mock('commercial/modules/dfp/apply-creative-template', function () {
-                return Promise.resolve();
-            });
-
-            injector.mock('lib/load-script', {
-                loadScript: function () {
+            injector.mock({
+                'common/modules/analytics/google': function noop() {
+                    // No implementation
+                },
+                'commercial/modules/dfp/apply-creative-template': function () {
                     return Promise.resolve();
+                },
+                'lib/load-script': {
+                    loadScript: function () {
+                        return Promise.resolve();
+                    }
+                },
+                'svgs/icon/tick.svg': {
+                    markup: ''
                 }
             });
-
             injector.require([
                 'commercial/modules/dfp/prepare-googletag',
                 'commercial/modules/dfp/fill-advert-slots',

--- a/static/test/javascripts-legacy/spec/commercial/dfp/render-advert-label.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/dfp/render-advert-label.spec.js
@@ -1,37 +1,48 @@
 define([
     'bonzo',
-    'commercial/modules/dfp/render-advert-label'
+    'helpers/injector'
 ], function (
     bonzo,
-    renderAdvertLabel
+    Injector
 ) {
     describe('Rendering advert labels', function () {
 
         var adverts = {};
         var labelSelector = '.ad-slot__label';
+        var injector = new Injector();
+        var renderAdvertLabel;
 
-        beforeEach(function () {
-            adverts.withLabel = bonzo(bonzo.create(
-                '<div class="js-ad-slot"></div>'
-            ));
+        beforeEach(function (done) {
+            injector.mock('svgs/icon/tick.svg', {
+                markup: ''
+            });
+            injector.require(['commercial/modules/dfp/render-advert-label'], function(renderAdvertLabelModule) {
+                renderAdvertLabel = renderAdvertLabelModule;
 
-            adverts.labelDisabled = bonzo(bonzo.create(
-                '<div class="js-ad-slot" data-label="false"></div>'
-            ));
+                adverts.withLabel = bonzo(bonzo.create(
+                    '<div class="js-ad-slot"></div>'
+                ));
 
-            adverts.alreadyLabelled = bonzo(bonzo.create(
-                '<div class="js-ad-slot">' +
+                adverts.labelDisabled = bonzo(bonzo.create(
+                    '<div class="js-ad-slot" data-label="false"></div>'
+                ));
+
+                adverts.alreadyLabelled = bonzo(bonzo.create(
+                    '<div class="js-ad-slot">' +
                     '<div class="ad-slot__label">Advertisement</div>' +
-                '</div>'
-            ));
+                    '</div>'
+                ));
 
-            adverts.guStyle = bonzo(bonzo.create(
-                '<div class="js-ad-slot gu-style"></div>'
-            ));
+                adverts.guStyle = bonzo(bonzo.create(
+                    '<div class="js-ad-slot gu-style"></div>'
+                ));
 
-            adverts.frame = bonzo(bonzo.create(
-                '<div class="js-ad-slot ad-slot--frame"></div>'
-            ));
+                adverts.frame = bonzo(bonzo.create(
+                    '<div class="js-ad-slot ad-slot--frame"></div>'
+                ));
+
+                done();
+            });
         });
 
         it('Can add a label', function (done) {

--- a/static/test/javascripts-legacy/spec/commercial/third-party-tags.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/third-party-tags.spec.js
@@ -9,6 +9,9 @@ define([
             tagsContainer, commercialFeatures;
 
         beforeEach(function (done) {
+            injector.mock('svgs/icon/thumb.svg', {
+                markup: ''
+            });
             injector.require([
                 'commercial/modules/third-party-tags',
                 'commercial/modules/commercial-features'

--- a/static/test/javascripts-legacy/spec/common/article/rich-links.spec.js
+++ b/static/test/javascripts-legacy/spec/common/article/rich-links.spec.js
@@ -1,18 +1,14 @@
 define([
     'helpers/injector',
     'helpers/fixtures',
-
     'lib/$',
     'lodash/utilities/template',
-
     'raw-loader!common/views/content/richLinkTag.html'
 ], function (
     Injector,
     fixtures,
-
     $,
     template,
-
     richLinkTagTmpl
 ) {
     describe('richLinks', function () {
@@ -35,6 +31,9 @@ define([
         beforeEach(function (done) {
             articleBodyFixtureElement = fixtures.render(articleBodyConf);
 
+            injector.mock('svgs/icon/thumb.svg', {
+                markup: ''
+            });
             injector.require(['common/modules/article/rich-links', 'lib/config', 'common/modules/article/space-filler'], function () {
                 richLinks = arguments[0];
                 config = arguments[1];

--- a/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
+++ b/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js
@@ -36,9 +36,14 @@ define([
 
         beforeEach(function (done) {
             config.page.edition = 'UK';
-            injector.mock('common/views/svgs', {
-                inlineSvg: function() {
-                    return '';
+            injector.mock({
+                'common/views/svgs': {
+                    inlineSvg: function() {
+                        return '';
+                    }
+                },
+                'svgs/icon/thumb.svg': {
+                    markup: ''
                 }
             });
             injector.require([

--- a/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
+++ b/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
@@ -9,9 +9,11 @@ define([
 
             beforeEach(function (done) {
                 var injector = new Injector();
-                
-                sandbox = sinon.sandbox.create();
 
+                sandbox = sinon.sandbox.create();
+                injector.mock('svgs/icon/thumb.svg', {
+                    markup: ''
+                });
                 injector.require([
                     'common/modules/experiments/ab-test-clash'
                 ], function (sut) {

--- a/static/test/javascripts-legacy/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts-legacy/spec/common/experiments/ab.spec.js
@@ -17,6 +17,9 @@ define([
             ab, config, mvtCookie;
 
         beforeEach(function (done) {
+            injector.mock('svgs/icon/thumb.svg', {
+                markup: ''
+            });
             injector.require(['common/modules/experiments/ab', 'lib/config', 'common/modules/analytics/mvt-cookie'], function () {
                 ab = arguments[0];
                 config = arguments[1];

--- a/static/test/javascripts-legacy/spec/common/onward/tech-feedback.spec.js
+++ b/static/test/javascripts-legacy/spec/common/onward/tech-feedback.spec.js
@@ -1,5 +1,21 @@
-define(['common/modules/onward/tech-feedback'], function (TechFeedback) {
+define([
+    'helpers/injector'
+], function (
+    Injector
+) {
     describe('Tech-feedback', function () {
+        var injector = new Injector();
+        var TechFeedback;
+
+        beforeEach(function(done) {
+           injector.mock('svgs/icon/thumb.svg', {
+               markup: ''
+           });
+           injector.require(['common/modules/onward/tech-feedback'], function(TechFeedbackModule) {
+               TechFeedback = TechFeedbackModule;
+               done();
+           })
+        });
 
         it('should exist', function () {
             expect(TechFeedback).toBeDefined();


### PR DESCRIPTION
## What does this change?

Flow doesn't know what the `svg-loader` exports, so I've added a line in the `.flowconfig` that points to a stubbed out SVG.

I've also had to mock out SVGs in a bunch of legacy tests.

## What is the value of this and can you measure success?

Flow know what SVGs are

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

:goberserk: 

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
