### PR TITLE
add always ask if tagged test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -188,4 +188,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 6, 13),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-always-ask-if-tagged",
+    "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 7, 19),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,0 +1,33 @@
+define([
+    'common/modules/commercial/contributions-utilities'
+], function (
+    contributionsUtilities
+) {
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicAlwaysAskWithTag',
+        campaignId: 'epic_always_ask_with_tag',
+
+        start: '2017-05-25',
+        expiry: '2018-07-19',
+        useTargetingTool: true,
+        author: 'Jonathan Rankin',
+        description: 'This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed',
+        successMeasure: 'Acquisitions',
+        idealOutcome: 'We have the ability to turn the epic to always on for specific tags',
+        audienceCriteria: 'All',
+        audience: 1.0,
+        showForSensitive: true,
+        audienceOffset: 0,
+
+        pageCheck: function(page) {
+            return (page.contentType === 'Article' || page.contentType === 'Interactive');
+        },
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,0 +1,28 @@
+define([
+    'common/modules/commercial/contributions-utilities'
+], function (
+    contributionsUtilities
+) {
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicAlwaysAskWithTag',
+        campaignId: 'epic_always_ask_with_tag',
+
+        start: '2017-05-25',
+        expiry: '2018-07-19',
+        useTargetingTool: true,
+        author: 'Jonathan Rankin',
+        description: 'This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed',
+        successMeasure: 'Acquisitions',
+        idealOutcome: 'We have the ability to turn the epic to always on for specific tags',
+        audienceCriteria: 'All',
+        audience: 1.0,
+        showForSensitive: true,
+        audienceOffset: 0,
+
+        variants: [
+            {
+                id: 'control'
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
@@ -46,6 +46,7 @@ define([
                         testimonialMessage: 'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible, independent check on the government, this contribution was pretty good value for money.',
                         testimonialName: 'Jack H.'
                     })
+                    
                 }
             },
             {

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -18,6 +18,8 @@ import acquisitionsEpicTestimonialsRoundTwo
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-round-two';
 import acquisitionsEpicPreElection
     from 'common/modules/experiments/tests/acquisitions-epic-pre-election';
+import acquisitionsEpicAlwaysAskIfTagged
+    from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -28,6 +30,7 @@ const tests = [
     acquisitionsEpicTestimonialsRoundTwo,
     askFourEarning,
     acquisitionsEpicLiveBlog,
+    acquisitionsEpicAlwaysAskIfTagged,
 ].map(Test => new Test());
 
 const isViewable = (v: Variant): boolean => {


### PR DESCRIPTION
## What does this change?

This PR adds a "test" to the framework (inverted commas cause, like the ask 4 earning "test", it is an earner rather than a learner). 

It's primary function is to allow us to turn the epic always on for **articles** or **interactives** that are tagged with any tag that is chosen in the targetting tool (https://targeting.gutools.co.uk/#).

It ignores the sensitive flag, so any articles tagged with and whitelisted tags will show the epic, regardless of whether they are sensitive or not. This is the desired behaviour, as it solves a probelm we have sometimes where an article is marked as sensitive for reasons that shouldn't stop us showing our asks on them.

**All** articles or interactives with the selected tags will **always** display the epic (until the tag is deselected in the targetting tool).

It also allows us to go into Hyper Mode™ when big events happen and we want to guarantee that certain stories display the epic. 

It will always display the control version of the epic. 


## What is the value of this and can you measure success?



## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
This is what the control epic looks like currently:
<img width="667" alt="control" src="https://cloud.githubusercontent.com/assets/2844554/26456426/ece0cf4c-4164-11e7-8f16-033e976a7fc1.png">


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
