### PR TITLE
Sticky options to override defaults

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -14,11 +14,15 @@ class Sticky {
     constructor(element: HTMLElement, options: Object = {}): void {
         this.element = element;
 
-        this.opts = Object.assign(options, {
-            top: 0,
-            containInParent: true,
-            emitMessage: false,
-        });
+        this.opts = Object.assign(
+            {},
+            {
+                top: 0,
+                containInParent: true,
+                emitMessage: false,
+            },
+            options
+        );
     }
 
     init(): void {


### PR DESCRIPTION
## What does this change?

Currently the default sticky options are overriding any options that are provided to the `Sticky` class. This is the opposite of what ought to be happening. This is causing the liveblog toast to appear at a specific location at the top of the liveblog, instead of in a fixed position relative to the viewport.

## What is the value of this and can you measure success?

Fixes the position of the liveblog toast once more. It may fix other unreported issues with the sticky MPU, which also passes its own options.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

![jun-07-2017 11-33-27](https://user-images.githubusercontent.com/5931528/26874351-32ffbf82-4b75-11e7-8991-0cdb1b98232f.gif)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
