### PR TITLE
Fix mobile in menu scrolling behavoir

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -20,12 +20,6 @@
             display: none;
         }
     }
-
-    [aria-expanded='true'] ~ & {
-        @include mq($until: desktop) {
-            margin-bottom: -1px;
-        }
-    }
 }
 
 .menu-group--primary {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -133,30 +133,35 @@
         pointer-events: none;
     }
 
+    .menu-group--primary > *:not(:last-child) > &,
     &[data-link-name='nav2 : the guardian app'],
     &[data-link-name='nav2 : facebook'] {
         @include mq($until: desktop) {
-            margin-top: $gs-baseline * 2;
-        }
-    }
-
-    .menu-group--primary > *:not(:first-child) > &,
-    &[data-link-name='nav2 : the guardian app'],
-    &[data-link-name='nav2 : facebook'] {
-        @include mq($until: desktop) {
-            &:before {
+            &:not([aria-expanded='true']):after {
                 background-color: darken($guardian-brand-dark, 4%);
+                bottom: 0;
                 content: '';
                 display: block;
                 height: 1px;
                 left: $menu-spacing-left-small;
                 position: absolute;
-                top: 0;
                 width: 100%;
 
                 @include mq(tablet) {
                     left: $menu-spacing-left-medium;
                 }
+            }
+        }
+    }
+
+    &[data-link-name='nav2 : the guardian app'],
+    &[data-link-name='nav2 : facebook'] {
+        @include mq($until: desktop) {
+            margin-top: $gs-baseline * 2;
+
+            &:after {
+                bottom: auto;
+                top: 0;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Fixes an issue, where you'd scroll within `menu-group` instead of the whole menu, if a group was opened (see screenshots).

## What is the value of this and can you measure success?

Proper scrolling.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

(sorry for the huuge gifs 🐢 )

**Before**

![kapture 2017-06-21 at 12 25 16](https://user-images.githubusercontent.com/2244375/27382072-42772712-567d-11e7-823f-1ec1609676ea.gif)

**After**

![kapture 2017-06-21 at 12 24 02](https://user-images.githubusercontent.com/2244375/27382036-14b99e7c-567d-11e7-96e5-569b16ec6ada.gif)


## Tested in CODE?

No.
