### PR TITLE
mobileMedium just got smaller

### DIFF
--- a/common/app/layout/Breakpoint.scala
+++ b/common/app/layout/Breakpoint.scala
@@ -12,7 +12,7 @@ case object Mobile extends Breakpoint {
 }
 
 case object MobileMedium extends Breakpoint {
-  val minWidth = Some(375)
+  val minWidth = Some(360)
 }
 
 case object MobileLandscape extends Breakpoint {

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -50,7 +50,7 @@ $veggie-burger-medium: 54px;
 
 $mq-breakpoints: (
     mobile:          gs-span(4)  + $gs-gutter,   // 320px
-    mobileMedium:    gs-span(5)  - $gs-gutter/4, // 375px
+    mobileMedium:    gs-span(5)  - $gs-gutter,   // 360px
     mobileLandscape: gs-span(6)  + $gs-gutter,   // 480px
     phablet:         gs-span(8)  + $gs-gutter*2, // 660px
     tablet:          gs-span(9)  + $gs-gutter*2, // 740px


### PR DESCRIPTION
# Before on Galaxy S7
<img width="360" alt="screen shot 2017-06-01 at 11 19 32" src="https://cloud.githubusercontent.com/assets/14570016/26675576/65ffff40-46bc-11e7-8d98-333ca412b90d.png">

# After on Galaxy S7
<img width="360" alt="screen shot 2017-06-01 at 11 19 55" src="https://cloud.githubusercontent.com/assets/14570016/26675577/6612f06e-46bc-11e7-8ff3-0f0801ca932d.png">

Updated mobileMedium breakpoint to support large range of Android devices, rather than just iphone.

<img width="1419" alt="screen shot 2017-06-01 at 11 22 19" src="https://cloud.githubusercontent.com/assets/14570016/26675638/a10207c8-46bc-11e7-8b16-25626e381242.png">


https://mydevice.io/devices/ 