### PR TITLE
Add loader animation to account deletion

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -89,7 +89,7 @@
                 </p>
             </div>
 
-            <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post">
+            <form class="form" novalidate action="@idUrlBuilder.buildUrl("/delete", idRequest)" role="main" method="post" id="deleteForm">
                 @views.html.helper.CSRF.formField
 
                 <div class="identity-section">
@@ -124,6 +124,7 @@
 
                             <li>
                                 <button type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
+                                <div id="deleteLoader" class="loading-animation is-updating inline-loading is-hidden"></div>
                             </li>
                         </ul>
                     </div>

--- a/static/src/javascripts-legacy/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/profile.js
@@ -10,6 +10,7 @@ define([
     'common/modules/identity/account-profile',
     'common/modules/identity/public-profile',
     'common/modules/identity/email-preferences',
+    'common/modules/identity/delete-account',
     'common/modules/discussion/user-avatars',
     'lib/mediator',
     'common/modules/ui/tabs'
@@ -25,6 +26,7 @@ define([
     AccountProfile,
     PublicProfile,
     EmailPreferences,
+    DeleteAccount,
     UserAvatars,
     mediator,
     Tabs
@@ -95,6 +97,12 @@ define([
             mediator.on('page:identity:ready', function () {
                 EmailPreferences.init();
             });
+        },
+
+        deleteAccount: function () {
+            mediator.on('page:identity:ready', function () {
+                DeleteAccount.init();
+            });
         }
     };
 
@@ -109,6 +117,7 @@ define([
             modules.tabs();
             modules.accountProfile();
             modules.emailPreferences();
+            modules.deleteAccount();
             PublicProfile.init();
 
             mediator.emit('page:identity:ready', config);

--- a/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
@@ -1,0 +1,19 @@
+define([
+    'lib/$',
+    'bean'
+], function (
+    $,
+    bean
+) {
+    function setupLoadingAnimation() {
+        bean.on($('#deleteForm')[0], 'submit', function() {
+            $('#deleteLoader')[0].classList.remove("is-hidden");
+        });
+    }
+
+    return {
+        init: function () {
+            setupLoadingAnimation();
+        }
+    };
+});

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -422,3 +422,12 @@
     float: none;
     min-width: $gs-baseline * 14;
 }
+
+/* Delete Account page
+   ========================================================================== */
+
+.inline-loading {
+    display: inline-block;
+    margin-top: 0;
+    vertical-align: middle;
+}


### PR DESCRIPTION
## What does this change?

Shows a loader animation after user presses delete account button.

## What is the value of this and can you measure success?

Account deletion is not an instantaneous operation so a loader animation provides visual feedback to the user that the system is still processing the request.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/13835317/26725242/82927802-4795-11e7-905c-89cfc4f26c40.png)
