### PR TITLE
Support Re-Baseline AB Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -179,4 +179,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-rebaseline-support-proposition",
+    "Re-baseline the new support proposition against the old",
+    owners = Seq(Owner.withGithub("Ap0c")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 5),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -185,7 +185,7 @@ trait ABTestSwitches {
     "Re-baseline the new support proposition against the old",
     owners = Seq(Owner.withGithub("Ap0c")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 5),
+    sellByDate = new LocalDate(2017, 8, 15),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
@@ -51,9 +51,12 @@ define([
                 template: function makeControlTemplate(variant) {
                     return template(epicControlTemplate, {
                         copy: acquisitionsCopy.control,
-                        membershipUrl: variant.options.membershipURL,
-                        contributionUrl: variant.options.contributeURL,
                         componentName: variant.options.componentName,
+                        buttonTemplate: contributionsUtilities.defaultButtonTemplate({
+                            membershipUrl: variant.options.membershipURL,
+                            contributeUrl: variant.options.contributeURL,
+                            supportUrl: variant.options.supportURL,
+                        }),
                         testimonialBlock: variant.options.testimonialBlock,
                         epicClass: 'contributions__epic--interactive gs-container',
                         wrapperClass: 'contributions__epic-interactive-wrapper'

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -19,6 +19,7 @@ import { constructQuery as constructURLQuery } from 'lib/url';
 import { noop } from 'lib/noop';
 import lodashTemplate from 'lodash/utilities/template';
 import toArray from 'lodash/collections/toArray';
+import acquisitionsEpicButtons from 'raw-loader!common/views/acquisitions-epic-buttons.html';
 import acquisitionsEpicControlTemplate from 'raw-loader!common/views/acquisitions-epic-control.html';
 import acquisitionsTestimonialBlockTemplate from 'raw-loader!common/views/acquisitions-epic-testimonial-block.html';
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'commercial/modules/user-features';
@@ -43,6 +44,7 @@ type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
 const membershipBaseURL = 'https://membership.theguardian.com/supporter';
 const contributionsBaseURL = 'https://contribute.theguardian.com';
+const supportBaseURL = 'https://support.theguardian.com/uk';
 
 // How many times the user can see the Epic,
 // e.g. 6 times within 7 days with minimum of 1 day in between views.
@@ -56,13 +58,19 @@ const defaultMaxViews: {
     minDaysBetweenViews: 0,
 };
 
+const defaultButtonTemplate = urls =>
+    lodashTemplate(acquisitionsEpicButtons, urls);
+
 const controlTemplate: EpicTemplate = ({ options = {} }, copy) =>
     lodashTemplate(acquisitionsEpicControlTemplate, {
         copy,
-        membershipUrl: options.membershipURL,
-        contributionUrl: options.contributeURL,
         componentName: options.componentName,
         testimonialBlock: options.testimonialBlock,
+        buttonTemplate: options.buttonTemplate({
+            membershipUrl: options.membershipURL,
+            contributeUrl: options.contributeURL,
+            supportUrl: options.supportURL,
+        }),
     });
 
 const doTagsMatch = (test: ContributionsABTest): boolean =>
@@ -199,7 +207,9 @@ const makeABTestVariant = (
             campaignCode
         ),
         membershipURL = addTrackingCodesToUrl(membershipBaseURL, campaignCode),
+        supportURL = addTrackingCodesToUrl(supportBaseURL, campaignCode),
         template = controlTemplate,
+        buttonTemplate = defaultButtonTemplate,
         testimonialBlock = getTestimonialBlock(
             acquisitionsTestimonialParametersControl
         ),
@@ -236,7 +246,9 @@ const makeABTestVariant = (
             campaignCode,
             contributeURL,
             membershipURL,
+            supportURL,
             template,
+            buttonTemplate,
             testimonialBlock,
             blockEngagementBanner,
             engagementBannerParams,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -42,6 +42,12 @@ type ContributionsABTest = ABTest & {
 
 type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
+type CtaUrls = {
+    membershipUrl?: string,
+    contributeUrl?: string,
+    supportUrl?: string,
+};
+
 const membershipBaseURL = 'https://membership.theguardian.com/supporter';
 const contributionsBaseURL = 'https://contribute.theguardian.com';
 const supportBaseURL = 'https://support.theguardian.com/uk';
@@ -58,7 +64,7 @@ const defaultMaxViews: {
     minDaysBetweenViews: 0,
 };
 
-const defaultButtonTemplate = urls =>
+const defaultButtonTemplate = (urls: CtaUrls) =>
     lodashTemplate(acquisitionsEpicButtons, urls);
 
 const controlTemplate: EpicTemplate = ({ options = {} }, copy) =>
@@ -437,4 +443,5 @@ export {
     getTestimonialBlock,
     addTrackingCodesToUrl,
     makeABTest,
+    defaultButtonTemplate,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -16,6 +16,7 @@ import acquisitionsEpicAlwaysAskElection from 'common/modules/experiments/tests/
 import acquisitionsEpicThankYou from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import acquisitionsThisLandSeries from 'common/modules/experiments/tests/acquisitions-this-land-series';
 import epicForBrexitCohort from 'common/modules/experiments/tests/epic-for-brexit-cohort';
+import { acquisitionsEpicRebaselineSupportProposition } from 'common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -25,6 +26,7 @@ const tests = [
     acquisitionsThisLandSeries,
     bundlePriceTest1,
     epicForBrexitCohort,
+    acquisitionsEpicRebaselineSupportProposition,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveBlogDesignTest,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -2,7 +2,6 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import template from 'lodash/utilities/template';
 import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
-import config from 'lib/config';
 
 const buildButtonTemplate = ({ supportUrl }) =>
     template(singleButtonTemplate, {
@@ -25,9 +24,8 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
 
     audienceCriteria: 'UK all devices',
     audience: 0,
+    locations: ['GB'],
     audienceOffset: 0.9,
-
-    canRun: () => config.page.edition.toUpperCase() === 'UK',
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -13,8 +13,8 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
     id: 'AcquisitionsEpicRebaselineSupportProposition',
     campaignId: 'sandc_epic_rebaseline_support_proposition',
 
-    start: '2017-07-05',
-    expiry: '2017-08-05',
+    start: '2017-07-07',
+    expiry: '2017-08-15',
 
     author: 'Ap0c',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -2,6 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import template from 'lodash/utilities/template';
 import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
+import config from 'lib/config';
 
 const buildButtonTemplate = ({ supportUrl }) =>
     template(singleButtonTemplate, {
@@ -25,6 +26,8 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
     audienceCriteria: 'UK all devices',
     audience: 0,
     audienceOffset: 0.9,
+
+    canRun: () => config.page.edition.toUpperCase() === 'UK',
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -1,0 +1,48 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+
+export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
+    id: 'AcquisitionsEpicRebaselineSupportProposition',
+    campaignId: 'sandc_epic_rebaseline_support_proposition',
+
+    start: '2017-07-05',
+    expiry: '2017-08-05',
+
+    author: 'Ap0c',
+    description:
+        'This creates a single-button version of the epic that links off to the new support frontend bundles landing page',
+    successMeasure: 'Conversion rate',
+    idealOutcome:
+        'We get a baseline for conversion of the bundles landing page',
+
+    audienceCriteria: 'UK all devices',
+    audience: 0.1,
+    audienceOffset: 0.9,
+
+    variants: [
+        {
+            id: 'control',
+            maxViews: {
+                days: 30,
+                count: 4,
+                minDaysBetweenViews: 0,
+            },
+
+            useTailoredCopyForRegulars: true,
+            insertAtSelector: '.submeta',
+            successOnView: true,
+        },
+        {
+            id: 'support_proposition',
+            maxViews: {
+                days: 30,
+                count: 4,
+                minDaysBetweenViews: 0,
+            },
+
+            useTailoredCopyForRegulars: true,
+            insertAtSelector: '.submeta',
+            successOnView: true,
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -1,5 +1,12 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import template from 'lodash/utilities/template';
+import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
+
+const buildButtonTemplate = ({ supportUrl }) =>
+    template(singleButtonTemplate, {
+        url: supportUrl,
+    });
 
 export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
     id: 'AcquisitionsEpicRebaselineSupportProposition',
@@ -22,27 +29,12 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
     variants: [
         {
             id: 'control',
-            maxViews: {
-                days: 30,
-                count: 4,
-                minDaysBetweenViews: 0,
-            },
-
             useTailoredCopyForRegulars: true,
-            insertAtSelector: '.submeta',
-            successOnView: true,
         },
         {
             id: 'support_proposition',
-            maxViews: {
-                days: 30,
-                count: 4,
-                minDaysBetweenViews: 0,
-            },
-
+            buttonTemplate: buildButtonTemplate,
             useTailoredCopyForRegulars: true,
-            insertAtSelector: '.submeta',
-            successOnView: true,
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -23,7 +23,7 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
         'We get a baseline for conversion of the bundles landing page',
 
     audienceCriteria: 'UK all devices',
-    audience: 0.1,
+    audience: 0,
     audienceOffset: 0.9,
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -23,7 +23,7 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
         'We get a baseline for conversion of the bundles landing page',
 
     audienceCriteria: 'UK all devices',
-    audience: 0,
+    audience: 0.1,
     locations: ['GB'],
     audienceOffset: 0.9,
 

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-buttons.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-buttons.html
@@ -1,0 +1,17 @@
+<div class="contributions__amount-field">
+  <div>
+    <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
+      href="<%=membershipUrl%>"
+      target="_blank">
+      Become a supporter
+    </a>
+  </div>
+
+  <div>
+    <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
+     href="<%=contributeUrl%>"
+     target="_blank">
+     Make a contribution
+   </a>
+  </div>
+</div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-control.html
@@ -13,22 +13,6 @@
             </p>
         </div>
 
-        <div class="contributions__amount-field">
-            <div>
-                <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
-                   href="<%=membershipUrl%>"
-                   target="_blank">
-                    Become a supporter
-                </a>
-            </div>
-
-            <div>
-                <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member"
-                   href="<%=contributionUrl%>"
-                   target="_blank">
-                    Make a contribution
-                </a>
-            </div>
-        </div>
+        <%=buttonTemplate%>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/acquisitions-epic-single-button.html
+++ b/static/src/javascripts/projects/common/views/acquisitions-epic-single-button.html
@@ -1,0 +1,9 @@
+<div class="contributions__amount-field">
+  <div>
+    <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
+      href="<%=url%>"
+      target="_blank">
+      Support the Guardian
+    </a>
+  </div>
+</div>

--- a/static/src/stylesheets/module/experiments/_embed.scss
+++ b/static/src/stylesheets/module/experiments/_embed.scss
@@ -168,6 +168,10 @@
     width: 160px;
 }
 
+.contributions__contribute--epic-single-button {
+    width: 170px;
+}
+
 .contributions__option-button--support-landing-page {
     width: auto;
 }


### PR DESCRIPTION
## What does this change?

Implements an AB test using EPIC traffic to direct users to the [bundles landing page](https://support.theguardian.com/uk) on support-frontend. This is Q2-Test 1 for the S&C team. It will start switched off and visible to 0% of the audience. We will turn it on, test it, and then increase it to 10% when we're happy that it works.

The audience will be split into two, and will use the last 10% segment of the UK audience (see screenshots below):

- The control segment of the audience will see the current standard EPIC at the bottom of articles, which links out to the Supporter landing page on membership, and the home page on contributions.
- The 'support_proposition' segment of the audience will see a single-button version of the EPIC, and the button will link to the bundles landing page on support-frontend.

### Code Changes

- Added a new switch, default off, which expires in a month.
- Modified the control EPIC in `contributions-utilities`. Instead of having the CTA buttons hardcoded, it takes a rendered template. By default this template shows the two standard buttons ('Become a supporter' and 'Make a contribution').
- Added a `supportUrl` as part of the variant options.
- Created a new `AcquisitionsEpicRebaselineSupportProposition` test with two variants (`control` and `support_proposition`), which will show for the UK audience across all breakpoints.
- Created a single-button version of the button template with 'Support the Guardian' that will link to the bundles landing page.

## What is the value of this and can you measure success?

This is a re-baseline of the test implemented in #16290, its purpose is to compare the new product "universe", as seen on the bundles landing page, with the old "universe", a.k.a. membership + contributions + subscriptions. The metric for comparison is Annualised Value (for a more in-depth explanation speak to @patstirling).

## Does this affect other platforms - Amp, Apps, etc?

The reader revenue platforms (support, membership, subscriptions, contributions).

## Screenshots

**Control EPIC:**

![control-epic](https://user-images.githubusercontent.com/5131341/27913328-a8795bda-6257-11e7-8cde-0135033b60c1.png)

**support_proposition EPIC:**

![support-epic](https://user-images.githubusercontent.com/5131341/27913333-b0b6add4-6257-11e7-937e-f35d5df994f7.png)

**Bundles Landing Page - support-frontend:**

![bundles-landing](https://user-images.githubusercontent.com/5131341/27913411-e930a0de-6257-11e7-903b-f57735a541fd.png)

## Tested in CODE?

Not yet.