### PR TITLE
Add thank you epic for readers who have supported us

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -178,4 +178,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 6, 26),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-thank-you",
+    "Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 6, 19),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -64,6 +64,8 @@ define([
         }
     }
 
+    var daysSinceLastContribution = daysSince(lastContributionDate);
+
     function controlTemplate(variant) {
         return template(acquisitionsEpicControlTemplate, {
             membershipUrl: variant.options.membershipURL,
@@ -187,6 +189,10 @@ define([
             blockEngagementBanner: options.blockEngagementBanner || false,
             engagementBannerParams: options.engagementBannerParams || {},
             isOutbrainCompliant: options.isOutbrainCompliant || false,
+
+            // Set useLocalViewLog to true if only the views for the respective test
+            // should be used to determine variant viewability
+            useLocalViewLog: options.useLocalViewLog || false,
         };
 
         this.test = function () {
@@ -297,6 +303,7 @@ define([
             };
         },
 
-        variantBuilderFactory: variantBuilderFactory
+        variantBuilderFactory: variantBuilderFactory,
+        daysSinceLastContribution: daysSinceLastContribution
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -143,6 +143,10 @@ define([
         this.viewEvent = this.makeEvent('view');
         this.isEngagementBannerTest = options.isEngagementBannerTest || false;
 
+        // Set useLocalViewLog to true if only the views for the respective test
+        // should be used to determine variant viewability
+        this.useLocalViewLog =  options.useLocalViewLog || false;
+
         /**
          * Provides a default `canRun` function with typical rules (see function below) for Contributions messages.
          * If your test provides its own `canRun` option, it will be included in the check.
@@ -189,10 +193,6 @@ define([
             blockEngagementBanner: options.blockEngagementBanner || false,
             engagementBannerParams: options.engagementBannerParams || {},
             isOutbrainCompliant: options.isOutbrainCompliant || false,
-
-            // Set useLocalViewLog to true if only the views for the respective test
-            // should be used to determine variant viewability
-            useLocalViewLog: options.useLocalViewLog || false,
         };
 
         this.test = function () {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -1,0 +1,77 @@
+define([
+    'lodash/utilities/template',
+    'commercial/modules/user-features',
+    'common/modules/commercial/contributions-utilities',
+    'lib/config',
+    'raw-loader!common/views/acquisitions-epic-thank-you.html'
+], function (
+    template,
+    userFeatures,
+    contributionsUtilities,
+    config,
+    acquisitionsEpicThankYouTemplate
+) {
+
+    function isRecentContributor() {
+        return contributionsUtilities.daysSinceLastContribution < 180
+    }
+
+    function isTargetReader() {
+        return userFeatures.isPayingMember() || isRecentContributor()
+    }
+
+    function worksWellWithPageTemplate() {
+        return config.page.contentType === 'Article' &&
+            !config.page.isMinuteArticle &&
+            !(config.page.isImmersive === true)
+    }
+
+    function isTargetPage() {
+        return worksWellWithPageTemplate() &&
+            !config.page.isPaidContent &&
+            !config.page.shouldHideAdverts
+    }
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicThankYou',
+        campaignId: 'epic_thank_you',
+
+        start: '2017-06-01',
+        expiry: '2017-06-19',
+
+        author: 'Guy Dawson',
+        description: 'Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian',
+        successMeasure: 'N/A',
+        idealOutcome: 'N/A',
+        audienceCriteria: 'Readers who have supported the Guardian',
+        audience: 0,
+        audienceOffset: 1,
+
+        overrideCanRun: true,
+
+        canRun: function() {
+            return isTargetReader() && isTargetPage();
+        },
+
+        variants: [
+            {
+                id: 'control',
+
+                useLocalViewLog: true,
+
+                maxViews: {
+                  days: 365, // Arbitrarily high number - reader should only see the thank-you for one 'cycle'.
+                  count: 1,
+                  minDaysBetweenViews: 0
+                },
+
+                template: function(variant) {
+                    return template(acquisitionsEpicThankYouTemplate, {
+                        componentName: variant.options.componentName,
+                        membershipUrl: variant.getURL("https://www.theguardian.com/membership", variant.options.campaignCode)
+                    })
+                }
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -53,11 +53,11 @@ define([
             return isTargetReader() && isTargetPage();
         },
 
+        useLocalViewLog: true,
+
         variants: [
             {
                 id: 'control',
-
-                useLocalViewLog: true,
 
                 maxViews: {
                   days: 365, // Arbitrarily high number - reader should only see the thank-you for one 'cycle'.

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
@@ -21,12 +21,12 @@ const logView = (testId: string): void => {
     local.set(viewKey, viewLog.slice(-maxLogEntries));
 };
 
-const viewsInPreviousDays = (days: number, test?: ABTest): number => {
+const viewsInPreviousDays = (days: number, testId: ?string): number => {
     const ms = days * 1000 * 60 * 60 * 24;
     const now = new Date().getTime();
 
     return viewLog.filter(
-        view => (test ? view.testId === test.id : true) && view.date > now - ms
+        view => (testId ? view.testId === testId : true) && view.date > now - ms
     ).length;
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -52,7 +52,7 @@ const isViewable = (v: Variant, t: ABTest): boolean => {
     } = v.options.maxViews;
 
     const isUnlimited = v.options.isUnlimited;
-    const testId = v.options.useLocalViewLog ? t.id : undefined;
+    const testId = t.useLocalViewLog ? t.id : undefined;
 
     const withinViewLimit =
         viewsInPreviousDays(maxViewDays, testId) < maxViewCount;

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -24,6 +24,8 @@ import acquisitionsEpicTestimonialsUSA
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-usa';
 import acquisitionsEpicAlwaysAskElection
     from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
+import acquisitionsEpicThankYou
+    from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -37,9 +39,10 @@ const tests = [
     acquisitionsEpicLiveBlogDesignTest,
     acquisitionsEpicLiveBlog,
     acquisitionsEpicAlwaysAskElection,
+    acquisitionsEpicThankYou,
 ].map(Test => new Test());
 
-const isViewable = (v: Variant): boolean => {
+const isViewable = (v: Variant, t: ABTest): boolean => {
     if (!v.options || !v.options.maxViews) return false;
 
     const {
@@ -49,9 +52,12 @@ const isViewable = (v: Variant): boolean => {
     } = v.options.maxViews;
 
     const isUnlimited = v.options.isUnlimited;
+    const testId = v.options.useLocalViewLog ? t.id : undefined;
 
-    const withinViewLimit = viewsInPreviousDays(maxViewDays) < maxViewCount;
-    const enoughDaysBetweenViews = viewsInPreviousDays(minViewDays) === 0;
+    const withinViewLimit =
+        viewsInPreviousDays(maxViewDays, testId) < maxViewCount;
+    const enoughDaysBetweenViews =
+        viewsInPreviousDays(minViewDays, testId) === 0;
     return (withinViewLimit && enoughDaysBetweenViews) || isUnlimited;
 };
 
@@ -68,11 +74,13 @@ export const getTest = (): ?ABTest => {
     if (forcedTests.length)
         return forcedTests.find(t => {
             const variant: ?Variant = getForcedVariant(t);
-            return variant && testCanBeRun(t) && isViewable(variant);
+            return variant && testCanBeRun(t) && isViewable(variant, t);
         });
 
     return tests.find(t => {
         const variant: ?Variant = variantFor(t);
-        return variant && testCanBeRun(t) && isInTest(t) && isViewable(variant);
+        return (
+            variant && testCanBeRun(t) && isInTest(t) && isViewable(variant, t)
+        );
     });
 };

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
@@ -8,7 +8,7 @@
             the world enables our journalists to cover important issues like this year’s elections.
             And your knowledge and experience makes our reporting better too.
             Did you know we publish articles and podcasts for our supporters, featuring your views and voices?
-            <a href="<%=membershipUrl%>" target="_blank" class="u-underline">becoming a monthly supporter</a>
+            <a href="<%=membershipUrl%>" target="_blank" class="u-underline">You can learn more about how to get involved here.</a>
         </p>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
@@ -1,0 +1,14 @@
+<div class="contributions__epic" data-component="<%=componentName%>">
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Thank you …
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            … for supporting us. Your contribution and the similar pledges of hundreds of thousands of readers around
+            the world enables our journalists to cover important issues like this year’s elections.
+            And your knowledge and experience makes our reporting better too.
+            Did you know we publish articles and podcasts for our supporters, featuring your views and voices?
+            <a href="<%=membershipUrl%>" target="_blank" class="u-underline">becoming a monthly supporter</a>
+        </p>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-thank-you.html
@@ -4,11 +4,13 @@
             Thank you …
         </h2>
         <p class="contributions__paragraph contributions__paragraph--epic">
-            … for supporting us. Your contribution and the similar pledges of hundreds of thousands of readers around
-            the world enables our journalists to cover important issues like this year’s elections.
-            And your knowledge and experience makes our reporting better too.
-            Did you know we publish articles and podcasts for our supporters, featuring your views and voices?
-            <a href="<%=membershipUrl%>" target="_blank" class="u-underline">You can learn more about how to get involved here.</a>
+            … for supporting us, funding our independent journalism and keeping it open.
+            Your contribution and the similar pledges of hundreds of thousands of readers around the world enables the
+            Guardian’s journalists to cover important issues like this year’s elections.
+            And your knowledge and experience makes our reporting better too. Did you know we publish articles and podcasts for our supporters,
+            featuring your views and voices?
         </p>
+
+        <a href="<%=membershipUrl%>" target="_blank" class="u-underline">You can learn more about how to get involved here.</a>
     </div>
 </div>


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Bootstraps the AB testing framework to display a 'Thank You' Epic to (1) supporters; or (2) readers that have previously contributed to the Guardian.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

* __mobile__
  <img width="397" alt="thank_you_epic_mobile" src="https://cloud.githubusercontent.com/assets/4085817/26721685/adaf7596-4784-11e7-8fa2-2f2196599fad.png">


* __desktop__
  <img width="633" alt="thank_you_epic" src="https://cloud.githubusercontent.com/assets/4085817/26721693/b5883a1e-4784-11e7-9558-c349385c455c.png">

## Tested in CODE?

No, tested locally.
