### PR TITLE
Revert "Break code validation, if flow server dies, instead of continuing"

### DIFF
--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk');
-const execa = require('execa');
 
 const config = '--quiet --color';
 
@@ -8,6 +7,11 @@ const error = ctx => {
         .push(`${chalk.blue('make fix')} can correct simple errors automatically.`);
     ctx.messages
         .push(`Your editor may be able to catch eslint errors as you work:\n${chalk.underline('http://eslint.org/docs/user-guide/integrations#editors')}`);
+};
+
+const flowError = ctx => {
+    ctx.messages
+        .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://docs.google.com/a/guardian.co.uk/document/d/1-w5KdwNVAZcGRL3Q9QCvj5y3aQyoVizm6GrHQaqQHNE/edit?usp=sharing')}`);
 };
 
 module.exports = {
@@ -30,26 +34,8 @@ module.exports = {
         },
         {
             description: 'Run Flowtype checks on static/src/javascripts/',
-            task: ctx =>
-                execa('npm', ['run', 'flow'].concat(['--silent']))
-                    .then(res => {
-                        /* We end up here, if there is a problem with the flow
-                          server. The exit code would still 0, but flow logged
-                          something to res.stderr. In case flow found an error
-                          in the code it resolves within .catch() */
-                        if (res.stderr) {
-                            const err = new Error();
-                            err.stderr =
-                                'Apologies, flow server experienced a problem!';
-                            throw err;
-                        }
-                    })
-                    .catch(err => {
-                        ctx.messages
-                            .push(`Your editor may be able to catch flow errors as you work:\n${chalk.underline('https://github.com/guardian/frontend/wiki/So-you-want-to-ES6%3F')}`);
-
-                        throw err;
-                    }),
+            task: `flow`,
+            onError: flowError,
         },
     ],
     concurrent: true,


### PR DESCRIPTION
Reverts guardian/frontend#17086.

Build failure is around 50% - too much for the daily work.