### PR TITLE
Add check for keywordIds in interactive Epic test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive.js
@@ -30,7 +30,7 @@ define([
         showForSensitive: true,
 
         pageCheck: function(page) {
-            return page.keywordIds.includes('general-election-2017') && page.contentType === 'Interactive';
+            return page.keywordIds && page.keywordIds.includes('general-election-2017') && page.contentType === 'Interactive';
         },
 
         variants: [


### PR DESCRIPTION
This is currently breaking the comments history page.
