### PR TITLE
If capi gives us a 410 response, we should also serve a 410 response

### DIFF
--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -41,7 +41,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
   it should "display an expired message for expired content" in {
     val result = galleryController.render("theobserver/gallery/2012/jul/29/1")(TestRequest("/theobserver/gallery/2012/jul/29/1"))
-    status(result) should be(200)
+    status(result) should be(410)
     contentAsString(result) should include("Sorry - this page has been removed.")
   }
 

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -44,7 +44,7 @@ import scala.util.matching.Regex
 
   it should "display an expired message for expired content" in {
     val result = mediaController.render("world/video/2008/dec/11/guantanamo-bay")(TestRequest("/world/video/2008/dec/11/guantanamo-bay"))
-    status(result) should be(200)
+    status(result) should be(410)
     contentAsString(result) should include("Sorry - this page has been removed.")
   }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -184,7 +184,7 @@ object RenderOtherStatus {
   def apply(result: Result)(implicit request: RequestHeader, context: ApplicationContext) = result.header.status match {
     case 404 => NoCache(NotFound)
     case 410 if request.isJson => Cached(60)(JsonComponent(gonePage, "status" -> "GONE"))
-    case 410 => Cached(60)(WithoutRevalidationResult(Ok(views.html.expired(gonePage))))
+    case 410 => Cached(60)(WithoutRevalidationResult(Gone(views.html.expired(gonePage))))
     case _ => result
   }
 }


### PR DESCRIPTION
## What does this change?

When CP takes down a page, CAPI returns to us a 410 response. We then return an "expired" page with a 200 response. We really shouldn't be returning a 200 response though because the content isn't actually there anymore. We should also be returning a 410 error.

cc @jfsoul @stephanfowler @mchv 

## What is the value of this and can you measure success?
Returning a more accurate response code

## Does this affect other platforms - Amp, Apps, etc?
Will affect the amp cache/google results, but for the better.


## Screenshots
n/a

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
