### PR TITLE
Add legacy projects to Jest module directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
       "<rootDir>/static/src/javascripts",
       "<rootDir>/static/src/javascripts/projects",
       "<rootDir>/static/src/javascripts-legacy",
+      "<rootDir>/static/src/javascripts-legacy/projects",
       "<rootDir>/static/vendor/javascripts",
       "node_modules"
     ],

--- a/static/src/javascripts-legacy/bootstraps/enhanced/crosswords.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/crosswords.js
@@ -1,7 +1,7 @@
 define([
-    'projects/common/modules/crosswords/main',
-    'projects/common/modules/crosswords/comments',
-    'projects/common/modules/crosswords/series'
+    'common/modules/crosswords/main',
+    'common/modules/crosswords/comments',
+    'common/modules/crosswords/series'
 ], function (
     init,
     initComments,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -10,15 +10,14 @@ import { tracking } from './outbrain-tracking';
  not loading Outbrain. As Outbrain is being partially loaded behind the adblock we can
  make the call instantly when we detect adBlock in use.
 */
-const canLoadInstantly = function() {
-    return detect.adblockInUse.then(
+const canLoadInstantly = () =>
+    detect.adblockInUse.then(
         adblockInUse =>
             !document.getElementById('dfp-ad--merchandising-high') ||
             adblockInUse
     );
-};
 
-const onIsOutbrainNonCompliant = function(outbrainNonCompliant) {
+const onIsOutbrainNonCompliant = outbrainNonCompliant => {
     if (outbrainNonCompliant) load('nonCompliant');
     else load();
     tracking({
@@ -27,9 +26,7 @@ const onIsOutbrainNonCompliant = function(outbrainNonCompliant) {
     return Promise.resolve();
 };
 
-const onIsOutbrainMerchandiseCompliant = function(
-    outbrainMerchandiseCompliant
-) {
+const onIsOutbrainMerchandiseCompliant = outbrainMerchandiseCompliant => {
     if (outbrainMerchandiseCompliant) {
         load('merchandising');
         tracking({
@@ -42,7 +39,7 @@ const onIsOutbrainMerchandiseCompliant = function(
         .then(onIsOutbrainNonCompliant);
 };
 
-const onIsOutbrainBlockedByAds = function(outbrainBlockedByAds) {
+const onIsOutbrainBlockedByAds = outbrainBlockedByAds => {
     if (outbrainBlockedByAds) {
         tracking({
             state: 'outbrainBlockedByAds',
@@ -54,7 +51,7 @@ const onIsOutbrainBlockedByAds = function(outbrainBlockedByAds) {
         .then(onIsOutbrainMerchandiseCompliant);
 };
 
-const onCanLoadInstantly = function(loadInstantly) {
+const onCanLoadInstantly = loadInstantly => {
     if (loadInstantly) {
         return checkMediator
             .waitForCheck('isOutbrainNonCompliant')
@@ -65,7 +62,7 @@ const onCanLoadInstantly = function(loadInstantly) {
         .then(onIsOutbrainBlockedByAds);
 };
 
-const onIsOutbrainDisabled = function(outbrainDisabled) {
+const onIsOutbrainDisabled = outbrainDisabled => {
     if (outbrainDisabled) {
         tracking({
             state: 'outbrainDisabled',
@@ -75,10 +72,7 @@ const onIsOutbrainDisabled = function(outbrainDisabled) {
     return canLoadInstantly().then(onCanLoadInstantly);
 };
 
-const init = function() {
-    return checkMediator
-        .waitForCheck('isOutbrainDisabled')
-        .then(onIsOutbrainDisabled);
-};
+const init = () =>
+    checkMediator.waitForCheck('isOutbrainDisabled').then(onIsOutbrainDisabled);
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -1,6 +1,6 @@
 // @flow
 import detect from 'lib/detect';
-import checkMediator from 'projects/common/modules/check-mediator';
+import checkMediator from 'common/modules/check-mediator';
 import { load } from './outbrain-load';
 import { tracking } from './outbrain-tracking';
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import config from 'lib/config';
-import checkMediator from 'projects/common/modules/check-mediator';
+import checkMediator from 'common/modules/check-mediator';
 import detect from 'lib/detect';
 import { load } from './outbrain-load';
 import { tracking } from './outbrain-tracking';

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -2,7 +2,7 @@
 import config from 'lib/config';
 import detect from 'lib/detect';
 import { local } from 'lib/storage';
-import userFeatures from 'projects/commercial/modules/user-features';
+import userFeatures from 'commercial/modules/user-features';
 
 const adblockInUse = (): Promise<boolean> => detect.adblockInUse;
 

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.spec.js
@@ -1,12 +1,12 @@
 // @flow
 
-import userFeatures from 'projects/commercial/modules/user-features';
+import userFeatures from 'commercial/modules/user-features';
 import detect from 'lib/detect';
 import config from 'lib/config';
 import { local } from 'lib/storage';
 import { showAdblockMsg } from './adblock-messages';
 
-jest.mock('projects/commercial/modules/user-features', () => ({
+jest.mock('commercial/modules/user-features', () => ({
     isPayingMember: jest.fn(),
 }));
 

--- a/static/src/javascripts/projects/common/modules/user-prefs.spec.js
+++ b/static/src/javascripts/projects/common/modules/user-prefs.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import userPrefs from 'projects/common/modules/user-prefs';
+import userPrefs from 'common/modules/user-prefs';
 import { local } from 'lib/storage';
 
 class LocalStorageMock {

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
@@ -4,7 +4,7 @@ import bean from 'bean';
 import $ from 'lib/$';
 import sinon from 'sinon';
 
-import { SearchTool } from 'projects/facia/modules/onwards/search-tool';
+import { SearchTool } from 'facia/modules/onwards/search-tool';
 import mediator from 'lib/mediator';
 
 describe('Search tool', () => {

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
@@ -3,7 +3,7 @@
 import bonzo from 'bonzo';
 import qwery from 'qwery';
 
-import { _ } from 'projects/facia/modules/ui/container-show-more';
+import { _ } from 'facia/modules/ui/container-show-more';
 
 const { itemsByArticleId, dedupShowMore } = _;
 


### PR DESCRIPTION
## What does this change?

@gidsg drew my attention to an issue apparently within Jest, when ES6 code under test imports legacy modules. In this case, the path to the legacy module needs to include `projects/` at the start, as has been implemented in [`adblock-messages.js`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js#L5).

The correct fix for this issue is to add a line to the [`moduleDirectories`](https://github.com/guardian/frontend/blob/master/package.json#L144-L150) section of `package.json`. 

I have taken the trouble to eradicate references to `projects/` in all import paths, to avoid future confusion.

I have also fixed some lint issues in `outbrain.js`, while I was there.

## What is the value of this and can you measure success?

Avoids the need for devs to update import paths when writing tests for converted modules that depend on legacy modules.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
