### PR TITLE
Story questions: use email if signed in

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -34,7 +34,7 @@
                             </div>
                             <div class="storyquestion-submission-container js-storyquestion-submission-container">
                                 <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                        Thank you, we've registered your vote. Enter your email address and we'll send you an answer.
+                                    Thank you, we've registered your vote. Sign up and we will email you an answer.
                                 </span>
                                 @*********************
                                 * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
@@ -46,11 +46,11 @@
                                 @if("test/test" == storyquestions.data.relatedStoryId) {
                                     @storyquestions.atom.labels.find(_.length == 4).map { listId =>
                                         <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                            <div class="form-field">
-                                                <input class="text-input" type="email" name="email" placeholder="Email address" required />
+                                            <div class="form-field js-storyquestion-email-signup-input-container">
+                                                <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
                                             </div>
                                             <input class="" type="hidden" name="listId" value="@listId" />
-                                            <button type="submit" class="button button--primary">Notify me</button>
+                                            <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
                                         </form>
                                     }
                                 }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -5,7 +5,9 @@ define([
     'lib/fetch',
     'bean',
     'lib/config',
-    'ophan/ng'
+    'ophan/ng',
+    'common/modules/identity/api',
+    'fastdom'
 ], function (
     mediator,
     detect,
@@ -13,7 +15,9 @@ define([
     fetch,
     bean,
     config,
-    ophan
+    ophan,
+    Id,
+    fastdom
 ) {
 
     function askQuestion(event, isEmailSubmissionReady) {
@@ -115,6 +119,20 @@ define([
 
             answersEmailSignupForms.each(function (el) {
                 bean.on(el, 'submit', submitSignUpForm);
+            });
+
+
+            Id.getUserFromApi(function (userFromId) {
+                if (userFromId && userFromId.primaryEmailAddress) {
+                    fastdom.write(function () {
+                        $('.js-storyquestion-email-signup-form').each(function(form) {
+                            $('.js-storyquestion-email-signup-button', form).removeClass('button--with-input');
+                            $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
+                            $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
+                            $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
+                        });
+                    });
+                }
             });
 
 

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -134,11 +134,12 @@
 
 .storyquestion-email-signup-form.form {
     margin: 0;
+    margin-bottom: $gs-baseline;
 
     .form-field {
         float: left;
         width: 50%;
-        margin-bottom: $gs-baseline;
+        margin-bottom: 0;
     }
 
     .text-input {
@@ -149,8 +150,14 @@
 
     .button--primary {
         height: $gs-baseline * 3;
+    }
+
+    .button--with-input {
         border-bottom-left-radius: 0;
         border-top-left-radius: 0;
     }
 
+    .storyquestion-email-signup-button-envelope {
+        display: inline;
+    }
 }


### PR DESCRIPTION
## What does this change?
If the user has asked a question and they are signed in, auto-populate the form with their email address. Currently they have to enter it manually.

## What is the value of this and can you measure success?
We're hoping to get more signups if we make it easier.

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots
Not signed in:
![picture 8](https://user-images.githubusercontent.com/1513454/28313408-a7d8e924-6bae-11e7-975e-88e58762b0c2.png)

Signed in:
![picture 9](https://user-images.githubusercontent.com/1513454/28313407-a7d7fe4c-6bae-11e7-8a9d-14f4c3061e2d.png)


## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
