### PR TITLE
Remove disabling of slots based on commercial features.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -6,8 +6,7 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 
 const shouldDisableAdSlot = adSlot =>
-    window.getComputedStyle(adSlot).display === 'none' ||
-    (!commercialFeatures.articleAsideAdverts && adSlot.id === 'dfp-ad--right');
+    window.getComputedStyle(adSlot).display === 'none';
 
 const closeDisabledSlots = once((): Promise<void> => {
     // Get all ad slots


### PR DESCRIPTION
This reverts https://github.com/guardian/frontend/pull/17475, as it seems this is too broad a condition to see whether a slot should be disabled or not.

@guardian/commercial-dev 