### PR TITLE
add slot-fabric key values

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -73,6 +73,16 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slot.setTargeting('isbn', config.page.isbn);
     }
 
+    const fabricKeyValues = new Map([
+        ['top-above-nav', 'fabric1'],
+        ['merchandising-high', 'fabric2'],
+        ['merchandising', 'fabric3'],
+    ]);
+
+    if (fabricKeyValues.has(slotTarget)) {
+        slot.setTargeting('slot-fabric', fabricKeyValues.get(slotTarget));
+    }
+
     slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
 
     return {


### PR DESCRIPTION
## What does this change?
Add additional slot to target fabric creatives. (Decoupled from names specific to .com) 

## What is the value of this and can you measure success?
Prerequisite to supporting Fabric in future on Apps

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-06-15 at 11 23 24](https://user-images.githubusercontent.com/1764158/27177117-2fcb22d6-51bd-11e7-83d9-5bea819dcc1c.png)

## Tested in CODE?
No. But tested with line item on localhost

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
CC @guardian/commercial-dev 