### PR TITLE
Lets start to build the desktop header!

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -39,6 +39,17 @@ object ABNewRecipeDesign extends TestDefinition(
   }
 }
 
+object ABNewDesktopHeader extends TestDefinition(
+  name = "ab-new-desktop-header",
+  description = "Users in this test will see the new desktop design.",
+  owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
+  sellByDate = new LocalDate(2017, 7, 5)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-desktop-header").contains("variant")
+  }
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -53,7 +64,8 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
-    ABNewRecipeDesign
+    ABNewRecipeDesign,
+    ABNewDesktopHeader
   )
 }
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -9,112 +9,122 @@
 @* TODO: #new-recipe - remove when removing the test *@
 @hasSlimHeader = @{page.metadata.hasSlimHeader || (page.metadata.isNewRecipeDesign && mvt.ABNewRecipeDesign.isParticipating)}
 
-<header id="header"
-        class="l-header u-cf @if(hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header hide-on-mobile"
-        role="banner"
-        data-link-name="global navigation: header">
-    <div class="js-navigation-header navigation-container navigation-container--collapsed">
-        <div class="gs-container l-header__inner">
-            <div class="l-header-pre u-cf">
-                <div class="brand-bar">
-                    @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-                        <div class="brand-bar__item brand-bar__item--profile popup-container
+@if(!mvt.ABNewDesktopHeader.isParticipating) {
+    <header id="header"
+    class="l-header u-cf @if(hasSlimHeader && !showNormalHeader) {l-header--is-slim l-header--no-navigation} js-header hide-on-mobile"
+    role="banner"
+    data-link-name="global navigation: header">
+        <div class="js-navigation-header navigation-container navigation-container--collapsed">
+            <div class="gs-container l-header__inner">
+                <div class="l-header-pre u-cf">
+                    <div class="brand-bar">
+                        @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
+                            <div class="brand-bar__item brand-bar__item--profile popup-container
                                     has-popup js-profile-nav"
-                             data-component="identity-profile">
-                             <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
-                               data-link-name="User profile"
-                               data-toggle="popup--profile"
-                               data-toggle-signed-in="true"
-                               class="brand-bar__item--action popup__toggle"
-                               data-test-id="sign-in-link"
-                               aria-haspopup="true">
-                                @fragments.inlineSvg("profile-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                                <span class="js-profile-info control__info"
-                                      data-test-id="sign-in-name">sign in</span>
-                            </a>
-                            <div class="js-profile-popup">
-                                <ul class="popup popup--default popup__group popup--profile is-off" data-link-name="Sub Sections" data-test-id="popup-profile">
-                                    <li class="popup__item"><a class="brand-bar__item--action js-comment-activity u-h" data-link-name="Comment activity">Comment activity</a></li>
-                                    <li class="popup__item"><a href="@Configuration.id.url/public/edit" class="brand-bar__item--action" data-link-name="Edit profile">Edit profile</a></li>
-                                    <li class="popup__item"><a href="@Configuration.id.url/email-prefs" class="brand-bar__item--action" data-link-name="Email preferences">Email preferences</a></li>
-                                    <li class="popup__item"><a href="@Configuration.id.url/password/change" class="brand-bar__item--action" data-link-name="Change password">Change password</a></li>
-                                    <li class="popup__item"><a href="@Configuration.id.url/signout" class="brand-bar__item--action" data-link-name="Sign out">Sign out</a></li>
-                                </ul>
+                            data-component="identity-profile">
+                                <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
+                                data-link-name="User profile"
+                                data-toggle="popup--profile"
+                                data-toggle-signed-in="true"
+                                class="brand-bar__item--action popup__toggle"
+                                data-test-id="sign-in-link"
+                                aria-haspopup="true">
+                                    @fragments.inlineSvg("profile-36", "icon", List("rounded-icon", "control__icon-wrapper"))
+                                    <span class="js-profile-info control__info"
+                                    data-test-id="sign-in-name">sign in</span>
+                                </a>
+                                <div class="js-profile-popup">
+                                    <ul class="popup popup--default popup__group popup--profile is-off" data-link-name="Sub Sections" data-test-id="popup-profile">
+                                        <li class="popup__item"><a class="brand-bar__item--action js-comment-activity u-h" data-link-name="Comment activity">
+                                            Comment activity</a></li>
+                                        <li class="popup__item"><a href="@Configuration.id.url/public/edit" class="brand-bar__item--action" data-link-name="Edit profile">
+                                            Edit profile</a></li>
+                                        <li class="popup__item"><a href="@Configuration.id.url/email-prefs" class="brand-bar__item--action" data-link-name="Email preferences">
+                                            Email preferences</a></li>
+                                        <li class="popup__item"><a href="@Configuration.id.url/password/change" class="brand-bar__item--action" data-link-name="Change password">
+                                            Change password</a></li>
+                                        <li class="popup__item"><a href="@Configuration.id.url/signout" class="brand-bar__item--action" data-link-name="Sign out">
+                                            Sign out</a></li>
+                                    </ul>
+                                </div>
                             </div>
-                        </div>
-                    }
+                        }
 
