### PR TITLE
turn on ima debugging

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/media/main.js
@@ -247,14 +247,18 @@ define([
                                     }
 
                                     if (withPreroll) {
+                                        var isDebugMode = !!window.location.hash && window.location.hash === '#debug';
+
                                         raven.wrap({ tags: { feature: 'media' } }, function () {
                                             player.ima({
+                                                debug: isDebugMode,
                                                 id: mediaId,
                                                 adTagUrl: videoAdUrl.get(),
                                                 prerollTimeout: 1000,
                                                 // We set this sightly higher so contrib-ads never timeouts before ima.
                                                 contribAdsSettings: {
-                                                    timeout: 2000
+                                                    timeout: 2000,
+                                                    debug: isDebugMode
                                                 }
                                             });
                                             player.on('adstart', function() {


### PR DESCRIPTION
## What does this change?
Video pre-roll is acting up, I can't reproduce in DEV so lets optionally turn on [debugging](https://github.com/videojs/videojs-contrib-ads#debug) in PROD 🙃

## What is the value of this and can you measure success?
🐛 ⬇️ 

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
n/a

## Tested in CODE?
n/a

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
