### PR TITLE
Add two more test suites for commercial third party tags

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/simple-reach.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/simple-reach.spec.js
@@ -1,0 +1,42 @@
+// @flow
+import { shouldRun, url } from './simple-reach';
+
+jest.mock('lib/config', () => ({
+    switches: {
+        simpleReach: true,
+    },
+    page: {
+        headline: 'Starship Enterprise',
+        author: 'Captain Kirk',
+        sectionName: 'Space Exploration',
+        keywords: 'Space,Travel',
+        webPublicationDate: 1498113262000,
+        isFront: false,
+        isPaidContent: true,
+        pageId: 100,
+    },
+}));
+
+describe('third party tag SimpleReach', () => {
+    it('should exist', () => {
+        expect(shouldRun).toBe(true);
+        expect(url).toBe('//d8rk54i4mohrb.cloudfront.net/js/reach.js');
+    });
+
+    it('should set a global config', () => {
+        // SimpleReach demands a dangling underscore in the global config
+        // eslint-disable-next-line no-underscore-dangle
+        const reachConfig = window.__reach_config;
+        const expectedConfig = {
+            pid: '58ff7f3a736b795c10004930',
+            title: 'Starship Enterprise',
+            date: new Date(1498113262000),
+            authors: ['Captain Kirk'],
+            channels: ['Space Exploration'],
+            tags: ['Space', 'Travel'],
+            article_id: 100,
+            ignore_errors: false,
+        };
+        expect(reachConfig).toEqual(expectedConfig);
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/tourism-australia.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/tourism-australia.spec.js
@@ -1,0 +1,22 @@
+// @flow
+import { shouldRun, url, useImage } from './tourism-australia';
+
+jest.mock('lib/config', () => ({
+    switches: {
+        tourismAustralia: true,
+    },
+    page: {
+        section: 'ashes-australia-travel',
+    },
+}));
+
+describe('third party tag Tourism Australia', () => {
+    it('should exist and have exported values', () => {
+        const expectedUrl =
+            '//tourismaustralia.sc.omtrdc.net/b/ss/tuatourism-australia-global';
+
+        expect(shouldRun).toBe(true);
+        expect(url).toContain(expectedUrl);
+        expect(useImage).toBe(true);
+    });
+});


### PR DESCRIPTION
## What does this change?

- Add tests for SimpleReach
- Add tests for Tourism Australia

## What is the value of this and can you measure success?

More Tests!
Prevent regressions

## Does this affect other platforms - Amp, Apps, etc?

Nope
