### PR TITLE
Horizontal scrollbar bug on expanded header

### DIFF
--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -5,6 +5,11 @@ from scrolling */
         overflow: hidden;
         width: 100%;
     }
+
+    // Prevents horizontal scrollbar https://codepen.io/tigt/post/bust-elements-out-of-containers-with-one-line-of-css#oh-no-a-horizontal-scrollbar-6
+    @include mq(desktop) {
+        overflow-x: hidden;
+    }
 }
 
 .new-header {


### PR DESCRIPTION
A bug in some instances of Chrome v 5.9 causing a horizontal scrollbar when the menu is expanded.  

Fixed with `overflox-x: hidden` on html element.

Info from here: https://codepen.io/tigt/post/bust-elements-out-of-containers-with-one-line-of-css#oh-no-a-horizontal-scrollbar-6