### PR TITLE
Use activeVersion on YouTube atoms

### DIFF
--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -54,11 +54,6 @@ final case class MediaAtom(
       "^0".r.replaceFirstIn(formattedDuration, "") //strip leading zero
     }
   }
-
-  def activeAsset: MediaAsset = activeVersion match {
-    case Some(version) => assets.find(_.version == version).getOrElse(assets.head)
-    case _ => assets.head
-  }
 }
 
 
@@ -241,6 +236,19 @@ object MediaAtom extends common.Logging {
     )
   }
 
+  def activeYouTubeAsset(atom: MediaAtom): Option[MediaAsset] = {
+    val defaultAsset = atom.assets.headOption
+
+    val activeAsset = for {
+      version <- atom.activeVersion
+      asset <- atom.assets.find(_.version == version)
+    } yield asset
+
+    val asset = activeAsset orElse defaultAsset
+
+    // sanity check the platform to avoid template rendering errors
+    asset.filter(_.platform == MediaAssetPlatform.Youtube)
+  }
 }
 
 object Quiz extends common.Logging {

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -37,7 +37,8 @@ final case class MediaAtom(
   source: Option[String],
   posterImage: Option[ImageMedia],
   endSlatePath: Option[String],
-  expired: Option[Boolean]
+  expired: Option[Boolean],
+  activeVersion: Option[Long]
 ) extends Atom {
 
   def isoDuration: Option[String] = {
@@ -52,6 +53,11 @@ final case class MediaAtom(
       val formattedDuration = DurationFormatUtils.formatDuration(jodaDuration.getMillis, durationPattern, true)
       "^0".r.replaceFirstIn(formattedDuration, "") //strip leading zero
     }
+  }
+
+  def activeAsset: MediaAsset = activeVersion match {
+    case Some(version) => assets.find(_.version == version).getOrElse(assets.head)
+    case _ => assets.head
   }
 }
 
@@ -204,7 +210,8 @@ object MediaAtom extends common.Logging {
       source = mediaAtom.source,
       posterImage = mediaAtom.posterImage.map(imageMediaMake(_, mediaAtom.title)),
       endSlatePath = endSlatePath,
-      expired = expired
+      expired = expired,
+      activeVersion = mediaAtom.activeVersion
     )
   }
 

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -41,6 +41,10 @@ final case class MediaAtom(
   activeVersion: Option[Long]
 ) extends Atom {
 
+  def activeAssets: Seq[MediaAsset] = activeVersion
+    .map { version => assets.filter(_.version == version) }
+    .getOrElse(assets)
+
   def isoDuration: Option[String] = {
     duration.map(d => new Duration(Duration.standardSeconds(d)).toString)
   }
@@ -234,20 +238,6 @@ object MediaAtom extends common.Logging {
         "altText" -> Some(caption)
       ).collect{ case(k, Some(v)) => (k,v) }
     )
-  }
-
-  def activeYouTubeAsset(atom: MediaAtom): Option[MediaAsset] = {
-    val defaultAsset = atom.assets.headOption
-
-    val activeAsset = for {
-      version <- atom.activeVersion
-      asset <- atom.assets.find(_.version == version)
-    } yield asset
-
-    val asset = activeAsset orElse defaultAsset
-
-    // sanity check the platform to avoid template rendering errors
-    asset.filter(_.platform == MediaAssetPlatform.Youtube)
   }
 }
 

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,10 +1,11 @@
 @import model.content.MediaWrapper
