### PR TITLE
Digital archive

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -236,7 +236,7 @@ trait Navigation {
   val saturdayreview = SectionLink("todayspaper", "saturday review", "Saturday Review", "/theguardian/guardianreview")
 
   // Archive
-  val digitalNewspaperArchive = SectionLink("todayspaper", "digital newspaper archive", "Digital Newspaper Archive", "https://theguardian.newspapers.com")
+  val digitalNewspaperArchive = SectionLink("archive", "digital archive", "Digital Newspaper Archive", "https://theguardian.newspapers.com")
 
   // Observer newspaper
   val sundayPaper = SectionLink("theobserver", "sunday's paper", "The Observer", "/theobserver")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -51,9 +51,9 @@ object Au extends Edition(
       NavItem(fashion),
       NavItem(science),
       NavItem(membership),
-      NavItem(digitalNewspaperArchive),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video, Seq(podcast))
+      NavItem(video, Seq(podcast)),
+      NavItem(digitalNewspaperArchive)
     )
   }
 

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -111,11 +111,11 @@ object International extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
-      NavItem(digitalNewspaperArchive),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video, Seq(podcast))
+      NavItem(video, Seq(podcast)),
+      NavItem(digitalNewspaperArchive)
     )
   }
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -113,11 +113,11 @@ object Uk extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(letters, editorials, obituaries, g2, weekend, theGuide, saturdayreview)),
-      NavItem(digitalNewspaperArchive),
       NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(video, Seq(podcast))
+      NavItem(video, Seq(podcast)),
+      NavItem(digitalNewspaperArchive)
     )
   }
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -72,8 +72,8 @@ object Us extends Edition(
       NavItem(science),
       NavItem(media),
       NavItem(crosswords, crosswordsLocalNav),
-      NavItem(digitalNewspaperArchive),
-      NavItem(video, Seq(podcast))
+      NavItem(video, Seq(podcast)),
+      NavItem(digitalNewspaperArchive)
     )
   }
 


### PR DESCRIPTION
## What does this change?
Follow up from https://github.com/guardian/frontend/pull/17029

* Moves Digital Archive link to the bottom of the header menu
* Renames Digital Newspaper Archive to Digital Archive so its not cut off on the Leftcol breakpoint. Right now it looks like this:
![image](https://user-images.githubusercontent.com/8774970/26840369-c460b730-4add-11e7-9257-e6df779b8243.png)

Which isn't very accurate.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
N/A


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
