### PR TITLE
Add length check to truncate Related Content count... for aesthetic reasons

### DIFF
--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -19,8 +19,11 @@ class PopularInTag(val contentApiClient: ContentApiClient, val mostReadAgent: Mo
   }
 
   private def renderPopularInTag(trails: RelatedContent)(implicit request: RequestHeader) = Cached(600) {
+    // Initially a fix for PaidFor related content (where this problem is more common), the decision to truncate is due
+    // to aesthetic issues with the second slice when there are only 5 or 6 results in related content (7 looks fine).
+    val numberOfCards = if (trails.faciaItems.length == 5 || trails.faciaItems.length == 6) 4 else 8
     val html = views.html.fragments.containers.facia_cards.container(
-      onwardContainer("related content", trails.faciaItems take 8),
+      onwardContainer("related content", trails.faciaItems take numberOfCards),
       FrontProperties.empty
     )
 


### PR DESCRIPTION
## What does this change?

On Labs pages, if not enough `related content` is available, the container at the bottom of the page looks broken on tablet and desktop.

The existing code assumes that `popularInTag` will always contain at least 8 items to place in `related content`. However, on Labs content we often do not have enough results to fill the second slice in the container. If there are only 5 items, it looks very broken. If there are 6 it looks kinda broken.

This is a bigger issue with PaidFor cards, since these (currently) will always display an image. When the item cards expand to fill the slice, the trail image is visibly pixelated.

This PR adds a check to see if the item count in `related content` is 5 or 6. If so we truncate the results to 4 (only one slice)

## What is the value of this and can you measure success?

Pleasing layout at end of article (see screenshots)

Examples articles can be found here: https://www.theguardian.com/tone/advertisement-features

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

##### Before:
<img width="1187" alt="picture 811" src="https://user-images.githubusercontent.com/8607683/27736508-54d49f5e-5d9c-11e7-8293-30a4c0ccab85.png">

<img width="1309" alt="picture 810" src="https://user-images.githubusercontent.com/8607683/27736328-a4e81134-5d9b-11e7-8837-c889e2f84d8e.png">


##### After:
<img width="1185" alt="picture 812" src="https://user-images.githubusercontent.com/8607683/27736538-78d81e4e-5d9c-11e7-82af-6c6df448a40e.png">

<img width="1296" alt="picture 804" src="https://user-images.githubusercontent.com/8607683/27736027-379f31f8-5d9a-11e7-95c8-dc1f361323a8.png">

##### No change for 7 or 8 items:
<img width="1320" alt="picture 813" src="https://user-images.githubusercontent.com/8607683/27736636-ee0a7220-5d9c-11e7-9b38-d69e48d58e09.png">

<img width="1187" alt="picture 814" src="https://user-images.githubusercontent.com/8607683/27736716-4789c7ec-5d9d-11e7-8bc6-1b772d160e4c.png">

