### PR TITLE
Header/Footer link updates

### DIFF
--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -122,6 +122,7 @@ object NavLinks {
 
   val todaysPaper = NavLink("today's paper", "/theguardian", "theguardian")
   val observer = NavLink("the observer", "/observer", "observer")
+  val digitalNewspaperArchive = NavLink("digital newspaper archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink("crosswords", "/crosswords", "crosswords")
   val video =  NavLink("video", "/video")
   val podcasts =  NavLink("podcasts", "/podcasts")

--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -61,6 +61,8 @@ object NavLinks {
   val theGuardianView = NavLink("the guardian view", "/profile/editorial", "profile/editorial")
   val cartoons = NavLink("cartoons", "/cartoons/archive", "cartoons/archive")
   val inMyOpinion = NavLink("opinion videos", "/commentisfree/series/comment-is-free-weekly", "commentisfree/series/comment-is-free-weekly")
+  val letters = NavLink("letters", "/theguardian/mainsection/editorialsandreply")
+  val editorials = NavLink("editorials", "/tone/editorials")
 
   /* SPORT */
   val sport = NavLink("sport", "/sport", longTitle = "sport home", iconName = "home", uniqueSection = "sport")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -235,6 +235,8 @@ trait Navigation {
   val theGuide = SectionLink("todayspaper", "the guide", "The Guide", "/theguardian/theguide")
   val saturdayreview = SectionLink("todayspaper", "saturday review", "Saturday Review", "/theguardian/guardianreview")
 
+  // Archive
+  val digitalNewspaperArchive = SectionLink("todayspaper", "digital newspaper archive", "Digital Newspaper Archive", "https://theguardian.newspapers.com")
 
   // Observer newspaper
   val sundayPaper = SectionLink("theobserver", "sunday's paper", "The Observer", "/theobserver")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -227,7 +227,8 @@ trait Navigation {
 
   // Guardian newspaper
   val todaysPaper = SectionLink("todayspaper", "today's paper", "Today's Paper", "/theguardian")
-  val editorialsandletters = SectionLink("todayspaper", "editorials & letters", "Editorials & Letters", "/theguardian/mainsection/editorialsandreply")
+  val letters = SectionLink("todayspaper", "letters", "Letters", "/theguardian/mainsection/editorialsandreply")
+  val editorials = SectionLink("todayspaper", "editorials", "Editorials", "/tone/editorials")
   val obituaries = SectionLink("todayspaper", "obituaries", "Obituaries", "/tone/obituaries")
   val g2 = SectionLink("todayspaper", "g2", "G2", "/theguardian/g2")
   val weekend = SectionLink("todayspaper", "weekend", "Weekend", "/theguardian/weekend")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -68,6 +68,7 @@ trait Navigation {
   val africa = SectionLink("world", "africa", "Africa", "/world/africa")
   val middleEast = SectionLink("world", "middle east", "Middle east", "/world/middleeast")
   val video = SectionLink("video", "video", "Video", "/video")
+  val podcast = SectionLink("podcast", "podcast", "Podcast", "/podcast")
   val guardianProfessional = SectionLink("guardian-professional", "professional networks", "Guardian Professional", "/guardian-professional")
   val observer = SectionLink("observer", "the observer", "The Observer", "/observer")
   val health = SectionLink("society", "health", "Health", "/society/health")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -103,13 +103,12 @@ object NewNavigation {
         inMyOpinion
       ),
       List(
+        letters,
+        editorials,
         NavLink("Polly Toynbee", "/profile/pollytoynbee"),
         NavLink("Owen Jones", "/profile/owen-jones"),
         NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
-        NavLink("Marina Hyde", "/profile/marinahyde"),
-        NavLink("George Monbiot", "/profile/georgemonbiot"),
-        NavLink("Gary Younge", "/profile/garyyounge"),
-        NavLink("Nick Cohen", "/profile/nickcohen")
+        NavLink("Marina Hyde", "/profile/marinahyde")
       )
     )
 
@@ -127,9 +126,7 @@ object NewNavigation {
         NavLink("Kristina Keneally", "/profile/kristina-keneally"),
         NavLink("Richard Ackland", "/profile/richard-ackland"),
         NavLink("Van Badham", "/profile/van-badham"),
-        NavLink("Lenore Taylor", "/profile/lenore-taylor"),
-        NavLink("Jason Wilson", "/profile/wilson-jason"),
-        NavLink("Brigid Delaney", "/profile/brigiddelaney")
+        NavLink("Lenore Taylor", "/profile/lenore-taylor")
       )
     )
 
@@ -427,8 +424,8 @@ object NewNavigation {
     val todaysPaperSubNav = NavLinkLists(
       List(
         todaysPaper,
-        NavLink("letters", "/theguardian/mainsection/editorialsandreply"),
-        NavLink("editorials", "/tone/editorials"),
+        letters,
+        editorials,
         NavLink("obituaries", "/tone/obituaries"),
         NavLink("g2", "/theguardian/g2"),
         NavLink("weekend", "/theguardian/weekend"),

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -427,7 +427,8 @@ object NewNavigation {
     val todaysPaperSubNav = NavLinkLists(
       List(
         todaysPaper,
-        NavLink("editorials & letters", "/theguardian/mainsection/editorialsandreply"),
+        NavLink("letters", "/theguardian/mainsection/editorialsandreply"),
+        NavLink("editorials", "/tone/editorials"),
         NavLink("obituaries", "/tone/obituaries"),
         NavLink("g2", "/theguardian/g2"),
         NavLink("weekend", "/theguardian/weekend"),

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -238,6 +238,7 @@ object NewNavigation {
       newsletters,
       todaysPaper,
       observer,
+      digitalNewspaperArchive,
       crosswords
     ))
 
@@ -249,6 +250,7 @@ object NewNavigation {
       video,
       pictures,
       newsletters,
+      digitalNewspaperArchive,
       crosswords
     ))
 
@@ -259,6 +261,7 @@ object NewNavigation {
       video,
       pictures,
       newsletters,
+      digitalNewspaperArchive,
       crosswords
     ))
 
@@ -272,6 +275,7 @@ object NewNavigation {
       newsletters,
       todaysPaper,
       observer,
+      digitalNewspaperArchive,
       crosswords
     ))
   }

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -52,7 +52,7 @@ object Au extends Edition(
       NavItem(science),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video)
+      NavItem(video, Seq(podcast))
     )
   }
 

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -51,6 +51,7 @@ object Au extends Edition(
       NavItem(fashion),
       NavItem(science),
       NavItem(membership),
+      NavItem(digitalNewspaperArchive),
       NavItem(crosswords, crosswordsLocalNav),
       NavItem(video, Seq(podcast))
     )

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -110,7 +110,7 @@ object International extends Edition(
       NavItem(science),
       NavItem(guardianProfessional),
       NavItem(observer),
-      NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),
+      NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -111,6 +111,7 @@ object International extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
+      NavItem(digitalNewspaperArchive),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -114,7 +114,7 @@ object International extends Edition(
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video)
+      NavItem(video, Seq(podcast))
     )
   }
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -116,7 +116,7 @@ object Uk extends Edition(
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video)
+      NavItem(video, Seq(podcast))
     )
   }
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -112,7 +112,7 @@ object Uk extends Edition(
       NavItem(science),
       NavItem(guardianProfessional),
       NavItem(observer),
-      NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),
+      NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -113,6 +113,7 @@ object Uk extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
+      NavItem(digitalNewspaperArchive),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -72,6 +72,7 @@ object Us extends Edition(
       NavItem(science),
       NavItem(media),
       NavItem(crosswords, crosswordsLocalNav),
+      NavItem(digitalNewspaperArchive),
       NavItem(video, Seq(podcast))
     )
   }

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -72,7 +72,7 @@ object Us extends Edition(
       NavItem(science),
       NavItem(media),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video)
