### PR TITLE
Fix for missing onward journey on Hosted preview pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -20,8 +20,8 @@ const generateUrlFromConfig = (
         },
     } = config
 ): string =>
-    c.page.ajaxUrl && c.page.pageId && c.page.contentType
-        ? `${c.page.ajaxUrl}/${c.page
+    c.page.pageId && c.page.contentType
+        ? `${c.page.ajaxUrl || ''}/${c.page
               .pageId}/${c.page.contentType.toLowerCase()}/onward.json`
         : '';
 


### PR DESCRIPTION
Remove check for ajaxUrl config value, this is not compulsory, when it's empty a relative URL works fine (as on preview env).
