### PR TITLE
Put the closing of  video ad slots behind a switch.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -15,6 +15,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val VideoSlotsSwitch = Switch(
+    SwitchGroup.Commercial,
+    "keep-video-ad-slots-open",
+    "Deactivates the sizecallback for videos (620x1) that hides the slot.",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 7, 12),
+    exposeClientSide = true
+  )
+
   val SurveySwitch = Switch(
     SwitchGroup.Commercial,
     "surveys",

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -68,11 +68,13 @@ sizeCallbacks[adSizes.halfPage] = () => {
     mediator.emit('page:commercial:sticky-mpu');
 };
 
-sizeCallbacks[adSizes.video] = (_, advert) => {
-    fastdom.write(() => {
-        advert.node.classList.add('u-h');
-    });
-};
+if (config.switches.keepVideoAdSlotsOpen) {
+    sizeCallbacks[adSizes.video] = (_, advert) => {
+        fastdom.write(() => {
+            advert.node.classList.add('u-h');
+        });
+    };
+}
 
 sizeCallbacks[adSizes.video2] = (_, advert) => {
     fastdom.write(() => {


### PR DESCRIPTION
## What does this change?
Ad slots for serving video ads will continue to be closed when this switch is off. When the switch is on, the ad slot will remain visible.

> Why do we normally make the ad slot invisible?

Currently the way that video ads (specifically AppNexus Outstream) are added to the page is that a new element is created outside of the ad slot, thus the original ad slot needs hiding. I am looking to stop this behaviour and to render the video inside the extant ad slot.

> Why can't you test this locally?

AppNexus have a whitelist of domains on which their video ads can run: localhost is not one of them, but our CODE domain is. As long as people are using fairly recent branches on CODE, this should allow me to test on CODE without blocking others from using it.

@guardian/commercial-dev 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
