### PR TITLE
Guarantee the lazy-load observer will be registered for every Advert

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -31,7 +31,9 @@ const displayLazyAds = (): void => {
     window.googletag.pubads().collapseEmptyDivs();
     window.googletag.enableServices();
     instantLoad();
-    enableLazyLoad();
+    dfpEnv.advertsToLoad.forEach((advert: Advert): void => {
+        enableLazyLoad(advert);
+    });
 };
 
 export { displayLazyAds };

--- a/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
@@ -8,21 +8,19 @@ import { onIntersect, onScroll } from 'commercial/modules/dfp/lazy-load';
 /* observer: IntersectionObserver?. The observer used to detect when ad slots enter the viewport */
 let observer: window.IntersectionObserver = null;
 
-const enableLazyLoad = (advert?: Advert): void => {
+const enableLazyLoad = (advert: Advert): void => {
     if (!dfpEnv.lazyLoadEnabled) {
         dfpEnv.lazyLoadEnabled = true;
         if (dfpEnv.lazyLoadObserve) {
             observer = new window.IntersectionObserver(onIntersect, {
                 rootMargin: '200px 0%',
             });
-            dfpEnv.advertsToLoad.forEach((ad: Object): void => {
-                observer.observe(ad.node);
-            });
         } else {
             mediator.on('window:throttledScroll', onScroll);
             onScroll();
         }
-    } else if (dfpEnv.lazyLoadObserve && advert) {
+    }
+    if (dfpEnv.lazyLoadObserve) {
         observer.observe(advert.node);
     }
 };


### PR DESCRIPTION
Another race condition, unrelated to the previous one. The `enableLazyLoad()` [sic, nor arg] was clearly intended to be used once, to initialise the observer. But it was also assumed to be the first `enableLazyLoad` call. If a dynamic ad slot is created quick enough to call `enableLazyLoad(advert)` first, and the no-arg call follows second, then the `advertsToLoad` array is skipped; none of the adverts in the array will be observed.

A simple fix is to remove the `?` call signature in-situ, into `display-lazy-ads`.