### PR TITLE
Navigation: Add floating veggie burger label

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -59,7 +59,7 @@
                        tabindex="0"
                        data-link-name="nav2 : veggie-burger : show">
                     <span class="veggie-burger__icon"></span>
-                    <span class="u-h">Menu</span>
+                    <span class="veggie-burger__label">Menu</span>
                 </label>
 
                 <input type="checkbox"

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -60,16 +60,16 @@
 
 .veggie-burger__label {
     @include fs-textSans(5);
-    bottom: -25px;
+    bottom: -24px;
     color: $neutral-3;
-    display: none;
+    font-size: 16px;
     left: 50%;
     position: absolute;
     text-transform: lowercase;
     transform: translateX(-50%);
 
-    @include mq(desktop) {
-        display: block;
+    @include mq($until: 'desktop') {
+        @include u-h();
     }
 
     .new-header--open & {

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -58,6 +58,25 @@
     }
 }
 
+.veggie-burger__label {
+    @include fs-textSans(5);
+    bottom: -25px;
+    color: $neutral-3;
+    display: none;
+    left: 50%;
+    position: absolute;
+    text-transform: lowercase;
+    transform: translateX(-50%);
+
+    @include mq(desktop) {
+        display: block;
+    }
+
+    .new-header--open & {
+        display: none;
+    }
+}
+
 .veggie-burger__icon {
     top: 50%;
     display: block;


### PR DESCRIPTION
## What does this change?

This adds the floating veggie burger label for the new desktop navigation (it was accidentally added in another PR already, so I didn't just wanted it to throw away).

## What is the value of this and can you measure success?

Crawling towards the new desktop header.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1060" alt="screen shot 2017-05-31 at 15 48 08" src="https://cloud.githubusercontent.com/assets/2244375/26637879/9587733c-4618-11e7-9ed6-40c7750c4e17.png">

**After**

<img width="1062" alt="screen shot 2017-05-31 at 15 48 47" src="https://cloud.githubusercontent.com/assets/2244375/26637911/ae2fcb32-4618-11e7-8645-3b958290945c.png">



## Tested in CODE?

No.