### PR TITLE
Use proper article URLs for prbuilds

### DIFF
--- a/.prbuilds/config.yml
+++ b/.prbuilds/config.yml
@@ -4,8 +4,8 @@ teardown:
   ansible: .prbuilds/cleanup.playbook.yml
 checks:
   screenshots:
-      url: http://localhost:9000/uk
+      url: http://localhost:9000/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism
   exceptions:
-      url: http://localhost:9000/uk
+      url: http://localhost:9000/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism
   a11yvalidation:
         dummy: dummy


### PR DESCRIPTION
## What does this change?

Exceptions on prbuilds was failing because the url wasn't valid (fronts is not supported on prbuilds right now). So switch to using an article like it was originally.

## What is the value of this and can you measure success?

Makes exceptions output work again on prbuilds

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
