### PR TITLE
Remove momentum scrolling from the header

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -395,7 +395,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     font-family: $f-sans-serif-text;
     text-transform: lowercase;
     overflow: auto;
-    -webkit-overflow-scrolling: touch;
     font-size: 20px;
     will-change: transform;
     transition: transform .2s cubic-bezier(.23, 1, .32, 1);


### PR DESCRIPTION
## What does this change?

Sadly, we need to remove momentum scrolling from the new header. [Our trello card](https://trello.com/c/0n4vaNRH/287-css-scrolling-property-seems-to-be-causing-ios-sharing-panel-to-crash) explains the bug.

From what I have read, we are not the only ones who have this issue:
http://stackoverflow.com/questions/12665641/ios-browser-crashing-when-using-webkit-overflow-scrolling-touch

And we aren't advised to use this feature yet according to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling):
![image](https://cloud.githubusercontent.com/assets/8774970/26001318/dfd7362e-3723-11e7-8cb4-697946815b36.png)

This unfortunately degrades the experience for all IOS users. 

It seems like if our pages were lighter we wouldn't have as much of an issue using this feature so I propose we remove it now, and add it back after the markup for the header is reduced. At the moment we are showing both the new header and the old and when we finally delete the old, this might be enough to add this feature back.

cc @stephanfowler @guardian/ios-developers 

## What is the value of this and can you measure success?
One less bug.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Visually nothing changes, the scroll is just more clunky in IOS

## Tested in CODE?
Nope 
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
