### PR TITLE
Remove BundleDigitalSubPriceTest from ab-tests.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -7,7 +7,6 @@ import MembershipEngagementBannerTests from 'common/modules/experiments/tests/me
 import PaidContentVsOutbrain2 from 'common/modules/experiments/tests/paid-content-vs-outbrain';
 import { tailorSurvey } from 'common/modules/experiments/tests/tailor-survey';
 import BookmarksEmailVariants2 from 'common/modules/experiments/tests/bookmarks-email-variants-2';
-import BundleDigitalSubPriceTest1 from 'common/modules/experiments/tests/bundle-digital-sub-price-test-1';
 import { ExplainerSnippet } from 'common/modules/experiments/tests/explainer-snippet';
 
 import AcquisitionsEpicElectionInteractiveEnd from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
@@ -20,7 +19,6 @@ export const TESTS: Array<ABTest> = [
     getAcquisitionTest(),
     tailorSurvey,
     BookmarksEmailVariants2,
-    new BundleDigitalSubPriceTest1(),
     ExplainerSnippet(),
     new AcquisitionsEpicElectionInteractiveEnd(),
     new AcquisitionsEpicElectionInteractiveSlice(),


### PR DESCRIPTION
## What does this change?

Remove BundleDigitalSubPriceTest from ab-tests.js becuase it is included in acquisition-test-selector.js so including it in ab-test.js causes it to be displayed twice.

## What is the value of this and can you measure success?

Stops displaying epic twice

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
