### PR TITLE
Add check for shouldShowAds before adding slots to AMP liveblog pages

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -1,4 +1,5 @@
 @import model.{Article, LiveBlogPage, LatestBlock}
+@import views.support.Commercial.{shouldShowAds}
 
 @(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
@@ -11,7 +12,7 @@
         @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp = true)
 
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
-        @if(blockGroup.length == 5 && index < 8) {
+        @if(shouldShowAds(model) && blockGroup.length == 5 && index < 8) {
             <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick"
                 data-loading-strategy="prefer-viewability-over-views"


### PR DESCRIPTION
## What does this change?

Stop showing ads on AMP liveblogs if shouldShowAds is false

## What is the value of this and can you measure success?

Pages such as: https://www.theguardian.com/uk-news/live/2017/may/22/manchester-arena-ariana-grande-concert-explosion-england are (currently) marked as sensitive and should not display ads.

The amp version of this page can be seen to be showing ads:
https://amp.theguardian.com/uk-news/live/2017/may/22/manchester-arena-ariana-grande-concert-explosion-england

Ads should only appear where they are supposed to.

## Does this affect other platforms - Amp, Apps, etc?

Only AMP

## Screenshots

##### BEFORE:

<img width="590" alt="picture 773" src="https://cloud.githubusercontent.com/assets/8607683/26731161/0f59354a-47ab-11e7-84fe-1df0cc4b5959.png">

##### AFTER:

<img width="580" alt="picture 774" src="https://cloud.githubusercontent.com/assets/8607683/26731171/166f2baa-47ab-11e7-8a1e-c37b98bd8ef7.png">

## Tested in CODE?

No.. @NataliaLKB @SiAdcock, do you think it is necessary?

- make validate-amp passes
- I'm seeing some local console errors relating to `<amp-pixel>`, however, these predate my change and are present on the master branch too:

<img width="728" alt="picture 775" src="https://cloud.githubusercontent.com/assets/8607683/26731384/d9b4e3e8-47ab-11e7-9cc6-8a1da28e6d51.png">
