### PR TITLE
Fix paid container when no targetUrl exists

### DIFF
--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -16,8 +16,10 @@
         optStamp = Some(stamp),
         optBadge = if(containerModel.isSingleSponsorContainer){ Some(logoSlot) } else { None }
     ){
-        <a class="adverts__logo u-text-hyphenate"
-           href="/@containerModel.content.targetUrl">@containerModel.content.title</a>
+        @containerModel.content.targetUrl match {
+            case None => { <span tabindex="0">@containerModel.content.title</span> }
+            case Some(href) => { <a class="adverts__logo u-text-hyphenate" href="/@href">@containerModel.content.title</a> }
+        }
     }{
 
         @containerModel.layoutName match {


### PR DESCRIPTION
## What does this change?

This changes paid containers; when there is no `href` on the container, it links back to `/` of the site, bringing users that click it back to the home page.
This is different to how all other containers work; when they do now contain a `href`; they are not clickable.

## Tested in CODE/DEV?

Yes


@ScottPainterGNM @katebee 