### PR TITLE
Feedback form - solve quirks created by js fallback

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -28,7 +28,7 @@
                                         <div class="feedback__element">
                                             <label for="feedback-category">Please choose a service below </label>
                                             <select name="category" id="feedback-category" class="feedback__select">
-                                                <option value="nothing">Please choose a selection...</option>
+                                                <option value="nothing">Please choose a category first...</option>
                                                 <option value="feedback-form-account">Help with my Guardian account</option>
                                                 <option value="feedback-form-website">Report a problem/give feedback on your website</option>
                                                 <option value="feedback-form-jobs">Unsubscribe from Jobs alerts/have other issues with my jobs account</option>

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -21,30 +21,61 @@
 
                                     <h2>Contact us</h2>
 
-                                    <div class="feedback__element">
-                                        <label for="feedback-category">Please choose a service below </label>
-                                        <select id="feedback-category" class="feedback__select">
-                                            <option value="nothing">Please choose a selection...</option>
-                                            <option value="feedback-form-account">Help with my Guardian account</option>
-                                            <option value="feedback-form-website">Report a problem/give feedback on your website</option>
-                                            <option value="feedback-form-jobs">Unsubscribe from Jobs alerts/have other issues with my jobs account</option>
-                                            <option value="feedback-form-email">Manage my email preferences</option>
-                                            <option value="feedback-form-membership">Report a Memberships/subscriptions technical issue or give some feedback</option>
-                                            <option value="feedback-form-membership-billing">Membership payment or billing issues</option>
-                                            <option value="feedback-form-subs-billing">Subscriptions payment, billing or fulfillment issues</option>
-                                            <option value="feedback-form-adverts">Feedback about Adverts on your website/apps</option>
-                                            <option value="feedback-form-android">Help with my Android news app</option>
-                                            <option value="feedback-form-ios">Help with my iOS news app</option>
-                                            <option value="feedback-form-daily">Help with the daily edition on my iPad</option>
-                                            <option value="feedback-form-tablet">Help with the daily edition on my Android or Kindle Fire tablet</option>
-                                            <option value="feedback-form-windows">help with my Windows mobile news app</option>
-                                            <option value="feedback-form-editorial">Comment or query about an article</option>
-                                            <option value="feedback-form-discussion">Questions about commenting/moderation/community</option>
-                                            <option value="feedback-form-other">Other</option>
-                                        </select>
-                                    </div>
+                                    <form id="feedback__form" action="tech-feedback/send" method="post">
 
