### PR TITLE
Remove referrer meta tag

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -82,17 +82,6 @@
     <meta name="apple-itunes-app" content="app-id=@Configuration.ios.ukAppId, app-argument=@page.metadata.webUrl, affiliate-data=ct=newsmartappbanner&pt=304191">
 }
 
-@*
- * This referrer policy preserves URLs in the Referrer header when navigating
- * from HTTPS->HTTP.
- *
- * We need it for tracking to work properly while we do section-by-section
- * rollout of HTTPS.
- *
- * See https://www.w3.org/TR/referrer-policy/#referrer-policy-state-unsafe-url
-*@
-<meta name="referrer" content="unsafe-url">
-
 @* https://support.google.com/plus/answer/1713826 *@
 <link rel="publisher" href="https://plus.google.com/113000071431138202574" />
 


### PR DESCRIPTION
## What does this change?
This PR attempts to fix an issue with facebook post embeds in Safari 8 on iOS.   Safari doesn't recognise our current `unsafe-url` value for the referrer meta tag which causes it to default to `never` (equivalent to `no-referrer` AFAIK).  Facebook post embeds (with js enabled) don't seem to work with this referrer value.

Removing this tag entirely fixes the issue as browsers should default to the `no-referrer-when-downgrade` value which works with Facebook embeds.  This is actually a more secure option than our current choice because it won't leak referrers in non-secure requests.  My only reservation is that there may be somewhere that relies on the full URL of the referrer (which will no longer be sent, only the origin).

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-name

## What is the value of this and can you measure success?
Facebook post embeds work on Safari iOS 8

## Does this affect other platforms - Amp, Apps, etc?
Possibly

## Screenshots

## Tested in CODE?
Not yet

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
