### PR TITLE
Remove post election message

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -1,9 +1,7 @@
 define([
-    'common/modules/commercial/contributions-utilities',
-    'common/modules/commercial/acquisitions-post-election'
+    'common/modules/commercial/contributions-utilities'
 ], function (
-    contributionsUtilities,
-    acquisitionsPostElection
+    contributionsUtilities
 ) {
 
 
@@ -30,11 +28,6 @@ define([
                 id: 'control',
                 isUnlimited : true,
                 useTailoredCopyForRegulars: true
-            },
-            {
-                id: 'post_election_message',
-                isUnlimited: true,
-                template: acquisitionsPostElection.template
             }
         ]
     });


### PR DESCRIPTION
## What does this change?
The post election variant has been performing particularly badly (less than half as well as the control) and it's costing us money, so this PR removes it

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
