### PR TITLE
Deps: Upgrade chance to 1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "git-user-name": "^1.2.0",
     "glob": "^7",
     "gzip-size": "^3.0.0",
-    "hasha": "^2.2.0",
+    "hasha": "^3.0.0",
     "jasmine-core": "^2.3.2",
     "jest": "^20.0.3",
     "jest-teamcity-reporter": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bs-fullscreen-message": "^1.1.0",
     "btoa": "1.1.2",
     "chalk": "^1.1.3",
-    "chance": "^1.0.6",
+    "chance": "^1.0.10",
     "chokidar": "^1.7.0",
     "cp-file": "^4.2.0",
     "cpy": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,9 +1404,9 @@ chalk, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chance@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.6.tgz#4734f62d02b738cdc2882d8b5d41f89af49e7bfd"
+chance@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.10.tgz#03500b04ad94e778dd2891b09ec73a6ad87b1996"
 
 charenc@~0.0.1:
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,7 +3613,13 @@ hash.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
-hasha, hasha@~2.2.0:
+hasha@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
+  dependencies:
+    is-stream "^1.0.1"
+
+hasha@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1"
   dependencies:


### PR DESCRIPTION
## What does this change?

Upgrades `chance` to 1.0.10. No breaking changes, but we should keep an eye on this dependency, because the developer isn't really following semver (couple of new features were added in a patch release and the commit messages are hard to read).

[Changes](https://github.com/chancejs/chancejs/compare/1.0.6...master)

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
