### PR TITLE
Increase Re-baseline Test Audience on Epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-multiple-testimonials.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-multiple-testimonials.js
@@ -34,7 +34,7 @@ export const acquisitionsEpicMultipleTestimonials: ContributionsABTest = makeABT
         campaignId: 'epic_multiple_testimonials',
 
         audienceCriteria: 'All',
-        audience: 0.8,
+        audience: 0.68,
         audienceOffset: 0.1,
 
         variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -23,9 +23,9 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
         'We get a baseline for conversion of the bundles landing page',
 
     audienceCriteria: 'UK all devices',
-    audience: 0.1,
+    audience: 0.22,
     locations: ['GB'],
-    audienceOffset: 0.9,
+    audienceOffset: 0.78,
 
     variants: [
         {


### PR DESCRIPTION
## What does this change?

Increases the audience of the re-baseline test introduced in #17376. It started at 10% of the UK Epic traffic, this increases it to 20%. This will come as a result of a reduction in the audience percentage of the multiple testimonials test.

**Note:** It actually increases to 22% in the code, because 2% of the traffic will be lost to the [always ask test](https://github.com/guardian/frontend/blob/master/static/src/javascripts-legacy/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js).

## What is the value of this and can you measure success?

It should speed up the support re-baseline test.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Tested in CODE?

No.