### PR TITLE
Disable button on submitting account deletion form

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -123,7 +123,7 @@
                                 (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
 
                             <li>
-                                <button type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
+                                <button id="deleteButton" type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
                                 <div id="deleteLoader" class="loading-animation is-updating inline-loading is-hidden"></div>
                             </li>
                         </ul>

--- a/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
@@ -5,17 +5,21 @@ define([
     $,
     bean
 ) {
+    var deleteButtonElm = $('#deleteButton')[0];
+    var deleteFormElm = $('#deleteForm')[0];
+    var deleteLoaderElm = $('#deleteLoader')[0];
+
     function disableDeleteButton() {
-        $('#deleteButton')[0] && ($('#deleteButton')[0].disabled = true);
+        deleteButtonElm && (deleteButtonElm.disabled = true);
     }
 
     function showLoader() {
-        $('#deleteLoader')[0] && $('#deleteLoader')[0].classList.remove("is-hidden");
+        deleteLoaderElm && deleteLoaderElm.classList.remove("is-hidden");
     }
 
     function setupLoadingAnimation() {
-        if ($('#deleteForm')[0] && $('#deleteLoader')[0]) {
-            bean.on($('#deleteForm')[0], 'submit', function() {
+        if (deleteFormElm && deleteLoaderElm) {
+            bean.on(deleteFormElm, 'submit', function() {
                 disableDeleteButton();
                 showLoader();
             });

--- a/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
@@ -1,20 +1,26 @@
 define([
     'lib/$',
-    'bean'
+    'bean',
+    'fastdom'
 ], function (
     $,
-    bean
+    bean,
+    fastdom
 ) {
     var deleteButtonElm = $('#deleteButton')[0];
     var deleteFormElm = $('#deleteForm')[0];
     var deleteLoaderElm = $('#deleteLoader')[0];
 
     function disableDeleteButton() {
-        deleteButtonElm && (deleteButtonElm.disabled = true);
+        fastdom.write(function () {
+            deleteButtonElm && (deleteButtonElm.disabled = true);
+        });
     }
 
     function showLoader() {
-        deleteLoaderElm && deleteLoaderElm.classList.remove("is-hidden");
+        fastdom.write(function () {
+            deleteLoaderElm && deleteLoaderElm.classList.remove("is-hidden");
+        });
     }
 
     function setupLoadingAnimation() {

--- a/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts-legacy/projects/common/modules/identity/delete-account.js
@@ -5,10 +5,19 @@ define([
     $,
     bean
 ) {
+    function disableDeleteButton() {
+        $('#deleteButton')[0] && ($('#deleteButton')[0].disabled = true);
+    }
+
+    function showLoader() {
+        $('#deleteLoader')[0] && $('#deleteLoader')[0].classList.remove("is-hidden");
+    }
+
     function setupLoadingAnimation() {
-        if ($('#deleteForm').length && $('#deleteLoader').length) {
+        if ($('#deleteForm')[0] && $('#deleteLoader')[0]) {
             bean.on($('#deleteForm')[0], 'submit', function() {
-                $('#deleteLoader')[0].classList.remove("is-hidden");
+                disableDeleteButton();
+                showLoader();
             });
         }
     }

--- a/static/src/stylesheets/pasteup/forms/_styles.scss
+++ b/static/src/stylesheets/pasteup/forms/_styles.scss
@@ -247,10 +247,18 @@
     width: 13px;
 }
 
+$delete-warn-red: #b20a0a;
+
 .delete-input-warn {
-    background: #b20a0a;
+    background: $delete-warn-red;
     &:hover,
     &:focus {
-        background: darken(#b20a0a, 5%);
+        background: darken($delete-warn-red, 5%);
     }
+}
+
+.delete-input-warn[disabled] {
+    background: lighten($delete-warn-red, 5%);
+    opacity: .6;
+    pointer-events: none;
 }

--- a/static/src/stylesheets/pasteup/forms/_styles.scss
+++ b/static/src/stylesheets/pasteup/forms/_styles.scss
@@ -247,18 +247,16 @@
     width: 13px;
 }
 
-$delete-warn-red: #b20a0a;
-
 .delete-input-warn {
-    background: $delete-warn-red;
+    background-color: $live-main-1;
     &:hover,
     &:focus {
-        background: darken($delete-warn-red, 5%);
+        background-color: darken($live-main-1, 5%);
     }
 }
 
 .delete-input-warn[disabled] {
-    background: lighten($delete-warn-red, 5%);
+    background-color: lighten($live-main-1, 5%);
     opacity: .6;
     pointer-events: none;
 }


### PR DESCRIPTION
## What does this change?

Disables the button when the users submits the form to delete the account. 

## What is the value of this and can you measure success?

Prevents the user from submitting the form multiple times.

## Screenshots

![delete_account_button_disable](https://cloud.githubusercontent.com/assets/13835317/26786209/b6fed6e8-49fd-11e7-9ce6-1fc25757af9e.gif)