### PR TITLE
Remove double commercial module load

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -46,9 +46,7 @@ if (!commercialFeatures.adFree) {
         ['cm-articleAsideAdverts', articleAsideAdvertsInit, true],
         ['cm-articleBodyAdverts', articleBodyAdvertsInit],
         ['cm-liveblogAdverts', initLiveblogAdverts, true],
-        ['cm-stickyTopBanner', stickyTopBanner.init],
-        ['cm-paidContainers', paidContainers],
-        ['cm-paidforBand', paidforBand.init]
+        ['cm-stickyTopBanner', stickyTopBanner.init]
     );
 }
 


### PR DESCRIPTION
This removes `cm-paidContainers` and `cm-paidforBand` from the non ad free push to `commercialModules`. They already are going to be initialised in the code above it. I am presuming it was from the non ad free push we would like it removed from. (They will still load if it is ad-free)

@regiskuckaertz 

@JustinPinner Might want to look at this, perhaps the intention was to only load them when it was not ad free?