### PR TITLE
Header: track recent search in ophan

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -68,11 +68,11 @@
 
             @if(SearchSwitch.isSwitchedOn) {
                 <div class="menu-group menu-group--search">
-                    <form class="menu-search"
+                    <form class="menu-search js-menu-search"
                           action="https://www.google.co.uk/search">
                         <input type="text"
                                name="q"
-                               class="menu-search__search-box"
+                               class="menu-search__search-box js-menu-search-term"
                                id="google-search"
                                placeholder="search"
                                data-link-name="nav2 : search">

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -1,13 +1,16 @@
 // @flow
 
 import debounce from 'lodash/functions/debounce';
+import ophan from 'ophan/ng';
 import { isBreakpoint } from 'lib/detect';
 import fastdom from 'lib/fastdom-promise';
+import { local } from 'lib/storage';
 import { scrollToElement } from 'lib/scroller';
 import { addEventListener } from 'lib/events';
 import { showMyAccountIfNecessary, enhanceAvatar } from './user-account';
 
 const enhanced = {};
+const SEARCH_STORAGE_KEY = 'gu.recent.search';
 let avatarIsEnhanced = false;
 
 const getMenu = (): ?HTMLElement =>
@@ -250,8 +253,28 @@ const toggleMenuWithOpenSection = () => {
     toggleMenu();
 };
 
+const getRecentSearch = (): ?string => local.get(SEARCH_STORAGE_KEY);
+
+const clearRecentSearch = (): void => local.remove(SEARCH_STORAGE_KEY);
+
+const trackRecentSearch = (): void => {
+    const recent = getRecentSearch();
+
+    if (recent) {
+        ophan.record({
+            component: 'new-header-search',
+            value: recent,
+        });
+
+        clearRecentSearch();
+    }
+};
+
+const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
+
 const addEventHandler = (): void => {
     const menu = getMenu();
+    const search = menu && menu.querySelector('.js-menu-search');
     const toggleWithMoreButton = document.querySelector(
         '.js-toggle-nav-section'
     );
@@ -272,6 +295,19 @@ const addEventHandler = (): void => {
         });
     }
 
+    if (search) {
+        search.addEventListener('submit', (event: Event) => {
+            const target = (event.target: any).querySelector(
+                '.js-menu-search-term'
+            );
+
+            if (target) {
+                const term = target.value;
+                saveSearchTerm(term);
+            }
+        });
+    }
+
     if (toggleWithMoreButton) {
         toggleWithMoreButton.addEventListener('click', () => {
             toggleMenuWithOpenSection();
@@ -284,4 +320,5 @@ export const newHeaderInit = (): void => {
     addEventHandler();
     showMyAccountIfNecessary();
     closeAllMenuSections();
+    trackRecentSearch();
 };


### PR DESCRIPTION
## What does this change?

With this PR we start tracking the search-terms, which people enter into the search of the new header, so we can look if there is anything useful in the data, that we could add to the list of links.

Since the search is sumitted to google and we don't want to block navigation, the term is stored in localstorage, till the next pageload and then submitted.

**TODO**

- [x] Find out where this data ends up

## What is the value of this and can you measure success?

Better insights into what people are looking for.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
