### PR TITLE
Add switch for requesting out of page slot for surveys.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -15,6 +15,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val SurveySwitch = Switch(
+    SwitchGroup.Commercial,
+    "surveys",
+    "For delivering surveys, enables the requesting of the out-of-page slot on non-fronts",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val BlockIASSwitch = Switch(
     SwitchGroup.Commercial,
     "block-ias",

--- a/common/app/views/fragments/commercial/survey.scala.html
+++ b/common/app/views/fragments/commercial/survey.scala.html
@@ -1,0 +1,8 @@
+@fragments.commercial.standardAd(
+    "survey",
+    Seq.empty[String],
+    Map("wide" -> Seq("1,1")),
+    showLabel=false,
+    refresh=false,
+    outOfPage=true
+)

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @(page: model.Page, projectName: Option[String] = None)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import common.{Edition, Navigation, commercial}
-@import conf.switches.Switches.BreakingNewsSwitch
+@import conf.switches.Switches.{BreakingNewsSwitch, SurveySwitch}
 @import model.Page.getContent
 @import views.support.{Commercial, RenderClasses}
 @import play.api.Mode.Dev
@@ -53,6 +53,10 @@
 
         @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
             @fragments.commercial.pageSkin()
+        }
+
+        @if(!page.metadata.isFront && SurveySwitch.isSwitchedOn) {
+            @fragments.commercial.survey()
         }
 
         @page match {


### PR DESCRIPTION
## What does this change?
This PR provides the ability to request the out-of-page slot on non-front pages.

I was originally going to do something more elegant in looking at the list of cached DFP line items to then determine whether to fire off the slot based on the URL being requested, essentially matching the targeting of DFP. The gain in reducing doomed ad requests would be eclipsed by the complexity and fragility of this solution so I've opted not to go there.

## What is the value of this and can you measure success?
We can run surveys!

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
