### PR TITLE
Don't init feedback if not on a feedback page

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
@@ -125,12 +125,16 @@ define([
 
     return function () {
 
-        detect.adblockInUse.then(function(adblockInUse){
-            adblockBeingUsed = adblockInUse;
-        });
+        if(document.getElementById("feedback-category")){
 
-        initForms();
-        hideUnenhancedFallback();
+            detect.adblockInUse.then(function(adblockInUse){
+                adblockBeingUsed = adblockInUse;
+            });
+
+            initForms();
+            hideUnenhancedFallback();
+            
+        }
 
     };
 


### PR DESCRIPTION
## What does this change?

Quick and dirty fix for an exception thrown on pages that are not feedback pages.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
