### PR TITLE
fix audience and audience offset

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -44,8 +44,8 @@ define([
         successMeasure: 'N/A',
         idealOutcome: 'N/A',
         audienceCriteria: 'Readers who have supported the Guardian',
-        audience: 0,
-        audienceOffset: 1,
+        audience: 1,
+        audienceOffset: 0,
 
         overrideCanRun: true,
 


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Corrects the audience offset values for the AB test implemented in pull request #16969.

## What is the value of this and can you measure success?

Means the test will work as intended.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No, tested locally.
