### PR TITLE
Extend a switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -65,7 +65,7 @@ trait ABTestSwitches {
     "This places the epic (slice design) in the middle of UK election-related interactives",
     owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 7, 3),
+    sellByDate = new LocalDate(2018, 7, 3),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
# What does this change? 
Extends the switch for adding the Epic to election interactives, as it should still be visible on those articles.