### PR TITLE
Revert "ES6 ✨ commercial messenger - dfp origin"

### DIFF
--- a/static/src/javascripts-legacy/projects/commercial/modules/messenger/dfp-origin.js
+++ b/static/src/javascripts-legacy/projects/commercial/modules/messenger/dfp-origin.js
@@ -1,0 +1,3 @@
+define(function () {
+    return location.protocol + '//tpc.googlesyndication.com';
+});

--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -1,6 +1,6 @@
 // @flow
 import reportError from 'lib/report-error';
-import { dfpOrigin } from 'commercial/modules/messenger/dfp-origin';
+import dfpOrigin from 'commercial/modules/messenger/dfp-origin';
 import postMessage from 'commercial/modules/messenger/post-message';
 
 const ALLOWED_HOSTS = [dfpOrigin, `${location.protocol}//${location.host}`];

--- a/static/src/javascripts/projects/commercial/modules/messenger/dfp-origin.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/dfp-origin.js
@@ -1,2 +1,0 @@
-// @flow
-export const dfpOrigin = `${location.protocol}//tpc.googlesyndication.com`;

--- a/static/test/javascripts-legacy/spec/commercial/messenger/messenger.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/messenger/messenger.spec.js
@@ -29,7 +29,7 @@ define([
                 'commercial/modules/messenger/dfp-origin'
             ], function($1, $2) {
                 messenger = $1;
-                dfpOrigin = $2.dfpOrigin;
+                dfpOrigin = $2;
                 mockWindow = jasmine.createSpyObj('window', ['addEventListener', 'removeEventListener', 'postMessage']);
                 mockWindow.addEventListener.and.callFake(function(_, _onMessage) {
                     onMessage = _onMessage;

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -4,6 +4,7 @@
   "Regis Kuckaertz": [],
   "Richard Nguyen": [],
   "Kate Whalen": [
+    "projects/commercial/modules/messenger/dfp-origin.js",
     "projects/commercial/modules/messenger/get-stylesheet.js",
     "projects/commercial/modules/messenger/post-message.js",
     "projects/commercial/modules/messenger/resize.js",


### PR DESCRIPTION
Reverts guardian/frontend#17153

This seems to have broken paid for merch slots, the bookshop component and also inline components. Basically, any component that makes an AJAX call is not longer is making the call and ending up empty.

One thing I have noticed is that in the scripts that come from DFP, the script tags that make the AJAX calls (in the paid for merch slot for example), aren't scoped using brackets, and instead are using a global function definition.

![screen shot 2017-06-16 at 13 31 54](https://user-images.githubusercontent.com/445472/27226766-718d94c0-5298-11e7-87c4-df1e5b39db51.png)

😆 😂 


@katebee @ScottPainterGNM 