### PR TITLE
Update epic control copy to new control

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
@@ -42,7 +42,7 @@ define([
                         contributionUrl: variant.options.contributeURL,
                         componentName: variant.options.componentName,
                         quoteSvg: quoteSvg.markup,
-                        p1: '&hellip; we have a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help, especially during this UK election.',
+                        p1: '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help, especially during this UK election.',
                         testimonialMessage: 'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible, independent check on the government, this contribution was pretty good value for money.',
                         testimonialName: 'Jack H.'
                     })

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control-regulars.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control-regulars.html
@@ -4,7 +4,7 @@
             Hello again …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … today we have a small favour to ask. More people than ever are regularly reading the Guardian, but far fewer are paying for it.  Advertising revenues across the media are falling fast. And <span class="contributions__highlight"> unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
+            … today we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight"> unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So we think it’s fair to ask people who visit us often for their help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -5,7 +5,7 @@
                 Since you’re here …
             </h2>
             <p class="contributions__paragraph contributions__paragraph--epic">
-                … we have a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
+                … we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
             </p>
             <p class="contributions__paragraph contributions__paragraph--epic">
                 If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog-old-design-minimal.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog-old-design-minimal.html
@@ -8,8 +8,8 @@
     <div class="block-elements block-elements--no-byline">
         <p>
             <em>
-                Since you’re here … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it.
-                Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash;
+                Since you’re here … we’ve got a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast.
+                And unlike many news organisations, we haven’t put up a paywall &ndash;
                 we want to keep our journalism as open as we can. So you can see why we need to ask for your help.
                 The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.
                 But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog-old-design-subtle.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog-old-design-subtle.html
@@ -10,8 +10,8 @@
             Since you’re here…
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it.
-            Advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash;
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast.
+            And unlike many news organisations, we haven’t put up a paywall &ndash;
             we want to keep our journalism as open as we can. So you can see why we need to ask for your help.
             The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce.
             But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-liveblog.html
@@ -4,7 +4,7 @@
             Since you’re here …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
+            … we’ve got a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
         </p>
         <p class="contributions__paragraph contributions__paragraph--epic">
             If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.


### PR DESCRIPTION
## What does this change?
We no longer wish to have the line "and far fewer people are paying than ever". This PR removes that line and replaces it with a new copy. 

Old line :  More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast.

New Line :  More people are reading the Guardian than ever but advertising revenues across the media are falling fast. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 