### PR TITLE
Use build-page-targeting export in AMD module

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/video-ad-url.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/video-ad-url.js
@@ -11,7 +11,7 @@ define([
         var queryParams = {
             ad_rule: 1,
             correlator: new Date().getTime(),
-            cust_params: encodeURIComponent(urlUtils.constructQuery(buildPageTargeting())),
+            cust_params: encodeURIComponent(urlUtils.constructQuery(buildPageTargeting.buildPageTargeting())),
             env: 'vp',
             gdfp_req: 1,
             impl:'s',


### PR DESCRIPTION
A reference to the new es6 module needs to be updated to use the exported function.

This fixes video pre-rolls.