### PR TITLE
Close slots before inline slot creation

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -14,7 +14,6 @@ import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import prepareGoogletag from 'commercial/modules/dfp/prepare-googletag';
 import prepareSonobiTag from 'commercial/modules/dfp/prepare-sonobi-tag';
 import prepareSwitchTag from 'commercial/modules/dfp/prepare-switch-tag';
-import { fillAdvertSlots } from 'commercial/modules/dfp/fill-advert-slots';
 import hostedAbout from 'commercial/modules/hosted/about';
 import { initHostedVideo } from 'commercial/modules/hosted/video';
 import hostedGallery from 'commercial/modules/hosted/gallery';
@@ -48,7 +47,6 @@ const commercialModules: Array<Array<any>> = [
     ['cm-liveblogAdverts', initLiveblogAdverts, true],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-stickyTopBanner', stickyTopBanner.init],
-    ['cm-fill-advert-slots', fillAdvertSlots, true],
     ['cm-paidContainers', paidContainers],
     ['cm-paidforBand', paidforBand.init],
 ];

--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -21,4 +21,4 @@ const closeDisabledSlots = (force: boolean): Promise<void> => {
     );
 };
 
-export { closeDisabledSlots };
+export { closeDisabledSlots, adSlotSelector };

--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -1,24 +1,22 @@
 // @flow
 import qwery from 'qwery';
 import fastdom from 'lib/fastdom-promise';
-
-const adSlotSelector: string = '.js-ad-slot';
+import once from 'lodash/functions/once';
+import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 
 const shouldDisableAdSlot = adSlot =>
     window.getComputedStyle(adSlot).display === 'none';
 
-const closeDisabledSlots = (force: boolean): Promise<void> => {
+const closeDisabledSlots = once((): Promise<void> => {
     // Get all ad slots
-    let adSlots: Array<Element> = qwery(adSlotSelector);
+    let adSlots: Array<Element> = qwery(dfpEnv.adSlotSelector);
 
-    if (!force) {
-        // remove the ones which should not be there
-        adSlots = adSlots.filter(shouldDisableAdSlot);
-    }
+    // remove the ones which should not be there
+    adSlots = adSlots.filter(shouldDisableAdSlot);
 
     return fastdom.write(() =>
         adSlots.forEach((adSlot: Element) => adSlot.remove())
     );
-};
+});
 
-export { closeDisabledSlots, adSlotSelector };
+export { closeDisabledSlots };

