### PR TITLE
Break code validation, if flow server dies, instead of continuing

### DIFF
--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const execa = require('execa');
 
 const config = '--quiet --color';
 
@@ -7,11 +8,6 @@ const error = ctx => {
         .push(`${chalk.blue('make fix')} can correct simple errors automatically.`);
     ctx.messages
         .push(`Your editor may be able to catch eslint errors as you work:\n${chalk.underline('http://eslint.org/docs/user-guide/integrations#editors')}`);
-};
-
-const flowError = ctx => {
-    ctx.messages
-        .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://docs.google.com/a/guardian.co.uk/document/d/1-w5KdwNVAZcGRL3Q9QCvj5y3aQyoVizm6GrHQaqQHNE/edit?usp=sharing')}`);
 };
 
 module.exports = {
@@ -34,8 +30,26 @@ module.exports = {
         },
         {
             description: 'Run Flowtype checks on static/src/javascripts/',
-            task: `flow`,
-            onError: flowError,
+            task: ctx =>
+                execa('npm', ['run', 'flow'].concat(['--silent']))
+                    .then(res => {
+                        /* We end up here, if there is a problem with the flow
+                          server. The exit code would still 0, but flow logged
+                          something to res.stderr. In case flow found an error
+                          in the code it resolves within .catch() */
+                        if (res.stderr) {
+                            const err = new Error();
+                            err.stderr =
+                                'Apologies, flow server experienced a problem!';
+                            throw err;
+                        }
+                    })
+                    .catch(err => {
+                        ctx.messages
+                            .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://docs.google.com/a/guardian.co.uk/document/d/1-w5KdwNVAZcGRL3Q9QCvj5y3aQyoVizm6GrHQaqQHNE/edit?usp=sharing')}`);
+
+                        throw err;
+                    }),
         },
     ],
     concurrent: true,

--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -46,7 +46,7 @@ module.exports = {
                     })
                     .catch(err => {
                         ctx.messages
-                            .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://docs.google.com/a/guardian.co.uk/document/d/1-w5KdwNVAZcGRL3Q9QCvj5y3aQyoVizm6GrHQaqQHNE/edit?usp=sharing')}`);
+                            .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://github.com/guardian/frontend/wiki/So-you-want-to-ES6%3F')}`);
 
                         throw err;
                     }),


### PR DESCRIPTION
## What does this change?

This is an attempt to catch various cases, where a TC build succeeded, even if the flow type checks broke. One theory is, that this could happen, if the flow server dies for whatever reason. Previously `make validate` would simply continue and assume, that everything is fine. With this PR it breaks and assumes, there was an error.

The issue is reproducible, if you kill various flow processes, while it's spinning up or running the checks.

Possible improvements to get more information out of this could be:

-  Log the full `stderr`: in it's current form it doesn't look very useful, because it only contains log messages about the startup process of flow.
- Parse the flow log file location (mentioned in `stderr`), read the file and log it's content as part of the error.
- Log more system metrics to find out, why the flow server breaks.

[Trello reference](https://trello.com/c/lT2aTXgo/324-flow-validation-errors-dont-break-build-on-teamcity)

## What is the value of this and can you measure success?

(Hopefully) proper builds and no broken master. 🌞 

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

<img width="860" alt="screen shot 2017-06-09 at 16 02 22" src="https://user-images.githubusercontent.com/2244375/26981432-104cc606-4d2d-11e7-93b0-113c72e65708.png">

## Tested in CODE?

No.
