### PR TITLE
ES6: Remove `bootstraps/enhanced/preferences.js`

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/preferences.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/preferences.js
@@ -1,7 +1,0 @@
-define([
-    'common/modules/preferences/main'
-], function (init) {
-    return {
-        init: init
-    };
-});

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -265,7 +265,7 @@ const bootEnhanced = (): void => {
             require => {
                 bootstrapContext(
                     'preferences',
-                    require('bootstraps/enhanced/preferences').init
+                    require('common/modules/preferences/main').init
                 );
             },
             'preferences'

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -94,7 +94,6 @@
     "projects/common/modules/tailor/fetch-data.js",
     "projects/common/modules/ui/accessibility-prefs.js",
     "projects/common/modules/ui/autoupdate.js",
-    "bootstraps/enhanced/preferences.js",
     "projects/commercial/modules/messenger/type.js"
   ],
   "NataliaLKB": [


### PR DESCRIPTION
## What does this change?

Removes `bootstraps/enhanced/preferences.js` because it's only a wrapper around another module. Even though this is slightly inconsistent, I'd prefer it that way, instead on converting it into ES6 (and keep it), because of its questionable value.

## What is the value of this and can you measure success?

ES6.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
