### PR TITLE
Always ask election epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -161,6 +161,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-epic-always-ask-election",
+    "This will guarantee that the epic is always displayed on election stories",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 7, 19),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-testimonials-usa",
     "Test placing localised reader testimonials in the Epic",
     owners = Seq(Owner.withGithub("desbo")),

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -1,0 +1,33 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+], function (
+    contributionsUtilities
+) {
+
+
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsEpicAlwaysAskElection',
+        campaignId: 'epic_always_ask_election',
+
+        start: '2017-06-01',
+        expiry: '2018-07-19',
+
+        author: 'Jonathan Rankin',
+        description: 'This will guarantee that the epic is always displayed on election stories',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'We can always show the epic on election articles',
+        audienceCriteria: 'All',
+        audience: 1,
+        locations: ['GB'],
+        audienceOffset: 0,
+        useTargetingTool: true,
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited : true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -22,6 +22,8 @@ import acquisitionsEpicAlwaysAskIfTagged
     from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import acquisitionsEpicTestimonialsUSA
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-usa';
+import acquisitionsEpicAlwaysAskElection
+    from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -34,6 +36,7 @@ const tests = [
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveBlogDesignTest,
     acquisitionsEpicLiveBlog,
+    acquisitionsEpicAlwaysAskElection,
 ].map(Test => new Test());
 
 const isViewable = (v: Variant): boolean => {


### PR DESCRIPTION
## What does this change?
This adds the epic to all election and eu referendum stories with no limit on number of impressions. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
![screenshot at jun 01 16-31-55](https://cloud.githubusercontent.com/assets/2844554/26688305/2f342968-46ea-11e7-92d4-1b9b080a3a36.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
