### PR TITLE
remove noopener and noreferrer

### DIFF
--- a/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog.html
@@ -15,8 +15,7 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
                href="<%=membershipUrl%>"
-               target="_blank"
-               rel="noopener noreferrer">
+               target="_blank">
                 Become a supporter
             </a>
         </div>
@@ -24,8 +23,7 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
                href="<%=contributionUrl%>"
-               target="_blank"
-               rel="noopener noreferrer">
+               target="_blank">
                 Make a contribution
             </a>
         </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-testimonials.html
@@ -29,8 +29,7 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
                href="<%=membershipUrl%>"
-               target="_blank"
-               rel="noopener noreferrer">
+               target="_blank">
                 Become a supporter
             </a>
         </div>
@@ -38,8 +37,7 @@
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
                href="<%=contributionUrl%>"
-               target="_blank"
-               rel="noopener noreferrer">
+               target="_blank">
                 Make a contribution
             </a>
         </div>


### PR DESCRIPTION
## What does this change?
We recently added `rel="noopener noreferrer"`  to our contributions and supporter links to cover [this](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/) security threat.

We rely on the referrer url header being to track what articles lead to acquisition, and this change broke our reporting. 

Following a conversation with @desbo and @joelochlann , we have decided to revert this change because we control the sites that we are linking to here (contributions and membership) so we are not worried about these pages changing the original page where the link is. 

## What is the value of this and can you measure success?
We can report on what articles are leading to contributions and supporter sign ups. 


## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
