### PR TITLE
Less cookie refreshes from discussion

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/loader.js
@@ -296,9 +296,9 @@ Loader.prototype.getUser = function() {
     if (Id.getUserFromCookie()) {
         DiscussionApi.getUser().then(function(resp) {
             self.user = resp.userProfile;
-            Id.getUserFromApiWithRefreshedCookie().then(function (response) {
-                if (response.user.publicFields.username) {
-                    self.username = response.user.publicFields.username;
+            Id.getUserFromApi(function (user) {
+                if (user && user.publicFields.username) {
+                    self.username = user.publicFields.username;
                 }
                 self.emit('user:loaded');
             });


### PR DESCRIPTION
## What does this change?
We observed a precipitous rise in the number of cookie refreshes we are performing on identity.  It turns out that the change to load the user's username in discussion is the source.  Instead of using the `getUserFromApiWithRefreshedCookie` method I have switched to fetching the username without refreshing the cookie.

## What is the value of this and can you measure success?
Less cookie refreshes performed by identity. Not sure this is necessarily a huge improvement given that we are only replacing it with a different call to identity.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/26981009-c2175f42-4d2b-11e7-8608-66563094cff1.png)



## Tested in CODE?
No

@guardian/dotcom-platform 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
