### PR TITLE
Change bundle price test and cookie name

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -151,8 +151,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-bundle-digital-sub-price-test-1-m",
-    "Test pricing options for digital subs",
+    "ab-bundle-digital-sub-price-test-1-m-e",
+    "Test pricing options for digital subs from epic",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 7, 6),  // Thursday 6th July

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
@@ -23,7 +23,7 @@ define([
 ) {
     var buildTemplate = function(variant) {
         return template(contributionsEpicSingleButton, {
-            linkUrl1: config.page.membershipUrl + '/bundles?INTCMP=' + 'BUNDLE_PRICE_TEST_1M_' + config.page.edition.toUpperCase() + '_' + variant.id.toUpperCase(),
+            linkUrl1: config.page.membershipUrl + '/bundles?INTCMP=' + 'BUNDLE_PRICE_TEST_1M_E_' + config.page.edition.toUpperCase() + '_' + variant.id.toUpperCase(),
             componentName: variant.componentName,
             title: 'Since you’re here…',
             p1: '… we’ve got a small favour to ask. More people are reading the Guardian than ever, but far fewer are paying for it. Advertising revenues across the media are falling fast. And ' +
@@ -36,7 +36,7 @@ define([
     };
 
     return contributionsUtilities.makeABTest({
-        id: 'BundleDigitalSubPriceTest1M',
+        id: 'BundleDigitalSubPriceTest1ME',
         campaignPrefix: '',
         campaignSuffix: '',
         start: '2017-05-10',
@@ -55,7 +55,7 @@ define([
 
         overrideCanRun: false,
         canRun: function () {
-            return !cookies.getCookie('GU_DBPT1M') &&
+            return !cookies.getCookie('GU_DBPT1ME') &&
                 config.page.edition.toUpperCase() === 'UK' &&
                 config.page.contentType === 'Article' &&
                 !config.page.isMinuteArticle &&


### PR DESCRIPTION
## What does this change?
Renames an existing test in order to create a new one with the correct audience segment. Also changes the cookie used to identify completion.

## What is the value of this and can you measure success?
Because the previous thrasher-based test was switched off manually and didn't expire, the audience that had been participating in that test would be retained as we move over to the epic-based version. That has the potential to have a negative impact on the epics generally, as we only want to use 10% of that audience, not 35% as would be the case if this change is not implemented.

As a result of changing these values, there is an accompanying change in membership-frontend here https://github.com/guardian/membership-frontend/issues/1677.

## Does this affect other platforms - Amp, Apps, etc?
No, web only

## Screenshots
<img width="861" alt="screen shot 2017-06-19 at 08 32 16" src="https://user-images.githubusercontent.com/690395/27274379-e7e74a74-54ca-11e7-874a-1013d38747d2.png">

## Tested in CODE?
Yes

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
