### PR TITLE
Update MVT to last until after the election where it can be revisited.

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -20,12 +20,12 @@ object CommercialGalleryBannerAds extends TestDefinition(
   name = "commercial-gallery-banner-ads",
   description = "Users in the test will see banner ads instead of MPUs in galleries",
   owners = Seq(Owner.withGithub("JonNorman")),
-  sellByDate = new LocalDate(2017, 6, 8)
+  sellByDate = new LocalDate(2017, 7, 11)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-commercial-gallery-banner-ads")
 
-  def canRun(implicit request: RequestHeader): Boolean = participationGroup.isDefined
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
 }
 
 object CommercialClientLoggingVariant extends TestDefinition(


### PR DESCRIPTION
I'm removing the header logic from `fastly-edge-cache` but I want to keep this in PROD as we will revisit it once the election is over.

@guardian/commercial-dev 