### PR TITLE
Increase banner ad z-index

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -234,3 +234,4 @@ $zindex-popover: 1040; // Breaking news
 $zindex-overlay: 1050; // Lightbox
 $zindex-notifications-permissions-warning: 1060; //Chrome Live Blog notifications
 $zindex-main-menu: 1070; // New header navigation dropdown
+$zindex-sticky-top-banner: 1080;  // Sticky header

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -74,7 +74,7 @@
 
     &:not(.top-banner-ad-container--not-sticky) {
         position: sticky;
-        z-index: $zindex-sticky;
+        z-index: $zindex-sticky-top-banner;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Ideally we should just go back to doing this: https://github.com/guardian/frontend/pull/15025 (I have started the discussion offline)

But in the meantime, this just increases the z-index of the banner ad so that this doesn't happen:

![image](https://user-images.githubusercontent.com/8774970/27138716-08e15388-5119-11e7-8538-586bd43c0523.png)

cc @guardian/commercial-dev 

## What is the value of this and can you measure success?
Users don't think they can close the ad by the burger menu :crossed_swords: 

## Does this affect other platforms - Amp, Apps, etc
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
