### PR TITLE
Log route controller and method for each request

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -2,8 +2,9 @@ package common
 
 import play.api.mvc.{RequestHeader, Result}
 import common.LoggingField._
+import play.api.routing.Router.Tags
 
-import scala.util.Random
+import scala.util.{Random, Try}
 
 case class RequestLoggerFields(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch]) {
 
@@ -54,7 +55,14 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       )
     }.getOrElse(Nil)
 
-    requestHeaders ++ responseHeaders ++ stopWatchHeaders
+    val actionInfo: List[LogField] = request.map { r: RequestHeader =>
+      List[LogField](
+        "action.controller" -> Try(r.tags(Tags.RouteController)).getOrElse("unknown"),
+        "action.method" -> Try(r.tags(Tags.RouteActionMethod)).getOrElse("unknown")
+      )
+    }.getOrElse(Nil)
+
+    requestHeaders ++ responseHeaders ++ stopWatchHeaders ++ actionInfo
   }
 
   def toList: List[LogField] = customFields ++ requestHeadersFields

--- a/common/test/common/RequestLoggerTest.scala
+++ b/common/test/common/RequestLoggerTest.scala
@@ -33,7 +33,9 @@ class RequestLoggerTest extends FlatSpec with Matchers {
       "req.header.X-GU-header1" -> "value1",
       "req.header.X-GU-header2" -> "value2",
       "req.header.Host" -> "someHost",
-      "req.header.Referer" -> "someReferer"
+      "req.header.Referer" -> "someReferer",
+      "action.controller" -> "unknown",
+      "action.method" -> "unknown"
     )
     val notExpectedFields: List[LogField] = List("NotSupported" -> "value")
     expectedFields.forall(fields.toList.contains) should be(true)


### PR DESCRIPTION
## What does this change?
Add the controller and method name to the info we log for every incoming request

## What is the value of this and can you measure success?
It would help:
- investigating which controller/methods are being frequently called and could be a bottleneck.
- identify if a method is never called

## Tested in CODE?
Yes

![screen shot 2017-05-23 at 14 01 38](https://cloud.githubusercontent.com/assets/233326/26355409/7010fb68-3fc0-11e7-874b-dc8370ca46b3.png)
