### PR TITLE
[DO NOT MERGE] Proof Of Concept - UI componentisation

### DIFF
--- a/applications/app/components/MyComponent.scala
+++ b/applications/app/components/MyComponent.scala
@@ -1,0 +1,30 @@
+package components
+
+import components.core.{ComponentCss, Css, HtmlComponent}
+import model.ApplicationContext
+import play.twirl.api.Html
+
+case class MyComponent(implicit context: ApplicationContext) extends HtmlComponent {
+
+  val myTitle: MyTitle = MyTitle("This is the title")
+  val myText: MyText = MyText("This is the text")
+
+  override def html: Html = views.html.prototype.MyComponent()(myTitle.html, myText.html)
+  override def componentCss: Seq[Css] = Seq(
+    ComponentCss.load("component-myComponent")
+  )
+}
+
+case class MyTitle(title: String)(implicit context: ApplicationContext) extends HtmlComponent {
+  override def html: Html = views.html.prototype.MyTitle(title)
+  override def componentCss: Seq[Css] = Seq(
+    ComponentCss.load("component-myTitle")
+  )
+}
+
+case class MyText(text: String)(implicit context: ApplicationContext) extends HtmlComponent {
+  override def html: Html = views.html.prototype.MyText(text)
+  override def componentCss: Seq[Css] = Seq(
+    ComponentCss.load("component-myText")
+  )
+}

--- a/applications/app/controllers/ApplicationsControllers.scala
+++ b/applications/app/controllers/ApplicationsControllers.scala
@@ -43,4 +43,6 @@ trait ApplicationsControllers {
 
   //A fake geolocation controller to test it locally
   lazy val geolocationController = wire[FakeGeolocationController]
+
+  lazy val myComponentController = wire[MyComponentController]
 }

--- a/applications/app/controllers/MyComponentController.scala
+++ b/applications/app/controllers/MyComponentController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import model.{ApplicationContext, Cached}
+import model.Cached.RevalidatableResult
+import play.api.mvc.{Action, Controller}
+
+import scala.concurrent.duration._
+
+class MyComponentController(implicit context: ApplicationContext) extends Controller {
+
+  def show() = Action { implicit request =>
+    Cached(7.days)(RevalidatableResult.Ok(components.MyComponent().render))
+  }
+
+}

--- a/applications/app/views/prototype/MyComponent.scala.html
+++ b/applications/app/views/prototype/MyComponent.scala.html
@@ -1,0 +1,12 @@
+@()(title: Html, text: Html)
+
+<html>
+   <head>
+   </head>
+   <body>
+       <div class="my-component__center">
+           @title
+           @text
+       </div>
+   </body>
+</html>

--- a/applications/app/views/prototype/MyText.scala.html
+++ b/applications/app/views/prototype/MyText.scala.html
@@ -1,0 +1,5 @@
+@(text: String)
+
+<div class="my-text__error">
+   @text
+</div>

