### PR TITLE
Messenger: fix null reference

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/resize.js
@@ -4,13 +4,12 @@ define([
     'commercial/modules/messenger'
 ], function (assign, fastdom, messenger) {
     messenger.register('resize', function(specs, ret, iframe) {
-        return resize(specs, iframe, iframe.closest('.js-ad-slot'));
+        var adSlot = iframe && iframe.closest('.js-ad-slot');
+        return resize(specs, iframe, adSlot);
     });
 
-    return resize;
-
     function resize(specs, iframe, adSlot) {
-        if (!specs || !('height' in specs || 'width' in specs)) {
+        if (!specs || !('height' in specs || 'width' in specs) || !adSlot) {
             return null;
         }
 
@@ -39,4 +38,6 @@ define([
         }
         return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
     }
+
+    return resize;
 });

--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/resize.js
@@ -9,7 +9,7 @@ define([
     });
 
     function resize(specs, iframe, adSlot) {
-        if (!specs || !('height' in specs || 'width' in specs) || !adSlot) {
+        if (!specs || !('height' in specs || 'width' in specs) || !iframe || !adSlot) {
             return null;
         }
 


### PR DESCRIPTION
## What does this change?

Fixes a case where an element could be null, but we are calling the method `.closest` on it. [Sentry issues](https://sentry.io/the-guardian/client-side-prod/issues/243868779/).

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
