### PR TITLE
Mock config in Breaking News spec

### DIFF
--- a/static/test/javascripts-legacy/spec/common/onward/breaking-news.spec.js
+++ b/static/test/javascripts-legacy/spec/common/onward/breaking-news.spec.js
@@ -48,10 +48,16 @@ define([
                         return '';
                     }
                 };
+                var fakeConfig = {
+                    page: {
+                        edition: 'UK'
+                    }
+                };
 
                 injector.mock({
                     'lib/storage': storage,
                     'lib/fetch-json': fetchJson,
+                    'lib/config': fakeConfig,
                     'common/views/svgs': fakeSvgs
                 }).require(['common/modules/onward/breaking-news'], function (breakingNews) {
                     breakingNews.DEFAULT_DELAY = 100;
@@ -71,7 +77,6 @@ define([
 
         beforeAll(function () {
             fetchJson = jasmine.createSpy('fetch-json');
-            config.page.edition = 'UK';
         });
 
         beforeEach(function (done) {


### PR DESCRIPTION
## What does this change?

There is an [intermittent test failure](https://teamcity.gu-web.net/viewLog.html?buildId=35992&buildTypeId=dotcom_frontend&tab=buildLog) that crops up now and again in Team City, specifically:

```
[Breaking news user can dismiss alerts.PhantomJS 2.1.1 (Linux 0.0.0)] should prune known alerts
[should prune known alerts]  
[should prune known alerts] FAILED
[should prune known alerts] Expected undefined not to be undefined.

http://localhost:9876/base/static/test/javascripts-legacy/spec/common/onward/breaking-news.spec.js?27cd0b6cd516a2b2349aa2ba9d801a49c1c4d878:238:98
```

I have not been able to reliably reproduce the failure locally, but it may be caused by the code's reliance on the value of `window.guardian.config.page.edition`. The property is set to `"UK"` before all tests are run, but since test specs can run simultaneously, it is possible that it is being updated by [other](https://github.com/guardian/frontend/blob/master/static/test/javascripts-legacy/spec/commercial/dfp/dfp-api.spec.js#L99) [specs](https://github.com/guardian/frontend/blob/master/static/test/javascripts-legacy/spec/common/commercial/membership-engagement-banner.spec.js#L194).

This change stubs out `lib/config` in this spec, ensuring that state set in other specs does not bleed into these tests.

## What is the value of this and can you measure success?

Hopefully prevents intermittent test failures. Definitely makes the tests more deterministic.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
