### PR TITLE
Make testimonials the default on the pre-election test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-pre-election.js
@@ -27,13 +27,10 @@ define([
         idealOutcome: 'We are able to determine which message has a higher conversion rate',
         locations: ['GB'],
         audienceCriteria: 'All',
-        audience: 0.5,
-        audienceOffset: 0.5,
+        audience: 1,
+        audienceOffset: 0,
 
         variants: [
-            {
-                id: 'control'
-            },
             {
                 id: 'testimonial',
                 template: function(variant) {
@@ -45,22 +42,6 @@ define([
                         p1: '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help, especially during this UK election.',
                         testimonialMessage: 'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible, independent check on the government, this contribution was pretty good value for money.',
                         testimonialName: 'Jack H.'
-                    })
-                }
-            },
-            {
-                id: 'election',
-                template:  function(variant) {
-                    return template(acquisitionsEpicTestTemplate, {
-                        title: 'Since you’re here &hellip;',
-                        membershipUrl: variant.options.membershipURL,
-                        contributionUrl: variant.options.contributeURL,
-                        componentName: variant.options.componentName,
-                        p1: '&hellip; we have a small favour to ask. Whoever wins the UK election, we promise to hold them to account with facts you can trust and opinions you can believe in. But advertising revenues are falling and <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.',
-                        p2: 'If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.',
-                        p3: '',
-                        cta1: 'Become a supporter',
-                        cta2: 'Make a contribution'
                     })
                 }
             }


### PR DESCRIPTION
## What does this change?

This puts the pre election test to 100% and removes the losing variants. This will essentially overrride ask4earning 

This PR pulls the epic copy into it's own module

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
<img width="651" alt="testimonial" src="https://cloud.githubusercontent.com/assets/2844554/26735650/b28369c0-47ba-11e7-83a8-4692bf1e26d3.png">

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
