### PR TITLE
Menu: Fix sign in/ sign up area on Safari 9 / 10

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -85,11 +85,12 @@
         flex-direction: column;
         margin-left: 0;
         padding-left: $gs-gutter / 2 - 1;
-        width: gs-span(2) + $gs-gutter / 2;
+        // substracting the border-width, otherwise it breaks in Safari
+        width: gs-span(2) + $gs-gutter / 2 - 2;
     }
 
     @include mq(wide) {
-        width: gs-span(3) + $gs-gutter / 2;
+        width: gs-span(3) + $gs-gutter / 2 - 2;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Fixes the misaligned log-in/ sign-up area on Safari.

## What is the value of this and can you measure success?

Proper layout.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**
<img width="1172" alt="screen shot 2017-07-03 at 14 17 21" src="https://user-images.githubusercontent.com/2244375/27794603-b9bf16c8-5ffa-11e7-98ba-05e0adb6cb00.png">

**After**
<img width="1268" alt="screen shot 2017-07-03 at 14 16 31" src="https://user-images.githubusercontent.com/2244375/27794594-b0f7442a-5ffa-11e7-912a-c761539a9421.png">

## Tested in CODE?

No.
