### PR TITLE
Fix forcing into tests in Acquisitions test selector

### DIFF
--- a/dev/flow-typed-guardian-frontend/ab-tests.js
+++ b/dev/flow-typed-guardian-frontend/ab-tests.js
@@ -26,6 +26,7 @@ declare type ABTest = {
     variants: Array<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,
+    isEngagementBannerTest?: boolean,
 };
 
 /**

--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -18,7 +18,7 @@ const selectRadios = () => {
     });
 
     abTests.forEach(test => {
-        $(`#${test.id}-${test.variant}`).attr('checked', true);
+        $(`#${test.variantId}-${test.variantId}`).attr('checked', true);
     });
 };
 
@@ -29,13 +29,13 @@ const bindEvents = () => {
             const variantId = label.getAttribute('data-ab-variant');
             const abTests = getSelectedAbTests();
             const existingVariantForThisTest = abTests.find(
-                test => test.id === testId
+                test => test.testId === testId
             );
 
             if (existingVariantForThisTest) {
-                existingVariantForThisTest.variant = variantId;
+                existingVariantForThisTest.variantId = variantId;
             } else {
-                abTests.push({ id: testId, variant: variantId });
+                abTests.push({ testId, variantId });
             }
             storage.set('gu.devtools.ab', JSON.stringify(abTests));
         });

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -53,7 +53,7 @@ export const TESTS: Array<ABTest> = [
     MeasureUnderstanding(),
 ]
     .concat(MembershipEngagementBannerTests)
-    .filter(t => t !== undefined && t !== null);
+    .filter(Boolean);
 
 export const getActiveTests = (): Array<ABTest> =>
     TESTS.filter(test => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -17,8 +17,8 @@ import {
     addParticipation,
     getTestVariantId,
     cleanParticipations,
+    getForcedTests,
 } from 'common/modules/experiments/utils';
-import { local } from 'lib/storage';
 
 const noop = (): null => null;
 
@@ -42,19 +42,6 @@ const allocateUserToTest = test => {
     if (testCanBeRun(test) && !isParticipating(test)) {
         addParticipation(test, variantIdFor(test));
     }
-};
-
-const getForcedIntoTests = () => {
-    if (window.location.hash.startsWith('#ab')) {
-        const tokens = window.location.hash.replace('#ab-', '').split(',');
-
-        return tokens.map(token => {
-            const [id, variant] = token.split('=');
-            return { id, variant };
-        });
-    }
-
-    return JSON.parse(local.get('gu.devtools.ab')) || [];
 };
 
 export const shouldRunTest = (testId: string, variantName: string) => {
@@ -97,12 +84,12 @@ export const forceVariantCompleteFunctions = (
 };
 
 export const segmentUser = () => {
-    const forcedIntoTests = getForcedIntoTests();
+    const forcedIntoTests = getForcedTests();
 
     if (forcedIntoTests.length) {
         forcedIntoTests.forEach(test => {
-            forceSegment(test.id, test.variant);
-            forceVariantCompleteFunctions(test.id, test.variant);
+            forceSegment(test.testId, test.variantId);
+            forceVariantCompleteFunctions(test.testId, test.variantId);
         });
     } else {
         segment(getActiveTests());

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -1,5 +1,9 @@
 // @flow
 import { variantFor, isInTest } from 'common/modules/experiments/segment-util';
+import {
+    getForcedTests,
+    getForcedVariant,
+} from 'common/modules/experiments/utils';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import {
     viewsInPreviousDays,
@@ -21,47 +25,44 @@ const tests = [
     acquisitionsEpicTestimonialsRoundTwo,
     askFourEarning,
     acquisitionsEpicLiveBlog,
-];
+].map(Test => new Test());
 
-export const epicEngagementBannerTests = tests.reduce((out, Test) => {
-    const testInstance = new Test();
+const isViewable = (v: Variant): boolean => {
+    if (!v.options || !v.options.maxViews) return false;
 
-    if (testInstance.isEngagementBannerTest) {
-        out.push(testInstance);
-    }
-    return out;
-}, []);
+    const {
+        count: maxViewCount,
+        days: maxViewDays,
+        minDaysBetweenViews: minViewDays,
+    } = v.options.maxViews;
 
-export const abTestClashData = tests.map(Test => new Test());
+    const isUnlimited = v.options.isUnlimited;
+
+    const withinViewLimit = viewsInPreviousDays(maxViewDays) < maxViewCount;
+    const enoughDaysBetweenViews = viewsInPreviousDays(minViewDays) === 0;
+
+    return (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;
+};
+
+export const epicEngagementBannerTests = () =>
+    tests.filter(t => t.isEngagementBannerTest);
+
+export const abTestClashData = tests;
 
 // This can be annotated with a return type of ABTest when all of the imported tests are converted
 export const getTest = () => {
-    const eligibleTests = tests.filter(Test => {
-        const t = new Test();
-        const forced = window.location.hash.indexOf(`ab-${t.id}`) > -1;
-        const variant: Variant = variantFor(t);
+    const forcedTests = getForcedTests()
+        .map(({ testId }) => tests.find(t => t.id === testId))
+        .filter(Boolean);
 
-        if (!variant || !variant.options || !variant.options.maxViews)
-            return false;
+    if (forcedTests.length)
+        return forcedTests.find(t => {
+            const variant: ?Variant = getForcedVariant(t);
+            return variant && testCanBeRun(t) && isViewable(variant);
+        });
 
-        const {
-            count: maxViewCount,
-            days: maxViewDays,
-            minDaysBetweenViews: minViewDays,
-        } = variant.options.maxViews;
-
-        const isUnlimited = variant.options.isUnlimited;
-
-        const withinViewLimit = viewsInPreviousDays(maxViewDays) < maxViewCount;
-        const enoughDaysBetweenViews = viewsInPreviousDays(minViewDays) === 0;
-
-        const hasNotReachedRateLimit =
-            (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;
-
-        return (
-            forced || (testCanBeRun(t) && isInTest(t) && hasNotReachedRateLimit)
-        );
+    return tests.find(t => {
+        const variant: ?Variant = variantFor(t);
+        return variant && testCanBeRun(t) && isInTest(t) && isViewable(variant);
     });
-
-    return eligibleTests[0] && new eligibleTests[0]();
 };

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -49,8 +49,7 @@ export const epicEngagementBannerTests = () =>
 
 export const abTestClashData = tests;
 
-// This can be annotated with a return type of ABTest when all of the imported tests are converted
-export const getTest = () => {
+export const getTest = (): ?ABTest => {
     const forcedTests = getForcedTests()
         .map(({ testId }) => tests.find(t => t.id === testId))
         .filter(Boolean);

--- a/static/src/javascripts/projects/common/modules/experiments/segment-util.js
+++ b/static/src/javascripts/projects/common/modules/experiments/segment-util.js
@@ -42,7 +42,7 @@ export const variantIdFor = memoize(computeVariantIdFor, getId);
 export const isInTest = (test: ABTest): boolean =>
     variantIdFor(test) !== NOT_IN_TEST;
 
-export const variantFor = (test: ABTest): Variant => {
+export const variantFor = (test: ABTest): ?Variant => {
     const variantId = variantIdFor(test);
-    return test.variants.filter(variant => variant.id === variantId)[0];
+    return test.variants.find(variant => variant.id === variantId);
 };

--- a/static/src/javascripts/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.js
@@ -81,3 +81,26 @@ export const isInVariant = (test: ABTest, variant: Variant): boolean =>
     getParticipations()[test.id] &&
     getParticipations()[test.id].variant === variant.id &&
     testCanBeRun(test);
+
+export const getForcedTests = (): Array<{
+    testId: string,
+    variantId: string,
+}> => {
+    if (window.location.hash.startsWith('#ab')) {
+        const tokens = window.location.hash.replace('#ab-', '').split(',');
+
+        return tokens.map(token => {
+            const [testId, variantId] = token.split('=');
+            return { testId, variantId };
+        });
+    }
+
+    return JSON.parse(local.get('gu.devtools.ab')) || [];
+};
+
+export const getForcedVariant = (test: ABTest): ?Variant => {
+    const forcedVariantIds: Array<string> = getForcedTests().map(
+        t => t.variantId
+    );
+    return test.variants.find(v => forcedVariantIds.includes(v.id));
+};


### PR DESCRIPTION
## What does this change?
Fixes an issue where forcing yourself into a test doesn't work for 
`acquisitions-test-selector`. 

This involved a little refactoring to move the code that determines if
you've forced yourself into a test into `experiments/utils` and split
out the view limit code in the selector to its own function.

@guardian/contributions 