### PR TITLE
Subnav should show all the things on desktop

### DIFF
--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -1,7 +1,25 @@
 @(page: model.Page, isFooter: Boolean = false)(implicit request: RequestHeader)
 
-@import common.{NewNavigation, Edition, LinkTo}
+@import common.{NewNavigation, NavLink, Edition, LinkTo}
 @import views.support.RenderClasses
+
+
+@subNavItem(link: NavLink, id: String, shouldHideUntilDesktop: Boolean) = {
+    <li class="@RenderClasses(Map(
+            "hide-until-desktop" -> shouldHideUntilDesktop
+        ), "subnav__item")">
+        <a class="@RenderClasses(Map(
+                "subnav-link" -> true,
+                "subnav-link--current-section" -> (id == link.uniqueSection)
+            ))"
+            href="@LinkTo(link.url)"
+            data-link-name="nav2 : subnav : @{if(link.longTitle.isEmpty) link.title else link.longTitle}">
+
+            @link.title
+        </a>
+    </li>
+}
+
 
 <div class="subnav">
     <div class="gs-container">
@@ -10,22 +28,16 @@
             <ul class="subnav__list"
                 data-pillar-title="@activePillarName">
 
-                @NewNavigation.SubSectionLinks.getSubSectionNavLinks(id, Edition(request), page.metadata.isFront).map { link =>
-                    <li class="subnav__item">
-                        <a class="@RenderClasses(Map(
-                                "subnav-link" -> true,
-                                "subnav-link--current-section" -> (id == link.uniqueSection)
-                           ))"
-                           href="@LinkTo(link.url)"
-                           data-link-name="nav2 : subnav : @{if(link.longTitle.isEmpty) link.title else link.longTitle}">
-                            @link.title
-                        </a>
-                    </li>
+                @defining(
+                    NewNavigation.SubSectionLinks.getSubSectionNavLinks(id, Edition(request), page.metadata.isFront)
+                ) { case (mostPopular, leastPopular) =>
+                    @mostPopular.map { link => @subNavItem(link, id, false)}
+                    @leastPopular.map { link => @subNavItem(link, id, true)}
                 }
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!(id == "uk" ||  id == "us" ||  id == "au" ||  id == "international" || isFooter)) {
-                <li class="subnav__item js-visible">
+                <li class="subnav__item js-visible hide-on-desktop">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -11,6 +11,11 @@
         max-height: $gs-baseline * 4.8;
     }
 
+    @include mq(desktop) {
+        // to make sure that the words are not visible on subnav desktop if they fall to the second line
+        margin-bottom: $gs-baseline;
+    }
+
     &:hover,
     &:focus {
         text-decoration: none;

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -14,6 +14,10 @@
         padding: $gs-baseline / 2 0;
     }
 
+    @include mq(desktop) {
+        max-height: $gs-baseline * 2;
+    }
+
     // Spacer to prevent text from sitting directly beneath the veggie burger
     &:before {
         content: '';
@@ -42,6 +46,10 @@
         padding-left: $gs-gutter;
         padding-right: $gs-gutter;
     }
+
+    @include mq(desktop) {
+        padding-right: $gs-column-width * 3;
+    }
 }
 
 .subnav__item {
@@ -52,17 +60,17 @@
         color: #ffffff;
     }
 
-    > *:after {
+    > *:before {
         content: '/';
         color: rgba(255, 255, 255, .3);
         display: inline-block;
         font-size: 1em;
+        pointer-events: none;
         margin-left: -2px;
         margin-right: -2px;
-        pointer-events: none;
     }
 
-    &:last-child > *:after {
+    &:first-child > *:before {
         content: '';
     }
 }


### PR DESCRIPTION
## What does this change?
On desktop there is room to show all the subnav items, not just the most popular ones. 

This is the initial stab at it.

## What is the value of this and can you measure success?
More options for users

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27634158-1c8fbdac-5bfa-11e7-9277-ab9a41575857.png)

![image](https://user-images.githubusercontent.com/8774970/27634165-2adf21a4-5bfa-11e7-8398-adff3d942f9e.png)


## Tested in CODE?
I will actually because the subnav stuff is hard to test locally
- [x]  .

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
