### PR TITLE
Include atomId in snippet ophan reports

### DIFF
--- a/static/src/javascripts/projects/journalism/snippet-feedback.js
+++ b/static/src/javascripts/projects/journalism/snippet-feedback.js
@@ -28,7 +28,7 @@ const SnippetFeedback = (): void => {
 
             if (value && ack) {
                 const data = {
-                    snippetId,
+                    atomId: snippetId,
                     component,
                     value: `${snippetType}_feedback_${value}`,
                 };
@@ -55,7 +55,7 @@ const SnippetFeedback = (): void => {
         if (handle) {
             handle.addEventListener('click', function onExpand(e: Event) {
                 const data = {
-                    snippetId,
+                    atomId: snippetId,
                     component,
                     value: `${snippetType}_expanded`,
                 };
@@ -81,7 +81,7 @@ const SnippetFeedback = (): void => {
                 const component = `snippet_${snippetType}`;
 
                 const data = {
-                    snippetId,
+                    atomId: snippetId,
                     component,
                     value: `${snippetType}_component_in_view`,
                 };


### PR DESCRIPTION
## What does this change?
Includes the atomId under the correct name in the request to ophan

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