-                                    @fragments.feedbackForms()
+                                        <!-- category dropdown -->
+
+                                        <div class="feedback__element">
+                                            <label for="feedback-category">Please choose a service below </label>
+                                            <select name="category" id="feedback-category" class="feedback__select">
+                                                <option value="nothing">Please choose a selection...</option>
+                                                <option value="feedback-form-account">Help with my Guardian account</option>
+                                                <option value="feedback-form-website">Report a problem/give feedback on your website</option>
+                                                <option value="feedback-form-jobs">Unsubscribe from Jobs alerts/have other issues with my jobs account</option>
+                                                <option value="feedback-form-email">Manage my email preferences</option>
+                                                <option value="feedback-form-membership">Report a Memberships/subscriptions technical issue or give some feedback</option>
+                                                <option value="feedback-form-membership-billing">Membership payment or billing issues</option>
+                                                <option value="feedback-form-subs-billing">Subscriptions payment, billing or fulfillment issues</option>
+                                                <option value="feedback-form-adverts">Feedback about Adverts on your website/apps</option>
+                                                <option value="feedback-form-android">Help with my Android news app</option>
+                                                <option value="feedback-form-ios">Help with my iOS news app</option>
+                                                <option value="feedback-form-daily">Help with the daily edition on my iPad</option>
+                                                <option value="feedback-form-tablet">Help with the daily edition on my Android or Kindle Fire tablet</option>
+                                                <option value="feedback-form-windows">help with my Windows mobile news app</option>
+                                                <option value="feedback-form-editorial">Comment or query about an article</option>
+                                                <option value="feedback-form-discussion">Questions about commenting/moderation/community</option>
+                                                <option value="feedback-form-other">Other</option>
+                                            </select>
+                                        </div>
+
+                                        <!-- hidden blurb -->
+
+                                        @fragments.feedbackForms()
+
+                                        <!-- other form elements -->
+
+                                        <input class="feedback__element" name="extra" type="hidden" value="none available"/>
+
+                                        <div class="feedback__element">
+                                            <label for="fb-desc-entry">Description</label>
+                                            <textarea name="body" id="fb-desc-entry" class="feedback__entry feedback__input--wide feedback__textarea" placeholder="Please provide a description of your problem or feedback" required></textarea>
+                                        </div>
+                                        <div class="feedback__element">
+                                            <label for="fb-name-entry">Name</label>
+                                            <input name="name" class="feedback__entry feedback__input--wide" id="fb-name-entry" type="text" value="" placeholder="Alex Smith" required>
+                                        </div>
+                                        <div class="feedback__element">
+                                            <label for="fb-email-entry">Email</label>
+                                            <input name="user" class="feedback__entry feedback__input--wide" id="fb-email-entry" type="email" value="" placeholder="E.g. alexsmith@@example.com" required>
+                                        </div>
+
+                                        <!-- submit button -->
+
+                                        <div class="feedback__element">
+                                            <button class="button button--large button--primary" id="" type="submit">Submit Feedback</button>
+                                        </div>
+
+                                    </form>
 
                                     <p id="feedback__explainer"></p>
 
@@ -52,7 +83,7 @@
                                         Or email us directly at <a data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a> and someone should get back to you.
                                     </small>
 
-                                </div>
+                                </form>
                             </div>
                         </div>
                     </div>

--- a/onward/app/views/fragments/feedbackForms.scala.html
+++ b/onward/app/views/fragments/feedbackForms.scala.html
@@ -82,6 +82,7 @@
 </div>
 
 <div id="feedback-form-other" class="feedback__blurb">
+    <p>This category should be used as last resort if no others apply</p>
 </div>
 
 <div id="feedback-form-default">

--- a/onward/app/views/fragments/feedbackForms.scala.html
+++ b/onward/app/views/fragments/feedbackForms.scala.html
@@ -1,106 +1,89 @@
 @()(implicit request: RequestHeader)
 
-<div id="feedback-form-account" class="feedback__form">
+<div id="feedback-form-account" class="feedback__blurb">
     <p>This is for queries about accessing or managing your Guardian account on the website or apps, most of which can be edited <a href="https://profile.theguardian.com/account/edit">here</a></p>
     <p>Please note that queries about payment and billing should be sent to the relevant membership or subscription team using this form.</p>
-    @fragments.feedbackForm("account")
 </div>
 
-<div id="feedback-form-website" class="feedback__form">
+<div id="feedback-form-website" class="feedback__blurb">
     <p>If you are having an issue with a particular page it would be very helpful if you could provide the link to the page. It would also be useful to know which country you're accessing the Guardian from.</p>
-    @fragments.feedbackForm("website")
 </div>
 
-<div id="feedback-form-jobs" class="feedback__form">
+<div id="feedback-form-jobs" class="feedback__blurb">
     <h4>How can I unsubscribe from Job alerts? </h4>
     <p>At the bottom of the email you will see an unsubscribe link.  By clicking the link you will be taken to a page confirming you have unsubscribed from the emails. </p>
     <h4>How can I unsubscribe from Job Match emails?</h4>
     <p>As with Job alerts there will be an unsubscribe link at the bottom of the email.  The link will take you to your Guardian account page.  At the bottom of the page there are two tick boxes.
-
         Select No and Save then log back into your Jobs account.  You will no longer receive any Job Match emails.
     </p>
     <br/>
