### PR TITLE
Fix redirection bug in account deletion

### DIFF
--- a/identity/app/controllers/AccountDeletionController.scala
+++ b/identity/app/controllers/AccountDeletionController.scala
@@ -42,6 +42,7 @@ class AccountDeletionController(
   import views.html.profile.deletion._
 
   val page = IdentityPage("/deletion", "Account Deletion")
+  val pageConfirm = IdentityPage("/deletion/confirm", "Account Deletion Confirmation")
 
   val accountDeletionForm = Form(
     tuple(
@@ -67,6 +68,10 @@ class AccountDeletionController(
     }
   }
 
+  def renderAccountDeletionConfirmation(autoDeletion: Boolean) = Action.async { implicit request =>
+    Future(NoCache(Ok(accountDeletionConfirm(pageConfirm, autoDeletion))))
+  }
+
   private def deleteAccount[A](
       boundForm: Form[(String, Option[String])],
       emailPasswdAuth: EmailPassword,
@@ -86,7 +91,7 @@ class AccountDeletionController(
 
         case Right(deletionResult) =>
           logger.info(s"Account deletion succeeded for user ${request.user.user.id}: $deletionResult")
-          Ok(accountDeletionConfirm(page, deletionResult.auto == "true"))
+          SeeOther(routes.AccountDeletionController.renderAccountDeletionConfirmation(deletionResult.auto == "true").url)
       }
     }
 }

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -50,3 +50,4 @@ OPTIONS    /email                                                               
 # Account deletion
 GET         /delete                                 controllers.AccountDeletionController.renderAccountDeletionForm
 POST        /delete                                 controllers.AccountDeletionController.processAccountDeletionForm
+GET         /delete/confirm                         controllers.AccountDeletionController.renderAccountDeletionConfirmation(autoDeletion: Boolean)


### PR DESCRIPTION
## What does this change?

After successful POST, it redirects to account deletion confirmation page which is not behind authentication.

## What is the value of this and can you measure success?

This fixes an issue where the users would not see the account deletion confirmation page after deletion. 
