### PR TITLE
Story questions - Add  padding only in live blogs

### DIFF
--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -4,7 +4,6 @@
 
     &.submeta {
         border: 0;
-        padding: 16px;
     }
 }
 .user__question-title {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -332,7 +332,7 @@ $block-padding-right: $gs-gutter;
         > .element-embed,
         > .element-audio,
         > .element-interactive,
-        > .element-atom {
+        > .element-atom:not(.element-atom--media) {
             width: auto;
             margin: $gs-baseline $gs-gutter/2 ($gs-baseline / 3) * 4;
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -331,7 +331,8 @@ $block-padding-right: $gs-gutter;
         > .element-comment,
         > .element-embed,
         > .element-audio,
-        > .element-interactive {
+        > .element-interactive,
+        > .element-atom {
             width: auto;
             margin: $gs-baseline $gs-gutter/2 ($gs-baseline / 3) * 4;
 


### PR DESCRIPTION
## What does this change?
See #17410 for the context.

Previous changed where updating the `padding` in all context. Those changes only focus in the `liveblog` context and target all atom except the youtube video one which does not need it.

With the changes the padding for atoms (except youtube videos) in liveblog is similar to interactives.

**interactive** 
<img width="641" alt="screen shot 2017-07-11 at 15 46 49" src="https://user-images.githubusercontent.com/615085/28074416-6ae9179a-6650-11e7-80af-a97be7b7db0b.png">

**story questions atom**
<img width="647" alt="screen shot 2017-07-11 at 15 46 37" src="https://user-images.githubusercontent.com/615085/28074440-8142dab2-6650-11e7-9b12-0965579f888f.png">