-    @fragments.feedbackForm("jobs")
 </div>
 
-<div id="feedback-form-email" class="feedback__form">
+<div id="feedback-form-email" class="feedback__blurb">
     <p>If you have an existing Guardian account you can easily subscribe/unsubscribe from emails <a href="https://profile.theguardian.com/email-prefs">here</a></p>
     <p>Alternatively, if you want to unsubscribe from a particular mailing list please simply use the link at the bottom of the email</p>
     <p>If you have a query about job alerts, please contact the jobs team using the dropdown.</p>
-    @fragments.feedbackForm("email")
 </div>
 
-<div id="feedback-form-membership" class="feedback__form">
+<div id="feedback-form-membership" class="feedback__blurb">
     <p>Please include any information you have about your membership or subscription - for example membership tier and membership number; or type of subscription.
         You may find the answer to your questions here:  our membership FAQs <a href="https://membership.theguardian.com/help">here</a> and our subscription FAQs <a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">here</a></p>
     <p>For queries about free registration and commenting accounts, please use 'I need help with my Guardian account' dropdown.</p>
-    @fragments.feedbackForm("membership")
 </div>
 
-<div id="feedback-form-membership-billing" class="feedback__form">
+<div id="feedback-form-membership-billing" class="feedback__blurb">
     <p>If you have any payment issue with your supporter, partner or patron tier membership then please use this drop-down. <a href="https://membership.theguardian.com/help">See this first for clarification</a></p>
-    @fragments.feedbackForm("membership-billing")
 </div>
 
-<div id="feedback-form-subs-billing" class="feedback__form">
+<div id="feedback-form-subs-billing" class="feedback__blurb">
     <p>If you have any issue with your digital pack, your newpaper delivery or voucher delivery either of the Guardian or Guardian Weekly or Observer then please use this form. <a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">See this first for clarification</a></p>
-    @fragments.feedbackForm("subs-billing")
 </div>
 
-<div id="feedback-form-adverts" class="feedback__form">
+<div id="feedback-form-adverts" class="feedback__blurb">
     <p>If you are having an issue with a particular advert it would be very helpful if you could let us know what page you were on when you saw this advert. It would also be useful to know which country you're accessing the Guardian from.</p>
-    @fragments.feedbackForm("adverts")
 </div>
 
-<div id="feedback-form-android" class="feedback__form">
+<div id="feedback-form-android" class="feedback__blurb">
     <p>Please ensure that you are on the latest version of the app.</p>
     <p>If you are, and your problem persists, please contact us from within the app if you can (press menu icon > cog icon > send feedback).</p>
     <p>If you cannot use the app at all, can you please use this form and let us know the make and model of your device, the version of Android you are running, and the version number of the Guardian app?</p>
-    @fragments.feedbackForm("android")
 </div>
 
-<div id="feedback-form-ios" class="feedback__form">
+<div id="feedback-form-ios" class="feedback__blurb">
     <p>Please ensure that you are on the latest version of the app.</p>
     <p>If you are, and your problem persists, please contact us from within the app if you can (press menu icon > cog icon > help > iOS app feedback email address).</p>
     <p>If you cannot use the app at all, can you please use this form and let us know which iPhone or iPad you are using, the version of iOS you are running, and the version number of the Guardian app?</p>
-    @fragments.feedbackForm("ios")
 </div>
 
-<div id="feedback-form-daily" class="feedback__form">
+<div id="feedback-form-daily" class="feedback__blurb">
     <p>Please ensure that you are on the latest version of the app.</p>
     <p>If you are, and your problem persists, please contact us from within the app if you can (from issue picker screen press settings icon > contact us > iOS edition feedback email address).</p>
     <p>If you cannot use the app at all, can you please use this form and let us know which iPad you are using, the version of iOS you are running, and the version number of the daily edition app?</p>
