### PR TITLE
Removing election link from the nav

### DIFF
--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -52,7 +52,6 @@ object NavLinks {
   val borrowing = NavLink("borrowing", "/money/debt", "money/debt")
   val careers = NavLink("careers", "/money/work-and-careers", "money/work-and-careers")
   val obituaries = NavLink("obituaries", "/tone/obituaries")
-  val ukElection2017 = NavLink("election", "/politics/general-election-2017")
 
   /* OPINION */
   val opinion = NavLink("opinion", "/commentisfree", longTitle = "opinion home", iconName = "home", uniqueSection = "commentisfree")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -75,7 +75,6 @@ trait Navigation {
   val scotland = SectionLink("scotland", "scotland", "Scotland", "/uk/scotland")
   val wales = SectionLink("wales", "wales", "Wales", "/uk/wales")
   val northernIreland = SectionLink("northernireland", "northern ireland", "Northern Ireland", "/uk/northernireland")
-  val ukElection2017 = SectionLink("politics", "election", "election", "/politics/general-election-2017")
 
   // Columnists
   val columnists = SectionLink("columnists", "columnists", "Columnists", "/index/contributors")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -64,7 +64,7 @@ object NewNavigation {
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(List(headlines, ukNews, ukElection2017, world, tech, business, football))
+    val uk = NavLinkLists(List(headlines, ukNews, environment, world, tech, business, football))
     val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, environment, economy, football))
     val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, science, soccer))
     val int = NavLinkLists(List(headlines, world, ukNews, business, science, globalDevelopment, football))
@@ -74,7 +74,7 @@ object NewNavigation {
     val name = "news"
 
     val uk = NavLinkLists(
-      List(headlines, ukNews, world, business, ukElection2017, tech, politics),
+      List(headlines, ukNews, world, business, environment, tech, politics),
       List(science, globalDevelopment, cities, obituaries)
     )
     val au = NavLinkLists(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -96,7 +96,7 @@ object Uk extends Edition(
     Seq(
       NavItem(home),
       NavItem(uk, ukLocalNav),
-      NavItem(politics, Seq(ukElection2017)),
+      NavItem(politics),
       NavItem(world, worldLocalNav),
       NavItem(sport, sportLocalNav),
       NavItem(football, footballNav),
@@ -124,7 +124,7 @@ object Uk extends Edition(
   override val briefNav: Seq[NavItem] = Seq(
     NavItem(home),
     NavItem(uk, ukLocalNav),
-    NavItem(ukElection2017),
+    NavItem(politics),
     NavItem(world, worldLocalNav),
     NavItem(sport, sportLocalNav),
     NavItem(football, footballNav),


### PR DESCRIPTION
## What does this change?
Unfortunately I couldn't automatically revert this anymore: https://github.com/guardian/frontend/pull/16741. But this is my manual revert 😄 

Election is done so we don't need it in the nav anymore. 

## What is the value of this and can you measure success?
Pleasing editorial demand

## Does this affect other platforms - Amp, Apps, etc?
Election will be removed from the AMP nav too

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27229501-c30c4764-52a3-11e7-8ec8-1fbce05a5100.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
