### PR TITLE
Menu: Improve a11y of search by adding labels

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -89,7 +89,7 @@
                                 for="submit-google-search"
                                 type="submit">
                             <i class="right-arrow__icon"></i>
-                            <span class="u-h">Submit your search</span>
+                            <span class="u-h">Search with google</span>
                         </button>
 
                         @* Google sitesearch fields *@

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -77,13 +77,10 @@
                                placeholder="search"
                                data-link-name="nav2 : search">
 
-                        <input type="hidden"
-                               name="as_sitesearch"
-                               value="www.theguardian.com">
-
                        <label class="menu-search__glass"
                               for="google-search">
                            @fragments.inlineSvg("search-36", "icon", List("main-menu__icon", "main-menu__icon--search"))
+                           <span class="u-h">What term do you want to search?</span>
                        </label>
 
                         @* Button that shows itself on form focus *@
@@ -92,12 +89,13 @@
                                 for="submit-google-search"
                                 type="submit">
                             <i class="right-arrow__icon"></i>
+                            <span class="u-h">Submit your search</span>
                         </button>
 
-                        <label for="q"
-                               class="u-h">
-                            What term do you want to search?
-                        </label>
+                        @* Google sitesearch fields *@
+                        <input type="hidden"
+                               name="as_sitesearch"
+                               value="www.theguardian.com">
                     </form>
                 </div>
             }


### PR DESCRIPTION
## What does this change?

When we implemented all the fancy CSS for the new search input, we forgot to migrate readable labels, as @ScottPainterGNM [pointed out](https://docs.google.com/document/d/1Hx93Ytr0FaUHYpU3SSNRaY3KCY_cd9gUSj1AC1iY55s/edit?ts=596c996e) (See 4).

## What is the value of this and can you measure success?

Better a11y.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
