### PR TITLE
Contribute should go to a different link

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -12,6 +12,14 @@
     }
 }
 
+@ContributionOrSupporterUrl(edition: String) = {
+    @if(edition == "us") {
+        https://contribute.theguardian.com/us?INTCMP=gdnwb_copts_co_dotcom_header
+    } else {
+        @{Configuration.id.membershipUrl}/@{edition}/supporter?INTCMP=mem_@{edition}_web_newheader_trapezoid
+    }
+}
+
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> mvt.ABNewDesktopHeader.isParticipating,
             "new-header--slim" -> page.metadata.hasSlimHeader
@@ -40,7 +48,7 @@
                         <a class="header-cta-item header-cta-item--primary"
                             data-link-name="nav2 : supporter-cta"
                             data-edition="@{editionId}"
-                            href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
+                            href="@ContributionOrSupporterUrl(editionId)">
                             <span class="header-cta-item__label">
                                 @if(editionId == "us") {
                                     make a <span class="header-cta-item__new-line">contribution</span>


### PR DESCRIPTION
## What does this change?
"make a contribution" should go to a different link than "be a supporter"

## What is the value of this and can you measure success?
People go to the right link

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
n/a

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
