### PR TITLE
Header: Implement non-flexbox fallback

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -29,6 +29,7 @@
 }
 
 .menu-group--primary {
+    @include clearfix();
     color: $news-support-1;
     padding-top: 0;
 
@@ -91,7 +92,16 @@
         order: 3;
         padding-bottom: 0;
         padding-top: $gs-baseline / 2;
+        position: absolute;
+        right: 0;
+        top: 0;
         width: 100%;
+
+        @supports(display: flex) {
+            position: relative;
+            right: auto;
+            top: auto;
+        }
     }
 
     @include mq(leftCol) {
@@ -105,7 +115,12 @@
 
 .menu-group--editions {
     @include mq(desktop) {
+        padding-bottom: $gs-baseline * 2;
         order: 5;
+
+        @supports(display: flex) {
+            padding-bottom: 0;
+        }
     }
 
     .menu-group {
@@ -137,10 +152,18 @@
 
 .menu-group--footer {
     @include mq(desktop) {
-        order: 2;
         padding-left: $gs-gutter / 2;
-        position: relative;
+        position: absolute;
+        right: gs-span(2) + $gs-gutter * 1.5 + 1;
+        top: 0;
         width: gs-span(2) + $gs-gutter / 2 - 1;
+
+        @supports(display: flex) {
+            order: 2;
+            position: relative;
+            right: auto;
+            top: auto;
+        }
     }
 
     @include mq(leftCol) {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -6,20 +6,21 @@
 
     .menu-group--primary > & {
         @include mq(desktop) {
-            width: 100%;
+            border-right: 2px solid rgba($news-main-2, .3);
+            float: left;
+            width: gs-span(2) + $gs-gutter / 2 + 1;
 
             &:not(:first-child) {
                 margin-left: $gs-gutter / 2 - 1;
             }
 
-            & {
-                border-right: 2px solid rgba($news-main-2, .3);
-                width: gs-span(2) + $gs-gutter / 2 + 1;
-            }
-
             &:not(:last-child) {
                 margin-top: -$gs-baseline * 3.5;
                 padding-top: $gs-baseline * 3.5;
+            }
+
+            @supports(display: flex) {
+                float: none;
             }
         }
     }
@@ -35,11 +36,16 @@
         @include mq(desktop) {
             background-color: $guardian-brand;
             display: block;
+            float: left;
             height: $search-and-edition-height-desktop;
             border-radius: 50%;
             margin-right: $gs-gutter / 2;
             text-align: center;
             width: $search-and-edition-height-desktop;
+
+            @supports(display: flex) {
+                float: none;
+            }
         }
 
         &:hover,
@@ -57,6 +63,7 @@
             }
         }
     }
+
     .menu-group--membership-actions & {
         @include mq($from: desktop, $until: leftCol) {
             margin-left: $gs-gutter / 2 - 1;

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -1,5 +1,6 @@
 .menu-search {
     box-sizing: border-box;
+    display: block;
     margin-left: 13px;
     position: relative;
 

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -28,12 +28,9 @@ from scrolling */
 }
 
 .new-header__inner {
-    align-items: flex-start;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    @include clearfix();
 
-    @supports (display: flex) {
+    @supports(display: flex) {
         align-items: flex-start;
         display: flex;
         flex-wrap: wrap;
@@ -72,7 +69,7 @@ from scrolling */
     display: block;
     float: right;
 
-    @supports (display: flex) {
+    @supports(display: flex) {
         display: flex;
         float: none;
         margin-left: auto;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -28,14 +28,22 @@ from scrolling */
 }
 
 .new-header__inner {
-    align-items: flex-start;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    @include clearfix();
+}
+
+@supports (display: flex) {
+    .new-header__inner {
+        align-items: flex-start;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        padding-bottom: 0;
+    }
 }
 
 .new-header__cta-container {
     left: $gs-gutter / 4;
+    overflow: hidden;
     position: absolute;
     top: 0;
 
@@ -45,8 +53,16 @@ from scrolling */
 }
 
 .new-header__logo {
-    display: flex;
-    margin-left: auto;
+    display: block;
+    float: right;
+}
+
+@supports (display: flex) {
+    .new-header__logo {
+        display: flex;
+        float: none;
+        margin-left: auto;
+    }
 }
 
 .new-header__logo__svg {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -1,4 +1,5 @@
 .pillars {
+    clear: right;
     color: $news-support-1;
     font-size: 0;
     list-style: none;
@@ -25,10 +26,6 @@
     @include mq(desktop) {
         .new-header--open & {
             width: gs-span(2) + $gs-gutter / 2 + 1;
-        }
-
-        .new-header--open &:not(:first-child) {
-            margin-left: $gs-gutter / 2 - 1;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -38,6 +38,10 @@
         .new-header--open & {
             width: gs-span(2) + $gs-gutter / 2 + 1;
         }
+
+        .new-header--open &:not(:first-child) {
+            margin-left: $gs-gutter / 2 - 1;
+        }
     }
 
     > *:after {

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -22,13 +22,13 @@
         & ~ .pillars {
             .pillars__item:not(:first-child) > .pillar-link {
                 @include mq(desktop) {
-                    padding-left: $gs-gutter / 2;
+                    margin-left: $gs-gutter / 2 - 1;
                 }
             }
 
             .pillar-link {
                 @include mq(desktop) {
-                    width: gs-span(2) + $gs-gutter;
+                    width: gs-span(2) + $gs-gutter / 2 + 1;
                 }
             }
 


### PR DESCRIPTION
## What does this change?

This implements the non-flexbox fallback for the new header.

## What is the value of this and can you measure success?

Wide cross browser support, even for the grandparents.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots (IE9)

**Before**

<img width="1263" alt="screen shot 2017-06-21 at 13 24 03" src="https://user-images.githubusercontent.com/2244375/27383955-09a9fb28-5685-11e7-8650-08fc752d0c1d.png">

<img width="1263" alt="screen shot 2017-06-21 at 13 24 49" src="https://user-images.githubusercontent.com/2244375/27383954-09a66f9e-5685-11e7-8bc9-a731c57d5cd6.png">

**After**

<img width="1264" alt="screen shot 2017-06-21 at 13 09 21" src="https://user-images.githubusercontent.com/2244375/27383739-31525932-5684-11e7-9acb-1332482bb761.png">

<img width="1264" alt="screen shot 2017-06-21 at 13 12 51" src="https://user-images.githubusercontent.com/2244375/27383728-27bc94aa-5684-11e7-8de3-db79622e7da5.png">


## Tested in CODE?

No.
