### PR TITLE
Update campaign codes in election tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
@@ -16,7 +16,7 @@ define([
 ) {
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsElectionInteractiveEnd',
-        campaignId: 'epic_election_interactive_end',
+        campaignId: 'epic_ge2017_interactive_end',
 
         start: '2017-05-22',
         expiry: '2017-07-03',

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
@@ -15,7 +15,7 @@ define([
 ) {
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsElectionInteractiveSlice',
-        campaignId: 'epic_election_interactive_slice',
+        campaignId: 'epic_ge2017_interactive_slice',
 
         start: '2017-05-22',
         expiry: '2017-07-03',


### PR DESCRIPTION
Use `ge2017` instead of `election` in the campaign code for the interactive asks.