### PR TITLE
Specify domain for notification update

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/notifications.js
@@ -178,7 +178,7 @@ define([
             return modules.getSub().then(function (sub) {
                 var endpoint = sub && sub.endpoint;
                 if (endpoint) {
-                    return fetch(notificationsEndpoint, {
+                    return fetch(config.page.ajaxUrl + notificationsEndpoint, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## What does this change?
773f1e2d403a22aecd569c77bf9cdf7faf9b8ad8 (from April 4th 😱 ) swapped `lib/ajax` for `lib/fetch`.
Unfortunately while `lib/ajax` prepends the ajax domain if url is relative, `lib/fetch` doesn't have such logic and therefore the request is made on the current page domain (`www.theguardian.com`) rather than `nextgen.api.guardianapps.co.uk`
This patch specifies the url domain in `notification.js`

## What is the value of this and can you measure success?
It works! 🦈 

## Tested in CODE?
No