### PR TITLE
Add the "useTailoredCopy" feature to variants in epic ab tests

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -244,7 +244,7 @@ define([
             var onView = options.onView || noop;
 
             function render(templateFn) {
-                return getCopy(options.useTailoredCopy).then(function (copy) {
+                return getCopy(options.useTailoredCopyForRegulars).then(function (copy) {
                     var template = templateFn || this.options.template;
                     return template(this, copy);
                 }.bind(this)).then(function(template) {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -26,7 +26,8 @@ define([
         variants: [
             {
                 id: 'control',
-                isUnlimited : true
+                isUnlimited : true,
+                useTailoredCopy: true
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -27,7 +27,7 @@ define([
             {
                 id: 'control',
                 isUnlimited : true,
-                useTailoredCopy: true
+                useTailoredCopyForRegulars: true
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -29,6 +29,7 @@ define([
                 id: 'control',
                 isUnlimited : true,
                 successOnView: true,
+                useTailoredCopy: true
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -29,7 +29,7 @@ define([
                 id: 'control',
                 isUnlimited : true,
                 successOnView: true,
-                useTailoredCopy: true
+                useTailoredCopyForRegulars: true
             }
         ]
     });

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -1,16 +1,7 @@
 define([
-    'common/modules/commercial/contributions-utilities',
-    'raw-loader!common/views/acquisitions-epic-control.html',
-    'common/modules/tailor/tailor',
-    'lodash/utilities/template',
-    'common/modules/commercial/acquisitions-copy'
-
+    'common/modules/commercial/contributions-utilities'
 ], function (
-    contributionsUtilities,
-    acquisitionsEpicControlTemplate,
-    tailor,
-    template,
-    acquisitionsCopy
+    contributionsUtilities
 ) {
 
    return contributionsUtilities.makeABTest({
@@ -37,20 +28,8 @@ define([
                     count: 4,
                     minDaysBetweenViews: 0
                 },
-                test: function(render) {
-                    tailor.isRegular().then(function (regular) {
-                        var copy = regular ? acquisitionsCopy.regulars: acquisitionsCopy.control;
-                        return render(function(variant) {
-                            return template(acquisitionsEpicControlTemplate, {
-                                copy: copy,
-                                membershipUrl: variant.options.membershipURL,
-                                contributionUrl: variant.options.contributeURL,
-                                componentName: variant.options.componentName,
-                                testimonialBlock: variant.options.testimonialBlock
-                            });
-                        });
-                    });
-                },
+
+                useTailoredCopy: true,
                 insertAtSelector: '.submeta',
                 successOnView: true
             }

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -29,7 +29,7 @@ define([
                     minDaysBetweenViews: 0
                 },
 
-                useTailoredCopy: true,
+                useTailoredCopyForRegulars: true,
                 insertAtSelector: '.submeta',
                 successOnView: true
             }


### PR DESCRIPTION
## What does this change?

Previously, if we wanted to decide to show the tailored copy for regulars, we had to put it in the individual AB test. This wasn't an issue when it was only the Ask4Earning test, but now we have 2 other tests that want to show the tailoerd copy for regulars, the alwaysAskEleciton test and the alwausAskIfTagged test. 

To duplicate the check in all 3 files would result in unneeded boiler plate, so this PR moves it to contributions utilities. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
