### PR TITLE
Fix editions for browsers without flexbox support

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -53,17 +53,6 @@
     }
 }
 
-.menu-group--editions {
-    padding-bottom: 0;
-}
-
-.menu-group--editions .menu-group {
-    @include mq($until: desktop) {
-        color: $guardian-brand-dark;
-        background-color: darken($news-main-2, 10%);
-    }
-}
-
 .menu-group--membership {
     padding-bottom: 0;
     position: relative;
@@ -116,16 +105,22 @@
     }
 
     .menu-group {
+        @include mq($until: desktop) {
+            color: $guardian-brand-dark;
+            background-color: darken($news-main-2, 10%);
+        }
+
         @include mq(desktop) {
-            flex-direction: row;
-            flex-wrap: nowrap;
+            @supports(display: flex) {
+                flex-direction: row;
+                flex-wrap: nowrap;
+            }
         }
     }
-}
 
-.menu-group--editions-details {
-    @include mq(desktop) {
-        flex-direction: row;
+    .menu-group .menu-item {
+        display: inline-block;
+        width: auto;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Fixes menu editions for browsers without flexbox support.

## What is the value of this and can you measure success?

Proper fallbacks.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1055" alt="screen shot 2017-06-28 at 13 14 18" src="https://user-images.githubusercontent.com/2244375/27636493-b79a043e-5c03-11e7-9e14-3f83fe0b6cd4.png">

**After**

<img width="1144" alt="screen shot 2017-06-28 at 13 08 51" src="https://user-images.githubusercontent.com/2244375/27636442-780ff0f8-5c03-11e7-9521-34697e8a1265.png">


## Tested in CODE?

No.
