### PR TITLE
Avoid weather MatchError for int edition

### DIFF
--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -2,10 +2,10 @@ package weather.controllers
 
 import common._
 import weather.geo._
-import model.Cached
+import model.{CacheTime, Cached}
 import weather.models.CityResponse
 import play.api.libs.json.Json
-import play.api.mvc.{Controller, Action}
+import play.api.mvc.{Action, Controller}
 import weather.WeatherApi
 
 import scala.language.postfixOps
@@ -65,7 +65,10 @@ class LocationsController(weatherApi: WeatherApi) extends Controller with Execut
             }
         }
 
-      case (_, _, _) => Future.successful(Cached(1 hour)(JsonComponent(cityFromRequestEdition)))
+      case (_, _, _) =>
+        cityFromRequestEdition.fold
+          { Future.successful(Cached(CacheTime.NotFound)(JsonNotFound())) }
+          { city => Future.successful(Cached(1 hour)(JsonComponent(city))) }
     }
   }
 }

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -68,11 +68,13 @@ class LocationsController(weatherApi: WeatherApi) extends Controller with Execut
         }
 
       case (_, _, _) =>
-        cityFromRequestEdition.fold {
-          Future.successful(Cached(CacheTime.NotFound)(JsonNotFound()))
-        } { city =>
-          Future.successful(Cached(1 hour)(JsonComponent(city)))
-        }
+        Future.successful(
+          cityFromRequestEdition.fold {
+            Cached(CacheTime.NotFound)(JsonNotFound())
+          } { city =>
+            Cached(1 hour)(JsonComponent(city))
+          }
+        )
     }
   }
 }

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -57,18 +57,22 @@ class LocationsController(weatherApi: WeatherApi) extends Controller with Execut
             log.warn(s"Could not find $city, $region, $country in database, trying text search")
             weatherApi.searchForLocations(city) map { locations =>
               val cities = CityResponse.fromLocationResponses(locations.filter(_.Country.ID == country).toList)
-              val weatherCity = cities.headOption.getOrElse(cityFromRequestEdition)
 
-              log.info(s"Resolved geo info (City=$city Region=$region Country=$country) to city $weatherCity")
-
-              Cached(1 hour)(JsonComponent(weatherCity))
+              cities.headOption.fold {
+                Cached(CacheTime.NotFound)(JsonNotFound())
+              } { weatherCity =>
+                log.info(s"Resolved geo info (City=$city Region=$region Country=$country) to city $weatherCity")
+                Cached(1 hour)(JsonComponent(weatherCity))
+              }
             }
         }
 
       case (_, _, _) =>
-        cityFromRequestEdition.fold
-          { Future.successful(Cached(CacheTime.NotFound)(JsonNotFound())) }
-          { city => Future.successful(Cached(1 hour)(JsonComponent(city))) }
+        cityFromRequestEdition.fold {
+          Future.successful(Cached(CacheTime.NotFound)(JsonNotFound()))
+        } { city =>
+          Future.successful(Cached(1 hour)(JsonComponent(city)))
+        }
     }
   }
 }

--- a/onward/app/weather/models/CityResponse.scala
+++ b/onward/app/weather/models/CityResponse.scala
@@ -59,11 +59,12 @@ object CityResponse {
     country = "Australia"
   )
 
-  def fromEdition(edition: Edition) = {
+  def fromEdition(edition: Edition): Option[CityResponse] = {
     edition match {
-      case Uk => London
-      case Us => NewYork
-      case Au => Sydney
+      case Uk => Some(London)
+      case Us => Some(NewYork)
+      case Au => Some(Sydney)
+      case _ => None
     }
   }
 }


### PR DESCRIPTION
## What does this change?
I noticed a lot of MatchErrors for the international edition (when geolocation fails to find the city, region or country).  This happens commonly for China at first glance.  This change avoids the error and instead returns a 404 when geolocation fails (at least partially) and the edition is international.

## What is the value of this and can you measure success?
Less errors and noise in the logs.

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
