### PR TITLE
Extend commercial MVT (and switch)

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -20,7 +20,7 @@ object CommercialGalleryBannerAds extends TestDefinition(
   name = "commercial-gallery-banner-ads",
   description = "Users in the test will see banner ads instead of MPUs in galleries",
   owners = Seq(Owner.withGithub("JonNorman")),
-  sellByDate = new LocalDate(2017, 6, 6)
+  sellByDate = new LocalDate(2017, 6, 8)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-commercial-gallery-banner-ads")


### PR DESCRIPTION
Now we have the access to the control data through the logs, we need a couple of extra days of data for this test.

@guardian/commercial-dev 
