### PR TITLE
Commercial - TravelOffer - Only allow distinct countries

### DIFF
--- a/commercial/app/model/merchandise/Merchandise.scala
+++ b/commercial/app/model/merchandise/Merchandise.scala
@@ -272,7 +272,7 @@ object TravelOffer {
       fromPrice = parseDouble(text("@fromprice")),
       earliestDeparture = DateTime.parse(text("@earliestdeparture")),
       keywordIdSuffixes = Nil,
-      countries = tagText("Country"),
+      countries = tagText("Country").distinct,
       category = tagText("Holiday Type").headOption,
       tags = Nil,
       duration = parseInt(text("@duration")),


### PR DESCRIPTION
## What does this change?

The list of countries is currently not deduplicated and the associated change deduplicates them.

## What is the value of this and can you measure success?

This prevent thousands of requests to be sent to the Content API every 15 minutes, as for each country in the list we send a `/tags?section=travel&q=<country>` request in [TravelOffersAgent](https://github.com/guardian/frontend/blob/master/commercial/app/model/merchandise/travel/TravelOffersAgent.scala#L28-L32)

```scala
def fetchKeywords(country: String): Future[Seq[String]] = for {
      keywords <- lookup.keyword("\"" + country + "\"", section = Some("travel"))
    } yield keywords.map(_.id).distinct

    def keywordsForOffer(offer: TravelOffer): Future[Seq[String]] = Future.sequence(offer.countries.map(fetchKeywords)).map(_.flatten)
```


The problem is amplified by 2 things:

- As the number of `product` grows in the travel offer feeds, the number of similar countries increase. That is why the problem was not visible initially, but our current feed contains `144` times `Germany` and `144` times France.

- Each developer running frontend locally will send the same thousands of requests every 15 minutes, creating spikes bigger in the middle of the day when everyone is working.  

See below a spike this morning:

<img width="1018" alt="screen shot 2017-06-06 at 09 56 53" src="https://cloud.githubusercontent.com/assets/615085/26821928/244b01e8-4aa0-11e7-8479-491589a7bd28.png">


## Does this affect other platforms - Amp, Apps, etc?

no

## Screenshots

no

@TBonnin @NataliaLKB @LATaylor-guardian @annebyrne @tomrf1 