### PR TITLE
Reprioritise some ES6 conversions

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -23,15 +23,16 @@
     "bootstraps/enhanced/gallery.js"
   ],
   "Simon Adcock": [
-      "lib/client-rects.js",
-      "projects/common/modules/ui/toggles.js",
+      "projects/common/modules/onward/breaking-news.js",
+      "projects/commercial/modules/sticky-top-banner.js",
       "projects/common/modules/article/membership-events.js",
       "projects/common/modules/discussion/upvote.js",
       "projects/common/modules/discussion/user-avatars.js",
       "projects/common/modules/discussion/whole-discussion.js",
       "projects/common/modules/experiments/tests/bookmarks-email-variants-2.js",
       "projects/common/modules/ui/blockSharing.js",
-      "projects/common/modules/ui/clickstream.js"
+      "projects/common/modules/ui/clickstream.js",
+      "lib/client-rects.js"
   ],
   "Nicolas Long": [
     "lib/atob.js",
@@ -60,7 +61,7 @@
   "GHaberis": [
     "projects/common/modules/media/videojs-plugins/fullscreener.js",
     "projects/common/modules/media/videojs-plugins/skip-ad.js",
-    "projects/common/modules/onward/breaking-news.js",
+    "projects/common/modules/ui/toggles.js",
     "projects/common/modules/onward/geo-most-popular.js",
     "projects/common/modules/onward/history.js",
     "projects/common/modules/discussion/activity-stream.js",
@@ -119,8 +120,7 @@
     "projects/common/modules/ui/expandable.js",
     "projects/common/modules/ui/faux-block-link.js",
     "projects/common/modules/ui/full-height.js",
-    "projects/common/modules/experiments/affix.js",
-    "projects/commercial/modules/sticky-top-banner.js"
+    "projects/common/modules/experiments/affix.js"
   ],
   "davidfurey": [
     "projects/common/modules/experiments/tests/editorial-email-variants.js",


### PR DESCRIPTION
## What does this change?

There are some intermittently failing tests in `sticker-banner.spec.js` and `breaking-news.spec.js`. Before attempting to fix these, I'd like to first convert the tests to Jest. This might just do the trick, or will at least leave us in a better position to fix the failing tests permanently

I have also deprioritised the conversion of  `lib/client-rects.js`, as we might remove the code and instead install [`rangefix`](https://github.com/edg2s/rangefix) as a dependency (depending on the outcome of edg2s/rangefix#7)

## What is the value of this and can you measure success?

Do more important things first

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
