### PR TITLE
Add 'The Recap' and 'Business Today' to the Email List

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -83,11 +83,23 @@ object EmailNewsletters {
     signupPage = Some("/world/guardian-australia-morning-mail/2014/jun/24/-sp-guardian-australias-morning-mail-subscribe-by-email")
   )
 
-  val mediaBriefing = EmailNewsletter(
-    name = "MediaGuardian Briefing",
+  val businessToday = EmailNewsletter(
+    name = "Business Today",
     theme = "news",
-    teaser = "An indispensable summary of what the papers are saying about media on your desktop at 9am",
-    description = "An indispensable summary of the media industry headlines in your inbox at 9am. We dig out the most important stories from every and any newspaper, broadcaster and website",
+    teaser = "Every morning, Business Today will deliver the biggest stories, smartest analysis and hottest topics direct to your inbox",
+    description = "We'll deliver the biggest stories, smartest analysis and hottest topics direct to your inbox. Along with the key news headlines, there’ll be an at-a-glance agenda of the day’s main events, insightful opinion pieces and a quality feature to sink your teeth into",
+    frequency = "Weekday mornings",
+    listId = 3887,
+    tone = Some("news"),
+    signupPage = Some("/info/2017/may/16/guardian-business-today-sign-up-financial-news-email"),
+    exampleUrl = Some("/email/business-today")
+  )
+
+  val mediaBriefing = EmailNewsletter(
+    name = "Media Briefing",
+    theme = "news",
+    teaser = "An indispensable summary of the media industry headlines in your inbox at 9am, plus thought-provoking features and the liveliest debate",
+    description = "An indispensable summary of the media industry headlines in your inbox at 9am, plus thought-provoking features and the liveliest debate. Whether you’re in broadcasting, digital or print, whether you’re in news or marketing, we’ve got the stories you need to read",
     frequency = "Weekday mornings",
     listId = 217,
     tone = Some("news"),
@@ -148,6 +160,17 @@ object EmailNewsletters {
     frequency = "Weekdays at 10am",
     listId = 1866,
     signupPage = Some("/australia-news/2014/dec/10/australian-politics-subscribe-by-email")
+  )
+
+  val theRecap = EmailNewsletter(
+    name = "The Recap",
+    theme = "sport",
+    teaser = "With the best of our sports journalism from the past seven days and a heads-up on the weekend’s action, you won’t miss a thing",
+    description = "With the best of our sports journalism from the past seven days and a heads-up on the weekend’s action, you won’t miss a thing. Expect stand-out features and interviews, insightful analysis and highlights from the archive, plus films, podcasts, galleries and more.",
+    frequency = "Every Friday",
+    listId = 3888,
+    signupPage = Some("/sport/2017/may/15/the-recap-sign-up-for-the-best-of-the-guardians-sport-coverage"),
+    exampleUrl = Some("/email/the-recap")
   )
 
   val theFiver = EmailNewsletter(
@@ -417,6 +440,7 @@ object EmailNewsletters {
   )
 
   val newsEmails = List(
+    businessToday,
     mediaBriefing,
     brexitBriefing,
     greenLight,
@@ -426,6 +450,7 @@ object EmailNewsletters {
   )
 
   val sportEmails = List(
+    theRecap,
     theFiver,
     theBreakdown,
     theSpin,


### PR DESCRIPTION
## What does this change?

- Add 'The Recap' to the Newsletter page and Email Prefs centre
- Add 'Business Today' to the Newsletter page and Email Prefs centre
- Rename MediaGuardian Briefing to Media Briefing

## What is the value of this and can you measure success?

New emails 💌 🚀 ⭐️

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

<img width="1330" alt="picture 780" src="https://user-images.githubusercontent.com/8607683/26837939-9eed5dde-4ad6-11e7-8cee-8973508a88fe.png">
