### PR TITLE
Made the trailing slashes switch from before to afters (Only at mobile)

### DIFF
--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -60,17 +60,35 @@
         color: #ffffff;
     }
 
-    > *:before {
-        content: '/';
-        color: rgba(255, 255, 255, .3);
-        display: inline-block;
-        font-size: 1em;
-        pointer-events: none;
-        margin-left: -2px;
-        margin-right: -2px;
+    @include mq($until: tablet) {
+        > *:after {
+            content: '/';
+            color: rgba(255, 255, 255, .3);
+            display: inline-block;
+            font-size: 1em;
+            pointer-events: none;
+            margin-left: -2px;
+            margin-right: -2px;
+        }
+
+        &:last-child > *:after {
+            content: '';
+        }
     }
 
-    &:first-child > *:before {
-        content: '';
+    @include mq(tablet) {
+        > *:before {
+            content: '/';
+            color: rgba(255, 255, 255, .3);
+            display: inline-block;
+            font-size: 1em;
+            pointer-events: none;
+            margin-left: -2px;
+            margin-right: -2px;
+        }
+
+        &:first-child > *:before {
+            content: '';
+        }
     }
 }


### PR DESCRIPTION
Keeps multi-line text looking nicer at mobile.

# Before
<img width="559" alt="screen shot 2017-07-07 at 14 56 58" src="https://user-images.githubusercontent.com/14570016/27960927-ef1a0152-6324-11e7-9b7e-d3c46b1c5ed7.png">

# After
![screen shot 2017-07-07 at 14 56 58](https://user-images.githubusercontent.com/14570016/27961031-4ea440d8-6325-11e7-94aa-69f318b93434.jpg)

