### PR TITLE
Deps: Remove strip-ansi

### DIFF
--- a/dev/flow-typed/npm/strip-ansi_v3.x.x.js
+++ b/dev/flow-typed/npm/strip-ansi_v3.x.x.js
@@ -1,6 +1,0 @@
-// flow-typed signature: 8b05dd8048f5193e21269eab58859283
-// flow-typed version: 94e9f7e0a4/strip-ansi_v3.x.x/flow_>=v0.28.x
-
-declare module 'strip-ansi' {
-  declare module.exports: (input: string) => string;
-}

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "sinon": "^2.1.0",
     "split": "^1.0.0",
     "stream-to-observable": "^0.2.0",
-    "strip-ansi": "^3.0.1",
     "svgo": "^0.7.2",
     "uglify-js": "^2.7.4",
     "webpack": "^3.0.0",


### PR DESCRIPTION
## What does this change?

Removes `strip-ansi`. It's not used anywhere and `listr`, which depends on it, has it in it's own dependencies.

## What is the value of this and can you measure success?

Less dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
