### PR TITLE
(Re-)implement non-js behavoir for new header

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -60,6 +60,11 @@
                     }
                 </div>
 
+                <input type="checkbox"
+                       id="main-menu-toggle"
+                       class="veggie-burger-fallback js-enhance-checkbox"
+                       aria-controls="main-menu">
+
                 <ul class="pillars">
                     @NewNavigation.PrimaryLinks.map { link =>
                         <li class="pillars__item">
@@ -81,11 +86,6 @@
                     <span class="veggie-burger__icon"></span>
                     <span class="veggie-burger__label">Menu</span>
                 </label>
-
-                <input type="checkbox"
-                       id="main-menu-toggle"
-                       class="veggie-burger-fallback js-enhance-checkbox"
-                       aria-controls="main-menu">
 
                 @fragments.nav.newHeaderMenu()
             </nav>

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -21,7 +21,9 @@
     }
 
     [aria-expanded='true'] ~ & {
-        margin-bottom: -1px;
+        @include mq($until: desktop) {
+            margin-bottom: -1px;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -18,5 +18,49 @@
                 width: 100%;
             }
         }
+
+        & ~ .pillars {
+            .pillars__item:not(:first-child) > .pillar-link {
+                @include mq(desktop) {
+                    padding-left: $gs-gutter / 2;
+                }
+            }
+
+            .pillar-link {
+                @include mq(desktop) {
+                    width: gs-span(2) + $gs-gutter;
+                }
+            }
+
+            .pillar-link:after {
+                @include mq(desktop) {
+                    display: none;
+                }
+            }
+        }
+
+        & ~ .veggie-burger {
+            z-index: $zindex-main-menu + 1;
+
+            .veggie-burger__icon {
+                background-color: transparent;
+
+                &:before {
+                    top: 0;
+                    transform: rotate(-45deg);
+                }
+
+                &:after {
+                    bottom: 0;
+                    transform: rotate(45deg);
+                }
+            }
+
+            .veggie-burger__label {
+                @include mq(desktop) {
+                    @include u-h();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does this change?

Restores proper non-js behavoir on mobile.
Adds non-js menu opening on desktop. It doesn't look any different, than with JS enabled.

## What is the value of this and can you measure success?

The past told us stuff will break and we want users to be able to navigat in any case.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

Looks the same as with JS.

## Tested in CODE?

No.
