### PR TITLE
Guard against undefined local storage

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.js
@@ -95,7 +95,7 @@ export const getForcedTests = (): Array<{
         });
     }
 
-    return JSON.parse(local.get('gu.devtools.ab')) || [];
+    return JSON.parse(local.get('gu.devtools.ab') || null) || [];
 };
 
 export const getForcedVariant = (test: ABTest): ?Variant => {


### PR DESCRIPTION
## What does this change?
Guards against a js error when local storage is undefined (private browsing in safari).

## What is the value of this and can you measure success?
javascript runs in safari private browsing mode.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
