### PR TITLE
fix reference to close function in toggles

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -47,7 +47,7 @@ class Toggles {
                         doNotReset.includes(control.getAttribute('data-toggle'))
                     )
             )
-            .forEach(close);
+            .forEach(this.close);
     }
 
     prepareControl(control: HTMLElement): void {


### PR DESCRIPTION
## What does this change?

Fix bug in toggles that closes windows opened by script

## What is the value of this and can you measure success?

Fixes bug!

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

N/A

## Tested in CODE?

No