### PR TITLE
add always ask for tag test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -187,6 +187,16 @@ trait ABTestSwitches {
     safeState = On,
     sellByDate = new LocalDate(2017, 6, 13),
     exposeClientSide = true
+    )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-always-ask-if-tagged",
+    "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 7, 19),
+    exposeClientSide = true
   )
 
   Switch(

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,0 +1,34 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+], function (
+    contributionsUtilities
+) {
+
+
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicAlwaysAskIfTagged',
+        campaignId: 'epic_always_ask_if_tagged',
+
+        start: '2017-05-23',
+        expiry: '2018-07-19',
+
+        author: 'Jonathan Rankin',
+        description: 'This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'We can always show the epic on articles with a pre selected tag',
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+        showForSensitive: true,
+        useTargetingTool: true,
+
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited : true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -18,6 +18,8 @@ import acquisitionsEpicTestimonialsRoundTwo
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-round-two';
 import acquisitionsEpicPreElection
     from 'common/modules/experiments/tests/acquisitions-epic-pre-election';
+import acquisitionsEpicAlwaysAskIfTagged
+    from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import acquisitionsEpicTestimonialsUSA
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-usa';
 
@@ -30,6 +32,7 @@ const tests = [
     acquisitionsEpicTestimonialsUSA,
     acquisitionsEpicTestimonialsRoundTwo,
     askFourEarning,
+    acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveBlog,
 ].map(Test => new Test());
 


### PR DESCRIPTION
## What does this change?

This PR adds a "test" to the framework (inverted commas cause, like the ask 4 earning "test", it is an earner rather than a learner). 

It's primary function is to allow us to turn the epic always on for articles that are tagged with any tag that is chosen in the targetting tool (https://targeting.gutools.co.uk/campaigns/a06fb83b-ef3a-4d50-83d7-7917b864e171).

It ignores the sensitive flag, so any articles tagged with and whitelisted tags will show the epic, regardless of whether they are sensitive or not. This is the desired behaviour, as it solves a problem we have sometimes where an article is marked as sensitive for reasons that shouldn't stop us showing our asks on them.

**All** articles with the selected tags will **always** display the epic (until the tag is deselected in the targetting tool).

It also allows us to go into Hyper Mode™ when big events happen and we want to guarantee that certain stories display the epic. 

It will always display the control version of the epic. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

This is what the control epic looks like currently:
<img width="667" alt="control" src="https://cloud.githubusercontent.com/assets/2844554/26456426/ece0cf4c-4164-11e7-8f16-033e976a7fc1.png">

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
