### PR TITLE
Go live with Ad feedback

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/commercial-features.js
@@ -126,6 +126,10 @@ define([
                 return !adblockUsed && self.canReasonablyAskForMoney;
             })
         };
+
+        this.adFeedback =
+            config.switches.adFeedback &&
+            ['artanddesign', 'society', 'tvandradio'].indexOf(config.page.section) > -1;
     }
 
     try {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -3,7 +3,7 @@ import fastdom from 'lib/fastdom-promise';
 import template from 'lodash/utilities/template';
 import popupTemplate from 'raw-loader!commercial/views/ad-feedback-popup.html';
 import tick from 'svgs/icon/tick.svg';
-import config from 'lib/config';
+import commercialFeatures from 'commercial/modules/commercial-features';
 
 const shouldRenderLabel = adSlotNode =>
     !(adSlotNode.classList.contains('ad-slot--fluid') ||
@@ -16,7 +16,7 @@ const renderAdvertLabel = (adSlotNode: any) => {
     if (shouldRenderLabel(adSlotNode)) {
         let feedbackPopup = '';
         let feedbackThanksMessage = '';
-        if (config.switches.adFeedback) {
+        if (commercialFeatures.adFeedback) {
             feedbackPopup = template(popupTemplate, {
                 feedbackOptions: {
                     inappropriate: "It's offensive or inappropriate",

--- a/static/src/stylesheets/module/_popup.scss
+++ b/static/src/stylesheets/module/_popup.scss
@@ -269,10 +269,7 @@ $control-offset: 36 + $gs-gutter/2;
 /* Ad feedback menu
    ========================================================================== */
 .ad-feedback.popup__toggle {
-    position: absolute;
-    padding-right: $gs-gutter/2;
-    right: 0;
-    top: 0;
+    display: inline;
     cursor: pointer;
 
     &::after {
@@ -288,8 +285,6 @@ $control-offset: 36 + $gs-gutter/2;
 .ad-feedback.popup {
     width: 240px;
     top: 100%;
-    left: auto;
-    right: $gs-gutter/2;
     border: 1px solid $neutral-4;
     z-index: $zindex-overlay;
     padding: 0;


### PR DESCRIPTION
## What does this change?
Enables the ad feedback feature on `society`, `artanddesign` and `society`. Also tweaked the popup to inline so that it can accomodate various top banner sizes. It's also further away from AdChoices, and more contextual.

## What is the value of this and can you measure success?
In the short term, this will be used for the programmatic tests.
## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-05-23 at 11 59 05](https://cloud.githubusercontent.com/assets/4549425/26351544/012fb35c-3fb0-11e7-80be-da1cd67a02de.png)
![screen shot 2017-05-23 at 11 59 23](https://cloud.githubusercontent.com/assets/4549425/26351549/054feb6e-3fb0-11e7-8680-338a98d68df2.png)
