### PR TITLE
Digipack engagement banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -179,4 +179,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 7, 31),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-membership-engagement-banner-digipack-price-test",
+    "Find the optimal price point for the digipack",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 3),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -168,4 +168,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 7, 31),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-membership-engagement-banner-digipack-price-test",
+    "Find the optimal price point for the digipack",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 3),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts-legacy/projects/common/modules/commercial/membership-engagement-banner.js
@@ -19,7 +19,6 @@ define([
         'common/modules/experiments/acquisition-test-selector',
         'common/modules/commercial/membership-engagement-banner-parameters',
         'common/modules/commercial/membership-engagement-banner-block',
-        'common/modules/commercial/contributions-utilities',
         'ophan/ng',
         'lib/geolocation',
         'lib/url'
@@ -43,7 +42,6 @@ define([
                  acquisitionTestSelector,
                  membershipEngagementBannerUtils,
                  membershipEngagementBannerBlock,
-                 contributionsUtilities,
                  ophan,
                  geolocation,
                  url) {
@@ -85,8 +83,8 @@ define([
 
         function getUserVariantParams(userVariant, campaignId, defaultOffering) {
 
-            if (userVariant && userVariant.options && userVariant.options.engagementBannerParams) {
-                var userVariantParams = userVariant.options.engagementBannerParams;
+            if (userVariant && userVariant.engagementBannerParams) {
+                var userVariantParams = userVariant.engagementBannerParams;
 
                 if (!userVariantParams.campaignCode) {
                     var offering = userVariantParams.offering || defaultOffering;
@@ -129,7 +127,7 @@ define([
             var campaignId = userTest ? userTest.campaignId : undefined;
             var userVariant = getUserVariant(userTest);
 
-            if (userVariant && userVariant.options && userVariant.options.blockEngagementBanner) {
+            if (userVariant && userVariant.blockEngagementBanner) {
                 return DO_NOT_RENDER_ENGAGEMENT_BANNER;
             }
 
@@ -155,7 +153,7 @@ define([
 
 
         function showBanner(params) {
-            
+
 
             if (params === DO_NOT_RENDER_ENGAGEMENT_BANNER || membershipEngagementBannerBlock.isBlocked()) {
                 return;
@@ -169,6 +167,8 @@ define([
                 REFPVID : params.pageviewId,
                 INTCMP:  params.campaignCode
             };
+            
+                     
             var linkUrl = params.linkUrl + '?' + url.constructQuery(urlParameters);
 
             var renderedBanner = template(messageTemplate, {

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -5,7 +5,8 @@ define([
     'lib/storage',
     'lodash/utilities/template',
     'common/modules/commercial/contributions-utilities',
-    'lib/mediator'
+    'lib/mediator',
+    'lib/geolocation'
 ], function (
     bean,
     qwery,
@@ -13,7 +14,8 @@ define([
     storage,
     template,
     contributionsUtilities,
-    mediator) {
+    mediator,
+    geolocation) {
     var EditionTest = function (edition, id, start, expiry, campaignPrefix) {
 
         this.edition = edition;
@@ -81,14 +83,15 @@ define([
         this.expiry = '2017-08-03';
         this.author = 'Jonathan Rankin';
         this.description = 'Send ';
-        this.audience = 1;
+        this.audience = 0.25;
         this.audienceOffset = 0;
         this.successMeasure = 'Each variant points to a different price point on the landing page. The success is measured' +
             'by the click rate on th landing page';
         this.audienceCriteria = 'UK';
         this.idealOutcome = 'We are able to establish which price point is better for the digital edition';
-        this.canRun = function() {return true;};
-
+        this.canRun = function() {
+            return contributionsUtilities.shouldShowReaderRevenue() && geolocation.getSync() === 'GB';
+        };
         this.variants = [];
     };
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -75,5 +75,80 @@ define([
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
 
-    return []
+    var MembershipEngagementBannerDigipackPriceTest = function() {
+        this.id = 'MembershipEngagementBannerDigipackPriceTest';
+        this.start = '2017-07-03';
+        this.expiry = '2017-08-03';
+        this.author = 'Jonathan Rankin';
+        this.description = 'Send ';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Each variant points to a different price point on the landing page. The success is measured' +
+            'by the click rate on th landing page';
+        this.audienceCriteria = 'UK';
+        this.idealOutcome = 'We are able to establish which price point is better for the digital edition';
+        this.canRun = function() {return true;};
+
+        this.variants = [];
+    };
+
+    // cta should be a function which returns the call-to-action which is placed after the message text.
+    MembershipEngagementBannerDigipackPriceTest.prototype.addVariant = function(variantId, messageText, cta, paypalClass) {
+
+        function createCampaignCode(variantId) {
+            // Campaign code follows convention. Talk to Alex for more information.
+            return 'BUNDLE_PRICE_TEST_1M_B_UK_' + variantId;
+        }
+
+        var engagementBannerParams = {
+            campaignCode: createCampaignCode(variantId),
+            buttonCaption: 'Support the Guardian',
+            linkUrl: 'https://membership.theguardian.com/bundles',
+            messageText: 'Unlike many others, we haven\'t put up a paywall. Support us today and help us keep our journalism as open as we can',
+            pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found'
+        };
+
+        if (messageText) {
+
+            if (typeof cta === 'function') {
+                messageText = messageText + ' ' + cta()
+            }
+
+            engagementBannerParams.messageText = messageText;
+        }
+
+        if(paypalClass) {
+            engagementBannerParams.paypalClass = paypalClass;
+        }
+
+        this.variants.push({
+            id: variantId,
+
+            // We don't want to run any 'code' in this test, we just want a variant to be selected.
+            // All message display is performed in membership-engagement-banner.js,
+            // modifying the banner using the data in variantParams.
+            test: function () {},
+
+            success: this.completer,
+
+            // This allows a lot of the deriveBannerParams() logic (in membership-engagement-banner.js) to be by-passed.
+            // If that function has picked up a variant from the CopyTest test, call this method and be done with it.
+            engagementBannerParams : engagementBannerParams
+
+        });
+
+        return this;
+    };
+
+    return [
+        new MembershipEngagementBannerDigipackPriceTest()
+            .addVariant(
+                'A'
+            )
+            .addVariant(
+                'B'
+            ).addVariant(
+            'C'
+        )
+    ]
 });


### PR DESCRIPTION
## What does this change?

S&C wish to send people from the engagement banner to their digipack pricing test (https://github.com/guardian/membership-frontend/pull/1605). This PR facilitates that desire. 

So that the message makes sense in terms of the proposition, we have had to change it slightly from the current engagement banner text 

## What is the value of this and can you measure success?

The digipack test gets more impressions

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
![screenshot at jul 05 10-17-02](https://user-images.githubusercontent.com/2844554/27857971-717c805e-616b-11e7-9c00-5daf3b49c53f.png)


<img width="245" src ="http://www.clker.com/cliparts/e/a/c/a/12065697821256125215pitr_red_arrows_set_5.svg.hi.png">
<img width="645" alt="byndles" src="https://user-images.githubusercontent.com/2844554/27833144-65f17584-60c9-11e7-9b9c-f1e38b4a0676.png">![screenshot at jul 05 10-17-02](https://user-images.githubusercontent.com/2844554/27857960-65418424-616b-11e7-9558-92086df8ad37.png)




## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
