### PR TITLE
Get true dimensions for image metadata

### DIFF
--- a/article/app/model/structuredData/Image.scala
+++ b/article/app/model/structuredData/Image.scala
@@ -1,7 +1,7 @@
 package model.structuredData
 
 import model.ImageElement
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsNumber, JsString, JsValue, Json}
 import views.support.Item700
 
 object Image {
@@ -10,8 +10,8 @@ object Image {
     Json.obj(
       "@type" -> "ImageObject",
       "url" -> JsString(Item700.bestSrcFor(picture.images).getOrElse("")),
-      "height" -> Item700.trueHeightFor(picture.images).getOrElse(0),
-      "width" -> Item700.trueWidthFor(picture.images).getOrElse(0)
+      "height" -> JsNumber(BigDecimal(Item700.trueHeightFor(picture.images).getOrElse(0))),
+      "width" -> JsNumber(BigDecimal(Item700.trueWidthFor(picture.images).getOrElse(0)))
     )
 
 }

--- a/article/app/model/structuredData/Image.scala
+++ b/article/app/model/structuredData/Image.scala
@@ -1,17 +1,22 @@
 package model.structuredData
 
 import model.ImageElement
-import play.api.libs.json.{JsNumber, JsString, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 import views.support.Item700
 
 object Image {
 
-  def apply(picture: ImageElement): JsValue =
+  def apply(picture: ImageElement): JsValue = {
+    val url = Item700.bestSrcFor(picture.images).getOrElse("")
+    val height = Item700.trueHeightFor(picture.images).getOrElse(0)
+    val width = Item700.trueWidthFor(picture.images).getOrElse(0)
+
     Json.obj(
       "@type" -> "ImageObject",
-      "url" -> JsString(Item700.bestSrcFor(picture.images).getOrElse("")),
-      "height" -> JsNumber(BigDecimal(Item700.trueHeightFor(picture.images).getOrElse(0))),
-      "width" -> JsNumber(BigDecimal(Item700.trueWidthFor(picture.images).getOrElse(0)))
+      "url" -> url,
+      "height" -> height,
+      "width" -> width
     )
+  }
 
 }

--- a/article/app/model/structuredData/Image.scala
+++ b/article/app/model/structuredData/Image.scala
@@ -1,19 +1,17 @@
 package model.structuredData
 
-import model.{ImageAsset, ImageElement}
+import model.ImageElement
 import play.api.libs.json.{JsString, JsValue, Json}
 import views.support.Item700
 
 object Image {
 
-  def apply(picture: ImageElement): JsValue = {
-    val asset: Option[ImageAsset] = Item700.bestFor(picture.images)
+  def apply(picture: ImageElement): JsValue =
     Json.obj(
       "@type" -> "ImageObject",
       "url" -> JsString(Item700.bestSrcFor(picture.images).getOrElse("")),
-      "height" -> asset.fold(0)(_.height),
-      "width" -> asset.fold(0)(_.width)
+      "height" -> Item700.trueHeightFor(picture.images).getOrElse(0),
+      "width" -> Item700.trueWidthFor(picture.images).getOrElse(0)
     )
-  }
 
 }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -138,7 +138,7 @@ import collection.JavaConversions._
           include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=")
 
         And("I should see the image width")
-        findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("700")
+        findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("460")
 
         And("I should see the image height")
         findFirst("[itemprop='associatedMedia image'] [itemprop=height]").getAttribute("content") should be("276")

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -138,7 +138,7 @@ import collection.JavaConversions._
           include("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=")
 
         And("I should see the image width")
-        findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("460")
+        findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("700")
 
         And("I should see the image height")
         findFirst("[itemprop='associatedMedia image'] [itemprop=height]").getAttribute("content") should be("276")

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -38,11 +38,9 @@
             <meta itemprop="representativeOfPage" content="true">
         }
 
-        @defining(Item700.bestFor(picture)) { asset =>
-            <meta itemprop="url" content="@Item700.bestSrcFor(picture).getOrElse("")">
-            <meta itemprop="width" content="@asset.fold(0)(_.width)">
-            <meta itemprop="height" content="@asset.fold(0)(_.height)">
-        }
+        <meta itemprop="url" content="@Item700.bestSrcFor(picture).getOrElse("")">
+        <meta itemprop="width" content="@Item700.trueWidthFor(picture.images).getOrElse(0)">
+        <meta itemprop="height" content="@Item700.trueHeightFor(picture.images).getOrElse(0)">
 
         @defining(
             if (isMain) {

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -39,8 +39,8 @@
         }
 
         <meta itemprop="url" content="@Item700.bestSrcFor(picture).getOrElse("")">
-        <meta itemprop="width" content="@Item700.trueWidthFor(picture.images).getOrElse(0)">
-        <meta itemprop="height" content="@Item700.trueHeightFor(picture.images).getOrElse(0)">
+        <meta itemprop="width" content="@Item700.trueWidthFor(picture).getOrElse(0)">
+        <meta itemprop="height" content="@Item700.trueHeightFor(picture).getOrElse(0)">
 
         @defining(
             if (isMain) {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -47,8 +47,8 @@ sealed trait ElementProfile {
     if(ImageServerSwitch.isSwitchedOn) default
     else bestFor(image).map(dimension)
 
-  def trueWidthFor = trueDimensionFor(_.width, width)
-  def trueHeightFor = trueDimensionFor(_.height, height)
+  def trueWidthFor = trueDimensionFor(_.width, width) _
+  def trueHeightFor = trueDimensionFor(_.height, height) _
 
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
   val qualityparam = if (hidpi) {"q=20"} else {"q=55"}

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -43,6 +43,13 @@ sealed trait ElementProfile {
   def altTextFor(image: ImageMedia): Option[String] =
     bestFor(image).flatMap(_.altText)
 
+  private def trueDimensionFor(dimension: ImageAsset => Int, default: Option[Int])(image: ImageMedia): Option[Int] =
+    if(ImageServerSwitch.isSwitchedOn) default
+    else bestFor(image).map(dimension)
+
+  def trueWidthFor = trueDimensionFor(_.width, width)
+  def trueHeightFor = trueDimensionFor(_.height, height)
+
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
   val qualityparam = if (hidpi) {"q=20"} else {"q=55"}
   val autoParam = if (autoFormat) "auto=format" else ""

--- a/common/test/views/support/ProfileTest.scala
+++ b/common/test/views/support/ProfileTest.scala
@@ -1,0 +1,56 @@
+package views.support
+
+import com.gu.contentapi.client.model.v1.AssetType
+import conf.switches.Switches._
+import model.{ImageAsset, ImageMedia}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class ProfileTest extends FlatSpec with Matchers with BeforeAndAfter {
+
+  before {
+    ImageServerSwitch.switchOn()
+  }
+
+  after {
+    ImageServerSwitch.switchOn()
+  }
+
+  object HidpiProfileSmall extends Profile(width = Some(100), height = Some(60), hidpi = true)
+
+  val imageAsset: ImageAsset = ImageAsset(
+    fields = Map("width" -> "460", "height" -> "276"),
+    mediaType = AssetType.Image.name,
+    mimeType = Some("image/jpeg"),
+    url = Some("https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg")
+  )
+  val image: ImageMedia = ImageMedia.apply(Seq(imageAsset))
+
+  "A hidpi profile with small width" should "return double the dimensions of the profile for the true dimensions" in {
+    HidpiProfileSmall.trueWidthFor(image) should be(Some(200))
+    HidpiProfileSmall.trueHeightFor(image) should be(Some(120))
+  }
+
+  object HidpiProfileLarge extends Profile(width = Some(1000), height = Some(600), hidpi = true)
+
+  "A hidpi profile with large width" should "return the dimensions of the original asset" in {
+    HidpiProfileLarge.trueWidthFor(image) should be(Some(460))
+    HidpiProfileLarge.trueHeightFor(image) should be(Some(276))
+  }
+
+  "A non hidpi profile with small width" should "return the dimensions of the profile" in {
+    Item120.trueWidthFor(image) should be(Some(120))
+    Item120.trueHeightFor(image) should be(Some(72))
+  }
+
+  "A non hidpi profile with large width" should "return the dimensions of the original asset" in {
+    Item1200.trueWidthFor(image) should be(Some(460))
+    Item1200.trueHeightFor(image) should be(Some(276))
+  }
+
+
+  "A non hidpi profile with small width and image resizing off" should "return the dimensions of the original asset" in {
+    ImageServerSwitch.switchOff()
+    Item120.trueWidthFor(image) should be(Some(460))
+    Item120.trueHeightFor(image) should be(Some(276))
+  }
+}


### PR DESCRIPTION
## What does this change?
Image metadata dimensions were based on the base image asset dimensions, but really should have been the true image dimensions that we actually serve after resizing.  Tidy up after #17258 

## What is the value of this and can you measure success?
Image metadata dimensions are accurate.  I don't know whether this has much effect, because I'm not sure how much these numbers are used by search engines etc.

## Does this affect other platforms - Amp, Apps, etc?
Yes

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
