### PR TITLE
Inline interactive styles on interactive articles

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -62,6 +62,7 @@ object css {
   def liveblogAmp(implicit context: ApplicationContext) = inline("head.amp-liveblog")
   def emailArticle(implicit context: ApplicationContext) = inline("head.email-article")
   def emailFront(implicit context: ApplicationContext) = inline("head.email-front")
+  def interactive(implicit context: ApplicationContext) = inline("head.interactive")
 
   def projectCss(projectOverride: Option[String])(implicit context: ApplicationContext) = project(projectOverride.getOrElse(context.applicationIdentity.name))
   def headOldIE(projectOverride: Option[String])(implicit context: ApplicationContext) = cssOldIE(projectOverride.getOrElse(context.applicationIdentity.name))

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -14,7 +14,7 @@
 
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
 @defining(getContent(page)) { content =>
-    @fragments.stylesheets(projectName, content.exists(_.tags.isCrossword), content.exists(_.tags.isInteractive));
+    @fragments.stylesheets(projectName, content.exists(_.tags.isCrossword), content.exists(_.tags.isInteractive))
 }
 
 @*

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -13,7 +13,9 @@
 @head
 
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
-@fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
+@defining(getContent(page)) { content =>
+    @fragments.stylesheets(projectName, content.exists(_.tags.isCrossword), content.exists(_.tags.isInteractive));
+}
 
 @*
 Protect against ReferenceErrors in IE:

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -1,4 +1,4 @@
-@(projectName: Option[String], isCrossword: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(projectName: Option[String], isCrossword: Boolean = false, isInteractive: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches._
 @import play.api.Mode.Dev
@@ -57,6 +57,9 @@
 } else {
     <style class="js-loggable">
         @Html(common.Assets.css.head(projectName))
+        @if(isInteractive) {
+            @Html("assets/inline-stylesheets/head.interactive.css")
+        }
     </style>
 }
 @fragments.stylesheetLink(common.Assets.css.projectCss(projectName), isCrossword)

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -58,7 +58,7 @@
     <style class="js-loggable">
         @Html(common.Assets.css.head(projectName))
         @if(isInteractive) {
-            @Html("assets/inline-stylesheets/head.interactive.css")
+            @Html(common.Assets.css.interactive)
         }
     </style>
 }

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -44,7 +44,6 @@
 @import 'module/_discussion';
 @import 'module/identity/_disc';
 @import 'module/identity/_activity-stream';
-@import 'module/content/_interactive';
 
 @import 'module/_overlay';
 @import 'module/content/_gallery';

--- a/static/src/stylesheets/head.interactive.scss
+++ b/static/src/stylesheets/head.interactive.scss
@@ -1,0 +1,7 @@
+@charset 'UTF-8';
+
+@import '_vars';
+@import '_mixins';
+@import '_extends-only';
+
+@import 'module/content/_interactive';


### PR DESCRIPTION
## What does this change?

Styles specific to interactives are loaded asynchronously, but there are a number of above-the-line changes that happen in interactive articles.

This change inlines interactive-specific styles in interactive articles, so we avoid above-the-line layout changes.

## What is the value of this and can you measure success?

Interactive styles are on the critical path, and so interactives are positioned correctly as soon as the page loads.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![jumping_interactive_layout](https://cloud.githubusercontent.com/assets/5931528/26460340/49991602-4171-11e7-8182-8ecc29d5d6ab.gif)


## Tested in CODE?

- [x] Tested

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
