### PR TITLE
New snippet atoms

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -211,6 +211,7 @@ object ContentTypeFormat {
   implicit val qandaAtomForm = Json.format[model.content.QandaAtom]
   implicit val guideAtomForm = Json.format[model.content.GuideAtom]
   implicit val profileAtomForm = Json.format[model.content.ProfileAtom]
+  implicit val timelineItemForm = Json.format[model.content.TimelineItem]
   implicit val timelineAtomForm = Json.format[model.content.TimelineAtom]
 
   implicit val atomsWrite = Json.writes[Atoms]

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,4 +1,8 @@
 @import model.content.MediaWrapper
+@import model.content.QandaAtom
+@import model.content.TimelineAtom
+@import model.content.GuideAtom
+@import model.content.ProfileAtom
 @(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom}
@@ -9,6 +13,10 @@
         case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
         case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp)
+        case qanda: QandaAtom => views.html.fragments.atoms.snippets.qanda(qanda, isAmp = amp)
+        case timeline: TimelineAtom => views.html.fragments.atoms.snippets.timeline(timeline, isAmp = amp)
+        case guide: GuideAtom => views.html.fragments.atoms.snippets.guide(guide, isAmp = amp)
+        case profile: ProfileAtom => views.html.fragments.atoms.snippets.profile(profile, isAmp = amp)
         case _ =>
     }
 }

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -1,6 +1,6 @@
-@(className: String, label: String, headline: String)(body: Html)(implicit request: RequestHeader)
+@(className: String, label: String, headline: String, id: String)(body: Html)(implicit request: RequestHeader)
 
-<details class="clean explainer-snippet explainer-snippet--light explainer-snippet--@className">
+<details data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
   <summary class="explainer-snippet__header">
     <span class="explainer-snippet__label">@label</span>
     <h4 class="explainer-snippet__headline">@headline</h4>

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -1,0 +1,25 @@
+@(className: String, label: String, headline: String)(body: Html)(implicit request: RequestHeader)
+
+<details class="clean explainer-snippet explainer-snippet--light explainer-snippet--@className">
+  <summary class="explainer-snippet__header">
+    <span class="explainer-snippet__label">@label</span>
+    <h4 class="explainer-snippet__headline">@headline</h4>
+    <button class="button button--large explainer-snippet__handle" aria-hidden="true">
+      <span>@fragments.inlineSvg("plus", "icon") Show</span>
+      <span>@fragments.inlineSvg("minus", "icon") Hide</span>
+    </button>
+  </summary>
+  <div class="explainer-snippet__body">
+    @body
+  </div>
+  <footer class="explainer-snippet__footer">
+    <div class="explainer-snippet__feedback">
+      <div>Was this explainer-snippet helpful?</div>
+      <button class="button" value="like" aria-label="Yes">@fragments.inlineSvg("thumb", "icon")</button>
+      <button class="button" value="dislike" aria-label="No">@fragments.inlineSvg("thumb", "icon")</button>
+    </div>
+    <div class="explainer-snippet__ack" hidden aria-role="alert" aria-live="polite">
+      Thank you for your feedback.
+    </div>
+  </footer>
+</details>

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -14,7 +14,7 @@
   </div>
   <footer class="explainer-snippet__footer">
     <div class="explainer-snippet__feedback">
