### PR TITLE
Navigation: Replace politics/ environment with UK election

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -74,6 +74,7 @@ trait Navigation {
   val scotland = SectionLink("scotland", "scotland", "Scotland", "/uk/scotland")
   val wales = SectionLink("wales", "wales", "Wales", "/uk/wales")
   val northernIreland = SectionLink("northernireland", "northern ireland", "Northern Ireland", "/uk/northernireland")
+  val ukElection2017 = SectionLink("politics", "UK election", "UK election", "/politics/general-election-2017")
 
   // Columnists
   val columnists = SectionLink("columnists", "columnists", "Columnists", "/index/contributors")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -74,7 +74,7 @@ trait Navigation {
   val scotland = SectionLink("scotland", "scotland", "Scotland", "/uk/scotland")
   val wales = SectionLink("wales", "wales", "Wales", "/uk/wales")
   val northernIreland = SectionLink("northernireland", "northern ireland", "Northern Ireland", "/uk/northernireland")
-  val ukElection2017 = SectionLink("politics", "UK election", "UK election", "/politics/general-election-2017")
+  val ukElection2017 = SectionLink("politics", "election", "election", "/politics/general-election-2017")
 
   // Columnists
   val columnists = SectionLink("columnists", "columnists", "Columnists", "/index/contributors")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -64,7 +64,7 @@ object NewNavigation {
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(List(headlines, ukNews, world, business, environment, tech, football))
+    val uk = NavLinkLists(List(headlines, ukNews, world, business, ukElection2017, tech, football))
     val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, environment, economy, football))
     val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, science, soccer))
     val int = NavLinkLists(List(headlines, world, ukNews, business, science, globalDevelopment, football))
@@ -74,7 +74,7 @@ object NewNavigation {
     val name = "news"
 
     val uk = NavLinkLists(
-      List(headlines, ukNews, world, business, environment, tech, politics),
+      List(headlines, ukNews, world, business, ukElection2017, tech, politics),
       List(science, globalDevelopment, cities, obituaries)
     )
     val au = NavLinkLists(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -96,7 +96,7 @@ object Uk extends Edition(
     Seq(
       NavItem(home),
       NavItem(uk, ukLocalNav),
-      NavItem(politics),
+      NavItem(politics, Seq(ukElection2017)),
       NavItem(world, worldLocalNav),
       NavItem(sport, sportLocalNav),
       NavItem(football, footballNav),
@@ -124,7 +124,7 @@ object Uk extends Edition(
     NavItem(home),
     NavItem(uk, ukLocalNav),
     NavItem(world, worldLocalNav),
-    NavItem(politics),
+    NavItem(ukElection2017),
     NavItem(sport, sportLocalNav),
     NavItem(football, footballNav),
     NavItem(opinion, Seq(columnists)),

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -52,6 +52,7 @@ object NavLinks {
   val borrowing = NavLink("borrowing", "/money/debt", "money/debt")
   val careers = NavLink("careers", "/money/work-and-careers", "money/work-and-careers")
   val obituaries = NavLink("obituaries", "/tone/obituaries")
+  val ukElection2017 = NavLink("UK election", "/politics/general-election-2017")
 
   /* OPINION */
   val opinion = NavLink("opinion", "/commentisfree", longTitle = "opinion home", iconName = "home", uniqueSection = "commentisfree")

--- a/common/app/common/navlinks.scala
+++ b/common/app/common/navlinks.scala
@@ -52,7 +52,7 @@ object NavLinks {
   val borrowing = NavLink("borrowing", "/money/debt", "money/debt")
   val careers = NavLink("careers", "/money/work-and-careers", "money/work-and-careers")
   val obituaries = NavLink("obituaries", "/tone/obituaries")
-  val ukElection2017 = NavLink("UK election", "/politics/general-election-2017")
+  val ukElection2017 = NavLink("election", "/politics/general-election-2017")
 
   /* OPINION */
   val opinion = NavLink("opinion", "/commentisfree", longTitle = "opinion home", iconName = "home", uniqueSection = "commentisfree")


### PR DESCRIPTION
## What does this change?

Replaces `politics` with `UK election` for the desktop navigation.
Replaces `environment` with `UK election` for the mobile navigation.

[Trello reference](https://trello.com/c/ygtiskAp/295-add-election-to-uk-navs)

## What is the value of this and can you measure success?

Some people say elections matter, so let's promote them.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

** Desktop before **

<img width="821" alt="screen shot 2017-05-12 at 12 52 05" src="https://cloud.githubusercontent.com/assets/2244375/25996979/e4c6e70e-3711-11e7-8dfe-6dc74895eb6b.png">


** Desktop after **

<img width="824" alt="screen shot 2017-05-12 at 12 52 25" src="https://cloud.githubusercontent.com/assets/2244375/25996986/e8c6e160-3711-11e7-9cb6-9bc38bf8ba04.png">


** Mobile before **

<img width="483" alt="screen shot 2017-05-12 at 12 53 13" src="https://cloud.githubusercontent.com/assets/2244375/25997016/099f3694-3712-11e7-9941-68886b93b781.png">

** Desktop after **

<img width="484" alt="screen shot 2017-05-12 at 12 53 32" src="https://cloud.githubusercontent.com/assets/2244375/25997018/0d306c9c-3712-11e7-97cc-14a8732a5eee.png">


## Tested in CODE?

No.
