### PR TITLE
Fix element id in devtools

### DIFF
--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -18,7 +18,7 @@ const selectRadios = () => {
     });
 
     abTests.forEach(test => {
-        $(`#${test.variantId}-${test.variantId}`).attr('checked', true);
+        $(`#${test.testId}-${test.variantId}`).attr('checked', true);
     });
 };
 


### PR DESCRIPTION
## What does this change?

Due to a tangential refactor in #16869, devtools stopped highlighting which AB tests you have opted into.

## What is the value of this and can you measure success?

Devtools now correctly displays which tests are being opted into.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
