### PR TITLE
Bump commercial-shared to 5.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   val targetingClient = "com.gu" %% "targeting-client" % "0.11.0"
   val scanamo = "com.gu" %% "scanamo" % "0.8.3"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.6"
-  val commercialShared = "com.gu" %% "commercial-shared" % "5.0.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "5.0.1"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"


### PR DESCRIPTION
This brings in the small change in https://github.com/guardian/commercial-shared/pull/36

@kelvin-chappell 