### PR TITLE
In-app snippets: send path to Ophan

### DIFF
--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -21,8 +21,8 @@ Promise.all([
           }),
     new Promise(domready),
     new Promise(comready),
-]).then(() => {
-    SnippetFeedback({ scroll: false });
+]).then(([, , result]) => {
+    SnippetFeedback({ scroll: false, ophan: { path: result.src } });
     [...document.getElementsByTagName('details')]
         .slice(0, 1)
         .forEach(details => {

--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -22,7 +22,7 @@ Promise.all([
     new Promise(domready),
     new Promise(comready),
 ]).then(([, , result]) => {
-    SnippetFeedback({ scroll: false, ophan: { path: result.src } });
+    SnippetFeedback({ scroll: false, ophan: { path: result.src || null } });
     [...document.getElementsByTagName('details')]
         .slice(0, 1)
         .forEach(details => {

--- a/static/src/javascripts/lib/comready.js
+++ b/static/src/javascripts/lib/comready.js
@@ -15,11 +15,16 @@ const comready = (resolve: (?any) => void, reject: (?any) => void) => {
         send('syn', true);
     }, 500);
     window.addEventListener('message', evt => {
-        if (JSON.parse(evt.data).result !== 'ack') {
+        const response = JSON.parse(evt.data);
+        if (
+            typeof response !== 'object' ||
+            typeof response.result !== 'object' ||
+            response.result.msg !== 'ack'
+        ) {
             return;
         }
         clearInterval(intId);
-        resolve();
+        resolve(response.result);
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -171,8 +171,7 @@ const pruneSummary = (summary: Object, newToday: number = today) => {
                         .filter(Boolean);
 
                     return visits.length > 1 ||
-                        (visits.length === 1 &&
-                            visits[0][0] < forgetUniquesAfter)
+                    (visits.length === 1 && visits[0][0] < forgetUniquesAfter)
                         ? visits
                         : [];
                 }

--- a/static/src/javascripts/projects/journalism/snippet-feedback.js
+++ b/static/src/javascripts/projects/journalism/snippet-feedback.js
@@ -5,7 +5,7 @@ import ophan from 'ophan/ng';
 import detect from 'lib/detect';
 
 const SnippetFeedback = (
-    options: { scroll: boolean, ophan: object } = { scroll: true, ophan: {} }
+    options: { scroll: boolean, ophan: Object } = { scroll: true, ophan: {} }
 ) => {
     let snippets = [...document.querySelectorAll('.explainer-snippet--new')];
 

--- a/static/src/javascripts/projects/journalism/snippet-feedback.js
+++ b/static/src/javascripts/projects/journalism/snippet-feedback.js
@@ -4,7 +4,9 @@ import mediator from 'lib/mediator';
 import ophan from 'ophan/ng';
 import detect from 'lib/detect';
 
-const SnippetFeedback = (options: { scroll: boolean } = { scroll: true }) => {
+const SnippetFeedback = (
+    options: { scroll: boolean, ophan: object } = { scroll: true, ophan: {} }
+) => {
     let snippets = [...document.querySelectorAll('.explainer-snippet--new')];
 
     snippets.forEach(snippet => {
@@ -27,11 +29,14 @@ const SnippetFeedback = (options: { scroll: boolean } = { scroll: true }) => {
                 button && button instanceof HTMLButtonElement && button.value;
 
             if (value && ack) {
-                const data = {
-                    atomId: snippetId,
-                    component,
-                    value: `${snippetType}_feedback_${value}`,
-                };
+                const data = Object.assign(
+                    {
+                        atomId: snippetId,
+                        component,
+                        value: `${snippetType}_feedback_${value}`,
+                    },
+                    options.ophan
+                );
                 ophan.record(data);
                 fastdom.write(() => {
                     ack.hidden = false;
@@ -54,11 +59,14 @@ const SnippetFeedback = (options: { scroll: boolean } = { scroll: true }) => {
         );
         if (handle) {
             handle.addEventListener('click', function onExpand(e: Event) {
-                const data = {
-                    atomId: snippetId,
-                    component,
-                    value: `${snippetType}_expanded`,
-                };
+                const data = Object.assign(
+                    {
+                        atomId: snippetId,
+                        component,
+                        value: `${snippetType}_expanded`,
+                    },
+                    options.ophan
+                );
                 ophan.record(data);
 
                 e.currentTarget.removeEventListener('click', onExpand);
@@ -81,11 +89,14 @@ const SnippetFeedback = (options: { scroll: boolean } = { scroll: true }) => {
                     }
                     const component = `snippet_${snippetType}`;
 
-                    const data = {
-                        atomId: snippetId,
-                        component,
-                        value: `${snippetType}_component_in_view`,
-                    };
+                    const data = Object.assign(
+                        {
+                            atomId: snippetId,
+                            component,
+                            value: `${snippetType}_component_in_view`,
+                        },
+                        options.ophan
+                    );
                     ophan.record(data);
 
                     return false;


### PR DESCRIPTION
Needs to be merged in parallel with [this one](https://github.com/guardian/mobile-apps-article-templates/pull/651).