### PR TITLE
Add vote warning for commenting during election

### DIFF
--- a/common/app/conf/switches/DiscussionSwitches.scala
+++ b/common/app/conf/switches/DiscussionSwitches.scala
@@ -1,6 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
+import org.joda.time.LocalDate
 
 trait DiscussionSwitches {
   val DiscussionAllPageSizeSwitch = Switch(
@@ -41,6 +42,16 @@ trait DiscussionSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
+  )
+
+  val DiscussionWarnVoteDeclaration = Switch(
+    SwitchGroup.Discussion,
+    "discussion-warn-vote-declaration",
+    "If this is switched on, warn readers not to share voting behaviour before commenting",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 6, 13),
+    exposeClientSide = false
   )
 
 }

--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -1,4 +1,6 @@
-@()(implicit request: RequestHeader)
+@import conf.switches.Switches._
+
+@(isPolitics: Boolean)(implicit request: RequestHeader)
 <form class="component js-comment-box d-comment-box">
 
     <div class="d-comment-box__meta">
@@ -47,7 +49,12 @@
             <span class="d-discussion__error-text">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</span>
         </div>
 
-        <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
+        @if(DiscussionWarnVoteDeclaration.isSwitchedOn && isPolitics) {
+          <div class="d-comment-box__community-standards">While polls remain open, and if you are entitled to vote in the election, please refrain from disclosing your voting choices. Any comment declaring how you cast your vote will be removed by moderators owing to restrictions on polls and reporting, set out in article 66A of the Representation of the People Act 1983. Once all polling stations have closed this restriction will be lifted. Thank you for your cooperation.</div>
+        } else {
+          <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
+        }
+
         <label for="d-comment-box" class="u-h">Enter comment</label>
         <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…" id="d-comment-box"></textarea>
         <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__submit">Post your comment</button>

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -126,7 +126,7 @@
                         </button>
 
                         <script type="text/template" id="tmpl-comment-box">
-                        @fragments.commentBox()
+                        @fragments.commentBox(content.metadata.section.map(_.id).contains("politics"))
                         </script>
 
                     </div>


### PR DESCRIPTION
## What does this change?

Adds a notice to ask people not to mention their voting behaviour in the comments *for politics* articles only - mostly we are targeting the liveblog here. The wording has been approved by legal and the mods.

## What is the value of this and can you measure success?

Mods have had to remove lots of comments in the past - hopefully this helps. But it's too short a period to test so we'll just turn on the switch and see.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

![vote-warning](https://user-images.githubusercontent.com/858402/26924751-fa5a4c68-4c3e-11e7-80c7-0d771da67d6a.gif)


## Tested in CODE?

Yes.
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