--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -15,9 +15,9 @@ const closeDisabledSlots = once((): Promise<void> => {
     // remove the ones which should not be there
     adSlots = adSlots.filter(shouldDisableAdSlot);
 
-    return fastdom.write(() =>
-        adSlots.forEach((adSlot: Element) => adSlot.remove())
-    );
+    return fastdom.write(() => {
+        adSlots.forEach((adSlot: Element) => adSlot.remove());
+    });
 });
 
 const mpuCandidateClass: string = 'fc-slice__item--mpu-candidate';

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -55,10 +55,7 @@ class CommercialFeatures {
             userFeatures.isAdFreeUser();
 
         this.dfpAdvertising =
-            !this.adFree &&
-            switches.commercial &&
-            externalAdvertising &&
-            !sensitiveContent;
+            switches.commercial && externalAdvertising && !sensitiveContent;
 
         this.stickyTopBannerAd =
             !this.adFree &&
@@ -67,6 +64,7 @@ class CommercialFeatures {
 
         this.articleBodyAdverts =
             this.dfpAdvertising &&
+            !this.adFree &&
             !isMinuteArticle &&
             isArticle &&
             !isLiveBlog &&
@@ -75,26 +73,26 @@ class CommercialFeatures {
 
         this.articleAsideAdverts =
             this.dfpAdvertising &&
+            !this.adFree &&
             !isMinuteArticle &&
             !isMatchReport &&
             !!(isArticle || isLiveBlog) &&
             !newRecipeDesign;
 
-        this.videoPreRolls = this.dfpAdvertising;
+        this.videoPreRolls = this.dfpAdvertising && !this.adFree;
 
         this.highMerch =
-            (this.dfpAdvertising || this.adFree) &&
+            this.dfpAdvertising &&
             !isMinuteArticle &&
             !isHosted &&
             !isInteractive &&
             !config.page.isFront &&
             !newRecipeDesign;
 
-        this.thirdPartyTags =
-            (externalAdvertising || this.adFree) && !isIdentityPage;
+        this.thirdPartyTags = externalAdvertising && !isIdentityPage;
 
         this.outbrain =
-            (this.dfpAdvertising || this.adFree) &&
+            this.dfpAdvertising &&
             switches.outbrain &&
             !noadsUrl &&
             !sensitiveContent &&
@@ -105,13 +103,15 @@ class CommercialFeatures {
 
         this.commentAdverts =
             this.dfpAdvertising &&
+            !this.adFree &&
             !isMinuteArticle &&
             config.switches.discussion &&
             config.page.commentable &&
             identityApi.isUserLoggedIn() &&
             (!isLiveBlog || isWidePage);
 
-        this.liveblogAdverts = isLiveBlog && this.dfpAdvertising;
+        this.liveblogAdverts =
+            isLiveBlog && this.dfpAdvertising && !this.adFree;
 
         this.paidforBand =
             config.page.isPaidContent &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -22,7 +22,7 @@ const fillAdvertSlots = (): Promise<void> => {
     // This module has the following strict dependencies. These dependencies must be
     // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
     // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-    const dependencies = Promise.all([
+    const dependencies: Promise<void>[] = Promise.all([
         setupSonobi(),
         setupSwitch(),
         closeDisabledSlots(),

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -23,12 +23,13 @@ const fillAdvertSlots = (): Promise<void> => {
     // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
     // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
     const dependencies = Promise.all([
-        setupSonobi,
-        setupSwitch,
-        closeDisabledSlots,
+        setupSonobi(),
+        setupSwitch(),
+        closeDisabledSlots(),
     ]);
 
     return dependencies.then(() => {
+        console.log('running ad slot selector');
         // Get all ad slots
         const adverts = qwery(dfpEnv.adSlotSelector)
             .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -29,7 +29,6 @@ const fillAdvertSlots = (): Promise<void> => {
     ]);
 
     return dependencies.then(() => {
-        console.log('running ad slot selector');
         // Get all ad slots
         const adverts = qwery(dfpEnv.adSlotSelector)
             .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -1,64 +1,54 @@
 // @flow
 
 import qwery from 'qwery';
-import sha1 from 'lib/sha1';
-import identity from 'common/modules/identity/api';
-import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import queueAdvert from 'commercial/modules/dfp/queue-advert';
 import { displayLazyAds } from 'commercial/modules/dfp/display-lazy-ads';
 import { displayAds } from 'commercial/modules/dfp/display-ads';
-import refreshOnResize from 'commercial/modules/dfp/refresh-on-resize';
-import prepareSwitchTag from 'commercial/modules/dfp/prepare-switch-tag';
+import { setupSonobi } from 'commercial/modules/dfp/prepare-sonobi-tag';
+import prepareSwitchTag, {
+    setupSwitch,
+} from 'commercial/modules/dfp/prepare-switch-tag';
+import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 
-const createAdverts = (): void => {
-    // Get all ad slots
-    const adverts = qwery(dfpEnv.adSlotSelector)
-        .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))
-        .map(adSlot => new Advert(adSlot));
-    const currentLength = dfpEnv.adverts.length;
-    dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
-    adverts.forEach((advert, index) => {
-        dfpEnv.advertIds[advert.id] = currentLength + index;
+// Pre-rendered ad slots that were rendered on the page by the server are collected here.
+// For dynamic ad slots that are created at js-runtime, see:
+//  article-aside-adverts
+//  article-body-adverts
+//  liveblog-adverts
+//  high-merch
+const fillAdvertSlots = (): Promise<void> => {
+    // This module has the following strict dependencies. These dependencies must be
+    // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
+    // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
+    const dependencies = Promise.all([
+        setupSonobi,
+        setupSwitch,
+        closeDisabledSlots,
+    ]);
+
+    return dependencies.then(() => {
+        // Get all ad slots
+        const adverts = qwery(dfpEnv.adSlotSelector)
+            .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))
+            .map(adSlot => new Advert(adSlot));
+        const currentLength = dfpEnv.adverts.length;
+        dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
+        adverts.forEach((advert, index) => {
+            dfpEnv.advertIds[advert.id] = currentLength + index;
+        });
+        dfpEnv.adverts.forEach(queueAdvert);
+
+        // Once Advert constructors are called, Switch can be called, if needed.
+        prepareSwitchTag.maybeCallSwitch();
+
+        if (dfpEnv.shouldLazyLoad()) {
+            displayLazyAds();
+        } else {
+            displayAds();
+        }
     });
-};
-
-/**
- * Loop through each slot detected on the page and define it based on the data
- * attributes on the element.
- */
-const queueAdverts = (): void => {
-    // queue ads for load
-    dfpEnv.adverts.forEach(queueAdvert);
-};
-
-const setPublisherProvidedId = (): void => {
-    const user: ?Object = identity.getUserFromCookie();
-    if (user) {
-        const hashedId = sha1.hash(user.id);
-        window.googletag.pubads().setPublisherProvidedId(hashedId);
-    }
-};
-
-const fillAdvertSlots = (
-    start: () => void,
-    stop: () => void
-): Promise<void> => {
-    if (commercialFeatures.dfpAdvertising) {
-        window.googletag.cmd.push(
-            start,
-            createAdverts,
-            queueAdverts,
-            setPublisherProvidedId,
-            prepareSwitchTag.maybeCallSwitch,
-            dfpEnv.shouldLazyLoad() ? displayLazyAds : displayAds,
-            // anything we want to happen after displaying ads
-            refreshOnResize,
-            stop
-        );
-    }
-    return Promise.resolve();
 };
 
 export { fillAdvertSlots };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -88,13 +88,14 @@ const init = (start: () => void, stop: () => void): Promise<void> => {
     };
 
     if (commercialFeatures.dfpAdvertising) {
+        if (commercialFeatures.adFree) {
+            setupAdvertising().then(adFreeSlotRemove).catch(removeAdSlots);
+            return Promise.resolve();
+        }
         // A promise error here, from a failed module load,
         // could be a network problem or an intercepted request.
         // Abandon the init sequence.
         setupAdvertising().catch(removeAdSlots);
-        return Promise.resolve();
-    } else if (commercialFeatures.adFree) {
-        setupAdvertising().then(adFreeSlotRemove).catch(removeAdSlots);
         return Promise.resolve();
     }
     return removeAdSlots();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -5,7 +5,7 @@ import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { buildPageTargeting } from 'commercial/modules/build-page-targeting';
-import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
+import { adSlotSelector } from 'commercial/modules/close-disabled-slots';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import onSlotRender from 'commercial/modules/dfp/on-slot-render';
 import onSlotLoad from 'commercial/modules/dfp/on-slot-load';
@@ -37,7 +37,14 @@ const setPageTargeting = (): void => {
     });
 };
 
-const removeAdSlots = (): Promise<void> => closeDisabledSlots(true);
+const removeAdSlots = (): Promise<void> => {
+    // Get all ad slots
+    let adSlots: Array<Element> = qwery(adSlotSelector);
+
+    return fastdom.write(() =>
+        adSlots.forEach((adSlot: Element) => adSlot.remove())
+    );
+};
 
 const init = (start: () => void, stop: () => void): Promise<void> => {
     const setupAdvertising = (): Promise<void> => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -63,8 +63,12 @@ const init = (start: () => void, stop: () => void): Promise<void> => {
     const setupAdvertising = (): Promise<void> => {
         addTag(dfpEnv.sonobiEnabled ? 'sonobi' : 'waterfall');
 
+        start();
+
+        // note: fillAdvertSlots isn't synchronous like most buffered cmds, it's a promise. It's put in here to ensure
+        // it strictly follows preceding prepare-googletag work (and the module itself ensures dependencies are
+        // fulfilled), but don't assume fillAdvertSlots is complete when queueing subsequent work using cmd.push
         window.googletag.cmd.push(
-            start,
             setDfpListeners,
             setPageTargeting,
             setPublisherProvidedId,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -98,7 +98,7 @@ const init = (start: () => void, stop: () => void): Promise<void> => {
         setupAdvertising().catch(removeAdSlots);
         return Promise.resolve();
     }
-    return removeAdSlots();
+    return removeAdSlots().then(stop);
 };
 
 export default {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -73,8 +73,9 @@ const init = (start: () => void, stop: () => void): Promise<void> => {
             setPageTargeting,
             setPublisherProvidedId,
             refreshOnResize,
-            fillAdvertSlots,
-            stop
+            () => {
+                fillAdvertSlots().then(stop);
+            }
         );
 
         // Just load googletag. Sonobi's wrapper will already be loaded, and googletag is already added to the window by sonobi.

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -30,7 +30,7 @@ const catchPolyfillErrors = () => {
     };
 };
 
-const setupSonobi: Promise<void> = once(() => {
+const setupSonobi: () => Promise<void> = once(() => {
     buildPageTargeting();
     // Setting the async property to false will _still_ load the script in
     // a non-blocking fashion but will ensure it is executed before googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -4,6 +4,7 @@ import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { buildPageTargeting } from 'commercial/modules/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
+import once from 'lodash/functions/once';
 
 // Wrap the native implementation of getOwnPropertyNames in a try-catch. If any polyfill attempts
 // to re-implement this function, and doesn't consider the "access permissions" issue that exists in IE11,
@@ -29,24 +30,25 @@ const catchPolyfillErrors = () => {
     };
 };
 
-const setupSonobi = (start: () => void, stop: () => void) => {
-    start();
-
+const setupSonobi: Promise<void> = once(() => {
+    buildPageTargeting();
     // Setting the async property to false will _still_ load the script in
     // a non-blocking fashion but will ensure it is executed before googletag
-    loadScript(config.libs.sonobi, { async: false })
-        .then(catchPolyfillErrors)
-        .then(stop);
-};
+    return loadScript(config.libs.sonobi, { async: false }).then(
+        catchPolyfillErrors
+    );
+});
 
 const init = (start: () => void, stop: () => void) => {
     if (dfpEnv.sonobiEnabled && commercialFeatures.dfpAdvertising) {
-        buildPageTargeting();
-        setupSonobi(start, stop);
+        start();
+        setupSonobi().then(stop);
     }
 
     return Promise.resolve();
 };
+
+export { setupSonobi };
 
 export default {
     init,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -11,6 +11,8 @@ import adSizes from 'commercial/modules/ad-sizes';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import uniq from 'lodash/arrays/uniq';
+import once from 'lodash/functions/once';
+
 // The view id is used as the unique load id, for easier Switch log querying.
 const loadId = window.esi && window.esi.viewId;
 const REQUEST_TIMEOUT = 5000;
@@ -28,17 +30,11 @@ const setupLoadId = () => {
     });
 };
 
-const setupSwitch = (start: () => void, stop: () => void) => {
-    start();
-
+const setupSwitch: Promise<void> = once(() =>
     // Setting the async property to false will _still_ load the script in
     // a non-blocking fashion but will ensure it is executed before googletag
-    loadScript(config.libs.switch, {
-        async: false,
-    })
-        .then(setupLoadId)
-        .then(stop);
-};
+    loadScript(config.libs.switch, { async: false }).then(setupLoadId)
+);
 
 // The switch api's callSwitch function will perform the retrieval of a pre-flight ad call,
 // using the load id that has been previously set with setupLoadId.
@@ -119,11 +115,14 @@ const maybePushAdUnit = (dfpDivId: string, sizeMapping: any) => {
 
 const init = (start: () => void, stop: () => void) => {
     if (commercialFeatures.dfpAdvertising) {
-        setupSwitch(start, stop);
+        start();
+        setupSwitch().then(stop);
     }
 
     return Promise.resolve();
 };
+
+export { setupSwitch };
 
 export default {
     init,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -30,7 +30,7 @@ const setupLoadId = () => {
     });
 };
 
-const setupSwitch: Promise<void> = once(() =>
+const setupSwitch: () => Promise<void> = once(() =>
     // Setting the async property to false will _still_ load the script in
     // a non-blocking fashion but will ensure it is executed before googletag
     loadScript(config.libs.switch, { async: false }).then(setupLoadId)

--- a/static/test/javascripts-legacy/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts-legacy/spec/common/commercial/commercial-features.spec.js
@@ -88,15 +88,6 @@ define(['helpers/injector'], function (Injector) {
             });
         });
 
-        describe('DFP advertising under ad-free', function() {
-           it('is disabled', function() {
-              config.switches.adFreeMembershipTrial = true;
-              isSignedIn = true;
-              features = new CommercialFeatures;
-              expect(features.dfpAdvertising).toBe(false);
-           });
-        });
-
         describe('Article body adverts', function () {
             it('Runs by default', function () {
                 features = new CommercialFeatures;


### PR DESCRIPTION
## What does this change?
We've confirmed some race conditions with the commercial boot (it's so so fast). Unfortunately we are going to have to re-introduce some explicit dependencies to `fill-advert-slots`, so that it waits for slots to be closed. Without this, the commercial system runs a query selector and finds ad slot nodes that are css-hidden. The good news is the promise chain remains deferred, so this won't slow enhanced (it should only slow the fill-advert-slots process).

@JustinPinner I've made some changes to adfree during merge, and took the opportunity to isolate adfree logic, inverted some booleans here and there to keep `dfpAdvertising` meaningful, and the module arrays are a bit neater. Generally tried to do the "right thing", which is challenging when maintaining an ad free test and you work on commercial ;)

## Tested in CODE?
yeah