### PR TITLE
Re-add the ability to force yourself into a local ab test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -44,6 +44,7 @@ export const getTest = () => {
         const forced = window.location.hash.indexOf(`ab-${t.id}`) > -1;
         const variant: Variant = variantFor(t);
 
+        if (forced) return true;
         if (!variant || !variant.options || !variant.options.maxViews)
             return false;
 
@@ -63,9 +64,7 @@ export const getTest = () => {
         const hasNotReachedRateLimit =
             (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;
 
-        return (
-            forced || (testCanBeRun(t) && isInTest(t) && hasNotReachedRateLimit)
-        );
+        return testCanBeRun(t) && isInTest(t) && hasNotReachedRateLimit;
     });
 
     return eligibleTests[0] && new eligibleTests[0]();


### PR DESCRIPTION
## What does this change?
When we converted ab-test-selector to es6 (https://github.com/guardian/frontend/pull/16778), we inadvertently broke the ability to force yourself into a test by adding `#ab-<testname>=<test varaint>` to the url, as if the user isn't in the correct segment for the test, `variantFor(t) `returns `undefined`, and then the       `  if (!variant || !variant.options || !variant.options.maxViews)` check returns `false` before the check for `forced` takes place. 


This PR fixes this by returning `true` before the variant check takes place, if indeed `forced` is set to `true`.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 