### PR TITLE
Reader question - add padding to ease inclusion in liveblogs

### DIFF
--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -4,7 +4,7 @@
 
     &.submeta {
         border: 0;
-        padding: ($gs-baseline / 3) * 4;
+        padding: 16px;
     }
 }
 .user__question-title {

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -4,6 +4,7 @@
 
     &.submeta {
         border: 0;
+        padding: ($gs-baseline / 3) * 4;
     }
 }
 .user__question-title {


### PR DESCRIPTION
## What does this change?

Add padding so story questions could be embedded nicely in liveblogs

<img width="656" alt="screen shot 2017-07-10 at 17 49 22" src="https://user-images.githubusercontent.com/615085/28030733-e2b0e83e-659c-11e7-9e5c-19af09a5fb93.png">


## What is the value of this and can you measure success?

allow story questions to be embedded in live blogs

## Does this affect other platforms - Amp, Apps, etc?

no

## Tested in CODE?
no