### PR TITLE
Fix bug with paid-content-vs-outbrain test

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-content-vs-outbrain.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/paid-content-vs-outbrain.js
@@ -1,25 +1,27 @@
 define([
-    'lib/config'
-], function (config) {
-    return function () {
-        this.id = 'PaidContentVsOutbrain2';
-        this.start = '2017-04-24';
-        this.expiry = '2018-01-08';
-        this.author = 'Regis Kuckaertz / Lydia Shepherd';
-        this.description = 'Measure the revenue generated (or lost) by replacing the Outbrain widget with a paid content widget';
-        this.audience = .05;
-        this.audienceOffset = 0;
-        this.successMeasure = 'The paid content widget allows to release enough inventory to cover up for the lost revenue from Outbrain';
-        this.audienceCriteria = '';
-        this.dataLinkNames = '';
-        this.idealOutcome = 'We generate more revenue *without* Outbrain and the brand image gets its shiny back';
-        this.showForSensitive = true;
+    'lib/config',
+    'common/modules/commercial/contributions-utilities'
+], function (config, contributionsUtilities) {
 
-        this.canRun = function () {
+    return contributionsUtilities.makeABTest({
+        id: 'PaidContentVsOutbrain2',
+        start: '2017-04-24',
+        expiry: '2018-01-08',
+        author: 'Regis Kuckaertz / Lydia Shepherd',
+        description: 'Measure the revenue generated (or lost) by replacing the Outbrain widget with a paid content widget',
+        audience: .05,
+        audienceOffset: 0,
+        successMeasure: 'The paid content widget allows to release enough inventory to cover up for the lost revenue from Outbrain',
+        audienceCriteria: '',
+        dataLinkNames: '',
+        idealOutcome: 'We generate more revenue *without* Outbrain and the brand image gets its shiny back',
+        showForSensitive: true,
+
+        canRun: function () {
             return config.page.edition === 'UK';
-        };
+        },
 
-        this.variants = [
+        variants: [
             {
                 id: 'paid-content',
                 test: function () {
@@ -30,6 +32,7 @@ define([
                 test: function () {
                 }
             }
-        ];
-    };
+        ]
+
+    });
 });

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -14,7 +14,7 @@ import AcquisitionsThrasherUkElection from 'common/modules/experiments/tests/acq
 import BundleDigitalSubPriceTest1Thrasher from 'common/modules/experiments/tests/bundle-digital-sub-price-test-1-thrasher';
 
 export const TESTS: Array<ABTest> = [
-    new PaidContentVsOutbrain2(),
+    PaidContentVsOutbrain2,
     getAcquisitionTest(),
     tailorSurvey,
     ExplainerSnippet(),


### PR DESCRIPTION
## What does this change?

When switching on the test `paid-content-vs-outbrain`, it was working as the module exported a function that took no parameters to receive the test object, but in `third-part-tags` and in `high-merch`, we were referencing the function without calling it, and passing it to both `testCanBeRun` and `getTestVariantId`; they subsequently were calling things like `id` and `expiry` on a `function` object.

## Fix

Instead of fixing the references to the test, I have opted to update the test to use `contributionsUtilities.makeABTest`, which is a helper function to make AB tests; these tests are now objects.

## Screenshots

![outbrain](https://user-images.githubusercontent.com/445472/27791001-e8abf2f4-5fea-11e7-90c5-36d343450747.png)

gets replaced with

![paid-content](https://user-images.githubusercontent.com/445472/27791003-ecdd2c94-5fea-11e7-9867-420649473d0c.png)

## Tested in CODE?

No, but this reliably works on DEV. I will test on PROD.

@rich-nguyen @lps88 
