### PR TITLE
Add global `hide-reader-revenue` CSS class

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -64,43 +64,32 @@
         }).join(' ');
     }
 
+    function getCookieValue(name) {
+        var val = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+        return val ? val.pop() : undefined;
+    }
+
     /*
         This is a shortened version of shouldSeeReaderRevenue() from
         user-features.js. Since we are blocking rendering at this time we
         can't/ don't want to online all required JS from this module.
     */
-    function hideReaderRevenue() {
-        var getCookieValue = function(name) {
-            var val = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
-            return val ? val.pop() : undefined;
-        };
+    function isRecentContributor() {
+        var value = getCookieValue('gu.contributions.contrib-timestamp');
 
-        var contribution = {
-            cookie: 'gu.contributions.contrib-timestamp',
-            check: function(value) {
-                if (!value) {
-                    return false;
-                }
+        if (!value) {
+            return false;
+        }
 
-                var now = new Date().getTime();
-                var lastContribution = new Date(value).getTime();
-                var diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
+        var now = new Date().getTime();
+        var lastContribution = new Date(value).getTime();
+        var diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
 
-                return diffDays <= 180;
-            },
-        };
+        return diffDays <= 180;
+    }
 
-        var member = {
-            cookie: 'gu_paying_member',
-            check: function(value) {
-                return value === 'true';
-            },
-        };
-
-        var contribCookie = getCookieValue(contribution.cookie);
-        var memberCookie = getCookieValue(member.cookie);
-
-        return member.check(memberCookie) || contribution.check(contribCookie);
+    function isPayingMember() {
+        return getCookieValue('gu_paying_member') === 'true';
     }
 
     // http://modernizr.com/download/#-svg
@@ -141,8 +130,12 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (hideReaderRevenue()) {
-        docClass += ' hide-reader-revenue';
+    if (isPayingMember()) {
+        docClass += ' is-paying-member';
+    }
+
+    if (isRecentContributor()) {
+        docClass += ' is-recent-contributor';
     }
 
     documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -64,6 +64,47 @@
         }).join(' ');
     }
 
+    /*
+        This is a shortened version of shouldSeeReaderRevenue() from
+        user-features.js. Since we are blocking rendering at this time we
+        can't/ don't want to online all required JS from this module.
+    */
+    function hideReaderRevenue() {
+        var cookies = document.cookie.split('; ');
+        var contribution = {
+            cookie: 'gu.contributions.contrib-timestamp',
+            fullfilled: false,
+            check: function(value) {
+                var now = new Date().getTime();
+                var lastContribution = new Date(value).getTime();
+                var diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
+
+                return diffDays <= 180;
+            },
+        };
+        var member = {
+            cookie: 'gu_paying_member',
+            fullfilled: false,
+            check: function(value) {
+                return value === 'true';
+            },
+        };
+
+        for(var i = 0; i < cookies.length; ++i) {
+            var cookie = cookies[i].split('=');
+
+            if (cookie.indexOf(contribution.cookie) !== -1) {
+                contribution.fullfilled = contribution.check(cookie[1]);
+            }
+
+            if (cookie.indexOf(member.cookie) !== -1) {
+                member.fullfilled = member.check(cookie[1]);
+            }
+        }
+
+        return member.fullfilled && contribution.fullfilled;
+    }
+
     // http://modernizr.com/download/#-svg
     if (!!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGRect) {
         docClass += ' svg';
@@ -101,5 +142,10 @@
     if (baseFontSize && parseInt(baseFontSize, 10) !== 16) {
         documentElement.style.fontSize = baseFontSize
     }
+
+    if (hideReaderRevenue()) {
+        docClass += ' hide-reader-revenue';
+    }
+
     documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');
 })(document.documentElement, window, navigator);

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -102,7 +102,7 @@
             }
         }
 
