### PR TITLE
Fix background style bug using Object.assign.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -48,7 +48,7 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
     // Create an element to hold the background image
     const background = document.createElement('div');
     background.className = `creative__background creative__background--${specs.scrollType}`;
-    background.style = Object.assign(background.style, specStyles);
+    Object.assign(background.style, specStyles);
 
     // Wrap the background image in a DIV for positioning. Also, we give
     // this DIV a background colour if it is provided. This is because


### PR DESCRIPTION
## What does this change?
Full disclosure, I'm not _entirely_ sure why the code as it is doesn't work properly(!)

We have an object that contains several style properties - `specStyles` and we want to apply these styles to the `style` property of a `background` object we have created, hence: 

`background.style = Object.assign(background.style, specStyles);`.

[Object.assign](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) returns the target object and so the above line should be first adding the styles to `background` and then (redundantly) performing `background.style = background.style`.

However, when this executes, `background.style` does not have any of the properties set. Removing the assignment _does_ then correctly copy the styles to `background.style`.

I suspect this may have _something_ to do with how `Object.assign` copies accessor methods, since the `style` object of an element is actually a `CSSStyleObject` and not a standard `Object`. Either way, this fixes the bug and removes the impression that `Object.assign` provides a _new_ object.

## What is the value of this and can you measure success?
The background messenger functionality now works, which fixes a bunch of native ad bugs.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
