### PR TITLE
Fix comment history page

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
@@ -17,8 +17,8 @@ define([
 ) {
 
     function hasBrexitTag(){
-        var tags = config.page.keywordIds && config.page.keywordIds.concat(config.page.nonKeywordTagIds);
-        return tags && tags.indexOf('politics/eu-referendum') > -1;
+        var tags = config.get('page.keywordIds', []).concat(config.get('page.nonKeywordTagIds', []));
+        return tags.indexOf('politics/eu-referendum') > -1;
     }
 
     function createBrexitTestTemplate() {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
@@ -17,7 +17,7 @@ define([
 ) {
 
     function hasBrexitTag(){
-        var tags = config.page.keywordIds.concat(config.page.nonKeywordTagIds);
+        var tags = config.page.keywordIds && config.page.keywordIds.concat(config.page.nonKeywordTagIds);
         return tags.indexOf('politics/eu-referendum') > -1;
     }
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/epic-for-brexit-cohort.js
@@ -18,7 +18,7 @@ define([
 
     function hasBrexitTag(){
         var tags = config.page.keywordIds && config.page.keywordIds.concat(config.page.nonKeywordTagIds);
-        return tags.indexOf('politics/eu-referendum') > -1;
+        return tags && tags.indexOf('politics/eu-referendum') > -1;
     }
 
     function createBrexitTestTemplate() {


### PR DESCRIPTION
## What does this change?
Safely accesses `config.page.keywordIds` to avoid error on comment history page for users in the brexit cohort.  Note: this is not the first time this has happened so we will look into if/how we can make the interface to config safer.

## What is the value of this and can you measure success?
Comment histories work again.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
