### PR TITLE
Add mobile ad sizes to desktop breakpoint

### DIFF
--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -7,7 +7,7 @@
 
 @commonSizes = @{Seq("1,1", "2,2", "300,250", "fluid")}
 
-@additionalDesktopSizes = @{
+@desktopSizes = @{
     if(CommercialGalleryBannerAds.isParticipating)
         Map("desktop" -> (commonSizes ++ Seq("970,250", "900,250")))
     else
@@ -22,7 +22,7 @@
         @fragments.commercial.adSlot(
             slotName,
             Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
-            Map("mobile" -> sizes) ++ additionalDesktopSizes,
+            Map("mobile" -> sizes) ++ desktopSizes,
             optId = if(isMobile) Some(s"$slotName--mobile") else None,
             optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
         ){ }

--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -5,22 +5,24 @@
 @import conf.switches.Switches.CommercialSwitch
 @import mvt.CommercialGalleryBannerAds
 
-@additionalSizes = @{
+@commonSizes = @{Seq("1,1", "2,2", "300,250", "fluid")}
+
+@additionalDesktopSizes = @{
     if(CommercialGalleryBannerAds.isParticipating)
-        Map("desktop" -> Seq("970,250", "900,250"))
+        Map("desktop" -> (commonSizes ++ Seq("970,250", "900,250")))
     else
-        Map.empty
+        Map.empty[String, Seq[String]]
 }
 
 @if(CommercialSwitch.isSwitchedOn) {
     @defining((isMobile, id) match {
-        case (true, 0) => ("top-above-nav", Seq("1,1", "2,2", "88,71", "300,250", "fluid"))
-        case _         => (s"inline$id", Seq("1,1", "2,2", "300,250", "fluid"))
-    }) { case(slotName, sizes) =>
+        case (true, 0) => ("top-above-nav", (commonSizes :+ "88,71"))
+        case _         => (s"inline$id", commonSizes)
+    }) { case(slotName: String, sizes: Seq[String]) =>
         @fragments.commercial.adSlot(
             slotName,
             Seq("gallery-inline", "dark") ++ (if(isMobile) Some("mobile") else None),
-            Map("mobile" -> sizes) ++ additionalSizes,
+            Map("mobile" -> sizes) ++ additionalDesktopSizes,
             optId = if(isMobile) Some(s"$slotName--mobile") else None,
             optClassNames = if(isMobile) Some("mobile-only") else Some("hide-until-tablet")
         ){ }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -20,7 +20,7 @@ object CommercialGalleryBannerAds extends TestDefinition(
   name = "commercial-gallery-banner-ads",
   description = "Users in the test will see banner ads instead of MPUs in galleries",
   owners = Seq(Owner.withGithub("JonNorman")),
-  sellByDate = new LocalDate(2017, 6, 1)
+  sellByDate = new LocalDate(2017, 6, 6)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-commercial-gallery-banner-ads").contains("variant")


### PR DESCRIPTION
## What does this change?
For an MVT, we are adding in banner sizes into the ad slots between gallery images (on desktop only).

When making the ad call, the sizes are taken from the maximum applicable breakpoint; it is not the aggregate applicable set of ad sizes i.e. mobile + desktop. As a result, we need to add the common sizes to the desktop breakpoint, otherwise (as is happening currently) only the banner ads are requested when on desktop and included in the test.)

## What is the value of this and can you measure success?
The test can go live and earn some more money from banner-competitive MPUs!

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
No - tested locally.

@guardian/commercial-dev 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
