### PR TITLE
Jest test improvements

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -77,6 +77,7 @@ describe('Article Aside Adverts', () => {
             enableServices: jest.fn(),
             display: jest.fn(),
         };
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -43,8 +43,9 @@ describe('Article Body Adverts', () => {
     beforeEach(() => {
         jest.resetAllMocks();
         commercialFeatures.articleBodyAdverts = true;
-        spaceFillerStub.mockImplementation(() => Promise.resolve(true));
-        detect.getViewport.mockReturnValue({ height: 1000 });
+        spaceFillerStub.mockImplementation(() => Promise.resolve(2));
+        detect.getViewport.mockReturnValue({ height: 1300 });
+        expect.hasAssertions();
     });
 
     it('should exist', () => {
@@ -149,8 +150,9 @@ describe('Article Body Adverts', () => {
                 // We do not want the same ad-density on long-read
                 // articles that we have on shorter pieces
                 articleBodyAdvertsInit().then(() => {
+                    expect(spaceFillerStub).toHaveBeenCalledTimes(2);
                     const longArticleInsertCalls = spaceFillerStub.mock.calls.slice(
-                        2
+                        1
                     );
                     const longArticleInsertRules = longArticleInsertCalls.map(
                         call => call[0]

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.spec.js
@@ -92,6 +92,8 @@ describe('Build Page Targeting', () => {
         getKruxSegments.mockReturnValue(['E012712', 'E012390', 'E012478']);
 
         local.set('gu.alreadyVisited', 0);
+
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
@@ -82,6 +82,8 @@ describe('Commercial features', () => {
         isAdFreeUser.mockReturnValue(false);
 
         identity.isUserLoggedIn.mockReturnValue(true);
+
+        expect.hasAssertions();
     });
 
     describe('DFP advertising', () => {

--- a/static/src/javascripts/projects/commercial/modules/messenger.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.spec.js
@@ -47,6 +47,7 @@ describe('Cross-frame messenger', () => {
 
     beforeEach(() => {
         jest.resetAllMocks();
+        expect.hasAssertions();
     });
 
     it('should expose register and unregister as a public API', () => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
@@ -12,33 +12,29 @@ const adSpec = {
 };
 
 describe('Cross-frame messenger: setBackground', () => {
-    beforeEach(done => {
+    beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
               <div>
                   <div id="slot01"><div id="iframe01" class="iframe"></div></div>
               </div>`;
         }
-        done();
+        expect.hasAssertions();
     });
 
-    it('should create new elements if there are specs', done => {
+    it('should create new elements if there are specs', () => {
         const fallback = document.createElement('div');
         const fakeAdSlot = document.getElementById('slot01') || fallback;
 
-        setBackground(adSpec, fakeAdSlot)
-            .then(() => {
-                const creative: Object =
-                    document.querySelector('.creative__background') || {};
-                const parent: Object =
-                    document.querySelector('.creative__background-parent') ||
-                    {};
-                expect(creative.toString()).toEqual('[object HTMLDivElement]');
-                expect(parent.toString()).toEqual('[object HTMLDivElement]');
-                expect(creative.className).toMatch(/background--fixed/);
-            })
-            .then(done)
-            .catch(done.fail);
+        return setBackground(adSpec, fakeAdSlot).then(() => {
+            const creative: Object =
+                document.querySelector('.creative__background') || {};
+            const parent: Object =
+                document.querySelector('.creative__background-parent') || {};
+            expect(creative.toString()).toEqual('[object HTMLDivElement]');
+            expect(parent.toString()).toEqual('[object HTMLDivElement]');
+            expect(creative.className).toMatch(/background--fixed/);
+        });
     });
 });
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.spec.js
@@ -7,16 +7,14 @@ const { hide } = _;
 
 describe('Cross-frame messenger: hide', () => {
     describe('hide function', () => {
-        it('should hide the ad slot', done => {
+        it('should hide the ad slot', () => {
+            expect.hasAssertions();
             const fallback = document.createElement('div');
             const fakeIframe = document.getElementById('iframe01') || fallback;
             const fakeAdSlot = document.getElementById('slot01') || fallback;
-            foolFlow(hide(fakeAdSlot))
-                .then(() => {
-                    expect(fakeIframe.classList.contains('u-h'));
-                })
-                .then(done)
-                .catch(done.fail);
+            return foolFlow(hide(fakeAdSlot)).then(() => {
+                expect(fakeIframe.classList.contains('u-h')).toBe(true);
+            });
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -7,7 +7,7 @@ const { normalise, resize } = _;
 const foolFlow = (mockFn: any) => ((mockFn: any): JestMockT);
 
 describe('Cross-frame messenger: resize', () => {
-    beforeEach(done => {
+    beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
               <div id="slot01" class="js-ad-slot"><div id="iframe01" class="iframe" data-unit="ch"></div></div>
@@ -21,7 +21,7 @@ describe('Cross-frame messenger: resize', () => {
               <div id="slot09" class="js-ad-slot"><div id="iframe09" class="iframe" data-unit="ex"></div></div>
               </div>`;
         }
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {
@@ -63,21 +63,18 @@ describe('Cross-frame messenger: resize', () => {
             expect(result).toBeNull();
         });
 
-        it('should set width and height of the ad slot', done => {
+        it('should set width and height of the ad slot', () => {
             const fallback = document.createElement('div');
             const fakeIframe = document.getElementById('iframe01') || fallback;
             const fakeAdSlot = document.getElementById('slot01') || fallback;
-            foolFlow(
+            return foolFlow(
                 resize({ width: '20', height: '10' }, fakeIframe, fakeAdSlot)
-            )
-                .then(() => {
-                    expect(fakeIframe.style.height).toBe('10px');
-                    expect(fakeIframe.style.width).toBe('20px');
-                    expect(fakeAdSlot.style.height).toBe('10px');
-                    expect(fakeAdSlot.style.width).toBe('20px');
-                })
-                .then(done)
-                .catch(done.fail);
+            ).then(() => {
+                expect(fakeIframe.style.height).toBe('10px');
+                expect(fakeIframe.style.width).toBe('20px');
+                expect(fakeAdSlot.style.height).toBe('10px');
+                expect(fakeAdSlot.style.width).toBe('20px');
+            });
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
@@ -40,7 +40,7 @@ describe('Cross-frame messenger: scroll', () => {
             }));
     };
 
-    beforeEach(done => {
+    beforeEach(() => {
         jest
             .spyOn(global, 'addEventListener')
             .mockImplementation((_, callback) => {
@@ -57,7 +57,7 @@ describe('Cross-frame messenger: scroll', () => {
 
         detect.getViewport.mockReturnValue({ width: 400, height: 300 });
 
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/viewport.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/viewport.spec.js
@@ -32,13 +32,13 @@ describe('Cross-frame messenger: viewport', () => {
         },
     };
 
-    beforeEach(done => {
+    beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = domSnippet;
         }
         iframe = document.getElementById('iframe1');
         reset(mockWindow);
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {
@@ -49,32 +49,27 @@ describe('Cross-frame messenger: viewport', () => {
         }
     });
 
-    it('should send viewport dimensions as soon as the iframe starts listening', done => {
+    it('should send viewport dimensions as soon as the iframe starts listening', () => {
         const size = {
             width: 800,
             height: 600,
         };
         detect.getViewport.mockReturnValue(size);
-        addResizeListener(iframe, respond)
-            .then(() => {
-                expect(respond).toHaveBeenCalledWith(null, size);
-            })
-            .then(done)
-            .catch(done.fail);
+        return addResizeListener(iframe, respond).then(() => {
+            expect(respond).toHaveBeenCalledWith(null, size);
+        });
     });
 
-    it('should send viewport dimensions when the window gets resized', done => {
+    it('should send viewport dimensions when the window gets resized', () => {
         const size = {
             width: 1024,
             height: 768,
         };
         detect.getViewport.mockReturnValue(size);
-        addResizeListener(iframe, respond)
+        return addResizeListener(iframe, respond)
             .then(() => onResize && onResize())
             .then(() => {
                 expect(respond).toHaveBeenCalledWith(null, size);
-            })
-            .then(done)
-            .catch(done.fail);
+            });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
@@ -49,6 +49,7 @@ describe('Sticky ad banner', () => {
         }
         header = document.getElementById('header');
         stickyBanner = document.getElementById('top-banner-parent');
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -9,6 +9,7 @@ beforeEach(() => {
     if (document.body && firstScript) {
         document.body.appendChild(firstScript);
     }
+    expect.hasAssertions();
 });
 
 afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -1,7 +1,8 @@
 // @flow
 import { imrWorldwide } from './imr-worldwide';
 
-const { shouldRun, url, onLoad } = imrWorldwide;
+const { shouldRun, url } = imrWorldwide;
+const onLoad: any = imrWorldwide.onLoad;
 
 jest.mock('lib/config', () => ({
     switches: {
@@ -44,7 +45,6 @@ describe('third party tag IMR worldwide', () => {
             apid: 'P0EE0F4F4-8D7C-4082-A2A4-82C84728DC59',
             apn: 'theguardian',
         };
-        // $FlowFixMe - onLoad will be there, and be a function. Promise.
         onLoad();
         expect(nSdkInstance.ggInitialize).toBeCalledWith(expectedNolggParams);
     });
@@ -55,7 +55,6 @@ describe('third party tag IMR worldwide', () => {
             section: 'The Guardian - brand only',
             type: 'static',
         };
-        // $FlowFixMe - onLoad will be there, and be a function. Promise.
         onLoad();
         expect(nSdkInstance.ggPM).toBeCalledWith(
             'staticstart',

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.spec.js
@@ -17,7 +17,7 @@ jest.mock('./outbrain-tracking', () => ({ tracking: jest.fn() }));
 detect.getBreakpoint.mockReturnValue('desktop');
 
 describe('Outbrain Load', () => {
-    beforeEach(done => {
+    beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
                 <div id="dfp-ad--merchandising-high"></div>
@@ -25,7 +25,7 @@ describe('Outbrain Load', () => {
                 <div class="js-outbrain"><div class="js-outbrain-container"></div></div>
                 `;
         }
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -15,7 +15,7 @@ jest.mock('lib/load-script', () => ({ loadScript: jest.fn() }));
 jest.mock('./outbrain-load', () => ({ load: jest.fn() }));
 
 describe('Outbrain', () => {
-    beforeEach(done => {
+    beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
                 <div id="dfp-ad--merchandising-high"></div>
@@ -33,7 +33,7 @@ describe('Outbrain', () => {
             commentable: true,
         };
 
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
@@ -29,7 +29,7 @@ let loadSpy: any;
 trackAdRenderMock.mockReturnValue(Promise.resolve(true));
 
 describe('Plista', () => {
-    beforeEach(done => {
+    beforeEach(() => {
         config.switches.plistaForOutbrainAu = true;
         config.page = {
             section: 'uk-news',
@@ -49,7 +49,7 @@ describe('Plista', () => {
             getBreakpoint: jest.fn(() => 'desktop'),
             adblockInUse: Promise.resolve(false),
         });
-        done();
+        expect.hasAssertions();
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
@@ -2,7 +2,8 @@
 
 import { remarketing } from 'commercial/modules/third-party-tags/remarketing';
 
-const { shouldRun, url, onLoad } = remarketing;
+const { shouldRun, url } = remarketing;
+const onLoad: any = remarketing.onLoad;
 
 jest.mock('lib/config', () => ({
     switches: {
@@ -22,7 +23,6 @@ describe('Remarketing', () => {
     it('should call google_trackConversion', () => {
         window.google_trackConversion = jest.fn();
         window.google_tag_params = 'google_tag_params__test';
-        // $FlowFixMe - onLoad will be there, and be a function. Promise.
         onLoad();
         expect(window.google_trackConversion).toHaveBeenCalledWith({
             google_conversion_id: 971225648,


### PR DESCRIPTION
## What does this change?
Add `expect.hasAssertions()` to `beforeEach` on test specs to check that at least one assertion is made per test.

## What is the value of this and can you measure success?
Tests with no assertions will pass, which means problems can be missed, e.g. when: 

 - assertions are made asynchronously (see https://github.com/guardian/frontend/pull/17368)
 - iterating over an array which may be empty (see `article-body-adverts.spec.js` below)
 - assertions are accidentally omitted altogether (see `hide.spec.js` below)

Two tests have been fixed in the process!



