### PR TITLE
Add es2017 set to Polyfill

### DIFF
--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,default-3.6&flags=gated&callback=guardianPolyfilled
+https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6&flags=gated&callback=guardianPolyfilled


### PR DESCRIPTION
## What does this change?
I'm adding `es2017` to polyfill.io, so that developers can use things like `Object.entries`.

## Tested in CODE?
In Browserstack.