### PR TITLE
Deps: Upgrade pify to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ora": "^1.1.0",
     "pa11y": "^4.10.0",
     "perfectionist": "^2.3.1",
-    "pify": "^2.3.0",
+    "pify": "^3.0.0",
     "postcss": "^6.0.1",
     "postcss-pxtorem": "^4.0.1",
     "prettier": "^1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6000,6 +6000,10 @@ pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
## What does this change?

Upgrades `pify` to 3.0.0. The breaking change is in the interface, which now doesn't accept the Promise instance as optional argument anymore, but as part of the options object. Seems like we did not use this anywhere.

Once we upgrade to `node@8` we should replace this with [`util.promisify`](https://nodejs.org/api/util.html#util_util_promisify_original).

[Changelog](https://github.com/sindresorhus/pify/releases/tag/v3.0.0)

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
