### PR TITLE
Article: avoid rendering duplicated mainMedia fragment

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -44,16 +44,11 @@
             } else {
                 <div class="hide-on-mobile">
                     @fragments.headTonal(article, model, isPaidContent, amp = amp)
+                </div>
 
-                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                        @fragments.mainMedia(article, amp)
-                    }
-                </div>
-                <div class="mobile-only">
-                    @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
-                        @fragments.mainMedia(article, amp)
-                    }
-                </div>
+                @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
+                    @fragments.mainMedia(article, amp)
+                }
             }
 
             <div class="content__main tonal__main tonal__main--@toneClass(article)">


### PR DESCRIPTION
## What does this change?

Removes a duplication of `@fragments.mainMedia(article, amp)` from article body. Previously it was rendered twice: once in a container, which is hidden on mobile and another time in a container which was only visible on mobile.

This broke our non-js image caption toggle, because an element with the same id existed twice on the page ([trello reference](https://trello.com/c/6g1s5aes/333-i-icon-for-showing-caption-credit-broken)).

Mind bending template ...

## What is the value of this and can you measure success?

Less HTML, working image-caption toggle.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

Should be the same as before.

## Tested in CODE?

No.
