### PR TITLE
Extend bundle price test by one week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,7 +28,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 5, 29),
     exposeClientSide = true
   )
-  
+
   Switch(
     ABTests,
     "ab-measure-understanding",
@@ -185,7 +185,7 @@ trait ABTestSwitches {
     "Test pricing options for digital subs",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 5, 25),  // Thursday
+    sellByDate = new LocalDate(2017, 6, 1),  // Thursday 1st June
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
@@ -17,7 +17,7 @@ define([
         var self = this;
         this.id = 'BundleDigitalSubPriceTest1M';
         this.start = '2017-05-10';
-        this.expiry = '2017-05-25'; // Thursday 25th May
+        this.expiry = '2017-06-01'; // Thursday 1st June
         this.author = 'Justin Pinner';
         this.description = 'Test digital subs price points via thrasher';
         this.showForSensitive = true;


### PR DESCRIPTION
## What does this change?
Extends the AB switch and test by one week. We almost have statistical significance so one week should be enough, and gets us past the bank holiday anyway.

## What is the value of this and can you measure success?
No broken builds, and a longer-running test.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
N/A

## Tested in CODE?
No.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
