### PR TITLE
UK election thrasher updated

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-thrasher-uk-election.js
@@ -16,7 +16,11 @@ define([
 
     var UK_ELECTION_THRASHER_VIEW_COUNTER = "gu.uk-election-thrasher.views";
 
-    var UK_ELECTION_THRASHER_BLOCK_ELEMENT = "election-supporters__wrapper";
+    var UK_ELECTION_THRASHER_BLOCK_ELEMENT = "election-supporters__container";
+
+    // Default is used for when the AB test can't be run.
+    // The instance we know about is Safari in incognito mode, where local storage is not available.
+    var UK_ELECTION_THRASHER_DEFAULT_CLASS_LIST = "election-supporters__container--ask election-supporters__container--0";
 
     function getThrasherViewedCount() {
         return parseInt(storage.local.get(UK_ELECTION_THRASHER_VIEW_COUNTER)) || 0;
@@ -85,6 +89,7 @@ define([
                     id: 'control',
 
                     test: function() {
+                        $ukElectionThrasher.removeClass(UK_ELECTION_THRASHER_DEFAULT_CLASS_LIST);
                         $ukElectionThrasher.addClass(getReaderSpecificUkElectionThrasherClassList())
                     },
 


### PR DESCRIPTION
## What does this change?

Changes the block element for the UK election thrasher and assumes default CSS classes.

## What is the value of this and can you measure success?

Having default CSS classes means the reader will see a variant of the thrasher, even if the AB test is not run.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

N/A

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
