### PR TITLE
Add lang attribute, and rtl for Arabic content

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -75,8 +75,8 @@
                             <hr class="content__hr hide-until-leftcol" />
                         }
 
-                        <div class="content__article-body from-content-api js-article__body" dir="auto" itemprop="@bodyType(model)"
-                            data-test-id="article-review-body">
+                        <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
+                            data-test-id="article-review-body" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>
                             @BodyCleaner(article, article.fields.body, amp = amp)
 
                             @* A value for the image field is required for AMP article

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,5 +1,6 @@
 @(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
+@import views.html.fragments.langAttributes
 @import common.LinkTo
 @import views.BodyCleaner
 @import views.support.Commercial.{isPaidContent, articleAsideOptionalSizes, shouldShowAds}
@@ -76,7 +77,7 @@
                         }
 
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
-                            data-test-id="article-review-body" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>
+                            data-test-id="article-review-body" @langAttributes(article.content)>
                             @BodyCleaner(article, article.fields.body, amp = amp)
 
                             @* A value for the image field is required for AMP article

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -75,7 +75,7 @@
                             <hr class="content__hr hide-until-leftcol" />
                         }
 
-                        <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
+                        <div class="content__article-body from-content-api js-article__body" dir="auto" itemprop="@bodyType(model)"
                             data-test-id="article-review-body">
                             @BodyCleaner(article, article.fields.body, amp = amp)
 

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -34,7 +34,7 @@
 
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
-                             data-test-id="article-review-body">
+                             data-test-id="article-review-body" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -1,5 +1,6 @@
 @(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
+@import views.html.fragments.langAttributes
 @import common.LinkTo
 @import views.BodyCleaner
 @import views.support.Commercial.{isPaidContent, articleAsideOptionalSizes, shouldShowAds}
@@ -34,7 +35,7 @@
 
                         <div class="content__article-body from-content-api js-article__body"
                              itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
-                             data-test-id="article-review-body" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>
+                             data-test-id="article-review-body" @langAttributes(article.content)>
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -5,5 +5,5 @@
 <header class="content__head tonal__head tonal__head--@toneClass(article) @if(article.isTheMinute) { content__head--minute-article }">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@
-    <h1 class="is-hidden" itemprop="headline">@Html(article.trail.headline)</h1>
+    <h1 class="is-hidden" itemprop="headline" lang="@{article.content.fields.isRightToLeftLang}" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>@Html(article.trail.headline)</h1>
 </header>

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -1,9 +1,10 @@
 @(article: model.Article)(implicit request: RequestHeader)
 
 @import views.support.TrailCssClasses.toneClass
+@import views.html.fragments.langAttributes
 
 <header class="content__head tonal__head tonal__head--@toneClass(article) @if(article.isTheMinute) { content__head--minute-article }">
     @* Hidden because we visually show this data in the head, but needed
     here for SEO. *@
-    <h1 class="is-hidden" itemprop="headline" lang="@{article.content.fields.isRightToLeftLang}" @article.fields.lang.map { l => lang="@l" } @if(article.content.fields.isRightToLeftLang){ dir="rtl" }>@Html(article.trail.headline)</h1>
+    <h1 class="is-hidden" itemprop="headline" @langAttributes(article.content)>@Html(article.trail.headline)</h1>
 </header>

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -62,8 +62,7 @@ object Fields {
       shouldHideReaderRevenue = apiContent.fields.flatMap(_.shouldHideReaderRevenue),
       legallySensitive = apiContent.fields.flatMap(_.legallySensitive),
       firstPublicationDate = apiContent.fields.flatMap(_.firstPublicationDate).map(_.toJodaDateTime),
-      lang = apiContent.fields.flatMap(_.lang),
-      rightToLeftLang = apiContent.fields.flatMap(_.lang).filter(_.equals("ar"))
+      lang = apiContent.fields.flatMap(_.lang)
     )
   }
 }
