### PR TITLE
Default impression and success functions added in contribution utilities

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -216,6 +216,14 @@ define([
             iframeId: test.campaignId + '_' + 'iframe',
         };
 
+        this.impression = options.impression || (function(callback) {
+            return mediator.once(test.insertEvent, callback)
+        });
+
+        this.success = options.success || (function(callback) {
+            return mediator.once(test.viewEvent, callback)
+        });
+
         this.test = function () {
             var displayEpic = (typeof options.canEpicBeDisplayed === 'function') ?
                 options.canEpicBeDisplayed(test) : true;
@@ -275,8 +283,6 @@ define([
         };
 
         this.registerIframeListener();
-        this.registerListener('impression', 'impressionOnInsert', test.insertEvent, options);
-        this.registerListener('success', 'successOnView', test.viewEvent, options);
     }
 
     function getCampaignCode(campaignCodePrefix, campaignID, id, campaignCodeSuffix) {
@@ -299,15 +305,6 @@ define([
 
     ContributionsABTestVariant.prototype.membershipURLBuilder = function(codeModifier) {
         return this.getURL(membershipBaseURL, codeModifier(this.options.campaignCode));
-    };
-
-    ContributionsABTestVariant.prototype.registerListener = function (type, defaultFlag, event, options) {
-        if (options[type]) this[type] = options[type];
-        else if (options[defaultFlag]) {
-            this[type] = (function (track) {
-                return mediator.on(event, track);
-            }).bind(this);
-        }
     };
 
     ContributionsABTestVariant.prototype.registerIframeListener = function() {

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -216,12 +216,12 @@ define([
             iframeId: test.campaignId + '_' + 'iframe',
         };
 
-        this.impression = options.impression || (function(callback) {
-            return mediator.once(test.insertEvent, callback)
+        this.impression = options.impression || (function(submitImpression) {
+            return mediator.once(test.insertEvent, submitImpression)
         });
 
-        this.success = options.success || (function(callback) {
-            return mediator.once(test.viewEvent, callback)
+        this.success = options.success || (function(submitSuccess) {
+            return mediator.once(test.viewEvent, submitSuccess)
         });
 
         this.test = function () {


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Currently the `impression()` function for a test created by `contributionUtilities.makeTest()` is inferred from the respective function provided in the options. If this don't exist, but the boolean flag `insertOnView` equals `true`, then an impressions function is created which executes the passed callback once the Epic is inserted. However, there is no default, meaning the test will not have an impression function if neither of these cases occur. This behaviour applies to the `success()` function too, though the semantics are different.

This pull request adds defaults for the `impression()` and `success()` functions that match informally what we have been considering as defaults. However, as raised previously, it is worth discussing formally what these should be at some point, and even whether it makes sense to have configurable `impression()` and `success()` functions for the Epic.