### PR TITLE
Show weather time in the location local time

### DIFF
--- a/onward/app/weather/models/ForecastResponse.scala
+++ b/onward/app/weather/models/ForecastResponse.scala
@@ -38,8 +38,5 @@ case class ForecastResponse(
     }
   }
 
-  def hourString(implicit request: RequestHeader) = {
-    val edition = Edition(request)
-    new DateTime(epochDateTime * 1000L).withZone(edition.timezone).toString("HH:00")
-  }
+  def hourString = new DateTime(epochDateTime * 1000L).toString("HH:00")
 }


### PR DESCRIPTION
Showing the time according to the edition leads to inconcistency issue:
Weather icons (coming from accuweather) are related to the location
local time (ex: moonshine during the night, sunshine during the day)
but the time is shown according to the edition time. See screenshot below

![screen shot 2017-06-30 at 14 48 56](https://user-images.githubusercontent.com/233326/27738450-45e675d8-5da3-11e7-90f0-a14ec8d3dc13.png)

## What does this change?
Show weather in local time

## What is the value of this and can you measure success?
No inconsistency between icons and times

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots

## Tested in CODE?
No

cc @guardian/dotcom-platform 