### PR TITLE
Deps: Upgrade babel-jest to 20.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
-    "babel-jest": "^19.0.0",
+    "babel-jest": "^20.0.3",
     "babel-loader": "^7.1.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
## What does this change?

Upgrade `babel-jest` to 20.0.3. Jest is already on 20, so this shouldn't cause any problems.

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
