### PR TITLE
set showinfo=0 on youtube atoms

### DIFF
--- a/common/app/views/fragments/atoms/ampYoutube.scala.html
+++ b/common/app/views/fragments/atoms/ampYoutube.scala.html
@@ -6,7 +6,7 @@
     <amp-youtube
     data-videoid="@asset.id"
     layout="responsive"
-    width="16" height="9" data-param-rel="0">
+    width="16" height="9" data-param-rel="0" data-param-showinfo="0">
     </amp-youtube>
 }
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -38,6 +38,7 @@
                 .addParams(List(
                 "enablejsapi" -> 1,
                 "rel" -> 0,
+                "showinfo" -> 0,
                 "origin" -> (if(mediaWrapper.contains(EmbedPage)) Some(Media.externalEmbedHost) else if(!host.isEmpty) Some(host) else None)
                 )).toString
                 }") { embedUri: String  =>


### PR DESCRIPTION
## What does this change?
`showinfo=0` removes the video title appearing in on top of the video. This title links off to youtube.com.

Contrary to PR #16240, YouTube have now said this parameter is available to PfP instances...

## What is the value of this and can you measure success?
Keeping people on platform.

## Does this affect other platforms - Amp, Apps, etc?
Yes.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/836140/28169325-ddae5922-67d9-11e7-9eb0-92aa72021901.png)

After
![image](https://user-images.githubusercontent.com/836140/28169300-ce8c8ba8-67d9-11e7-8116-08a3fe9d9a47.png)

## Tested in CODE?
nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
