### PR TITLE
Improve error messaging when IP is throttled from commenting

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/comment-box.js
@@ -69,6 +69,7 @@ CommentBox.prototype.errorMessages = {
     EMPTY_COMMENT_BODY: 'Please write a comment.',
     COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
     USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
+    IP_THROTTLED: 'Commenting has been temporarily blocked for this IP address (<a href="/community-faqs">why?</a>).',
     DISCUSSION_CLOSED: 'Sorry your comment can not be published as the discussion is now closed for comments.',
     PARENT_COMMENT_MODERATED: 'Sorry the comment can not be published as the comment you replied to has been moderated since.',
     COMMENT_RATE_LIMIT_EXCEEDED: 'You can only post one comment every minute. Please try again in a moment.',
@@ -374,7 +375,9 @@ CommentBox.prototype.fail = function(xhr) {
         this.error('API_CORS_BLOCKED');
     } else if (response.errorCode === 'EMAIL_NOT_VALIDATED') {
         this.invalidEmailError();
-    } else if (this.errorMessages[response.errorCode]) {
+    } else if (response.errorCode === 'IP_ADDRESS_BLOCKED'){
+        this.error('IP_THROTTLED')
+    }else if (this.errorMessages[response.errorCode]) {
         this.error(response.errorCode);
     } else {
         this.error('API_ERROR', this.errorMessages.API_ERROR + xhr.status);// templating would be ideal here


### PR DESCRIPTION
## What does this change?
- Improves the frontend error message when an ip is blocked by a moderator and trying to comment. 
- This is linked with the discussion API PR https://github.com/guardian/discussion-api/pull/549 .

## What is the value of this and can you measure success?
- Produce a useful error message to users and hopefully stop so many confused messages to user help.

## Does this affect other platforms - Amp, Apps, etc?
- shouldn't do
## Screenshots
Before:
![image](https://user-images.githubusercontent.com/14179210/28031342-d77b09d4-659e-11e7-90dc-eea605f60dc5.png)

After:
![image](https://user-images.githubusercontent.com/14179210/28031087-19c09dbe-659e-11e7-9242-2977d41009df.png)

## Tested in CODE?
Yep

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