--- a/applications/app/views/prototype/MyTitle.scala.html
+++ b/applications/app/views/prototype/MyTitle.scala.html
@@ -1,0 +1,3 @@
+@(title: String)
+
+<h1 class="my-title__bold">@title</h1>

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -7,6 +7,8 @@ GET         /assets/*path                                                       
 
 GET        /_healthcheck                                                        controllers.HealthCheck.healthCheck()
 
+GET        /myComponent                                                         controllers.MyComponentController.show()
+
 GET        /sitemaps/news.xml                                                   controllers.SiteMapController.renderNewsSiteMap()
 GET        /sitemaps/video.xml                                                  controllers.SiteMapController.renderVideoSiteMap()
 

--- a/common/app/common/RelativePathEscaper.scala
+++ b/common/app/common/RelativePathEscaper.scala
@@ -1,7 +1,7 @@
 package common
 
 object RelativePathEscaper {
-  def apply(unescaped: String) = {
+  def apply(unescaped: String): String = {
     // We are getting Googlebot 404s because Google is incorrectly assessing paths in curl js & json config data
     // so we need to escape them out.
     // "../foo"
@@ -12,7 +12,7 @@ object RelativePathEscaper {
     escapeLeadingSlashFootballPaths(escapeLeadingDotPaths(unescaped))
   }
 
-  def escapeLeadingDotPaths(unescaped: String) = {
+  def escapeLeadingDotPaths(unescaped: String): String = {
     val leadingDotPathRegex = """["'](\.{1,2}\/){1,}\w*(\/){0,}\w*(\/)?['"]""".r
     val dotMatches = leadingDotPathRegex.findAllIn(unescaped)
     dotMatches.foldLeft(unescaped) {
@@ -21,7 +21,7 @@ object RelativePathEscaper {
     }
   }
 
-  def escapeLeadingSlashFootballPaths(unescaped: String) = {
+  def escapeLeadingSlashFootballPaths(unescaped: String): String = {
     val leadingSlashFootballPathRegex = """["']?(\/football)(\/team|\/tournament)(\/\w+)['"]?""".r
     val footballMatches = leadingSlashFootballPathRegex.findAllIn(unescaped)
     footballMatches.foldLeft(unescaped) {

--- a/common/app/components/core/ComponentCss.scala
+++ b/common/app/components/core/ComponentCss.scala
@@ -1,0 +1,10 @@
+package components.core
+
+import common.Assets.AssetLoader
+import model.ApplicationContext
+
+object ComponentCss {
+
+  def load(cssFilename: String)(implicit context: ApplicationContext): Css =
+    Css(AssetLoader.load(s"assets/inline-stylesheets/$cssFilename.css"))
+}

--- a/common/app/components/core/Css.scala
+++ b/common/app/components/core/Css.scala
@@ -1,0 +1,16 @@
+package components.core
+
+import play.twirl.api.Txt
+import scala.language.implicitConversions
+
+case class Css(asString: String) {
+  def :+(css: Css): Css = Css(asString + css.asString)
+}
+
+object Css {
+  def empty: Css = Css("")
+  implicit def txtToCss(txt: Txt): Css = Css(txt.toString)
+}
+
+
+

--- a/common/app/components/core/HtmlComponent.scala
+++ b/common/app/components/core/HtmlComponent.scala
@@ -1,0 +1,48 @@
+package components.core
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.parser.Parser
+import play.twirl.api.Html
+import scala.collection.JavaConversions._
+
+trait HtmlComponent {
+
+  def html: Html
+  def componentCss: Seq[Css]
+
+  def render(): Html = {
+    val document: Document = Jsoup.parse(html.toString, "", Parser.xmlParser()) //Provide an XML Parser so Jsoup doesn't automatically add <html>, <head> and <body> tags
+
+    // Adding inlined css if component has a head tag
+    document.getElementsByTag("head").headOption.map { el =>
+
+      val cssAsString = css.reduce(_ :+ _).asString
+
+      el.getElementsByTag("style").map(_.remove)
+      el.appendChild(document.createElement("style").text(cssAsString))
+    }
+
+    Html(document.html)
+  }
+
+  def css: Seq[Css] = (componentCss ++ children.flatMap(_.css)).distinct
+
+  lazy val children: Seq[HtmlComponent] = this
+    .getClass
+    .getDeclaredFields
+    .flatMap { field =>
+      field.setAccessible(true)
+      field.get(this) match {
+        case h: HtmlComponent => Some(h)
+        case _ => None
+      }
+    }
+    .filterNot(_ == this)
+    .toSeq
+}
+
+object HtmlComponent {
+  import scala.language.implicitConversions
+  implicit def raw(c: HtmlComponent): String = c.html.toString
+}

--- a/common/test/components/core/ComponentTest.scala
+++ b/common/test/components/core/ComponentTest.scala
@@ -1,0 +1,58 @@
+package components.core
+
+import model.{ApplicationContext, ApplicationIdentity}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.Environment
+import play.twirl.api.Html
+
+class ComponentTest extends FlatSpec with Matchers {
+
+  implicit val testContext = ApplicationContext(Environment.simple(), ApplicationIdentity("tests"))
+
+  object PageComponent extends HtmlComponent {
+    override def html: Html = Html(
+      """
+        |<html>
+        |   <head>
+        |   </head>
+        |   <body>
+        |      <div class="text">Text</div>
+        |   </body>
+        |</html>
+        |""".stripMargin)
+
+    override def componentCss: Seq[Css] = Seq(
+      Css(
+        """
+          |.text {
+          |   color: black;
+          |}
+        """.stripMargin)
+    )
+  }
+
+  object ButtonComponent extends HtmlComponent {
+    override def html: Html = Html("""
+        |<button type="button" class="info">Click Me!</button>
+        |""".stripMargin)
+
+    override def componentCss: Seq[Css] = Seq(
+      Css(
+        """
+          |.info {
+          |   color: blue;
+          |}
+        """.stripMargin)
+    )
+  }
+
+  "A component with a head tag" should "be rendered with inlined css" in {
+    PageComponent.render().toString should include("<style>")
+  }
+
+  "A component without a head tag" should "not contain inlined css" in {
+    ButtonComponent.render().toString should not include("<style>")
+  }
+
+}
+

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -56,7 +56,7 @@ object Frontend extends Build with Prototypes {
       commercialShared
     )
   ).settings(
-      mappings in TestAssets ~= filterAssets
+    mappings in TestAssets ~= filterAssets
   )
 
   private def filterAssets(testAssets: Seq[(File, String)]) = testAssets.filterNot{ case (file, fileName) =>
@@ -80,8 +80,7 @@ object Frontend extends Build with Prototypes {
     .dependsOn(commonWithTests)
     .aggregate(common)
 
-  val archive = application("archive").dependsOn(commonWithTests).aggregate(common).settings(
-  )
+  val archive = application("archive").dependsOn(commonWithTests).aggregate(common)
 
   val sport = application("sport").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -10,6 +10,7 @@ import Dependencies._
 import play.sbt.PlayScala
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
+import play.twirl.sbt.Import.TwirlKeys
 
 trait Prototypes {
   val version = "1-SNAPSHOT"
@@ -117,6 +118,10 @@ trait Prototypes {
     }).value
   )
 
+  val TwirlSettings = Seq(
+    TwirlKeys.templateFormats += ("css" -> "play.twirl.api.TxtFormat")
+  )
+
   def root() = Project("root", base = file(".")).enablePlugins(PlayScala, RiffRaffArtifact)
     .settings(frontendCompilationSettings)
     .settings(frontendRootSettings)
@@ -129,6 +134,7 @@ trait Prototypes {
     .settings(VersionInfo.settings)
     .settings(libraryDependencies ++= Seq(macwire, commonsIo))
     .settings(packageName in Universal := applicationName)
+    .settings(TwirlSettings)
     .settingSets(settingSetsOrder)
   }
 

--- a/static/src/stylesheets/inline/component-myComponent.scss
+++ b/static/src/stylesheets/inline/component-myComponent.scss
@@ -1,0 +1,4 @@
+.my-component__center {
+    width: 100%;
+    text-align: center;
+}

--- a/static/src/stylesheets/inline/component-myText.scss
+++ b/static/src/stylesheets/inline/component-myText.scss
@@ -1,0 +1,6 @@
+@import '../_vars';
+
+.my-text__error {
+    color: $news-main-1;
+    background-color: #ffff00;
+}

--- a/static/src/stylesheets/inline/component-myTitle.scss
+++ b/static/src/stylesheets/inline/component-myTitle.scss
@@ -1,0 +1,3 @@
+.my-title__bold {
+    font-weight: bold;
+}


### PR DESCRIPTION
This is a proof of concept / draf to show UI 'componentisation'.

Please: **DO NOT MERGE**

cc @guardian/dotcom-platform 

# What do we mean by UI `component`
In this context, a component (in our case an HTML component) is the encapsulation of `html` and `css`.

# Why `component`
Components allows the creation of reusable and composable piece of UI. `Play/Twirl` html templates already provide this feature for the markup. However in the `Play` world, css is totally disassociated from the markup.

Tying html and css together brings the following benefits:

1. Easier to reason about a piece of UI. Developers can concentrate on the local context of the component html and css without knowing how the rest of the page is being rendered. Scoping of css can be done automatically, removing the burden of manually prefixing css class names for instance.
2. Make it easy to serve the minimal amount of inlined css for a specific page. Transfer and rendering performance in the browser would be greatly improved.

# Concept vs implementation?

## Concept
The most important part of this POC is to introduce the concept of`Component`: 
a class instance that:

- encapsulates `html` and `css` 
- is aware of its children
- has a render function

By introducing this component layer between Play controllers and templates, this PR also decouples Play from the rendering engine. 
Even though in this PR the "rendering engine" is still using Twirl template, it is not hard to imagine delegating the rendering to another solution (ex: scalaTags or something in the Javascript world 😝 )

## Implementation
My main goal was to introduce the concept of Component without having to rewrite the whole frontend app. Using framework (twirl) and processes (asset building pipeline) already in place would allow an incremental and smoother transition (ex: partial conversion)

`html` is provided by Twirl template. The main difference with our current usage of Twirl is that sub templates would need to be passed as parameters of its parent rather than being called from the global scope.
`css` is loaded from a compiled css asset. At the moment css of all subcomponents are only concatenated but it would be possible to do more complex processing (ex: scoping, ...)

# Potential concerns?

- With this PR `html` and `css` are still in 2 different files, which force developers to move back and forth between them when creating/modifying a component. Ideally it would be great to have markup and css in the same file but I don't know how to achieve this given our current asset pipeline (scss and twirl templates).
- The benefit of minimal inlined css can only be achieved if a page is entirely "componentized"
- This PR doesn't address all the chalenging of loading component asynchronously from the client-side.
- Performance

# Feedback
I am ready to discuss. Please feel free to stop by my desk to talk about this.
