### PR TITLE
Revert election-based testimonial to paywall version

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -113,11 +113,6 @@ define([
         });
     }
 
-    function getControlTestimonialBlock(location){
-        var testimonialParameters = location == 'GB' ? acquisitionsTestimonialParameters.controlGB : acquisitionsTestimonialParameters.control;
-        return getTestimonialBlock(testimonialParameters);
-    }
-
     function defaultCanEpicBeDisplayed(testConfig) {
         var enoughTimeSinceLastContribution = testConfig.showToContributors || daysSince(lastContributionDate) >= 180;
         var canReasonablyAskForMoney = testConfig.showToSupporters || commercialFeatures.commercialFeatures.canReasonablyAskForMoney;
@@ -210,7 +205,7 @@ define([
             membershipURL: options.membershipURL || this.getURL(membershipBaseURL, campaignCode),
             componentName: 'mem_acquisition_' + trackingCampaignId + '_' + this.id,
             template: options.template || controlTemplate,
-            testimonialBlock: options.testimonialBlock || getControlTestimonialBlock(geolocation.getSync()),
+            testimonialBlock: options.testimonialBlock || getTestimonialBlock(acquisitionsTestimonialParameters.control),
             blockEngagementBanner: options.blockEngagementBanner || false,
             engagementBannerParams: options.engagementBannerParams || {},
             isOutbrainCompliant: options.isOutbrainCompliant || false,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -16,10 +16,6 @@ const controlMessage =
     'Because I appreciate there not being a paywall: it is more democratic for the media to be available for all and not a commodity to be purchased by a few. I’m happy to make a contribution so others with less means still have access to information.';
 const controlName = 'Thomasine F-R.';
 
-const gbControlMessage =
-    'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible, independent check on the government, this contribution was pretty good value for money.';
-const gbControlName = 'Jack H.';
-
 const usLocalisedMessage =
     'I made a contribution to the Guardian today because I believe our country, the US, is in peril and we need quality independent journalism more than ever. Reading news from websites like this helps me keep some sense of sanity and provides a bit of hope in these dangerous, alarming times. Keep up the good work! I appreciate you.';
 const usLocalisedName = 'Charru B.';
@@ -28,12 +24,6 @@ export const control: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage: controlMessage,
     testimonialName: controlName,
-};
-
-export const controlGB: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: gbControlMessage,
-    testimonialName: gbControlName,
 };
 
 export const usLocalised: AcquisitionsEpicTestimonialTemplateParameters = {


### PR DESCRIPTION
⚠️  Don't merge this until the exit polls are in ⚠️ 
## What does this change?
Restores the original Thomasine F-R quote from the election focused one which was tested in #16889 and made the default in #16991

## What is the value of this and can you measure success?
It's a part of the scheduling of various Epic work in line with the election.

## Does this affect other platforms - Amp, Apps, etc?
No 

## Screenshots
![screen shot 2017-06-07 at 16 18 15](https://user-images.githubusercontent.com/1064734/26886317-ec528cf4-4b9c-11e7-85b1-6a5f415ea336.png)

@guardian/contributions 