### PR TITLE
Hyphenate tv and radio

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -116,7 +116,7 @@ class CommercialFeatures {
 
         this.adFeedback =
             config.switches.adFeedback &&
-            ['artanddesign', 'society', 'tvandradio'].indexOf(
+            ['artanddesign', 'society', 'tv-and-radio'].indexOf(
                 config.page.section
             ) > -1;
     }


### PR DESCRIPTION
The tv and radio section is hyphenated, unlike `artanddesign`!