### PR TITLE
Revert "Brandy snaps (link and dream)"

### DIFF
--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -1,7 +1,7 @@
 package services
 
-import com.gu.contentapi.client.model.v1.{Tag, Content => ApiContent}
-import com.gu.facia.api.utils.{ContentProperties, ResolvedMetaData}
+import com.gu.contentapi.client.model.v1.{Content => ApiContent, Tag}
+import com.gu.facia.api.utils.{ResolvedMetaData, ContentProperties}
 import com.gu.facia.api.{models => fapi}
 import common._
 import contentapi.ContentApiClient
@@ -9,9 +9,8 @@ import implicits.Dates
 import layout.{CollectionEssentials, FaciaContainer}
 import model.pressed.{CollectionConfig, LinkSnap, PressedContent}
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone}
+import org.joda.time.{DateTimeConstants, DateTime, DateTimeZone}
 import slices.{ContainerDefinition, Fixed, FixedContainers, TTT}
-
 import scala.concurrent.Future
 
 case class BookSectionContent(tag: Tag, content: Seq[ApiContent])
@@ -154,22 +153,7 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends ExecutionContex
       val displayFormat = d.toString(dateForFrontPagePattern)
       val hrefDateFormat = d.toString(hrefFormat).toLowerCase
       val href = if(d.getDayOfWeek == DateTimeConstants.SUNDAY) s"/theobserver/$hrefDateFormat" else s"/theguardian/$hrefDateFormat"
-      val fapiSnap = fapi.LinkSnap(
-        id = "no-id",
-        maybeFrontPublicationDate = None,
-        snapType = "no-snap-type",
-        snapUri = None,
-        snapCss = None,
-        headline = Some(displayFormat),
-        href = Some(href),
-        trailText = None,
-        group = "group",
-        image = None,
-        properties = ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
-        byline = None,
-        kicker = None,
-        brandingByEdition = Map.empty
-      )
+      val fapiSnap = fapi.LinkSnap("no-id", None, "no-snap-type", None, None, Some(displayFormat), Some(href), None, "group", None, ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default), None, None)
       LinkSnap.make(fapiSnap)
     }
   }

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -168,6 +168,7 @@ object FaciaContainer {
     None,
     useShowMore = true,
     hasShowMoreEnabled = !config.config.hideShowMore,
+    showBranding = config.config.showBranding,
     isThrasher = config.config.collectionType == "fixed/thrasher"
   )
 
