### PR TITLE
Remove show-tags from most popular agent

### DIFF
--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -65,7 +65,6 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
         contentApiClient
           .getResponse(contentApiClient
             .item(urlToContentPath(url), edition)
-            .showTags("paid-content")
             .showSection(true)
             .showFields((QueryDefaults.trailFieldsList :+ "isInappropriateForSponsorship").mkString(",")))
           .map(_.content


### PR DESCRIPTION
The default query uses `showTags=all`, this removes the `showTags` from the most-popular agent query and allows all tags to flow through.

Currently, when something is a liveblog, the colour of the `live` text is coming out as blue because the liveblog tag isn't being requested.

@jfsoul 