-    @fragments.feedbackForm("daily")
 </div>
 
-<div id="feedback-form-tablet" class="feedback__form">
+<div id="feedback-form-tablet" class="feedback__blurb">
     <p>Please ensure that you are on the latest version of the app.</p>
     <p>If you are, and your problem persists, please contact us from within the app if you can (from issue picker screen press cog icon > contact us > Android edition feedback email address).</p>
     <p>If you cannot use the app at all, can you please use this form and let us know which make and model of tablet you are using, the version of Android you are running, and the version number of the daily edition app?</p>
-    @fragments.feedbackForm("membership-tablet")
 </div>
 
-<div id="feedback-form-windows" class="feedback__form">
+<div id="feedback-form-windows" class="feedback__blurb">
     <p>Please ensure that you are on the latest version of the app.</p>
     <p>If you are, and your problem persists, please contact us from within the app if you can (press menu icon > cog icon > support > send feedback).</p>
     <p>If you cannot use the app at all, can you please use this form and let us know which make and model of device that you are using, the version of Windows mobile you are running, and the version number of the Guardian app?</p>
-    @fragments.feedbackForm("windows")
 </div>
 
-<div id="feedback-form-editorial" class="feedback__form">
+<div id="feedback-form-editorial" class="feedback__blurb">
     <p>If you've spotted a mistake in our copy please let us know so that we can fix it. If you have a complaint about content please see here to find out what to do next. <a href="https://www.theguardian.com/info/2014/sep/12/-sp-how-to-make-a-complaint-about-guardian-or-observer-content">Link to readers editor page</a></p>
-    @fragments.feedbackForm("editorial")
 </div>
 
-<div id="feedback-form-discussion" class="feedback__form">
+<div id="feedback-form-discussion" class="feedback__blurb">
     <p>Our community FAQs can be found <a href="https://www.theguardian.com/community-faqs">here</a>. If you are having difficulties either reading comments or posting a comment please use the 'I want to report a problem with/have some feedback on your Website' option above</p>
-    @fragments.feedbackForm("discussion")
 </div>
 
-<div id="feedback-form-other" class="feedback__form">
-    @fragments.feedbackForm("other")
+<div id="feedback-form-other" class="feedback__blurb">
 </div>
 
 <div id="feedback-form-default">
-    @fragments.feedbackForm("default")
 </div>
+

