### PR TITLE
ES6 ✨ Give Kate the remaining commercial third-party-tags to convert

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -3,7 +3,12 @@
   "Jon Norman": [],
   "Regis Kuckaertz": [],
   "Richard Nguyen": [],
-  "Kate Whalen": [],
+  "Kate Whalen": [
+    "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js",
+    "projects/commercial/modules/third-party-tags.js",
+    "projects/commercial/modules/third-party-tags/audience-science-gateway.js",
+    "projects/commercial/modules/third-party-tags/audience-science-pql.js"
+  ],
   "Lydia Shepherd": [],
   "sndrs": [
     "lib/detect.js",
@@ -129,8 +134,7 @@
     "projects/common/modules/identity/api.js",
     "projects/common/modules/identity/cookierefresh.js",
     "projects/common/modules/identity/email-preferences.js",
-    "bootstraps/enhanced/notifications.js",
-    "projects/commercial/modules/third-party-tags.js"
+    "bootstraps/enhanced/notifications.js"
   ],
   "shaundillon": [
     "projects/common/modules/identity/forms.js",
@@ -143,7 +147,6 @@
     "projects/common/modules/navigation/membership.js",
     "projects/common/modules/navigation/navigation.js",
     "projects/common/modules/navigation/profile.js",
-    "projects/commercial/modules/third-party-tags/audience-science-gateway.js"
   ],
   "jfsoul": [
     "projects/common/modules/navigation/search.js",
@@ -153,7 +156,6 @@
     "projects/common/modules/onward/tech-feedback.js",
     "projects/common/modules/open/cta.js",
     "projects/common/modules/preferences/main.js",
-    "projects/commercial/modules/third-party-tags/audience-science-pql.js"
   ],
   "Joseph Smith": [
     "projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js",
@@ -166,7 +168,6 @@
     "projects/common/modules/ui/message.js",
     "projects/common/modules/ui/notification-counter.js",
     "projects/common/modules/ui/relativedates.js",
-    "projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js",
     "projects/commercial/modules/paidfor-band.js"
   ],
   "Philip Wills": [],


### PR DESCRIPTION
## What does this change?

Gives me some more of the commercial modules 
Getting all the commercial third-party-tags in ES6 land ASAP

## What is the value of this and can you measure success?

More ES6 stuff done!
Commercial JS conversions nearing completion

## Does this affect other platforms - Amp, Apps, etc?

Nope


