### PR TITLE
Bump config to provide new CODE route for Morpheus script

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -65,7 +65,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 37
+    val s3ConfigVersion = 38
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
## What does this change?
We want to test a new Morpheus (Sonobi) script in CODE environment. This value is only set for the CODE environment, such that [when it is missing](https://github.com/guardian/frontend/blob/febc7b95c5680c42203bbbff74162b6332b91879/common/app/common/configuration.scala#L229), we hit our [Fastly proxy](https://github.com/guardian/fastly-edge-cache/blob/7b8361c9956827e40a6d165e49b02601d6ff2950/services_guardian_apps/src/main/resources/varnish/main.vcl#L93) for the correct PROD script.

## Tested in CODE?
Will do before merging.