### PR TITLE
Correctly track impressions for liveblog epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -283,10 +283,7 @@ const makeABTestVariant = (
                                     component.insertBefore(targets);
                                 }
 
-                                mediator.emit(
-                                    parentTest.insertEvent,
-                                    component
-                                );
+                                mediator.emit(parentTest.insertEvent);
                                 onInsert(component);
 
                                 component.each(element => {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -150,6 +150,7 @@ export const acquisitionsEpicLiveblog: ContributionsABTest = makeABTest({
             test(renderFn, variant, test) {
                 const epicHtml = variant.options.template(variant);
                 addEpicToBlocks(epicHtml, test);
+                mediator.emit(test.insertEvent);
 
                 if (!isAutoUpdateHandlerBound) {
                     mediator.on('modules:autoupdate:updates', () => {


### PR DESCRIPTION
Our custom `test()` function in `acquisitions-epic-liveblog.js` wasn't firing the insert event that records an impression in Ophan.

Also the second argument to the event handler is never used so I removed it