### PR TITLE
Add This Land Is Your Land epic tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -101,6 +101,36 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-this-land-series-epic",
+    "This places a custom Epic at the ehnd of This Land Is Your Land articles",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-this-land-environment-epic-earning",
+    "This places a custom Epic at the ennd of environment articles",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-this-land-environment-epic-learning",
+    "This places a custom Epic at the ennd of environment articles",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-liveblog-design-test",
     "This tests some different designs of the liveblog epic",
     owners = Seq(Owner.withGithub("joelochlann")),

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -93,8 +93,8 @@ define([
     }
 
     function defaultCanEpicBeDisplayed(testConfig) {
-        var enoughTimeSinceLastContribution =
-            testConfig.showToContributors ? true : daysSince(lastContributionDate) >= 180;
+        var enoughTimeSinceLastContribution = testConfig.showToContributors || daysSince(lastContributionDate) >= 180;
+        var canReasonablyAskForMoney = testConfig.showToSupporters || commercialFeatures.commercialFeatures.canReasonablyAskForMoney;
 
         var worksWellWithPageTemplate = (typeof testConfig.pageCheck === 'function')
             ? testConfig.pageCheck(config.page)
@@ -109,9 +109,6 @@ define([
         var isImmersive = config.page.isImmersive === true;
 
         var tagsMatch = doTagsMatch(testConfig);
-
-        var canReasonablyAskForMoney =
-            testConfig.showToSupporters ? true : commercialFeatures.commercialFeatures.canReasonablyAskForMoney;
 
         return enoughTimeSinceLastContribution &&
             canReasonablyAskForMoney &&

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-environment-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-environment-earning.js
@@ -1,0 +1,40 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lodash/utilities/template',
+    'raw-loader!common/views/acquisitions-epic-iframe.html',
+], function (contributionsUtilities, template, iframeTemplate) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsThisLandEnvironmentEpicEarning',
+        campaignId: 'this_land_epic_bottom_environment',
+
+        start: '2017-06-02',
+        expiry: '2017-08-01',
+
+        author: 'Sam Desborough',
+        description: 'Display a custom Epic on environment articles',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Lots of supporters and contributions',
+        audienceCriteria: 'US',
+        locations: ['US'],
+        audience: 0.7,
+        audienceOffset: 0,
+        showForSensitive: true,
+        useTargetingTool: true,
+
+        variants: [
+            {
+                id: 'earning',
+                isUnlimited: true,
+                template: function (variant) {
+                    return template(iframeTemplate, {
+                        componentName: variant.options.componentName,
+                        id: variant.options.iframeId,
+                        iframeUrl: 'https://interactive.guim.co.uk/embed/2017/05/this-land-is-your-land/contribute-enviro.html',
+                    })
+                },
+                usesIframe: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-environment-learning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-environment-learning.js
@@ -1,0 +1,45 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lodash/utilities/template',
+    'raw-loader!common/views/acquisitions-epic-iframe.html',
+], function (contributionsUtilities, template, iframeTemplate) {
+
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsThisLandEnvironmentEpicLearning',
+        campaignId: 'this_land_epic_bottom_environment',
+
+        start: '2017-06-02',
+        expiry: '2017-08-01',
+
+        author: 'Sam Desborough',
+        description: 'Display a custom Epic on environment articles',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Lots of supporters and contributions',
+        audienceCriteria: 'US',
+        locations: ['US'],
+        audience: 0.3,
+        audienceOffset: 0.7,
+        showForSensitive: true,
+        showToContributors: true,
+        showToSupporters: true,
+        useTargetingTool: true,
+
+        variants: [
+            {
+                id: 'control'
+            },
+            {
+                id: 'environment',
+                isUnlimited: true,
+                template: function (variant) {
+                    return template(iframeTemplate, {
+                        componentName: variant.options.componentName,
+                        id: variant.options.iframeId,
+                        iframeUrl: 'https://interactive.guim.co.uk/embed/2017/05/this-land-is-your-land/contribute-enviro.html',
+                    })
+                },
+                usesIframe: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-series.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-this-land-series.js
@@ -1,0 +1,43 @@
+define([
+    'common/modules/commercial/contributions-utilities',
+    'lodash/utilities/template',
+    'raw-loader!common/views/acquisitions-epic-iframe.html',
+], function (contributionsUtilities, template, iframeTemplate) {
+    return contributionsUtilities.makeABTest({
+        id: 'AcquisitionsThisLandSeriesEpic',
+        campaignId: 'this_land_epic_bottom_series',
+
+        start: '2017-06-02',
+        expiry: '2017-08-01',
+
+        author: 'Sam Desborough',
+        description: 'Display a custom Epic on This Land Is Your Land articles',
+        successMeasure: 'Conversion rate',
+        idealOutcome: 'Lots of supporters and contributions',
+
+        audienceCriteria: 'All',
+        audience: 1,
+        audienceOffset: 0,
+
+        showForSensitive: true,
+        showToContributors: true,
+        showToSupporters: true,
+
+        useTargetingTool: true,
+
+        variants: [
+            {
+                id: 'control',
+                isUnlimited: true,
+                template: function(variant) {
+                    return template(iframeTemplate, {
+                        componentName: variant.options.componentName,
+                        id: variant.options.iframeId,
+                        iframeUrl: 'https://interactive.guim.co.uk/embed/2017/05/this-land-is-your-land/contribute-series.html',
+                    })
+                },
+                usesIframe: true
+            }
+        ]
+    });
+});

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -23,11 +23,21 @@ import acquisitionsEpicAlwaysAskIfTagged
 import acquisitionsEpicTestimonialsUSA
     from 'common/modules/experiments/tests/acquisitions-epic-testimonials-usa';
 
+import acquisitionsThisLandSeries
+    from 'common/modules/experiments/tests/acquisitions-this-land-series';
+import acquisitionsThisLandEnvironmentEarning
+    from 'common/modules/experiments/tests/acquisitions-this-land-environment-earning';
+import acquisitionsThisLandEnvironmentLearning
+    from 'common/modules/experiments/tests/acquisitions-this-land-environment-learning';
+
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests = [
     alwaysAsk,
+    acquisitionsThisLandSeries,
+    acquisitionsThisLandEnvironmentEarning,
+    acquisitionsThisLandEnvironmentLearning,
     acquisitionsEpicPreElection,
     acquisitionsEpicTestimonialsUSA,
     askFourEarning,

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-iframe.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-iframe.html
@@ -1,0 +1,5 @@
+<iframe src="<%=iframeUrl %>"
+        data-component="<%=componentName%>"
+        class="acquisitions-epic-iframe"
+        id="<%=id%>">
+</iframe>

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -240,3 +240,8 @@
     vertical-align: middle;
 }
 
+.acquisitions-epic-iframe {
+    border: 0;
+    width: 100%;
+    max-width: 620px;
+}


### PR DESCRIPTION
## What does this change?
Adds three new tests: 

* one that targets the "this land is your land" series, to a global audience (1 variant)
* one that targets the `environment` tag, to 70% of the US audience (1 variant) 
* one that targets the `environment` tag to 30% of the US audience (2 variants, the new design and the standard Epic control) 

I've also made a few changes to `contributions-utilities`, mainly to support resizing iframe containers and to add a couple of flags to run tests against existing supporters/contributors (a requirement here). 

## What is the value of this and can you measure success?
The first two tests show a new version of the Epic on applicable articles. The third test is so we can compare the performance of the new design to the control.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-06-05 at 12 29 21](https://cloud.githubusercontent.com/assets/1064734/26782451/95aa3b0c-49eb-11e7-9b6b-81510406afc1.png)
![screen shot 2017-06-05 at 12 29 08](https://cloud.githubusercontent.com/assets/1064734/26782452/95aa75ae-49eb-11e7-989c-019248661244.png)
![screen shot 2017-06-05 at 12 19 45](https://cloud.githubusercontent.com/assets/1064734/26782453/95ac2476-49eb-11e7-9fd8-8f611bca239f.png)

@guardian/contributions 