+      NavItem(video, Seq(podcast))
     )
   }
 

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -129,6 +129,9 @@
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
                                 securedrop</a>
                             </li>
+                            <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
+                                digital newspaper archive</a>
+                            </li>
                             <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
                                 complaints &amp; corrections</a>
                             </li>
@@ -226,6 +229,9 @@
                             <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="https://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
                                 subscribe</a>
                             </li>
+                            <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
+                                digital newspaper archive</a>
+                            </li>
                         </ul>
 
                     }
@@ -270,11 +276,11 @@
 
                         <ul class="colophon__list">
                             <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                                terms &amp; conditions</a><
-                                /li>
-                        <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
+                                terms &amp; conditions</a>
+                            </li>
+                            <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
                                 privacy policy</a>
-                        </li>
+                            </li>
                             <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                 cookie policy</a>
                             </li>
@@ -304,6 +310,9 @@
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="https://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                                 subscribe</a>
+                            </li>
+                            <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
+                                digital newspaper archive</a>
                             </li>
                         </ul>
                     }
@@ -347,6 +356,9 @@
                                 privacy policy</a></li>
                             <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">
                                 cookie policy</a>
+                            </li>
+                            <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
+                                digital newspaper archive</a>
                             </li>
                         </ul>
 


### PR DESCRIPTION
## What does this change?

**Old desktop:**
* in all sections, add secondary podcast link (/podcasts) to the video row

* in all sections, replace editorials and letters with two links

* Add digital newspaper archive (https://theguardian.newspapers.com/) in all sections

**New nav:**
* in opinion's subnav, add editorials and letters (same links), remove George Monbiot, Gary Younge, Nick Cohen (we must enforce a max of ten!)

* in the dropdown, add digital newspaper archive (https://theguardian.newspapers.com/) in all sections

Footer: 
* add digital newspaper archive (https://theguardian.newspapers.com/) to all sections

## What is the value of this and can you measure success?
These were all editorial requests so I hope this makes those people happy 😄 

## Does this affect other platforms - Amp, Apps, etc?
Any changes in the New header links will be reflected in AMP

## Screenshots
N/A

## Tested in CODE?
Nope
