### PR TITLE
Add acquisitions interactive slice test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -81,8 +81,18 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-election-interactive",
+    "ab-acquisitions-election-interactive-end",
     "This places the epic underneath UK election-related interactives",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 7, 3),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-election-interactive-slice",
+    "This places the epic (slice design) in the middle of UK election-related interactives",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 7, 3),

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -240,7 +240,7 @@ define([
                 }.bind(this));
             }
 
-            return (typeof options.test === 'function') ? options.test(render.bind(this)) : render.apply(this);
+            return (typeof options.test === 'function') ? options.test(render.bind(this), this) : render.apply(this);
         };
 
         this.registerListener('impression', 'impressionOnInsert', test.insertEvent, options);

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
@@ -1,0 +1,61 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lib/$',
+    'lib/geolocation',
+    'lodash/utilities/template',
+    'lib/config',
+    'raw-loader!common/views/acquisitions-epic-control.html',
+    'raw-loader!common/views/acquisitions-epic-slice.html',
+], function (
+    contributionsUtilities,
+    $,
+    geolocation,
+    template,
+    config,
+    epicControlTemplate
+) {
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsElectionInteractiveEnd',
+        campaignId: 'epic_election_interactive_end',
+
+        start: '2017-05-22',
+        expiry: '2017-07-03',
+
+        author: 'Sam Desborough',
+        description: 'This places the epic underneath UK election-related interactives',
+        successMeasure: 'Member acquisition and contributions',
+        idealOutcome: 'Our wonderful readers will support The Guardian in this time of need!',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        showForSensitive: true,
+
+        pageCheck: function(page) {
+            return page.keywordIds &&
+                page.keywordIds.includes('general-election-2017') &&
+                page.contentType === 'Interactive';
+        },
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited: true,
+
+                insertAtSelector: '.content-footer',
+                successOnView: true,
+
+                template: function makeControlTemplate(variant) {
+                    return template(epicControlTemplate, {
+                        membershipUrl: variant.options.membershipURL,
+                        contributionUrl: variant.options.contributeURL,
+                        componentName: variant.options.componentName,
+                        epicClass: 'contributions__epic--interactive gs-container',
+                        wrapperClass: 'contributions__epic-interactive-wrapper'
+                    });
+                }
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
@@ -1,25 +1,27 @@
 define([
     'common/modules/commercial/contributions-utilities',
+    'lib/$',
     'lib/geolocation',
     'lodash/utilities/template',
     'lib/config',
-    'raw-loader!common/views/acquisitions-epic-control.html'
+    'raw-loader!common/views/acquisitions-epic-slice.html',
 ], function (
     contributionsUtilities,
+    $,
     geolocation,
     template,
     config,
-    epicControlTemplate
+    epicSlice
 ) {
     return contributionsUtilities.makeABTest({
-        id: 'AcquisitionsElectionInteractive',
-        campaignId: 'epic_election_interactive_end',
+        id: 'AcquisitionsElectionInteractiveSlice',
+        campaignId: 'epic_election_interactive_slice',
 
         start: '2017-05-22',
         expiry: '2017-07-03',
 
         author: 'Sam Desborough',
-        description: 'This places the epic underneath UK election-related interactives',
+        description: 'This places the epic (slice design) in the middle of UK election-related interactives',
         successMeasure: 'Member acquisition and contributions',
         idealOutcome: 'Our wonderful readers will support The Guardian in this time of need!',
 
@@ -30,7 +32,9 @@ define([
         showForSensitive: true,
 
         pageCheck: function(page) {
-            return page.keywordIds && page.keywordIds.includes('general-election-2017') && page.contentType === 'Interactive';
+            return page.keywordIds &&
+                page.keywordIds.includes('general-election-2017') &&
+                page.contentType === 'Interactive';
         },
 
         variants: [
@@ -38,18 +42,16 @@ define([
                 id: 'control',
                 isUnlimited: true,
 
-                insertAtSelector: '.content-footer',
+                insertAtSelector: '#js-interactive-epic',
                 successOnView: true,
 
-                template: function (variant) {
-                    return template(epicControlTemplate, {
+                template: function makeSliceTemplate(variant) {
+                    return template(epicSlice, {
                         membershipUrl: variant.options.membershipURL,
                         contributionUrl: variant.options.contributeURL,
                         componentName: variant.options.componentName,
-                        epicClass: 'contributions__epic--interactive gs-container',
-                        wrapperClass: 'contributions__epic-interactive-wrapper'
                     });
-                },
+                }
             }
         ]
     });

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -22,6 +22,11 @@ import {
     MeasureUnderstanding,
 } from 'common/modules/experiments/tests/measure-understanding';
 
+import AcquisitionsEpicElectionInteractiveEnd
+    from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
+import AcquisitionsEpicElectionInteractiveSlice
+    from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-slice';
+
 export const TESTS: Array<ABTest> = [
     new OpinionEmailVariants(),
     new PaidContentVsOutbrain2(),
@@ -31,6 +36,8 @@ export const TESTS: Array<ABTest> = [
     new BundleDigitalSubPriceTest1(),
     ExplainerSnippet(),
     MeasureUnderstanding(),
+    new AcquisitionsEpicElectionInteractiveEnd(),
+    new AcquisitionsEpicElectionInteractiveSlice(),
 ]
     .concat(MembershipEngagementBannerTests)
     .filter(Boolean);

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -16,8 +16,6 @@ import acquisitionsEpicLiveBlog
     from 'common/modules/experiments/tests/acquisitions-epic-liveblog';
 import acquisitionsEpicLiveBlogDesignTest
     from 'common/modules/experiments/tests/acquisitions-epic-liveblog-design-test';
-import acquisitionsEpicElectionInteractive
-    from 'common/modules/experiments/tests/acquisitions-epic-election-interactive';
 import acquisitionsEpicPreElection
     from 'common/modules/experiments/tests/acquisitions-epic-pre-election';
 import acquisitionsEpicAlwaysAskIfTagged
@@ -36,7 +34,6 @@ const tests = [
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveBlogDesignTest,
     acquisitionsEpicLiveBlog,
-    acquisitionsEpicElectionInteractive,
 ].map(Test => new Test());
 
 const isViewable = (v: Variant): boolean => {

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-slice.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-slice.html
@@ -1,0 +1,22 @@
+<div class="contributions__epic-slice-wrapper">
+    <div class="contributions__epic-slice gs-container">
+        <hr class="contributions__epic-slice__bar"/>
+
+        <h2 class="contributions__epic-slice__heading">Support the Guardian</h2>
+
+        <h3 class="contributions__epic-slice__subheading">
+            Join the hundreds of thousands who choose to fund independent journalism and keep it open
+        </h3>
+
+        <div class="contributions__epic-slice__buttons">
+            <a href="<%=membershipUrl %>"
+               class="contributions__option-button contributions__contribute contributions__contribute--epic-slice">
+                Become a supporter
+            </a>
+            <a href="<%=contributionUrl %>"
+               class="contributions__option-button contributions__contribute contributions__contribute--epic-slice">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>

--- a/static/src/stylesheets/head.interactive.scss
+++ b/static/src/stylesheets/head.interactive.scss
@@ -6,3 +6,4 @@
 
 @import 'module/content/_interactive';
 @import 'module/experiments/_acquisitions-epic-interactive';
+@import 'module/experiments/_acquisitions-epic-interactive-slice';

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive-slice.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive-slice.scss
@@ -1,0 +1,98 @@
+@import 'svg';
+
+.contributions__epic-slice-wrapper {
+    background: $neutral-3;
+
+    @include mq(tablet) {
+        margin-left: -100%;
+        margin-right: -100%;
+    }
+}
+
+.contributions__epic-slice,
+.contributions__contribute.contributions__contribute--epic-slice {
+    background: $neutral-4;
+}
+
+.contributions__epic-slice.gs-container {
+    padding: 0 $gs-gutter $gs-gutter;
+}
+
+.contributions__epic-slice {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.contributions__epic-slice__bar {
+    border: 0;
+    background: $news-main-2;
+    width: 6.5rem;
+    height: $gs-gutter / 2;
+    margin: 0;
+    text-align: left;
+
+    @include mq(tablet) {
+        width: 8.25rem;
+    }
+}
+
+.contributions__epic-slice__heading,
+.contributions__epic-slice__subheading {
+    font-family: $f-serif-headline;
+}
+
+.contributions__epic-slice__heading,
+.contributions__contribute.contributions__contribute--epic-slice {
+    color: #005689;
+}
+
+.contributions__epic-slice__heading {
+    @include fs-headline(5, true);
+    color: $guardian-brand;
+    flex-basis: 100%;
+
+    @include mq(tablet) {
+        @include fs-headline(7, true);
+    }
+}
+
+.contributions__epic-slice__subheading {
+    @include fs-header(4, true);
+
+    @include mq(tablet) {
+        @include fs-header(5, true);
+        max-width: 42rem;
+    }
+}
+
+.contributions__epic-slice__buttons {
+    float: right;
+}
+
+.contributions__contribute.contributions__contribute--epic-slice {
+    width: auto;
+    background: transparent;
+    border: 1px solid #4bc6df;
+    margin-top: 0;
+    margin-left: $gs-gutter / 2;
+    font-size: 12px;
+
+    @include mq(tablet) {
+        font-size: 16px;
+    }
+
+    &:first-of-type {
+        margin-left: 0;
+    }
+
+    &:hover {
+        background: transparent;
+        border-color: $guardian-brand;
+        color: $guardian-brand;
+    }
+
+    &:after {
+        background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path fill="#005689" stroke="#005689" d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"/></svg>')
+    }
+}


### PR DESCRIPTION
## What does this change?
Adds a slice asking for supporters/contributions as a slice in elections interactives. 

## Screenshots
![screen shot 2017-06-01 at 15 56 26](https://cloud.githubusercontent.com/assets/1064734/26685989/956136ec-46e3-11e7-8d3e-e3fea6439b19.png)
![screen shot 2017-06-01 at 15 56 22](https://cloud.githubusercontent.com/assets/1064734/26685988/9542e3f4-46e3-11e7-9809-7fc4665bfd04.png)
![screen shot 2017-06-01 at 15 56 14](https://cloud.githubusercontent.com/assets/1064734/26685983/9285f1a6-46e3-11e7-9883-c7140af74ca6.png)
![screen shot 2017-06-01 at 15 56 02](https://cloud.githubusercontent.com/assets/1064734/26685982/92495c50-46e3-11e7-8b54-e115102637e7.png)

@guardian/contributions 