### PR TITLE
improve discussion UI switch description

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -110,7 +110,7 @@ trait PerformanceSwitches {
     "async-css",
     "If this switch is on CSS will be loaded with media set to 'only x' and updated to 'all' when the stylesheet " +
       "has loaded using javascript. Disabling it will use standard link elements.",
-    owners = Seq(Owner.withGithub("johnduffell")),
+    owners = Seq(Owner.withGithub("Calum-Campbell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -148,8 +148,8 @@ trait PerformanceSwitches {
 
   val DiscussionSwitch = Switch(
     SwitchGroup.Performance,
-    "discussion",
-    "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
+    "comments-visible-on-article",
+    "If this switch is on, comments are displayed on articles on dotcom. This switch only show/hides the UI from the bottom of articles on dotcom and does not disable any underlying services/endpoints etc..",
     owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,


### PR DESCRIPTION
## What does this change?
Change the description of the discussion web switch.
- The description was not entirely clear as it was expected that it would turn of commenting services when we saw an issue on dotcom, in fact it just removes the comment UI from the bottom of articles.  

## What is the value of this and can you measure success?
Makes the description more accurate to actual behaviour 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
