### PR TITLE
New Header: Fix ipad air collapsed edition picker

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -68,16 +68,7 @@
         order: 3;
         padding-bottom: 0;
         padding-top: $gs-baseline;
-        position: absolute;
-        right: 0;
-        top: 0;
         width: 100%;
-
-        @supports(display: flex) {
-            position: relative;
-            right: auto;
-            top: auto;
-        }
     }
 
     @include mq(leftCol) {
@@ -87,6 +78,15 @@
         padding-left: $gs-gutter / 2 - 1;
         // substracting the border-width, otherwise it breaks in Safari
         width: gs-span(2) + $gs-gutter / 2 - 2;
+        position: absolute;
+        right: 0;
+        top: 0;
+
+        @supports(display: flex) {
+            position: relative;
+            right: auto;
+            top: auto;
+        }
     }
 
     @include mq(wide) {

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -129,8 +129,10 @@
     }
 
     .menu-group .menu-item {
-        display: inline-block;
-        width: auto;
+        @include mq(desktop) {
+            display: inline-block;
+            width: auto;
+        }
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -153,7 +153,7 @@
     @include mq(desktop) {
         color: $news-support-1;
         position: absolute;
-        right: gs-span(2) + $gs-gutter * 1.5;
+        right: $gs-gutter;
         top: 0;
         width: gs-span(2);
 
@@ -167,6 +167,11 @@
 
     @include mq(leftCol) {
         margin-right: $gs-gutter / 2;
+        right: gs-span(2) + $gs-gutter * 1.5;
+
+        @supports(display: flex) {
+            right: auto;
+        }
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?
The edition menu on ipad air is not properly laid out. This should fix the problem.

## What is the value of this and can you measure success?
Looks better!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/8774970/27802842-2087af32-601e-11e7-89f3-24c71c6187bb.png)

![image](https://user-images.githubusercontent.com/8774970/27803113-d03dbe3e-601f-11e7-976f-e7fa0cf7cb75.png)



**After:**
![image](https://user-images.githubusercontent.com/8774970/27802981-121d359c-601f-11e7-8c20-40660477fb91.png)

![image](https://user-images.githubusercontent.com/8774970/27803514-c5edc22e-6021-11e7-9b88-694af5304428.png)



## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
