### PR TITLE
Reinstate logo on paid immersive articles

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -35,7 +35,6 @@
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                              data-test-id="article-review-body">
-                            @fragments.commercial.badge(article, model)
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -77,7 +77,7 @@
 
 
     @if(
-        item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !isPaidContent(page))
+        item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && (item.content.isImmersive || !isPaidContent(page)))
     ) {
         @fragments.commercial.badge(item, page)
     }


### PR DESCRIPTION
Now where it should be!

Before:
![image](https://user-images.githubusercontent.com/1722550/27040402-c7e51ff4-4f88-11e7-8903-ecb8b067f3b3.png)

After:
![image](https://user-images.githubusercontent.com/1722550/27040415-d02b8176-4f88-11e7-9f76-bce8f3a3ebb3.png)
