### PR TITLE
Remove `isImmersive` check from Epic canRun criteria

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -129,8 +129,6 @@ define([
         }) : true;
         var locationCheck = (typeof testConfig.locationCheck === 'function') ? testConfig.locationCheck(storedGeolocation) : true;
 
-        var isImmersive = config.page.isImmersive === true;
-
         var tagsMatch = doTagsMatch(testConfig);
 
         return enoughTimeSinceLastContribution &&
@@ -138,7 +136,6 @@ define([
             worksWellWithPageTemplate &&
             inCompatibleLocation &&
             locationCheck &&
-            !isImmersive &&
             tagsMatch
     }
 


### PR DESCRIPTION
This is preventing the new This Land epic showing up on the right
articles. I don't know of a good reason for it to be blocked from
all immersive articles as they are basically the same as regular 
articles as far as the Epic is concernced (only the header is 
significantly different), so I'm removing the check altogether for now