### PR TITLE
Make `menu` clickable

### DIFF
--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -11,6 +11,7 @@
     border-radius: 50%;
     outline: none;
     right: $gutter-small;
+    z-index: 1;
 
     @include mq(mobileMedium) {
         height: $veggie-burger-medium;


### PR DESCRIPTION
## What does this change?
At the moment the little menu label isn't clickable because it is covered by the subnav. This just makes it clickable

## What is the value of this and can you measure success?
Slightly better UX

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27225002-16236cac-5290-11e7-8fa3-4196e801d772.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
