### PR TITLE
Fix hosted video volume setting

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -91,8 +91,8 @@ const onPlayerReady = (
 
     // unglitching the volume on first load
     if (vol) {
-        player.setVolume(0);
-        player.setVolume(vol);
+        player.volume(0);
+        player.volume(vol);
     }
 
     player.fullscreener();


### PR DESCRIPTION
## What does this change?

A small issue was introduced in #17097. It was assumed that we should be calling the `setVolume` method on the VideoJS player to set the volume [as specified in the API docs](http://docs.videojs.com/Html5.html#setVolume). However, these were docs for the HTML5 media controller. We should have consulted the [docs for the VideoJS player API](http://docs.videojs.com/docs/api/player.html#Methodsvolume).

## What is the value of this and can you measure success?

Fewer bugs (88 reports in Sentry in the last 13 days)

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
