### PR TITLE
Send server side AB test values to DFP

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -22,21 +22,21 @@ const abParam = (): Array<string> => {
     const abParticipations: Object = getParticipations();
     const abParams: Array<string> = [];
 
-    Object.keys(abParticipations).forEach((testKey: string): void => {
-        const testValue: { variant: string } = abParticipations[testKey];
-        if (testValue.variant && testValue.variant !== 'notintest') {
-            const testData: string = `${testKey}-${testValue.variant}`;
-            // DFP key-value pairs accept value strings up to 40 characters long
+    const pushAbParams = (testName: string, testValue: mixed): void => {
+        if (typeof testValue === 'string' && testValue !== 'notintest') {
+            const testData: string = `${testName}-${testValue}`;
             abParams.push(testData.substring(0, 40));
         }
+    };
+
+    Object.keys(abParticipations).forEach((testKey: string): void => {
+        const testValue: { variant: string } = abParticipations[testKey];
+        pushAbParams(testKey, testValue.variant);
     });
 
     if (config.tests) {
-        Object.keys(config.tests).forEach((testKey: string) => {
-            const testValue: string = config.tests[testKey];
-            if (typeof testValue === 'string') {
-                abParams.push(testValue);
-            }
+        Object.entries(config.tests).forEach(([testName, testValue]) => {
+            pushAbParams(testName, testValue);
         });
     }
 

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -25,6 +25,7 @@ const abParam = (): Array<string> => {
     const pushAbParams = (testName: string, testValue: mixed): void => {
         if (typeof testValue === 'string' && testValue !== 'notintest') {
             const testData: string = `${testName}-${testValue}`;
+            // DFP key-value pairs accept value strings up to 40 characters long
             abParams.push(testData.substring(0, 40));
         }
     };

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -19,7 +19,6 @@ const formatTarget = (target: ?string): ?string =>
     target ? format(target).replace(/&/g, 'and').replace(/'/g, '') : null;
 
 const abParam = (): Array<string> => {
-    const cmRegex: RegExp = /^(cm|commercial)/;
     const abParticipations: Object = getParticipations();
     const abParams: Array<string> = [];
 
@@ -35,7 +34,7 @@ const abParam = (): Array<string> => {
     if (config.tests) {
         Object.keys(config.tests).forEach((testKey: string) => {
             const testValue: string = config.tests[testKey];
-            if (typeof testValue === 'string' && cmRegex.test(testValue)) {
+            if (typeof testValue === 'string') {
                 abParams.push(testValue);
             }
         });


### PR DESCRIPTION
## What does this change?
Sends server-side AB test values to DFP in the same format as currently done for client-side tests

## What is the value of this and can you measure success?
Required to measure the impact of server side AB tests on advertising metrics

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
_from the Google Publisher Console_
![screen shot 2017-07-07 at 11 56 36](https://user-images.githubusercontent.com/1764158/27955236-d82cbec6-630b-11e7-9acb-17e375f85abf.png)


## Tested in CODE?
Yes
CC @guardian/commercial-dev 
_H/T @JonNorman for pointing me in the right direction_ 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
