### PR TITLE
show election onward container

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/trail.js
@@ -17,7 +17,8 @@ define([
     'common/modules/onward/popular',
     'common/modules/onward/related',
     'common/modules/onward/tonal',
-    'common/modules/social/share-count'
+    'common/modules/social/share-count',
+    'common/modules/onward/election-onward-content',
 ], function (
     fastdom,
     qwery,
@@ -35,7 +36,8 @@ define([
     Popular,
     Related,
     TonalComponent,
-    shareCount
+    shareCount,
+    ElectionOnward
 ) {
 
     function insertOrProximity(selector, insert) {
@@ -81,7 +83,12 @@ define([
 
     function initOnwardContent() {
         insertOrProximity('.js-onward', function () {
-            if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
+            // isGeneralElectionContent and ElectionOnward import are temporary and will be removed in time
+            var isGeneralElectionContent = config.page.keywordIds && config.page.keywordIds.split(',').includes('politics/general-election-2017');
+
+            if (isGeneralElectionContent) {
+                new ElectionOnward.ElectionOnwardContent(qwery('.js-onward'));
+            } else if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
                 new Onward(qwery('.js-onward'));
             } else if (config.page.tones !== '') {
                 $('.js-onward').each(function (c) {

--- a/static/src/javascripts/projects/common/modules/onward/election-onward-content.js
+++ b/static/src/javascripts/projects/common/modules/onward/election-onward-content.js
@@ -1,0 +1,27 @@
+// @flow
+import mediator from 'lib/mediator';
+import register from 'common/modules/analytics/register';
+import Component from 'common/modules/component';
+
+class ElectionOnwardContent extends Component {
+    static ready(): void {
+        register.end('general-election-content');
+        mediator.emit('modules:onward:loaded');
+        mediator.emit('page:new-content');
+        mediator.emit('ui:images:upgradePictures');
+    }
+
+    static error(): void {
+        register.error('general-election-content');
+    }
+
+    constructor(context: Array<Element>): void {
+        super();
+        register.begin('general-election-content');
+        this.context = context;
+        this.endpoint = '/container/381f3487-3726-40d7-9742-136bed95a244.json';
+        this.fetch(this.context, 'html');
+    }
+}
+
+export { ElectionOnwardContent };


### PR DESCRIPTION
## What does this change?

If an article is tagged with 'politics/general-election-2017' then show the election specific onward container in the 'onward' container beneath the article. This is temporary and will be reverted at some point.

## What is the value of this and can you measure success?

Promotes election specific content.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

election specific onward container...

![picture 61](https://user-images.githubusercontent.com/1590704/26883151-3a46fee4-4b94-11e7-8352-d93cbb6a2d8e.png)

## Tested in CODE?

No