-      <div>Was this explainer-snippet helpful?</div>
+      <div>Was this helpful?</div>
       <button class="button" value="like" aria-label="Yes">@fragments.inlineSvg("thumb", "icon")</button>
       <button class="button" value="dislike" aria-label="No">@fragments.inlineSvg("thumb", "icon")</button>
     </div>

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -4,7 +4,8 @@
   @fragments.atoms.snippet(
     className = "guide",
     label = guide.data.typeLabel.getOrElse("Quick Guide"),
-    headline = guide.atom.title.getOrElse("")
+    headline = guide.atom.title.getOrElse(""),
+    guide.id
   ){
     @for(guideImage <- guide.data.guideImage; master <- guideImage.master) {
       <div class="explainer-snippet__image">

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -1,5 +1,20 @@
 @(guide: model.content.GuideAtom, isAmp: Boolean)(implicit request: RequestHeader)
 
 @if(!isAmp) {
-    <div></div>
+  @fragments.atoms.snippet(
+    className = "guide",
+    label = guide.data.typeLabel.getOrElse("Quick Guide"),
+    headline = guide.atom.title.getOrElse("")
+  ){
+    @guide.data.guideImage.map { image => image.master }
+
+    @for(item <- guide.data.items) {
+      <div class="explainer-snippet__item">
+        @item.title.map { t =>
+          <div class="explainer-snippet__heading"><b>@t</b></div>
+        }
+        @item.body
+      </div>
+    }
+  }
 }

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -6,9 +6,9 @@
     label = guide.data.typeLabel.getOrElse("Quick Guide"),
     headline = guide.atom.title.getOrElse("")
   ){
-    @guide.data.guideImage.map { image =>
+    @for(guideImage <- guide.data.guideImage; master <- guideImage.master) {
       <div class="explainer-snippet__image">
-        image.master
+        <img src="@master.file"/>
       </div>
     }
 

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -6,7 +6,11 @@
     label = guide.data.typeLabel.getOrElse("Quick Guide"),
     headline = guide.atom.title.getOrElse("")
   ){
-    @guide.data.guideImage.map { image => image.master }
+    @guide.data.guideImage.map { image =>
+      <div class="explainer-snippet__image">
+        image.master
+      </div>
+    }
 
     @for(item <- guide.data.items) {
       <div class="explainer-snippet__item">

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -1,5 +1,20 @@
-@(guide: model.content.ProfileAtom, isAmp: Boolean)(implicit request: RequestHeader)
+@(profile: model.content.ProfileAtom, isAmp: Boolean)(implicit request: RequestHeader)
 
 @if(!isAmp) {
-    <div></div>
+  @fragments.atoms.snippet(
+    className = "profile",
+    label = profile.data.typeLabel.getOrElse("Quick Guide"),
+    headline = profile.atom.title.getOrElse("")
+  ){
+    @profile.data.headshot.map { image => image.master }
+
+    @for(item <- profile.data.items) {
+      <div class="explainer-snippet__item">
+        @item.title.map { t =>
+          <div class="explainer-snippet__heading"><b>@t</b></div>
+        }
+        @item.body
+      </div>
+    }
+  }
 }

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -4,7 +4,8 @@
   @fragments.atoms.snippet(
     className = "profile",
     label = profile.data.typeLabel.getOrElse("Quick Guide"),
-    headline = profile.atom.title.getOrElse("")
+    headline = profile.atom.title.getOrElse(""),
+    profile.id
   ){
     @for(headshot <- profile.data.headshot; master <- headshot.master) {
       <div class="explainer-snippet__image">

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -6,7 +6,11 @@
     label = profile.data.typeLabel.getOrElse("Quick Guide"),
     headline = profile.atom.title.getOrElse("")
   ){
-    @profile.data.headshot.map { image => image.master }
+    @profile.data.headshot.map { image =>
+      <div class="explainer-snippet__image">
+        image.master
+      </div>
+    }
 
     @for(item <- profile.data.items) {
       <div class="explainer-snippet__item">

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -6,9 +6,9 @@
     label = profile.data.typeLabel.getOrElse("Quick Guide"),
     headline = profile.atom.title.getOrElse("")
   ){
-    @profile.data.headshot.map { image =>
+    @for(headshot <- profile.data.headshot; master <- headshot.master) {
       <div class="explainer-snippet__image">
-        image.master
+        <img src="@master.file"/>
       </div>
     }
 

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -6,15 +6,12 @@
     label = qa.data.typeLabel.getOrElse("Q&amp;A"),
     headline = qa.atom.title.getOrElse("")
   ){
-    @qa.data.eventImage.map { image =>
+    @for(eventImage <- qa.data.eventImage; master <- eventImage.master) {
       <div class="explainer-snippet__image">
-        image.master
+        <img src="@master.file"/>
       </div>
     }
 
-    @qa.data.item.title.map { t =>
-      <div class="explainer-snippet__heading"><b>@t</b></div>
-    }
     @qa.data.item.body
   }
 }

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -1,5 +1,18 @@
-@(guide: model.content.QandaAtom, isAmp: Boolean)(implicit request: RequestHeader)
+@(qa: model.content.QandaAtom, isAmp: Boolean)(implicit request: RequestHeader)
 
 @if(!isAmp) {
-    <div></div>
+  @fragments.atoms.snippet(
+    className = "qanda",
+    label = qa.data.typeLabel.getOrElse("Q&amp;A"),
+    headline = qa.atom.title.getOrElse("")
+  ){
+    @qa.data.eventImage.map { image => image.master }
+
+    <div class="explainer-snippet__item">
+      @qa.data.item.title.map { t =>
+        <div class="explainer-snippet__heading"><b>@t</b></div>
+      }
+      @qa.data.item.body
+    </div>
+  }
 }

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -6,13 +6,15 @@
     label = qa.data.typeLabel.getOrElse("Q&amp;A"),
     headline = qa.atom.title.getOrElse("")
   ){
-    @qa.data.eventImage.map { image => image.master }
+    @qa.data.eventImage.map { image =>
+      <div class="explainer-snippet__image">
+        image.master
+      </div>
+    }
 
-    <div class="explainer-snippet__item">
-      @qa.data.item.title.map { t =>
-        <div class="explainer-snippet__heading"><b>@t</b></div>
-      }
-      @qa.data.item.body
-    </div>
+    @qa.data.item.title.map { t =>
+      <div class="explainer-snippet__heading"><b>@t</b></div>
+    }
+    @qa.data.item.body
   }
 }

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -4,7 +4,8 @@
   @fragments.atoms.snippet(
     className = "qanda",
     label = qa.data.typeLabel.getOrElse("Q&amp;A"),
-    headline = qa.atom.title.getOrElse("")
+    headline = qa.atom.title.getOrElse(""),
+    qa.id
   ){
     @for(eventImage <- qa.data.eventImage; master <- eventImage.master) {
       <div class="explainer-snippet__image">

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -1,5 +1,19 @@
-@(guide: model.content.TimelineAtom, isAmp: Boolean)(implicit request: RequestHeader)
+@(timeline: model.content.TimelineAtom, isAmp: Boolean)(implicit request: RequestHeader)
+
+@import org.joda.time.format.DateTimeFormat
 
 @if(!isAmp) {
-    <div></div>
+  @fragments.atoms.snippet(
+    className = "timeline",
+    label = timeline.data.typeLabel.getOrElse("Quick Guide"),
+    headline = timeline.atom.title.getOrElse("")
+  ){
+    @for(item <- timeline.data.events) {
+      <div class="explainer-snippet__item">
+        <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.forPattern("").print(item.date)</time>
+        <div class="explainer-snippet__heading"><b>@item.title</b></div>
+        @item.body
+      </div>
+    }
+  }
 }

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -6,7 +6,8 @@
   @fragments.atoms.snippet(
     className = "timeline",
     label = timeline.data.typeLabel.getOrElse("Timeline"),
-    headline = timeline.atom.title.getOrElse("")
+    headline = timeline.atom.title.getOrElse(""),
+    timeline.id
   ){
     @for(item <- timeline.data.events) {
       <div class="explainer-snippet__item">

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -5,7 +5,7 @@
 @if(!isAmp) {
   @fragments.atoms.snippet(
     className = "timeline",
-    label = timeline.data.typeLabel.getOrElse("Quick Guide"),
+    label = timeline.data.typeLabel.getOrElse("Timeline"),
     headline = timeline.atom.title.getOrElse("")
   ){
     @for(item <- timeline.data.events) {

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -10,7 +10,7 @@
   ){
     @for(item <- timeline.data.events) {
       <div class="explainer-snippet__item">
-        <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.forPattern("").print(item.date)</time>
+        <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.longDate.print(item.date)</time>
         <div class="explainer-snippet__heading"><b>@item.title</b></div>
         @item.body
       </div>

--- a/static/src/javascripts-legacy/bootstraps/enhanced/article.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/article.js
@@ -14,7 +14,8 @@ define([
     'common/modules/atoms/story-questions',
     'bootstraps/enhanced/article-liveblog-common',
     'bootstraps/enhanced/trail',
-    'ophan/ng'
+    'ophan/ng',
+    'projects/journalism/snippet-feedback'
 ], function (
     qwery,
     $,
@@ -30,7 +31,8 @@ define([
     storyQuestions,
     articleLiveblogCommon,
     trail,
-    ophan
+    ophan,
+    snippetFeedback
 ) {
     var modules = {
         initCmpParam: function () {
@@ -71,6 +73,7 @@ define([
         mediator.emit('page:article:ready');
         quiz.handleCompletion();
         storyQuestions.init();
+        snippetFeedback.SnippetFeedback();
     };
 
     return {

--- a/static/src/javascripts/projects/journalism/snippet-feedback.js
+++ b/static/src/javascripts/projects/journalism/snippet-feedback.js
@@ -1,0 +1,84 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import mediator from 'lib/mediator';
+import ophan from 'ophan/ng';
+import detect from 'lib/detect';
+
+const SnippetFeedback = () => {
+    const snippets = document.querySelectorAll('.explainer-snippet--new');
+
+    [].forEach.call(snippets, snippet => {
+        const atomId = snippet.getAttribute('data-snippet-id');
+        const snippetType = snippet.getAttribute('data-snippet-type');
+        if (!atomId || !snippetType) {
+            return;
+        }
+        const component = `snippet_${snippetType}`;
+
+        // Callback for like/dislike
+        const onFeedback = e => {
+            const question = e.currentTarget;
+            const ack = snippet.querySelector('.explainer-snippet__ack');
+            if (!(question instanceof HTMLElement)) {
+                throw new Error('Flow phantom exception');
+            }
+            const button =
+                e.target instanceof Element && e.target.closest('.button');
+            const value =
+                button && button instanceof HTMLButtonElement && button.value;
+
+            if (value) {
+                const data = {
+                    atomId,
+                    component,
+                    value: `${snippetType}_feedback_${value}`,
+                };
+                ophan.record(data);
+                fastdom.write(() => {
+                    ack.hidden = false;
+                    question.hidden = true;
+                });
+                e.currentTarget.removeEventListener('click', onFeedback);
+            }
+        };
+
+        snippet
+            .querySelector('.explainer-snippet__feedback')
+            .addEventListener('click', onFeedback);
+
+        // Callback for scroll into view
+        mediator.on('window:throttledScroll', function onScroll() {
+            const height = detect.getViewport().height;
+            const coords = snippet.getBoundingClientRect();
+            const isInView = coords.top >= 0 && coords.bottom <= height;
+
+            if (isInView) {
+                const data = {
+                    atomId,
+                    component,
+                    value: `${snippetType}_component_in_view`,
+                };
+                ophan.record(data);
+
+                mediator.off('window:throttledScroll', onScroll);
+            }
+        });
+
+        // Callback for expand
+        const handle = snippet.querySelector('.explainer-snippet__handle');
+        if (handle) {
+            handle.addEventListener('click', function onExpand(e) {
+                const data = {
+                    atomId,
+                    component,
+                    value: `${snippetType}_expanded`,
+                };
+                ophan.record(data);
+
+                e.currentTarget.removeEventListener('click', onExpand);
+            });
+        }
+    });
+};
+
+export { SnippetFeedback };

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -21,6 +21,7 @@
 @import 'module/atoms/_media';
 @import 'module/atoms/_storyquestions';
 @import 'module/atoms/_explainers';
+@import 'module/atoms/_snippets';
 @import 'module/commercial/_commercial';
 @import 'module/crosswords/_main';
 @import 'module/email-signup/_main';

--- a/static/src/stylesheets/module/atoms/_explainers.scss
+++ b/static/src/stylesheets/module/atoms/_explainers.scss
@@ -62,6 +62,7 @@
 }
 
 .explainer-snippet__body {
+    overflow: hidden;
     // > p {
     //     @include faux-bullet-point;
     //
@@ -159,6 +160,7 @@
 
     .explainer-snippet__label {
         color: $news-support-1;
+        margin-top: 2px;
     }
 
     .explainer-snippet__handle {

--- a/static/src/stylesheets/module/atoms/_snippets.scss
+++ b/static/src/stylesheets/module/atoms/_snippets.scss
@@ -1,19 +1,45 @@
-.explainer-snippet--guide {
-    .explainer-snippet__image {
-        float: left;
-        margin-right: $gs-gutter / 2;
+.explainer-snippet__image {
+    float: left;
+    margin-right: $gs-gutter / 2;
+}
+
+.explainer-snippet__item::before {
+    content: '';
+    display: block;
+    width: 200px;
+    height: 0;
+    border-top: 1px dotted $neutral-2;
+}
+
+.explainer-snippet__item+.explainer-snippet__item {
+    padding-top: $gs-baseline;
+}
+
+.explainer-snippet__heading {
+    font-size: 18px;
+}
+
+.explainer-snippet__event-date::before {
+    content: '';
+    width: 16px;
+    height: 16px;
+    border-radius: 100%;
+    float: left;
+    margin-left: -26px;
+    background-color: $neutral-2;
+}
+
+.explainer-snippet__event-date {
+    font-size: 18px;
+}
+
+.explainer-snippet--timeline {
+    .explainer-snippet__body {
+        margin-left: 8px;
     }
 
-    .explainer-snippet__item::before {
-        content: '';
-        display: block;
-        width: 100px;
-        height: 0;
-        border-top: 1px dotted #ffffff;
-    }
-
-    .explainer-snippet__heading {
-        color: $news-support-5;
-        font-size: 18px;
+    .explainer-snippet__item {
+        padding-left: 17px;
+        border-left: 1px solid rgba($neutral-2, .5);
     }
 }

--- a/static/src/stylesheets/module/atoms/_snippets.scss
+++ b/static/src/stylesheets/module/atoms/_snippets.scss
@@ -1,0 +1,19 @@
+.explainer-snippet--guide {
+    .explainer-snippet__image {
+        float: left;
+        margin-right: $gs-gutter / 2;
+    }
+
+    .explainer-snippet__item::before {
+        content: '';
+        display: block;
+        width: 100px;
+        height: 0;
+        border-top: 1px dotted #ffffff;
+    }
+
+    .explainer-snippet__heading {
+        color: $news-support-5;
+        font-size: 18px;
+    }
+}

--- a/static/src/stylesheets/module/atoms/_snippets.scss
+++ b/static/src/stylesheets/module/atoms/_snippets.scss
@@ -1,12 +1,32 @@
 .explainer-snippet__image {
     float: left;
     margin-right: $gs-gutter / 2;
+
+    display: inline-block;
+    position: relative;
+    width: 33%;
+    height: 0;
+    overflow: hidden;
+    border-radius: 50%;
+    padding-top: 33%;
+}
+
+.explainer-snippet__image img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    object-fit: cover;
 }
 
 .explainer-snippet__item::before {
     content: '';
-    display: block;
+    display: flex;
     width: 200px;
+    @include mq($until: mobileLandscape) {
+        width: 100px;
+    }
     height: 0;
     border-top: 1px dotted $neutral-2;
 }
@@ -36,6 +56,7 @@
 .explainer-snippet--timeline {
     .explainer-snippet__body {
         margin-left: 8px;
+        overflow: visible;
     }
 
     .explainer-snippet__item {

--- a/static/src/stylesheets/module/atoms/_snippets.scss
+++ b/static/src/stylesheets/module/atoms/_snippets.scss
@@ -24,11 +24,11 @@
     content: '';
     display: flex;
     width: 200px;
+    height: 0;
+    border-top: 1px dotted $neutral-2;
     @include mq($until: mobileLandscape) {
         width: 100px;
     }
-    height: 0;
-    border-top: 1px dotted $neutral-2;
 }
 
 .explainer-snippet__item+.explainer-snippet__item {


### PR DESCRIPTION
## What does this change?
Adds support for 4 new expandable 'snippet' atoms.

## What is the value of this and can you measure success?
Editorial have agreed to start creating these atoms.
Each snippet can send 3 events to ophan:
1. on viewed
2. on expanded
3. on like/dislike

## Does this affect other platforms - Amp, Apps, etc?
N/A

## Screenshots
![picture 13](https://user-images.githubusercontent.com/1513454/27697312-c385a864-5ceb-11e7-9a7e-bc69a9c7c39c.png)
![picture 14](https://user-images.githubusercontent.com/1513454/27697326-cac43df2-5ceb-11e7-8903-06ea506b0123.png)
![picture 15](https://user-images.githubusercontent.com/1513454/27697332-cf59a168-5ceb-11e7-9dda-c4b51fb565d5.png)

(profile snippet not yet available)

## Tested in CODE?
Yes