@@ -83,10 +82,12 @@ final case class Fields(
   shouldHideReaderRevenue: Option[Boolean],
   legallySensitive: Option[Boolean],
   firstPublicationDate: Option[DateTime],
-  lang: Option[String],
-  rightToLeftLang: Option[String]
+  lang: Option[String]
 ){
   lazy val shortUrlId = shortUrl.replaceFirst("^[a-zA-Z]+://gu.com", "") //removing scheme://gu.com
+  lazy val isRightToLeftLang: Boolean = lang.contains("ar")
+
+
 
   def javascriptConfig: Map[String, JsValue] = {
     Map(

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -62,7 +62,8 @@ object Fields {
       shouldHideReaderRevenue = apiContent.fields.flatMap(_.shouldHideReaderRevenue),
       legallySensitive = apiContent.fields.flatMap(_.legallySensitive),
       firstPublicationDate = apiContent.fields.flatMap(_.firstPublicationDate).map(_.toJodaDateTime),
-      lang = apiContent.fields.flatMap(_.lang)
+      lang = apiContent.fields.flatMap(_.lang),
+      rightToLeftLang = apiContent.fields.flatMap(_.lang).filter(_.equals("ar"))
     )
   }
 }
@@ -82,7 +83,8 @@ final case class Fields(
   shouldHideReaderRevenue: Option[Boolean],
   legallySensitive: Option[Boolean],
   firstPublicationDate: Option[DateTime],
-  lang: Option[String]
+  lang: Option[String],
+  rightToLeftLang: Option[String]
 ){
   lazy val shortUrlId = shortUrl.replaceFirst("^[a-zA-Z]+://gu.com", "") //removing scheme://gu.com
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -61,7 +61,8 @@ object Fields {
       sensitive = apiContent.fields.flatMap(_.sensitive),
       shouldHideReaderRevenue = apiContent.fields.flatMap(_.shouldHideReaderRevenue),
       legallySensitive = apiContent.fields.flatMap(_.legallySensitive),
-      firstPublicationDate = apiContent.fields.flatMap(_.firstPublicationDate).map(_.toJodaDateTime)
+      firstPublicationDate = apiContent.fields.flatMap(_.firstPublicationDate).map(_.toJodaDateTime),
+      lang = apiContent.fields.flatMap(_.lang)
     )
   }
 }
@@ -80,7 +81,8 @@ final case class Fields(
   sensitive: Option[Boolean],
   shouldHideReaderRevenue: Option[Boolean],
   legallySensitive: Option[Boolean],
-  firstPublicationDate: Option[DateTime]
+  firstPublicationDate: Option[DateTime],
+  lang: Option[String]
 ){
   lazy val shortUrlId = shortUrl.replaceFirst("^[a-zA-Z]+://gu.com", "") //removing scheme://gu.com
 

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -19,7 +19,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline" itemprop="headline">
+                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.rightToLeftLang}" dir="auto">
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -1,5 +1,6 @@
 @(item: model.ContentType, page: model.Page, showBadge: Boolean = false, showMeta: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
 
+@import views.html.fragments.langAttributes
 @import model.Badges.badgeFor
 @import views.support.Commercial.isPaidContent
 @import views.support.ContributorLinks
@@ -19,7 +20,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.isRightToLeftLang}" @item.fields.lang.map { l => lang="@l" } @if(item.content.fields.isRightToLeftLang){ dir="rtl" }>
+                <h1 class="content__headline js-score" itemprop="headline" @langAttributes(item.content)>
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -19,7 +19,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.rightToLeftLang}" dir="auto">
+                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.isRightToLeftLang}" dir="auto">
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -20,7 +20,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline js-score" itemprop="headline" @langAttributes(item.content)>
+                <h1 class="content__headline" itemprop="headline" @langAttributes(item.content)>
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -19,7 +19,7 @@
                     @fragments.meta.metaInline(item)
                 }
 
