### PR TITLE
Add logging after competition agents refresh

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -149,9 +149,12 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
 
   override def competitions: Seq[Competition] = competitionAgents.map(_.competition)
 
-  def refreshCompetitionAgent(id: String) {
-    competitionAgents find { _.competition.id == id } map { _.refresh() }
-  }
+  def refreshCompetitionAgent(id: String): Option[Unit] = competitionAgents
+    .find { _.competition.id == id }
+    .map { c =>
+      c.refresh()
+      log.info(s"Completed refresh of competition '${c.competition.fullName}': currently ${c.competition.matches.length} matches")
+    }
 
   def refreshCompetitionData() = {
     log.info("Refreshing competition data")


### PR DESCRIPTION
@jfsoul and I are investigating an issue with the `football/results`.
Hopefully this logs would help us narrow down the causes of the problem.

