### PR TITLE
Reintroduce the gallery banner ads test, now with control.

### DIFF
--- a/applications/app/views/fragments/gallerySlot.scala.html
+++ b/applications/app/views/fragments/gallerySlot.scala.html
@@ -3,12 +3,12 @@
     isMobile: Boolean = false
 )(implicit request: RequestHeader)
 @import conf.switches.Switches.CommercialSwitch
-@import mvt.CommercialGalleryBannerAds
+@import mvt.CommercialGalleryBannerAdsVariant
 
 @commonSizes = @{Seq("1,1", "2,2", "300,250", "fluid")}
 
 @desktopSizes = @{
-    if(CommercialGalleryBannerAds.isParticipating)
+    if(CommercialGalleryBannerAdsVariant.isParticipating)
         Map("desktop" -> (commonSizes ++ Seq("970,250", "900,250")))
     else
         Map.empty[String, Seq[String]]

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -16,16 +16,28 @@ import conf.switches.Switches.ServerSideTests
 //    val tests = List(ExampleTest)
 // }
 
-object CommercialGalleryBannerAds extends TestDefinition(
-  name = "commercial-gallery-banner-ads",
-  description = "Users in the test will see banner ads instead of MPUs in galleries",
+object CommercialGalleryBannerAdsVariant extends TestDefinition(
+  name = "ab-commercial-gallery-banner-ads-variant",
+  description = "Users in this test will see banner ads in galleries",
   owners = Seq(Owner.withGithub("JonNorman")),
   sellByDate = new LocalDate(2017, 7, 11)
 ) {
 
-  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-commercial-gallery-banner-ads")
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-commercial-gallery-banner-ads")
 
   def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
+}
+
+object CommercialGalleryBannerAdsControl extends TestDefinition(
+  name = "ab-commercial-gallery-banner-ads-control",
+  description = "Users in this test will not see banner ads in galleries, as a control.",
+  owners = Seq(Owner.withGithub("JonNorman")),
+  sellByDate = new LocalDate(2017, 7, 11)
+) {
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-commercial-gallery-banner-ads")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("control")
 }
 
 object CommercialClientLoggingVariant extends TestDefinition(
@@ -88,7 +100,8 @@ trait ServerSideABTests {
 object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
-    CommercialGalleryBannerAds,
+    CommercialGalleryBannerAdsVariant,
+    CommercialGalleryBannerAdsControl,
     ABNewDesktopHeaderVariant,
     ABNewDesktopHeaderControl
   )


### PR DESCRIPTION
## What does this change?
This adds a control to the commercial-gallery-banner-ads test. This was initially added in just before the election but left dormant (the fastly change was reverted to ease any strain on Fastly.)

## What is the value of this and can you measure success?
We can measure the impact of opening up gallery slots to banner ads, in theory this should make us more $.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
