### PR TITLE
Reprioritise ES6 conversions

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -20,14 +20,15 @@
   ],
   "Simon Adcock": [
     "projects/commercial/modules/sticky-top-banner.js",
+    "projects/common/modules/commercial/membership-engagement-banner.js",
+    "lib/client-rects.js",
     "projects/common/modules/article/membership-events.js",
     "projects/common/modules/discussion/upvote.js",
     "projects/common/modules/discussion/user-avatars.js",
     "projects/common/modules/discussion/whole-discussion.js",
     "projects/common/modules/experiments/tests/bookmarks-email-variants-2.js",
     "projects/common/modules/ui/blockSharing.js",
-    "projects/common/modules/ui/clickstream.js",
-    "lib/client-rects.js"
+    "projects/common/modules/ui/clickstream.js"
   ],
   "Nicolas Long": [
     "lib/atob.js",


### PR DESCRIPTION
## What does this change?

I noticed that [`membership-engagement-banner.js`](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js) is currently missing from the list of modules to convert, so I have assigned it to myself with high priority. I consider this high priority as its tests are causing intermittent build failures (to such an extent that we have deleted them from the repo - #17282!). I will presently reinstate these tests and attempt to fix the intermittent failure by moving them to the more deterministic Jest framework. 

I have also bumped `lib/client-rect` up the list as I believe I can probably delete this module and install [the source](https://github.com/edg2s/rangefix) directly.

## What is the value of this and can you measure success?

ES6 conversion trundles on

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
