### PR TITLE
Add referer pageview id to engagement banner links

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -11,6 +11,7 @@ define([
     'lib/mediator',
     'lib/storage',
     'lib/geolocation',
+    'lib/url',
     'lodash/objects/assign',
     'lodash/utilities/template',
     'lodash/collections/toArray',
@@ -28,6 +29,7 @@ define([
     mediator,
     storage,
     geolocation,
+    url,
     assign,
     template,
     toArray,
@@ -179,8 +181,8 @@ define([
         this.campaignCode = getCampaignCode(test.campaignPrefix, this.campaignId, this.id, test.campaignSuffix);
         this.campaignCodes = [this.campaignCode];
 
-        this.contributeURL = options.contributeURL || this.makeURL(contributionsBaseURL, this.campaignCode);
-        this.membershipURL = options.membershipURL || this.makeURL(membershipBaseURL, this.campaignCode);
+        this.contributeURL = options.contributeURL || this.getURL(contributionsBaseURL, this.campaignCode);
+        this.membershipURL = options.membershipURL || this.getURL(membershipBaseURL, this.campaignCode);
 
         this.componentName = 'mem_acquisition_' + trackingCampaignId + '_' + this.id;
 
@@ -254,21 +256,21 @@ define([
         return campaignCodePrefix + '_' + campaignID + '_' + id + suffix;
     }
 
-    ContributionsABTestVariant.prototype.makeURL = function(base, campaignCode) {
-        var params = [
-            'REFPVID=' + this.pageviewId,
-            'INTCMP=' + campaignCode
-        ];
-
-        return base + '?' + params.filter(Boolean).join('&');
+    ContributionsABTestVariant.prototype.getURL = function(base, campaignCode) {
+        var params = {
+            REFPVID: this.pageviewId,
+            INTCMP: campaignCode
+        };
+        return base + '?' + url.constructQuery(params);
     };
 
+
     ContributionsABTestVariant.prototype.contributionsURLBuilder = function(codeModifier) {
-        return this.makeURL(contributionsBaseURL, codeModifier(this.campaignCode));
+        return this.getURL(contributionsBaseURL, codeModifier(this.campaignCode));
     };
 
     ContributionsABTestVariant.prototype.membershipURLBuilder = function(codeModifier) {
-        return this.makeURL(membershipBaseURL, codeModifier(this.campaignCode));
+        return this.getURL(membershipBaseURL, codeModifier(this.campaignCode));
     };
 
     ContributionsABTestVariant.prototype.registerListener = function (type, defaultFlag, event, options) {
@@ -291,7 +293,6 @@ define([
 
     return {
         defaultCanEpicBeDisplayed: defaultCanEpicBeDisplayed,
-
         makeABTest: function (test) {
             // this is so it can be instantiated with `new` later
             return function () {

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -95,7 +95,8 @@ define([
             buttonCaption: 'Become a Supporter',
             linkUrl: 'https://membership.theguardian.com/supporter',
             offering: offerings.membership,
-            messageText: supporterEngagementBannerCopy(location)
+            messageText: supporterEngagementBannerCopy(location),
+            pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found'
         })
     }
 
@@ -104,7 +105,8 @@ define([
             buttonCaption: 'Make a Contribution',
             linkUrl: 'https://contribute.theguardian.com',
             offering: offerings.contributions,
-            messageText: contributionEngagementBannerCopy()
+            messageText: contributionEngagementBannerCopy(),
+            pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found'
         });
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -19,8 +19,10 @@ define([
         'common/modules/experiments/segment-util',
         'common/modules/experiments/acquisition-test-selector',
         'common/modules/commercial/membership-engagement-banner-parameters',
+        'common/modules/commercial/contributions-utilities',
         'ophan/ng',
-        'lib/geolocation'
+        'lib/geolocation',
+        'lib/url'
     ], function (bean,
                  $,
                  config,
@@ -41,8 +43,10 @@ define([
                  segmentUtil,
                  acquisitionTestSelector,
                  membershipEngagementBannerUtils,
+                 contributionsUtilities,
                  ophan,
-                 geolocation) {
+                 geolocation,
+                 url) {
 
 
         // change messageCode to force redisplay of the message to users who already closed it.
@@ -160,8 +164,14 @@ define([
 
             var messageText = Array.isArray(params.messageText)?selectSequentiallyFrom(params.messageText):params.messageText;
 
+            var urlParameters = {
+                REFPVID : params.pageviewId,
+                INTCMP:  params.campaignCode
+            };
+            var linkUrl = params.linkUrl + '?' + url.constructQuery(urlParameters);
+
             var renderedBanner = template(messageTemplate, {
-                linkHref: params.linkUrl + '?INTCMP=' + params.campaignCode,
+                linkHref: linkUrl,
                 messageText: messageText,
                 buttonCaption: params.buttonCaption,
                 colourClass: colourClass,


### PR DESCRIPTION
## What does this change?

Currently, the epic attatches the current pageview id to both contributions and supporter links, which we use to analyse which content is driving acquisition. The banner was not sending through this parameter, so this PR adds this functionality. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
