### PR TITLE
correct aspect ratio for amp-video

### DIFF
--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -10,8 +10,8 @@
     @if(amp) {
         <amp-video
             controls
-            width="5"
-            height="3"
+            width="16"
+            height="9"
             layout="responsive"
             poster="@player.poster"
         >


### PR DESCRIPTION
## What does this change?
videos are 16x9

## What is the value of this and can you measure success?
removes letterboxing of videos on amp pages

## Does this affect other platforms - Amp, Apps, etc?
yep, amp

## Screenshots
hoping they're not needed...

## Tested in CODE?
nope