### PR TITLE
[Admin] Fix troubleshooter tests

### DIFF
--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -202,8 +202,8 @@ class ContentApiClient(httpClient: HttpClient) extends ApiQueryDefaults {
 
 // The Admin server uses this PreviewContentApi to check the preview environment.
 // The Preview server uses the standard ContentApiClient object, configured with preview settings.
-class PreviewContentApi(httpClient: HttpClient) {
-  val client = CircuitBreakingContentApiClient(
+class PreviewContentApi(httpClient: HttpClient) extends ContentApiClient(httpClient) {
+  override val thriftClient = CircuitBreakingContentApiClient(
     httpClient = httpClient,
     targetUrl = Configuration.contentApi.previewHost,
     apiKey = contentApi.key.getOrElse("")


### PR DESCRIPTION
- Use correct capi client for live content
- Pass correct virtual host for request to preview
- Fetch router content from the instance directly rather than the router ELB. (depends on a [small CFN change](https://github.com/guardian/platform/pull/1219))

The last one is quite controversial and definitely an ugly workaround: the router public ELBs can only accept connections coming from Fastly or the Guardian IP/VPN but cannot be accessed via its private IP/DNS. To workaround the issue, the troubleshooter is fetching results from an router instance instead.
In an ideal world we could rewrite the troubleshooter entirely to make client-side requests but I think we have more important projects to tackle at the moment.

This fixes the troubleshooter and keep the ugliness into the `TroubleshooterController`. (no additional infrastructure or workaround in fastly, ...)

## What is the value of this and can you measure success?
Bring troubleshooter back to life. Mostly for CP use

## Tested in CODE?
yes