### PR TITLE
Reset new header

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -173,6 +173,7 @@ const toggleSidebar = (): void => {
 
         if (isOpen) {
             resetItemOrder();
+            closeAllSidebarSections();
         } else {
             focusFirstSidebarSection();
         }

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -9,7 +9,8 @@ import debounce from 'lodash/functions/debounce';
 
 const enhanced = {};
 
-const getMenu = (): ?HTMLElement => document.getElementById('main-menu');
+const getMenu = (): ?HTMLElement =>
+    document.getElementsByClassName('js-main-menu')[0];
 
 const getSectionToggleMenuItem = (section: HTMLElement): ?HTMLElement => {
     const children = [...section.children];

--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -243,7 +243,9 @@ const toggleSidebarWithOpenSection = () => {
 
 const addEventHandler = (): void => {
     const menu = getMenu();
-    const toggle = document.querySelector('.js-toggle-nav-section');
+    const toggleWithMoreButton = document.querySelector(
+        '.js-toggle-nav-section'
+    );
 
     if (menu) {
         menu.addEventListener('click', (event: Event) => {
@@ -261,8 +263,8 @@ const addEventHandler = (): void => {
         });
     }
 
-    if (toggle) {
-        toggle.addEventListener('click', () => {
+    if (toggleWithMoreButton) {
+        toggleWithMoreButton.addEventListener('click', () => {
             toggleSidebarWithOpenSection();
         });
     }


### PR DESCRIPTION
## What does this change?

The behaviour I would expect from the new header is that if I open a section and close the menu, when I open the menu again the sections are all closed.

## What is the value of this and can you measure success?
For me this is the expected experience.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before:**
![before-reset](https://user-images.githubusercontent.com/8774970/27084692-b0397e60-5044-11e7-89e6-b2c6b9dbbc13.gif)

**After:**
![after-rest](https://user-images.githubusercontent.com/8774970/27084689-ad91fa66-5044-11e7-9f3c-fdba69c36e02.gif)




## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
