### PR TITLE
pass callback instead of result of calling callback

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -57,7 +57,7 @@ define([
 
     function onThrasherViewed(thrasherElement, callback) {
         // Element in view logic taken from contribution utilities.
-        elementInView(thrasherElement, window, { top: 18 }).on('firstview', callback())
+        elementInView(thrasherElement, window, { top: 18 }).on('firstview', callback)
     }
 
     return function() {


### PR DESCRIPTION
## What does this change?

Fixes a bug which prevented the success function of the uk election acquisition thrasher from firing.

## What is the value of this and can you measure success?

Allows us to analyse the conversion rate of the uk election thrasher.

## Tested in CODE?

Yes. @GHaberis neither of the exceptions we saw are displayed in the console after this change on CODE. Hopefully it'll be the same for PROD 🙏 
