### PR TITLE
Enable thrasher-driven bundle price test on more fronts

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1-thrasher.js
@@ -21,21 +21,28 @@ define([
 
         this.description = 'Test digital subs price points via thrasher';
         this.showForSensitive = true;
-        this.audience = 0.25;   // 25% of UK front audience (non-paying only)
+        this.audience = 0.25;   // 25% of UK fronts audience (non-paying only)
         this.audienceOffset = 0.1;  // offset by 10% for our Epic version
         this.successMeasure = '';
-        this.audienceCriteria = 'Non-paying UK network front users - mobile resolution and above';
+        this.audienceCriteria = 'Non-paying UK selected front users - mobile resolution and above';
         this.dataLinkNames = '';
         this.idealOutcome = 'Find the price that works for most people.';
         this.hypothesis = 'One of our price points will be more desirable than the others';
 
         this.canRun = function () {
+            var pageIdLowered = config.page.pageId.toLowerCase();
             return document.querySelector('#membership-ab-thrasher') &&
                 !cookies.getCookie('GU_DBPT1ME') && // have to piggy-back this onto the epic version's dropped cookie
                 !userFeatures.isPayingMember() &&
                 config.page.isFront &&
-                config.page.pageId.toLowerCase() === "uk" &&
-                config.page.edition.toUpperCase() === "UK";
+                config.page.edition.toUpperCase() === "UK" &&
+                (pageIdLowered === "uk" ||
+                    pageIdLowered === "football" ||
+                    pageIdLowered === "politics" ||
+                    pageIdLowered === "world" ||
+                    pageIdLowered === "education" ||
+                    pageIdLowered === "uk/sport"
+                );
         };
 
         this.thrasherContainer = function() {


### PR DESCRIPTION
## What does this change?
In addition to the uk front, we'll start serving the thrasher-driven bundle price test on the football, politics, world, education and uk/sport fronts.

The audience allocation is remaining unchanged, so the test shouldn't need to be re-issued as a new one.

## What is the value of this and can you measure success?
It's to help us get this test finished quickly. Numbers are still too low for statistical significance as it stands.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
All captured from CODE. PROD placement will depend on where the thrasher is positioned by Central Production.

**Football**
![football-screencapture-m-code-dev-theguardian-football-1498754518217](https://user-images.githubusercontent.com/690395/27699644-daf658e8-5cf2-11e7-8b9a-4e2b1d1976a6.png)

**Politics**
![politics-screencapture-m-code-dev-theguardian-politics-1498754558422](https://user-images.githubusercontent.com/690395/27699658-e619e4ce-5cf2-11e7-8f07-cb81f6f9b984.png)

**World**
![world-screencapture-m-code-dev-theguardian-world-1498754595338](https://user-images.githubusercontent.com/690395/27699705-0f7b76f2-5cf3-11e7-834a-c23b0531c450.png)

**Education**
![education-screencapture-m-code-dev-theguardian-education-1498754630764](https://user-images.githubusercontent.com/690395/27699717-192ee38c-5cf3-11e7-9571-227c462fa9f2.png)

**Sport**
![sport-screencapture-m-code-dev-theguardian-uk-sport-1498754448962](https://user-images.githubusercontent.com/690395/27699730-24e6faac-5cf3-11e7-8ad4-d4a99dae0a68.png)

## Tested in CODE?
Yes

cc @rupertbates @davidfurey @svillafe
see also: https://github.com/guardian/membership-frontend/pull/1685

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
