### PR TITLE
Special report gallery 

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -10,6 +10,7 @@
 
 <div class="gallery__main-content">
 
+    @* Manually placing tonal--tone-media as temporary fix to ensute special report tones have it *@
     <article id="article" class="@RenderClasses(
             Map("content--paidgallery" -> isPaidContent(page)),
             "content", "content--media", "content--gallery", "tonal", "content--immersive", "tonal--tone-media", s"tonal--${toneClass(page.item)}"

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -8,42 +8,49 @@
 
 @(page: GalleryPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-<div class="@RenderClasses(
-            Map("l-side-margins--paidgallery" -> isPaidContent(page)),
-            "l-side-margins", "l-side-margins--media", "l-side-margins--gallery"
-        )">
+<div class="gallery__main-content">
 
     <article id="article" class="@RenderClasses(
             Map("content--paidgallery" -> isPaidContent(page)),
-            "content", "content--media", "content--gallery", "tonal", "content--immersive", s"tonal--${toneClass(page.item)}"
+            "content", "content--media", "content--gallery", "tonal", "content--immersive", "tonal--tone-media", s"tonal--${toneClass(page.item)}"
         )"
         itemscope itemtype="@page.item.metadata.schemaType" role="main">
 
         @fragments.galleryHeader(page)
 
-        <div class="content__main tonal__main tonal__main--@toneClass(page.item)">
-            <div class="gs-container gallery__divider">
-                <div class="content__main-column content__main-column--gallery">
-                    @fragments.witnessCallToAction(page.item.content)
-                    <ul class="gallery">
-                        @page.item.lightbox.largestCrops.zipWithRowInfo.map { case (image, row) =>
-                            @galleryItem(4, image, row.rowNum, page.item.lightbox.imageContainer(row.rowNum - 1))
-                        }
-                    </ul>
-                    @fragments.witnessCallToAction(page.item.content)
-                    @fragments.submeta(page.item)
+        <div class="@RenderClasses(
+                    Map("l-side-margins--paidgallery" -> isPaidContent(page)),
+                    "l-side-margins", "l-side-margins--media", "l-side-margins--gallery"
+                )">
+            <div class="content__main tonal__main tonal__main--@toneClass(page.item)">
+                <div class="gs-container gallery__divider">
+                    <div class="content__main-column content__main-column--gallery">
+                        @fragments.witnessCallToAction(page.item.content)
+                        <ul class="gallery">
+                            @page.item.lightbox.largestCrops.zipWithRowInfo.map { case (image, row) =>
+                                @galleryItem(4, image, row.rowNum, page.item.lightbox.imageContainer(row.rowNum - 1))
+                            }
+                        </ul>
+                        @fragments.witnessCallToAction(page.item.content)
+                        @fragments.submeta(page.item)
+                    </div>
                 </div>
             </div>
         </div>
     </article>
 
     @if(page.item.content.showInRelated && !isPaidContent(page)) {
-        <div class="gallery__most-popular facia-container fc-container fc-container--media hide-on-childrens-books-site js-gallery-most-popular tonal--@toneClass(page.item)">
-            <div class="fc-container__inner">
-                <div class="fc-container__header">
-                    <h2 class="fc-container__header__title">
-                        <a class="most-viewed-no-js tone-colour" href="@LinkTo{/gallery/most-viewed}" data-link-name="Most viewed galleries">More galleries</a>
-                    </h2>
+        <div class="@RenderClasses(
+                    Map("l-side-margins--paidgallery" -> isPaidContent(page)),
+                    "l-side-margins", "l-side-margins--media", "l-side-margins--gallery"
+                )">
+            <div class="gallery__most-popular facia-container fc-container fc-container--media hide-on-childrens-books-site js-gallery-most-popular tonal--@toneClass(page.item)">
+                <div class="fc-container__inner">
+                    <div class="fc-container__header">
+                        <h2 class="fc-container__header__title">
+                            <a class="most-viewed-no-js tone-colour" href="@LinkTo{/gallery/most-viewed}" data-link-name="Most viewed galleries">More galleries</a>
+                        </h2>
+                    </div>
                 </div>
             </div>
         </div>

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -2,7 +2,7 @@
 
 @import views.support.TrailCssClasses.toneClass
 
-<header class="content__head tonal__head tonal__head--@toneClass(gallery.item)">
+<header class="content__head tonal__head tonal__head--tone-media tonal__head--@toneClass(gallery.item)">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@
     <h1 class="is-hidden" itemprop="headline">@Html(gallery.item.trail.headline)</h1>

--- a/applications/app/views/fragments/galleryHeader.scala.html
+++ b/applications/app/views/fragments/galleryHeader.scala.html
@@ -2,6 +2,7 @@
 
 @import views.support.TrailCssClasses.toneClass
 
+@* Manually placing tonal__head--tone-media as temporary fix to ensute special report tones have it *@
 <header class="content__head tonal__head tonal__head--tone-media tonal__head--@toneClass(gallery.item)">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@

--- a/static/src/stylesheets/module/content/_gallery.head.scss
+++ b/static/src/stylesheets/module/content/_gallery.head.scss
@@ -1,5 +1,5 @@
 .content__labels--gallery,
-.l-side-margins--gallery .content__meta-container,
+.gallery__main-content .content__meta-container,
 .content__headline--gallery,
 .content__standfirst--gallery {
     @include mq(desktop) {
@@ -8,7 +8,7 @@
     }
 }
 
