### PR TITLE
Lint against namespace imports

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
         'import/no-extraneous-dependencies': 'off', // necessary while we use aliases
         'import/extensions': 'off',
         'import/no-webpack-loader-syntax': 'off', // used for require plugins still
+        'import/no-namespace': 2,
 
         // these are bad habits in react that we're already abusing.
         // if we go more [p]react we should look at them.

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -26,8 +26,13 @@ import stickyTopBanner from 'commercial/modules/sticky-top-banner';
 import thirdPartyTags from 'commercial/modules/third-party-tags';
 import paidforBand from 'commercial/modules/paidfor-band';
 import { paidContainers } from 'commercial/modules/paid-containers';
-import * as performanceLogging
-    from 'commercial/modules/dfp/performance-logging';
+import {
+    defer,
+    wrap,
+    addStartTimeBaseline,
+    addEndTimeBaseline,
+    primaryBaseline,
+} from 'commercial/modules/dfp/performance-logging';
 import { trackPerformance } from 'common/modules/analytics/google';
 import userFeatures from 'commercial/modules/user-features';
 
@@ -58,7 +63,7 @@ if (config.page.isHosted) {
 }
 
 const loadModules = (modules, baseline): Promise<void> => {
-    performanceLogging.addStartTimeBaseline(baseline);
+    addStartTimeBaseline(baseline);
 
     const modulePromises = [];
 
@@ -75,8 +80,8 @@ const loadModules = (modules, baseline): Promise<void> => {
                     // perf logging, to time when their async work is done. The command buffer guarantees execution order,
                     // so we don't use the returned promise to order the bootstrap's module invocations.
                     const wrapped = moduleDefer
-                        ? performanceLogging.defer(moduleName, moduleInit)
-                        : performanceLogging.wrap(moduleName, moduleInit);
+                        ? defer(moduleName, moduleInit)
+                        : wrap(moduleName, moduleInit);
                     const result = wrapped();
                     modulePromises.push(result);
                 },
@@ -85,7 +90,7 @@ const loadModules = (modules, baseline): Promise<void> => {
     });
 
     return Promise.all(modulePromises).then((): void => {
-        performanceLogging.addEndTimeBaseline(baseline);
+        addEndTimeBaseline(baseline);
     });
 };
 
@@ -114,7 +119,7 @@ export default (): Promise<void> => {
         cmd: [],
     };
 
-    return loadModules(commercialModules, performanceLogging.primaryBaseline)
+    return loadModules(commercialModules, primaryBaseline)
         .then(() => {
             markTime('commercial end');
             catchErrorsWithContext([

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -3,7 +3,9 @@ import type { Variant } from 'common/modules/experiments/ab-types';
 
 import { variantFor, isInTest } from 'common/modules/experiments/segment-util';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
-import * as viewLog from 'common/modules/commercial/acquisitions-view-log';
+import {
+    viewsInPreviousDays,
+} from 'common/modules/commercial/acquisitions-view-log';
 import alwaysAsk
     from 'common/modules/experiments/tests/contributions-epic-always-ask-strategy';
 import askFourEarning
@@ -52,10 +54,8 @@ export const getTest = () => {
 
         const isUnlimited = variant.options.isUnlimited;
 
-        const withinViewLimit =
-            viewLog.viewsInPreviousDays(maxViewDays) < maxViewCount;
-        const enoughDaysBetweenViews =
-            viewLog.viewsInPreviousDays(minViewDays) === 0;
+        const withinViewLimit = viewsInPreviousDays(maxViewDays) < maxViewCount;
+        const enoughDaysBetweenViews = viewsInPreviousDays(minViewDays) === 0;
 
         const hasNotReachedRateLimit =
             (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;

--- a/static/src/javascripts/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.js
@@ -6,8 +6,7 @@ import type {
 } from 'common/modules/experiments/ab-types';
 
 import { local } from 'lib/storage';
-import * as testCanRunChecks
-    from 'common/modules/experiments/test-can-run-checks';
+import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 
 const participationsKey = 'gu.ab.participations';
 
@@ -73,4 +72,4 @@ export const setTestVariant = (testId: string, variant: string): void => {
 export const isInVariant = (test: ABTest, variant: Variant): boolean =>
     getParticipations()[test.id] &&
     getParticipations()[test.id].variant === variant.id &&
-    testCanRunChecks.testCanBeRun(test);
+    testCanBeRun(test);


### PR DESCRIPTION
## What does this change?

Using namespace imports currently hinders tree-shaking in Webpack (webpack/webpack#2867), so we'd like to avoid it if possible.

## What is the value of this and can you measure success?

More consistent import statements, potentially smaller bundle size.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
