### PR TITLE
Remove userhelp email from email prefs page

### DIFF
--- a/identity/app/controllers/EmailController.scala
+++ b/identity/app/controllers/EmailController.scala
@@ -17,23 +17,24 @@ import play.filters.csrf._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json._
 
-class EmailController(returnUrlVerifier: ReturnUrlVerifier,
-                      conf: IdentityConfiguration,
-                      api: IdApiClient,
-                      idRequestParser: IdRequestParser,
-                      idUrlBuilder: IdentityUrlBuilder,
-                      authenticatedActions: AuthenticatedActions,
-                      val messagesApi: MessagesApi,
-                      csrfCheck: CSRFCheck,
-                      csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext)
-  extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
-    import EmailPrefsData._
+class EmailController(
+    returnUrlVerifier: ReturnUrlVerifier,
+    conf: IdentityConfiguration,
+    api: IdApiClient,
+    idRequestParser: IdRequestParser,
+    idUrlBuilder: IdentityUrlBuilder,
+    authenticatedActions: AuthenticatedActions,
+    val messagesApi: MessagesApi,
+    csrfCheck: CSRFCheck,
+    csrfAddToken: CSRFAddToken)(implicit context: ApplicationContext)
+    extends Controller with ExecutionContexts with SafeLogging with I18nSupport {
+
+  import EmailPrefsData._
   import authenticatedActions.authAction
 
   val page = IdentityPage("/email-prefs", "Email preferences")
-  protected def formActionUrl(idUrlBuilder: IdentityUrlBuilder, idRequest: IdentityRequest): String = idUrlBuilder.buildUrl("/email-prefs", idRequest)
 
-  def preferences = csrfAddToken {
+  def preferences: Action[AnyContent] = csrfAddToken {
     authAction.async { implicit request =>
       val idRequest = idRequestParser(request)
       val userId = request.user.getId()
@@ -61,12 +62,19 @@ class EmailController(returnUrlVerifier: ReturnUrlVerifier,
           }
         }
       }).map{ form =>
-        Ok(views.html.profile.emailPrefs(page, form, formActionUrl(idUrlBuilder, idRequest), getEmailSubscriptions(form).toList, EmailNewsletters.all))
+        Ok(views.html.profile.emailPrefs(
+            page,
+            form,
+            getEmailSubscriptions(form).toList, EmailNewsletters.all,
+            idRequest,
+            idUrlBuilder
+          )
+        )
       }
     }
   }
 
-  def savePreferences = csrfCheck {
+  def savePreferences: Action[AnyContent] = csrfCheck {
     authAction.async { implicit request =>
 
       val idRequest = idRequestParser(request)

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -3,10 +3,16 @@
 @import views.html.fragments.form.radioField
 @import views.support.RenderClasses
 @import views.support.`package`.Seq2zipWithRowInfo
-
 @import common.LinkTo
+@import conf.Configuration
 
-@(page: model.Page, emailPrefsForm: Form[EmailPrefsData], formActionUrl: String, emailSubscriptions: List[String], availableLists: EmailNewsletters)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+@(
+    page: model.Page,
+    emailPrefsForm: Form[EmailPrefsData],
+    emailSubscriptions: List[String],
+    availableLists: EmailNewsletters,
+    idRequest: services.IdentityRequest,
+    idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
     @fragments.dropdown(theme, isActive = isActive) {
@@ -49,12 +55,16 @@
     }
 }
 
+@buildIdentityUrl(endpoint: String) = {
+    @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
+}
+
 @main(page, projectName = Option("identity")){
 }{
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Email preferences</h1>
-        <h4 class="email-subscription__meta">For any problems managing email preferences please contact <a href="mailto:userhelp@@theguardian.com?subject=Email%20preferences%20help" data-link-name="Email Userhelp">userhelp@@theguardian.com</a></h4>
-        <form class="form" novalidate action="@formActionUrl" role="main" method="post">
+        <h4 class="email-subscription__meta">To change your email address please click <a href=@buildIdentityUrl("account/edit")>here.</a></h4>
+        <form class="form" novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post">
             @views.html.helper.CSRF.formField
             @if(emailPrefsForm.globalError.isDefined) {
               <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
@@ -67,14 +77,14 @@
 
             <fieldset class="fieldset">
                 <div class="fieldset__heading">
-                    <h2 class="form__heading">Edit your email preferences</h2>
+                    <h2 class="form__heading">Edit email format</h2>
                 </div>
 
                 <div class="fieldset__fields">
                     <ul class="u-unstyled">
 
                         <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
-                            <label class="label">How do you like to receive your emails?</label>
+                            <label class="label">In which format would you like to receive email?</label>
                             <div class="form-field__note">
                                 HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
                                 <br />
@@ -114,6 +124,7 @@
 
             <ul class="nav nav--registration identity-section" data-link-name="Email prefs footer">
                 <li class="nav__item"><a class="nav__link" href="@controllers.routes.EditProfileController.displayPrivacyForm" data-link-name="Privacy and marketing settings">Privacy &amp; marketing settings</a></li>
+                <li class="nav__item"><a class="nav__link" href="@Configuration.site.host/info/tech-feedback" data-link-name="Report technical issue">Report technical issue</a></li>
             </ul>
 
         </form>

--- a/identity/test/controllers/EmailControllerTest.scala
+++ b/identity/test/controllers/EmailControllerTest.scala
@@ -70,7 +70,7 @@ import actions.AuthenticatedActions
         val result = emailController.preferences()(authRequest)
         status(result) should equal(OK)
         val content = contentAsString(result)
-        content should include("""<form class="form" novalidate action="/email-prefs" role="main" method="post">""")
+        content should include("addEmailSubscription")
       }
     }
 


### PR DESCRIPTION
## What does this change?

Replaces userhelp address with link to `Edit Profile` page, and adds `Report technical issue` to the footer.

## What is the value of this and can you measure success?

Some users, when they want to change their email address, go to `Email Preferences` page which is designed just for newsletters and does not provide an option to change email address. In this case users email userhelp requesting the change. This PR will reduce userhelp's workload.

## Screenshots

Replaces userhelp address with link to Edit Profile page:

![remove-userhelp-from-email-prefs](https://user-images.githubusercontent.com/13835317/28078079-94a60a56-665b-11e7-8b07-d6a9517c3ecd.gif)

Footer change: 

![image](https://user-images.githubusercontent.com/13835317/28078339-6d3d190e-665c-11e7-9fbf-b3b33e45a793.png)

@andrewfindlay