### PR TITLE
Add Epic at end of general election interactives

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,6 +81,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-election-interactive",
+    "This places the epic underneath UK election-related interactives",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 7, 3),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-tailor-survey",
     "Integrate Tailor with ab tests",
     owners = Seq(Owner.withGithub("oilnam")),

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive.js
@@ -1,0 +1,56 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lib/geolocation',
+    'lodash/utilities/template',
+    'lib/config',
+    'raw-loader!common/views/acquisitions-epic-control.html'
+], function (
+    contributionsUtilities,
+    geolocation,
+    template,
+    config,
+    epicControlTemplate
+) {
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsElectionInteractive',
+        campaignId: 'epic_election_interactive_end',
+
+        start: '2017-05-22',
+        expiry: '2017-07-03',
+
+        author: 'Sam Desborough',
+        description: 'This places the epic underneath UK election-related interactives',
+        successMeasure: 'Member acquisition and contributions',
+        idealOutcome: 'Our wonderful readers will support The Guardian in this time of need!',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        showForSensitive: true,
+
+        pageCheck: function(page) {
+            return page.keywordIds.includes('general-election-2017') && page.contentType === 'Interactive';
+        },
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited: true,
+
+                insertAtSelector: '.content-footer',
+                successOnView: true,
+
+                template: function (variant) {
+                    return template(epicControlTemplate, {
+                        membershipUrl: variant.options.membershipURL,
+                        contributionUrl: variant.options.contributeURL,
+                        componentName: variant.options.componentName,
+                        epicClass: 'contributions__epic--interactive gs-container',
+                        wrapperClass: 'contributions__epic-interactive-wrapper'
+                    });
+                },
+            }
+        ]
+    });
+});

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,6 +14,8 @@ import askFourEarning
     from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import acquisitionsEpicLiveBlog
     from 'common/modules/experiments/tests/acquisitions-epic-liveblog';
+import acquisitionsEpicElectionInteractive
+    from 'common/modules/experiments/tests/acquisitions-epic-election-interactive';
 import acquisitionsEpicPreElection
     from 'common/modules/experiments/tests/acquisitions-epic-pre-election';
 import acquisitionsEpicAlwaysAskIfTagged
@@ -31,6 +33,7 @@ const tests = [
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveBlog,
+    acquisitionsEpicElectionInteractive,
 ].map(Test => new Test());
 
 const isViewable = (v: Variant): boolean => {

--- a/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
+++ b/static/src/javascripts/projects/common/modules/experiments/test-can-run-checks.js
@@ -14,6 +14,7 @@ export const isExpired = (testExpiry: string): boolean => {
 export const testCanBeRun = (test: ABTest): boolean => {
     const expired = isExpired(test.expiry);
     const isSensitive = config.page.isSensitive;
+
     return (
         (isSensitive ? !!test.showForSensitive : true) &&
         isTestSwitchedOn(test) &&

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -1,31 +1,33 @@
-<div class="contributions__epic" data-component="<%=componentName%>">
-    <div>
-        <h2 class="contributions__title contributions__title--epic">
-            Since you’re here …
-        </h2>
-        <p class="contributions__paragraph contributions__paragraph--epic">
-            … we have a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
-        </p>
-        <p class="contributions__paragraph contributions__paragraph--epic">
-            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
-        </p>
-    </div>
-
-    <div class="contributions__amount-field">
+<div class="contributions__epic <%=typeof epicClass !== "undefined" ? epicClass : ''%>" data-component="<%=componentName%>">
+    <div class="<%=typeof wrapperClass !== "undefined" ? wrapperClass : ''%>">
         <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
-               href="<%=membershipUrl%>"
-               target="_blank">
-                Become a supporter
-            </a>
+            <h2 class="contributions__title contributions__title--epic">
+                Since you’re here …
+            </h2>
+            <p class="contributions__paragraph contributions__paragraph--epic">
+                … we have a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
+            </p>
+            <p class="contributions__paragraph contributions__paragraph--epic">
+                If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+            </p>
         </div>
 
-        <div>
-            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-               href="<%=contributionUrl%>"
-               target="_blank">
-                Make a contribution
-            </a>
+        <div class="contributions__amount-field">
+            <div>
+                <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
+                   href="<%=membershipUrl%>"
+                   target="_blank">
+                    Become a supporter
+                </a>
+            </div>
+
+            <div>
+                <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+                   href="<%=contributionUrl%>"
+                   target="_blank">
+                    Make a contribution
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/static/src/stylesheets/head.interactive.scss
+++ b/static/src/stylesheets/head.interactive.scss
@@ -5,3 +5,4 @@
 @import '_extends-only';
 
 @import 'module/content/_interactive';
+@import 'module/experiments/_acquisitions-epic-interactive';

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
@@ -5,17 +5,13 @@
 .contributions__epic-interactive-wrapper {
     padding: 0 20px;
     max-width: 620px;
-    clear: both
-}
+    clear: both;
 
-@media (min-width: 71.25em) {
-    .contributions__epic-interactive-wrapper {
-        margin-left: 160px
+    @include mq(leftCol) {
+        margin-left: 160px;
     }
-}
 
-@media (min-width: 81.25em) {
-    .contributions__epic-interactive-wrapper {
-        margin-left: 240px
+    @include mq(wide) {
+        margin-left: 240px;
     }
 }

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
@@ -1,0 +1,21 @@
+.contributions__epic.contributions__epic--interactive {
+    padding: ($gs-baseline / 3) 0 $gs-baseline;
+}
+
+.contributions__epic-interactive-wrapper {
+    padding: 0 20px;
+    max-width: 620px;
+    clear: both
+}
+
+@media (min-width: 71.25em) {
+    .contributions__epic-interactive-wrapper {
+        margin-left: 160px
+    }
+}
+
+@media (min-width: 81.25em) {
+    .contributions__epic-interactive-wrapper {
+        margin-left: 240px
+    }
+}


### PR DESCRIPTION
## What does this change?
Adds a new test to display the Epic at the end of interactives tagged for the election.

## What is the value of this and can you measure success?
More supporters and contributors 

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-05-30 at 11 39 18](https://cloud.githubusercontent.com/assets/1064734/26579986/1739f1f2-452e-11e7-9966-79cf48f224d4.png)
![screen shot 2017-05-30 at 11 38 59](https://cloud.githubusercontent.com/assets/1064734/26579984/17377472-452e-11e7-8556-dfaff4234aeb.png)
![screen shot 2017-05-30 at 11 38 23](https://cloud.githubusercontent.com/assets/1064734/26579985/173914e4-452e-11e7-9197-745e37babb9f.png)
![screen shot 2017-05-30 at 11 37 49](https://cloud.githubusercontent.com/assets/1064734/26579983/17373160-452e-11e7-9860-e2c82dc2c9b4.png)


## Tested in CODE?
Only locally


@guardian/contributions 