### PR TITLE
Make it so that the epic for the Brexit cohort can actually appear

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
@@ -45,6 +45,7 @@ define([
         audienceCriteria: 'Readers who began supporting the Guardian in the Brexit cohort',
         audience: 1,
         audienceOffset: 0,
+        showToContributorsAndSupporters: true,
 
         canRun: function() {
             return userFeatures.isInBrexitCohort() && hasBrexitTag();


### PR DESCRIPTION
## What does this change?
[PR 17204](https://github.com/guardian/frontend/pull/17204) adds an epic specifically for supporters who joined shortly after the EU referendum but I forgot to set the flag showToContributorsAndSupporters in the test.

## What is the value of this and can you measure success?
The epic will actually be visible to the Brexit cohort.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@guardian/contributions 