### PR TITLE
Deps: Upgrade sass-graph to 2.2.4

### DIFF
--- a/dev/watch.js
+++ b/dev/watch.js
@@ -65,7 +65,7 @@ const chokidar = require('chokidar');
 
 const sassDir = path.resolve(__dirname, '../', 'static', 'src', 'stylesheets');
 const sassGraph = require('sass-graph').parseDir(sassDir, {
-    loadPaths: sassDir,
+    loadPaths: [sassDir],
 });
 
 const compileSass = require('../tools/compile-css');

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "requireindex": "^1.1.0",
     "requirejs": "^2.3.2",
     "rimraf": "^2.5.4",
-    "sass-graph": "^2.1.2",
+    "sass-graph": "^2.2.4",
     "sass-lint": "~1.10.2",
     "sass-mq": "~3.3.2",
     "semver": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,7 +4425,7 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-js-base64@^2.1.9:
+js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
@@ -6929,13 +6929,22 @@ sane@~1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sass-graph@^2.1.1, sass-graph@^2.1.2:
+sass-graph@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.1.2.tgz#965104be23e8103cb7e5f710df65935b317da57b"
   dependencies:
     glob "^7.0.0"
     lodash "^4.0.0"
     yargs "^4.7.1"
+
+sass-graph@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
+  dependencies:
+    glob "^7.0.0"
+    lodash "^4.0.0"
+    scss-tokenizer "^0.2.3"
+    yargs "^7.0.0"
 
 sass-lint@~1.10.2:
   version "1.10.2"
@@ -6962,6 +6971,13 @@ sass-mq@~3.3.2:
 sax@1.2.1, sax@>=0.6.0, sax@^1.2.1, sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+scss-tokenizer@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
+  dependencies:
+    js-base64 "^2.1.8"
+    source-map "^0.4.2"
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
@@ -8316,7 +8332,7 @@ yargs@^4.2.0, yargs@^4.7.1:
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
 
-yargs@^7.0.2:
+yargs@^7.0.0, yargs@^7.0.2:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
   dependencies:


### PR DESCRIPTION
## What does this change?

Upgrades sass-graph to 2.2.4. Only breaking change is, that `loadPaths` has to be an array now. Output of the before/ after is similar.

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
