### PR TITLE
Fix head.interactive not loading in Dev mode

### DIFF
--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -54,6 +54,10 @@
 <!--[if (gt IE 9)|(IEMobile)]><!-->
 @if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
     <link rel="stylesheet" id="head-css" data-reload="head@projectName.map("." + _).getOrElse(".content")" type="text/css" href="@Static("stylesheets/head" + projectName.map("." + _).getOrElse(".content") + ".css")" />
+
+    @if(isInteractive) {
+        <link rel="stylesheet" id="head-interactive" data-reload="head.interactive" type="text/css" href="@Static("stylesheets/head.interactive.css")" />
+    }
 } else {
     <style class="js-loggable">
         @Html(common.Assets.css.head(projectName))


### PR DESCRIPTION
## What does this change?
The interactive stylesheet introduced in #16907 is currently only added to the page in production mode, so interactive rendering is broken when working locally. This change loads the new file in `Dev` mode too.