### PR TITLE
Desktop header style changes

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -75,7 +75,7 @@ object NewNavigation {
 
     val uk = NavLinkLists(
       List(headlines, ukNews, world, business, environment, tech, politics),
-      List(science, cities, obituaries, globalDevelopment)
+      List(science, globalDevelopment, cities, obituaries)
     )
     val au = NavLinkLists(
       List(headlines, australiaNews, world, auPolitics, environment, economy),

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -75,7 +75,7 @@ object NewNavigation {
 
     val uk = NavLinkLists(
       List(headlines, ukNews, world, business, environment, tech, politics),
-      List(science, globalDevelopment, cities, obituaries)
+      List(science, cities, obituaries, globalDevelopment)
     )
     val au = NavLinkLists(
       List(headlines, australiaNews, world, auPolitics, environment, economy),

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -140,17 +140,21 @@
                 }
 
                 @NewNavigation.OtherLinks.getAllEditionalisedNavLinks(edition).map { item =>
-                    <li class="menu-item"
-                    role="menuitem">
+                    <li class="@RenderClasses(Map(
+                            "hide-on-desktop" -> (item.title == "the guardian app"),
+                            "menu-item--no-border" -> (item.title == "video")
+                        ), "menu-item")"
+                        role="menuitem">
+
                         <a class="menu-item__title"
-                        href="@LinkTo { @item.url }"
-                        data-link-name="nav2 : @item.title">
-                        @item.title
+                            href="@LinkTo { @item.url }"
+                            data-link-name="nav2 : @item.title">
+                            @item.title
                         </a>
                     </li>
                 }
 
-                <li class="menu-item"
+                <li class="menu-item hide-on-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://www.facebook.com/theguardian"
@@ -160,7 +164,7 @@
                     </a>
                 </li>
 
-                <li class="menu-item"
+                <li class="menu-item hide-on-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://twitter.com/guardian"

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -73,6 +73,7 @@
                         <input type="text"
                                name="q"
                                class="menu-search__search-box"
+                               id="google-search"
                                placeholder="search"
                                data-link-name="nav2 : search">
 
@@ -80,16 +81,18 @@
                                name="as_sitesearch"
                                value="www.theguardian.com">
 
-                        @* label surrounding the input and icon so that if you
-                        click the search icon it will trigger the submit *@
-                        <label for="submit-google-search"
-                               class="menu-search__submit">
-                            <input class="u-h"
-                                   type="submit"
-                                   id="submit-google-search"
-                                   data-link-name="nav2 : search : submit">
-                            @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
-                        </label>
+                       <label class="menu-search__glass"
+                              for="google-search">
+                           @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
+                       </label>
+
+                        @* Button that shows itself on form focus *@
+                        <button class="menu-search__submit"
+                                data-link-name="nav2 : search : submit"
+                                for="submit-google-search"
+                                type="submit">
+                            <i class="right-arrow__icon"></i>
+                        </button>
 
                         <label for="q"
                                class="u-h">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -63,7 +63,7 @@
 
                 <input type="checkbox"
                        id="main-menu-toggle"
-                       class="veggie-burger-fallback js-enhance-checkbox"
+                       class="veggie-burger-fallback js-enhance-checkbox u-h"
                        aria-controls="main-menu">
 
                 <ul class="pillars">

--- a/static/src/stylesheets/layout/new-header/_header-cta-item.scss
+++ b/static/src/stylesheets/layout/new-header/_header-cta-item.scss
@@ -2,12 +2,12 @@
     color: $news-support-1;
     float: left;
     position: relative;
-    transition: color 250ms;
 
     &:hover,
     &:focus {
         color: #ffffff;
         text-decoration: none;
+        outline: none;
     }
 }
 
@@ -56,7 +56,6 @@
         right: -$gs-gutter / 2;
         top: -$gs-baseline / 2;
         transform: rotate(-3deg);
