### PR TITLE
Navigation: Hide home links on large screens

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -2,6 +2,7 @@
 
 @import common.{ NewNavigation, LinkTo, Edition }
 @import conf.switches.Switches.SearchSwitch
+@import views.support.RenderClasses
 
 @sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection) = {
     @defining(Edition(request)) { edition =>
@@ -21,7 +22,9 @@
                 aria-label="Submenu @{topLevelSection.name}"
                 role="menu">
                 @topLevelSection.getAllEditionalisedNavLinks(edition).map { sectionItem =>
-                    <li class="menu-item"
+                    <li class="@RenderClasses(Map(
+                                "menu-item--home" -> (sectionItem.iconName == "home")
+                            ), "menu-item")"
                         role="menuitem">
                         <a class="menu-item__title"
                            href="@LinkTo { @sectionItem.url }"

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -25,6 +25,13 @@
         @include mq(desktop) {
             width: 100%;
         }
+
+        // hide * home links, which are duplicated on large screens
+        &:first-child {
+            @include mq(desktop) {
+                display: none;
+            }
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -25,13 +25,12 @@
         @include mq(desktop) {
             width: 100%;
         }
+    }
+}
 
-        // hide * home links, which are duplicated on large screens
-        &:first-child {
-            @include mq(desktop) {
-                display: none;
-            }
-        }
+.menu-item--home {
+    @include mq(desktop) {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Hides "home" links on large screens, because of the duplication with pillars.

## What is the value of this and can you measure success?

Less links, less choice -> more happy.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

<img width="1280" alt="screen shot 2017-06-07 at 14 49 47" src="https://user-images.githubusercontent.com/2244375/26881855-99ae3bbc-4b90-11e7-860c-25bb320c9b1a.png">

## Tested in CODE?

No.
