### PR TITLE
Create hide message to hide ad slots from an iFrame.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -24,13 +24,23 @@ import { init as initMessenger } from 'commercial/modules/messenger';
 
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as getStyles } from 'commercial/modules/messenger/get-stylesheet';
+import { init as hide } from 'commercial/modules/messenger/hide';
 import { init as resize } from 'commercial/modules/messenger/resize';
 import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
 import { init as sendClick } from 'commercial/modules/messenger/click';
 import { init as background } from 'commercial/modules/messenger/background';
 
-initMessenger(type, getStyles, resize, scroll, viewport, sendClick, background);
+initMessenger(
+    type,
+    getStyles,
+    resize,
+    hide,
+    scroll,
+    viewport,
+    sendClick,
+    background
+);
 
 const setDfpListeners = (): void => {
     setListeners(window.googletag);

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.js
@@ -21,4 +21,6 @@ const init = (register: RegisterListeners) => {
     });
 };
 
+export const _ = { hide };
+
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.js
@@ -1,0 +1,24 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import type { RegisterListeners } from 'commercial/modules/messenger';
+
+const hide = (adSlot: HTMLElement): ?Promise<any> => {
+    if (!adSlot) {
+        return null;
+    }
+
+    return fastdom.write(() => {
+        adSlot.classList.add('u-h');
+    });
+};
+
+const init = (register: RegisterListeners) => {
+    register('hide', (specs, ret, iframe) => {
+        if (iframe) {
+            const adSlot = iframe && iframe.closest('.js-ad-slot');
+            return hide(adSlot);
+        }
+    });
+};
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.spec.js
@@ -1,0 +1,22 @@
+// @flow
+import type { JestMockT } from 'jest';
+import { _ } from './hide.js';
+
+const foolFlow = (mockFn: any) => ((mockFn: any): JestMockT);
+const { hide } = _;
+
+describe('Cross-frame messenger: hide', () => {
+    describe('hide function', () => {
+        it('should hide the ad slot', done => {
+            const fallback = document.createElement('div');
+            const fakeIframe = document.getElementById('iframe01') || fallback;
+            const fakeAdSlot = document.getElementById('slot01') || fallback;
+            foolFlow(hide(fakeAdSlot))
+                .then(() => {
+                    expect(fakeIframe.classList.contains('u-h'));
+                })
+                .then(done)
+                .catch(done.fail);
+        });
+    });
+});


### PR DESCRIPTION
## What does this change?
This extends the commercial messenger API to receive 'hide' requests. There is no data payload needed - whenever a hide request is received, the `u-h` class is added to the parent ad slot.

## What is the value of this and can you measure success?
This allows the Outstream video ad player to send a message to close the ad slot when a user hits 'close' on their in-ad player.

@regiskuckaertz @guardian/commercial-dev 