-@(media: model.content.MediaAtom,  displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
+@import model.content.MediaAtom.activeYouTubeAsset
+@(media: model.content.MediaAtom, displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
 
-@if(media.assets.nonEmpty) {
+@for(asset <- activeYouTubeAsset(media)) {
     <amp-youtube
-    data-videoid="@media.activeAsset.id"
+    data-videoid="@asset.id"
     layout="responsive"
     width="16" height="9" data-param-rel="0">
     </amp-youtube>

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -2,7 +2,7 @@
 @(media: model.content.MediaAtom,  displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
     <amp-youtube
-    data-videoid="@media.assets.head.id"
+    data-videoid="@media.activeAsset.id"
     layout="responsive"
     width="16" height="9" data-param-rel="0">
     </amp-youtube>

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,9 +1,8 @@
 @import model.content.MediaWrapper
-@import model.content.MediaAtom.activeYouTubeAsset
 @(media: model.content.MediaAtom, displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
 
-@for(asset <- activeYouTubeAsset(media)) {
+@for(asset <- media.activeAssets.headOption) {
     <amp-youtube
     data-videoid="@asset.id"
     layout="responsive"

--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -1,11 +1,14 @@
 @import model.content.MediaWrapper
 @(media: model.content.MediaAtom,  displayCaption: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader)
 @import views.html.fragments.atoms.mediaAtomCaption
+
+@if(media.assets.nonEmpty) {
     <amp-youtube
     data-videoid="@media.activeAsset.id"
     layout="responsive"
     width="16" height="9" data-param-rel="0">
     </amp-youtube>
+}
 
 @if(displayCaption) {
     @mediaAtomCaption(media.title, mediaWrapper.contains(MediaWrapper.MainMedia))

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -9,14 +9,13 @@
 @import model.content.MediaWrapper._
 @import model.content.MediaWrapper
 @import model.content.MediaAsset
-@import model.content.MediaAtom.activeYouTubeAsset
 @import conf.switches.Switches.YouTubePosterOverride
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
 
-@defining(activeYouTubeAsset(media)) { activeAsset: Option[MediaAsset] =>
+@defining(media.activeAssets.headOption) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
 @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -8,12 +8,15 @@
 @import model.ImageMedia
 @import model.content.MediaWrapper._
 @import model.content.MediaWrapper
+@import model.content.MediaAsset
+@import model.content.MediaAtom.activeYouTubeAsset
 @import conf.switches.Switches.YouTubePosterOverride
 @import model.VideoFaciaProperties
 @import views.html.fragments.items.elements.facia_cards.title
 
 @(media: model.content.MediaAtom, displayCaption: Boolean, displayDuration: Boolean = true, displayEndSlate: Boolean = true, playable: Boolean = true, posterImageOverride: Option[ImageMedia] = None, cardStyle: Option[CardStyle] = None, mediaWrapper: Option[MediaWrapper] = None, faciaHeaderProperties: Option[VideoFaciaProperties] = None)(implicit request: RequestHeader)
 
+@defining(activeYouTubeAsset(media)) { activeAsset: Option[MediaAsset] =>
 @defining(media.expired.getOrElse(false)){expired: Boolean =>
 @defining(playable && !posterImageOverride.exists(_ => YouTubePosterOverride.isSwitchedOn)){sixteenByNine: Boolean =>
 
@@ -30,16 +33,16 @@
     >
 }
 
-        @if(playable && !expired && media.assets.nonEmpty) {
+        @for(asset <- activeAsset if playable && !expired) {
             @defining(s"https://www.youtube.com/embed${
-                media.activeAsset.id
+                asset.id
                 .addParams(List(
                 "enablejsapi" -> 1,
                 "rel" -> 0,
                 "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>
-                <iframe class="youtube-media-atom__iframe" id="youtube-@media.activeAsset.id" width="100%" height="100%"
+                <iframe class="youtube-media-atom__iframe" id="youtube-@asset.id" width="100%" height="100%"
                         src="@embedUri" frameborder="0"
                         allowfullscreen="">
                 </iframe>
@@ -106,6 +109,7 @@
             }
         }
         </div>
+}
 }
 
 @if(displayCaption & !mediaWrapper.contains(ImmersiveMainMedia)) {

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -30,7 +30,7 @@
     >
 }
 
-        @if(playable && !expired) {
+        @if(playable && !expired && media.assets.nonEmpty) {
             @defining(s"https://www.youtube.com/embed${
                 media.activeAsset.id
                 .addParams(List(

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -32,14 +32,14 @@
 
         @if(playable && !expired) {
             @defining(s"https://www.youtube.com/embed${
-                media.assets.head.id
+                media.activeAsset.id
                 .addParams(List(
                 "enablejsapi" -> 1,
                 "rel" -> 0,
                 "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>
-                <iframe class="youtube-media-atom__iframe" id="youtube-@media.assets.head.id" width="100%" height="100%"
+                <iframe class="youtube-media-atom__iframe" id="youtube-@media.activeAsset.id" width="100%" height="100%"
                         src="@embedUri" frameborder="0"
                         allowfullscreen="">
                 </iframe>

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -28,16 +28,19 @@ class AtomCleanerTest extends FlatSpec
 
   val image: ImageMedia = ImageMedia.apply(Seq(imageAsset))
 
+  val youTubeAsset = MediaAsset(id = "nQuN9CUsdVg", version = 1L, platform = MediaAssetPlatform.Youtube, mimeType = None)
+
   val youTubeAtom = Some(Atoms(quizzes = Nil,
     media = Seq(MediaAtom(id = "887fb7b4-b31d-4a38-9d1f-26df5878cf9c",
       defaultHtml = "<iframe width=\"420\" height=\"315\"\n src=\"https://www.youtube.com/embed/nQuN9CUsdVg\" frameborder=\"0\"\n allowfullscreen=\"\">\n</iframe>",
-      assets = Seq(MediaAsset(id = "nQuN9CUsdVg", version = 1L, platform = MediaAssetPlatform.Youtube, mimeType = None)),
+      assets = Seq(youTubeAsset),
       title = "Bird",
       duration = Some(36),
       source = None,
       posterImage = Some(image),
       endSlatePath = Some("/video/end-slate/section/football.json?shortUrl=https://gu.com/p/6vf9z"),
-      expired = None)
+      expired = None,
+      activeVersion = None)
     ),
     interactives = Nil,
     recipes = Nil,
@@ -91,6 +94,36 @@ class AtomCleanerTest extends FlatSpec
     val html = views.html.fragments.atoms.media(media = youTubeAtom.map(_.media.head).get, displayCaption = false, mediaWrapper = None)(TestRequest())
     val doc = Jsoup.parse(html.toString())
     doc.getElementsByClass("youtube-media-atom__bottom-bar__duration").html() should be("0:36")
+  }
+
+  "Youtube template" should "use active asset" in {
+    val atom = youTubeAtom.get.media.head.copy(
+      activeVersion = Some(2L),
+      assets = Seq(
+        youTubeAsset,
+        youTubeAsset.copy(id = "gyVuRflcEKM", version = 2),
+        youTubeAsset.copy(id = "QRplDNMsS4U", version = 3)
+      )
+    )
+
+    val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+
+    doc.getElementsByClass("youtube-media-atom__iframe").attr("id") should be("youtube-gyVuRflcEKM")
+  }
+
+  "Youtube template" should "use latest asset if no active version" in {
+    val atom = youTubeAtom.get.media.head.copy(
+      assets = Seq(
+        youTubeAsset.copy(id = "gyVuRflcEKM", version = 2),
+        youTubeAsset.copy(id = "QRplDNMsS4U", version = 3)
+      )
+    )
+
+    val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+
+    doc.getElementsByClass("youtube-media-atom__iframe").attr("id") should be(s"youtube-gyVuRflcEKM")
   }
 
   "Formatted duration" should "produce the expected format" in {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -65,7 +65,7 @@ class AtomCleanerTest extends FlatSpec
   }
 
  private def renderAndGetId(atom: MediaAtom): String = {
-   val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+   val html = views.html.fragments.atoms.youtube(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
    val doc = Jsoup.parse(html.toString())
 
    doc.getElementsByClass("youtube-media-atom__iframe").attr("id")
@@ -125,6 +125,21 @@ class AtomCleanerTest extends FlatSpec
     )
 
     renderAndGetId(atom) should be(s"youtube-gyVuRflcEKM")
+  }
+
+  "Youtube template" should "render nothing if there are no assets" in {
+    val atom = youTubeAtom.get.media.head.copy(assets = Seq.empty)
+
+    renderAndGetId(atom) shouldBe empty
+  }
+
+  "AMP Youtube template" should "render nothing if there are no assets" in {
+    val atom = youTubeAtom.get.media.head.copy(assets = Seq.empty)
+
+    val html = views.html.fragments.atoms.ampYoutube(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+    val doc = Jsoup.parse(html.toString())
+
+    doc.getElementsByTag("amp-youtube") shouldBe empty
   }
 
   "Formatted duration" should "produce the expected format" in {

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -64,6 +64,13 @@ class AtomCleanerTest extends FlatSpec
     document
   }
 
+ private def renderAndGetId(atom: MediaAtom): String = {
+   val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
+   val doc = Jsoup.parse(html.toString())
+
+   doc.getElementsByClass("youtube-media-atom__iframe").attr("id")
+ }
+
   "AtomsCleaner" should "create YouTube template" in {
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc, youTubeAtom, amp = false)
@@ -100,30 +107,24 @@ class AtomCleanerTest extends FlatSpec
     val atom = youTubeAtom.get.media.head.copy(
       activeVersion = Some(2L),
       assets = Seq(
-        youTubeAsset,
-        youTubeAsset.copy(id = "gyVuRflcEKM", version = 2),
-        youTubeAsset.copy(id = "QRplDNMsS4U", version = 3)
+        youTubeAsset.copy(id = "gyVuRflcEKM", version = 3),
+        youTubeAsset.copy(id = "QRplDNMsS4U", version = 2),
+        youTubeAsset
       )
     )
 
-    val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
-    val doc = Jsoup.parse(html.toString())
-
-    doc.getElementsByClass("youtube-media-atom__iframe").attr("id") should be("youtube-gyVuRflcEKM")
+    renderAndGetId(atom) should be("youtube-QRplDNMsS4U")
   }
 
   "Youtube template" should "use latest asset if no active version" in {
     val atom = youTubeAtom.get.media.head.copy(
       assets = Seq(
-        youTubeAsset.copy(id = "gyVuRflcEKM", version = 2),
-        youTubeAsset.copy(id = "QRplDNMsS4U", version = 3)
+        youTubeAsset.copy(id = "gyVuRflcEKM", version = 3),
+        youTubeAsset.copy(id = "QRplDNMsS4U", version = 2)
       )
     )
 
-    val html = views.html.fragments.atoms.media(media = atom, displayCaption = false, mediaWrapper = None)(TestRequest())
-    val doc = Jsoup.parse(html.toString())
-
-    doc.getElementsByClass("youtube-media-atom__iframe").attr("id") should be(s"youtube-gyVuRflcEKM")
+    renderAndGetId(atom) should be(s"youtube-gyVuRflcEKM")
   }
 
   "Formatted duration" should "produce the expected format" in {


### PR DESCRIPTION
## What does this change?

We were displaying the first video asset in the list attached to a YouTube media atom. It is possible in the tools to revert an atom to a previous asset but changes were not reflected on site.

This changes the rendering to select the asset based on the `activeVersion` field in the media atom. If not set, the first asset is used as before.

## What is the value of this and can you measure success?

- Reverting is required if the wrong video is uploaded to a live media atom
- The site and tools do the same thing, which confused us when we initially found the problem

## Does this affect other platforms - Amp, Apps, etc?

- The AMP YouTube template now uses the same code to select the right asset.
- I've put a 'do not merge' label on so we can synchronise fixing this with apps

## Screenshots

## Tested in CODE?

Not yet.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
