### PR TITLE
Resurrect structured data on AMP pages

### DIFF
--- a/article/app/views/articleAMP.scala.html
+++ b/article/app/views/articleAMP.scala.html
@@ -1,5 +1,7 @@
 @(model: ArticlePage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @mainAMP(model, model.related, model.article.content){
+
+}{
     @fragments.articleBody(model, amp = true)
 }

--- a/article/app/views/liveBlogAMP.scala.html
+++ b/article/app/views/liveBlogAMP.scala.html
@@ -1,7 +1,19 @@
 @import model.LiveBlogPage
+@import model.structuredData.{Organisation, LiveBlogPosting}
+@import model.LiveBlogHelpers
 
 @(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @mainAMP(model, model.related, model.article.content){
+    <script type="application/ld+json">
+        @Html(Organisation().toString())
+    </script>
+    <script type="application/ld+json">
+        @Html(LiveBlogPosting(
+            model.article,
+            LiveBlogHelpers.blocksForLiveBlogRequest(model.article, request.getQueryString("page"))
+        ).toString())
+    </script>
+}{
     @views.html.liveblog.liveBlogBody(model, amp = true)
 }

--- a/common/app/views/fragments/amp/headAmp.scala.html
+++ b/common/app/views/fragments/amp/headAmp.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page, content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, content: model.Content)(head: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <head>
     @* "utf-8" meta tag needs to be first according to AMP spec *@
@@ -27,4 +27,7 @@
     <script custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js" async></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script src="https://cdn.ampproject.org/v0.js" async></script>
+
+    @head
+
 </head>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -1,11 +1,11 @@
-@(page: model.Page, related: model.RelatedContent, content: model.Content)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, related: model.RelatedContent, content: model.Content)(head: Html)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.{CanonicalLink, LinkTo}
 
 <!doctype html>
 <html AMP>
 
-    @fragments.amp.headAmp(page, content)
+    @fragments.amp.headAmp(page, content)(head)
 
     <body class="guardian-egyptian-loading">
 


### PR DESCRIPTION
## What does this change?

(readers note: Structured Data is a simple `<script>{json structure}</script>` tag that must appear in the `<head>` of a page)

A long time ago, all Live Blog structured data code lived inside the Common module, because I thought that the only way to provide custom content inside of `<head>` was from within Common.

I then realised that the main html template had a parameter that lets you pass in custom html that gets rendered inside of head. This meant we could take all the structured data code for live blogs out of Common, and put it back into Article where it rightly belongs, and pass the structured data as custom html into the template's head parameter. All was good.

However when we did this, we neglected to apply the new logic universally. We presented structured data on the normal live blog pages, but *not* on the AMP live blog version.

This PR puts the Structured Data definitions into the AMP version of the Live Blog articles.

One catch: it looks like the mainAmp template doesn't support passing in custom Html into the head like the normal main template does. So I have ADDED support for this by introducing the new parameter.

## What is the value of this and can you measure success?

Getting structured data working again on AMP pages will make the Google Indexing API work

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
