### PR TITLE
Create a new ad slot PoC for driving traffic to GLabs campaigns.

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -72,6 +72,8 @@
 
                         @fragments.contentMeta(article, model, amp = amp)
 
+                        @fragments.commercial.carrot()
+
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
                         }

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -72,7 +72,7 @@
 
                         @fragments.contentMeta(article, model, amp = amp)
 
-                        @fragments.commercial.carrot()
+                        <div class="js-carrot"></div>
 
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -179,4 +179,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-carrot-slot",
+    "Displays a new ad slot at the top of articles to drive traffic to GLabs content",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 23),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -25,6 +25,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val CarrotSlotSwitch = Switch(
+    SwitchGroup.Commercial,
+    "carrot-slot",
+    "Allows the serving of a new type of slot: the carrot",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 23),
+    exposeClientSide = true
+  )
+
   val SurveySwitch = Switch(
     SwitchGroup.Commercial,
     "surveys",

--- a/common/app/views/fragments/commercial/carrot.scala.html
+++ b/common/app/views/fragments/commercial/carrot.scala.html
@@ -1,0 +1,7 @@
+@fragments.commercial.standardAd(
+    "carrot",
+    Seq.empty[String],
+    Map("mobile" -> Seq("fluid")),
+    showLabel=false,
+    refresh=false
+)

--- a/common/app/views/fragments/commercial/carrot.scala.html
+++ b/common/app/views/fragments/commercial/carrot.scala.html
@@ -1,7 +1,0 @@
-@fragments.commercial.standardAd(
-    "carrot",
-    Seq.empty[String],
-    Map("mobile" -> Seq("fluid")),
-    showLabel=false,
-    refresh=false
-)

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -4,6 +4,7 @@ import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
 import highMerch from 'commercial/modules/high-merch';
+import { carrotSlotInit } from 'commercial/modules/carrot-slot';
 import { articleAsideAdvertsInit } from 'commercial/modules/article-aside-adverts';
 import { articleBodyAdvertsInit } from 'commercial/modules/article-body-adverts';
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
@@ -44,6 +45,7 @@ if (!commercialFeatures.adFree) {
         ['cm-prepare-sonobi-tag', prepareSonobiTag.init, true],
         ['cm-prepare-switch-tag', prepareSwitchTag.init, true],
         ['cm-articleAsideAdverts', articleAsideAdvertsInit, true],
+        ['cm-carrotSlot', carrotSlotInit, true],
         ['cm-articleBodyAdverts', articleBodyAdvertsInit],
         ['cm-liveblogAdverts', initLiveblogAdverts, true],
         ['cm-stickyTopBanner', initStickyTopBanner]

--- a/static/src/javascripts/projects/commercial/modules/carrot-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-slot.js
@@ -13,8 +13,8 @@ const carrotSlotInit = () => {
 
         return fastdom
             .write(() => {
-                if (anchor && anchor.parentNode) {
-                    anchor.parentNode.insertBefore(slot, anchor.nextSibling);
+                if (anchor) {
+                    anchor.insertAdjacentElement('beforebegin', slot);
                 }
             })
             .then(() => {

--- a/static/src/javascripts/projects/commercial/modules/carrot-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-slot.js
@@ -1,0 +1,28 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import { addSlot } from 'commercial/modules/dfp/add-slot';
+import createSlot from 'commercial/modules/dfp/create-slot';
+import { commercialFeatures } from 'commercial/modules/commercial-features';
+
+const carrotSlotInit = () => {
+    if (commercialFeatures.carrotSlot) {
+        const anchorSelector = '.js-carrot';
+        const anchor = document.querySelector(anchorSelector);
+
+        const slot = createSlot('carrot');
+
+        return fastdom
+            .write(() => {
+                if (anchor && anchor.parentNode) {
+                    anchor.parentNode.insertBefore(slot, anchor.nextSibling);
+                }
+            })
+            .then(() => {
+                addSlot(slot, true);
+            });
+    }
+
+    return Promise.resolve();
+};
+
+export { carrotSlotInit };

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -5,6 +5,7 @@ import { isAdFreeUser } from 'commercial/modules/user-features';
 import identityApi from 'common/modules/identity/api';
 import userPrefs from 'common/modules/user-prefs';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import { getTestVariantId } from 'common/modules/experiments/utils';
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
@@ -71,7 +72,9 @@ class CommercialFeatures {
             !isHosted &&
             !newRecipeDesign;
 
-        this.carrotSlot = this.articleBodyAdverts;
+        this.carrotSlot =
+            this.articleBodyAdverts &&
+            getTestVariantId('CarrotSlot') === 'opt-in';
 
         this.articleAsideAdverts =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -74,6 +74,7 @@ class CommercialFeatures {
 
         this.carrotSlot =
             this.articleBodyAdverts &&
+            switches.carrotSlot &&
             getTestVariantId('CarrotSlot') === 'opt-in';
 
         this.articleAsideAdverts =

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -12,6 +12,7 @@ class CommercialFeatures {
     stickyTopBannerAd: any;
     articleBodyAdverts: any;
     articleAsideAdverts: any;
+    carrotSlot: any;
     videoPreRolls: any;
     highMerch: any;
     thirdPartyTags: any;
@@ -69,6 +70,8 @@ class CommercialFeatures {
             !isLiveBlog &&
             !isHosted &&
             !newRecipeDesign;
+
+        this.carrotSlot = this.articleBodyAdverts;
 
         this.articleAsideAdverts =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
@@ -62,6 +62,14 @@ const adSlotDefinitions = {
             ],
         },
     },
+    carrot: {
+        level: false,
+        refresh: false,
+        name: 'carrot',
+        sizeMappings: {
+            mobile: [adSizes.fluid],
+        },
+    },
     inline: inlineDefinition,
     mostpop: inlineDefinition,
     comments: inlineDefinition,

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
@@ -63,7 +63,7 @@ const adSlotDefinitions = {
         },
     },
     carrot: {
-        level: false,
+        label: false,
         refresh: false,
         name: 'carrot',
         sizeMappings: {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,6 +4,7 @@ import { removeParticipation } from 'common/modules/experiments/utils';
 import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquisition-test-selector';
 import MembershipEngagementBannerTests from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import PaidContentVsOutbrain2 from 'common/modules/experiments/tests/paid-content-vs-outbrain';
+import { carrotSlot } from 'common/modules/experiments/tests/carrot-slot';
 import { tailorSurvey } from 'common/modules/experiments/tests/tailor-survey';
 
 import AcquisitionsEpicElectionInteractiveEnd from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
@@ -15,6 +16,7 @@ export const TESTS: Array<ABTest> = [
     PaidContentVsOutbrain2,
     getAcquisitionTest(),
     tailorSurvey,
+    carrotSlot,
     AcquisitionsEpicElectionInteractiveEnd,
     AcquisitionsEpicElectionInteractiveSlice,
     new BundleDigitalSubPriceTest1Thrasher(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/carrot-slot.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/carrot-slot.js
@@ -1,0 +1,28 @@
+// @flow
+
+export const carrotSlot: ABTest = {
+    id: 'CarrotSlot',
+    start: '2017-07-24',
+    expiry: '2017-08-23',
+    author: 'Jon Norman',
+    description:
+        'Provides the ability to opt-in behind query param, so we can test a new ad slot - carrot - that drives traffic to GLabs content.',
+    audience: 0,
+    audienceOffset: 0,
+    successMeasure:
+        'GLabs can opt in and play with traffic driving to Labs content',
+    audienceCriteria: 'GLabs and Commercial Dev',
+    dataLinkNames: '',
+    idealOutcome: '',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'opt-in',
+            test: () => {},
+        },
+        {
+            id: 'opt-out',
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -414,6 +414,11 @@
     padding: 0;
     margin: 0;
 
+    &.ad-slot--carrot {
+        min-height: 0;
+        margin-bottom: 8px;
+    }
+
     &:not(.ad-slot--im) {
         width: auto;
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -416,7 +416,7 @@
 
     &.ad-slot--carrot {
         min-height: 0;
-        margin-bottom: 8px;
+        margin-bottom: 16px;
     }
 
     &:not(.ad-slot--im) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -414,11 +414,6 @@
     padding: 0;
     margin: 0;
 
-    &.ad-slot--carrot {
-        min-height: 0;
-        margin-bottom: 16px;
-    }
-
     &:not(.ad-slot--im) {
         width: auto;
     }
@@ -441,6 +436,12 @@
             margin-right: -$gs-gutter;
         }
     }
+}
+
+.ad-slot--carrot {
+    min-height: 0;
+    padding: 0;
+    margin-bottom: 16px
 }
 
 .ad-slot--fabric-v1 {


### PR DESCRIPTION
## What does this change?
This is a new ad slot, which will sit at the top of articles, and will be intended to drive traffic to GLabs content.

This slot sits behind a 0% ad test such that it can be opted into while we try out new designs.

@guardian/commercial-dev