### PR TITLE
Add liveblog epics on auto-update

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -287,7 +287,7 @@ define([
                 });
             }
 
-            return (typeof options.test === 'function') ? options.test(render.bind(this), this) : render.apply(this);
+            return (typeof options.test === 'function') ? options.test(render.bind(this), this, test) : render.apply(this);
         };
 
         this.registerIframeListener();

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -1,7 +1,6 @@
 define([
     'common/modules/commercial/contributions-utilities',
     'common/modules/commercial/acquisitions-view-log',
-    'lib/geolocation',
     'lodash/utilities/template',
     'lib/$',
     'lib/config',
@@ -13,7 +12,6 @@ define([
 ], function (
     contributionsUtilities,
     viewLog,
-    geolocation,
     template,
     $,
     config,

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -1,19 +1,57 @@
 define([
     'common/modules/commercial/contributions-utilities',
+    'common/modules/commercial/acquisitions-view-log',
     'lib/geolocation',
     'lodash/utilities/template',
+    'lib/$',
     'lib/config',
+    'lib/mediator',
+    'lib/element-inview',
+    'lib/fastdom-promise',
     'raw-loader!common/views/acquisitions-epic-liveblog.html',
     'common/modules/commercial/acquisitions-copy',
 ], function (
     contributionsUtilities,
+    viewLog,
     geolocation,
     template,
+    $,
     config,
+    mediator,
+    ElementInView,
+    fastdom,
     liveblogEpicTemplate,
     acquisitionsCopy
 ) {
     var pageId = config.page.pageId || '';
+
+    var isAutoUpdateHandlerBound = false;
+
+    var INSERT_EPIC_AFTER_CLASS = 'js-insert-epic-after';
+
+    function setupViewTracking(el, test) {
+        // top offset of 18 ensures view only counts when half of element is on screen
+        var elementInView = ElementInView(el, window, { top: 18 });
+
+        elementInView.on('firstview', function () {
+            viewLog.logView(test.id);
+            mediator.emit(test.viewEvent);
+        });
+    }
+
+    function addEpicToBlocks(epicHtml, test) {
+        return fastdom.write(function() {
+            var $blocksToInsertEpicAfter = $('.' + INSERT_EPIC_AFTER_CLASS);
+
+            $blocksToInsertEpicAfter.each(function(el) {
+                var $epic = $.create(epicHtml);
+                $epic.insertAfter(el);
+                $(el).removeClass(INSERT_EPIC_AFTER_CLASS);
+
+                setupViewTracking(el, test);
+            });
+        });
+    }
 
     return contributionsUtilities.makeABTest({
         id: 'AcquisitionsEpicLiveblog',
@@ -56,6 +94,18 @@ define([
                         componentName: variant.options.componentName
                     });
                 },
+
+                test: function(renderFn, variant, test) {
+                    var epicHtml = variant.options.template(variant);
+                    addEpicToBlocks(epicHtml, test);
+
+                    if (!isAutoUpdateHandlerBound) {
+                        mediator.on('modules:autoupdate:updates', function() {
+                            addEpicToBlocks(epicHtml, test);
+                        });
+                        isAutoUpdateHandlerBound = true;
+                    }
+                }
             }
         ]
     });


### PR DESCRIPTION
## What does this change?
Allows liveblog epics to be inserted for blocks which are being dynamically added to the page on auto-update

## What is the value of this and can you measure success?
More people seeing liveblog epics, more money

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
Yep!

@guardian/contributions 
