### PR TITLE
Remove unused live-blog-chrome-notifications-prod switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -464,17 +464,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  // Owner: Francis Carr
-  val LiveBlogChromeNotificationsProd = Switch(
-    SwitchGroup.Feature,
-    "live-blog-chrome-notifications-prod",
-    "Live blog chrome notifications - prod",
-    owners = Seq(Owner.withGithub("janua")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 6, 30), //Friday
-    exposeClientSide = true
-  )
-
   // Owner: David Furey
   val guTodayEmailAds = Switch(
     SwitchGroup.Feature,


### PR DESCRIPTION
## What does this change?
Removing a switch that is not being used anymore. This is a leftover of https://github.com/guardian/frontend/pull/17025

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No
