### PR TITLE
Tonal changes for expanded meta and overlay in special report gallery

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -105,8 +105,17 @@
             background-color: $multimedia-support-5;
 
             .tonal__head,
-            .tonal__standfirst {
-                background-color: $news-support-6;
+            .meta__social .social--expanded-top {
+                background-color: lighten($news-support-6, 5%);
+            }
+
+            .social__tray-close .inline-close {
+                background-color: rgba(0, 0, 0, .1);
+
+                &:hover,
+                &:focus {
+                    background-color: rgba(0, 0, 0, .3);
+                }
             }
 
             .meta__extras,
@@ -158,7 +167,7 @@
             &:hover,
             &:focus {
                 background-color: rgba(0, 0, 0, .3);
-                color: #ffffff;
+                color: inherit;
             }
         }
     }


### PR DESCRIPTION
A couple of tiny tonal changes. The expanded social icons now blend in with the page background. 

<img width="1662" alt="screen shot 2017-05-15 at 11 12 54" src="https://cloud.githubusercontent.com/assets/14570016/26053187/c38f96ee-395f-11e7-9c7d-ca9d30050354.png">