-        transition: border-color 250ms, transform 250ms;
 
         @include mq(mobileMedium) {
             border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
@@ -77,10 +76,10 @@
 
     &:hover,
     &:focus {
-        color: currentColor;
+        color: $guardian-brand-dark;
 
         &:before {
-            transform: rotate(-3deg) scale(1.05);
+            border-top-color: darken($news-main-2, 10%);
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
@@ -1,4 +1,8 @@
 .menu-brand-extensions-item {
     color: currentColor;
-    font-size: 21px;
+    font-size: 24px;
+
+    &:focus {
+        outline: none;
+    }
 }

--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
@@ -5,7 +5,7 @@
 
 .menu-brand-extensions__inner {
     box-sizing: border-box;
-    padding: $gs-baseline / 2 $gs-gutter;
+    padding: $gs-baseline / 1.5 $gs-gutter;
 }
 
 .menu-brand-extensions__list {
@@ -24,18 +24,10 @@
         content: '/';
         display: inline-block;
         font-size: 22px;
-        opacity: .5;
+        opacity: .6;
         margin-left: -2px;
         margin-right: -2px;
         pointer-events: none;
-    }
-}
-
-.menu-brand-extensions-item {
-    &:focus,
-    &:hover {
-        color: darken($guardian-brand-dark, 5%);
-        text-decoration: none;
     }
 }
 
@@ -43,7 +35,7 @@
     display: inline-block;
     margin-right: $gs-gutter / 3;
     position: relative;
-    top: 4px;
+    top: 2px;
     vertical-align: middle;
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions.scss
@@ -24,10 +24,18 @@
         content: '/';
         display: inline-block;
         font-size: 22px;
-        opacity: .6;
-        padding-left: -2px;
-        padding-right: -2px;
+        opacity: .5;
+        margin-left: -2px;
+        margin-right: -2px;
         pointer-events: none;
+    }
+}
+
+.menu-brand-extensions-item {
+    &:focus,
+    &:hover {
+        color: darken($guardian-brand-dark, 5%);
+        text-decoration: none;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -160,16 +160,17 @@
     }
 
     @include mq(leftCol) {
-        width: gs-span(2) + $gs-gutter - 1;
+        margin-right: $gs-gutter / 2 - 1;
     }
 
     @include mq(wide) {
-        width: gs-span(3) + $gs-gutter - 1;
+        margin-right: gs-span(1) + $gs-gutter * 1.5 - 1;
     }
 }
 
 .menu-group--search {
     @include mq(desktop) {
+        margin-right: $gs-gutter;
         order: 4;
         width: gs-span(8);
     }

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -9,7 +9,6 @@
     padding: 0 0 $gs-baseline;
 
     @include mq(desktop) {
-        color: $news-support-1;
         display: flex;
         flex-direction: column;
         padding-bottom: 0;
@@ -28,10 +27,8 @@
     padding-top: 0;
 
     @include mq(desktop) {
-        color: $news-support-1;
         flex-direction: row;
         flex-wrap: nowrap;
-        margin-bottom: $gs-row-height / 2;
         order: 1;
     }
 }
@@ -44,6 +41,7 @@
     @include mq(desktop) {
         background-color: transparent;
         padding-bottom: 0;
+        transition: color 250ms;
         width: 100%;
     }
 }
