### PR TITLE
Better error handling for mma page

### DIFF
--- a/identity/app/views/fragments/error.scala.html
+++ b/identity/app/views/fragments/error.scala.html
@@ -1,0 +1,5 @@
+@(name: String)(contact: Html)
+<div class="is-hidden js-@{name}-error">
+    <p>We were not able to fetch your details at this time, please try again later. If you are unable to access your details, please contact us.</p>
+    @contact
+</div>

--- a/identity/app/views/fragments/profile/digitalPackDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/digitalPackDetailsForm.scala.html
@@ -3,6 +3,11 @@
 @import views.html.fragments.registrationFooter
 
 <div class="manage-account-tab">
+    @fragments.error("dig") {
+        <p>
+            For help with Guardian and Observer subscription services please email <a href="mailto:subscriptions@@theguardian.com">✉️ subscriptions@@theguardian.com</a> or call <a href="00443303336767">📞 +44 (0) 330 333 6767</a>. Open BST 8am to 8pm, Monday to Sunday.
+        </p>
+    }
     <div class="manage-account-loader js-dig-loader">
         <span class="is-updating show-updating"></span>
     </div>

--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -8,6 +8,11 @@
         <span class="is-updating show-updating"></span>
     </div>
     <div id="qa-success-message" class="form__success is-hidden js-mem-card-change-success-msg">Your card details have been updated</div>
+    @fragments.error("mem") {
+        <p>
+            Please contact us on <a href="mailto:membershipsupport@@theguardian.com">✉️ membershipsupport@@theguardian.com</a> or phone <a href="tel:0044330 333 6898">📞 +44 (0)330 333 6898</a>.
+        </p>
+}
     @fragments.profile.membershipForm.cancelled()
     @fragments.profile.membershipForm.changed()
     @fragments.profile.membershipForm.details(user)

