### PR TITLE
Update Scala, Play and SBT to the latest versions supported by Play

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -26,7 +26,7 @@ trait Prototypes {
     sources in (Compile,doc) := Seq.empty,
     doc in Compile := target.map(_ / "none").value,
     incOptions := incOptions.value.withNameHashing(true),
-    scalaVersion := "2.11.8",
+    scalaVersion := "2.11.11",
     initialize := {
       val _ = initialize.value
       assert(sys.props("java.specification.version") == "1.8",
@@ -115,10 +115,9 @@ trait Prototypes {
          println("Tests failed, no riff raff upload will be performed.")
          throw inc
        }
-       case Value(_) => {
+       case Value(_) =>
          println("Tests passed, uploading artifact to riff raff.")
          upload.toTask
-       }
      }
     }).value
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ resolvers ++= Seq(
   Resolver.url("bintray-sbt-plugin-releases", url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.10")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 


### PR DESCRIPTION
Play doesn't support Scala 2.12, therefore, I am upgrading Play, Sbt and Scala to the latest version supported by the framework.
Play 2.6 will support Scala 2.12.

@jfsoul @TBonnin @markjamesbutler @NataliaLKB 