### PR TITLE
Inline ads vs fill ads race condition

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/enable-lazy-load.js
@@ -17,11 +17,12 @@ const enableLazyLoad = (advert: Advert): void => {
             });
         } else {
             mediator.on('window:throttledScroll', onScroll);
-            onScroll();
         }
     }
     if (dfpEnv.lazyLoadObserve) {
         observer.observe(advert.node);
+    } else {
+        onScroll();
     }
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -36,7 +36,7 @@ const fillAdvertSlots = (): Promise<void> => {
         adverts.forEach((advert, index) => {
             dfpEnv.advertIds[advert.id] = currentLength + index;
         });
-        dfpEnv.adverts.forEach(queueAdvert);
+        adverts.forEach(queueAdvert);
 
         // Once Advert constructors are called, Switch can be called, if needed.
         prepareSwitchTag.maybeCallSwitch();


### PR DESCRIPTION
There's a race condition in Commercial app, I think it must have been around since other timing fixes I've made have "slowed down" `fill-advert-slots` to control ordering. Most recently, if you load an article in Firefox a few times, without scrolling, the top banner occasionally goes missing.

It could be that this might be causing the double `advertisement` label too, but I can't reproduce the issue reliably.

Firstly, the move of `onScroll` should allow `enableLazyLoad` to be called at any time. Whilst this does carry an additional cost (more `onScroll` executions), this a throttled event handler after all, and the code is more readable and less sensitive to module execution order. Without this, only the first entrant would call `onScroll`, and nowadays we can't guarantee that this would happen after the top banner `Advert` object has been scanned from the DOM, and added to `dfpEnv.adverts`.

Secondly, I've switched the advert array being used for `queueAdvert`. It isn't immediately obvious why, but ever since the "great module parallelisation" of the commercial app, it is now possible to dynamically create a slot using `add-slot.js` before `fill-advert-slots.js` has scanned the DOM. This means that `dfpEnv.adverts` array could contain advert objects that have already been queued, and queuing something twice leads to duplicates in `dfpEnv.advertsToLoad` (but not duplicated in `dfpEnv.advertIds`)!!