-.l-side-margins--gallery {
+.gallery__main-content {
     .content__meta-container {
         position: relative;
         width: auto;

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -25,7 +25,6 @@
 
 .gallery__divider {
     border-top: 1px solid $media-mute;
-    margin-top: $gs-baseline;
 
     @include mq(desktop) {
         padding-top: $gs-baseline / 2;
@@ -198,7 +197,15 @@
     }
 }
 
-.l-side-margins--gallery {
+.gallery__main-content {
+    .content__head {
+        padding-bottom: $gs-baseline;
+    }
+
+    .content--immersive .content__main {
+        padding-top: 0;
+    }
+
     .content__meta-container {
         border: 0;
         min-height: auto;
@@ -223,6 +230,10 @@
         }
     }
 
+    .content {
+        padding-bottom: 0;
+    }
+
     .witness-cta {
         border: 0;
     }
@@ -230,6 +241,7 @@
     .meta__extras {
         border-top: 1px dotted $media-mute;
         border-bottom: 1px dotted $media-mute;
+        margin-top: $gs-baseline / 2;
     }
 
     // Reset the styles from _content.scss

--- a/static/src/stylesheets/module/content/tones/_tone-media.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-media.scss
@@ -122,7 +122,7 @@
             background: none;
         }
 
-        .l-side-margins--gallery .meta__extras {
+        .gallery__main-content .meta__extras {
             border: 0;
         }
 

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -41,7 +41,7 @@
         }
     }
 
-    &.content--media {
+    &.content--media:not(.content--gallery) {
         .content__main,
         .tonal__standfirst,
         .content__standfirst {
@@ -90,5 +90,80 @@
                 darken($neutral-2, 10%)
             );
         }
+    }
+
+    .immersive-main-media__headline-container--dark {
+        background-color: rgba($news-support-6, .6);
+        background: linear-gradient(rgba($news-support-6, .6), $news-support-6) !important;
+    }
+}
+
+// Gallery styles
+.gallery__main-content {
+    .tonal--tone-special-report {
+        &.content {
+            background-color: $multimedia-support-5;
+
+            .tonal__head,
+            .tonal__standfirst {
+                background-color: $news-support-6;
+            }
+
+            .meta__extras,
+            .gallery__meta-container:before,
+            .meta__number:not(.u-h)+.meta__number {
+                border-color: rgba(255, 255, 255, .4);
+            }
+
+            .content__meta-container,
+            .byline,
+            .byline .tone-colour,
+            .byline .tone-colour:hover,
+            .content__dateline,
+            .meta__numbers .commentcount2__heading {
+                color: #ffffff;
+            }
+
+            .meta__numbers .sharecount__heading,
+            .meta__numbers .sharecount__value {
+                color: rgba(255, 255, 255, .6);
+            }
+
+            .meta__numbers .inline-share {
+                fill: rgba(255, 255, 255, .6);
+            }
+
+            .meta__numbers .inline-comment-16 {
+                fill: #ffffff;
+            }
+
+            .social-icon {
+                border-color: rgba(255, 255, 255, .6);
+
+                svg {
+                    fill: rgba(255, 255, 255, .8);
+                }
+            }
+        }
+
+        .meta__twitter .button,
+        .meta__email .button {
+            background-color: rgba(0, 0, 0, .1);
+            color: #ffffff;
+
+            svg {
+                fill: rgba(255, 255, 255, .8);
+            }
+
+            &:hover,
+            &:focus {
+                background-color: rgba(0, 0, 0, .3);
+                color: #ffffff;
+            }
+        }
+    }
+
+    .gallery__most-popular {
+        background-color: $multimedia-support-5;
     }
 }


### PR DESCRIPTION
Special report tone galleries were looking pretty special...

# See
<img width="1664" alt="screen shot 2017-05-12 at 14 19 31" src="https://cloud.githubusercontent.com/assets/14570016/26000017/2c826570-371f-11e7-90de-7fe20502d94a.png">

<img width="1663" alt="screen shot 2017-05-12 at 14 43 26" src="https://cloud.githubusercontent.com/assets/14570016/26000577/643627ca-3721-11e7-8eb3-cb88fa2bf9ad.png">

Now I have made them look special in a nice way

# See
<img width="1664" alt="screen shot 2017-05-12 at 14 40 22" src="https://cloud.githubusercontent.com/assets/14570016/26000469/fcbd5014-3720-11e7-8141-259596e2c65a.png">

<img width="375" alt="screen shot 2017-05-12 at 14 19 00" src="https://cloud.githubusercontent.com/assets/14570016/26000476/023d8824-3721-11e7-9199-8be7489c6fb4.png">

<img width="373" alt="screen shot 2017-05-12 at 14 19 11" src="https://cloud.githubusercontent.com/assets/14570016/26000477/024e8250-3721-11e7-89aa-1682232b732f.png">

In doing this I have made some small changes to galleries as a whole. The l-side-margins now begin after the standfirst, which results in less banded and strange looking colour blocks.

# See
<img width="1665" alt="screen shot 2017-05-12 at 14 26 33" src="https://cloud.githubusercontent.com/assets/14570016/26000522/350099a4-3721-11e7-9bd1-11f5b985b87a.png">

This also affects immersive overlays with a special report tone too, but more work should be done separately to further improve immersives with a special report tone. 

<img width="1664" alt="screen shot 2017-05-12 at 15 39 00" src="https://cloud.githubusercontent.com/assets/14570016/26002942/27614390-3729-11e7-8d96-dcfa566a15fb.png">