@@ -201,6 +202,7 @@ case class FaciaContainer(
   dateLinkPath: Option[String],
   useShowMore: Boolean,
   hasShowMoreEnabled: Boolean,
+  showBranding: Boolean,
   isThrasher: Boolean
 ) {
   def transformCards(f: ContentCard => ContentCard) = copy(

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -4,9 +4,8 @@ import com.gu.commercial.branding.Branding
 import com.gu.contentapi.client.model.v1.ElementType
 import com.gu.facia.api.utils.FaciaContentUtils
 import com.gu.facia.api.{models => fapi, utils => fapiutils}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata}
+import com.gu.facia.client.models.{Backfill, Branded, CollectionConfigJson, Metadata}
 import common.Edition
-import common.commercial.EditionBranding
 import model.{ContentType, SupportedUrl}
 import org.joda.time.DateTime
 
@@ -65,7 +64,9 @@ final case class CollectionConfig(
   showTimestamps: Boolean,
   hideShowMore: Boolean,
   displayHints: Option[DisplayHints]
-)
+) {
+  def showBranding = metadata exists (_ contains Branded)
+}
 
 object CardStyle {
   def make(cardStyle: fapiutils.CardStyle): CardStyle = cardStyle match {
@@ -137,10 +138,7 @@ object PressedProperties {
       section = FaciaContentUtils.section(content),
       maybeFrontPublicationDate = FaciaContentUtils.maybeFrontPublicationDate(content),
       href = FaciaContentUtils.href(content),
-      webUrl = FaciaContentUtils.webUrl(content),
-      editionBrandings = Some(content.brandingByEdition.flatMap {
-        case (editionId, branding) => Edition.byId(editionId) map (EditionBranding(_, branding))
-      }.toSeq)
+      webUrl = FaciaContentUtils.webUrl(content)
     )
   }
 
@@ -175,9 +173,14 @@ final case class PressedProperties(
   section: String,
   maybeFrontPublicationDate: Option[Long],
   href: Option[String],
-  webUrl: Option[String],
-  editionBrandings: Option[Seq[EditionBranding]]
-)
+  webUrl: Option[String]
+) {
+  def branding(edition: Edition): Option[Branding] = for {
+    content <- maybeContent
+    commercial <- content.metadata.commercial
+    branding <- commercial.branding(edition)
+  } yield branding
+}
 
 object PressedCardHeader {
   def make(content: fapi.FaciaContent): PressedCardHeader = {
@@ -299,14 +302,8 @@ sealed trait PressedContent {
   def discussion: PressedDiscussionSettings
   def display: PressedDisplaySettings
 
-  def branding(edition: Edition): Option[Branding] =
-    for {
-      brandings <- properties.editionBrandings
-      editionBranding <- brandings find (_.edition == edition)
-      branding <- editionBranding.branding
-    } yield branding
+  def branding(edition: Edition): Option[Branding] = properties.branding(edition)
 }
-
 sealed trait Snap extends PressedContent
 
 object CuratedContent {

--- a/common/app/services/FaciaContentConvert.scala
+++ b/common/app/services/FaciaContentConvert.scala
@@ -1,10 +1,9 @@
 package services
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.facia.api.utils.{ContentProperties, ItemKicker, ResolvedMetaData}
 import com.gu.facia.api.{models => fapi}
+import com.gu.facia.api.utils.{ContentProperties, ResolvedMetaData, ItemKicker}
 import com.gu.facia.client.models.TrailMetaData
-import common.commercial.EditionBranding
 import model.pressed.PressedContent
 
 object FaciaContentConvert {
@@ -29,11 +28,7 @@ object FaciaContentConvert {
       kicker = ItemKicker.fromContentAndTrail(Some(content), trailMetaData, resolvedMetaData, None),
       embedType = None,
       embedUri = None,
-      embedCss = None,
-      brandingByEdition = EditionBranding.fromContent(content).map { editionBranding =>
-        editionBranding.edition.id -> editionBranding.branding
-      }.toMap
-    )
+      embedCss = None)
 
     PressedContent.make(curated)
   }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -26,7 +26,7 @@
 
         case _: model.MostPopular if isPaidFront => {}
 
-        case Fixed(_) if shouldRenderAsPaidContainer(isPaidFront, maybeContainerModel) => {
+        case Fixed(_) if shouldRenderAsPaidContainer(isPaidFront, containerDefinition, maybeContainerModel) => {
             @maybeContainerModel match {
                 case Some(containerModel) => {
                     @paidContainer(frontId.getOrElse(""), containerDefinition.index, containerModel)

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -115,14 +115,29 @@ object Commercial {
 
   object container {
 
-    def shouldRenderAsPaidContainer(isPaidFront: Boolean, optContainerModel: Option[ContainerModel]): Boolean = {
+    def shouldRenderAsPaidContainer(isPaidFront: Boolean,
+                                    container: FaciaContainer,
+                                    optContainerModel: Option[ContainerModel]): Boolean = {
 
-      def isPaid(containerModel: ContainerModel): Boolean = containerModel.branding exists {
-        case PaidMultiSponsorBranding => true
-        case b: Branding => b.isPaid
+      def isPaid(containerModel: ContainerModel): Boolean = {
+
+        val isPaidContainer = {
+          containerModel.branding exists {
+            case PaidMultiSponsorBranding => true
+            case b: Branding => b.isPaid
+          }
+        }
+
+        val isAllPaidContent = {
+          val content = containerModel.content
+          val cards = content.initialCards ++ content.showMoreCards
+          cards.nonEmpty && cards.forall(_.branding.exists(_.isPaid))
+        }
+
+        isPaidContainer || isAllPaidContent
       }
 
-      !isPaidFront && optContainerModel.exists(isPaid)
+      !isPaidFront && container.showBranding && optContainerModel.exists(isPaid)
     }
 
     def numberOfItems(container: FaciaContainer): Int = container.containerLayout.map {

--- a/common/test/common/commercial/FixtureBuilder.scala
+++ b/common/test/common/commercial/FixtureBuilder.scala
@@ -27,8 +27,7 @@ object FixtureBuilder {
       section = "",
       maybeFrontPublicationDate = None,
       href = None,
-      webUrl = None,
-      editionBrandings = None
+      webUrl = None
     )
 
     def mkHeader(): PressedCardHeader = PressedCardHeader(

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -46,9 +46,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       image = None,
       properties = ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
       byline = None,
-      kicker = None,
-      brandingByEdition = Map.empty
-    )
+      kicker = None)
 
     LatestSnap.make(fapiLatestSnap)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
-  val faciaVersion = "2.1.0"
+  val faciaVersion = "2.0.17"
   val capiVersion = "11.12"
   val dispatchVersion = "0.11.3"
   val configurationMagicVersion = "1.2.2"

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -115,6 +115,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
           dateLinkPath = None,
           useShowMore = false,
           hasShowMoreEnabled = true,
+          showBranding = false,
           isThrasher = false
         )
         Some(faciaContainer)


### PR DESCRIPTION
There are broken fronts because of failing queries to the content API. It seems that the extra requests made from the `facia-scala-client` are causing failures.

@reettaphant @kelvin-chappell 