### PR TITLE
Add JS circular dependency module to build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-runtime": "^6.20.0",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
+    "circular-dependency-plugin": "3.0.0",
     "classnames": "~2.2.0",
     "curl": "cujojs/curl#0.8.9",
     "domready": "^1.0.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,7 @@ module.exports = {
 
         new CircularDependencyPlugin({
             // exclude detection of files based on a RegExp
-            exclude: /a\.js|node_modules/,
+            exclude: /node_modules/,
             // add errors to webpack instead of warnings
             failOnError: true,
         }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const path = require('path');
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 const webpack = require('webpack');
 
 module.exports = {
@@ -92,6 +93,13 @@ module.exports = {
         // but it's sufficient to scope it at the chunk level
         new webpack.ProvidePlugin({
             videojs: 'videojs',
+        }),
+
+        new CircularDependencyPlugin({
+            // exclude detection of files based on a RegExp
+            exclude: /a\.js|node_modules/,
+            // add errors to webpack instead of warnings
+            failOnError: true,
         }),
     ],
     externals: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,15 +873,7 @@ babel-plugin-transform-system-register@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-system-register/-/babel-plugin-transform-system-register-0.0.1.tgz#9dff40390c2763ac518f0b2ad7c5ea4f65a5be25"
 
-babel-polyfill@^6.16.0, babel-polyfill@^6.6.1, babel-polyfill@^6.9.1:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.20.0.tgz#de4a371006139e20990aac0be367d398331204e7"
-  dependencies:
-    babel-runtime "^6.20.0"
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-polyfill@^6.23.0:
+babel-polyfill@^6.16.0, babel-polyfill@^6.23.0, babel-polyfill@^6.6.1, babel-polyfill@^6.9.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:
@@ -1487,6 +1479,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
   dependencies:
     inherits "^2.0.1"
+
+circular-dependency-plugin@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-3.0.0.tgz#9b68692e35b0e3510998d0164b6ae5011bea5760"
 
 circular-json@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
### Background
On Friday there was a tricky-to-debug [problem](https://github.com/guardian/frontend/pull/16819/commits/3dcfba330524af0381e96b0bf57b0e3a0db0b240) ultimately caused by a circular dependency between es6 modules. When circular dependencies arise, one of the modules will be instantiated as an empty object in order to break the instantiation deadlock, before being subsequently fully resolved, see [here](https://github.com/webpack/webpack/issues/1788) for details.

### What does this change?
This PR adds in a build step to test for circular dependencies during the building of the javascript.

- It will be immediately clear when a circular dependency is introduced (it throws an error during the bundling - it could be more concise; given the dependency graph is by definition a cycle, one path printout would probably suffice:
```
Error: Circular dependency detected:
static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js -> static/src/javascripts/projects/commercial/modules/dfp/Advert.js -> static/src/javascripts/projects/commercial/modules/dfp/define-slot.js -> static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js -> static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js,Circular dependency detected:
static/src/javascripts/projects/commercial/modules/dfp/Advert.js -> static/src/javascripts/projects/commercial/modules/dfp/define-slot.js -> static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js -> static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js -> static/src/javascripts/projects/commercial/modules/dfp/Advert.js,Circular dependency detected:
static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js -> static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js -> static/src/javascripts/projects/commercial/modules/dfp/Advert.js -> static/src/javascripts/projects/commercial/modules/dfp/define-slot.js -> static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js,Circular dependency detected:
static/src/javascripts/projects/commercial/modules/dfp/define-slot.js -> static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js -> static/src/javascripts/projects/commercial/modules/dfp/dfp-env.js -> static/src/javascripts/projects/commercial/modules/dfp/Advert.js -> static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
    at bundler.run (/Users/jon_norman/dev/frontend/tools/__tasks__/compile/javascript/webpack.js:28:27)
    at /Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:256:15
    at Compiler.emitRecords (/Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:351:37)
    at /Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:249:12
    at /Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:344:11
    at next (/Users/jon_norman/dev/frontend/node_modules/tapable/lib/Tapable.js:154:11)
    at Compiler.compiler.plugin (/Users/jon_norman/dev/frontend/node_modules/webpack/lib/performance/SizeLimitsPlugin.js:99:4)
    at Compiler.applyPluginsAsyncSeries1 (/Users/jon_norman/dev/frontend/node_modules/tapable/lib/Tapable.js:158:13)
    at Compiler.afterEmit (/Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:341:8)
    at Compiler.<anonymous> (/Users/jon_norman/dev/frontend/node_modules/webpack/lib/Compiler.js:336:14)
make: *** [compile-javascript] Error 1
```

- It adds a couple of seconds to the build time (~2% increase), which seems reasonable (see testing below).
- It can be configured to not throw an exception on the detection of a circular dependency (it's conceivable that we may need to introduce one in future).

### Have you tested this?
![image](https://cloud.githubusercontent.com/assets/1821099/26312711/626ab410-3f00-11e7-8e6c-b6c55693e4fe.png)
