### PR TITLE
Support html body for qandas

### DIFF
--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -20,6 +20,6 @@
       </div>
     }
 
-    @qa.data.item.body
+    @Html(qa.data.item.body)
   }
 }


### PR DESCRIPTION
## What does this change?
The Q&A snippet atom (aka qanda) will soon support `<p>` tags - see https://github.com/guardian/atom-workshop/pull/144.
This change creates an html fragment from the qanda body.

## What is the value of this and can you measure success?
We're encouraging Editorial to keep the word count down with a warning in atom-workshop, but basic formatting is still useful.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
<img width="632" alt="picture 10" src="https://user-images.githubusercontent.com/1513454/28078561-2fab1d1a-665d-11e7-80b3-165f8eb31ff6.png">

## Tested in CODE?
👍 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
