### PR TITLE
Remove MostPopularExpandableAgent

### DIFF
--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -38,7 +38,6 @@ trait OnwardServices {
   lazy val geoMostPopularAgent = wire[GeoMostPopularAgent]
   lazy val dayMostPopularAgent = wire[DayMostPopularAgent]
   lazy val mostPopularAgent = wire[MostPopularAgent]
-  lazy val mostPopularExpandableAgent = wire[MostPopularExpandableAgent]
   lazy val mostReadAgent = wire[MostReadAgent]
   lazy val mostPopularSocialAutoRefresh = wire[MostPopularSocialAutoRefresh]
   lazy val mostViewedAudioAgent = wire[MostViewedAudioAgent]

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -12,7 +12,6 @@ class OnwardJourneyLifecycle(
   geoMostPopularAgent: GeoMostPopularAgent,
   dayMostPopularAgent: DayMostPopularAgent,
   mostPopularAgent: MostPopularAgent,
-  mostPopularExpandableAgent: MostPopularExpandableAgent,
   mostViewedAudioAgent: MostViewedAudioAgent,
   mostViewedGalleryAgent: MostViewedGalleryAgent,
   mostViewedVideoAgent: MostViewedVideoAgent)(implicit ec: ExecutionContext) extends LifecycleComponent {
@@ -28,7 +27,6 @@ class OnwardJourneyLifecycle(
     // fire every min
     jobs.schedule("OnwardJourneyAgentsRefreshJob", "0 * * * * ?") {
       mostPopularAgent.refresh()
-      mostPopularExpandableAgent.refresh()
       geoMostPopularAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostViewedAudioAgent.refresh()
@@ -42,7 +40,6 @@ class OnwardJourneyLifecycle(
 
     akkaAsync.after1s {
       mostPopularAgent.refresh()
-      mostPopularExpandableAgent.refresh()
       geoMostPopularAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostViewedAudioAgent.refresh()


### PR DESCRIPTION
It's content is never used but it makes 20 requests to CAPI every
minute

## What is the value of this and can you measure success?
Less requests to CAPI, no useless code

## Tested in CODE?
No