### PR TITLE
Extend the "Thank you" epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -176,7 +176,7 @@ trait ABTestSwitches {
     "Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 6, 21),
+    sellByDate = new LocalDate(2017, 7, 3),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -37,7 +37,7 @@ define([
         campaignId: 'epic_thank_you',
 
         start: '2017-06-01',
-        expiry: '2017-06-19',
+        expiry: '2017-07-03',
 
         author: 'Guy Dawson',
         description: 'Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian',


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Extends the "Thank you" epic.

## What is the value of this and can you measure success?

Thanking members for contributing is a good thing; but measuring 'success' is hard.

## Does this affect other platforms - Amp, Apps, etc?

N/A

## Screenshots

#16969

## Tested in CODE?

No.
