### PR TITLE
Breathing room for pillars

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -46,7 +46,7 @@
     }
 
     &::placeholder {
-        color: #ffffff;
+        color: $news-support-1;
     }
 
     &:focus {
@@ -73,7 +73,7 @@
     }
 
     .inline-search-36__svg {
-        fill: $news-support-2;
+        fill: $news-main-2;
         height: 22px;
         width: 22px;
 

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -34,7 +34,7 @@
 
     @include mq(desktop) {
         min-width: 0;
-        padding-right: 16px;
+        padding-right: $gs-gutter;
         transition: min-width 200ms ease;
         will-change: min-width;
 
@@ -57,7 +57,7 @@
 
         // Slashes switch to left hand side for open animation
         @include mq(desktop) {
-            left: -12px;
+            left: -$gs-gutter / 1.5;
             margin: 0;
             position: absolute;
             top: 0;


### PR DESCRIPTION
A bit more breathing room between the pillars and a higher contrast and more harmonious search field.

Before:
<img width="441" alt="screen shot 2017-06-29 at 15 59 13" src="https://user-images.githubusercontent.com/14570016/27694636-8cf4cc32-5ce4-11e7-99d4-f15f907468ac.png">

After:
<img width="443" alt="screen shot 2017-06-29 at 15 59 01" src="https://user-images.githubusercontent.com/14570016/27694634-8cf3a32a-5ce4-11e7-8cd9-843968591936.png">

Before:
<img width="636" alt="screen shot 2017-06-29 at 16 02 15" src="https://user-images.githubusercontent.com/14570016/27694635-8cf4a05e-5ce4-11e7-8628-450161a73c7e.png">

After:
<img width="636" alt="screen shot 2017-06-29 at 16 02 11" src="https://user-images.githubusercontent.com/14570016/27694637-8cf601d8-5ce4-11e7-9974-fd8410baba0f.png">

