### PR TITLE
Bump version of the configuration to 32

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -65,7 +65,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 31
+    val s3ConfigVersion = 32
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
## What does this change?

This bumps the version of the configuration to `32`.

The config contains new configuration around `CODE: sonobi.js.location` which sets it to `12914` of the script.

This only affects CODE. (Even when deployed to PROD).

@rich-nguyen 