### PR TITLE
Prevented fullscreen icon bleeding out

### DIFF
--- a/static/src/stylesheets/inline/article-photo-essay.scss
+++ b/static/src/stylesheets/inline/article-photo-essay.scss
@@ -128,6 +128,10 @@
             & + .element-pullquote.element--halfWidth {
                 margin-top: 0;
             }
+
+            & + .element-image:not(.element--halfWidth) {
+                clear: left;
+            }
         }
         &.element--halfWidth.half-width-odd {
             margin-right: 2%;


### PR DESCRIPTION
When you hover the puffin that feels shame, the full screen icon appears over the loving puffins.

<img width="909" alt="screen shot 2017-07-07 at 14 34 40" src="https://user-images.githubusercontent.com/14570016/27959971-74204342-6321-11e7-8bf3-8842fd192d9d.png">

# NOT ON BEN'S WATCH 
(I'm doing this for Ben)

Now the shame puffin gets a full-screen icon.
<img width="972" alt="screen shot 2017-07-07 at 14 35 56" src="https://user-images.githubusercontent.com/14570016/27960026-a32ce654-6321-11e7-9863-d7c2dbd27b18.png">
