### PR TITLE
Correct link for jobs

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -51,7 +51,7 @@
 
                             <a class="header-cta-item hide-until-tablet header-cta-item--secondary"
                                 data-link-name="nav2 : job-cta"
-                                data-edition="@{editionId}" href="@{Configuration.commercial.jobsUrl}?INTCMP=jobs_@{editionId}_web_newheader">
+                                data-edition="@{editionId}" href="https://jobs.theguardian.com?INTCMP=jobs_@{editionId}_web_newheader">
                                 <span class="header-cta-item__label">
                                     <span class="hide-until-tablet">find a job</span>
                                     <span class="hide-from-tablet">jobs</span>


### PR DESCRIPTION
## What does this change?
Turns out the `commercial.jobsUrl` wasn't what I thought it was and actually this should be just hardcoded.

## What is the value of this and can you measure success?
The correct link is on the desktop header

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
n/a

## Tested in CODE?
n/a

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
