### PR TITLE
Nav feedack changes

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -235,13 +235,11 @@ object NewNavigation {
 
     val au = NavLinkLists(List(
       jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
-      auEvents,
-      holidays
+      auEvents
     ))
 
     val us = NavLinkLists(List(
-      jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader"),
-      holidays.copy(title = "vacations")
+      jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader")
     ))
 
     val int = NavLinkLists(List(

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -133,8 +133,7 @@ object NewNavigation {
         opinion,
         theGuardianView,
         columnists,
-        letters,
-        editorials
+        letters
       ),
       List(
         NavLink("Jill Abramson", "/profile/jill-abramson"),

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -42,7 +42,11 @@
                             data-edition="@{editionId}"
                             href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
                             <span class="header-cta-item__label">
-                                become a <span class="header-cta-item__new-line">supporter</span>
+                                @if(editionId == "us") {
+                                    make a <span class="header-cta-item__new-line">contribution</span>
+                                } else {
+                                    become a <span class="header-cta-item__new-line">supporter</span>
+                                }
                             </span>
                         </a>
 


### PR DESCRIPTION
## What does this change?
Some more nav changes based on editorial feedback

* Holidays are only UK based really so it is removed from AU and US edition
* In the US _become a supporter_ turns into _make a contribution_ because 4/5 people in the states will more likely do that
* editorials is removed from US edition (in opinion nav)

## What is the value of this and can you measure success?
Just some tweaks :upside_down_face: 

## Does this affect other platforms - Amp, Apps, etc?
Not really

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27585213-2df9294c-5b33-11e7-9e52-fc6926b54634.png)



## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
