### PR TITLE
Removed duplicate supporter cta from header

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -46,19 +46,6 @@
                         Edition(request).id.toLowerCase()
                     ) { editionId =>
                       @if(!page.metadata.hasSlimHeader) {
-                          <a class="header-cta-item header-cta-item--primary"
-                              data-link-name="nav2 : supporter-cta"
-                              data-edition="@{editionId}"
-                              href="@ContributionOrSupporterUrl(editionId)">
-                              <span class="header-cta-item__label">
-                                  @if(editionId == "us") {
-                                      make a <span class="header-cta-item__new-line">contribution</span>
-                                  } else {
-                                      become a <span class="header-cta-item__new-line">supporter</span>
-                                  }
-                              </span>
-                          </a>
-
                             <a class="header-cta-item header-cta-item--primary"
                                 data-link-name="nav2 : supporter-cta"
                                 data-edition="@{editionId}"

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -47,16 +47,16 @@
                     ) { editionId =>
                       @if(!page.metadata.hasSlimHeader) {
                             <a class="header-cta-item header-cta-item--primary"
-                                data-link-name="nav2 : supporter-cta"
-                                data-edition="@{editionId}"
-                                href="@{Configuration.id.membershipUrl}/@{editionId}/supporter?INTCMP=mem_@{editionId}_web_newheader_trapezoid">
-                                <span class="header-cta-item__label">
-                                    @if(editionId == "us") {
-                                        make a <span class="header-cta-item__new-line">contribution</span>
-                                    } else {
-                                        become a <span class="header-cta-item__new-line">supporter</span>
-                                    }
-                                </span>
+                              data-link-name="nav2 : supporter-cta"
+                              data-edition="@{editionId}"
+                              href="@ContributionOrSupporterUrl(editionId)">
+                              <span class="header-cta-item__label">
+                                  @if(editionId == "us") {
+                                      make a <span class="header-cta-item__new-line">contribution</span>
+                                  } else {
+                                      become a <span class="header-cta-item__new-line">supporter</span>
+                                  }
+                              </span>
                             </a>
 
                             <a class="header-cta-item hide-until-tablet header-cta-item--secondary"


### PR DESCRIPTION
Slim nav PR introduced two supporter CTAs, which is too avant-garde even for us. 