### PR TITLE
When logging errors, log with the original error to capture stacktrace.

### DIFF
--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -27,7 +27,7 @@ trait DataAgent[K, V] extends ExecutionContexts with Logging with implicits.Stri
           log.error("No fresh data loaded so keeping old data")
           oldCache
         case Failure(e) =>
-          log.error(ExceptionUtils.getStackTrace(e))
+          log.error("Loading of fresh data has failed.", e)
           oldCache
       }
     }

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -45,7 +45,7 @@ private[dfp] object SessionLogger extends Logging {
         log.error(
           s"$baseMessage failed: API exception in field '$path', " +
           s"caused by an invalid value '$trigger', " +
-          s"with the error message $msg"
+          s"with the error message $msg", e
         )
       }
     }
@@ -82,7 +82,7 @@ private[dfp] object SessionLogger extends Logging {
         logApiException(e, msgPrefix)
         None
       case NonFatal(e) =>
-        log.error(s"$msgPrefix failed: ${e.getMessage}")
+        log.error(s"$msgPrefix failed", e)
         None
     }
   }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -180,7 +180,7 @@ object SessionWrapper extends Logging {
       }
     } catch {
       case NonFatal(e) =>
-        log.error(s"Building DFP session failed: ${e.getMessage}")
+        log.error(s"Building DFP session failed.", e)
         None
     }
 

--- a/commercial/app/model/feeds/FeedReader.scala
+++ b/commercial/app/model/feeds/FeedReader.scala
@@ -49,7 +49,7 @@ class FeedReader(wsClient: WSClient) extends Logging {
             Try(parse(body)) match {
               case Success(parsedBody) => parsedBody
               case Failure(throwable) =>
-                log.error(s"Could not parse body: $throwable (Body: $body)")
+                log.error(s"Could not parse body: (Body: $body)", throwable)
                 throw throwable
             }
 
@@ -61,7 +61,7 @@ class FeedReader(wsClient: WSClient) extends Logging {
 
       contents onFailure {
         case NonFatal(e) =>
-          log.error(s"NonFatal exception: $e")
+          log.error(s"Failed to fetch feed contents.", e)
           recordLoad(-1)
       }
 
@@ -72,7 +72,7 @@ class FeedReader(wsClient: WSClient) extends Logging {
 
     initializedSwitch.onComplete {
       case Success(switch) => log.info(s"Successfully initialized ${switch.name} (isSwitchedOn: ${switch.isSwitchedOn})")
-      case Failure(throwable) => log.info(s"Failed to initialize switch: $throwable")
+      case Failure(throwable) => log.info(s"Failed to initialize switch.", throwable)
     }
 
     initializedSwitch flatMap { switch =>
@@ -92,7 +92,7 @@ class FeedReader(wsClient: WSClient) extends Logging {
 
     contents onFailure {
       case e: FeedSwitchOffException => log.warn(e.getMessage)
-      case NonFatal(e) => log.error(e.getMessage)
+      case NonFatal(e) => log.error(s"Failed to read feed ${request.feedName} with URL ${request.url}", e)
     }
 
     contents


### PR DESCRIPTION
Just a small clean-up PR to make it easier to debug errors using the logs/kibana. Instead of logging the stacktrace in the message, log the error message and then the error itself.

@guardian/commercial-dev 