### PR TITLE
Restrict use of lodash `find`

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
                     'lodash/collections/filter',
                     'lodash/collections/every',
                     'lodash/collections/contains',
+                    'lodash/collections/find',
                     'lodash/objects/assign',
                     'lodash/objects/values',
                     'lodash/objects/merge',

--- a/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
+++ b/static/src/javascripts/projects/admin/bootstraps/commercial-browser-performance.js
@@ -4,7 +4,6 @@ import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import template from 'lodash/utilities/template';
 import countBy from 'lodash/collections/countBy';
-import find from 'lodash/collections/find';
 
 // Globals that aren't imported
 declare var $: any;
@@ -66,8 +65,7 @@ const fetchData = (): void => {
         };
         const reports: Array<Report> = logs.reports || [];
         const appStartTimes: Array<number> = reports.map(report => {
-            const primaryBaseline: StartTime | void = find(
-                report.baselines,
+            const primaryBaseline: StartTime | void = report.baselines.find(
                 baseline => baseline.name === 'primary'
             );
             return primaryBaseline ? primaryBaseline.startTime : 0;

--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -3,7 +3,6 @@ import template from 'lodash/utilities/template';
 import { local as storage } from 'lib/storage';
 import $ from 'lib/$';
 import bean from 'bean';
-import find from 'lodash/collections/find';
 import overlay from 'raw-loader!common/views/devtools/overlay.html';
 import styles from 'raw-loader!common/views/devtools/styles.css';
 import { TESTS as tests } from 'common/modules/experiments/ab';
@@ -29,7 +28,9 @@ const bindEvents = () => {
             const testId = label.getAttribute('data-ab-test');
             const variantId = label.getAttribute('data-ab-variant');
             const abTests = getSelectedAbTests();
-            const existingVariantForThisTest = find(abTests, { id: testId });
+            const existingVariantForThisTest = abTests.find(
+                test => test.id === testId
+            );
 
             if (existingVariantForThisTest) {
                 existingVariantForThisTest.variant = variantId;


### PR DESCRIPTION
## What does this change?
Restricts the us of lodash's `find` in the new shiny ES6 world

## Why?
I find the lodash shorthands surprising and `Array.prototype.find` seems good enough

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
