### PR TITLE
Extend acquisitions switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -176,7 +176,7 @@ trait ABTestSwitches {
     "Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 6, 19),
+    sellByDate = new LocalDate(2017, 6, 21),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the **acquisitions epic thank you** switch by a couple of days to prevent the build from breaking

## What is the value of this and can you measure success?

Happy builds

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
