### PR TITLE
Header: Fix styles for non JS fallback

### DIFF
--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -18,19 +18,19 @@
         }
 
         & ~ .pillars {
-            .pillars__item:not(:first-child) > .pillar-link {
+            .pillars__item {
+                @include mq(desktop) {
+                    min-width: gs-span(2) + $gs-gutter / 2;
+                }
+            }
+
+            .pillars__item:not(:first-child) {
                 @include mq(desktop) {
                     margin-left: $gs-gutter / 2;
                 }
             }
 
-            .pillar-link {
-                @include mq(desktop) {
-                    width: gs-span(2) + $gs-gutter / 2;
-                }
-            }
-
-            .pillar-link:after {
+            .pillar-link--current-section:before {
                 @include mq(desktop) {
                     display: none;
                 }


### PR DESCRIPTION
## What does this change?

Fixes styles for new horizontal lines, when there is no JS enabled.

## What is the value of this and can you measure success?

Proper fallback styles -> 👍 UX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1280" alt="screen shot 2017-06-28 at 11 44 09" src="https://user-images.githubusercontent.com/2244375/27633879-e054d4b8-5bf8-11e7-884f-2214e401a74b.png">

**After**

<img width="1280" alt="screen shot 2017-06-28 at 11 52 30" src="https://user-images.githubusercontent.com/2244375/27633887-e5251980-5bf8-11e7-9968-194425fc5b26.png">


## Tested in CODE?

Nope.
