### PR TITLE
add additional class when pageskin is active

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -1,0 +1,33 @@
+// @flow
+import config from 'lib/config';
+import detect from 'lib/detect';
+import mediator from 'lib/mediator';
+import fastdom from 'fastdom';
+
+const pageSkin = (): void => {
+    const bodyEl = document.body;
+    const hasPageSkin: boolean = config.page.hasPageSkin;
+
+    const togglePageSkinActiveClass = (): void => {
+        if (bodyEl) {
+            fastdom.write(() => {
+                bodyEl.classList.toggle(
+                    'has-active-pageskin',
+                    detect.isBreakpoint({ min: 'wide' })
+                );
+            });
+        }
+    };
+
+    const togglePageSkin = (): void => {
+        if (hasPageSkin && detect.hasCrossedBreakpoint(true)) {
+            togglePageSkinActiveClass();
+        }
+    };
+
+    togglePageSkin();
+
+    mediator.on('window:throttledResize', togglePageSkin);
+};
+
+export { pageSkin };

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-ads.js
@@ -2,6 +2,7 @@
 
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import loadAdvert from 'commercial/modules/dfp/load-advert';
+import { pageSkin } from 'commercial/modules/creatives/page-skin';
 
 const displayAds = (): void => {
     window.googletag.pubads().enableSingleRequest();
@@ -11,6 +12,7 @@ const displayAds = (): void => {
     // slot)
     loadAdvert(dfpEnv.advertsToLoad[0]);
     dfpEnv.advertsToLoad.length = 0;
+    pageSkin();
 };
 
 export { displayAds };


### PR DESCRIPTION
## What does this change?
Adds a `has-active-pageskin` class when a pageskin is active 
(i.e. the page has a pageskin & the viewport is >= 'wide')

## What is the value of this and can you measure success?
Provides a hook by which we can change CSS in this state _(as requested by @duarte)_

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
No
CC @guardian/commercial-dev 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
