### PR TITLE
Extend bundle price tests to expire on July 20th

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -115,7 +115,7 @@ trait ABTestSwitches {
     "Test pricing options for digital subs from epic",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 7, 13),  // Thursday 13th July
+    sellByDate = new LocalDate(2017, 7, 20),  // Thursday 20th July
     exposeClientSide = true
   )
 
@@ -125,7 +125,7 @@ trait ABTestSwitches {
     "Test pricing options for digital subs from thrasher",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 7, 13),  // Thursday 13th July
+    sellByDate = new LocalDate(2017, 7, 20),  // Thursday 20th July
     exposeClientSide = true
   )
 

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1-thrasher.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1-thrasher.js
@@ -17,7 +17,7 @@ define([
         var self = this;
         this.id = 'BundleDigitalSubPriceTest1MT';
         this.start = '2017-06-21';
-        this.expiry = '2017-07-13';
+        this.expiry = '2017-07-20';
 
         this.description = 'Test digital subs price points via thrasher';
         this.showForSensitive = true;

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/bundle-digital-sub-price-test-1.js
@@ -40,7 +40,7 @@ define([
         campaignPrefix: '',
         campaignSuffix: '',
         start: '2017-05-10',
-        expiry: '2017-07-13',
+        expiry: '2017-07-20',
 
         author: 'Justin Pinner',
         description: 'Test digital subs price points via epic',


### PR DESCRIPTION
## What does this change?
Extends switches and test expiry dates

## What is the value of this and can you measure success?
We're calculating whether the test can end, but meanwhile we're going to extend to prevent build failures due to switches and in case we don't have stat sig yet.

## Does this affect other platforms - Amp, Apps, etc?
No web only

## Screenshots
N/A

## Tested in CODE?
No

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @rupertbates @Ap0c @svillafe @davidfurey 