### PR TITLE
Added rule to prevent embeds having top margin if they're the first item

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -207,6 +207,10 @@ figure {
         margin-top: ($gs-baseline/3)*4;
         margin-bottom: $gs-baseline;
         position: relative;
+
+        .content__article-body &:first-child {
+            margin-top: 0;
+        }
     }
     &.element-image {
         position: relative;


### PR DESCRIPTION
Behold, the great space of immersives.

When an immersive article begins with an embed, said embed has a top margin that pushes all the content away from the main media, resulting in a lot of SPACE.

I've added a rule that prevents the first embed having a top margin if it's the very first thing in the article.

# Before
<img width="1662" alt="screen shot 2017-05-26 at 10 56 12" src="https://cloud.githubusercontent.com/assets/14570016/26490119/f5ddb23e-4201-11e7-90d2-fea31ddf3122.png">

# After
<img width="1323" alt="screen shot 2017-05-25 at 17 48 19" src="https://cloud.githubusercontent.com/assets/14570016/26490136/0deea48c-4202-11e7-88fd-c29253ca767b.png">
