### PR TITLE
Inject all commercial deps in legacy tests

### DIFF
--- a/static/test/javascripts-legacy/spec/commercial/liveblog-adverts.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/liveblog-adverts.spec.js
@@ -1,18 +1,18 @@
 define([
-    'commercial/modules/liveblog-adverts',
-    'commercial/modules/commercial-features',
     'lib/mediator',
+    'helpers/injector',
     'helpers/fixtures',
     'lib/$'
 ], function (
-    liveblogAdverts,
-    commercialFeatures,
     mediator,
+    Injector,
     fixtures,
     $
 ) {
     var $style, body;
-    var slotsCounter;
+    var slotsCounter, liveblogAdverts, commercialFeatures;
+
+    var injector = new Injector();
 
     describe('Liveblog Dynamic Adverts', function () {
         var fixturesConfig = {
@@ -35,18 +35,27 @@ define([
         };
 
         beforeEach(function (done) {
-            fixtures.render(fixturesConfig);
-            body = document.querySelector('.js-liveblog-body');
-            $style = $.create('<style type="text/css"></style>')
-                .html('.block{ height: 1200px }')
-                .appendTo('head');
-            commercialFeatures.commercialFeatures.liveblogAdverts = true;
+            injector.require([
+                'commercial/modules/liveblog-adverts',
+                'commercial/modules/commercial-features',
+            ], function($1, $2) {
+                liveblogAdverts = $1;
+                commercialFeatures = $2;
+                fixtures.render(fixturesConfig);
+                body = document.querySelector('.js-liveblog-body');
+                $style = $.create('<style type="text/css"></style>')
+                    .html('.block{ height: 1200px }')
+                    .appendTo('head');
+                commercialFeatures.commercialFeatures.liveblogAdverts = true;
 
-            afterEach(function () {
-                fixtures.clean(fixturesConfig.id);
-            });
+                afterEach(function () {
+                    fixtures.clean(fixturesConfig.id);
+                });
 
-            done();
+                done();
+            },
+            done.fail);
+
         });
 
         afterEach(function () {

--- a/static/test/javascripts-legacy/spec/commercial/sticky-mpu.spec.js
+++ b/static/test/javascripts-legacy/spec/commercial/sticky-mpu.spec.js
@@ -1,9 +1,22 @@
 define([
-    'commercial/modules/sticky-mpu'
+    'helpers/injector'
 ], function (
-    StickyMpu
+    Injector
 ) {
     describe('Sticky MPU', function () {
+
+        var injector = new Injector(),
+            StickyMpu;
+
+        beforeEach(function (done) {
+            injector.require([
+                'commercial/modules/sticky-mpu'
+            ], function($1) {
+                StickyMpu = $1;
+                done();
+            },
+            done.fail);
+        });
 
         it('should exist', function () {
             expect(StickyMpu).toBeDefined();


### PR DESCRIPTION
## What does this change?

Inject all commercial deps in karma tests

## What is the value of this and can you measure success?

if you don't (as now) the SVG mocking added in #16829 will not have happened at the point of import and and any SVG imports that occur in that dependency tree cannot be found, resulting in [errors like this](https://teamcity.gu-web.net/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=39223#_focus=1676)

```
[11:21:59][JavaScript Unit Tests] [11:21:59] → PhantomJS 2.1.1 (Linux 0.0.0) ERROR: 'There is no timestamp for /base/static/src/inline-svgs/icon/quote.svg.js!'
[11:21:59][JavaScript Unit Tests] [11:21:59] → PhantomJS 2.1.1 (Linux 0.0.0) ERROR
[11:21:59][JavaScript Unit Tests] [11:21:59] →   Error: Script error for "svgs/icon/quote.svg", needed by: common/modules/commercial/acquisitions-epic-testimonial-parameters
[11:21:59][JavaScript Unit Tests] [11:21:59] →   http://requirejs.org/docs/errors.html#scripterror
[11:21:59][JavaScript Unit Tests] [11:21:59] →   at node_modules/requirejs/require.js:143
[11:21:59][JavaScript Unit Tests] [11:21:59] → 
[11:21:59][Step 2/5] [11:21:59] Run commercial tests (legacy) [failed]
```

## Does this affect other platforms - Amp, Apps, etc?

this only updates commercial tests since they're the ones failing in #17310. no others are failing currently but the problem could reappear in others if any of their deps begin importing an svg

cc @joelochlann 