### PR TITLE
Navigation: Fix icon positions

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -52,16 +52,17 @@
 .menu-item__icon,
 .menu-item__toggle {
     color: $news-support-2;
+    position: absolute;
+}
+
+.menu-item__toggle {
     left: -25px;
     margin-top: -4px;
-    position: absolute;
 
     details[open] & {
         margin-top: 2px;
     }
-}
 
-.menu-item__toggle {
     &:before {
         border: 2px solid currentColor;
         border-top: 0;
@@ -79,9 +80,20 @@
 }
 
 .menu-item__icon {
-    left: -$gs-gutter * 2;
+    left: -28px;
 
-    > svg {
+    .inline-icon__svg {
         fill: currentColor;
+    }
+
+    .inline-home__svg {
+        height: 16px;
+        width: 16px;
+    }
+
+    .inline-share-facebook__svg,
+    .inline-share-twitter__svg {
+        margin-left: -6px;
+        margin-top: -5px;
     }
 }


### PR DESCRIPTION
## What does this change?

After [the refactoring](https://github.com/guardian/frontend/pull/16803) the position of the home icons was broken.

## What is the value of this and can you measure success?

Alignment!

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**
<img width="575" alt="screen shot 2017-05-30 at 16 52 15" src="https://cloud.githubusercontent.com/assets/2244375/26592325/61119724-4558-11e7-8512-bfdf3ec2e10c.png">

**After**
<img width="573" alt="screen shot 2017-05-30 at 16 52 02" src="https://cloud.githubusercontent.com/assets/2244375/26592326/613c67f6-4558-11e7-89f1-53e8e714a297.png">


## Tested in CODE?

No.
