### PR TITLE
Add regular tailoring to epic tests that should have it

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -1,11 +1,18 @@
 define([
     'common/modules/commercial/contributions-utilities',
+    'raw-loader!common/views/acquisitions-epic-control.html',
+    'common/modules/tailor/tailor',
+    'lodash/utilities/template',
+    'common/modules/commercial/acquisitions-copy'
+
 ], function (
-    contributionsUtilities
+    contributionsUtilities,
+    acquisitionsEpicControlTemplate,
+    tailor,
+    template,
+    acquisitionsCopy
 ) {
-
-
-
+    
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicAlwaysAskElection',
         campaignId: 'epic_always_ask_election',
@@ -26,7 +33,21 @@ define([
         variants: [
             {
                 id: 'control',
-                isUnlimited : true
+                isUnlimited : true,
+                successOnView: true,
+                test: function(render) {
+                    tailor.isRegular().then(function (regular) {
+                        var copy = regular ? acquisitionsCopy.regulars: acquisitionsCopy.control;
+                        return render(function(variant) {
+                            return template(acquisitionsEpicControlTemplate, {
+                                copy: copy,
+                                membershipUrl: variant.options.membershipURL,
+                                contributionUrl: variant.options.contributeURL,
+                                componentName: variant.options.componentName
+                            });
+                        });
+                    });
+                }
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -1,12 +1,19 @@
 define([
     'common/modules/commercial/contributions-utilities',
+    'raw-loader!common/views/acquisitions-epic-control.html',
+    'common/modules/tailor/tailor',
+    'lodash/utilities/template',
+    'common/modules/commercial/acquisitions-copy'
+
 ], function (
-    contributionsUtilities
+    contributionsUtilities,
+    acquisitionsEpicControlTemplate,
+    tailor,
+    template,
+    acquisitionsCopy
 ) {
 
-
-
-    return contributionsUtilities.makeABTest({
+   return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicAlwaysAskIfTagged',
         campaignId: 'epic_always_ask_if_tagged',
 
@@ -29,6 +36,19 @@ define([
                 id: 'control',
                 isUnlimited : true,
                 successOnView: true,
+                test: function(render) {
+                    tailor.isRegular().then(function (regular) {
+                        var copy = regular ? acquisitionsCopy.regulars: acquisitionsCopy.control;
+                        return render(function(variant) {
+                            return template(acquisitionsEpicControlTemplate, {
+                                copy: copy,
+                                membershipUrl: variant.options.membershipURL,
+                                contributionUrl: variant.options.contributeURL,
+                                componentName: variant.options.componentName
+                            });
+                        });
+                    });
+                }
             }
         ]
     });


### PR DESCRIPTION
## What does this change?

Depending on whether you are a regular or not, if you are in the always as if tagged or always ask election tests, you should see either :
<img width="521" alt="screenshot at jun 06 11-35-59" src="https://cloud.githubusercontent.com/assets/2844554/26835427/3b8ef320-4ad0-11e7-9d4f-53eed9563883.png">

if you are regular, or :
<img width="695" alt="control" src="https://cloud.githubusercontent.com/assets/2844554/26835462/4cab1904-4ad0-11e7-8b5c-8547ef8a8be1.png">

If you are not. This PR ensures this. 



## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