@@ -146,6 +144,7 @@
 
 .menu-group--footer {
     @include mq(desktop) {
+        color: $news-support-1;
         padding-left: $gs-gutter / 2;
         position: absolute;
         right: gs-span(2) + $gs-gutter * 1.5 + 1;

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -41,7 +41,6 @@
     @include mq(desktop) {
         background-color: transparent;
         padding-bottom: 0;
-        transition: color 250ms;
         width: 100%;
     }
 }
@@ -95,6 +94,7 @@
     @include mq(leftCol) {
         border-left: 2px solid $guardian-brand;
         flex-direction: column;
+        margin-left: -9px;
         padding-left: $gs-gutter / 2 - 1;
         width: gs-span(2) + $gs-gutter / 2 + 1;
     }
@@ -145,11 +145,10 @@
 .menu-group--footer {
     @include mq(desktop) {
         color: $news-support-1;
-        padding-left: $gs-gutter / 2;
         position: absolute;
         right: gs-span(2) + $gs-gutter * 1.5 + 1;
         top: 0;
-        width: gs-span(2) + $gs-gutter / 2 - 1;
+        width: gs-span(2);
 
         @supports(display: flex) {
             order: 2;

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -56,10 +56,6 @@
 
 .menu-group--editions {
     padding-bottom: 0;
-
-    @include mq(desktop) {
-        margin-top: $gs-row-height / 2;
-    }
 }
 
 .menu-group--editions .menu-group {

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -94,13 +94,13 @@
     @include mq(leftCol) {
         border-left: 2px solid $guardian-brand;
         flex-direction: column;
-        margin-left: -9px;
+        margin-left: 0;
         padding-left: $gs-gutter / 2 - 1;
-        width: gs-span(2) + $gs-gutter / 2 + 1;
+        width: gs-span(2) + $gs-gutter / 2;
     }
 
     @include mq(wide) {
-        width: gs-span(3) + $gs-gutter / 2 + 1;
+        width: gs-span(3) + $gs-gutter / 2;
     }
 }
 
@@ -146,7 +146,7 @@
     @include mq(desktop) {
         color: $news-support-1;
         position: absolute;
-        right: gs-span(2) + $gs-gutter * 1.5 + 1;
+        right: gs-span(2) + $gs-gutter * 1.5;
         top: 0;
         width: gs-span(2);
 
@@ -159,11 +159,11 @@
     }
 
     @include mq(leftCol) {
-        margin-right: $gs-gutter / 2 - 1;
+        margin-right: $gs-gutter / 2;
     }
 
     @include mq(wide) {
-        margin-right: gs-span(1) + $gs-gutter * 1.5 - 1;
+        margin-right: gs-span(1) + $gs-gutter * 1.5;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -74,7 +74,7 @@
     position: relative;
 
     @include mq($from: desktop, $until: leftCol) {
-        border-top: 1px solid rgba($news-main-2, .3);
+        border-top: 1px solid $guardian-brand;
         flex-wrap: nowrap;
         width: 100%;
     }
@@ -83,7 +83,7 @@
         flex-direction: row;
         order: 3;
         padding-bottom: 0;
-        padding-top: $gs-baseline / 2;
+        padding-top: $gs-baseline;
         position: absolute;
         right: 0;
         top: 0;
@@ -97,17 +97,21 @@
     }
 
     @include mq(leftCol) {
-        border-left: 2px solid rgba($news-main-2, .3);
+        border-left: 2px solid $guardian-brand;
         flex-direction: column;
         padding-left: $gs-gutter / 2 - 1;
-        padding-top: $gs-baseline;
-        width: gs-span(2) + $gs-gutter / 2 - 1;
+        width: gs-span(2) + $gs-gutter / 2 + 1;
+    }
+
+    @include mq(wide) {
+        width: gs-span(3) + $gs-gutter / 2 + 1;
     }
 }
 
 .menu-group--editions {
     @include mq(desktop) {
         padding-bottom: $gs-baseline * 2;
+        margin-top: $gs-baseline * 2;
         order: 5;
 
         @supports(display: flex) {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -46,8 +46,8 @@
 
     .menu-group--membership-actions & {
         @include mq($from: desktop, $until: leftCol) {
-            margin-left: $gs-gutter / 2 - 1;
-            width: gs-span(2) + $gs-gutter / 2 + 1;
+            margin-left: $gs-gutter / 2;
+            width: gs-span(2) + $gs-gutter / 2;
         }
     }
 }
@@ -60,7 +60,7 @@
 
 .menu-item--user-detail {
     @include mq($from: desktop, $until: leftCol) {
-        width: gs-span(4) + $gs-gutter / 2 + 1;
+        width: gs-span(4) + $gs-gutter / 2;
     }
 
     @include mq(leftCol) {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -170,15 +170,6 @@
         }
     }
 
-    .menu-group--editions & {
-        @include mq(desktop) {
-            font-size: 15px;
-            line-height: $search-and-edition-height-desktop;
-            padding: 0;
-            text-align: center;
-        }
-    }
-
     .menu-group--editions &[aria-haspopup='true'] {
         margin-bottom: $gs-baseline;
 
@@ -188,14 +179,47 @@
     }
 
     .menu-group--membership & {
-        @include mq($from: desktop, $until: leftCol) {
+        @include mq(desktop) {
             color: #ffffff;
-            font-size: 17px;
-            line-height: 20px;
 
             &:hover,
             &:focus {
-                color: $news-support-1;
+                color: #00d4ff;
+            }
+        }
+    }
+
+    .menu-group--editions & {
+        @include mq(desktop) {
+            background-color: $guardian-brand;
+            color: $news-support-1;
+            display: block;
+            font-size: 15px;
+            height: $search-and-edition-height-desktop;
+            border-radius: 50%;
+            line-height: $search-and-edition-height-desktop;
+            margin-right: $gs-gutter / 4;
+            padding: 0;
+            text-align: center;
+            width: $search-and-edition-height-desktop;
+        }
+
+        &:hover,
+        &:focus {
+            @include mq(desktop) {
+                background-color: lighten($guardian-brand, 4%);
+                color: #ffffff;
+            }
+        }
+    }
+
+    .menu-item--edition-active & {
+        @include mq(desktop) {
+            &,
+            &:hover,
+            &:focus {
+                background-color: $news-support-1;
+                color: $guardian-brand-dark;
             }
         }
     }
@@ -259,8 +283,8 @@
 }
 
 .menu-item__editions-label {
-    font-size: 17px;
-    left: 0;
-    position: absolute;
-    top: -$gs-baseline * 2;
+    color: #ffffff;
+    font-size: 16px;
+    line-height: $search-and-edition-height-desktop;
+    margin-right: $gs-gutter / 2;
 }

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -99,7 +99,7 @@
 
     @include mq(desktop) {
         font-size: 16px;
-        letter-spacing: .02rem;
+        letter-spacing: .3px;
         line-height: 18px;
         padding-bottom: 9px;
         padding-left: 0;
@@ -112,7 +112,7 @@
         text-decoration: none;
 
         @include mq(desktop) {
-            color: #00d4ff;
+            color: $highlight-blue;
         }
     }
 
@@ -184,7 +184,7 @@
 
             &:hover,
             &:focus {
-                color: #00d4ff;
+                color: $highlight-blue;
             }
         }
     }

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -6,18 +6,9 @@
 
     .menu-group--primary > & {
         @include mq(desktop) {
-            border-right: 2px solid rgba($news-main-2, .3);
             float: left;
-            width: gs-span(2) + $gs-gutter / 2 + 1;
-
-            &:not(:first-child) {
-                margin-left: $gs-gutter / 2 - 1;
-            }
-
-            &:not(:last-child) {
-                margin-top: -$gs-baseline * 3;
-                padding-top: $gs-baseline * 3;
-            }
+            margin-right: $gs-gutter;
+            width: gs-span(2);
 
             @supports(display: flex) {
                 float: none;
@@ -25,45 +16,31 @@
         }
     }
 
-    .menu-group--editions > &,
-    .menu-group--secondary > & {
+    .menu-group--secondary > &,
+    .menu-group--footer > & {
+        @include mq(desktop) {
+            border-top: 1px solid $guardian-brand;
+            width: gs-span(2) - 5;
+        }
+    }
+
+    .menu-group--secondary > &:nth-child(2),
+    &.menu-item--no-border {
+        @include mq(desktop) {
+            border: transparent;
+            margin-top: $gs-baseline / 4;
+        }
+    }
+
+    .menu-group--editions > & {
         @include mq(desktop) {
             width: 100%;
         }
     }
 
-    .menu-group--editions .menu-group & {
+    .menu-group--editions > & {
         @include mq(desktop) {
-            background-color: $guardian-brand;
-            display: block;
-            float: left;
-            height: $search-and-edition-height-desktop;
-            border-radius: 50%;
-            margin-right: $gs-gutter / 2;
-            text-align: center;
-            width: $search-and-edition-height-desktop;
-
-            @supports(display: flex) {
-                float: none;
-            }
-        }
-
-        &:hover,
-        &:focus {
-            @include mq(desktop) {
-                background-color: lighten($guardian-brand, 4%);
-            }
-        }
-
-        &--edition-active {
-            @include mq(desktop) {
-                &,
-                & .menu-item__title:focus,
-                & .menu-item__title:hover {
-                    background-color: $news-support-1;
-                    color: $guardian-brand-dark;
-                }
-            }
+            display: flex;
         }
     }
 
@@ -179,14 +156,6 @@
                 bottom: auto;
                 top: 0;
             }
-        }
-    }
-
-    &[data-link-name='nav2 : the guardian app'],
-    &[data-link-name='nav2 : facebook'],
-    &[data-link-name='nav2 : twitter'] {
-        @include mq(desktop) {
-            display: none;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -15,8 +15,8 @@
             }
 
             &:not(:last-child) {
-                margin-top: -$gs-baseline * 3.5;
-                padding-top: $gs-baseline * 3.5;
+                margin-top: -$gs-baseline * 3;
+                padding-top: $gs-baseline * 3;
             }
 
             @supports(display: flex) {
@@ -51,15 +51,18 @@
         &:hover,
         &:focus {
             @include mq(desktop) {
-                background-color: $news-main-2;
-                color: #ffffff;
+                background-color: lighten($guardian-brand, 4%);
             }
         }
 
         &--edition-active {
             @include mq(desktop) {
-                background-color: $guardian-brand-light;
-                color: $guardian-brand-dark;
+                &,
+                & .menu-item__title:focus,
+                & .menu-item__title:hover {
+                    background-color: $news-support-1;
+                    color: $guardian-brand-dark;
+                }
             }
         }
     }
@@ -119,20 +122,26 @@
 
     @include mq(desktop) {
         font-size: 16px;
+        letter-spacing: .02rem;
         line-height: 18px;
-        padding-bottom: $gs-baseline / 2;
+        padding-bottom: 9px;
         padding-left: 0;
-        padding-right: $gs-gutter / 2 - 1;
-        padding-top: $gs-baseline / 2;
+        padding-right: 0;
+        padding-top: $gs-baseline / 4;
     }
 
     &:hover,
     &:focus {
         text-decoration: none;
 
-        // TODO: maybe unify?
         @include mq(desktop) {
-            color: #ffffff;
+            color: #00d4ff;
+        }
+    }
+
+    &:focus {
+        @include mq(desktop) {
+            text-decoration: underline;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -5,8 +5,8 @@
     position: relative;
 
     @include mq($until: desktop) {
-        padding-bottom: $gs-baseline * 2;
-        padding-right: $veggie-burger-medium / 2 + $gs-gutter / 2;
+        margin-bottom: $gs-baseline * 2;
+        margin-right: $veggie-burger-medium / 2 + $gs-gutter / 2;
     }
 
     @include mq(tablet) {
@@ -14,10 +14,10 @@
     }
 
     @include mq(desktop) {
-        margin-bottom: $gs-baseline;
+        margin-bottom: $gs-baseline * 2;
         margin-left: 0;
-        margin-top: $gs-row-height / 2;
-        padding-right: $gs-gutter;
+        margin-top: $gs-baseline * 2;
+        padding-right: 0;
         width: 100%;
     }
 }
@@ -35,14 +35,14 @@
     width: 100%;
 
     @include mq(tablet) {
-        padding-left: 40px;
+        padding-left: $gs-gutter * 2;
     }
 
     @include mq(desktop) {
         height: $search-and-edition-height-desktop;
         max-width: none;
         padding-left: 48px;
-        font-size: 18px;
+        font-size: 24px;
 
         &:hover {
             background: lighten($guardian-brand, 4%);
@@ -57,6 +57,8 @@
         background-color: #ffffff;
         color: $neutral-1;
         outline: none;
+        padding-right: 38px;
+        transition: background-color 500ms;
 
         &::placeholder {
             color: $neutral-3;
@@ -64,21 +66,93 @@
     }
 }
 
-.menu-search__submit {
-    left: 10px;
+.menu-search__glass {
     position: absolute;
-    top: 10px;
+    left: 10px;
+    top: 7px;
 
     @include mq(desktop) {
         left: 12px;
+        top: 10px;
     }
 
     .inline-search-36__svg {
         fill: $news-support-2;
+        height: 22px;
+        width: 22px;
+
+        .menu-search__search-box:focus ~ & {
+            fill: $neutral-2;
+        }
+    }
+}
+
+.menu-search__submit {
+    background: transparent;
+    border: none;
+    bottom: 0;
+    cursor: pointer;
+    display: block;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: $gs-gutter * 2.5;
+
+    &:before,
+    &:after {
+        border: 2px solid $guardian-brand;
+        border-left: none;
+        border-top: none;
+        content: '';
+        display: block;
+        position: absolute;
+        right: 14px;
 
         @include mq(desktop) {
-            height: 22px;
-            width: 22px;
+            right: 16px;
         }
+    }
+
+    &:before {
+        height: $gs-baseline;
+        top: $gs-baseline - 1;
+        transform: rotate(-45deg);
+        width: $gs-baseline;
+
+        @include mq(desktop) {
+            top: $gs-baseline + 2;
+        }
+    }
+
+    &:after {
+        border-right: none;
+        top: 17px;
+        width: 20px;
+
+        @include mq(desktop) {
+            top: 20px;
+        }
+    }
+
+    &:hover,
+    &:active {
+        border-color: $guardian-brand;
+    }
+
+    &:focus {
+        &:before,
+        &:after {
+            border-color: #ffffff;
+        }
+    }
+
+    // Reveals search button & retains visibility of search button when form loses focus
+    .menu-search__search-box:focus ~ &,
+    &:focus {
+        opacity: 1;
+        outline: none;
+        pointer-events: all;
     }
 }

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -53,7 +53,7 @@
         background-color: #ffffff;
         color: $neutral-1;
         outline: none;
-        padding-right: 38px;
+        padding-right: $gs-gutter * 2;
         transition: background-color 500ms;
 
         &::placeholder {

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -2,11 +2,13 @@
     box-sizing: border-box;
     display: block;
     margin-left: 13px;
+    max-width: gs-span(5);
     position: relative;
+    width: 100%;
 
     @include mq($until: desktop) {
         margin-bottom: $gs-baseline * 2;
-        margin-right: $veggie-burger-medium / 2 + $gs-gutter / 2;
+        margin-right: $veggie-burger-medium / 2 + $gs-gutter;
     }
 
     @include mq(tablet) {
@@ -17,8 +19,8 @@
         margin-bottom: $gs-baseline * 2;
         margin-left: 0;
         margin-top: $gs-baseline * 2;
+        max-width: none;
         padding-right: 0;
-        width: 100%;
     }
 }
 
@@ -29,18 +31,12 @@
     box-sizing: border-box;
     font-size: 20px;
     height: $gs-row-height;
-    max-width: gs-span(4);
     padding-left: 38px;
     vertical-align: middle;
     width: 100%;
 
-    @include mq(tablet) {
-        padding-left: $gs-gutter * 2;
-    }
-
     @include mq(desktop) {
         height: $search-and-edition-height-desktop;
-        max-width: none;
         padding-left: 48px;
         font-size: 24px;
 

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -89,7 +89,7 @@
 
 .menu-search__submit {
     background: transparent;
-    border: none;
+    border: 0;
     bottom: 0;
     cursor: pointer;
     display: block;
@@ -103,8 +103,8 @@
     &:before,
     &:after {
         border: 2px solid $guardian-brand;
-        border-left: none;
-        border-top: none;
+        border-left: 0;
+        border-top: 0;
         content: '';
         display: block;
         position: absolute;
@@ -127,7 +127,7 @@
     }
 
     &:after {
-        border-right: none;
+        border-right: 0;
         top: 17px;
         width: 20px;
 

--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -43,6 +43,10 @@
         max-width: none;
         padding-left: 48px;
         font-size: 18px;
+
+        &:hover {
+            background: lighten($guardian-brand, 4%);
+        }
     }
 
     &::placeholder {

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -83,6 +83,12 @@ from scrolling */
         margin-left: auto;
     }
 
+    @include mq(desktop) {
+        &:focus {
+            outline: none;
+        }
+    }
+
     .new-header--slim.new-header--open & {
         @include mq($from: desktop, $until: leftCol) {
             display: none;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -110,12 +110,14 @@ from scrolling */
     }
 
     @include mq(tablet) {
-        height: calc(3 / 16 * 370px);
-        width: 370px;
+        height: calc(3 / 16 * 385px);
+        width: 385px;
     }
 
     @include mq(desktop) {
+        height: calc(3 / 16 * 385px);
         margin-bottom: $gs-baseline / 4;
+        width: 385px;
     }
 
     .new-header--slim & {

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -49,7 +49,6 @@ from scrolling */
 
 .new-header__cta-container {
     left: $gs-gutter / 4;
-    overflow: hidden;
     padding-right: 6px;
     position: absolute;
     top: 0;
@@ -60,7 +59,6 @@ from scrolling */
 
     .new-header--slim & {
         position: relative;
-        overflow: visible;
         left: -$gs-gutter / 4;
         order: -1;
         z-index: 1;

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -8,6 +8,7 @@
     font-size: 5.1vw;
     line-height: $gs-baseline * 2.5;
     position: relative;
+    transition: color 350ms;
 
     @include mq(mobileMedium) {
         line-height: $gs-baseline * 3;
@@ -20,15 +21,17 @@
 
     @include mq(tablet) {
         font-size: 28px;
+        letter-spacing: -0.04rem;
     }
 
     @include mq(desktop) {
-        font-size: 29px;
+        font-size: 32px;
     }
 
     &:focus,
     &:hover {
         color: #ffffff;
+        outline: none;
         text-decoration: none;
     }
 
@@ -42,6 +45,18 @@
 .pillar-link--current-section {
     color: #ffffff;
 
+    @include mq(desktop) {
+        .new-header--open & {
+            color: $news-support-1;
+
+            &:focus,
+            &:hover {
+                color: #ffffff;
+                text-decoration: none;
+            }
+        }
+    }
+
     // triangle
     &:before {
         content: '';
@@ -54,7 +69,9 @@
         border-right: $gs-baseline / 2 solid transparent;
 
         @include mq(desktop) {
-            display: none;
+            .new-header--open & {
+                display: none;
+            }
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -21,7 +21,7 @@
 
     @include mq(tablet) {
         font-size: 28px;
-        letter-spacing: -0.04rem;
+        letter-spacing: -.04rem;
     }
 
     @include mq(desktop) {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -35,8 +35,13 @@
     display: inline-block;
 
     @include mq(desktop) {
+        min-width: 0;
+        padding-right: 16px;
+        transition: min-width 600ms ease;
+
         .new-header--open & {
-            width: gs-span(2) + $gs-gutter / 2 + 1;
+            min-width: gs-span(2) + $gs-gutter / 2 + 1;
+            transition: min-width 300ms ease;
         }
 
         .new-header--open &:not(:first-child) {
@@ -48,21 +53,29 @@
         content: '/';
         color: $news-main-2;
         display: inline-block;
-        line-height: 1;
         margin-left: -1px;
         margin-right: 2px;
-        opacity: .6;
         pointer-events: none;
 
-        .new-header--open & {
-            @include mq(desktop) {
-                display: none;
-            }
+        // Slashes switch to left hand side for open animation
+        @include mq(desktop) {
+            left: -13px;
+            margin: 0;
+            position: absolute;
+            top: 0;
         }
     }
 
-    &:last-child > *:after {
-        display: none;
+    @include mq($until: desktop) {
+        &:last-child > *:after {
+            display: none;
+        }
+    }
+
+    @include mq(desktop) {
+        &:first-child > *:after {
+            display: none;
+        }
     }
 
     .new-header--slim.new-header--open & {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -37,11 +37,11 @@
     @include mq(desktop) {
         min-width: 0;
         padding-right: 16px;
-        transition: min-width 600ms ease;
+        transition: min-width 400ms ease;
 
         .new-header--open & {
             min-width: gs-span(2) + $gs-gutter / 2 + 1;
-            transition: min-width 300ms ease;
+            transition: min-width 200ms ease;
         }
 
         .new-header--open &:not(:first-child) {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -14,7 +14,7 @@
 
     @include mq(desktop) {
         .new-header--open & {
-            z-index: $zindex-main-menu + 1;
+            z-index: $zindex-main-menu;
         }
     }
 
@@ -40,12 +40,12 @@
         transition: min-width 400ms ease;
 
         .new-header--open & {
-            min-width: gs-span(2) + $gs-gutter / 2 + 1;
+            min-width: gs-span(2) + $gs-gutter / 2;
             transition: min-width 200ms ease;
         }
 
         .new-header--open &:not(:first-child) {
-            margin-left: $gs-gutter / 2 - 1;
+            margin-left: $gs-gutter / 2;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -47,6 +47,11 @@
 .subnav__item {
     display: inline-block;
 
+    &:focus,
+    &:hover {
+        color: #ffffff;
+    }
+
     > *:after {
         content: '/';
         color: rgba(255, 255, 255, .3);

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -3,6 +3,7 @@ $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
 $gutter-xlarge: 80px;
+$gutter-xxlarge: 103px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
 $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -2,8 +2,7 @@
 $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
-$gutter-xlarge: 80px;
-$gutter-xxlarge: 103px;
+$gutter-xlarge: 84px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
 $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -8,3 +8,5 @@ $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
 $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;
 
 $search-and-edition-height-desktop: 42px;
+
+$highlight-blue: #00d4ff;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -20,13 +20,13 @@
         & ~ .pillars {
             .pillars__item:not(:first-child) > .pillar-link {
                 @include mq(desktop) {
-                    margin-left: $gs-gutter / 2 - 1;
+                    margin-left: $gs-gutter / 2;
                 }
             }
 
             .pillar-link {
                 @include mq(desktop) {
-                    width: gs-span(2) + $gs-gutter / 2 + 1;
+                    width: gs-span(2) + $gs-gutter / 2;
                 }
             }
 

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -1,6 +1,4 @@
 .veggie-burger-fallback {
-    display: none;
-
     &:checked {
         & ~ .menu {
             @include mq($until: desktop) {
@@ -62,5 +60,9 @@
                 }
             }
         }
+    }
+
+    &:focus ~ .veggie-burger {
+        background-color: darken($news-main-2, 10%);
     }
 }

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -30,7 +30,11 @@
     }
 
     @include mq(desktop) {
-        right: $gutter-xxlarge;
+        transition: box-shadow 250ms;
+
+        &:focus {
+            background-color: darken($news-main-2, 10%);
+        }
     }
 
     // menu is open

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -29,6 +29,10 @@
         right: $gutter-xlarge;
     }
 
+    @include mq(desktop) {
+        right: $gutter-xxlarge;
+    }
+
     // menu is open
     .new-header--open & {
         z-index: $zindex-main-menu + 1;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -29,12 +29,6 @@
         right: $gutter-xlarge;
     }
 
-    @include mq(desktop) {
-        &:focus {
-            background-color: darken($news-main-2, 10%);
-        }
-    }
-
     // menu is open
     .new-header--open & {
         z-index: $zindex-main-menu + 1;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -42,21 +42,23 @@
         z-index: $zindex-main-menu + 1;
 
         &:before {
-            border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
-            // Extended hit area for veggie burger close state, for fat fingers
-            content: '';
-            height: $veggie-burger-small * 2;
-            position: absolute;
-            right: $veggie-burger-small / 2;
-            top: -$veggie-burger-small / 2;
-            width: $veggie-burger-small;
+            @include mq($until: desktop) {
+                border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
+                // Extended hit area for veggie burger close state, for fat fingers
+                content: '';
+                height: $veggie-burger-small * 2;
+                position: absolute;
+                right: $veggie-burger-small / 2;
+                top: -$veggie-burger-small / 2;
+                width: $veggie-burger-small;
 
-            @include mq(mobileMedium) {
-                height: $veggie-burger-medium * 2;
-                width: $veggie-burger-medium;
-                top: -$veggie-burger-medium / 2;
-                right: $veggie-burger-medium / 2;
-                border-radius: ($veggie-burger-medium * 2) 0 0 ($veggie-burger-medium * 2);
+                @include mq(mobileMedium) {
+                    height: $veggie-burger-medium * 2;
+                    width: $veggie-burger-medium;
+                    top: -$veggie-burger-medium / 2;
+                    right: $veggie-burger-medium / 2;
+                    border-radius: ($veggie-burger-medium * 2) 0 0 ($veggie-burger-medium * 2);
+                }
             }
         }
     }

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -30,8 +30,6 @@
     }
 
     @include mq(desktop) {
-        transition: box-shadow 250ms;
-
         &:focus {
             background-color: darken($news-main-2, 10%);
         }


### PR DESCRIPTION
## What does this change?
Mainly visual tweaks based on feedback from Alex, Ben, Stephan, Natalia, Duarte and many more.

Some of the main changes:

- Vertical lines have been removed and horizontal lines added
- Search bar now has a search button on its focus state
- Edition switcher has a label to the left for clarity, and to differentiate it from search field
- Animation of the pillars as the nav is open and closed (Something I want to further improve)
- Hover and focus states 

Before:
<img width="1664" alt="screen shot 2017-06-26 at 15 34 22" src="https://user-images.githubusercontent.com/14570016/27544428-061e0c5c-5a85-11e7-9ce2-30ce7c3e3d21.png">

After:
<img width="1664" alt="screen shot 2017-06-26 at 15 34 15" src="https://user-images.githubusercontent.com/14570016/27544425-061832fa-5a85-11e7-9820-4bc237b6b581.png">

Search active state:
<img width="924" alt="screen shot 2017-06-26 at 15 34 43" src="https://user-images.githubusercontent.com/14570016/27544426-0619bd3c-5a85-11e7-94de-04a7a8f2c763.png">

Menu hover state:
<img width="272" alt="screen shot 2017-06-26 at 15 34 51" src="https://user-images.githubusercontent.com/14570016/27544427-061b7014-5a85-11e7-8d2d-6fbd048bc7ec.png">

Header open/close animation:
![header](https://user-images.githubusercontent.com/14570016/27544631-aaee0e6c-5a85-11e7-8098-a357fb39b22f.gif)

Some of these changes may have an effect on browsers that don't support flexbox and as we were working in tandem, @gustavpursche will have to take a look to see if any of my stylistic changes affect anything.  There is more I want to do and will do, but this PR was getting too large and messy. I'll be looking at the slim nav separately, and reviewing proposed changes from another UX review. 