### PR TITLE
Tag combiner advertising

### DIFF
--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -20,7 +20,7 @@ case class CommercialProperties(
     branding <- editionBranding.branding
   } yield branding
 
-  def combineTheMaps(
+  def combineAdCallParams(
       leftMap: Map[AdCallParamKey, AdCallParamValue],
       rightMap: Map[AdCallParamKey, AdCallParamValue]): Map[AdCallParamKey, AdCallParamValue] = {
     leftMap.map{
@@ -45,7 +45,7 @@ case class CommercialProperties(
     editionAdTargetings.
       filter(_.edition == edition)
       .map(_.params)
-      .reduce{ (m1, m2) => combineTheMaps(m1, m2) }
+      .reduce{ (m1, m2) => combineAdCallParams(m1, m2) }
 
 }
 

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -1,7 +1,7 @@
 package common.commercial
 
 import com.gu.commercial.branding.Branding
-import com.gu.commercial.display.{AdCallParamKey, AdCallParamValue}
+import com.gu.commercial.display._
 import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
 import common.Edition
 import common.Edition.defaultEdition
@@ -20,12 +20,33 @@ case class CommercialProperties(
     branding <- editionBranding.branding
   } yield branding
 
-  def adTargeting(edition: Edition): Map[AdCallParamKey, AdCallParamValue] = {
-    val params = for {
-      editionAdTargeting <- editionAdTargetings.find(_.edition == edition)
-    } yield editionAdTargeting.params
-    params getOrElse Map.empty
+  def combineTheMaps(
+      leftMap: Map[AdCallParamKey, AdCallParamValue],
+      rightMap: Map[AdCallParamKey, AdCallParamValue]): Map[AdCallParamKey, AdCallParamValue] = {
+    leftMap.map{
+      case (leftKey, leftSingleValue@SingleValue(leftValue)) =>
+        val newSingleValue: SingleValue = rightMap.get(leftKey).collect {
+          case SingleValue(rightValue) if leftValue != rightValue => SingleValue(s"$leftValue$rightValue")
+        }.getOrElse(leftSingleValue)
+
+        (leftKey, newSingleValue)
+
+      case (leftKey, leftMultipleValues@MultipleValues(leftValues)) =>
+        val newMultipleValues: MultipleValues = rightMap.get(leftKey).collect {
+            case MultipleValues(rightValues) =>
+              MultipleValues(leftValues ++ rightValues)}
+          .getOrElse(leftMultipleValues)
+
+        (leftKey, newMultipleValues)
+    }
   }
+
+  def adTargeting(edition: Edition): Map[AdCallParamKey, AdCallParamValue] =
+    editionAdTargetings.
+      filter(_.edition == edition)
+      .map(_.params)
+      .reduce{ (m1, m2) => combineTheMaps(m1, m2) }
+
 }
 
 object CommercialProperties {

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -24,7 +24,8 @@ case class CommercialProperties(
     editionAdTargetings.
       filter(_.edition == edition)
       .map(_.params)
-      .reduce{ (m1, m2) => CommercialProperties.combineAdCallParams(m1, m2) }
+      .headOption
+      .getOrElse(Map.empty)
 
 }
 
@@ -64,25 +65,4 @@ object CommercialProperties {
     editionBrandings = Nil,
     editionAdTargetings = EditionAdTargeting.forFrontUnknownToCapi(frontId)
   )
-
-  def combineAdCallParams(
-    leftMap: Map[AdCallParamKey, AdCallParamValue],
-    rightMap: Map[AdCallParamKey, AdCallParamValue]): Map[AdCallParamKey, AdCallParamValue] = {
-    leftMap.map{
-      case (leftKey, leftSingleValue@SingleValue(leftValue)) =>
-        val newSingleValue: SingleValue = rightMap.get(leftKey).collect {
-          case SingleValue(rightValue) if leftValue != rightValue => SingleValue(s"$leftValue$rightValue")
-        }.getOrElse(leftSingleValue)
-
-        (leftKey, newSingleValue)
-
-      case (leftKey, leftMultipleValues@MultipleValues(leftValues)) =>
-        val newMultipleValues: MultipleValues = rightMap.get(leftKey).collect {
-          case MultipleValues(rightValues) =>
-            MultipleValues(leftValues ++ rightValues)}
-          .getOrElse(leftMultipleValues)
-
-        (leftKey, newMultipleValues)
-    }
-  }
 }

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -20,32 +20,11 @@ case class CommercialProperties(
     branding <- editionBranding.branding
   } yield branding
 
-  def combineAdCallParams(
-      leftMap: Map[AdCallParamKey, AdCallParamValue],
-      rightMap: Map[AdCallParamKey, AdCallParamValue]): Map[AdCallParamKey, AdCallParamValue] = {
-    leftMap.map{
-      case (leftKey, leftSingleValue@SingleValue(leftValue)) =>
-        val newSingleValue: SingleValue = rightMap.get(leftKey).collect {
-          case SingleValue(rightValue) if leftValue != rightValue => SingleValue(s"$leftValue$rightValue")
-        }.getOrElse(leftSingleValue)
-
-        (leftKey, newSingleValue)
-
-      case (leftKey, leftMultipleValues@MultipleValues(leftValues)) =>
-        val newMultipleValues: MultipleValues = rightMap.get(leftKey).collect {
-            case MultipleValues(rightValues) =>
-              MultipleValues(leftValues ++ rightValues)}
-          .getOrElse(leftMultipleValues)
-
-        (leftKey, newMultipleValues)
-    }
-  }
-
   def adTargeting(edition: Edition): Map[AdCallParamKey, AdCallParamValue] =
     editionAdTargetings.
       filter(_.edition == edition)
       .map(_.params)
-      .reduce{ (m1, m2) => combineAdCallParams(m1, m2) }
+      .reduce{ (m1, m2) => CommercialProperties.combineAdCallParams(m1, m2) }
 
 }
 
@@ -85,4 +64,25 @@ object CommercialProperties {
     editionBrandings = Nil,
     editionAdTargetings = EditionAdTargeting.forFrontUnknownToCapi(frontId)
   )
+
+  def combineAdCallParams(
+    leftMap: Map[AdCallParamKey, AdCallParamValue],
+    rightMap: Map[AdCallParamKey, AdCallParamValue]): Map[AdCallParamKey, AdCallParamValue] = {
+    leftMap.map{
+      case (leftKey, leftSingleValue@SingleValue(leftValue)) =>
+        val newSingleValue: SingleValue = rightMap.get(leftKey).collect {
+          case SingleValue(rightValue) if leftValue != rightValue => SingleValue(s"$leftValue$rightValue")
+        }.getOrElse(leftSingleValue)
+
+        (leftKey, newSingleValue)
+
+      case (leftKey, leftMultipleValues@MultipleValues(leftValues)) =>
+        val newMultipleValues: MultipleValues = rightMap.get(leftKey).collect {
+          case MultipleValues(rightValues) =>
+            MultipleValues(leftValues ++ rightValues)}
+          .getOrElse(leftMultipleValues)
+
+        (leftKey, newMultipleValues)
+    }
+  }
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -414,12 +414,6 @@ case class TagCombiner(
   pagination: Option[Pagination] = None
 ) extends StandalonePage {
 
-  //We only use the left tag for CommercialProperties
-  val commercialPropertiesEditionAdTargeting: Seq[EditionAdTargeting] =
-    leftTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil)
-  val commercialPropertiesEditionBrandings: Seq[EditionBranding] =
-    leftTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil)
-
   override val metadata: MetaData = MetaData.make(
     id = id,
     section = leftTag.metadata.section,
@@ -427,9 +421,10 @@ case class TagCombiner(
     pagination = pagination,
     description = Some(GuardianContentTypes.TagIndex),
     commercial = Some(
+      //We only use the left tag for CommercialProperties
       CommercialProperties(
-        commercialPropertiesEditionBrandings,
-        commercialPropertiesEditionAdTargeting
+        leftTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil),
+        leftTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil)
       )
     )
   )

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -4,7 +4,7 @@ import commercial.campaigns.PersonalInvestmentsCampaign
 import com.gu.contentapi.client.model.v1.{Content => CapiContent}
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
-import common.commercial.{AdUnitMaker, CommercialProperties}
+import common.commercial.{AdUnitMaker, CommercialProperties, EditionAdTargeting, EditionBranding}
 import common.dfp._
 import common.{Edition, ManifestData, NavItem, Pagination}
 import conf.Configuration
