### PR TITLE
Add the MVT header value into the config object.

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -22,9 +22,10 @@ object CommercialGalleryBannerAds extends TestDefinition(
   owners = Seq(Owner.withGithub("JonNorman")),
   sellByDate = new LocalDate(2017, 6, 6)
 ) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-commercial-gallery-banner-ads").contains("variant")
-  }
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-commercial-gallery-banner-ads")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.isDefined
 }
 
 object CommercialClientLoggingVariant extends TestDefinition(
@@ -33,9 +34,10 @@ object CommercialClientLoggingVariant extends TestDefinition(
   owners = Seq(Owner.withGithub("rich-nguyen")),
   sellByDate = new LocalDate(2018, 2, 1)
   ) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ccl").contains("ccl-A")
-  }
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ccl")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("ccl-A")
 }
 
 object ABNewDesktopHeader extends TestDefinition(
@@ -44,9 +46,10 @@ object ABNewDesktopHeader extends TestDefinition(
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
   sellByDate = new LocalDate(2017, 7, 5)
 ) {
-  def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-desktop-header").contains("variant")
-  }
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
 }
 
 trait ServerSideABTests {
@@ -55,7 +58,7 @@ trait ServerSideABTests {
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     tests
       .filter(_.isParticipating)
-      .map { test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}""" }
+      .map { test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}:${test.participationGroup.getOrElse("")}""" }
       .mkString(",")
   }
 }
@@ -88,5 +91,6 @@ abstract case class TestDefinition (
 
   def canRun(implicit request: RequestHeader): Boolean
   def isParticipating(implicit request: RequestHeader): Boolean = isSwitchedOn && canRun(request)
+  def participationGroup(implicit request: RequestHeader): Option[String]
 
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -60,11 +60,9 @@ trait ServerSideABTests {
     def testStatus(test: TestDefinition): String = {
 
       val safeName: String = CamelCase.fromHyphenated(test.name)
-      val switchStatus: String = test.switch.isSwitchedOn.toString
       val participationGroup: String = test.participationGroup.getOrElse("")
 
-
-      s""""$safeName" : "$switchStatus:$participationGroup""""
+      s""""$safeName" : "$participationGroup""""
     }
 
     tests

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -56,9 +56,20 @@ trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
+
+    def testStatus(test: TestDefinition): String = {
+
+      val safeName: String = CamelCase.fromHyphenated(test.name)
+      val switchStatus: String = test.switch.isSwitchedOn.toString
+      val participationGroup: String = test.participationGroup.getOrElse("")
+
+
+      s""""$safeName" : "$switchStatus:$participationGroup""""
+    }
+
     tests
       .filter(_.isParticipating)
-      .map { test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}:${test.participationGroup.getOrElse("")}""" }
+      .map { testStatus }
       .mkString(",")
   }
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -60,9 +60,10 @@ trait ServerSideABTests {
     def testStatus(test: TestDefinition): String = {
 
       val safeName: String = CamelCase.fromHyphenated(test.name)
-      val participationGroup: String = test.participationGroup.getOrElse("")
 
-      s""""$safeName" : "$participationGroup""""
+      test.participationGroup.fold(s""""$safeName"""") {
+        participationGroup: String => s""""$safeName" : "$participationGroup""""
+      }
     }
 
     tests

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -45,6 +45,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = true
+      def participationGroup(implicit request: RequestHeader): Option[String] = None
     }
     object test1 extends TestDefinition(
       "test1",
@@ -55,6 +56,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       def canRun(implicit request: RequestHeader): Boolean = {
         request.headers.get("X-GU-Test1").contains("test1variant")
       }
+      def participationGroup(implicit request: RequestHeader): Option[String] = None
     }
     object test2 extends TestDefinition(
       "test2",
@@ -65,6 +67,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       def canRun(implicit request: RequestHeader): Boolean = {
         request.headers.get("X-GU-Test2").contains("test2variant")
       }
+      def participationGroup(implicit request: RequestHeader): Option[String] = None
     }
 
     val tests = List(test0, test1, test2)

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -33,7 +33,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
         "X-GU-Test2" -> "test2variant"
       )
     val jsConfig = AllAbTests.getJavascriptConfig(testRequest)
-    jsConfig should be("\"test0\" : true,\"test2\" : true")
+    jsConfig should be(""""test0","test2" : "test2variant"""")
 
   }
 
@@ -54,9 +54,9 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = {
-        request.headers.get("X-GU-Test1").contains("test1variant")
+        participationGroup.contains("test1variant")
       }
-      def participationGroup(implicit request: RequestHeader): Option[String] = None
+      def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-Test1")
     }
     object test2 extends TestDefinition(
       "test2",
@@ -65,9 +65,9 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = {
-        request.headers.get("X-GU-Test2").contains("test2variant")
+        participationGroup.contains("test2variant")
       }
-      def participationGroup(implicit request: RequestHeader): Option[String] = None
+      def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-Test2")
     }
 
     val tests = List(test0, test1, test2)


### PR DESCRIPTION
## Background
Currently when running an MVT, a control and a variant must be set up as separate tests in order to access and identify the page views of each in the data lake.

## What does this change?
This PR aims to simplify this, such that the `variant`/`control` nature of the test participation is exposed in the `guardian.config.tests` object and thus makes its way to the data-lake.

**This is a potentially breaking change depending on how the `tests` object is parsed downstream in the data lake!**

Looking in the `clean.pageview` table, the value for each test in the config object is parsed as a `string`, not a `boolean` and so I don't believe that this will break any type constraints as it gets ingested:

![image](https://cloud.githubusercontent.com/assets/1821099/26788839/632b50ec-4a06-11e7-8db5-ab026b40ae57.png)


Currently the only people with MVTs running (included in `ActiveTests`) are @rich-nguyen ([CommercialClientLoggingVariant](https://github.com/guardian/frontend/blob/master/common/app/mvt/MultiVariateTesting.scala#L65)) and @NataliaLKB ([ABNewDesktopHeader](https://github.com/guardian/frontend/blob/master/common/app/mvt/MultiVariateTesting.scala#L67))

I don't want to disrupt the running of your tests, if it looks like this might then I'll pop over and we can have a chat about how to mitigate that.

## What is the value of this and can you measure success?
Easier to track the results of MVTs.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
**Before**
![image](https://cloud.githubusercontent.com/assets/1821099/26788650/d597706c-4a05-11e7-82b7-32f75adc46ee.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1821099/26788617/bd7855dc-4a05-11e7-9e92-6e18d09b9f80.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
