### PR TITLE
Deps: Upgrade yargs to 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "webpack-bundle-analyzer": "^2.8.2",
     "webpack-merge": "^4.1.0",
     "webpack-visualizer-plugin": "^0.1.11",
-    "yargs": "^8.0.1"
+    "yargs": "^8.0.2"
   },
   "optionalDependencies": {
     "fsevents": "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8372,9 +8372,9 @@ yargs@^7.0.0, yargs@^7.0.2:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yargs@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.1.tgz#420ef75e840c1457a80adcca9bc6fa3849de51aa"
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
## What does this change?

Last one for today: Upgrades `yargs` to 8.0.2. No breaking changes - only [internal dependency upgrades](https://github.com/yargs/yargs/compare/v8.0.1...v8.0.2).

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
