### PR TITLE
Add a sbt task to clean all projects

### DIFF
--- a/docs/01-start-here/05-development-tips.md
+++ b/docs/01-start-here/05-development-tips.md
@@ -21,6 +21,12 @@ make test
 
 ## Server-side development
 
+### Clean all projects
+
+It is often necessary to clean the `root` project when 3rd-party libs have been updated for instance.
+Developers can use the `cleanAll` sbt task to clean all sbt projects, rather than only cleaning the current project.
+
+
 ### Debugging Play application
 You can debug your local Frontend application, by attaching a debugger.
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -14,6 +14,8 @@ import com.typesafe.sbt.packager.Keys.packageName
 trait Prototypes {
   val version = "1-SNAPSHOT"
 
+  val cleanAll = taskKey[Unit]("Cleans all projects in a build, regardless of dependencies")
+
   val frontendCompilationSettings = Seq(
     organization := "com.gu",
     maxErrors := 20,
@@ -29,7 +31,11 @@ trait Prototypes {
       val _ = initialize.value
       assert(sys.props("java.specification.version") == "1.8",
         "Java 8 is required for this project.")
-    }
+    },
+    cleanAll := Def.taskDyn {
+      val allProjects = ScopeFilter(inAnyProject)
+      clean.all(allProjects)
+    }.value
   )
 
   val frontendIntegrationTestsSettings = Seq (


### PR DESCRIPTION
## What does this change?

Create a `cleanAll` sbt task and add it to all project settings. 
This task would clean all projects, not just the currently loaded one.

## What is the value of this and can you measure success?
Happier developers 👩 👨 ➡️  😁 

To properly clean the frontend project, one had to switch to the `root` project and clean it as well as running `clean` in the current project they were working on. 
`cleanAll` is the nuclear option, cleaning all the projects (including `root`)

cc @guardian/dotcom-platform 
