### PR TITLE
Give youtube player detailed naming of exported function

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/hosted/youtube.js
@@ -47,7 +47,7 @@ define([
         var playTimer;
 
         tracking.init(atomId);
-        youtubePlayer.init(el, {
+        youtubePlayer.initYoutubePlayer(el, {
             onPlayerStateChange: function (event) {
                 var player = event.target;
 

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/youtube.js
@@ -197,7 +197,7 @@ define([
 
                 tracking.init(getTrackingId(atomId));
 
-                youtubePlayer.init(iframe, {
+                youtubePlayer.initYoutubePlayer(iframe, {
                     onPlayerReady: onPlayerReady.bind(null, atomId, overlay, iframe),
                     onPlayerStateChange: onPlayerStateChange.bind(null, atomId)
                 }, iframe.id);

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -68,7 +68,11 @@ const setupPlayer = (videoId: string, onReady, onStateChange) =>
 
 const hasPlayerStarted = event => event.target.getCurrentTime() > 0;
 
-const init = (el: HTMLElement, handlers: Handlers, videoId: string) => {
+export const initYoutubePlayer = (
+    el: HTMLElement,
+    handlers: Handlers,
+    videoId: string
+) => {
     loadYoutubeJs();
 
     return promise.then(() => {
@@ -87,5 +91,3 @@ const init = (el: HTMLElement, handlers: Handlers, videoId: string) => {
         return setupPlayer(videoId, onPlayerReady, onPlayerStateChange);
     });
 };
-
-export { init };


### PR DESCRIPTION
## What does this change?

I have started converting `hosted/youtube.js`, and want to avoid importing a function called `init`, or having to alias it as I import it.

Otherwise, my new file will contain this code:

```
        tracking.init(atomId);
            init(el, {
```

With these changes, after the conversion, my new code will be:

```
        tracking.init(atomId);
            initYoutubePlayer(el, {
```

## What is the value of this and can you measure success?

Clearer naming of exported functions