### PR TITLE
Add AMP liveblog switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -336,10 +336,20 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val AmpSwitch = Switch(
+  val AmpArticleSwitch = Switch(
     SwitchGroup.Feature,
-    "amp-switch",
+    "amp-article-switch",
     "If this switch is on, link to amp pages will be in the metadata for articles",
+    owners = Seq(Owner.withGithub("NataliaLKB")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+  val AmpLiveBlogSwitch = Switch(
+    SwitchGroup.Feature,
+    "amp-liveblog-switch",
+    "If this switch is on, link to amp pages will be in the metadata for liveblogs",
     owners = Seq(Owner.withGithub("NataliaLKB")),
     safeState = On,
     sellByDate = never,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -81,6 +81,10 @@ final case class Content(
   lazy val isPaidContent: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
   lazy val campaigns: List[Campaign] = _root_.commercial.targeting.CampaignAgent.getCampaignsForTags(tags.tags.map(_.id))
 
+  lazy val isAmpSupportedArticleType: Boolean = (tags.isArticle && !tags.isLiveBlog) && !isImmersive && !tags.isQuiz
+  lazy val shouldAmpifyArticles: Boolean = isAmpSupportedArticleType && AmpArticleSwitch.isSwitchedOn
+  lazy val shouldAmpifyLiveblogs: Boolean = tags.isLiveBlog && AmpLiveBlogSwitch.isSwitchedOn
+
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
       case (Some(t), Some(b)) => tags.contributors.length == 1 && t.name == b

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -1,4 +1,3 @@
-@import model.Article
 @(page: model.Page, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.{AnalyticsHost, _}

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -6,7 +6,7 @@
 @import model.meta.LinkedData
 @import model.Page
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{ComscoreSwitch, SmartAppBanner}
 @import play.api.Mode.Dev
 
 @* Critical meta data that have an impact on rendering speed *@
@@ -42,10 +42,8 @@
 
     @Page.getContentPage(page).map { page =>
         @if(
-            page.item.tags.isArticle &&
-            !page.item.content.isImmersive &&
-            !page.item.tags.isQuiz &&
-            AmpSwitch.isSwitchedOn
+            page.item.content.shouldAmpifyArticles ||
+            page.item.content.shouldAmpifyLiveblogs
         ) {
             <link rel="amphtml" href="@AmpLinkTo{/@page.metadata.id}">
         }


### PR DESCRIPTION
## What does this change?
Trello task: https://trello.com/c/hFHxHPsl/316-add-a-switch-to-control-amp%27ification-of-liveblogs

For the election, we want to be able to turn off ampification of liveblogs as the embed used would be valid AMP, but not look great.

In the end though, this would be a useful switch to have and so we should keep it as a permanent feature switch.

## What is the value of this and can you measure success?
Election night the page won't look as bad

## Does this affect other platforms - Amp, Apps, etc?
Only affects AMP

## Screenshots
Nope

## Tested in CODE?
- [ ] .

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
