### PR TITLE
Implement design according to design doc for paid cards in containers.

### DIFF
--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -24,7 +24,8 @@
                 item = paidContentOnEditorialPage,
                 omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage),
                 containerIndex,
-                index
+                index,
+                isFirstContainer
             )
         }
 

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -1,8 +1,10 @@
-@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int)(implicit request: RequestHeader)
+@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int, isFirstContainer: Boolean)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards._
+@import views.support.GetClasses
+@import Function.const
 
-<div class="fc-item fc-item--has-image js-fc-item fc-item--list-media-mobile fc-item--standard-tablet adverts--within-unbranded @item.cardTypes.classes)">
+<div class="adverts--within-unbranded @GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}">
     <div class="fc-item__container">
         @item.paidImage.map(image => itemImage(
             image,
@@ -16,9 +18,13 @@
                 </div>
             </div>
 
+            @item.trailText.filter(const(item.showStandfirst)).map { text =>
+                <div class="fc-item__standfirst">@Html(text)</div>
+            }
+
             <div class="badge badge--no-image">
                 <div class="badge__label">
-                    Paid for by @item.branding.map(_.sponsorName)
+                    Paid for by <span class="badge__sponsor-name">@item.branding.map(_.sponsorName)</span>
                 </div>
             </div>
 

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -169,7 +169,7 @@ $paid-article-header:       #bfbfbf;
 $paid-article-header-bg:    #b8b8b8;
 $paid-article-subheader:    #cccccc;
 $paid-article-subheader-bg: #c4c4c4;
-$paid-article-card-bg:      #f6f6f6;
+$paid-article-card-bg:      $neutral-8;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -169,7 +169,7 @@ $paid-article-header:       #bfbfbf;
 $paid-article-header-bg:    #b8b8b8;
 $paid-article-subheader:    #cccccc;
 $paid-article-subheader-bg: #c4c4c4;
-$paid-article-card-bg:      #d7d7d7;
+$paid-article-card-bg:      #f6f6f6;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -385,7 +385,7 @@
     .fc-item__title {
         @include f-textSans;
         font-weight: 600;
-        color: #333333;
+        color: $neutral-1;
     }
 
     .fc-item__content {
@@ -399,7 +399,7 @@
     }
 
     .fc-item__standfirst {
-        color: #333333;
+        color: $neutral-1;
     }
 
     .badge {
@@ -448,7 +448,7 @@
 
     .badge__sponsor-name {
         @include f-textSans;
-        color: #333333;
+        color: $neutral-1;
     }
 
     .inline-icon__svg {

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -373,7 +373,7 @@
         background-color: $paid-article-card-bg;
         &:hover,
         &.u-faux-block-link--hover {
-            background: darken($paid-article-subheader, 7%);
+            background-color: $neutral-6;
         }
     }
     .fc-item__container:before {
@@ -383,7 +383,9 @@
         fill: $paid-article-brand;
     }
     .fc-item__title {
-        @include f-headlineSans;
+        @include f-textSans;
+        font-weight: 600;
+        color: #333333;
     }
 
     .fc-item__content {
@@ -394,6 +396,10 @@
         @include mq(mobileLandscape, tablet) {
             flex-direction: row;
         }
+    }
+
+    .fc-item__standfirst {
+        color: #333333;
     }
 
     .badge {
@@ -408,6 +414,7 @@
         }
     }
     .badge__label {
+        color: #757575;
         text-align: center;
         align-self: center;
     }
@@ -437,6 +444,11 @@
 
     .badge--no-image {
         margin-bottom: $gs-baseline/2;
+    }
+
+    .badge__sponsor-name {
+        @include f-textSans;
+        color: #333333;
     }
 
     .inline-icon__svg {


### PR DESCRIPTION
## What does this change?
This ensures that paid cards are designed as according to the design doc.

## What is the value of this and can you measure success?
This work is as the result of a previously successful test around integrating paid cards into editorial containers. By doing so we increase the discoverability of labs content.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Screenshots
<img width="1142" alt="picture 94" src="https://user-images.githubusercontent.com/8861681/27866046-d3d4a56c-618c-11e7-8023-f86eee8651ce.png">
<img width="1134" alt="picture 95" src="https://user-images.githubusercontent.com/8861681/27866048-d3d74e20-618c-11e7-9164-ca46d4de1c6e.png">
<img width="1180" alt="picture 96" src="https://user-images.githubusercontent.com/8861681/27866047-d3d5f174-618c-11e7-9222-963f760a0831.png">
<img width="1128" alt="picture 97" src="https://user-images.githubusercontent.com/8861681/27866049-d3d8ac0c-618c-11e7-8c33-35782940060d.png">

## Tested in CODE?
Yes.
