### PR TITLE
fix visible style change on youtube atom play button

### DIFF
--- a/static/src/stylesheets/module/atoms/_youtube.scss
+++ b/static/src/stylesheets/module/atoms/_youtube.scss
@@ -125,6 +125,7 @@
 }
 
 .youtube-media-atom__play-button.vjs-control-text {
+    transition: none;
     overflow: hidden !important;
     display: inline-block;
     z-index: 2;


### PR DESCRIPTION
## What does this change?

Prevents undesired visible transform on play button for non-playable youtube atoms.

## What is the value of this and can you measure success?

Looks better!

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

Before...

![yt-before](https://cloud.githubusercontent.com/assets/1590704/26583519/71b5d6b4-453d-11e7-8048-04f964c8c1ce.gif)

After...

![yt-after](https://cloud.githubusercontent.com/assets/1590704/26583522/774b7a02-453d-11e7-9646-0bd81e575fe4.gif)

## Tested in CODE?

No