### PR TITLE
Possible open state for skinny nav

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -62,6 +62,14 @@
         }
     }
 
+    .new-header--slim.new-header--open & {
+        margin-right: ($gs-gutter / 2) + ($veggie-burger-medium / 2);
+
+        @include mq(mobileLandscape) {
+            margin-right: $gs-gutter + ($veggie-burger-medium / 2);
+        }
+    }
+
     // Don't show menu on opera mini: https://wp-mix.com/css-target-opera/
     x:-o-prefocus & {
         display: none;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -59,9 +59,16 @@ from scrolling */
 
     .new-header--slim & {
         position: relative;
+        overflow: visible;
         left: -$gs-gutter / 4;
         order: -1;
         z-index: 1;
+    }
+
+    .new-header--slim.new-header--open & {
+        @include mq(tablet) {
+            display: none;
+        }
     }
 }
 
@@ -73,6 +80,12 @@ from scrolling */
         display: flex;
         float: none;
         margin-left: auto;
+    }
+
+    .new-header--slim.new-header--open & {
+        @include mq($from: desktop, $until: leftCol) {
+            display: none;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -64,4 +64,10 @@
     &:last-child > *:after {
         display: none;
     }
+
+    .new-header--slim.new-header--open & {
+        @include mq(tablet) {
+            padding-left: $gs-gutter / 2;
+        }
+    }
 }


### PR DESCRIPTION
## What does this change?
Possible open menu states for the skinny nav, but @zeftilldeath you will have to take a look and see if you are okay with this.

To me, the biggest problem with this is that between the desktop and leftCol breakpoints the logo won't show on the open state as its too wide to fit those and the pillars on the same line.

## What is the value of this and can you measure success?
Looks nicer I think.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27387243-0e966684-5690-11e7-880a-930e670f73d4.png)

![image](https://user-images.githubusercontent.com/8774970/27387089-a1d2344c-568f-11e7-8c2b-3b04cf7f2020.png)

![image](https://user-images.githubusercontent.com/8774970/27387014-6a9c8702-568f-11e7-9d69-d393a1ebe34a.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
