### PR TITLE
Deps: Upgrade node-sass to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "megalog": "^0.1.0",
     "mkdirp": "0.5.0",
     "moment": "2.8.3",
-    "node-sass": "^3.8.0",
+    "node-sass": "^4.3.0",
     "ora": "^1.1.0",
     "pa11y": "^4.10.0",
     "perfectionist": "^2.3.1",

--- a/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
@@ -1,4 +1,4 @@
-&.content__main-column--liveblog {
+.content__main-column--liveblog {
     @include mq(desktop) {
         margin-left: gs-span(4) + $gs-gutter;
         margin-right: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,7 +2527,7 @@ eslint-plugin-flowtype@^2.30.0:
     lodash "^4.15.0"
 
 "eslint-plugin-guardian-frontend@file:dev/eslint-plugin-guardian-frontend":
-  version "3.0.0"
+  version "4.0.0"
 
 eslint-plugin-import@^2.2.0:
   version "2.2.0"
@@ -4849,6 +4849,10 @@ lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.mergewith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
@@ -5310,9 +5314,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.0"
     tar-pack "~3.1.0"
 
-node-sass@^3.8.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.10.1.tgz#c535b2e1a5439240591e06d7308cb663820d616c"
+node-sass@^4.3.0:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -5323,13 +5327,15 @@ node-sass@^3.8.0:
     in-publish "^2.0.0"
     lodash.assign "^4.2.0"
     lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.3.2"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "^2.61.0"
+    request "^2.79.0"
     sass-graph "^2.1.1"
+    stdout-stream "^1.4.0"
 
 node-uuid@~1.4.3, node-uuid@~1.4.7:
   version "1.4.7"
@@ -6449,7 +6455,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@2.x, request@^2.58.0, request@^2.61.0, request@^2.67.0, request@^2.69.0, request@^2.74.0, request@^2.79.0, request@^2.81.0:
+request@2, request@2.x, request@^2.58.0, request@^2.67.0, request@^2.69.0, request@^2.74.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7063,6 +7069,12 @@ sshpk@^1.7.0:
 "statuses@>= 1.3.0 < 2", "statuses@>= 1.3.1 < 2", statuses@~1.3.0, statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
+stdout-stream@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/stdout-stream/-/stdout-stream-1.4.0.tgz#a2c7c8587e54d9427ea9edb3ac3f2cd522df378b"
+  dependencies:
+    readable-stream "^2.0.1"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## What does this change?

Upgrades `node-sass` to 4.3.0. Mainly performance improvements and updated libsass bindings. [Changelog](https://github.com/sass/node-sass/compare/v3.8.0...v4.3.0).

## What is the value of this and can you measure success?

Better sass compilation speed.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