--- a/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
@@ -3,6 +3,7 @@ define([
     'lib/$',
     'lib/fetch',
     'lib/config',
+    'lib/report-error',
     'membership/formatters',
     'membership/stripe'
 ], function (
@@ -10,6 +11,7 @@ define([
     $,
     fetch,
     config,
+    reportError,
     formatters,
     stripe
 ) {
@@ -51,10 +53,10 @@ define([
                 hideLoader();
                 displayDigitalPackUpSell();
             }
-        }).catch(function (){
+        }).catch(function (err){
             hideLoader();
             displayErrorMessage();
-            //TODO: handle this
+            reportError(err,{feature:'mma-digipack'})
        });
     }
 

--- a/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
@@ -6,15 +6,13 @@ define([
     'lib/report-error',
     'membership/formatters',
     'membership/stripe'
-], function (
-    bean,
-    $,
-    fetch,
-    config,
-    reportError,
-    formatters,
-    stripe
-) {
+], function (bean,
+             $,
+             fetch,
+             config,
+             reportError,
+             formatters,
+             stripe) {
 
     var PACKAGE_COST = '.js-dig-package-cost',
         PAYMENT_FORM = '.js-dig-card-details',
@@ -53,11 +51,11 @@ define([
                 hideLoader();
                 displayDigitalPackUpSell();
             }
-        }).catch(function (err){
+        }).catch(function (err) {
             hideLoader();
             displayErrorMessage();
-            reportError(err,{feature:'mma-digipack'})
-       });
+            reportError(err, {feature: 'mma-digipack'})
+        });
     }
 
     function hideLoader() {
@@ -98,7 +96,7 @@ define([
             $(NOTIFICATION_CANCEL).removeClass(IS_HIDDEN_CLASSNAME);
             $(DIGITALPACK_DETAILS).addClass(IS_HIDDEN_CLASSNAME);
         } else if (userDetails.subscription.card) {
-            stripe.display(PAYMENT_FORM,userDetails.subscription.card);
+            stripe.display(PAYMENT_FORM, userDetails.subscription.card);
         }
         $(DIG_INFO).removeClass(IS_HIDDEN_CLASSNAME);
     }

--- a/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/digitalpack-tab.js
@@ -33,7 +33,9 @@ define([
         UP_SELL = '.js-dig-up-sell',
         DIG_INFO = '.js-dig-info',
         LOADER = '.js-dig-loader',
-        IS_HIDDEN_CLASSNAME = 'is-hidden';
+        IS_HIDDEN_CLASSNAME = 'is-hidden',
+        ERROR = '.js-dig-error'
+    ;
 
     function fetchUserDetails() {
         fetch(config.page.userAttributesApiUrl + '/me/mma-digitalpack', {
@@ -49,7 +51,11 @@ define([
                 hideLoader();
                 displayDigitalPackUpSell();
             }
-        });
+        }).catch(function (){
+            hideLoader();
+            displayErrorMessage();
+            //TODO: handle this
+       });
     }
 
     function hideLoader() {
@@ -98,6 +104,11 @@ define([
     function displayDigitalPackUpSell() {
         $(UP_SELL).removeClass(IS_HIDDEN_CLASSNAME);
     }
+
+    function displayErrorMessage() {
+        $(ERROR).removeClass(IS_HIDDEN_CLASSNAME);
+    }
+
 
     return {
         init: fetchUserDetails

--- a/static/src/javascripts-legacy/projects/membership/membership-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/membership-tab.js
@@ -6,15 +6,13 @@ define([
     'lib/report-error',
     'membership/formatters',
     'membership/stripe'
-], function (
-    bean,
-    $,
-    fetch,
-    config,
-    reportError,
-    formatters,
-    stripe
-) {
+], function (bean,
+             $,
+             fetch,
+             config,
+             reportError,
+             formatters,
+             stripe) {
 
     var CARD_DETAILS = '.js-mem-card-details',
         PAYPAL = '.js-mem-paypal',
@@ -58,14 +56,14 @@ define([
             if (json && json.subscription) {
                 hideLoader();
                 populateUserDetails(json);
-                } else {
+            } else {
                 hideLoader();
                 displayMembershipUpSell();
             }
-        }).catch(function (err){
+        }).catch(function (err) {
             hideLoader();
             displayErrorMessage();
-            reportError(err,{feature:'mma-membership'})
+            reportError(err, {feature: 'mma-membership'})
         });
     }
 
@@ -87,7 +85,7 @@ define([
 
         if (userDetails.subscription.card) {
             $(CHANGE_TIER_CARD_LAST4).text(userDetails.subscription.card.last4);
-        } else if(userDetails.subscription.payPalEmail){
+        } else if (userDetails.subscription.payPalEmail) {
             $(PAYPAL_EMAIL_ADDRESS).text(userDetails.subscription.payPalEmail);
         }
 
@@ -126,7 +124,7 @@ define([
         } else if (userDetails.subscription.card) {
             // only show card details if user hasn't changed their subscription and has stripe as payment method
             stripe.display(CARD_DETAILS, userDetails.subscription.card);
-        } else if(userDetails.subscription.payPalEmail){
+        } else if (userDetails.subscription.payPalEmail) {
             // if the user hasn't changed their subscription and has PayPal as a payment method
             $(PAYPAL).removeClass(IS_HIDDEN_CLASSNAME);
             bean.one($(PAYPAL_SHOW_EMAIL_BUTTON)[0], 'click', showPayPalAccountName);

--- a/static/src/javascripts-legacy/projects/membership/membership-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/membership-tab.js
@@ -42,7 +42,9 @@ define([
         UP_SELL = '.js-mem-up-sell',
         MEMBER_INFO = '.js-mem-info',
         LOADER = '.js-mem-loader',
-        IS_HIDDEN_CLASSNAME = 'is-hidden';
+        IS_HIDDEN_CLASSNAME = 'is-hidden',
+        ERROR = '.js-mem-error'
+    ;
 
     function fetchUserDetails() {
         fetch(config.page.userAttributesApiUrl + '/me/mma-membership', {
@@ -54,10 +56,14 @@ define([
             if (json && json.subscription) {
                 hideLoader();
                 populateUserDetails(json);
-            } else {
+                } else {
                 hideLoader();
                 displayMembershipUpSell();
             }
+        }).catch(function (){
+            hideLoader();
+            displayErrorMessage();
+            //TODO: HANDLE THIS ERROR
         });
     }
 
@@ -143,6 +149,10 @@ define([
 
     function displayMembershipUpSell() {
         $(UP_SELL).removeClass(IS_HIDDEN_CLASSNAME);
+    }
+
+    function displayErrorMessage() {
+        $(ERROR).removeClass(IS_HIDDEN_CLASSNAME);
     }
 
     function init() {

--- a/static/src/javascripts-legacy/projects/membership/membership-tab.js
+++ b/static/src/javascripts-legacy/projects/membership/membership-tab.js
@@ -3,6 +3,7 @@ define([
     'lib/$',
     'lib/fetch',
     'lib/config',
+    'lib/report-error',
     'membership/formatters',
     'membership/stripe'
 ], function (
@@ -10,6 +11,7 @@ define([
     $,
     fetch,
     config,
+    reportError,
     formatters,
     stripe
 ) {
@@ -60,10 +62,10 @@ define([
                 hideLoader();
                 displayMembershipUpSell();
             }
-        }).catch(function (){
+        }).catch(function (err){
             hideLoader();
             displayErrorMessage();
-            //TODO: HANDLE THIS ERROR
+            reportError(err,{feature:'mma-membership'})
         });
     }
 


### PR DESCRIPTION
## What does this change?
Currently, if the manage-my-account page fails to load the users details from the members-data-api, it just spins forever. 

This will make it show a nice error message, instructing the user to get in touch.

## What is the value of this and can you measure success?

Fewer complaints.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @paulbrown1982 for OK on messaging