### PR TITLE
Add content atom block to email template

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -130,20 +130,18 @@
                     }
 
                     case ContentAtomBlockElement(atomId) => {
-                        @page.article.content.media.map { atom: MediaAtom =>
-                            @if(atom.id == atomId) {
-                                @row(Seq("padded")) {
-                                    @EmailVideoImage.bestFor(atom.posterImage.get).map { imageUrl =>
-                                        @atom.assets.map { asset =>
-                                            @asset.platform match {
-                                                case MediaAssetPlatform.Youtube => {
-                                                    <a href="https://www.youtube.com/watch?v=@asset.id">
-                                                    @imgForArticle(imageUrl, Some(atom.title))
-                                                    </a>
-                                                }
-                                                case _ => {
-                                                    @imgForArticle(imageUrl, Some(atom.title))
-                                                }
+                        @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
+                            @atom.posterImage.flatMap(EmailVideoImage.bestFor).map { imageUrl =>
+                                @atom.assets.map { asset =>
+                                    @row(Seq("padded")) {
+                                        @asset.platform match {
+                                            case MediaAssetPlatform.Youtube => {
+                                                <a href="https://www.youtube.com/watch?v=@asset.id">
+                                                @imgForArticle(imageUrl, Some(atom.title))
+                                                </a>
+                                            }
+                                            case _ => {
+                                                @imgForArticle(imageUrl, Some(atom.title))
                                             }
                                         }
                                     }

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -7,6 +7,7 @@
 @import fragments.email._
 @import model.liveblog._
 @import model.EmailAddons.EmailContentType
+@import model.content.{MediaAtom, MediaAssetPlatform}
 
 <table class="article-body">
 @defining(page.article) { article =>
@@ -123,6 +124,29 @@
                                     <a href="@linkUrl">
                                         @imgForArticle(imageUrl, data.get("alt"))
                                     </a>
+                                }
+                            }
+                        }
+                    }
+
+                    case ContentAtomBlockElement(atomId) => {
+                        @page.article.content.media.map { atom: MediaAtom =>
+                            @if(atom.id == atomId) {
+                                @row(Seq("padded")) {
+                                    @EmailVideoImage.bestFor(atom.posterImage.get).map { imageUrl =>
+                                        @atom.assets.map { asset =>
+                                            @asset.platform match {
+                                                case MediaAssetPlatform.Youtube => {
+                                                    <a href="https://www.youtube.com/watch?v=@asset.id">
+                                                    @imgForArticle(imageUrl, Some(atom.title))
+                                                    </a>
+                                                }
+                                                case _ => {
+                                                    @imgForArticle(imageUrl, Some(atom.title))
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -12,6 +12,7 @@ case class AudioBlockElement(assets: Seq[AudioAsset]) extends BlockElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String]) extends BlockElement
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
+case class ContentAtomBlockElement(atomId: String) extends BlockElement
 case class RichLinkBlockElement(url: Option[String], text: Option[String], prefix: Option[String]) extends BlockElement
 
 object BlockElement {
@@ -55,6 +56,8 @@ object BlockElement {
         else Some(VideoBlockElement(videoDataFor(element)))
 
       case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
+
+      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId))
 
       case _ => None
     }


### PR DESCRIPTION
## What does this change?

This adds `contentatom` element types to email templates (for example, the YouTube content atom on [this article](https://www.theguardian.com/world/2017/may/26/friday-briefing-manchester-fresh-arrest-as-terror-spotlight-falls-on-tech-firms) does not currently appear at the [email endpoint](https://www.theguardian.com/world/2017/may/26/friday-briefing-manchester-fresh-arrest-as-terror-spotlight-falls-on-tech-firms/email))

## What is the value of this and can you measure success?

Emails are very successful at driving users to video content, and especially good at encouraging users to watch videos to completion. This change allows us to drive traffic to our video content on YouTube via content atoms.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![picture 242](https://cloud.githubusercontent.com/assets/5931528/26829443/97676398-4abd-11e7-8a80-204eab20d856.png)

## Tested in CODE?

- [x] Tested

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
