### PR TITLE
Menu: Fix editions styling regression

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -57,14 +57,16 @@
     }
 }
 
+.menu-group--editions {
+    padding-bottom: 0;
+}
+
 .menu-group--editions .menu-group {
     @include mq($until: desktop) {
         color: $guardian-brand-dark;
         background-color: darken($news-main-2, 10%);
-        margin-bottom: -$gs-baseline;
     }
 }
-
 
 .menu-group--membership {
     padding-bottom: 0;

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -46,8 +46,10 @@
 
         &:hover,
         &:focus {
-            background-color: $news-main-2;
-            color: #ffffff;
+            @include mq(desktop) {
+                background-color: $news-main-2;
+                color: #ffffff;
+            }
         }
 
         &--edition-active {
@@ -177,6 +179,14 @@
         @include mq(desktop) {
             line-height: 40px;
             text-align: center;
+        }
+    }
+
+    .menu-group--editions &[aria-haspopup="true"] {
+        margin-bottom: $gs-baseline;
+
+        &[aria-expanded="true"] {
+            margin-bottom: 0;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -182,10 +182,10 @@
         }
     }
 
-    .menu-group--editions &[aria-haspopup="true"] {
+    .menu-group--editions &[aria-haspopup='true'] {
         margin-bottom: $gs-baseline;
 
-        &[aria-expanded="true"] {
+        &[aria-expanded='true'] {
             margin-bottom: 0;
         }
     }


### PR DESCRIPTION
## What does this change?

As part of the [menu editions refactoring](https://github.com/guardian/frontend/pull/17121) I introduced a styling regression, which get's fixed with this PR.

## What is the value of this and can you measure success?

Proper styles.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="555" alt="screen shot 2017-06-14 at 12 26 56" src="https://user-images.githubusercontent.com/2244375/27130125-d2ee9f68-50fc-11e7-8570-d978f5af2f14.png">

**After**

<img width="553" alt="screen shot 2017-06-14 at 12 27 13" src="https://user-images.githubusercontent.com/2244375/27130127-d5ddc69a-50fc-11e7-9b0f-48bb7560836b.png">

## Tested in CODE?

No.
