### PR TITLE
Make PaidFor badges behave at all breakpoints

### DIFF
--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -389,7 +389,7 @@
     }
 
     .fc-item__content {
-        display: flex;
+        display: flex !important;
         flex-direction: column;
         justify-content: space-between;
         // IE 11 hates shorthand flex CSS, and does something different to the
@@ -397,7 +397,7 @@
         flex-grow: 1;
         flex-shrink: 1;
         flex-basis: auto;
-        @include mq(mobileLandscape, tablet) {
+        @include mq(phablet, tablet) {
             flex-direction: row;
         }
     }
@@ -412,35 +412,29 @@
         justify-content: flex-end;
         pointer-events: none;
         flex-shrink: 0;
-        padding-left: $gs-gutter;
-        @include mq(mobileLandscape) {
-            flex-direction: column;
+        flex-direction: column;
+        align-items: flex-end;
+        margin-left: $gs-gutter / 2;
+        @include mq($until: phablet) {
+            flex-direction: row;
         }
     }
+
     .badge__label {
         color: #757575;
         text-align: center;
         align-self: center;
-    }
-    &.fc-item--list-media-tablet {
-        @include mq(tablet) {
-            .badge__link {
-                margin-left: $gs-gutter;
-            }
-            .badge {
-                flex-direction: row;
-                margin-top: 0;
-            }
+        @include mq($until: phablet) {
+            padding-right: $gs-gutter / 2;
         }
     }
+
     .badge__link {
-        @include mq($until: mobileLandscape) {
-            margin-left: $gs-gutter;
-        }
         @include mq($until: tablet) {
             width: $gs-gutter * 3;
         }
     }
+
     .badge__logo {
         max-width: 100%;
         margin-left: 0;


### PR DESCRIPTION
## What does this change?

PaidFor badges like to `flex`, but they look a bit odd at phablet and tablet breakpoints. 

- This changes the CSS to ensure the headline, badge and badge label all flow into aesthetically pleasing, and correct, configurations at every breakpoint.

- Adding a `!important` to the codebase... I tried, I really tried. 😭 Unfortunately, `.fc-item__content` aggressively tries to set a `display: block` property at phablet and tablet breakpoints, but PaidFor content has badges so needs ensure `display: flex` will override 

- mobileLandscape is swapping out for phablet, otherwise the headline gets squeezed too much

- Deleting some CSS that doesn't do anything

## What is the value of this and can you measure success?

- Pretty website 🌈 🦄

- Consistency

- Less CSS

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

##### BEFORE:

<img width="670" alt="picture 854" src="https://user-images.githubusercontent.com/8607683/28361381-898c1b4a-6c70-11e7-8dfd-34eac803cb85.png">

![related](https://user-images.githubusercontent.com/8607683/28361185-eb6c667c-6c6f-11e7-8c0d-8d6a6f3ebad8.gif)


##### AFTER:

<img width="673" alt="picture 855" src="https://user-images.githubusercontent.com/8607683/28361406-9734e25e-6c70-11e7-9e1f-4d49093306c2.png">


![related-after](https://user-images.githubusercontent.com/8607683/28361118-96737a8e-6c6f-11e7-8d25-8a075ab48cc0.gif)



## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
