### PR TITLE
Shining a light on the veggie burger

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -245,6 +245,7 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
     background-color: $news-main-2;
     cursor: pointer;
     bottom: -$gs-baseline / 2;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
 
     @include mq($until: mobileMedium) {
         //Smaller menu button
@@ -269,7 +270,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 
 .new-header__nav__menu-button--open {
     z-index: 1071;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
 
     &:before {
         // Extended hit area for veggie burger close state, for fat fingers


### PR DESCRIPTION
# Our University guide is bleeding into the veggie burger:
<img width="375" alt="screen shot 2017-05-16 at 17 06 03" src="https://cloud.githubusercontent.com/assets/14570016/26116216/38ca4c74-3a5a-11e7-9606-05d4cb067692.png">

# I've applied a super mega tiny 1px shadow to the circle (previously used for this purpose in the open state) to prevent an unsightly bleed when we have blue pages.
<img width="375" alt="screen shot 2017-05-16 at 17 07 07" src="https://cloud.githubusercontent.com/assets/14570016/26116215/38c90a26-3a5a-11e7-9954-62862fe42f77.png">

# Normally it is unnoticable. 
<img width="375" alt="screen shot 2017-05-16 at 17 07 28" src="https://cloud.githubusercontent.com/assets/14570016/26116217/38d131ce-3a5a-11e7-88a6-50a914289448.png">
