### PR TITLE
Extend video-slot switch.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -21,7 +21,7 @@ trait CommercialSwitches {
     "Deactivates the sizecallback for videos (620x1) that hides the slot.",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 7, 26),
+    sellByDate = new LocalDate(2017, 8, 23),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Extends the switch to render Outstream in regular ad slots, while we await Outstream changes.