### PR TITLE
Menu: Fix hidden toggle button on IE9

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -194,8 +194,7 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
         const checkboxId = checkbox.id;
         const checkboxControls = checkbox.getAttribute('aria-controls');
         const enhance = () => {
-            [...checkbox.classList].forEach(c => button.classList.add(c));
-
+            button.setAttribute('class', checkbox.getAttribute('class'));
             button.addEventListener('click', () => toggleSidebar());
             button.setAttribute('id', checkboxId);
             button.setAttribute('aria-expanded', 'false');

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -194,7 +194,12 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
         const checkboxId = checkbox.id;
         const checkboxControls = checkbox.getAttribute('aria-controls');
         const enhance = () => {
-            button.setAttribute('class', checkbox.getAttribute('class'));
+            const checkboxClassAttr = checkbox.getAttribute('class');
+
+            if (checkboxClassAttr) {
+                button.setAttribute('class', checkboxClassAttr);
+            }
+
             button.addEventListener('click', () => toggleSidebar());
             button.setAttribute('id', checkboxId);
             button.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
## What does this change?

Fixes the visible toggle button on IE9, but changing the way the classes are copied. Looks like the polyfill isn't working properly on IE9.

## What is the value of this and can you measure success?

Proper layout.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
