### PR TITLE
Reinstate Paid Content related content styling: Revert PRs 17366 and 17386

### DIFF
--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -24,8 +24,7 @@
                 item = paidContentOnEditorialPage,
                 omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage),
                 containerIndex,
-                index,
-                isFirstContainer
+                index
             )
         }
 

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -1,11 +1,8 @@
-@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int, isFirstContainer: Boolean)(implicit request: RequestHeader)
+@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards._
-@import views.support.GetClasses
-@import Function.const
-@import views.html.fragments.commercial.cardLogo
 
-<div class="adverts--within-unbranded @GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}">
+<div class="fc-item fc-item--has-image js-fc-item fc-item--list-media-mobile fc-item--standard-tablet adverts--within-unbranded @item.cardTypes.classes)">
     <div class="fc-item__container">
         @item.paidImage.map(image => itemImage(
             image,
@@ -19,13 +16,11 @@
                 </div>
             </div>
 
-            @item.trailText.filter(const(item.showStandfirst)).map { text =>
-                <div class="fc-item__standfirst">@Html(text)</div>
-            }
-
-            @item.branding.map { branding =>
-                @cardLogo(branding, isStandardSizeCard = false)
-            }
+            <div class="badge badge--no-image">
+                <div class="badge__label">
+                    Paid for by @item.branding.map(_.sponsorName)
+                </div>
+            </div>
 
         </div>
 

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -169,7 +169,7 @@ $paid-article-header:       #bfbfbf;
 $paid-article-header-bg:    #b8b8b8;
 $paid-article-subheader:    #cccccc;
 $paid-article-subheader-bg: #c4c4c4;
-$paid-article-card-bg:      $neutral-8;
+$paid-article-card-bg:      #d7d7d7;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -373,7 +373,7 @@
         background-color: $paid-article-card-bg;
         &:hover,
         &.u-faux-block-link--hover {
-            background-color: $neutral-6;
+            background: darken($paid-article-subheader, 7%);
         }
     }
     .fc-item__container:before {
@@ -383,9 +383,7 @@
         fill: $paid-article-brand;
     }
     .fc-item__title {
-        @include f-textSans;
-        font-weight: 600;
-        color: $neutral-1;
+        @include f-headlineSans;
     }
 
     .fc-item__content {
@@ -396,10 +394,6 @@
         @include mq(mobileLandscape, tablet) {
             flex-direction: row;
         }
-    }
-
-    .fc-item__standfirst {
-        color: $neutral-1;
     }
 
     .badge {
@@ -414,7 +408,6 @@
         }
     }
     .badge__label {
-        color: #757575;
         text-align: center;
         align-self: center;
     }
@@ -444,11 +437,6 @@
 
     .badge--no-image {
         margin-bottom: $gs-baseline/2;
-    }
-
-    .badge__sponsor-name {
-        @include f-textSans;
-        color: $neutral-1;
     }
 
     .inline-icon__svg {


### PR DESCRIPTION
Reverts #17366 and #17386 to reinstate related content container styling.
