### PR TITLE
Allow epic variants to override the campaign code 

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/contributions-utilities.js
@@ -195,7 +195,7 @@ define([
 
     function ContributionsABTestVariant(options, test) {
         var trackingCampaignId = test.epic ? 'epic_' + test.campaignId : test.campaignId;
-        var campaignCode = getCampaignCode(test.campaignPrefix, test.campaignId, options.id, test.campaignSuffix);
+        var campaignCode = options.campaignCode || getCampaignCode(test.campaignPrefix, test.campaignId, options.id, test.campaignSuffix);
 
         this.id = options.id;
 


### PR DESCRIPTION
## What does this change?

Some tests that create custom campaign codes for their links need to be able to manually set the campaign code field of their variants. 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
