### PR TITLE
Some ad slots in Safari are not lazy loading

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -3,7 +3,6 @@
 /* eslint no-use-before-define: "off" */
 
 import detect from 'lib/detect';
-import mediator from 'lib/mediator';
 import { getCurrentTime } from 'lib/user-timing';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import loadAdvert from 'commercial/modules/dfp/load-advert';
@@ -15,16 +14,6 @@ const IntersectionObserverEntry = window.IntersectionObserverEntry;
 
 /* depthOfScreen: double. Top and bottom margin of the visual viewport to check for the presence of an advert */
 const depthOfScreen = 1.5;
-
-const stopListening = (): void => {
-    dfpEnv.lazyLoadEnabled = false;
-    mediator.off('window:throttledScroll', onScroll);
-};
-
-const stopObserving = (observer: IntersectionObserver): void => {
-    dfpEnv.lazyLoadEnabled = false;
-    observer.disconnect();
-};
 
 const displayAd = (advertId: string): void => {
     const advert = getAdvertById(advertId);
@@ -55,10 +44,6 @@ const onScroll = (): void => {
         advert => !lazyLoadAds.includes(advert.id)
     );
 
-    if (dfpEnv.advertsToLoad.length === 0) {
-        stopListening();
-    }
-
     lazyLoadAds.forEach(displayAd);
 };
 
@@ -79,10 +64,6 @@ const onIntersect = (
     dfpEnv.advertsToLoad = dfpEnv.advertsToLoad.filter(
         advert => advertIds.indexOf(advert.id) < 0
     );
-
-    if (dfpEnv.advertsToLoad.length === 0) {
-        stopObserving(observer);
-    }
 };
 
 export { onIntersect, onScroll };


### PR DESCRIPTION
## What does this change?
The top above nav ad slot isn't reliably loading on ios safari. I believe this is due to our scroll listener; I'm not convinced the disconnect/stop listen mechanism works, and in some race conditions, this means that an `enableLazyLoad` call won't actually lead to the scroll listener being reinstated.

## Tested in CODE?
yes