### PR TITLE
Only add the double headline if its the first container

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -39,26 +39,28 @@ data-test-id="facia-card"
 @container(item: layout.ContentCard) = {
     <div class="fc-item__container">
 
-        @*****************************************************
-        * #election2017 Duplicate headline for election 2017 *
-        *****************************************************@
-        <div class="fc-item__content-election">
-            <div class="fc-item__header fc-item__header--election-title">
-                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
+        @if(isFirstContainer) {
+            @*****************************************************
+            * #election2017 Duplicate headline for election 2017 *
+            *****************************************************@
+            <div class="fc-item__content-election">
+                <div class="fc-item__header fc-item__header--election-title">
+                    @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
 
-                @item.bylineText.map { byline =>
-                    <div class="fc-item__byline">@byline</div>
-                }
+                    @item.bylineText.map { byline =>
+                        <div class="fc-item__byline">@byline</div>
+                    }
 
-                @item.starRating.map { rating =>
-                    @starRating(rating)
+                    @item.starRating.map { rating =>
+                        @starRating(rating)
+                    }
+                </div>
+
+                @item.trailText.filter(const(item.showStandfirst)).map { text =>
+                    <div class="fc-item__standfirst">@Html(text)</div>
                 }
             </div>
-
-            @item.trailText.filter(const(item.showStandfirst)).map { text =>
-                <div class="fc-item__standfirst">@Html(text)</div>
-            }
-        </div>
+        }
 
 
         @if(item.snapStuff.map(_.snapType).contains(FrontendLatestSnap)) {


### PR DESCRIPTION
## What does this change?
Fixing the double headline bug I introduced in  https://github.com/guardian/frontend/pull/16806

![image](https://cloud.githubusercontent.com/assets/8774970/26245186/d9cc313c-3c8a-11e7-8b34-57925ba4ec65.png)


cc @guardian/dotcom-platform 

