### PR TITLE
Change "Become a supporter" label on mobile breakpoint to say "thank you" if paid member

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/membership.js
@@ -4,8 +4,12 @@ define(['commercial/modules/user-features', 'lib/fastdom-promise', 'lib/$'], fun
     function init() {
         if (userFeatures.isPayingMember()) {
             var $becomeMemberLink = $('.js-become-member');
+            var $becomeSupporterLabel = $('.header-cta-item__label');
+            var $becomeSupporterNewLine = $('.header-cta-item__new-line');
             var $subscriberLink = $('.js-subscribe');
             fastdom.write(function () {
+                $becomeSupporterLabel.text('Thank you for')
+                $becomeSupporterNewLine.text('your support')
                 $becomeMemberLink.attr('hidden', 'hidden');
                 $subscriberLink.removeClass(LAST_CLASS);
             });

--- a/static/src/javascripts-legacy/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts-legacy/projects/common/modules/navigation/membership.js
@@ -5,11 +5,9 @@ define(['commercial/modules/user-features', 'lib/fastdom-promise', 'lib/$'], fun
         if (userFeatures.isPayingMember()) {
             var $becomeMemberLink = $('.js-become-member');
             var $becomeSupporterLabel = $('.header-cta-item__label');
-            var $becomeSupporterNewLine = $('.header-cta-item__new-line');
             var $subscriberLink = $('.js-subscribe');
             fastdom.write(function () {
-                $becomeSupporterLabel.text('Thank you for')
-                $becomeSupporterNewLine.text('your support')
+                $becomeSupporterLabel.html('Thank you for <span class="header-cta-item__new-line">your support</span>');
                 $becomeMemberLink.attr('hidden', 'hidden');
                 $subscriberLink.removeClass(LAST_CLASS);
             });


### PR DESCRIPTION
Status: Holding off on merge until this has been discussed further.

This changes the text of the "Become a supporter" label on the top of the nav at mobile breakpoint to say thank-you if the user is recognised as a paid member

This is a small change coming out of the membership design sprint. It is one of a number of ways we aim to recognise our supporters when they visit us in order to encourage an emotional connection.

## Does this affect other platforms - Amp, Apps, etc?
This change doesn't but these platforms may be updated by future changes

## Screenshots
![image](https://user-images.githubusercontent.com/7239344/26891575-660d63d8-4bad-11e7-889b-792e2f1fda50.png)



## Tested in CODE?
Yes.

@guardian/dotcom-platform 