-                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.isRightToLeftLang}" dir="auto">
+                <h1 class="content__headline js-score" itemprop="headline" lang="@{item.content.fields.isRightToLeftLang}" @item.fields.lang.map { l => lang="@l" } @if(item.content.fields.isRightToLeftLang){ dir="rtl" }>
                     @if(item.tags.isMedia) {
                         @defining(
                             item match {

--- a/common/app/views/fragments/langAttributes.scala.html
+++ b/common/app/views/fragments/langAttributes.scala.html
@@ -1,5 +1,5 @@
 @(content: model.Content)(implicit request: RequestHeader)
-
+@* CAPI defaults to 'en' for any unrecognised language. Therefore we filter 'en' out to avoid setting an erroneous value when a new language is used *@
 @defining(content.fields.lang.exists(!_.equals("en"))) { nonEnLang =>
     @if(nonEnLang){ lang="@content.fields.lang" } @if(content.fields.isRightToLeftLang){ dir="rtl" }
 }

--- a/common/app/views/fragments/langAttributes.scala.html
+++ b/common/app/views/fragments/langAttributes.scala.html
@@ -1,3 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
-@content.fields.lang.map { l => lang="@l" } @if(content.fields.isRightToLeftLang){ dir="rtl" }
+@defining(content.fields.lang.exists(!_.equals("en"))) { nonEnLang =>
+    @if(nonEnLang){ lang="@content.fields.lang" } @if(content.fields.isRightToLeftLang){ dir="rtl" }
+}
+
+

--- a/common/app/views/fragments/langAttributes.scala.html
+++ b/common/app/views/fragments/langAttributes.scala.html
@@ -1,0 +1,3 @@
+@(content: model.Content)(implicit request: RequestHeader)
+
+@content.fields.lang.map { l => lang="@l" } @if(content.fields.isRightToLeftLang){ dir="rtl" }

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -10,7 +10,7 @@
     "content__standfirst--explore" -> (item.content.isExplore && item.tags.isArticle),
     "content__standfirst--advertisement" -> (item.content.isImmersive && item.tags.isPaidContent),
     "content__standfirst--immersive-minute-article" -> item.tags.isTheMinuteArticle),
-    "content__standfirst")" data-link-name="standfirst" data-component="standfirst" dir="auto">
+    "content__standfirst")" data-link-name="standfirst" data-component="standfirst" @item.fields.lang.map { l => lang="@l" } @if(item.content.fields.isRightToLeftLang){ dir="rtl" }>
     @item.fields.trailText.map{ t =>
 
         @defining({

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,6 +1,7 @@
 @import common.Edition
 @import model.ContentType
 @import views.support.{BulletCleaner, ContributorLinks, InBodyLinkCleaner, RenderClasses, withJsoup}
+@import views.html.fragments.langAttributes
 
 @(item: ContentType)(implicit request: RequestHeader)
 
@@ -10,7 +11,7 @@
     "content__standfirst--explore" -> (item.content.isExplore && item.tags.isArticle),
     "content__standfirst--advertisement" -> (item.content.isImmersive && item.tags.isPaidContent),
     "content__standfirst--immersive-minute-article" -> item.tags.isTheMinuteArticle),
-    "content__standfirst")" data-link-name="standfirst" data-component="standfirst" @item.fields.lang.map { l => lang="@l" } @if(item.content.fields.isRightToLeftLang){ dir="rtl" }>
+    "content__standfirst")" data-link-name="standfirst" data-component="standfirst" @langAttributes(item.content)>
     @item.fields.trailText.map{ t =>
 
         @defining({

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -10,7 +10,7 @@
     "content__standfirst--explore" -> (item.content.isExplore && item.tags.isArticle),
     "content__standfirst--advertisement" -> (item.content.isImmersive && item.tags.isPaidContent),
     "content__standfirst--immersive-minute-article" -> item.tags.isTheMinuteArticle),
-    "content__standfirst")" data-link-name="standfirst" data-component="standfirst">
+    "content__standfirst")" data-link-name="standfirst" data-component="standfirst" dir="auto">
     @item.fields.trailText.map{ t =>
 
         @defining({


### PR DESCRIPTION
## What does this change?
Sets the HTML `lang` and `dir` attributes for non-English content; using the `lang` field provided by CAPI.

## What is the value of this and can you measure success?
* Arabic articles are displayed correctly
* `lang` attribute is set correctly for non English articles which should assist screen readers and other user-agent features

## Does this affect other platforms - Amp, Apps, etc?
Yes, change is inherited by AMP

## Screenshots

### Before

![screen shot 2017-06-14 at 14 26 27](https://user-images.githubusercontent.com/1764158/27333903-63a3dad4-55bf-11e7-8942-a72d44b6763d.png)
### After
![screen shot 2017-06-14 at 14 26 42](https://user-images.githubusercontent.com/1764158/27333918-719c7a7e-55bf-11e7-834a-955dea27fa4d.png)
#### AMP
<img width="637" alt="screen shot 2017-06-14 at 13 23 40" src="https://user-images.githubusercontent.com/1764158/27333966-9e3026a8-55bf-11e7-8de2-5a81516cb5de.png">

#### Video pages

![screen shot 2017-06-20 at 13 45 04](https://user-images.githubusercontent.com/1764158/27333998-ba80b2be-55bf-11e7-9a70-7f3e35cd7617.png)






## Tested in CODE?
No
CC @mchv @tomrf1 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
