### PR TITLE
Fix story questions style

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -14,45 +14,47 @@
                 <p>
                     <div class="user__question-section"></div>
                     @for(question <- qs.questions) {
-                        <div class="user__questions-text--wrapper js-ask-question-link">
-                            <span class="user__question-text">
-                                <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
-                                <span class="user__questions-text--inner">
-                                @question.questionText
+                        <div class="user__question-container">
+                            <div class="user__questions-text--wrapper js-ask-question-link">
+                                <div class="user__question-text">
+                                    <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
+                                    <span class="user__questions-text--inner">
+                                    @question.questionText
+                                    </span>
+                                </div>
+                                <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
+                                    Ask
+                                </button>
+                                <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we'll send you the answer soon.
                                 </span>
-                            </span>
-                            <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
-                                Ask
-                            </button>
-                            <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                Thanks, we'll send you the answer soon.
-                            </span>
-                            <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                Thanks, we've registered your vote.
-                            </span>
-                        </div>
-                        <div class="storyquestion-submission-container js-storyquestion-submission-container">
-                            <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                    Thank you we've registered your vote. Enter your email address and we'll send you an answer.
-                            </span>
-                            @*********************
-                            * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
+                                <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we've registered your vote.
+                                </span>
+                            </div>
+                            <div class="storyquestion-submission-container js-storyquestion-submission-container">
+                                <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
+                                        Thank you, we've registered your vote. Enter your email address and we'll send you an answer.
+                                </span>
+                                @*********************
+                                * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
 
-                            * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
-                            * show the form allowing a user to submit their email address and receive an answer.
-                            *********************@
+                                * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
+                                * show the form allowing a user to submit their email address and receive an answer.
+                                *********************@
 
-                            @if("test/test" == storyquestions.data.relatedStoryId) {
-                                @storyquestions.atom.labels.find(_.length == 4).map { listId =>
-                                    <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                        <div class="form-field">
-                                            <input class="text-input" type="email" name="email" placeholder="Email address" required />
-                                        </div>
-                                        <input class="" type="hidden" name="listId" value="@listId" />
-                                        <button type="submit" class="button button--primary">Notify me</button>
-                                    </form>
+                                @if("test/test" == storyquestions.data.relatedStoryId) {
+                                    @storyquestions.atom.labels.find(_.length == 4).map { listId =>
+                                        <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
+                                            <div class="form-field">
+                                                <input class="text-input" type="email" name="email" placeholder="Email address" required />
+                                            </div>
+                                            <input class="" type="hidden" name="listId" value="@listId" />
+                                            <button type="submit" class="button button--primary">Notify me</button>
+                                        </form>
+                                    }
                                 }
-                            }
+                            </div>
                         </div>
                     }
                 </p>

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -33,6 +33,7 @@
     margin-bottom: 0;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
+    padding-left: $gs-baseline - 4;
 
     &.is-clicked {
         background-color: $news-support-5;
@@ -71,9 +72,7 @@
     display: block;
     //used to avoid fixed width across multiple break points.
     max-width: 77%;
-    float: left;
     color: $news-main-1;
-    padding-left: $gs-baseline - 4;
     position: relative;
     margin-bottom: $gs-baseline;
 
@@ -85,6 +84,10 @@
     }
 }
 
+.user__question-container {
+    margin-bottom: $gs-baseline;
+}
+
 .user__question-response {
     @include fs-textSans(3);
     clear: both;
@@ -94,6 +97,7 @@
     line-height: 18px;
     width: 90%;
     display: block;
+    color: $neutral-1;
 
     @include mq($from: tablet) {
         clear: none;
@@ -124,7 +128,7 @@
 }
 .storyquestion-submission-container {
     overflow: hidden;
-    padding-left: $gs-gutter - 2;
+    padding-left: $gs-baseline - 4;
     margin-bottom: $gs-baseline;
 }
 

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -33,7 +33,7 @@
     margin-bottom: 0;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
-    padding-left: $gs-baseline - 4;
+    padding-left: 8px;
 
     &.is-clicked {
         background-color: $news-support-5;
@@ -85,7 +85,7 @@
 }
 
 .user__question-container {
-    margin-bottom: $gs-baseline;
+    margin-bottom: 12px;
 }
 
 .user__question-response {
@@ -103,6 +103,7 @@
         clear: none;
         margin-top: 0;
         font-size: 16px;
+        line-height: 20px;
     }
 }
 
@@ -128,8 +129,7 @@
 }
 .storyquestion-submission-container {
     overflow: hidden;
-    padding-left: $gs-baseline - 4;
-    margin-bottom: $gs-baseline;
+    padding-left: 8px;
 }
 
 .storyquestion-email-signup-form.form {


### PR DESCRIPTION
## What does this change?
Fixes styling issues in the story questions atom.

Inconsistent indentation here:
![picture 12](https://user-images.githubusercontent.com/1513454/28117587-f0cb9a94-6705-11e7-987b-32921d7fa079.png)

Position of "thanks" text and lack of spacing after the green box here:
![picture 11](https://user-images.githubusercontent.com/1513454/28117569-d9ffc7c2-6705-11e7-9d03-b3b88a9a8bda.png)

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
Before "ask":
<img width="639" alt="picture 4" src="https://user-images.githubusercontent.com/1513454/28123512-09f567a8-6719-11e7-9ae1-54ef8713e718.png">

After "ask":
<img width="642" alt="picture 5" src="https://user-images.githubusercontent.com/1513454/28123515-0a1ec71a-6719-11e7-8374-e96c0a73f40a.png">

After "notify me":
<img width="637" alt="picture 6" src="https://user-images.githubusercontent.com/1513454/28123514-0a168ece-6719-11e7-8b24-f2546f075819.png">

## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
