### PR TITLE
Extend Guardian Today US advertisements feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -482,7 +482,7 @@ trait FeatureSwitches {
     "When ON, the Guardian Today US Email will contain Live Intent advertisements",
     owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 6, 6),
+    sellByDate = new LocalDate(2017, 8, 8),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extends the switch which enables/disables MPU in Guardian Today US email

## What is the value of this and can you measure success?

Allows us to continue to explore making money from emails

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

n/a

## Tested in CODE?

no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
