### PR TITLE
Too much information...

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -115,7 +115,7 @@
                 </label>
 
                 <figcaption class="caption caption--main caption--img" itemprop="description">
-                    @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon"))
+                    @fragments.inlineSvg("information", "icon", List("rounded-icon", "centered-icon", "hide-until-tablet"))
                     @img.caption.map(Html(_))
                     @if(img.displayCredit && !img.creditEndsWithCaption) {
                         @img.credit.map(Html(_))


### PR DESCRIPTION
We have a _literal_ case of TMI:

<img width="374" alt="screen shot 2017-05-15 at 15 24 12" src="https://cloud.githubusercontent.com/assets/14570016/26062424/abf4f97a-3982-11e7-918b-ce2eba7ca091.png">

I've hidden the info icon until tablet so you don't get the doubling up of the icon like this.