### PR TITLE
Resolved invisible active state for brand bar

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-brand-extensions-item.scss
@@ -3,6 +3,8 @@
     font-size: 24px;
 
     &:focus {
+        color: currentColor;
         outline: none;
+        text-decoration: underline;
     }
 }


### PR DESCRIPTION
The active (click) state of the brand bar items is rather unaccesible:

# Before
<img width="1035" alt="nonono" src="https://user-images.githubusercontent.com/14570016/28119922-6364bf60-670e-11e7-865a-07ef6314fdfb.png">

# After
<img width="942" alt="screen shot 2017-07-12 at 14 26 29" src="https://user-images.githubusercontent.com/14570016/28119919-602a04d6-670e-11e7-89ab-b3e421387beb.png">

