### PR TITLE
Modify capi circuit breaker

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -195,11 +195,9 @@ class GuardianConfiguration extends Logging {
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
     lazy val timeout: FiniteDuration = Duration.create(configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000), MILLISECONDS)
 
-    lazy val circuitBreakerErrorThreshold =
-      configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(5)
-
-    lazy val circuitBreakerResetTimeout =
-      configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(20000)
+    lazy val circuitBreakerErrorThreshold: Int = configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(50)
+    lazy val circuitBreakerResetTimeout: FiniteDuration =
+      FiniteDuration(configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(3000), MILLISECONDS)
 
     lazy val previewAuth: Option[Auth] = for {
       user <- configuration.getStringProperty("content.api.preview.user")

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -146,22 +146,22 @@ final case class CircuitBreakingContentApiClient(
     scheduler = circuitBreakerActorSystem.scheduler,
     maxFailures = contentApi.circuitBreakerErrorThreshold,
     callTimeout = contentApi.timeout,
-    resetTimeout = Duration(contentApi.circuitBreakerResetTimeout, MILLISECONDS)
+    resetTimeout = contentApi.circuitBreakerResetTimeout
   )
 
-  circuitBreaker.onOpen({
-    log.error("Reached error threshold for Content API Client circuit breaker - breaker is OPEN!")
-  })
+  circuitBreaker.onOpen(
+    log.error(s"CAPI circuit breaker: reached error threshold (${contentApi.circuitBreakerErrorThreshold}). Breaker is OPEN!")
+  )
 
-  circuitBreaker.onHalfOpen({
-    log.info("Reset timeout finished. Entered half open state for Content API Client circuit breaker.")
-  })
+  circuitBreaker.onHalfOpen(
+    log.info(s"CAPI circuit breaker: Reset timeout (${contentApi.circuitBreakerResetTimeout}s) finished. Entered half open state.")
+  )
 
-  circuitBreaker.onClose({
-    log.info("Content API Client looks healthy again, circuit breaker is closed.")
-  })
+  circuitBreaker.onClose(
+    log.info("CAPI circuit breaker: Content API Client looks healthy again, circuit breaker is closed.")
+  )
 
-  override def fetch(url: String)(implicit executionContext: ExecutionContext) = {
+  override def fetch(url: String)(implicit executionContext: ExecutionContext): Future[Array[Byte]] = {
     if (CircuitBreakerSwitch.isSwitchedOn) {
       circuitBreaker.withCircuitBreaker(super.fetch(url)(executionContext))
     } else {


### PR DESCRIPTION
## What does this change?
I would like to bring back the capi circuit breaker feature in order to deal with CAPI issues more efficiently. It is behind a switch which has been off for quite some time.

This PR doesn't change the logic which is already in the code. It mainly modifies the failure threshold (when the circuit breaker open) and reset timeout (how long it stays open).
More doc about Akka CircuitBreaker: http://doc.akka.io/docs/akka/current/scala/common/circuitbreaker.html
I chose the following values:
- failure threshold: `50`. Low enough to catch small capi glitches but won't open for random capi timeout. Note: this is per machine.
- reset timeout: `3s`. Small so it retries quickly.
- No exponential backoff

## What is the value of this and can you measure success?
When capi experiences high latency, frontend keeps waiting for all requests to timeout, which leads to request piling up and waiting. Frontend latency then goes up and all waiting requests make the recovery longer (snowball effect)
This PR would force frontend app to fails faster by returning 500 immediately when the circuit is open. In this case the CDN will serve stale content, most users won't be seeing the errors.

## Does this affect other platforms - Amp, Apps, etc?
Yes

## Tested in CODE?
Yes
