### PR TITLE
This should be lowercase

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -119,7 +119,7 @@ object MembershipLink {
     if(mvt.ABNewDesktopHeaderControl.isParticipating) {
       s"${Configuration.id.membershipUrl}/supporter?INTCMP=mem_${edition.id}_web_newheader_control"
     } else {
-      s"${Configuration.id.membershipUrl}/supporter?countryGroup=${edition.id}&INTCMP=DOTCOM_HEADER_BECOMEMEMBER_${edition.id}"
+      s"${Configuration.id.membershipUrl}/supporter?countryGroup=${edition.id.toLowerCase}&INTCMP=DOTCOM_HEADER_BECOMEMEMBER_${edition.id}"
     }
   }
 }


### PR DESCRIPTION
## What does this change?
#17395 I overlooked the fact that The membership site seems reliant on a lowercase value for their redirect. Why? No idea.

This fixes the problem though.

## What is the value of this and can you measure success?
When the value is not lowercase the redirect fails on the membership site and you get:
![image](https://user-images.githubusercontent.com/8774970/27964964-0a9fe8bc-6332-11e7-8117-3f71bf788bdc.png)


## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
n/a

## Tested in CODE?
nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