-                    <div class="brand-bar__item has-popup brand-bar__item--has-control
+                        <div class="brand-bar__item has-popup brand-bar__item--has-control
                                 popup-container brand-bar__item--subscribe
                                  hide-on-slim-header hide-on-tablet"
-                         data-component="subscribe">
-                        @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                        <a href="@Configuration.id.membershipUrl/supporter?countryGroup=@Edition(request).id.toLowerCase&INTCMP=DOTCOM_HEADER_BECOMEMEMBER_@Edition(request).id"
-                        data-link-name="Register link"
-                        class="brand-bar__item--action brand-bar__item--split--first js-become-member">
-                            <span class="control__info js-control-info control__info--supporting">become a supporter</span>
-                        </a><a href="@SubscribeLink(Edition(request))" class="brand-bar__item--action brand-bar__item--split--last js-subscribe"
+                        data-component="subscribe">
+                            @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
+                            <a href="@Configuration.id.membershipUrl/supporter?countryGroup=@Edition(request).id.toLowerCase&INTCMP=DOTCOM_HEADER_BECOMEMEMBER_@Edition(request).id"
+                            data-link-name="Register link"
+                            class="brand-bar__item--action brand-bar__item--split--first js-become-member">
+                                <span class="control__info js-control-info control__info--supporting">
+                                    become a supporter</span>
+                            </a> <a href="@SubscribeLink(Edition(request))" class="brand-bar__item--action brand-bar__item--split--last js-subscribe"
                         data-link-name="@Edition(request).id.toLowerCase : topNav : subscribe">
                             <span class="control__info js-control-info">subscribe</span>
                         </a>