@@ -414,12 +414,24 @@ case class TagCombiner(
   pagination: Option[Pagination] = None
 ) extends StandalonePage {
 
+  val commercialPropertiesEditionBrandings: Seq[EditionBranding] =
+    leftTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil) ++ rightTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil)
+
+  val commercialPropertiesEditionAdTargeting: Seq[EditionAdTargeting] =
+    leftTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil) ++ rightTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil)
+
   override val metadata: MetaData = MetaData.make(
     id = id,
     section = leftTag.metadata.section,
     webTitle = s"${leftTag.name} + ${rightTag.name}",
     pagination = pagination,
-    description = Some(GuardianContentTypes.TagIndex)
+    description = Some(GuardianContentTypes.TagIndex),
+    commercial = Some(
+      CommercialProperties(
+        commercialPropertiesEditionBrandings,
+        commercialPropertiesEditionAdTargeting
+      )
+    )
   )
 }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -414,11 +414,11 @@ case class TagCombiner(
   pagination: Option[Pagination] = None
 ) extends StandalonePage {
 
-  val commercialPropertiesEditionBrandings: Seq[EditionBranding] =
-    leftTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil) ++ rightTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil)
-
+  //We only use the left tag for CommercialProperties
   val commercialPropertiesEditionAdTargeting: Seq[EditionAdTargeting] =
-    leftTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil) ++ rightTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil)
+    leftTag.properties.commercial.map(_.editionAdTargetings).getOrElse(Nil)
+  val commercialPropertiesEditionBrandings: Seq[EditionBranding] =
+    leftTag.properties.commercial.map(_.editionBrandings).getOrElse(Nil)
 
   override val metadata: MetaData = MetaData.make(
     id = id,


### PR DESCRIPTION
## What does this change?

This adds `sharedAdTargeting` to tag combiner pages. We only select the left tag to be used in `sharedAdTargeting`.

I think it is not worth combining both Tags in a tag combiner page, as it is full of edge cases. We instead will treat the "left" tag as the dominant tag.

## Example

The page `/music/music+tone/reviews` with get the `sharedAdTargeting` value of  `{"ct":"tag","url":"/music/music","edition":"uk","p":"ng","k":"music"}`

## What is the value of this and can you measure success?

This means we have better ad targeting on tag combiner pages.

@kelvin-chappell 