### PR TITLE
Switch extra auction

### DIFF
--- a/diagnostics/app/controllers/CommercialPreflightController.scala
+++ b/diagnostics/app/controllers/CommercialPreflightController.scala
@@ -106,7 +106,7 @@ class CommercialPreflightController(wsClient: WSClient) extends Controller with 
     } {
       val adHubRequest = Json.toJson(AdRequest(
         load_id = pageViewId,
-        zone_ids = List(229, 228),
+        zone_ids = List(229, 228, 228),
         /*  id    sizes
             229   970x250, 728x90
             228   300x250


### PR DESCRIPTION
## What does this change?

This changes the pre-flight request to Switch to request an extra auction for zone `228`, which is the zone used for `300x250`.

## What is the value of this and can you measure success?

More inventory passing through programmatic pipes.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

Not yet.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

@rich-nguyen 
