### PR TITLE
Fix Switch overlap

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -31,19 +31,19 @@ const catchPolyfillErrors = () => {
 };
 
 const setupSonobi: () => Promise<void> = once(() => {
-    buildPageTargeting();
-    // Setting the async property to false will _still_ load the script in
-    // a non-blocking fashion but will ensure it is executed before googletag
-    return loadScript(config.libs.sonobi, { async: false }).then(
-        catchPolyfillErrors
-    );
+    if (dfpEnv.sonobiEnabled && commercialFeatures.dfpAdvertising) {
+        buildPageTargeting();
+        // Setting the async property to false will _still_ load the script in
+        // a non-blocking fashion but will ensure it is executed before googletag
+        return loadScript(config.libs.sonobi, { async: false }).then(
+            catchPolyfillErrors
+        );
+    }
 });
 
 const init = (start: () => void, stop: () => void) => {
-    if (dfpEnv.sonobiEnabled && commercialFeatures.dfpAdvertising) {
-        start();
-        setupSonobi().then(stop);
-    }
+    start();
+    setupSonobi().then(stop);
 
     return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -39,6 +39,8 @@ const setupSonobi: () => Promise<void> = once(() => {
             catchPolyfillErrors
         );
     }
+
+    return Promise.resolve();
 });
 
 const init = (start: () => void, stop: () => void) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -38,6 +38,8 @@ const setupSwitch: () => Promise<void> = once(() => {
             setupLoadId
         );
     }
+
+    return Promise.resolve();
 });
 
 // The switch api's callSwitch function will perform the retrieval of a pre-flight ad call,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-switch-tag.js
@@ -30,11 +30,15 @@ const setupLoadId = () => {
     });
 };
 
-const setupSwitch: () => Promise<void> = once(() =>
-    // Setting the async property to false will _still_ load the script in
-    // a non-blocking fashion but will ensure it is executed before googletag
-    loadScript(config.libs.switch, { async: false }).then(setupLoadId)
-);
+const setupSwitch: () => Promise<void> = once(() => {
+    if (commercialFeatures.dfpAdvertising) {
+        // Setting the async property to false will _still_ load the script in
+        // a non-blocking fashion but will ensure it is executed before googletag
+        return loadScript(config.libs.switch, { async: false }).then(
+            setupLoadId
+        );
+    }
+});
 
 // The switch api's callSwitch function will perform the retrieval of a pre-flight ad call,
 // using the load id that has been previously set with setupLoadId.
@@ -114,10 +118,8 @@ const maybePushAdUnit = (dfpDivId: string, sizeMapping: any) => {
 };
 
 const init = (start: () => void, stop: () => void) => {
-    if (commercialFeatures.dfpAdvertising) {
-        start();
-        setupSwitch().then(stop);
-    }
+    start();
+    setupSwitch().then(stop);
 
     return Promise.resolve();
 };


### PR DESCRIPTION
## What does this change?

Sonobi is firing on pages where Switch is running. It is running later than usual meaning it may not actually affect anything, but it's hard to tell.

This moves the guards around when Sonobi and Switch run to the `setupX` methods in each module meaning they will only run when appropriate.

This also now means the `init` methods in each module are essentially only used for timing.

## Tested in CODE?

Not yet!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@rich-nguyen 