### PR TITLE
Actually show latest updates from live blog on front

### DIFF
--- a/static/src/javascripts-legacy/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts-legacy/projects/facia/modules/ui/live-blog-updates.js
@@ -96,7 +96,7 @@ define([
                 $element = bonzo(element);
 
             fastdomPromise.write(function () {
-                $element.append(el);
+                $element.empty().append(el);
             })
             .then(function () {
                 if (hasNewBlock) {


### PR DESCRIPTION
## What does this change?
Previously any updates after the front was loaded were added to the DOM, but were never visible

I believe this has been the case for more than two years, as this appears to be responsible for the regression:
https://github.com/guardian/frontend/commit/c07639941de836e3a52c06342a45a7b863c5c6a4

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![image](https://user-images.githubusercontent.com/68329/27547458-fc7816b2-5a8d-11e7-9929-f59390a2aad8.png)

## Tested in CODE?
Bug was discovered in CODE, but fix only tested locally.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
