### PR TITLE
Kill all occurrences of NodeList.forEach

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/pinterest.js
+++ b/static/src/javascripts/projects/common/modules/social/pinterest.js
@@ -8,9 +8,9 @@ const launchOverlay = (event: Event): void => {
 
     const scriptUrl = 'https://assets.pinterest.com/js/pinmarklet.js';
     const cachePurge = new Date().getTime();
-    const images = document.querySelectorAll(
-        'img:not(.gu-image):not(.responsive-img)'
-    );
+    const images = [
+        ...document.querySelectorAll('img:not(.gu-image):not(.responsive-img)'),
+    ];
 
     fastdom.write(() => {
         images.forEach(img => {
@@ -22,7 +22,7 @@ const launchOverlay = (event: Event): void => {
 };
 
 const initPinterest = (): void => {
-    const buttons = document.querySelectorAll('.social__item--pinterest');
+    const buttons = [...document.querySelectorAll('.social__item--pinterest')];
 
     fastdom.write(() => {
         buttons.forEach(el => {

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -79,22 +79,26 @@ const reducers = {
                     max: 'desktop',
                 })
             ) {
-                const youTubeIframes = state.container.querySelectorAll(
-                    '.youtube-media-atom iframe'
-                );
+                const youTubeIframes = [
+                    ...state.container.querySelectorAll(
+                        '.youtube-media-atom iframe'
+                    ),
+                ];
                 youTubeIframes.forEach(el => {
                     el.remove();
                 });
-                const overlayLinks = state.container.querySelectorAll(
-                    '.video-container-overlay-link'
-                );
+                const overlayLinks = [
+                    ...state.container.querySelectorAll(
+                        '.video-container-overlay-link'
+                    ),
+                ];
                 overlayLinks.forEach(el => {
                     el.classList.add('u-faux-block-link__overlay');
                 });
 
-                const atomWrapper = state.container.querySelectorAll(
-                    '.youtube-media-atom'
-                );
+                const atomWrapper = [
+                    ...state.container.querySelectorAll('.youtube-media-atom'),
+                ];
                 atomWrapper.forEach(el => {
                     el.classList.add('no-player');
                 });


### PR DESCRIPTION
## What does this change?

I had a quick look into all `.forEach()` calls (there are only 223 of them) and identified the ones, which operate on`NodeList`.

## What is the value of this and can you measure success?

Less JS errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Screenshots

No.

## Tested in CODE?

No.
