### PR TITLE
Bump CAPI so that new shouldHideReaderRevenue flag is visible on the page config

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -424,6 +424,7 @@ object Article {
       ("isHosted", JsBoolean(false)),
       ("isPhotoEssay", JsBoolean(content.isPhotoEssay)),
       ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
+      ("shouldHideReaderRevenue", JsBoolean(fields.shouldHideReaderRevenue)),
       "videoDuration" -> videoDuration
     ) ++ bookReviewIsbn ++ AtomProperties(content.atoms)
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -59,6 +59,7 @@ object Fields {
       displayHint = apiContent.fields.flatMap(_.displayHint).getOrElse(""),
       isLive = apiContent.fields.flatMap(_.liveBloggingNow).getOrElse(false),
       sensitive = apiContent.fields.flatMap(_.sensitive),
+      shouldHideReaderRevenue = apiContent.fields.flatMap(_.shouldHideReaderRevenue).getOrElse(false),
       legallySensitive = apiContent.fields.flatMap(_.legallySensitive),
       firstPublicationDate = apiContent.fields.flatMap(_.firstPublicationDate).map(_.toJodaDateTime)
     )
@@ -77,6 +78,7 @@ final case class Fields(
   displayHint: String,
   isLive: Boolean,
   sensitive: Option[Boolean],
+  shouldHideReaderRevenue: Boolean,
   legallySensitive: Option[Boolean],
   firstPublicationDate: Option[DateTime]
 ){

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.11.7"
   val faciaVersion = "2.1.3"
-  val capiVersion = "11.12"
+  val capiVersion = "11.17"
   val dispatchVersion = "0.11.3"
   val configurationMagicVersion = "1.2.2"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
A new flag which is to be read by our acquisition asks, shouldHideReaderRevenue, is how available in CAPI (https://github.com/guardian/content-api/pull/1951).

This PR adds the funcitonalilty to read this value and make it available as part of window.guardian.config.page


## What is the value of this and can you measure success?
It means we can have greater control over what content we feel comfortable showing acquisition asks on.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

![screenshot at jun 15 09-50-20](https://user-images.githubusercontent.com/2844554/27173622-34a04018-51b1-11e7-8d06-0a00664a3093.png)


## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
