### PR TITLE
Fixing nav menu when open - ad should not be covering it!

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -74,7 +74,11 @@
 
     &:not(.top-banner-ad-container--not-sticky) {
         position: sticky;
-        z-index: $zindex-sticky-top-banner;
+        z-index: $zindex-sticky;
+
+        @include mq(desktop) {
+            z-index: $zindex-sticky-top-banner;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?
Introduced in https://github.com/guardian/frontend/pull/17138

## What is the value of this and can you measure success?
🚫 🐛 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before**:
![image](https://user-images.githubusercontent.com/8774970/27143819-8abe0136-5127-11e7-8b6b-820048e0bff2.png)

**After:**
![image](https://user-images.githubusercontent.com/8774970/27143808-81da6528-5127-11e7-8057-a0ad1a256ec1.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