-        return member.fullfilled && contribution.fullfilled;
+        return member.fullfilled || contribution.fullfilled;
     }
 
     // http://modernizr.com/download/#-svg

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -70,11 +70,18 @@
         can't/ don't want to online all required JS from this module.
     */
     function hideReaderRevenue() {
-        var cookies = document.cookie.split('; ');
+        var getCookieValue = function(name) {
+            var val = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+            return val ? val.pop() : undefined;
+        };
+
         var contribution = {
             cookie: 'gu.contributions.contrib-timestamp',
-            fullfilled: false,
             check: function(value) {
+                if (!value) {
+                    return false;
+                }
+
                 var now = new Date().getTime();
                 var lastContribution = new Date(value).getTime();
                 var diffDays = Math.ceil((now - lastContribution) / (1000 * 3600 * 24));
@@ -82,27 +89,18 @@
                 return diffDays <= 180;
             },
         };
+
         var member = {
             cookie: 'gu_paying_member',
-            fullfilled: false,
             check: function(value) {
                 return value === 'true';
             },
         };
 
-        for(var i = 0; i < cookies.length; ++i) {
-            var cookie = cookies[i].split('=');
+        var contribCookie = getCookieValue(contribution.cookie);
+        var memberCookie = getCookieValue(member.cookie);
 
-            if (cookie.indexOf(contribution.cookie) !== -1) {
-                contribution.fullfilled = contribution.check(cookie[1]);
-            }
-
-            if (cookie.indexOf(member.cookie) !== -1) {
-                member.fullfilled = member.check(cookie[1]);
-            }
-        }
-
-        return member.fullfilled || contribution.fullfilled;
+        return member.check(memberCookie) || contribution.check(contribCookie);
     }
 
     // http://modernizr.com/download/#-svg

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -72,7 +72,7 @@
     /*
         This is a shortened version of shouldSeeReaderRevenue() from
         user-features.js. Since we are blocking rendering at this time we
-        can't/ don't want to online all required JS from this module.
+        can't inline all required JS from this module.
     */
     function isRecentContributor() {
         var value = getCookieValue('gu.contributions.contrib-timestamp');

--- a/static/src/javascripts/projects/commercial/modules/user-features.js
+++ b/static/src/javascripts/projects/commercial/modules/user-features.js
@@ -114,6 +114,11 @@ const isContributor = (): boolean => !!lastContributionDate;
 // in last six months
 const isRecentContributor = (): boolean => daysSinceLastContribution <= 180;
 
+/*
+    Whenever the checks are updated, please make sure to update
+    applyRenderConditions.scala.js too, where the global CSS class, indicating
+    the user should not see the revenue messages, is added to the body
+*/
 const shouldSeeReaderRevenue = (): boolean =>
     !isPayingMember() && !isRecentContributor();
 

--- a/static/src/stylesheets/layout/new-header/_header-cta-item.scss
+++ b/static/src/stylesheets/layout/new-header/_header-cta-item.scss
@@ -39,6 +39,10 @@
 .header-cta-item--primary {
     color: $guardian-brand-dark;
 
+    .hide-reader-revenue & {
+        display: none;
+    }
+
     &:before {
         border-top: $gs-baseline * 4 solid $news-main-2;
         border-left: $gs-gutter / 4 solid transparent;

--- a/static/src/stylesheets/layout/new-header/_header-cta-item.scss
+++ b/static/src/stylesheets/layout/new-header/_header-cta-item.scss
@@ -39,7 +39,8 @@
 .header-cta-item--primary {
     color: $guardian-brand-dark;
 
-    .hide-reader-revenue & {
+    .is-paying-member &,
+    .is-recent-contributor & {
         display: none;
     }
 


### PR DESCRIPTION
## What does this change?

Number one feedback for the new header so far "surprisingly" is: I am already supporting you, so please stop asking me. This PR adds a global CSS class, which indicates, we should hide revenue messages to the user.

Since this is done in the blocking JS, it adds no visual glitches/ jumps at pageload, but we have to keep the check small and synchronous. Once it has proven to be successful, other parts of the pages (thrashers, ...) could take advantage of the class aswell.

Unfortunately we can't do this server-side (yet), because it would require to split the cache in fastly.

## What is the value of this and can you measure success?

No revenue messages in the header anymore, for people who are already considered to be members and contributors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

**Before**

<img width="1280" alt="screen shot 2017-07-11 at 15 35 12" src="https://user-images.githubusercontent.com/2244375/28073876-00b3b3a4-664f-11e7-9576-353df5ac4a0f.png">

**After**

<img width="1280" alt="screen shot 2017-07-11 at 15 35 26" src="https://user-images.githubusercontent.com/2244375/28073884-072f3ca8-664f-11e7-8525-7ef0f0259d26.png">


## Tested in CODE?

No.
