### PR TITLE
Make lightbox appear above header

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -231,7 +231,8 @@ $zindex-content: 1015; // Modals and overlays inside content
 $zindex-sticky: 1020;  // Sticky header
 $zindex-modal: 1030;   // Search modal
 $zindex-popover: 1040; // Breaking news
-$zindex-overlay: 1050; // Lightbox
+$zindex-overlay: 1050; // Overlays
 $zindex-notifications-permissions-warning: 1060; //Chrome Live Blog notifications
 $zindex-main-menu: 1070; // New header navigation dropdown
 $zindex-sticky-top-banner: 1080;  // Sticky header
+$zindex-lightbox: 1090; // Lightbox

--- a/static/src/stylesheets/module/content/_gallery-lightbox.scss
+++ b/static/src/stylesheets/module/content/_gallery-lightbox.scss
@@ -13,6 +13,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     position: fixed;
     background-color: lighten($media-background, 2.5%);
     overflow: hidden;
+    z-index: $zindex-lightbox;
 }
 
 .gallery-lightbox--open {


### PR DESCRIPTION
## What does this change?

The gallery lightbox is currently appearing below the sticky banner, obscuring part of the image and the lightbox controls. This change pushes the lightbox back on top

## What is the value of this and can you measure success?

Lightbox is usable again

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

*Before*

![picture 245](https://user-images.githubusercontent.com/5931528/27173387-6ea5bff0-51b0-11e7-8315-6a4266329e71.png)

*After*

![picture 246](https://user-images.githubusercontent.com/5931528/27173398-7c6ba2da-51b0-11e7-989d-5424bd0199a9.png)

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
