### PR TITLE
Close down server-rendered ad slot when feature is disabled.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -6,7 +6,8 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 
 const shouldDisableAdSlot = adSlot =>
-    window.getComputedStyle(adSlot).display === 'none';
+    window.getComputedStyle(adSlot).display === 'none' ||
+    (!commercialFeatures.articleAsideAdverts && adSlot.id === 'dfp-ad--right');
 
 const closeDisabledSlots = once((): Promise<void> => {
     // Get all ad slots


### PR DESCRIPTION
## What does this change?
The right-side slot will no longer be rendered when on a match report or, more broadly, whenever the `articleAsideAdverts` commercial feature resolves to false.

### Why does this need to change?
This slot used to be added and rendered on the client side and this guard was applied at that point, but the rendering and placement have been decoupled and this guard fell out in the process. Whilst you could argue that the right side slot should not be added to the DOM to begin with, the list of features and conditions under which the slot should not be rendered are captured neatly in the client side and nowhere on the server side. If I were to block the ad slot creation on the server side then it would require a duplication in logic, which I think is more distasteful than adding this slot and then removing it later on. Gladly accept opinions on this though!

## What is the value of this and can you measure success?
We no longer have a right-side slot rendering when it shouldn't e.g. [here](https://www.theguardian.com/football/2017/mar/10/brighton-hove-albion-derby-county-match-report-anthony-knockaert-sam-baldock-glenn-murray).

I am planning on altering the way the sticky right hand slot is positioned and rendered, which will ultimately undo this PR, but in the meantime....