-                    </div>
-
-                    @if(SearchSwitch.isSwitchedOn) {
-                        <div class="brand-bar__item has-popup popup-container brand-bar__item--search" data-component="search">
-                            <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon"
-                               class="brand-bar__item--action popup__toggle js-search-toggle" data-toggle="popup--search"
-                               aria-haspopup="true">
-                                @fragments.inlineSvg("search-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                                <span class="control__info">search</span>
-                            </a>
                         </div>
-                    }
-                    @fragments.topNav.servicesLinks(page.metadata)
+
+                        @if(SearchSwitch.isSwitchedOn) {
+                            <div class="brand-bar__item has-popup popup-container brand-bar__item--search" data-component="search">
+                                <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com" data-is-ajax data-link-name="Search icon"
+                                class="brand-bar__item--action popup__toggle js-search-toggle" data-toggle="popup--search"
+                                aria-haspopup="true">
+                                    @fragments.inlineSvg("search-36", "icon", List("rounded-icon", "control__icon-wrapper"))
+                                    <span class="control__info">search</span>
+                                </a>
+                            </div>
+                        }
+                        @fragments.topNav.servicesLinks(page.metadata)
+                    </div>
                 </div>
-            </div>
 
-            <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
+                <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
 
-            <div class="l-header-main">
-                @if((page.metadata.sectionId == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {
-                    <a href="@LinkTo{@page.metadata.url}" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" data-component="logo">
+                <div class="l-header-main">
+                    @if((page.metadata.sectionId == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {
+                        <a href="@LinkTo {
+                            @page.metadata.url
+                        }" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" data-component="logo">
                         @if(hasSlimHeader) {
                             @fragments.inlineSvg("observer-logo-160", "logo")
                         } else {
                             <span class="u-h">The Observer - Back to home</span>
                             @fragments.inlineSvg("observer-logo-320", "logo")
                         }
-                    </a>
-                } else {
-                    <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" data-component="logo">
-                        <span class="u-h">The Guardian - Back to home</span>
+                        </a>
+                    } else {
+                        <a href="@LinkTo {/}" data-link-name="site logo" id="logo" class="logo-wrapper" data-component="logo">
+                            <span class="u-h">The Guardian - Back to home</span>
 
-                        @if(hasSlimHeader) {
-                            @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
-                            <!--[if (gt IE 8)|(IEMobile)]><!-->
+                            @if(hasSlimHeader) {
+                                @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
+                                    <!--[if (gt IE 8)|(IEMobile)]><!-->
                                 @fragments.inlineSvg("guardian-logo-160", "logo")
-                            <!--<![endif]-->
-                            <!--[if (lt IE 9)&(!IEMobile)]>
+                                    <!--<![endif]-->
+                                    <!--[if (lt IE 9)&(!IEMobile)]>
                               <span class="inline-logo inline-guardian-logo-160"></span>
                             <![endif]-->
-                        } else {
-                            <!--[if (gt IE 8)|(IEMobile)]><!-->
+                                } else {
+                                <!--[if (gt IE 8)|(IEMobile)]><!-->
                                 @fragments.inlineSvg("guardian-logo-320", "logo")
-                            <!--<![endif]-->
-                            <!--[if (lt IE 9)&(!IEMobile)]>
+                                <!--<![endif]-->
+                                <!--[if (lt IE 9)&(!IEMobile)]>
                                 <span class="inline-logo inline-guardian-logo-320"></span>
                             <![endif]-->
-                        }
-                    </a>
-                }
+                            }
+                        </a>
+                    }
 
-                @if(hasSlimHeader) {
-                    @fragments.nav.navigationToggle()
-                }
+                    @if(hasSlimHeader) {
+                        @fragments.nav.navigationToggle()
+                    }
+                </div>
             </div>
+
+            @fragments.nav.navigation(page)
         </div>
 
-        @fragments.nav.navigation(page)
-    </div>
-
-</header>
+    </header>
+}

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,7 +4,9 @@
 @import common.{LinkTo, NewNavigation, Edition}
 @import views.support.RenderClasses
 
-<header class="new-header"
+<header class="@RenderClasses(Map(
+            "mobile-only" -> !mvt.ABNewDesktopHeader.isParticipating
+        ), "new-header")"
         role="banner">
     @defining(NewNavigation.SubSectionLinks.getSectionOrTagId(page)) { id =>
         @defining(

--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -173,7 +173,6 @@ $navigation-horizontal-padding: $gs-gutter * 2 + $gs-gutter / 2;
 }
 
 .new-header {
-    @include mobile-only;
     background-color: $guardian-brand;
 }
 


### PR DESCRIPTION
## What does this change?
Completes: https://trello.com/c/TiC0grXY/46-dhdid-implement-mvt-test-with-no-audience-which-uses-just-the-new-header-template-for-better-collaboration-for-development

Adding a mvt test for local development. In the future we will use the same test and add a control to properly AB test the new header desktop design.

To note:
* This switch shouldn't be turned on in PROD yet, its only for local development
* There won't be any fastly changes until we are happy for users to see our work.

cc @stephanfowler @zeftilldeath 

## What is the value of this and can you measure success?
Instead of having one big PR, this will allow us to iterate on the desktop design without it impacting what users will see.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Doesn't look great right now, but that will change!

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