--- a/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
@@ -53,6 +53,8 @@ define([
 
     function toggleFormVisibility() {
 
+        // make the associated category blurb visible
+
         $.forEachElement("#feedback-category>option", function(elem){
             if(elem.selected && elem.value !== "nothing"){
                 document.getElementById(elem.value).classList.add("feedback__blurb--selected");
@@ -60,6 +62,13 @@ define([
                 document.getElementById(elem.value).classList.remove("feedback__blurb--selected");
             }
         });
+
+        // enable the form elements
+
+        $.forEachElement("#feedback__form input,#feedback__form textarea", function (elem) {
+            elem.disabled = false;
+        });
+
     }
 
     function isInputFilled(elem) {
@@ -105,6 +114,12 @@ define([
                 return !hasFailed;
 
             });
+        });
+
+        // set the form elements to disabled to begin with
+
+        $.forEachElement("#feedback__form input,#feedback__form textarea", function(elem){
+            elem.disabled = true;
         });
 
         // form toggling

--- a/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
@@ -55,9 +55,9 @@ define([
 
         $.forEachElement("#feedback-category>option", function(elem){
             if(elem.selected && elem.value !== "nothing"){
-                document.getElementById(elem.value).classList.add("feedback__form--selected");
+                document.getElementById(elem.value).classList.add("feedback__blurb--selected");
             } else if(elem.value !== "nothing") {
-                document.getElementById(elem.value).classList.remove("feedback__form--selected");
+                document.getElementById(elem.value).classList.remove("feedback__blurb--selected");
             }
         });
     }
@@ -80,19 +80,19 @@ define([
             }
         }
 
-        $.forEachElement(".feedback__form input,.feedback__form textarea", function(elem){
+        $.forEachElement("#feedback__form input,#feedback__form textarea", function(elem){
             elem.addEventListener("blur", function(){ toggleMandatoryOutline(elem); });
             elem.addEventListener("input", function(){ toggleMandatoryOutline(elem); });
         });
 
         // mandatory checks (on submit)
 
-        $.forEachElement(".feedback__form form", function(elem){
+        $.forEachElement(".feedback__form", function(elem){
             elem.addEventListener("submit", function() {
 
                 var hasFailed = false;
 
-                $.forEachElement(".feedback__form--selected input,.feedback__form--selected textarea", function(elem){
+                $.forEachElement("#feedback__form input,#feedback__form textarea", function(elem){
                     if(!isInputFilled(elem)){
                         hasFailed = true;
                     }
@@ -113,14 +113,10 @@ define([
 
         // insert hidden extra data into forms
 
-        $.forEachElement(".feedback__form input[name=extra]", function(elem){
+        $.forEachElement("#feedback__form input[name=extra]", function(elem){
             elem.value = JSON.stringify(getExtraDataInformation());
         })
 
-    }
-
-    function hideUnenhancedFallback() {
-        document.getElementById("feedback-form-default").remove();
     }
 
     return function () {
@@ -132,8 +128,7 @@ define([
             });
 
             initForms();
-            hideUnenhancedFallback();
-            
+
         }
 
     };

--- a/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
@@ -51,7 +51,7 @@ define([
         }
     }
 
-    function toggleFormVisibility() {
+    function toggleFormVisibility(evt) {
 
         // make the associated category blurb visible
 
@@ -65,8 +65,8 @@ define([
 
         // enable the form elements
 
-        $.forEachElement("#feedback__form input,#feedback__form textarea", function (elem) {
-            elem.disabled = false;
+        $.forEachElement("#feedback__form input,#feedback__form textarea,#feedback__form button", function (elem) {
+            elem.disabled = evt.target.value == "nothing"
         });
 
     }
@@ -118,7 +118,7 @@ define([
 
         // set the form elements to disabled to begin with
 
-        $.forEachElement("#feedback__form input,#feedback__form textarea", function(elem){
+        $.forEachElement("#feedback__form input,#feedback__form textarea,#feedback__form button", function(elem){
             elem.disabled = true;
         });
 

--- a/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts-legacy/projects/common/modules/onward/tech-feedback.js
@@ -79,21 +79,6 @@ define([
 
         var warning = document.getElementById("feedback__explainer");
 
-        // mandatory checks (realtime)
-
-        function toggleMandatoryOutline(elem) {
-            if(isInputFilled(elem)){
-                elem.classList.add("feedback__entry--mandatory-failed");
-            } else {
-                elem.classList.remove("feedback__entry--mandatory-failed");
-            }
-        }
-
-        $.forEachElement("#feedback__form input,#feedback__form textarea", function(elem){
-            elem.addEventListener("blur", function(){ toggleMandatoryOutline(elem); });
-            elem.addEventListener("input", function(){ toggleMandatoryOutline(elem); });
-        });
-
         // mandatory checks (on submit)
 
         $.forEachElement(".feedback__form", function(elem){

--- a/static/src/stylesheets/module/onward/_feedback.scss
+++ b/static/src/stylesheets/module/onward/_feedback.scss
@@ -3,6 +3,8 @@
     border: 0;
     outline: none;
     display: none;
+    background-color: $news-support-1;
+    padding: 10px;
 }
 
 .feedback__blurb--selected {
@@ -12,6 +14,10 @@
 .feedback__element {
     margin-top: $gs-baseline * 2;
     margin-bottom: $gs-baseline * 2;
+}
+
+.feedback__element input:disabled, .feedback__element textarea:disabled {
+    opacity: .5;
 }
 
 .feedback__entry {

--- a/static/src/stylesheets/module/onward/_feedback.scss
+++ b/static/src/stylesheets/module/onward/_feedback.scss
@@ -1,11 +1,11 @@
 
-.feedback__form {
+.feedback__blurb {
     border: 0;
     outline: none;
     display: none;
 }
 
-.feedback__form--selected {
+.feedback__blurb--selected {
     display: block;
 }
 

--- a/static/src/stylesheets/module/onward/_feedback.scss
+++ b/static/src/stylesheets/module/onward/_feedback.scss
@@ -16,7 +16,7 @@
     margin-bottom: $gs-baseline * 2;
 }
 
-.feedback__element input:disabled, .feedback__element textarea:disabled {
+.feedback__element input:disabled, .feedback__element textarea:disabled, .feedback__element button:disabled {
     opacity: .5;
 }
 

--- a/static/test/javascripts-legacy/spec/common/onward/tech-feedback.spec.js
+++ b/static/test/javascripts-legacy/spec/common/onward/tech-feedback.spec.js
@@ -13,10 +13,9 @@ define([
             id: 'related',
             fixtures: [
                 '<p id="feedback-warning"></p>',
-                '<select id="feedback-category"><option id="testoption" value="feedback-form-website">Website</option></select>',
+                '<form id="feedback__form"><select id="feedback-category"><option id="testoption" value="feedback-form-website">Website</option></select><input name="extra" value=""></form>',
                 '<div id="feedback-form-default"></div>',
-                '<div id="feedback-form-website"></div>',
-                '<div class="feedback__form"><input name="extra"/></div>'
+                '<div id="feedback-form-website"></div>'
             ]
         };
 
@@ -32,23 +31,22 @@ define([
             fixtures.clean(fixturesConfig.id);
         });
 
-        it("Should place the extra information into the forms", function(){
+        it("Should place the extra information into the form", function(){
             new TechFeedback();
-            expect(document.querySelectorAll(".feedback__form input[name=extra]")[0].value).toContain("browser");
-            expect(document.querySelectorAll(".feedback__form input[name=extra]")[0].value).toContain("No tests running");
+            expect(document.querySelectorAll("#feedback__form input[name=extra]")[0].value).toContain("browser");
         });
 
-        it("Should hide the un-enhanced form", function(){
+        it("Should start off with the inputs disabled", function(){
             new TechFeedback();
-            expect(document.getElementById("feedback-form-default")).toBeNull();
+            expect(document.querySelectorAll("#feedback__form input[name=extra]")[0].disabled).toBeTruthy();
         });
 
-        it("Should flip to the correct form after we choose something from the dropdown", function() {
+        it("Should enable inputs after we choose something from the category select", function() {
             new TechFeedback();
             document.getElementById("testoption").setAttribute('selected', 'selected');
             document.getElementById("feedback-category").value = "feedback-form-website";
             document.getElementById("feedback-category").dispatchEvent(new Event('change'));
-            expect(document.getElementById("feedback-form-website").classList).toContain("feedback__form--selected")
+            expect(document.querySelectorAll("#feedback__form input[name=extra]")[0].disabled).toBeFalsy();
         })
 
     });


### PR DESCRIPTION
## What does this change?

I want to solve a few problems here:

* Remove the pop-in effect from the fallback being swapped out for the real form
* Make sure that we have a proper category even when the user has javascript disabled
   (currently if JS is disabled, the category is always "default").
* Continue to make sure that the user is required to pick a good category if possible.
* The red outlining is kind of distracting

To resolve these:

* There is now only one feedback form, not one for each category, on the page.
* The form is always visible from the start, so no fallback swapping required (no pop-in).
* Changing the category now uses JS to swap out a blurb at the top of of the form.
* The category select element is now inside the form, so it's always populated.
* Removed the red-outline thing, it wasn't pulling it's weight.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
