### PR TITLE
New header iphone 5 fix pillars running into the veggie burger

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -30,9 +30,6 @@ $right-column:     gs-span(4);
 $left-column:      gs-span(2); // Grows to 3 columns on wide viewports
 $left-column-wide: gs-span(3);
 
-$veggie-burger-small: 42px;
-$veggie-burger-medium: 54px;
-
 // Breakpoints
 // =============================================================================
 

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -1,3 +1,4 @@
+@import 'new-header/_variables';
 @import 'footer/_variables';
 
 // Remove file once the new header design is out on desktop

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -5,7 +5,7 @@
     cursor: pointer;
     display: block;
     font-size: 16px;
-    font-size: 5.1vw;
+    font-size: 4.9vw;
     line-height: $gs-baseline * 2.5;
     position: relative;
     transition: color 350ms;

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -3,7 +3,7 @@
     color: currentColor;
     display: inline-block;
     font-size: 16px;
-    font-size: 5.1vw;
+    font-size: 4.9vw;
     line-height: 1.3em;
 
     @include mq(mobileLandscape) {

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -10,3 +10,6 @@ $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;
 $search-and-edition-height-desktop: 42px;
 
 $highlight-blue: #00d4ff;
+
+$veggie-burger-small: 42px;
+$veggie-burger-medium: 54px;


### PR DESCRIPTION
## What does this change?
Repeat of: https://github.com/guardian/frontend/pull/14614

`vw` seems to be calculated slightly different in IOS which means that the pillars run into the veggie burger. 

The simplest solution is to just knock down the font-size. 

## What is the value of this and can you measure success?
IOS 7 on an iphone 5 looks better.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/27801330-4eec9620-6015-11e7-9818-b342a867a73a.png)

After:
![image](https://user-images.githubusercontent.com/8774970/27801129-460930b4-6014-11e7-8cd8-13e26e082932.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
