### PR TITLE
Fix liveblog design test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog-design-test.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-liveblog-design-test.js
@@ -26,7 +26,7 @@ define([
     var insertEpicAfterSelector = '.js-insert-epic-after';
 
     function isEpic(el) {
-        $(el).hasClass('is-liveblog-epic');
+        return $(el).hasClass('is-liveblog-epic');
     }
 
     function getLiveblogEntryTimeData(el) {
@@ -55,6 +55,10 @@ define([
     }
 
     function setEpicLiveblogEntryTimeData(el, timeData) {
+        if (!el) {
+            return;
+        }
+
         var $epicTimeEl = $('time', el);
         $epicTimeEl.attr('datetime', timeData.datetime);
         $epicTimeEl.attr('title', timeData.title);


### PR DESCRIPTION
Fixes a bug in #16943 which caused it to overwrite the times of all liveblog entries when it should've just been copying it to the epic. That missing `return` makes all the difference!

Also adds an extra guard in case `el` is unexpectedly undefined - unhelpfully if the context argument is undefined then it searches globally, which is bad

@SiAdcock  