### PR TITLE
Restored dateline to immersives

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -59,10 +59,10 @@
             }
             @fragments.meta.contactAuthor(item.tags, amp)
         }
+    }
 
-        @if(!(item.trail.shouldHidePublicationDate || item.content.isGallery)) {
-            @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, item.content.hasBeenModified, item.fields.firstPublicationDate, item.tags.isLiveBlog, item.fields.isLive)
-        }
+    @if(!(item.trail.shouldHidePublicationDate || item.content.isGallery)) {
+        @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, item.content.hasBeenModified, item.fields.firstPublicationDate, item.tags.isLiveBlog, item.fields.isLive)
     }
 }
 


### PR DESCRIPTION
The dateline was wrapped up in a double negative... 

Pulled the dateline outside of the if statement that excludes galleries and immersives. Now we have a dateline on immersives. 

