### PR TITLE
Fix football results page race condition

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -134,16 +134,14 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     DateTimeComparator.getInstance.asInstanceOf[Comparator[DateTime]]
   )
 
-  private def mostRecentCompetitionSeason(competitions: List[Season]): List[Season] = {
-    def compMatchesSeason(compDef: Competition)(season: Season) =
-      season.competitionId == compDef.id && season.startDate.isBefore(LocalDate.now())
-
+  private def mostRecentCompetitionSeason(competitions: List[Season]): List[Season] =
     competitionDefinitions.flatMap { compDef =>
-      competitions.filter(compMatchesSeason(compDef))
+      competitions
+        .filter(_.competitionId == compDef.id)
+        .filter(_.startDate.isBefore(LocalDate.now()))
         .sortBy(_.startDate.toDateTimeAtStartOfDay.getMillis).reverse
         .headOption
     }
-  }
 
   override val teamNameBuilder = new TeamNameBuilder(this)
 


### PR DESCRIPTION
## What does this change?
This change fixes a race condition between 2 different processes that refresh `competition` data in `sport`.  

We have a series of `competition` agents which store result, fixture, start date and other data for particular competitions (note: these agents do not support multiple seasons).  The data contained within these agents is refreshed periodically using PA endpoints like `/fixtures` `/results` etc.  Importantly, `startDate` is refreshed separately by another process, but is in turn used in the refresh of results.

This other process for refreshing competition `startDate` which polls the PA competition endpoint is run on a separate schedule and therefore we can't rely on a competition to have a start date at all when the results are refreshed.  This race condition has been accounted for all along by defaulting the start date to 30 days ago.

Unfortunately when PA release their new season start dates, we prioritise the most recent season start date, which means the results may be empty depending on the timing of the competition result refresh and start date refresh.

~This PR fixes that issue by only taking the most recent _started_ season for the result refresh.  This could have consequences for the fixtures, but it turns out that those don't use the start date at all.  The only other affected construct is `wallcharts` which are for competitions that should only ever have one season anyway e.g. World Cups (afaik - we don't have any atm to test).~

## What is the value of this and can you measure success?
Results page is consistent once more.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
I plan to.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
