### PR TITLE
Footer: fix positioning after navigation refactoring

### DIFF
--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -237,7 +237,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
     position: relative;
     float: right;
     margin-top: -($gs-baseline / 2);
-    margin-bottom: -($gs-baseline / 2);
+    margin-bottom: -$gs-baseline;
     border-radius: 100%;
     background-color: $news-main-2;
     cursor: pointer;

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -4,6 +4,7 @@
     max-height: $gs-baseline * 3.4;
     overflow: hidden;
     padding: $gs-baseline / 3 $gs-gutter / 2;
+    width: 100%;
 
     @include mq(mobile) {
         max-height: $gs-baseline * 3.5;


### PR DESCRIPTION
## What does this change?

After [the navigation refactoring](https://github.com/guardian/frontend/pull/16803) some footer alignments were broken. These are fixed by this PR.

## What is the value of this and can you measure success?

Alignment! 👍 

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="575" alt="screen shot 2017-05-30 at 17 11 19" src="https://cloud.githubusercontent.com/assets/2244375/26593176/16934758-455b-11e7-944b-fe2bdc28dc67.png">

**After**

<img width="576" alt="screen shot 2017-05-30 at 17 11 42" src="https://cloud.githubusercontent.com/assets/2244375/26593174/16798de0-455b-11e7-8048-c2165dfb2436.png">

## Tested in CODE?

No.
