### PR TITLE
Revert previously reverted paid card designs.

### DIFF
--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -24,7 +24,8 @@
                 item = paidContentOnEditorialPage,
                 omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage),
                 containerIndex,
-                index
+                index,
+                isFirstContainer
             )
         }
 

--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -1,8 +1,11 @@
-@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int)(implicit request: RequestHeader)
+@(item: layout.ContentCard, omnitureId :String, containerIndex: Int, index: Int, isFirstContainer: Boolean)(implicit request: RequestHeader)
 
 @import views.html.fragments.items.elements.facia_cards._
+@import views.support.GetClasses
+@import Function.const
+@import views.html.fragments.commercial.cardLogo
 
-<div class="fc-item fc-item--has-image js-fc-item fc-item--list-media-mobile fc-item--standard-tablet adverts--within-unbranded @item.cardTypes.classes)">
+<div class="adverts--within-unbranded @GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!item.hasInlineSnapHtml) {js-snappable}">
     <div class="fc-item__container">
         @item.paidImage.map(image => itemImage(
             image,
@@ -16,11 +19,13 @@
                 </div>
             </div>
 
-            <div class="badge badge--no-image">
-                <div class="badge__label">
-                    Paid for by @item.branding.map(_.sponsorName)
-                </div>
-            </div>
+            @item.trailText.filter(const(item.showStandfirst)).map { text =>
+                <div class="fc-item__standfirst">@Html(text)</div>
+            }
+
+            @item.branding.map { branding =>
+                @cardLogo(branding, isStandardSizeCard = false)
+            }
 
         </div>
 

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -169,7 +169,7 @@ $paid-article-header:       #bfbfbf;
 $paid-article-header-bg:    #b8b8b8;
 $paid-article-subheader:    #cccccc;
 $paid-article-subheader-bg: #c4c4c4;
-$paid-article-card-bg:      #d7d7d7;
+$paid-article-card-bg:      $neutral-8;
 $paid-article-media-bg:     #bbb7b1;
 $paid-article-icon:         #767676;
 $paid-article-brand:        #69d1ca;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -373,7 +373,7 @@
         background-color: $paid-article-card-bg;
         &:hover,
         &.u-faux-block-link--hover {
-            background: darken($paid-article-subheader, 7%);
+            background-color: $neutral-6;
         }
     }
     .fc-item__container:before {
@@ -383,7 +383,9 @@
         fill: $paid-article-brand;
     }
     .fc-item__title {
-        @include f-headlineSans;
+        @include f-textSans;
+        font-weight: 600;
+        color: $neutral-1;
     }
 
     .fc-item__content {
@@ -394,6 +396,10 @@
         @include mq(mobileLandscape, tablet) {
             flex-direction: row;
         }
+    }
+
+    .fc-item__standfirst {
+        color: $neutral-1;
     }
 
     .badge {
@@ -408,6 +414,7 @@
         }
     }
     .badge__label {
+        color: #757575;
         text-align: center;
         align-self: center;
     }
@@ -437,6 +444,11 @@
 
     .badge--no-image {
         margin-bottom: $gs-baseline/2;
+    }
+
+    .badge__sponsor-name {
+        @include f-textSans;
+        color: $neutral-1;
     }
 
     .inline-icon__svg {

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -377,10 +377,10 @@
         }
     }
     .fc-item__container:before {
-        background-color: $paid-article-brand;
+        background-color: $paid-article-brand !important;
     }
     .inline-icon__svg {
-        fill: $paid-article-brand;
+        fill: $paid-article-brand !important;
     }
     .fc-item__title {
         @include f-textSans;


### PR DESCRIPTION
## What does this change?
Reverts the revert of the design for paid cards. We have agreed with Ben that this is the correct design that we want to move forward with and we are happy in the meantime to not have the background match on paid for articles. 

This change also ensures that the paid content colour is applied always for paid cards. This includes logos and the tone of the card.

## What is the value of this and can you measure success?
N/A

## Does this affect other platforms - Amp, Apps, etc?
N/A

## Screenshots
![picture 103](https://user-images.githubusercontent.com/8861681/28114057-13905466-66f7-11e7-9089-c0b6f4fd5873.png)

![picture 99](https://user-images.githubusercontent.com/8861681/28114086-36630c54-66f7-11e7-9c30-ac2268181d61.png)

## Tested in CODE?
No.
