### PR TITLE
Deps: Upgrade amphtml-validator to 1.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "amd-to-es6": "^0.1.0",
-    "amphtml-validator": "^1.0.10",
+    "amphtml-validator": "^1.0.20",
     "any-observable": "^0.2.0",
     "autoprefixer": "^7.1.1",
     "aws-sdk": "~2.0.0-rc4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,9 +120,9 @@ amdefine@>=0.0.4:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.0.tgz#fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
 
-amphtml-validator@^1.0.10:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.13.tgz#5e8a2d328cb12d41a6547d7c3e8f90d50dec326c"
+amphtml-validator@^1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/amphtml-validator/-/amphtml-validator-1.0.20.tgz#5f6a75ca1917844526e5d87f74c1334c0eccb514"
   dependencies:
     colors "1.1.2"
     commander "2.9.0"


### PR DESCRIPTION
## What does this change?

Upgrades the package. None of the changes seem to affect us.

### Changelog ###

**1.0.15**: Added support for installing on Windows. npm install -g amphtml-validator should now just work.

**1.0.16**: npm install amphtml-validator (local install) should now work on Windows, for require('amphtml-validator').

**1.0.17**: If the amphtml-validator command is already patched up for Windows, leave it alone instead of failing. Relevant if the package has been installed globally and now we're performing a local install on top of it.

**1.0.18**: Small tweaks to this file and package.json.

**1.0.19**: Set correct process exit status for old versions of Node.js (v0.10.25).

**1.0.20**: Better npm post-install for virtual machines, running debian over windows with SMB shared folder

## What is the value of this and can you measure success?

Up-to-date dependencies. ✨ 

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
