### PR TITLE
Excluded immersive meta from showcase setting

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -69,7 +69,7 @@
 <div class="content__meta-container js-content-meta js-football-meta u-cf
     @if(item.trail.byline.isEmpty){ content__meta-container--no-byline}
     @if(item.tags.isLiveBlog) { content__meta-container--liveblog}
-    @if(item.elements.hasShowcaseMainElement){ content__meta-container--showcase}
+    @if(item.elements.hasShowcaseMainElement && !item.content.isImmersive){ content__meta-container--showcase}
     @if(item.content.hasTonalHeaderByline){ content__meta-container--tonal-header}
     @item.content.contributorBio.map { bio => content__meta-container--bio}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}


### PR DESCRIPTION
If an immersive has the main media set to showcase, it results in an UNSIGHTLY gap caused by the meta area being static rather than absolute. 

NOT ON MY WATCH.

# Before
<img width="1423" alt="screen shot 2017-05-26 at 14 51 32" src="https://cloud.githubusercontent.com/assets/14570016/26498560/60d62100-4227-11e7-92d0-8b76dd9eabe7.png">

# After
<img width="1422" alt="screen shot 2017-05-26 at 14 51 20" src="https://cloud.githubusercontent.com/assets/14570016/26498563/62b65b34-4227-11e7-9aa2-3fa37d7015aa.png">
