### PR TITLE
Fix header styling for IE10

### DIFF
--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -37,6 +37,7 @@ from scrolling */
 .new-header__cta-container {
     left: $gs-gutter / 4;
     position: absolute;
+    top: 0;
 
     @include mq(mobileLandscape) {
         left: $gs-gutter / 2;
@@ -44,6 +45,7 @@ from scrolling */
 }
 
 .new-header__logo {
+    display: flex;
     margin-left: auto;
 }
 


### PR DESCRIPTION
## What does this change?

Fixes styling for IE10. Previously the logo and cta container collapsed.

## What is the value of this and can you measure success?

✨ 

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1260" alt="screen shot 2017-06-19 at 14 31 35" src="https://user-images.githubusercontent.com/2244375/27287561-06b40fe2-54fc-11e7-97d3-45d4b4799f72.png">

**After**

<img width="1261" alt="screen shot 2017-06-19 at 14 27 33" src="https://user-images.githubusercontent.com/2244375/27287532-eda7e280-54fb-11e7-890e-872fb83f3aa1.png">

## Tested in CODE?

No.
