### PR TITLE
Adding inequality as a link in world

### DIFF
--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -62,7 +62,6 @@ object NavLinks {
   val cartoons = NavLink("cartoons", "/cartoons/archive", "cartoons/archive")
   val inMyOpinion = NavLink("opinion videos", "/commentisfree/series/comment-is-free-weekly", "commentisfree/series/comment-is-free-weekly")
   val letters = NavLink("letters", "/tone/letters")
-  val editorials = NavLink("editorials", "/tone/editorials", "tone/editorials")
 
   /* SPORT */
   val sport = NavLink("sport", "/sport", longTitle = "sport home", iconName = "home", uniqueSection = "sport")
@@ -169,7 +168,6 @@ object NavLinks {
     "cartoons/archive",
     "type/cartoon",
     "profile/editorial",
-    "tone/editorials",
     "au/index/contributors",
     "index/contributors",
     "commentisfree/series/comment-is-free-weekly",

--- a/common/app/common/NavLinks.scala
+++ b/common/app/common/NavLinks.scala
@@ -35,6 +35,7 @@ object NavLinks {
   val africa = NavLink("africa", "/world/africa", "world/africa")
   val middleEast = NavLink("middle east", "/world/middleeast", "world/middleeast")
   val economics = NavLink("economics", "/business/economics", "business/economics")
+  val inequality = NavLink("inequality", "/inequality", "inequality")
   val banking = NavLink("banking", "/business/banking", "business/banking")
   val retail = NavLink("retail", "/business/retail", "business/retail")
   val markets = NavLink("markets", "/business/stock-markets", "business/stock-markets")

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -311,6 +311,7 @@ object NewNavigation {
       SectionsLink("media", media, News),
       SectionsLink("us-news", usNews, News),
       SectionsLink("cities", cities, News),
+      SectionsLink("inequality", inequality, News),
       SectionsLink("global-development", globalDevelopment, News),
       SectionsLink("sustainable-business", sustainableBusiness, News),
       SectionsLink("law", law, News),
@@ -423,7 +424,7 @@ object NewNavigation {
 
     val worldSubNav = NavLinkLists(
       List(world, europe, usNews, americas, asia, australiaNews, middleEast, africa),
-      List(cities, globalDevelopment)
+      List(inequality, cities, globalDevelopment)
     )
 
     val moneySubNav = NavLinkLists(List(money, property, pensions, savings, borrowing, careers))

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -57,7 +57,7 @@ object NewNavigation {
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(List(headlines, ukNews, environment, world, tech, business, football))
+    val uk = NavLinkLists(List(headlines, ukNews, world, business, environment, tech, football))
     val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, environment, football))
     val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, environment, soccer))
     val int = NavLinkLists(List(headlines, world, ukNews, business, science, globalDevelopment, football))

--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -97,7 +97,6 @@ object NewNavigation {
       ),
       List(
         letters,
-        editorials,
         NavLink("Polly Toynbee", "/profile/pollytoynbee"),
         NavLink("Owen Jones", "/profile/owen-jones"),
         NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
@@ -111,7 +110,7 @@ object NewNavigation {
         auColumnists,
         cartoons,
         indigenousAustraliaOpinion,
-        editorials
+        theGuardianView.copy(title="editorials")
       ),
       List(
         letters,
@@ -146,8 +145,7 @@ object NewNavigation {
           inMyOpinion
         ),
       List(
-        letters,
-        editorials
+        letters
       )
     )
   }
@@ -328,7 +326,6 @@ object NewNavigation {
       SectionsLink("index/contributors", columnists, Opinion),
       SectionsLink("commentisfree/series/comment-is-free-weekly", inMyOpinion, Opinion),
       SectionsLink("profile/editorial", theGuardianView, Opinion),
-      SectionsLink("tone/editorials", editorials, Opinion),
 
       SectionsLink("sport", sport, Sport),
       SectionsLink("football", football, Sport),


### PR DESCRIPTION
## What does this change?
* Inequality should be in the world subnav
* editorials is removed
* reordering most pop section for the homepage on UK

## What is the value of this and can you measure success?
editorial requested it

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/27873721-067c8986-61a5-11e7-8940-dc35d05cbf19.png)

![image](https://user-images.githubusercontent.com/8774970/27876356-b329274e-61ae-11e7-824d-200020a58968.png)


## Tested in CODE?
no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
