### PR TITLE
Special report media tone

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -15,7 +15,7 @@
                     "content--has-body" -> media.fields.body.nonEmpty,
                     "content--paid-content paid-content" -> isPaidContent
                 ),
-                "content", "content--media", s"content--media--$mediaType", "tonal", s"tonal--${toneClass(media)}"
+                "content", "content--media", s"content--media--$mediaType", "tonal", "tonal--tone-media", s"tonal--${toneClass(media)}"
             )"
             itemscope itemtype="@media.metadata.schemaType" role="main">
 

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -42,11 +42,8 @@
     }
 
     &.content--media:not(.content--gallery) {
-        .content__main,
-        .tonal__standfirst,
-        .content__standfirst {
-            background-color: $news-support-6;
-            color: #ffffff;
+        .tonal__standfirst {
+            background-color: $multimedia-support-5;
         }
 
         a.tone-colour {
@@ -56,40 +53,10 @@
                 color: mix($special-report-accent, #ffffff, 70%);
             }
         }
+    }
 
-        .byline,
-        .content__dateline,
-        .meta__numbers .sharecount__heading,
-        .meta__numbers .sharecount__value,
-
-        .meta__numbers .inline-share {
-            fill: #ffffff;
-        }
-
-        .byline,
-        .content__meta-container,
-        .content__secondary-column--media,
-        .content__dateline,
-        .fc-item:before,
-        .meta__social,
-        .meta__numbers,
-        .most-viewed-container--media,
-
-        .button--tag {
-            background-color: mix($news-support-6, $neutral-1, 70%);
-            border-color: mix($news-support-6, $neutral-1, 70%);
-        }
-
-        .button--secondary {
-            @include button-colour(
-                $neutral-2,
-                $neutral-1
-            );
-
-            @include button-hover-colour(
-                darken($neutral-2, 10%)
-            );
-        }
+    &.tonal--tone-media {
+        background-color: $multimedia-support-5;
     }
 
     .immersive-main-media__headline-container--dark {


### PR DESCRIPTION
Again I've had to manually add tonal--tone-media, which is definitely not great, and we'll need to look into how we can get it back, dynamically. This is a quick fix to get the pages looking nice.

# Before:
<img width="1664" alt="screen shot 2017-05-22 at 11 00 37" src="https://cloud.githubusercontent.com/assets/14570016/26303079/3e04da46-3ede-11e7-849b-b9b399c3afe1.png">

# After:
<img width="1665" alt="screen shot 2017-05-22 at 11 00 25" src="https://cloud.githubusercontent.com/assets/14570016/26303080/3f0c3b32-3ede-11e7-922d-9e3c778cb2a9.png">
