### PR TITLE
Min height as a fallback for ie on immersive embeds

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -16,10 +16,18 @@
 .immersive-main-media {
     // The headline wrapper is position absolute within this div
     position: relative;
+    min-height: 400px;
+
+    @include mq(desktop) {
+        min-height: 500px;
+    }
+
+    @include mq(wide) {
+        min-height: 800px;
+    }
 
     @supports (object-fit: cover) and (height: 1vh) and (display: flex) {
         flex: 1;
-        min-height: 400px;
     }
 
     &.atom-playing {
@@ -63,7 +71,6 @@
 
 .immersive-main-media__media {
     width: 100%;
-    height: 100vh;
     // Remove inline spacing
     display: block;
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -63,6 +63,7 @@
 
 .immersive-main-media__media {
     width: 100%;
+    height: 100vh;
     // Remove inline spacing
     display: block;
 
@@ -93,7 +94,6 @@
         position: absolute;
         top: 0;
         height: 100%;
-        width: 100%;
     }
 }
 


### PR DESCRIPTION
**In Internet Explorer:**
When inserting an embed as main media in the immersive template, the embed has no height because silly old IE doesn't speak flexbox fluently. A min-height that shouldn't conflict with img fallbacks has been added for 3 breakpoints which ensures the embeds are visible albeit not being 100% of the viewport height. 

# This is how an embedded iframe looks in ie currently:
<img width="1309" alt="screen shot 2017-05-24 at 14 12 03" src="https://cloud.githubusercontent.com/assets/14570016/26408068/b8d95406-4094-11e7-8c16-60f3efc58b97.png">

# With a min-height added it now looks like this
<img width="1667" alt="screen shot 2017-05-24 at 17 22 27" src="https://cloud.githubusercontent.com/assets/14570016/26414007/ac737ec4-40a5-11e7-8754-2d1cb686b8be.png">


