### PR TITLE
Header: Fix menu overlay non-js fallback

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -55,7 +55,7 @@
     transition: opacity .2s cubic-bezier(.23, 1, .32, 1);
     // Without this, in Safari/IOS this element appears above the menu
     width: 0;
-    z-index: $zindex-overlay;
+    z-index: $zindex-main-menu - 1;
 
     .new-header--open & {
         opacity: 1;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -8,6 +8,7 @@
 
         & ~ .menu__overlay {
             opacity: 1;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Fixes menu overlay if JS is disabled. Before this change the overlay would not be visible - after it is again and therefore the menu is closable.

## What is the value of this and can you measure success?

Proper non-js fallback.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
