### PR TITLE
Add meta tag to allow facebook link editing

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -65,7 +65,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 35
+    val s3ConfigVersion = 36
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")
@@ -349,6 +349,9 @@ class GuardianConfiguration extends Logging {
 
   object facebook {
     lazy val appId = configuration.getMandatoryStringProperty("guardian.page.fbAppId")
+    object pages {
+      lazy val authorisedIdsForLinkEdits = configuration.getStringPropertiesSplitByComma("facebook.pages.authorisedIdsForLinkEdits")
+    }
     object graphApi {
       lazy val version = configuration.getStringProperty("facebook.graphApi.version").getOrElse("2.8")
       lazy val accessToken = configuration.getMandatoryStringProperty("facebook.graphApi.accessToken")

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -140,6 +140,10 @@
     <meta property="og:image" content="@Html(imageUrl)" />
 }
 
+@Configuration.facebook.pages.authorisedIdsForLinkEdits.map { id =>
+    <meta property="fb:pages" content="@id" />
+}
+
 @page.metadata.pagination.map{ pagination =>
     @pagination.next.map{ next => <link rel="next" href="@LinkTo(page.metadata.url+"?page="+next)" /> }
     @pagination.previous.map{ prev => <link rel="prev" href="@LinkTo(page.metadata.url+(if(prev != 1){"?page="+prev}else{""}))" /> }


### PR DESCRIPTION
## What does this change?
Facebook are locking down editing of links (i.e. headline, standfirst) when sharing on facebook pages.  This means that we now need a new meta property specifying each facebook page id we want to be able to edit gu.com links.  This PR adds our global facebook page, more will likely follow.

## What is the value of this and can you measure success?
Audience team can still make vital edits to shared facebook links.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
