### PR TITLE
Search: stop initialization, if toggle isn't present

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/search.js
@@ -22,7 +22,10 @@ define([
             container,
             self = this;
 
-        if (config.switches.googleSearch && config.page.googleSearchUrl && config.page.googleSearchId) {
+        if (config.switches.googleSearch &&
+            config.page.googleSearchUrl &&
+            config.page.googleSearchId &&
+            toggle) {
 
             gcsUrl = config.page.googleSearchUrl + '?cx=' + config.page.googleSearchId;
             resultSetSize = config.page.section === 'identity' ? 3 : 10;


### PR DESCRIPTION
## What does this change?

Guards adding event listeners to the search toggle element, in case it does not exist. Bug was [reported this morning](https://theguardian.slack.com/archives/C0C9YCGHJ/p1495781262592515).

## What is the value of this and can you measure success?

Less errors, less bound events.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
