### PR TITLE
Remove userhelp email from the feedback page

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -79,10 +79,6 @@
 
                                     <p id="feedback__explainer"></p>
 
-                                    <small>
-                                        Or email us directly at <a data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a> and someone should get back to you.
-                                    </small>
-
                                 </form>
                             </div>
                         </div>


### PR DESCRIPTION
## What does this change?

Userhelp would like their email removed off of the tech feedback page now that we've verified that the form works in production for a while.

## What is the value of this and can you measure success?

More people using the form, fewer direct emails.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
