### PR TITLE
Small New Header Tweaks

### DIFF
--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -122,7 +122,7 @@ object NavLinks {
 
   val todaysPaper = NavLink("today's paper", "/theguardian", "theguardian")
   val observer = NavLink("the observer", "/observer", "observer")
-  val digitalNewspaperArchive = NavLink("digital newspaper archive", "https://theguardian.newspapers.com")
+  val digitalNewspaperArchive = NavLink("digital archive", "https://theguardian.newspapers.com")
   val crosswords = NavLink("crosswords", "/crosswords", "crosswords")
   val video =  NavLink("video", "/video")
   val podcasts =  NavLink("podcasts", "/podcasts")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -258,22 +258,22 @@ object NewNavigation {
     val name = ""
 
     val uk = NavLinkLists(List(
-      NavLink("professional networks", "/guardian-professional"),
       apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
-      podcasts,
       video,
+      podcasts,
       pictures,
       newsletters,
       todaysPaper,
       observer,
       digitalNewspaperArchive,
+      NavLink("professional networks", "/guardian-professional"),
       crosswords
     ))
 
     val au = NavLinkLists(List(
       apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
-      podcasts,
       video,
+      podcasts,
       pictures,
       newsletters,
       digitalNewspaperArchive,
@@ -282,8 +282,8 @@ object NewNavigation {
 
     val us = NavLinkLists(List(
       apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
-      podcasts,
       video,
+      podcasts,
       pictures,
       newsletters,
       digitalNewspaperArchive,
@@ -292,8 +292,8 @@ object NewNavigation {
 
     val int = NavLinkLists(List(
       apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
-      podcasts,
       video,
+      podcasts,
       pictures,
       newsletters,
       todaysPaper,

--- a/static/src/stylesheets/layout/new-header/_header-cta-item.scss
+++ b/static/src/stylesheets/layout/new-header/_header-cta-item.scss
@@ -28,10 +28,6 @@
     @include mq(tablet) {
         font-size: 17px;
     }
-
-    @include mq(desktop) {
-        font-size: 18px;
-    }
 }
 
 .header-cta-item__new-line {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -108,10 +108,8 @@
 
     @include mq(desktop) {
         font-size: 16px;
-        overflow-x: hidden;
+        line-height: 18px;
         padding: $gs-baseline / 2 0;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     &:hover,

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -40,10 +40,11 @@
         height: 42px;
         max-width: none;
         padding-left: 48px;
+        font-size: 18px;
     }
 
     &::placeholder {
-        color: $news-support-1;
+        color: #ffffff;
     }
 
     &:focus {


### PR DESCRIPTION
## What does this change?

Commits:
* knock back just a bit header cta font-size
* search should be white, and smaller at desktop
* reording other links in the nav
* shorting digital newspaper archive
* remove ellipsis from text
cc @paperboyo @stephanfowler 

## What is the value of this and can you measure success?
Looks better? 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots (on wide breakpoint)
**Before:**
![image](https://user-images.githubusercontent.com/8774970/27191669-72a5ea04-51f0-11e7-87a4-a99411f5fc9a.png)

**After:**
![image](https://user-images.githubusercontent.com/8774970/27191683-7d22503a-51f0-11e7-9db9-956164389df3.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
