### PR TITLE
Fix hosted video pages in Safari 9 & IE11

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -21,32 +21,46 @@ const upgradeVideoPlayerAccessibility = (player: Object): void => {
     const playerEl = player.el();
 
     fastdom.write(() => {
-        playerEl.querySelectorAll('.vjs-tech').forEach(el => {
+        Array.from(playerEl.querySelectorAll('.vjs-tech')).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
         // Hide superfluous controls, and label useful buttons.
-        playerEl.querySelectorAll('.vjs-big-play-button').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-big-play-button')
+        ).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
-        playerEl.querySelectorAll('.vjs-current-time').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-current-time')
+        ).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
-        playerEl.querySelectorAll('.vjs-time-divider').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-time-divider')
+        ).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
-        playerEl.querySelectorAll('.vjs-duration').forEach(el => {
+        Array.from(playerEl.querySelectorAll('.vjs-duration')).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
-        playerEl.querySelectorAll('.vjs-embed-button').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-embed-button')
+        ).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });
-        playerEl.querySelectorAll('.vjs-play-control').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-play-control')
+        ).forEach(el => {
             el.setAttribute('aria-label', 'video play');
         });
-        playerEl.querySelectorAll('.vjs-mute-control').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-mute-control')
+        ).forEach(el => {
             el.setAttribute('aria-label', 'video mute');
         });
-        playerEl.querySelectorAll('.vjs-fullscreen-control').forEach(el => {
+        Array.from(
+            playerEl.querySelectorAll('.vjs-fullscreen-control')
+        ).forEach(el => {
             el.setAttribute('aria-label', 'video fullscreen');
         });
     });
@@ -179,11 +193,11 @@ export const initHostedVideo = (
                 })
         )
         .then(videojsInstance => {
-            videoEl.forEach(el => {
+            Array.from(videoEl).forEach(el => {
                 setupVideo(el, videojsInstance);
             });
 
-            youtubeIframe.forEach(initHostedYoutube);
+            Array.from(youtubeIframe).forEach(initHostedYoutube);
         })
         .then(stop, stop);
 


### PR DESCRIPTION
## What does this change?
Previously we were attempting to call `.forEach` on some `NodeLists`. This was failing in some browsers. The fix is to convert them into Arrays before calling `.forEach`. I found this answer helpful to understand the issue: https://stackoverflow.com/a/24266344/238230

## What is the value of this and can you measure success?
Restore X-Browser support

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-06-22 at 11 37 30](https://user-images.githubusercontent.com/1764158/27430119-41f806e0-573f-11e7-984d-72f3e32163e5.png)
## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
