### PR TITLE
Adding 'data-component' attribute to individual cards of paid contents

### DIFF
--- a/common/app/views/fragments/commercial/cards/itemCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemCard.scala.html
@@ -17,6 +17,7 @@
 <div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a href="@item.targetUrl"
         data-link-name="@omnitureId"
+        data-component="@omnitureId"
         class="@CssClassBuilder.linkFromStandardCard(item, optAdvertClassNames, useCardBranding)"
         >
         <h2 class="advert__title">


### PR DESCRIPTION
This changes adds a `data-component` attribute, with same contents of the existing `data-link-name` to the Paid Contents GLabs individual cards.