### PR TITLE
Reinstate logo on paid immersive articles

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -35,6 +35,7 @@
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                              data-test-id="article-review-body">
+                            @fragments.commercial.badge(article, model)
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 


### PR DESCRIPTION
It seems to have been removed in [this commit](#2f4b852c2cc5aa8e7442c4517b3a3273bde337bf)
but I think it was done by mistake.

/cc @zeftilldeath 