### PR TITLE
Skinny nav immersives

### DIFF
--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -5,7 +5,6 @@
 @import model.ContentPage
 @import views.support.RenderClasses
 @import views.support.TrailCssClasses.toneClass
-@import views.support.Commercial.isPaidContent
 @import views.support.ImmersiveMainCleaner
 
 @(page: ContentPage)(implicit request: RequestHeader, context: model.ApplicationContext)

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -25,7 +25,7 @@
         "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
         <div class="gs-container immersive-main-media__logo">
-            @if(page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) {
+            @if((page.item.elements.hasMainMedia || page.item.fields.main.nonEmpty) & !mvt.ABNewDesktopHeader.isParticipating) {
                 <a href="@LinkTo {/}">
                     <span class="u-h">The Guardian</span>
                     @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -20,12 +20,14 @@
         ),
         "content", "tonal", s"tonal--${toneClass(page.item)}")
     ">
-        <div class="gs-container immersive-main-media__logo">
-            <a href="@LinkTo{/}">
-                <span class="u-h">The Guardian</span>
-                @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
-            </a>
-        </div>
+        @if(!mvt.ABNewDesktopHeader.isParticipating) {
+            <div class="gs-container immersive-main-media__logo">
+                <a href="@LinkTo {/}">
+                    <span class="u-h">The Guardian</span>
+                    @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
+                </a>
+            </div>
+        }
         <div class="immersive-main-media__media">
             @if(page.item.elements.hasMainPicture) {
                 @page.item.elements.mainPicture.map(_.images).orElse(page.item.trail.trailPicture).map { picture =>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -90,6 +90,9 @@
             }
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
+                    @if(mvt.ABNewDesktopHeader.isParticipating) {
+                        @fragments.header(page)
+                    }
                     @fragments.immersiveMainMedia(page)
                 </div>
             }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -83,7 +83,9 @@
                     ("immersive-header-container", page.item.fields.main.nonEmpty),
                     ("immersive-header-container--photo-essay", page.item.content.isPhotoEssay)))">
 
-                    @headerAndTopAds(showAdverts, edition, content)
+                    @if(mvt.ABNewDesktopHeader.isParticipating) {
+                        @fragments.header(page)
+                    }
 
                     @fragments.photoEssay(page)
                 </div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -90,7 +90,6 @@
             }
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive && !page.item.content.tags.isVideo) => {
                 <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
-                    @headerAndTopAds(showAdverts, edition, content)
                     @fragments.immersiveMainMedia(page)
                 </div>
             }


### PR DESCRIPTION
## What does this change?
Skinny nav (when you are in the desktop header test) on photo essays and immersives

## What is the value of this and can you measure success?
People can navigate on these pages.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27388647-01d7a260-5694-11e7-9a79-6be140acb7dd.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
