### PR TITLE
Add /deploy endpoint

### DIFF
--- a/admin/app/controllers/DeploysController.scala
+++ b/admin/app/controllers/DeploysController.scala
@@ -2,6 +2,7 @@ package controllers.admin
 
 import common.Logging
 import implicits.Requests
+import model.NoCache
 import model.deploys.{ApiResults, RiffRaffService}
 import play.api.mvc._
 import play.api.libs.concurrent.Execution.Implicits._
@@ -14,6 +15,12 @@ trait DeploysController extends Controller with Logging with Requests {
 
   def getDeploys(stage: Option[String], pageSize: Option[Int] = None) = Action.async {
     riffRaff.getRiffRaffDeploys(Some("dotcom:all"), stage, pageSize, Some("Completed")).map(ApiResults(_))
+  }
+
+  def deploy(stage: String, build: Int) = Action {
+    val msg = s"Build $build has been deployed to $stage"
+    log.info(msg) // Logging message so kibana can show deploy in graph
+    NoCache(Ok(msg))
   }
 
 }

--- a/admin/app/http/AdminFilters.scala
+++ b/admin/app/http/AdminFilters.scala
@@ -11,7 +11,8 @@ import play.api.mvc.EssentialFilter
 class AdminFilters(cryptoConfig: CryptoConfig)(implicit mat: Materializer, context: ApplicationContext) extends HttpFilters {
 
   val filterExemptions = FilterExemptions(
-    "/deploys" //not authenticated so it can be accessed by Prout to determine which builds have been deployed
+    "/deploys", //not authenticated so it can be accessed by Prout to determine which builds have been deployed
+    "/deploy"   //not authenticated so it can be accessed by Riff-Raff to notify about a new build being deployed
   )
   val adminAuthFilter = new AuthFilterWithExemptions(
     filterExemptions.loginExemption,

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -115,6 +115,7 @@ GET         /radiator/commit/*hash                                              
 
 # Used by Prout to know which builds/commits have been deployed in PROD
 GET         /deploys                                                                                controllers.admin.DeploysController.getDeploys(stage: Option[String], pageSize: Option[Int])
+POST        /deploy                                                                                 controllers.admin.DeploysController.deploy(stage: String, build: Int)
 
 # Redirects
 GET         /redirects                                                                              controllers.admin.RedirectController.redirect()


### PR DESCRIPTION
I want to add annotations in Kibana to show deploys
To do that I need to send an event/log to kibana when a new
deployment happens
This endpoint will be called by riff-raff post deployment hook

## Does this affect other platforms - Amp, Apps, etc?
No, only `admin`

## Tested in CODE?
No