### PR TITLE
Amp nav brand extensions

### DIFF
--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -1,6 +1,7 @@
 @()(implicit context: model.ApplicationContext)
 
 @import conf.Configuration
+@import common.Edition
 @import play.api.Mode.Dev
 
 <amp-sidebar class="menu" layout="nodisplay" id="sidebar1">
@@ -54,13 +55,34 @@
                     {{ /membershipLinks }}
 
                     <li class="menu-item">
-                        <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
-                            data-link-name="nav2 : sign in"
+                        <a href="@{Configuration.id.url}/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
+                            data-link-name="amp : nav : sign in"
                             class="menu-item__title">
                             Sign in/up
                         </a>
                     </li>
                 </ul>
+
+                <amp-accordion class="menu-group menu-group--editions">
+                    <section>
+                        <h2 class="menu-item__title">
+                            <i class="menu-item__toggle"></i>
+                            switch edition
+                        </h2>
+
+                        <ul class="menu-group">
+                            @Edition.all.map { edition =>
+                                <li class="menu-item">
+                                    <a data-link-name="amp : nav : edition-picker : @edition.id"
+                                    href="@{Configuration.id.url}/preference/edition/@{edition.id.toLowerCase}"
+                                    class="menu-item__title">
+                                        @edition.displayName
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+                    </section>
+                </amp-accordion>
 
                 <ul class="menu-group">
                     {{ #secondarySections }}

--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -39,8 +39,30 @@
                     {{ /topLevelSections }}
                 </ul>
 
-                <ul class="menu-group">
+                <ul class="menu-group menu-group--membership"
+                    role="menubar">
+                    {{ #membershipLinks }}
+                        <li class="menu-item hide-on-desktop"
+                            role="menuitem">
 
+                            <a class="menu-item__title"
+                                href="{{ url }}"
+                                data-link-name="amp : nav : {{ title }}">
+                                {{ title }}
+                            </a>
+                        </li>
+                    {{ /membershipLinks }}
+
+                    <li class="menu-item">
+                        <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_HEADER_SIGNIN"
+                            data-link-name="nav2 : sign in"
+                            class="menu-item__title">
+                            Sign in/up
+                        </a>
+                    </li>
+                </ul>
+
+                <ul class="menu-group">
                     {{ #secondarySections }}
                         <li class="menu-item">
                             <a class="menu-item__title"

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -65,6 +65,7 @@ class NavigationController extends Controller {
         "items" -> Json.arr(
           Json.obj(
             "topLevelSections" -> NewNavigation.topLevelSections.map( section => topLevelNavItems(section) ),
+            "membershipLinks" -> NewNavigation.getMembershipLinks(edition).mostPopular.map( section => navSectionLink(section)),
             "secondarySections" -> navSecondarySections
           )
         )

--- a/static/src/stylesheets/amp/header/_menu-group.scss
+++ b/static/src/stylesheets/amp/header/_menu-group.scss
@@ -17,8 +17,14 @@
     padding-top: 0;
 }
 
-.menu-group--membership {
+.menu-group--membership,
+.menu-group--editions {
     background-color: $news-main-2;
     color: $guardian-brand-dark;
     padding-bottom: 0;
+}
+
+.menu-group--editions .menu-group {
+    color: $guardian-brand-dark;
+    background-color: darken($news-main-2, 10%);
 }

--- a/static/src/stylesheets/amp/header/_menu-group.scss
+++ b/static/src/stylesheets/amp/header/_menu-group.scss
@@ -16,3 +16,9 @@
     margin-top: 0;
     padding-top: 0;
 }
+
+.menu-group--membership {
+    background-color: $news-main-2;
+    color: $guardian-brand-dark;
+    padding-bottom: 0;
+}

--- a/static/src/stylesheets/amp/header/_menu-item.scss
+++ b/static/src/stylesheets/amp/header/_menu-item.scss
@@ -3,6 +3,19 @@
     overflow-x: hidden;
     position: relative;
     width: 100%;
+
+    .menu-group--primary & {
+        &:not(:last-child):after {
+            background-color: darken($guardian-brand-dark, 4%);
+            bottom: 0;
+            content: '';
+            display: block;
+            height: 1px;
+            left: $menu-spacing-left-small;
+            position: absolute;
+            width: 100%;
+        }
+    }
 }
 
 .menu-item__title {
@@ -31,18 +44,8 @@
     font-weight: 400;
     padding-bottom: 16px;
     padding-top: $gs-baseline / 2;
-
-    &:after {
-        background-color: darken($guardian-brand-dark, 4%);
-        bottom: 0;
-        content: '';
-        display: block;
-        height: 1px;
-        left: $menu-spacing-left-small;
-        position: absolute;
-        width: 100%;
-    }
 }
+
 
 .menu-item__toggle {
     color: $news-support-2;

--- a/static/src/stylesheets/amp/header/_menu-item.scss
+++ b/static/src/stylesheets/amp/header/_menu-item.scss
@@ -26,6 +26,7 @@
     cursor: pointer;
     display: block;
     font-size: 20px;
+    font-weight: 400;
     line-height: 20px;
     outline: none;
     padding: 8px $veggie-burger-medium / 2 + $gs-gutter / 2 8px $menu-spacing-left-small;
@@ -41,7 +42,6 @@
 
 .menu-item__title--primary {
     font-size: 24px;
-    font-weight: 400;
     padding-bottom: 16px;
     padding-top: $gs-baseline / 2;
 }

--- a/static/src/stylesheets/amp/header/_menu.scss
+++ b/static/src/stylesheets/amp/header/_menu.scss
@@ -6,4 +6,8 @@
     .guardian-text-sans-loaded & {
         font-family: $f-sans-serif-text;
     }
+
+    div:first-of-type {
+        overflow-y: scroll;
+    }
 }


### PR DESCRIPTION
## What does this change?
The AMP nav has gotten a little behind so this should make it much closer to how the nav looks on the website. 

## What is the value of this and can you measure success?
Looks nicer and more options to click for a user.
I also fixed a scrolling bug for the AMP nav

## Does this affect other platforms - Amp, Apps, etc?
Just AMP

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/8774970/27543679-c27af6e2-5a82-11e7-838e-44014892ed5e.png)

**After:**
![image](https://user-images.githubusercontent.com/8774970/27543659-afa0d85c-5a82-11e7-9e60-f11cd4fb17d6.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
