### PR TITLE
Require name to be non-empty text

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -85,7 +85,7 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
             case Left(errors) => profileFormsView(page, forms.withErrors(errors), user)
             case Right(updatedUser) => profileFormsView(page, forms.bindForms(updatedUser), updatedUser)
           }
-      }.getOrElse(Future(profileFormsView(page, forms.bindForms(user), user)))
+      }.getOrElse(Future(profileFormsView(page, forms, user)))
     }
   }
 

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -14,8 +14,8 @@ class AccountDetailsMapping(val messagesApi: MessagesApi) extends UserFormMappin
     mapping(
       ("primaryEmailAddress", idEmail),
       ("title", comboList("" :: Titles.titles)),
-      ("firstName",  textField),
-      ("secondName", textField),
+      ("firstName",  nonEmptyText),
+      ("secondName", nonEmptyText),
       ("gender", comboList(genders)),
       "birthDate" -> dateMapping,
       "address" -> idAddress,


### PR DESCRIPTION
## What does this change?

[Trello ticket](https://trello.com/c/k1UWlPVm/57-salesforce-contact-schema-out-of-sync-with-identity)

Prevents users from entering empty string into name fields in `Edit Profile`

## What is the value of this and can you measure success?

Name fields are required fields in Salesforce, so the Identity sync to Salesforce fails when Identity is updated with empty name. Similar issue exists for Jobs Madgex.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/26251770/46e57420-3ca6-11e7-89b9-b647a0823429.png)



