### PR TITLE
Added active class to combat ios bug in mobile search

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-search.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-search.scss
@@ -146,7 +146,8 @@
 
     // Reveals search button & retains visibility of search button when form loses focus
     .menu-search__search-box:focus ~ &,
-    &:focus {
+    &:focus,
+    &:active {
         opacity: 1;
         outline: none;
         pointer-events: all;


### PR DESCRIPTION
Currently, the search cta in the mobile nav doesn't work on ios devices. Adding :active keeps the button present when you tap that area.

Now it works.
