### PR TITLE
New header should resize appropriately when there are page skins

### DIFF
--- a/static/src/stylesheets/layout/new-header/_feedback-form.scss
+++ b/static/src/stylesheets/layout/new-header/_feedback-form.scss
@@ -19,6 +19,12 @@
 
     @include mq(wide) {
         width: $gs-column-width * 3;
+
+        .has-page-skin & {
+            width: auto;
+            position: relative;
+            left: 0;
+        }
     }
 }
 
@@ -36,6 +42,12 @@
         position: absolute;
         top: 2px;
         left: -$gs-gutter * 2;
+
+        .has-page-skin & {
+            position: relative;
+            top: $gs-baseline / 2;
+            left: 0;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_feedback-form.scss
+++ b/static/src/stylesheets/layout/new-header/_feedback-form.scss
@@ -23,7 +23,7 @@
         .has-page-skin & {
             width: auto;
             position: relative;
-            left: 0;
+            right: auto;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -91,6 +91,15 @@
 
     @include mq(wide) {
         width: gs-span(3) + $gs-gutter / 2 - 2;
+
+        .has-page-skin & {
+            border-top: 1px solid $guardian-brand;
+            border-left-width: 0;
+            flex-wrap: nowrap;
+            flex-direction: row;
+            width: 100%;
+            padding-left: 0;
+        }
     }
 }
 
@@ -162,6 +171,10 @@
 
     @include mq(wide) {
         margin-right: gs-span(1) + $gs-gutter * 1.5;
+
+        .has-page-skin & {
+            margin-right: 0;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -49,6 +49,13 @@
             margin-left: $gs-gutter / 2;
             width: gs-span(2) + $gs-gutter / 2;
         }
+
+        .has-page-skin & {
+            @include mq(wide) {
+                margin-left: $gs-gutter / 2;
+                width: gs-span(2) + $gs-gutter / 2;
+            }
+        }
     }
 }
 
@@ -66,6 +73,12 @@
     @include mq(leftCol) {
         width: 100%;
     }
+
+    .has-page-skin & {
+        @include mq(wide) {
+            width: gs-span(4) + $gs-gutter / 2;
+        }
+    }
 }
 
 .menu-item--membership {
@@ -75,6 +88,12 @@
 
     @include mq(leftCol) {
         width: 100%;
+    }
+
+    .has-page-skin & {
+        @include mq(wide) {
+            width: gs-span(6) + $gs-gutter;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-user.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-user.scss
@@ -7,6 +7,13 @@
         flex-direction: column;
         margin-bottom: $gs-baseline / 3;
     }
+
+    .has-page-skin & {
+        @include mq(wide) {
+            flex-direction: row;
+            margin-bottom: 0;
+        }
+    }
 }
 
 .menu-user__avatar {

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -25,6 +25,12 @@ from scrolling */
             display: block;
         }
     }
+
+    .has-page-skin & .gs-container {
+        @include mq(wide) {
+            width: gs-span(12) + ($gs-gutter * 2);
+        }
+    }
 }
 
 .new-header__inner {


### PR DESCRIPTION
## What does this change?
When there is a page skin, the body and header should resize accordingly.

Please note page skins only happen at the wide breakpoint.

cc @ScottPainterGNM @guardian/commercial-dev 

## What is the value of this and can you measure success?
Looks less awful when there is a page skin.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/8774970/27799532-750f32b6-600d-11e7-9a7a-e896d1ad85ea.png)

**After:**
![image](https://user-images.githubusercontent.com/8774970/27799162-11b6f45c-600c-11e7-8fe4-cfc445d7e0f6.png)

![image](https://user-images.githubusercontent.com/8774970/27799175-1f29e9d2-600c-11e7-95aa-b7f1086a16bd.png)

## Tested in CODE?
I will be testing in CODE and take screenshots
- [x] .
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
