### PR TITLE
Create test to add banners in between gallery images.

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -29,8 +29,12 @@ class OptInController extends Controller {
 
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
+      case "commercial-gallery-banner-ads" => commercialGalleryBannerAds.opt(choice)
       case _ => NotFound
     }))
   }
+
+  //cookies should correspond with those checked by fastly-edge-cache
+  val commercialGalleryBannerAds = OptInFeature("commercial_gallery_banner_ads")
 
 }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -1,8 +1,16 @@
 @(
     id: Int,
     isMobile: Boolean = false
-)
+)(implicit request: RequestHeader)
 @import conf.switches.Switches.CommercialSwitch
+@import mvt.CommercialGalleryBannerAds
+
+@additionalSizes = @{
+    if(CommercialGalleryBannerAds.isParticipating)
+        Seq("970,250", "970,350")
+    else
+        Seq.empty
+}
 
 @if(CommercialSwitch.isSwitchedOn) {
     @defining((isMobile, id) match {
@@ -12,7 +20,7 @@
         @fragments.commercial.adSlot(
             slotName,
             Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
-            Map("mobile" -> sizes),
+            Map("mobile" -> (sizes ++ additionalSizes)),
             optId = if(isMobile) Some(s"$slotName--mobile") else None,
             optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
         ){ }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -7,7 +7,7 @@
 
 @additionalSizes = @{
     if(CommercialGalleryBannerAds.isParticipating)
-        Map("desktop" -> Seq("970,250", "900,350"))
+        Map("desktop" -> Seq("970,250", "900,250"))
     else
         Map.empty
 }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -7,9 +7,9 @@
 
 @additionalSizes = @{
     if(CommercialGalleryBannerAds.isParticipating)
-        Seq("970,250", "900,350")
+        Map("desktop" -> Seq("970,250", "900,350"))
     else
-        Seq.empty
+        Map.empty
 }
 
 @if(CommercialSwitch.isSwitchedOn) {
@@ -20,7 +20,7 @@
         @fragments.commercial.adSlot(
             slotName,
             Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
-            Map("mobile" -> (sizes ++ additionalSizes)),
+            Map("mobile" -> sizes) ++ additionalSizes,
             optId = if(isMobile) Some(s"$slotName--mobile") else None,
             optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
         ){ }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -7,7 +7,7 @@
 
 @additionalSizes = @{
     if(CommercialGalleryBannerAds.isParticipating)
-        Seq("970,250", "970,350")
+        Seq("970,250", "900,350")
     else
         Seq.empty
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -16,6 +16,17 @@ import conf.switches.Switches.ServerSideTests
 //    val tests = List(ExampleTest)
 // }
 
+object CommercialGalleryBannerAds extends TestDefinition(
+  name = "commercial-gallery-banner-ads",
+  description = "Users in the test will see banner ads instead of MPUs in galleries",
+  owners = Seq(Owner.withGithub("JonNorman")),
+  sellByDate = new LocalDate(2017, 6, 1)
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-commercial-gallery-banner-ads").contains("variant")
+  }
+}
+
 object CommercialClientLoggingVariant extends TestDefinition(
   name = "commercial-client-logging",
   description = "A slice of the audience who will post their commercial js performance data",
@@ -52,6 +63,7 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
+    CommercialGalleryBannerAds,
     ABNewDesktopHeader
   )
 }


### PR DESCRIPTION
## What does this change?
We have loads of room between images in a gallery and we only have MPUs serving there currently.

Why not banner ads?

## What is the value of this and can you measure success?
More $$$ from those sweet, sweet banner CPMs.

## Does this affect other platforms - Amp, Apps, etc?
No.

@ScottPainterGNM:

1. What % of people should this opt into the test automatically? (This will be done in a separate PR).

2. Should the ads between the gallery images be centred?

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
