### PR TITLE
Header size adjustments

### DIFF
--- a/static/src/stylesheets/layout/new-header/_feedback-form.scss
+++ b/static/src/stylesheets/layout/new-header/_feedback-form.scss
@@ -11,14 +11,10 @@
     bottom: $gs-baseline;
     margin-bottom: 0;
 
-    @include mq(leftCol) {
-        width: $gs-column-width * 2 + $gs-gutter;
-        position: absolute;
-        right: 0;
-    }
-
     @include mq(wide) {
-        width: $gs-column-width * 3;
+        width: gs-span(3) - 34px;
+        position: absolute;
+        right: $gs-gutter;
 
         .has-page-skin & {
             width: auto;
@@ -34,14 +30,15 @@
 
 .feedback-form__icon {
     fill: $news-support-1;
-    margin-right: $gs-gutter / 2;
+    margin-right: $gs-gutter / 4;
     position: relative;
     top: $gs-baseline / 2;
 
-    @include mq(leftCol) {
+    @include mq(wide) {
         position: absolute;
-        top: 2px;
-        left: -$gs-gutter * 2;
+        top: 0;
+        left: -$gs-gutter / 2;
+        transform: translateX(-100%);
 
         .has-page-skin & {
             position: relative;
@@ -52,6 +49,6 @@
 }
 
 .feedback-form__icon__svg {
-    height: 25px;
-    width: 25px;
+    height: 24px;
+    width: 24px;
 }

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -105,13 +105,13 @@ from scrolling */
     }
 
     @include mq(tablet) {
-        height: calc(3 / 16 * 385px);
-        width: 385px;
+        height: calc(3 / 16 * 345px);
+        margin-bottom: $gs-baseline / 4;
+        width: 345px;
     }
 
-    @include mq(desktop) {
+    @include mq(leftCol) {
         height: calc(3 / 16 * 385px);
-        margin-bottom: $gs-baseline / 4;
         width: 385px;
     }
 

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -2,7 +2,8 @@
 $gutter-small: 29px;
 $gutter-medium: 37px;
 $gutter-large: 55px;
-$gutter-xlarge: 84px;
+$gutter-xlarge: 75px;
+$gutter-xxlarge: 84px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
 $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -22,13 +22,17 @@
     }
 
     @include mq(mobileLandscape) {
-        //Align with the 'i' in 'theguardian'
         right: $gutter-large;
     }
 
     @include mq(tablet) {
         right: $gutter-xlarge;
     }
+
+    @include mq(leftCol) {
+        right: $gutter-xxlarge;
+    }
+
 
     // menu is open
     .new-header--open & {


### PR DESCRIPTION
Bumped down the size of the logo until leftCol. Also positioned the feedback request within our grid structure.

# Feedback request

Before:
<img width="1301" alt="screen shot 2017-07-04 at 16 31 21" src="https://user-images.githubusercontent.com/14570016/27836399-394a15a0-60d7-11e7-9764-efc4dbbd3dc2.png">

After:
<img width="1303" alt="screen shot 2017-07-04 at 16 31 03" src="https://user-images.githubusercontent.com/14570016/27836401-394be510-60d7-11e7-82e6-2967a6c8fbd4.png">

# Logo bumpin'

Before:
<img width="985" alt="screen shot 2017-07-04 at 16 37 40" src="https://user-images.githubusercontent.com/14570016/27836398-39493356-60d7-11e7-987d-a7309c78b9dc.png">

After:
<img width="987" alt="screen shot 2017-07-04 at 16 37 33" src="https://user-images.githubusercontent.com/14570016/27836400-394b819c-60d7-11e7-9418-35996822b338.png">
