### PR TITLE
Tweaking CAPI circuit breaker settings

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -195,9 +195,9 @@ class GuardianConfiguration extends Logging {
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
     lazy val timeout: FiniteDuration = Duration.create(configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000), MILLISECONDS)
 
-    lazy val circuitBreakerErrorThreshold: Int = configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(50)
+    lazy val circuitBreakerErrorThreshold: Int = configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(30)
     lazy val circuitBreakerResetTimeout: FiniteDuration =
-      FiniteDuration(configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(3000), MILLISECONDS)
+      FiniteDuration(configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(2000), MILLISECONDS)
 
     lazy val previewAuth: Option[Auth] = for {
       user <- configuration.getStringProperty("content.api.preview.user")


### PR DESCRIPTION
## What does this change?
Lowering circuit breaker max failures and timeout.

In case of slow but still functioning CAPI, the circuit breaker was
timing out but was not getting open because enough successful requests
were going through.
This patch is an attempt to make the circuit breaker more responsive to
this use case

## What is the value of this and can you measure success?
Adapting quicker to CAPI slow down to avoid snowball effect

## Tested in CODE?
No