### PR TITLE
Implementing the brand extensions bar for the desktop header

### DIFF
--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -133,6 +133,7 @@ object NavLinks {
   val apps = NavLink("the guardian app", "https://app.adjust.com/f8qm1x_8q69t7?campaign=NewHeader&adgroup=Mobile&creative=generic")
   val ukMasterClasses = NavLink("masterclasses", "/guardian-masterclasses?INTCMP=masterclasses_uk_web_newheader")
   val auEvents = NavLink("events", "/guardian-live-australia")
+  var holidays = NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav")
 
   val tagPages = List(
     "technology/games",

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -226,14 +226,38 @@ object NewNavigation {
     )
   }
 
-  case object NavFooterLinks extends EditionalisedNavigationSection {
+  case object BrandExtensions extends EditionalisedNavigationSection {
     val name = ""
 
     val uk = NavLinkLists(List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
-      NavLink("holidays", "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"),
-      ukMasterClasses,
+      holidays,
+      ukMasterClasses
+    ))
+
+    val au = NavLinkLists(List(
+      jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
+      auEvents,
+      holidays
+    ))
+
+    val us = NavLinkLists(List(
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
+      holidays
+    ))
+
+    val int = NavLinkLists(List(
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
+      dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
+      holidays
+    ))
+  }
+
+  case object OtherLinks extends EditionalisedNavigationSection {
+    val name = ""
+
+    val uk = NavLinkLists(List(
       NavLink("professional networks", "/guardian-professional"),
       apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
       podcasts,
@@ -247,8 +271,6 @@ object NewNavigation {
     ))
 
     val au = NavLinkLists(List(
-      jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
-      auEvents,
       apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
       podcasts,
       video,
@@ -259,7 +281,6 @@ object NewNavigation {
     ))
 
     val us = NavLinkLists(List(
-      jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
       apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
       podcasts,
       video,
@@ -270,8 +291,6 @@ object NewNavigation {
     ))
 
     val int = NavLinkLists(List(
-      jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
-      dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
       apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
       podcasts,
       video,

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -1,44 +1,52 @@
 @()(implicit request: RequestHeader)
 
-@import common.{ NewNavigation, LinkTo, Edition }
+@import common.{ NewNavigation, LinkTo, Edition, NavLink }
 @import conf.switches.Switches.SearchSwitch
 @import views.support.RenderClasses
 
-@sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection) = {
-    @defining(Edition(request)) { edition =>
-        <li class="menu-item js-navigation-item"
-            data-section-name="@topLevelSection.name"
-            role="menuitem">
-            <button class="menu-item__title hide-on-desktop js-navigation-toggle"
-                    data-link-name="nav2 : secondary : @topLevelSection.name"
-                    aria-haspopup="true"
-                    aria-expanded="true">
-                <i class="menu-item__toggle"></i>
-                @topLevelSection.name
-            </button>
+@sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection, edition: Edition) = {
+    <li class="menu-item js-navigation-item"
+        data-section-name="@topLevelSection.name"
+        role="menuitem">
+        <button class="menu-item__title hide-on-desktop js-navigation-toggle"
+                data-link-name="nav2 : secondary : @topLevelSection.name"
+                aria-haspopup="true"
+                aria-expanded="true">
+            <i class="menu-item__toggle"></i>
+            @topLevelSection.name
+        </button>
 
-            <ul class="menu-group menu-group--secondary"
-                data-edition="@{edition.id.toLowerCase}"
-                aria-label="Submenu @{topLevelSection.name}"
-                role="menu">
-                @topLevelSection.getAllEditionalisedNavLinks(edition).map { sectionItem =>
-                    <li class="@RenderClasses(Map(
-                                "menu-item--home" -> (sectionItem.iconName == "home")
-                            ), "menu-item")"
-                        role="menuitem">
-                        <a class="menu-item__title"
-                           href="@LinkTo { @sectionItem.url }"
-                           data-link-name="nav2 : secondary : @{ if(sectionItem.longTitle.isEmpty) sectionItem.title else sectionItem.longTitle }">
-                                @if(sectionItem.iconName.nonEmpty) {
-                                    @fragments.inlineSvg(sectionItem.iconName, "icon", List("menu-item__icon"))
-                                }
-                                @{ if(sectionItem.longTitle.isEmpty) sectionItem.title else sectionItem.longTitle }
-                        </a>
-                    </li>
-                }
-            </ul>
-        </li>
-    }
+        <ul class="menu-group menu-group--secondary"
+            data-edition="@{edition.id.toLowerCase}"
+            aria-label="Submenu @{topLevelSection.name}"
+            role="menu">
+            @topLevelSection.getAllEditionalisedNavLinks(edition).map { sectionItem =>
+                <li class="@RenderClasses(Map(
+                            "menu-item--home" -> (sectionItem.iconName == "home")
+                        ), "menu-item")"
+                    role="menuitem">
+                    <a class="menu-item__title"
+                       href="@LinkTo { @sectionItem.url }"
+                       data-link-name="nav2 : secondary : @{ if(sectionItem.longTitle.isEmpty) sectionItem.title else sectionItem.longTitle }">
+                            @if(sectionItem.iconName.nonEmpty) {
+                                @fragments.inlineSvg(sectionItem.iconName, "icon", List("menu-item__icon"))
+                            }
+                            @{ if(sectionItem.longTitle.isEmpty) sectionItem.title else sectionItem.longTitle }
+                    </a>
+                </li>
+            }
+        </ul>
+    </li>
+}
+
+@brandExtensions(item: NavLink) = {
+    <li class="menu-brand-extensions__list-item">
+        <a href="@LinkTo { @item.url }"
+           class="menu-brand-extensions-item"
+           data-link-name="nav2 : brand extension : @item.title">
+            @{item.title}
+        </a>
+    </li>
 }
 
 <label for="main-menu-toggle"
@@ -46,53 +54,53 @@
        aria-hidden="true"
        data-link-name="nav2 : overlay"></label>
 
-<div class="menu js-main-menu"
-     id="main-menu"
-     aria-hidden="true">
-    <div class="menu__inner gs-container">
-        <ul class="menu-group menu-group--primary"
-            role="menubar">
-            @NewNavigation.topLevelSections.map { section =>
-                @sectionList(section)
+@defining(Edition(request)) { edition =>
+    <div class="menu js-main-menu"
+         id="main-menu"
+         aria-hidden="true">
+        <div class="menu__inner gs-container">
+            <ul class="menu-group menu-group--primary"
+                role="menubar">
+                @NewNavigation.topLevelSections.map { section =>
+                    @sectionList(section, edition)
+                }
+            </ul>
+
+            @if(SearchSwitch.isSwitchedOn) {
+                <div class="menu-group menu-group--search">
+                    <form class="menu-search"
+                          action="https://www.google.co.uk/search">
+                        <input type="text"
+                               name="q"
+                               class="menu-search__search-box"
+                               placeholder="search"
+                               data-link-name="nav2 : search">
+
+                        <input type="hidden"
+                               name="as_sitesearch"
+                               value="www.theguardian.com">
+
+                        @* label surrounding the input and icon so that if you
+                        click the search icon it will trigger the submit *@
+                        <label for="submit-google-search"
+                               class="menu-search__submit">
+                            <input class="u-h"
+                                   type="submit"
+                                   id="submit-google-search"
+                                   data-link-name="nav2 : search : submit">
+                            @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
+                        </label>
+
+                        <label for="q"
+                               class="u-h">
+                            What term do you want to search?
+                        </label>
+                    </form>
+                </div>
             }
-        </ul>
 
-        @if(SearchSwitch.isSwitchedOn) {
-            <div class="menu-group menu-group--search">
-                <form class="menu-search"
-                      action="https://www.google.co.uk/search">
-                    <input type="text"
-                           name="q"
-                           class="menu-search__search-box"
-                           placeholder="search"
-                           data-link-name="nav2 : search">
-
-                    <input type="hidden"
-                           name="as_sitesearch"
-                           value="www.theguardian.com">
-
-                    @* label surrounding the input and icon so that if you
-                    click the search icon it will trigger the submit *@
-                    <label for="submit-google-search"
-                           class="menu-search__submit">
-                        <input class="u-h"
-                               type="submit"
-                               id="submit-google-search"
-                               data-link-name="nav2 : search : submit">
-                        @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
-                    </label>
-
-                    <label for="q"
-                           class="u-h">
-                        What term do you want to search?
-                    </label>
-                </form>
-            </div>
-        }
-
-        <ul class="menu-group menu-group--editions"
-            role="menubar">
-            @defining(Edition(request)) { edition =>
+            <ul class="menu-group menu-group--editions"
+                role="menubar">
                 @NewNavigation.getMembershipLinks(edition).mostPopular.map { item =>
                     <li class="menu-item hide-on-desktop"
                         data-edition="@{edition.id.toLowerCase}"
@@ -105,24 +113,33 @@
                         </a>
                     </li>
                 }
-            }
 
-            @fragments.nav.userAccountLinks()
-            @fragments.nav.editionPicker()
-        </ul>
+                @fragments.nav.userAccountLinks()
+                @fragments.nav.editionPicker()
+            </ul>
 
-        @defining(Edition(request)) { edition =>
             <ul class="menu-group menu-group--footer"
                 data-edition="@{edition.id.toLowerCase}"
                 role="menubar">
 
-                @NewNavigation.NavFooterLinks.getAllEditionalisedNavLinks(edition).map { item =>
-                    <li class="menu-item"
+                @NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map { item =>
+                    <li class="menu-item hide-on-desktop"
                         role="menuitem">
                         <a class="menu-item__title"
                            href="@LinkTo { @item.url }"
                            data-link-name="nav2 : @item.title">
                             @item.title
+                        </a>
+                    </li>
+                }
+
+                @NewNavigation.OtherLinks.getAllEditionalisedNavLinks(edition).map { item =>
+                    <li class="menu-item"
+                    role="menuitem">
+                        <a class="menu-item__title"
+                        href="@LinkTo { @item.url }"
+                        data-link-name="nav2 : @item.title">
+                        @item.title
                         </a>
                     </li>
                 }
@@ -147,6 +164,17 @@
                     </a>
                 </li>
             </ul>
-        }
+        </div>
+
+        <div class="menu-brand-extensions hide-until-desktop">
+            <div class="menu-brand-extensions__inner gs-container">
+                @fragments.inlineSvg("guardian-logo-160", "logo", List("menu-brand-extensions__logo"))
+                <ul class="menu-brand-extensions__list">
+                    @NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map { item =>
+                        @brandExtensions(item)
+                    }
+                </ul>
+            </div>
+        </div>
     </div>
-</div>
+}

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -40,6 +40,10 @@ class NavigationController extends Controller {
   //  This is to editionalise the menu on AMP
   def renderAmpNav = Action { implicit request =>
     val edition = Edition(request)
+    val navSecondarySections = List.concat(
+      NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map(section => navSectionLink(section)),
+      NewNavigation.OtherLinks.getAllEditionalisedNavLinks(edition).map(section => navSectionLink(section))
+    )
 
     Cached(900) {
 
@@ -61,7 +65,7 @@ class NavigationController extends Controller {
         "items" -> Json.arr(
           Json.obj(
             "topLevelSections" -> NewNavigation.topLevelSections.map( section => topLevelNavItems(section) ),
-            "secondarySections" -> NewNavigation.NavFooterLinks.getAllEditionalisedNavLinks(edition).map(section => navSectionLink(section))
+            "secondarySections" -> navSecondarySections
           )
         )
       )

--- a/static/src/stylesheets/layout/_new-header.scss
+++ b/static/src/stylesheets/layout/_new-header.scss
@@ -5,6 +5,8 @@
 @import 'new-header/_menu-group';
 @import 'new-header/_menu-item';
 @import 'new-header/_menu-search';
+@import 'new-header/_menu-brand-extensions';
+@import 'new-header/_menu-brand-extensions-item';
 @import 'new-header/_new-header';
 @import 'new-header/_pillars';
 @import 'new-header/_pillar-link';

--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
@@ -1,0 +1,4 @@
+.menu-brand-extensions-item {
+    color: currentColor;
+    font-size: 28px;
+}

--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
@@ -1,0 +1,46 @@
+.menu-brand-extensions {
+    background-color: $news-main-2;
+    color: $guardian-brand-dark;
+}
+
+.menu-brand-extensions__inner {
+    box-sizing: border-box;
+    padding: $gs-baseline $gs-gutter $gs-baseline / 3 $gs-gutter;
+}
+
+.menu-brand-extensions__list {
+    display: inline-block;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.menu-brand-extensions__list-item {
+    display: inline-block;
+
+    & + &:before {
+        color: currentColor;
+        content: '/';
+        display: inline-block;
+        font-size: 28px;
+        opacity: .6;
+        padding-left: -2px;
+        padding-right: -2px;
+        pointer-events: none;
+    }
+}
+
+.menu-brand-extensions__logo {
+    display: inline-block;
+    margin-right: $gs-gutter / 2;
+    vertical-align: middle;
+}
+
+.menu-brand-extensions__logo__svg {
+    height: 35px;
+    width: 185px;
+
+    path {
+        fill: currentColor;
+    }
+}

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -135,6 +135,12 @@
         }
     }
 
+    &[data-link-name='nav2 : the guardian app'] {
+        @include mq(desktop) {
+            display: none;
+        }
+    }
+
     // only match the ones, which are not in --secondary
     .menu-group--primary > .menu-item > & {
         font-size: 24px;

--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -44,6 +44,7 @@
         left: 50%;
         margin-left: -50vw;
         margin-right: -50vw;
+        padding-bottom: 0;
         position: absolute;
         right: 50%;
         top: 100%;


### PR DESCRIPTION
## What does this change?
Reopening a new PR for https://github.com/guardian/frontend/pull/17047.

Adds the brand extensions bar at the bottom of the desktop navigation. The section is invisible on smaller screens.

## What is the value of this and can you measure success?
Looks great, closer to the design, bigger impact for our revenue making things

## Does this affect other platforms - Amp, Apps, etc?
Affects AMP as the header data has changed, but it should look the same.

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27079445-92596280-502f-11e7-8f50-ccbd90b154a4.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
