### PR TITLE
Deps: Upgrade hasha to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "git-user-name": "^1.2.0",
     "glob": "^7",
     "gzip-size": "^3.0.0",
-    "hasha": "^2.2.0",
+    "hasha": "^3.0.0",
     "jasmine-core": "^2.3.2",
     "jest": "^20.0.3",
     "jest-teamcity-reporter": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,7 +3613,13 @@ hash.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
-hasha, hasha@~2.2.0:
+hasha@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
+  dependencies:
+    is-stream "^1.0.1"
+
+hasha@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/hasha/-/hasha-2.2.0.tgz#78d7cbfc1e6d66303fe79837365984517b2f6ee1"
   dependencies:


### PR DESCRIPTION
## What does this change?

Upgrades `hasha` to 3.0.0. [No breaking changes](https://github.com/sindresorhus/hasha/compare/v2.2.0...master) affect us.

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
