### PR TITLE
Menu: Align editions on IE10/11 and Safari 6 - 9

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -113,10 +113,8 @@
         }
 
         @include mq(desktop) {
-            @supports(display: flex) {
-                flex-direction: row;
-                flex-wrap: nowrap;
-            }
+            flex-direction: row;
+            flex-wrap: nowrap;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Brings editions back in line on IE10/11 and Safari 6 - 9.

## What is the value of this and can you measure success?

Proper layout.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1270" alt="screen shot 2017-07-03 at 16 16 25" src="https://user-images.githubusercontent.com/2244375/27798894-fedcb2d2-600a-11e7-9a28-962b74886d11.png">

**After**

<img width="1272" alt="screen shot 2017-07-03 at 16 15 35" src="https://user-images.githubusercontent.com/2244375/27798901-038df23c-600b-11e7-9f3e-bbdd09086c3f.png">

## Tested in CODE?

No.