### PR TITLE
Use proper apostrophes in Story Questions messaging

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -26,15 +26,15 @@
                                     Ask
                                 </button>
                                 <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we'll send you the answer soon.
+                                    Thanks, we&rsquo;ll send you the answer soon.
                                 </span>
                                 <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we've registered your vote.
+                                    Thanks, we&rsquo;ve registered your vote.
                                 </span>
                             </div>
                             <div class="storyquestion-submission-container js-storyquestion-submission-container">
                                 <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                    Thank you, we've registered your vote. Sign up and we will email you an answer.
+                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
                                 </span>
                                 @*********************
                                 * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.


### PR DESCRIPTION
## What does this change?
Another one of my earth-shattering changes. Huge visual impact, too (look closely, it moves!):
![apostrophe in story questions](https://user-images.githubusercontent.com/6032869/28390157-cdf6bd48-6cd0-11e7-9e42-8b05e273b266.gif)

## What is the value of this and can you measure success?
Proper typography will be measured on the judgement day.
## Does this affect other platforms - Amp, Apps, etc?
Probably not AMP. Apps may use this code (?) although at least Android isn’t exactly smart about it (signed user here):

![screenshot_20170719-223804](https://user-images.githubusercontent.com/6032869/28390851-9ca57af6-6cd3-11e7-95f4-cdbb9a26d79d.png)



## Tested in CODE?
Nope. I have used named HTML entities, but this will probably bring down the whole site anyway as this is what I like to do.

The atom that prompt me to do this (`9ce522e1-056f-4ca7-938d-c46542819261`) contains similar mistakes in its contents. Maybe Atom Workshop does not use Scribe for these fields? 🤔