### PR TITLE
Logic added to change UK election thrasher depending on user

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -215,7 +215,7 @@ trait ABTestSwitches {
     "Bootstrap the AB test framework to show a different UK election thrasher to supporters/non-supporters respectively",
     owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("joelochlann")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 6, 26),
+    sellByDate = new LocalDate(2017, 7, 3),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -208,4 +208,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 6, 19),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-thrasher-uk-election",
+    "Bootstrap the AB test framework to show a different UK election thrasher to supporters/non-supporters respectively",
+    owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("joelochlann")),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 6, 26),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -347,7 +347,7 @@ define([
         },
         getControlTestimonialBlock: getControlTestimonialBlock,
         variantBuilderFactory: variantBuilderFactory,
-        daysSinceLastContribution: daysSinceLastContribution
+        daysSinceLastContribution: daysSinceLastContribution,
         isContributor: isContributor
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -47,6 +47,8 @@ define([
 
     var lastContributionDate = cookies.getCookie('gu.contributions.contrib-timestamp');
 
+    var isContributor = !!lastContributionDate;
+
     /**
      * How many times the user can see the Epic, e.g. 6 times within 7 days with minimum of 1 day in between views.
      * @type {{days: number, count: number, minDaysBetweenViews: number}}
@@ -346,5 +348,6 @@ define([
         getControlTestimonialBlock: getControlTestimonialBlock,
         variantBuilderFactory: variantBuilderFactory,
         daysSinceLastContribution: daysSinceLastContribution
+        isContributor: isContributor
     };
 });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -39,10 +39,11 @@ define([
         })
     }
 
-    function getReaderSpecificUkElectionThrasherClass() {
+    function getReaderSpecificUkElectionThrasherClassList() {
         // There are eight variants of the thank you thrasher prefixed by -0, -1, -2, ..., -7
-        var modifier = isThankYouVariantReader() ? "thanks-" + getThrasherViewedCount() % 8 : "ask";
-        return UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + modifier;
+        var viewCountClass = UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + getThrasherViewedCount() % 8;
+        var thrasherVariantClass =  UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + isThankYouVariantReader() ? "thanks" : "ask";
+        return viewCountClass + " " + thrasherVariantClass
     }
 
     function onThrasherViewed(callback) {
@@ -76,7 +77,7 @@ define([
                     id: 'control',
 
                     test: function() {
-                        $ukElectionThrasher.addClass(getReaderSpecificUkElectionThrasherClass())
+                        $ukElectionThrasher.addClass(getReaderSpecificUkElectionThrasherClassList())
                     },
 
                     impression: function(callback) {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -31,18 +31,26 @@ define([
         return userFeatures.isPayingMember() || contributionUtilities.isContributor
     }
 
+    function getThrasherVariant() {
+        return isThankYouVariantReader() ? "thanks" : "ask"
+    }
+
+    function getThrasherCampaignCode() {
+        return "gdnwb_copts_memco_thrasher_uk_election_" + getThrasherVariant()
+    }
+
     function recordThrasherVariant() {
         // Enables the conversion rate of the ask variant to be calculated.
         ophan.record({
-            component: 'uk_election_thrasher_variant',
-            value: isThankYouVariantReader() ? "thank_you" : "ask"
+            component: 'uk_election_thrasher_campaign_code',
+            value: getThrasherCampaignCode()
         })
     }
 
     function getReaderSpecificUkElectionThrasherClassList() {
         // There are eight variants of the thank you thrasher prefixed by -0, -1, -2, ..., -7
         var viewCountClass = UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + getThrasherViewedCount() % 8;
-        var thrasherVariantClass =  UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + (isThankYouVariantReader() ? "thanks" : "ask");
+        var thrasherVariantClass = UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + getThrasherVariant();
         return viewCountClass + " " + thrasherVariantClass
     }
 
@@ -56,7 +64,7 @@ define([
 
             this.id = 'AcquisitionsThrasherUkElection';
 
-            this.start = '2017-06-02';
+            this.start = '2017-06-06';
             this.expiry = '2017-07-03';
 
             this.author = 'Guy Dawson and Joe Smith';

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -18,11 +18,11 @@ define([
     var UK_ELECTION_THRASHER_BLOCK_ELEMENT = "election-supporters__wrapper";
 
     function getThrasherViewedCount() {
-        return parseInt(storage.get(UK_ELECTION_THRASHER_VIEW_COUNTER)) || 0;
+        return parseInt(storage.local.get(UK_ELECTION_THRASHER_VIEW_COUNTER)) || 0;
     }
 
     function incrementThrasherViewedCount() {
-        storage.set(UK_ELECTION_THRASHER_VIEW_COUNTER, getThrasherViewedCount() + 1)
+        storage.local.set(UK_ELECTION_THRASHER_VIEW_COUNTER, getThrasherViewedCount() + 1)
     }
 
     var $ukElectionThrasher =  $("." + UK_ELECTION_THRASHER_BLOCK_ELEMENT);
@@ -42,7 +42,7 @@ define([
     function getReaderSpecificUkElectionThrasherClassList() {
         // There are eight variants of the thank you thrasher prefixed by -0, -1, -2, ..., -7
         var viewCountClass = UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + getThrasherViewedCount() % 8;
-        var thrasherVariantClass =  UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + isThankYouVariantReader() ? "thanks" : "ask";
+        var thrasherVariantClass =  UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + (isThankYouVariantReader() ? "thanks" : "ask");
         return viewCountClass + " " + thrasherVariantClass
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -1,0 +1,98 @@
+define([
+    'lib/$',
+    'lib/element-inview',
+    'lib/storage',
+    'commercial/modules/user-features',
+    'common/modules/commercial/contributions-utilities',
+    'ophan/ng'
+], function (
+    $,
+    elementInView,
+    storage,
+    userFeatures,
+    contributionUtilities,
+    ophan
+) {
+
+    var UK_ELECTION_THRASHER_VIEW_COUNTER = "gu.uk-election-thrasher.views";
+    var UK_ELECTION_THRASHER_BLOCK_ELEMENT = "election-supporters__wrapper";
+
+    function getThrasherViewedCount() {
+        return parseInt(storage.get(UK_ELECTION_THRASHER_VIEW_COUNTER)) || 0;
+    }
+
+    function incrementThrasherViewedCount() {
+        storage.set(UK_ELECTION_THRASHER_VIEW_COUNTER, getThrasherViewedCount() + 1)
+    }
+
+    var $ukElectionThrasher =  $("." + UK_ELECTION_THRASHER_BLOCK_ELEMENT);
+
+    function isThankYouVariantReader() {
+        return userFeatures.isPayingMember() || contributionUtilities.isContributor
+    }
+
+    function recordThrasherVariant() {
+        // Enables the conversion rate of the ask variant to be calculated.
+        ophan.record({
+            component: 'uk_election_thrasher_variant',
+            value: isThankYouVariantReader() ? "thank_you" : "ask"
+        })
+    }
+
+    function getReaderSpecificUkElectionThrasherClass() {
+        // There are eight variants of the thank you thrasher prefixed by -0, -1, -2, ..., -7
+        var modifier = isThankYouVariantReader() ? "thanks-" + getThrasherViewedCount() % 8 : "ask";
+        return UK_ELECTION_THRASHER_BLOCK_ELEMENT + "--" + modifier;
+    }
+
+    function onThrasherViewed(callback) {
+        // Safe selecting from array - function will only be called if length of array element is positive.
+        // Element in view logic taken from contribution utilities.
+        elementInView($ukElectionThrasher[0], window, { top: 18 }).on('firstview', callback())
+    }
+
+    return function() {
+
+            this.id = 'AcquisitionsThrasherUkElection';
+
+            this.start = '2017-06-02';
+            this.expiry = '2017-07-03';
+
+            this.author = 'Guy Dawson and Joe Smith';
+            this.description = 'Bootstrap the AB test framework to show a different UK election thrasher to supporters/non-supporters respectively';
+            this.successMeasure = 'Conversion rate - contributions and supporter sign ups / thrasher views';
+            this.idealOutcome = 'The thrasher drives acquisition';
+
+            this.audienceCriteria = 'All';
+            this.audience = 1;
+            this.audienceOffset = 0;
+
+            this.canRun = function() {
+                return $ukElectionThrasher.length > 0
+            };
+
+            this.variants = [
+                {
+                    id: 'control',
+
+                    test: function() {
+                        $ukElectionThrasher.addClass(getReaderSpecificUkElectionThrasherClass())
+                    },
+
+                    impression: function(callback) {
+                        // Fire callback on initialisation.
+                        // This method is only being overridden so the thrasher variant can be recorded.
+                        callback();
+                        recordThrasherVariant()
+                    },
+
+                    success: function(callback) {
+                        onThrasherViewed(function() {
+                            callback();
+                            incrementThrasherViewedCount()
+                        })
+                    }
+                }
+            ]
+    }
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -15,6 +15,7 @@ define([
 ) {
 
     var UK_ELECTION_THRASHER_VIEW_COUNTER = "gu.uk-election-thrasher.views";
+
     var UK_ELECTION_THRASHER_BLOCK_ELEMENT = "election-supporters__wrapper";
 
     function getThrasherViewedCount() {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -23,6 +23,8 @@ import AcquisitionsEpicElectionInteractiveEnd
     from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
 import AcquisitionsEpicElectionInteractiveSlice
     from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-slice';
+import AcquisitionsThrasherUkElection
+    from 'common/modules/experiments/tests/acquisitions-thrasher-uk-election';
 
 export const TESTS: Array<ABTest> = [
     new OpinionEmailVariants(),
@@ -34,6 +36,7 @@ export const TESTS: Array<ABTest> = [
     ExplainerSnippet(),
     new AcquisitionsEpicElectionInteractiveEnd(),
     new AcquisitionsEpicElectionInteractiveSlice(),
+    new AcquisitionsThrasherUkElection(),
 ]
     .concat(MembershipEngagementBannerTests)
     .filter(Boolean);


### PR DESCRIPTION
cc @guardian/contributions 

__NB__: _do not merge until tested in code_

## What does this change?

Bootstraps the AB testing framework to update the UK Election thrasher depending on whether the reader is either a supporter or contributor, or neither of these.

## What is the value of this and can you measure success?

Allows current supporters and contributors to be thanked; provides another channel for readers who aren't supporters or who haven't contributed to do so.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

_Coming soon..._

## Tested in CODE?

No