### PR TITLE
check referrer for facebook oauth and set to null

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -103,8 +103,14 @@
         @for(sponsorLogos <- listSponsorLogosOnPage(page)) {
           ga('@{trackerName}.set', 'dimension31', '@Html(sponsorLogos.mkString("|"))');
         }
+
         @for(brandingType <- Commercial.brandingType(page)) {
           ga('@{trackerName}.set', 'dimension42', '@brandingType.name');
+        }
+
+        var fbRegEx = new RegExp('https?:\/\/\w*\.?facebook\.com\/.*dialog\/auth');
+        if(document.referrer.match(fbRegEx)) {
+            ga('@{trackerName}.set', 'referrer', null);
         }
         ga('@{trackerName}.set', 'dimension43', getExperienceValue()); @* 'Experience' dimension, for short-lived experiment values. *@
     }


### PR DESCRIPTION
## What does this change?
When users use the facebook oauth login on dotcom (on everything but chrome ) the referrer is set to facebook despite the fact the user came from theguardian.com

The referrer looks something like m.facebook.com/v2.9/dialog/oauth/read . 

This change will set the referrer to null if it comes from facebooks Oauth. This prevents a new session being created with the incorrect facebook referrer for this traffic source. 

For chrome we will have to make a seperate change in https://github.com/guardian/identity-federation-api , as this is using the referrer-policy (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) to set the referrer policy to origin. This feature only works in chrome so is not applicable in this PR.

## What is the value of this and can you measure success?
- Correctly define the referrers for our traffic. 

## Does this affect other platforms - Amp, Apps, etc?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
