### PR TITLE
Use correct link in brandy snaps

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -398,7 +398,10 @@ object PaidCard {
       description = content.card.trailText,
       image,
       fallbackImageUrl,
-      targetUrl = header.url,
+      targetUrl = content match {
+        case snap: LinkSnap => snap.properties.href getOrElse ""
+        case _ => header.url
+      },
       cardTypes = cardTypes,
       branding = content.branding(defaultEdition)
     )


### PR DESCRIPTION
It was using the wrong property to build the link in branded link snaps.