### PR TITLE
Extend sleevenotes a/b test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -95,7 +95,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the new email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 19),
+    sellByDate = new LocalDate(2017, 5, 30),
     exposeClientSide = true
   )
 
@@ -105,7 +105,7 @@ trait ABTestSwitches {
     "Assign some of the new sleeve notes subscribers to receive the old email",
     owners = Seq(Owner.withGithub("lmath")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 19),
+    sellByDate = new LocalDate(2017, 5, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-legacy-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesLegacyEmailVariant',
             start: '2017-03-02',
-            end: '2017-05-19',
+            end: '2017-05-30',
             author: 'Leigh-Anne Mathieson',
             audience: 0.3,
             audienceOffset: 0.7,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/sleeve-notes-new-email-variant.js
@@ -7,7 +7,7 @@ define([
         {
             id: 'SleeveNotesNewEmailVariant',
             start: '2017-03-02',
-            end: '2017-05-19',
+            end: '2017-05-30',
             author: 'Leigh-Anne Mathieson',
             audience: 0.7,
             audienceOffset: 0,


### PR DESCRIPTION
## What does this change?
Extend sleevenotes a/b test. Otherwise, it would expire before we meet to review the data.

## What is the value of this and can you measure success?
The test needs to keep running until the subscriber lists are merged.

## Does this affect other platforms - Amp, Apps, etc?
Nope.

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
