### PR TITLE
We need a skinny nav

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -5,7 +5,8 @@
 @import views.support.RenderClasses
 
 <header class="@RenderClasses(Map(
-            "new-header--mvt-desktop" -> mvt.ABNewDesktopHeader.isParticipating
+            "new-header--mvt-desktop" -> mvt.ABNewDesktopHeader.isParticipating,
+            "new-header--slim" -> page.metadata.hasSlimHeader
         ), "new-header")"
         role="banner">
     @defining(NewNavigation.SubSectionLinks.getSectionOrTagId(page)) { id =>
@@ -37,24 +38,26 @@
                             </span>
                         </a>
 
-                        <a class="header-cta-item hide-until-tablet header-cta-item--secondary"
-                            data-link-name="nav2 : subscribe-cta"
-                            data-edition="@{editionId}"
-                            href="@{Configuration.id.digitalPackUrl}/@{editionId}?INTCMP=NGW_NEWHEADER_@{editionId}_GU_SUBSCRIBE">
-                            <span class="header-cta-item__label">
-                                subscribe
-                            </span>
-                        </a>
+                        @if(!page.metadata.hasSlimHeader) {
 
-                        <a class="header-cta-item hide-until-tablet header-cta-item--secondary"
-                            data-link-name="nav2 : job-cta"
-                            data-edition="@{editionId}"
-                            href="@{Configuration.commercial.jobsUrl}?INTCMP=jobs_@{editionId}_web_newheader">
-                            <span class="header-cta-item__label">
-                                <span class="hide-until-tablet">find a job</span>
-                                <span class="hide-from-tablet">jobs</span>
-                            </span>
-                        </a>
+                            <a class="header-cta-item hide-until-tablet header-cta-item--secondary"
+                                data-link-name="nav2 : subscribe-cta"
+                                data-edition="@{editionId}"
+                                href="@{Configuration.id.digitalPackUrl}/@{editionId}?INTCMP=NGW_NEWHEADER_@{editionId}_GU_SUBSCRIBE">
+                                <span class="header-cta-item__label">
+                                    subscribe
+                                </span>
+                            </a>
+
+                            <a class="header-cta-item hide-until-tablet header-cta-item--secondary"
+                                data-link-name="nav2 : job-cta"
+                                data-edition="@{editionId}" href="@{Configuration.commercial.jobsUrl}?INTCMP=jobs_@{editionId}_web_newheader">
+                                <span class="header-cta-item__label">
+                                    <span class="hide-until-tablet">find a job</span>
+                                    <span class="hide-from-tablet">jobs</span>
+                                </span>
+                            </a>
+                        }
                     }
                 </div>
 
@@ -82,7 +85,9 @@
                        tabindex="0"
                        data-link-name="nav2 : veggie-burger : show">
                     <span class="veggie-burger__icon"></span>
-                    <span class="veggie-burger__label">Menu</span>
+                    <span class="@RenderClasses(Map(
+                            "u-h" -> page.metadata.hasSlimHeader
+                        ), "veggie-burger__label")">Menu</span>
                 </label>
 
                 @fragments.nav.newHeaderMenu()

--- a/static/src/stylesheets/layout/new-header/_header-cta-item.scss
+++ b/static/src/stylesheets/layout/new-header/_header-cta-item.scss
@@ -28,6 +28,13 @@
     @include mq(tablet) {
         font-size: 17px;
     }
+
+    .new-header--slim & {
+        @include mq($until: desktop) {
+            padding-top: $gs-baseline / 2;
+            padding-bottom: 0;
+        }
+    }
 }
 
 .header-cta-item__new-line {
@@ -53,10 +60,18 @@
 
         @include mq(mobileMedium) {
             border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
+
+            .new-header--slim & {
+                border-top: $gs-baseline * 4 solid $news-main-2;
+            }
         }
 
         @include mq($from: tablet, $until: desktop) {
             border-top-width: ($gs-baseline * 5) + ($gs-baseline / 2);
+        }
+
+        .new-header--slim & {
+            border-top-width: ($gs-baseline * 4) + ($gs-baseline / 3);
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -32,6 +32,14 @@ from scrolling */
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+
+    .new-header--slim & {
+        @include content-gutter;
+
+        @include mq($until: desktop) {
+            max-width: 100%;
+        }
+    }
 }
 
 .new-header__cta-container {
@@ -41,6 +49,13 @@ from scrolling */
 
     @include mq(mobileLandscape) {
         left: $gs-gutter / 2;
+    }
+
+    .new-header--slim & {
+        position: relative;
+        left: -$gs-gutter / 4;
+        order: -1;
+        z-index: 1;
     }
 }
 
@@ -75,6 +90,17 @@ from scrolling */
 
     @include mq(desktop) {
         margin-bottom: $gs-baseline / 4;
+    }
+
+    .new-header--slim & {
+        height: calc(3 / 16 * 155px);
+        width: 155px;
+
+        @include mq(tablet) {
+            height: calc(3 / 16 * 170px);
+            width: 170px;
+            margin-right: $gs-gutter / 2;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -31,6 +31,12 @@
         color: #ffffff;
         text-decoration: none;
     }
+
+    .new-header--slim & {
+        @include mq($from: tablet, $until: desktop) {
+            font-size: 24px;
+        }
+    }
 }
 
 .pillar-link--current-section {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -16,6 +16,17 @@
             z-index: $zindex-main-menu + 1;
         }
     }
+
+    .new-header--slim & {
+        width: auto;
+        order: -1;
+        padding-left: $gs-gutter / 2;
+        padding-right: $gs-gutter / 2;
+
+        @include mq($until: tablet) {
+            display: none;
+        }
+    }
 }
 
 .pillars__item {

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -57,6 +57,15 @@
     x:-o-prefocus & {
         display: none;
     }
+
+    .new-header--slim & {
+        right: 0;
+        position: relative;
+        top: -$gs-baseline / 2;
+        margin-bottom: -$gs-baseline;
+        height: $veggie-burger-medium;
+        width: $veggie-burger-medium;
+    }
 }
 
 .veggie-burger__label {


### PR DESCRIPTION
## What does this change?
We need a skinny nav for content types such as galleries which match the styling of the new header.


Todo in separate PRs:
* Open state
* Immersives should have the skinny nav too

## What is the value of this and can you measure success?
Looks nicer, less distracting on some 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Mobile:
<img width="329" alt="screen shot 2017-06-21 at 10 27 02" src="https://user-images.githubusercontent.com/8774970/27377625-690950f4-566d-11e7-8dcc-6f84e2f3a07b.png">

Tablet:
<img width="385" alt="screen shot 2017-06-21 at 10 25 24" src="https://user-images.githubusercontent.com/8774970/27377571-3c108784-566d-11e7-8f10-61ccc0ee6840.png">


Desktop:

<img width="1274" alt="screen shot 2017-06-21 at 10 26 47" src="https://user-images.githubusercontent.com/8774970/27377617-62633166-566d-11e7-9f38-c23f277df414.png">


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
