### PR TITLE
Update the frequency of default epic variant parameter

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -40,12 +40,12 @@ define([
     var lastContributionDate = cookies.getCookie('gu.contributions.contrib-timestamp');
 
     /**
-     * How many times the user can see the Epic, e.g. 6 times within 7 days.
-     * @type {{days: number, count: number}}
+     * How many times the user can see the Epic, e.g. 6 times within 7 days with minimum of 1 day in between views.
+     * @type {{days: number, count: number, minDaysBetweenViews: number}}
      */
     var maxViews = {
-        days: 7,
-        count: 6,
+        days: 30,
+        count: 4,
         minDaysBetweenViews: 0
     };
 


### PR DESCRIPTION
## What does this change?
Our default epic deployment for variants where we do not specify the deployment frequency should follow the ask 4 strategy. This PR implements this. 


## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
