### PR TITLE
Snippet html bodies

### DIFF
--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -25,7 +25,7 @@
         @item.title.map { t =>
           <div class="explainer-snippet__heading"><b>@t</b></div>
         }
-        @item.body
+        @Html(item.body)
       </div>
     }
   }

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -25,7 +25,7 @@
         @item.title.map { t =>
           <div class="explainer-snippet__heading"><b>@t</b></div>
         }
-        @item.body
+        @Html(item.body)
       </div>
     }
   }

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -13,7 +13,7 @@
       <div class="explainer-snippet__item">
         <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.longDate.print(item.date)</time>
         <div class="explainer-snippet__heading"><b>@item.title</b></div>
-        @item.body
+        @item.body.map { body => @Html(body) }
       </div>
     }
   }


### PR DESCRIPTION
'Snippet' atom bodies will now contain html tags. This was already the case for the q&a snippet, but we've decided they should all support formatting.
See https://github.com/guardian/frontend/pull/17424 for q&a PR.

Tested in CODE