### PR TITLE
Survey out-of-page slot should not be seen 

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -486,7 +486,7 @@
 }
 
 .ad-slot--survey {
-     // we avoid 'display none' otherwise the slot would close, but the survey slot is
-     // out-of-page and shouldn't be seen
-     height: 0;
+    // we avoid 'display none' otherwise the slot would close, but the survey slot is
+    // out-of-page and shouldn't be seen
+    height: 0;
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -484,3 +484,9 @@
         margin-right: -25em;
     }
 }
+
+.ad-slot--survey {
+     // we avoid 'display none' otherwise the slot would close, but the survey slot is
+     // out-of-page and shouldn't be seen
+     height: 0;
+}


### PR DESCRIPTION
Adding a zero height to the survey ad slot, because it's out-of-page, and should never be seen, regardless of whether a survey is displayed or not.

**before (not flush with the top of window)**
<img width="1099" alt="screen shot 2017-06-13 at 15 44 22" src="https://user-images.githubusercontent.com/4549425/27088374-60926f10-504f-11e7-96b7-4f90bd024f02.png">

**after (flush)**
<img width="1108" alt="screen shot 2017-06-13 at 15 43 58" src="https://user-images.githubusercontent.com/4549425/27088384-69a07430-504f-11e7-959c-798732043897.png">

