### PR TITLE
Add custom message for prout bot `Seen` message

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -2,7 +2,10 @@
     "checkpoints": {
         "PROD": {
             "url": "https://frontend.gutools.co.uk/deploys?stage=PROD&pageSize=50",
-            "overdue": "30M"
+            "overdue": "30M",
+            "messages": {
+                "seen": "prout/seen.md",
+            }
         }
     }
 }

--- a/prout/seen.md
+++ b/prout/seen.md
@@ -1,0 +1,3 @@
+
+- Check your changes on [www.theguardian.com](https://www.theguardian.com) ✔️ 
+- Keep an eye on the [deploy dashboard](https://kibana.gu-web.net/app/kibana#/dashboard/8730df10-49fd-11e7-b778-ebbe55169b8f) 📉 


### PR DESCRIPTION
## What does this change?
Adding a custom messages containing direct link to website and dashboard to make it easier for devs to check their deploy was a success

It needs [this Prout PR](https://github.com/guardian/prout/pull/54) to be merged for it to work

@guardian/dotcom-platform Feel free to suggest a better message