### PR TITLE
Deps: Upgrade flow-bin to 0.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "esprima": "1.2.2",
     "execa": "^0.7.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.47.0",
+    "flow-bin": "^0.48.0",
     "flow-typed": "^2.1.2",
     "git-user-name": "^1.2.0",
     "glob": "^7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,9 +3115,9 @@ flatten@1.0.2, flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.47.0:
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
+flow-bin@^0.48.0:
+  version "0.48.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.48.0.tgz#72d075143524358db8901525e3c784dc13a7c7ee"
 
 flow-parser@0.45.0:
   version "0.45.0"


### PR DESCRIPTION
## What does this change?

Upgrades flow-bin to 0.48.0. [No breaking changes](https://github.com/facebook/flow/releases/tag/v0.48.0) this time (the joy of up to date dependencies ✨).

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
