### PR TITLE
Contribute in-Epic test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,7 +135,7 @@ trait ABTestSwitches {
     "Test whether allowing readers to pay in-Epic increases the conversion rate.",
     owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("desbo")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 8, 1),
+    sellByDate = new LocalDate(2017, 9, 9),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -118,7 +118,6 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 9, 5),
     exposeClientSide = true
   )
-
   Switch(
     ABTests,
     "ab-carrot-slot",
@@ -135,7 +134,7 @@ trait ABTestSwitches {
     "Test whether allowing readers to pay in-Epic increases the conversion rate.",
     owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("desbo")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 9, 9),
+    sellByDate = new LocalDate(2017, 9, 11),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -118,7 +118,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 9, 5),
     exposeClientSide = true
   )
-  
+
   Switch(
     ABTests,
     "ab-carrot-slot",
@@ -126,6 +126,16 @@ trait ABTestSwitches {
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 8, 23),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-paypal-pay-in-epic",
+    "Test whether allowing readers to pay in-Epic increases the conversion rate.",
+    owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("desbo")),
+    safeState = On,
+    sellByDate = new LocalDate(2017, 8, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/lib/geolocation.js
+++ b/static/src/javascripts/lib/geolocation.js
@@ -136,7 +136,6 @@ const isInEurope = (): boolean => {
     return europeCountryCodes.includes(countryCode) || countryCode === 'GB';
 };
 
-// Exposed for unit testing
 export {
     get,
     getSupporterPaymentRegion,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -6,6 +6,7 @@ import {
 } from 'common/modules/experiments/utils';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import { viewsInPreviousDays } from 'common/modules/commercial/acquisitions-view-log';
+import { payInEpic } from 'common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic';
 import { alwaysAsk } from 'common/modules/experiments/tests/contributions-epic-always-ask-strategy';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicLiveblog } from 'common/modules/experiments/tests/acquisitions-epic-liveblog';
@@ -18,6 +19,7 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
  */
 const tests = [
     alwaysAsk,
+    payInEpic,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
@@ -1,0 +1,151 @@
+// @flow
+import template from 'lodash/utilities/template';
+import config from 'lib/config';
+import { loadScript } from 'lib/load-script';
+import { getSupporterPaymentRegion, getSync } from 'lib/geolocation';
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import iframeTemplate from 'raw-loader!common/views/acquisitions-epic-iframe.html';
+import paypalPayInEpicControlTemplate from 'raw-loader!common/views/acquisitions-epic-paypal-pay-in-epic-control.html';
+
+const createFormData = (region, amounts) => {
+    const formDataByRegion = {
+        GB: {
+            amounts: amounts.GB,
+            symbol: '£',
+            countryGroup: 'uk',
+        },
+        EU: {
+            amounts: amounts.EU,
+            symbol: '€',
+            countryGroup: 'eu',
+        },
+        US: {
+            amounts: amounts.US,
+            symbol: '$',
+            countryGroup: 'us',
+        },
+        AU: {
+            amounts: amounts.AU,
+            symbol: '$',
+            countryGroup: 'au',
+        },
+    };
+
+    // INT and CA redirect to UK in contributions frontend.
+    return formDataByRegion[region] || formDataByRegion.GB;
+};
+
+const pageContext = (campaignCode, amounts) => {
+    const region = getSupporterPaymentRegion(getSync());
+
+    return {
+        intCmp: campaignCode,
+        refererPageviewId: config.ophan.pageViewId,
+        refererUrl: document.location.href,
+        ophanBrowserId: config.ophan.browserId,
+        formData: createFormData(region, amounts),
+    };
+};
+
+const iframeUrl = `${config.page && config.page.isDev
+    ? 'https://contribute.thegulocal.com'
+    : 'https://contribute.theguardian.com'}/components/epic/inline-payment`;
+
+const createVariant = (id, amounts) => ({
+    id,
+
+    products: ['ONE_OFF_CONTRIBUTION'],
+
+    options: {
+        isUnlimited: true,
+
+        template(variant) {
+            return template(iframeTemplate, {
+                componentName: variant.options.componentName,
+                id: variant.options.iframeId,
+                iframeUrl,
+            });
+        },
+
+        test(render, variant) {
+            window.addEventListener('message', event => {
+                if (event.data.type === 'PAGE_CONTEXT_REQUEST') {
+                    const iframe = document.getElementById(
+                        variant.options.iframeId
+                    );
+
+                    if (iframe instanceof HTMLIFrameElement) {
+                        iframe.contentWindow.postMessage(
+                            {
+                                type: 'PAGE_CONTEXT',
+                                pageContext: pageContext(
+                                    variant.options.campaignCode,
+                                    amounts
+                                ),
+                            },
+                            '*'
+                        );
+                    }
+                }
+            });
+
+            loadScript(
+                'https://www.paypalobjects.com/api/checkout.js'
+            ).then(() => render());
+        },
+
+        usesIframe: true,
+    },
+});
+
+const createControl = () => ({
+    id: 'control',
+
+    products: ['ONE_OFF_CONTRIBUTION'],
+
+    options: {
+        isUnlimited: true,
+
+        template(variant) {
+            return template(paypalPayInEpicControlTemplate, {
+                contributionUrl: `${variant.options
+                    .contributeURL}&disableStripe=true`,
+            });
+        },
+    },
+});
+
+export const payInEpic = makeABTest({
+    id: 'AcquisitionsEpicPaypalPayInEpic',
+    campaignId: 'epic_pay_in_epic',
+
+    start: '2017-07-04',
+    expiry: '2018-08-01',
+
+    author: 'Guy Dawson & Sam Desborough',
+    description:
+        'Test whether letting readers pay in-Epic with Paypal will lead to a higher conversion rate',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'The pay in-Epic variant smashes the control out of the park',
+    audienceCriteria: 'All',
+    audience: 0.2,
+    audienceOffset: 0.1,
+
+    variants: [
+        createControl(),
+
+        createVariant('default_amounts', {
+            GB: [25, 50, 100, 250],
+            EU: [25, 50, 100, 250],
+            US: [25, 50, 100, 250],
+            AU: [50, 100, 250, 500],
+        }),
+
+        createVariant('low_amounts', {
+            GB: [2, 5, 10, 25],
+            EU: [2, 5, 10, 25],
+            US: [2, 5, 10, 25],
+            AU: [5, 10, 25, 50],
+        }),
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
@@ -119,8 +119,8 @@ export const payInEpic = makeABTest({
     id: 'AcquisitionsEpicPaypalPayInEpic',
     campaignId: 'epic_pay_in_epic',
 
-    start: '2017-07-04',
-    expiry: '2018-08-01',
+    start: '2017-08-09',
+    expiry: '2018-09-09',
 
     author: 'Guy Dawson & Sam Desborough',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
@@ -47,10 +47,6 @@ const pageContext = (campaignCode, amounts) => {
     };
 };
 
-const iframeUrl = `${config.page && config.page.isDev
-    ? 'https://contribute.thegulocal.com'
-    : 'https://contribute.theguardian.com'}/components/epic/inline-payment`;
-
 const createVariant = (id, amounts) => ({
     id,
 
@@ -63,7 +59,8 @@ const createVariant = (id, amounts) => ({
             return template(iframeTemplate, {
                 componentName: variant.options.componentName,
                 id: variant.options.iframeId,
-                iframeUrl,
+                iframeUrl:
+                    'https://contribute.theguardian.com/components/epic/inline-payment',
             });
         },
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
@@ -117,7 +117,7 @@ export const payInEpic = makeABTest({
     campaignId: 'epic_pay_in_epic',
 
     start: '2017-08-09',
-    expiry: '2018-09-09',
+    expiry: '2018-09-11',
 
     author: 'Guy Dawson & Sam Desborough',
     description:

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-paypal-pay-in-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-paypal-pay-in-epic-control.html
@@ -1,0 +1,29 @@
+<div class="contributions__epic">
+    <div>
+        <h2 class="contributions__title contributions__title--epic">
+            Since you’re here&hellip;
+        </h2>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            &hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising
+            revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations,
+            we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can.</span>
+            So you can see why we need to ask for your help.
+            The Guardian’s independent, investigative journalism takes a lot of time,
+            money and hard work to produce. But we do it because we believe our perspective matters &ndash;
+            because it might well be your perspective, too.
+        </p>
+        <p class="contributions__paragraph contributions__paragraph--epic">
+            If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+        </p>
+    </div>
+
+    <div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+               href="<%=contributionUrl%>"
+               target="_blank">
+                Make a contribution
+            </a>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Adds an initial test to investigate whether letting readers pay in-Epic will increase the conversion rate. For security reasons, the Epic is served as an i-frame from the contributions front-end. See [here](https://github.com/guardian/contributions-frontend/pull/294) for the associated pull request.

## What is the value of this and can you measure success?

Potentially increase the conversion rate of the Epic.

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

- __Control:__
  <img width="634" alt="control" src="https://user-images.githubusercontent.com/4085817/27801689-34a35112-6017-11e7-9d09-2c98e2625f33.png">

- __Default amounts:__
  <img width="641" alt="default_amounts" src="https://user-images.githubusercontent.com/4085817/27801701-535d4658-6017-11e7-9e7c-945f690ff9c1.png">

- __Low amounts:__
  <img width="633" alt="low_amounts" src="https://user-images.githubusercontent.com/4085817/27801708-5fe037dc-6017-11e7-83dc-fc8cd701a0d3.png">

- __Paypal pop-up:__
  <img width="1269" alt="paypal_pop_up" src="https://user-images.githubusercontent.com/4085817/27827307-8ff3a746-60ae-11e7-89c4-022b4cab88e4.png">

- __Post-payment, success:__
  <img width="634" alt="epic_post_payment" src="https://user-images.githubusercontent.com/4085817/27827284-75dbcc9e-60ae-11e7-9900-12e1e441375f.png">

- __Post-payment, error:__
  <img width="635" alt="paypal_post_payment_error" src="https://user-images.githubusercontent.com/4085817/27827296-8359a81e-60ae-11e7-8248-2012c21ca302.png">

## Tested in CODE?

No, tested locally.

