### PR TITLE
Fix colour of paid gallery headline icon

### DIFF
--- a/static/src/stylesheets/module/content/_gallery.head.scss
+++ b/static/src/stylesheets/module/content/_gallery.head.scss
@@ -56,6 +56,12 @@
     }
 }
 
+.content__headline--paidgallery {
+    .inline-tone-fill {
+        fill: $paid-article-brand;
+    }
+}
+
 .gallery__fullscreen,
 .article__fullscreen {
     position: absolute;

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -146,10 +146,4 @@
             border-top: 1px solid $neutral-6;
         }
     }
-
-    .content__headline--paidgallery {
-        .inline-tone-fill {
-            fill: $paid-article-brand;
-        }
-    }
 }


### PR DESCRIPTION
Somehow the wrong tone is being applied to the paid gallery pages.

This fixes the icon colour so it's paid-for teal regardless of the page tone.

Before:
![image](https://cloud.githubusercontent.com/assets/6290008/25994061/38a84ff6-3704-11e7-893a-f0cdef762af2.png)

After:
![image](https://cloud.githubusercontent.com/assets/6290008/25994070/48eab3b8-3704-11e7-91f0-01b0bd916e61.png)
