### PR TITLE
Add engagement banner region blocking functionality

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -195,6 +195,36 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val MembershipEngagementBannerBlockUK = Switch(
+    SwitchGroup.Commercial,
+    "membership-engagement-banner-block-uk",
+    "Prevent the engagement banner from showing on UK fronts",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val MembershipEngagementBannerBlockUS = Switch(
+    SwitchGroup.Commercial,
+    "membership-engagement-banner-block-us",
+    "Prevent the engagement banner from showing on US fronts",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val MembershipEngagementBannerBlockAU = Switch(
+    SwitchGroup.Commercial,
+    "membership-engagement-banner-block-au",
+    "Prevent the engagement banner from showing on AU fronts",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val AdBlockMessage = Switch(
     SwitchGroup.Commercial,
     "adblock",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -198,7 +198,7 @@ trait CommercialSwitches {
   val MembershipEngagementBannerBlockUK = Switch(
     SwitchGroup.Commercial,
     "membership-engagement-banner-block-uk",
-    "Prevent the engagement banner from showing on UK fronts",
+    "If this switch is turned on, the engagement banner will NOT show up on UK fronts for readers in the UK",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     sellByDate = never,
@@ -208,7 +208,7 @@ trait CommercialSwitches {
   val MembershipEngagementBannerBlockUS = Switch(
     SwitchGroup.Commercial,
     "membership-engagement-banner-block-us",
-    "Prevent the engagement banner from showing on US fronts",
+    "If this switch is turned on, the engagement banner will NOT show up on US fronts for readers in the US",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     sellByDate = never,
@@ -218,7 +218,7 @@ trait CommercialSwitches {
   val MembershipEngagementBannerBlockAU = Switch(
     SwitchGroup.Commercial,
     "membership-engagement-banner-block-au",
-    "Prevent the engagement banner from showing on AU fronts",
+    "If this switch is turned on, the engagement banner will NOT show up on AU fronts for readers in AU",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     sellByDate = never,

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -19,6 +19,7 @@ define([
         'common/modules/experiments/segment-util',
         'common/modules/experiments/acquisition-test-selector',
         'common/modules/commercial/membership-engagement-banner-parameters',
+        'common/modules/commercial/membership-engagement-banner-block',
         'common/modules/commercial/contributions-utilities',
         'ophan/ng',
         'lib/geolocation',
@@ -43,6 +44,7 @@ define([
                  segmentUtil,
                  acquisitionTestSelector,
                  membershipEngagementBannerUtils,
+                 membershipEngagementBannerBlock,
                  contributionsUtilities,
                  ophan,
                  geolocation,
@@ -156,7 +158,7 @@ define([
 
         function showBanner(params) {
 
-            if (params === DO_NOT_RENDER_ENGAGEMENT_BANNER) {
+            if (params === DO_NOT_RENDER_ENGAGEMENT_BANNER || membershipEngagementBannerBlock.isBlocked()) {
                 return;
             }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.js
@@ -1,0 +1,41 @@
+// @flow
+import config from 'lib/config';
+import flatten from 'lodash/arrays/flatten';
+
+/**
+ * A set of front URLs associated with a given region
+ * that the engagement banner won't show up against
+ * if the appropriate block switch is turned on.
+ */
+type RegionalFrontURLs = Array<string>;
+
+/**
+ * Associate switch names with sets of URLs to block
+ */
+type SwitchURLMap = { [switchName: string]: RegionalFrontURLs };
+
+const UK: RegionalFrontURLs = ['/uk', '/uk-news'];
+const US: RegionalFrontURLs = ['/us', '/us-news'];
+const AU: RegionalFrontURLs = ['/au', '/australia-news'];
+
+const defaultSwitchUrls: SwitchURLMap = {
+    membershipEngagementBannerBlockUk: UK,
+    membershipEngagementBannerBlockUs: US,
+    membershipEngagementBannerBlockAu: AU,
+};
+
+const allSwitches: Array<string> = ['Uk', 'Us', 'Au'].map(
+    region => `membershipEngagementBannerBlock${region}`
+);
+
+export const isBlocked = (
+    switches: Array<string> = allSwitches,
+    switchUrls: SwitchURLMap = defaultSwitchUrls,
+    pathname: string = document.location.pathname
+): boolean => {
+    const blockedUrls: Array<string> = flatten(
+        switches.filter(s => !!config.switches[s]).map(s => switchUrls[s])
+    );
+
+    return blockedUrls.includes(pathname);
+};

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-block.spec.js
@@ -1,0 +1,32 @@
+// @flow
+import config from 'lib/config';
+import { isBlocked } from './membership-engagement-banner-block';
+
+const switches = ['foo', 'bar'];
+
+const switchUrls = {
+    foo: ['/a', '/b'],
+    bar: ['/c', '/d'],
+};
+
+describe('Engagement Banner blocking', () => {
+    it('should block correctly', () => {
+        config.switches.foo = true;
+        config.switches.bar = false;
+
+        expect(isBlocked(switches, switchUrls, '/a')).toBe(true);
+        expect(isBlocked(switches, switchUrls, '/b')).toBe(true);
+        expect(isBlocked(switches, switchUrls, '/c')).toBe(false);
+        expect(isBlocked(switches, switchUrls, '/d')).toBe(false);
+        expect(isBlocked(switches, switchUrls, '/e')).toBe(false);
+
+        config.switches.foo = false;
+        config.switches.bar = true;
+
+        expect(isBlocked(switches, switchUrls, '/a')).toBe(false);
+        expect(isBlocked(switches, switchUrls, '/b')).toBe(false);
+        expect(isBlocked(switches, switchUrls, '/c')).toBe(true);
+        expect(isBlocked(switches, switchUrls, '/d')).toBe(true);
+        expect(isBlocked(switches, switchUrls, '/e')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What does this change?
This introduces 3 switches that will prevent the engagement banner from showing up against front URLs associated with a given region. 

The URLs in the file will probably need adding to but the basic functionality should be complete. 

## What is the value of this and can you measure success?
When fronts contain a lot of sensitive articles (e.g. during crises)  we can enable these switches to ensure the engagement banner won't show up against the corresponding front URLs.

@guardian/contributions 