### PR TITLE
fix crossword anagram helper

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
@@ -18,9 +18,11 @@ const CluePreview = React.createClass({
         return this.props.entries.map(entry => {
             entry.solved = !!entry.value;
 
-            return this.props.hasShuffled
+            const returnVal = this.props.hasShuffled
                 ? (entry.value && entry) || unsolved.shift()
                 : entry;
+
+            return Object.assign({}, { key: entry.key }, returnVal);
         });
     },
 
@@ -85,11 +87,10 @@ const CluePreview = React.createClass({
                     'span',
                     {
                         className:
-                            classNames +
-                                (entry && entry.solved ? ' has-value' : ''),
+                            classNames + (entry.solved ? ' has-value' : ''),
                         key: entry.key,
                     },
-                    (entry && entry.value) || ''
+                    entry.value || ''
                 );
 
                 return span;


### PR DESCRIPTION
## What does this change?

Fixes a bug in the anagram helper. When a user clicks the 'shuffle' buttons the `getEntries` function in clue-preview returns an array, if you attempt to shuffle a word without enough letters then some items in the returned array are `undefined`. 

The code currently falls over as the function executed on `entries.map` on line 79 attempts to access the `key` property of undefined.

I've fixed this by making sure `getEntries` never returns an array that contains `undefined`. Each item in the returned list will always contain the `key` property.

This bug was introduced yesterday in this PR https://github.com/guardian/frontend/pull/17199.

## What is the value of this and can you measure success?

Crossword anagram helper works again!

## Does this affect other platforms - Amp, Apps, etc?

N/A

## Screenshots

before....

![cw-before](https://user-images.githubusercontent.com/1590704/27432991-83808744-574a-11e7-8d80-eebd004c5b4b.gif)

after....

![cw-after](https://user-images.githubusercontent.com/1590704/27432999-8f13260c-574a-11e7-858e-4c79d872bf19.gif)

## Tested in CODE?

No
