### PR TITLE
ES6: Remove already converted module

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -60,7 +60,6 @@
   "Gustav Pursche": [
     "projects/common/modules/ui/tabs.js",
     "projects/common/modules/social/hidden-share-toggle.js",
-    "projects/common/modules/social/pinterest.js",
     "projects/common/modules/sport/football/football.js",
     "projects/common/modules/sport/football/match-info.js",
     "projects/common/modules/sport/football/match-list-live.js",


### PR DESCRIPTION
## What does this change?

Already did the conversion, so now just remove it from the list.