### PR TITLE
Extend switches new header and explore template

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -21,7 +21,7 @@ trait FeatureSwitches {
     "If this switch is on, Explore template will be applied to explore articles. This template is part of a Membership Explore test",
     owners = Seq(Owner.withGithub("NataliaLKB"), Owner.withGithub("blongden73")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 7, 25),
+    sellByDate = new LocalDate(2017, 8, 24),
     exposeClientSide = true
   )
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -32,7 +32,7 @@ object ABNewDesktopHeaderVariant extends TestDefinition(
   name = "ab-new-desktop-header-variant",
   description = "Users in this test will see the new desktop design.",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 7, 25)
+  sellByDate = new LocalDate(2017, 8, 24)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header")
@@ -44,7 +44,7 @@ object ABNewDesktopHeaderControl extends TestDefinition(
   name = "ab-new-desktop-header-control",
   description = "Users in this test will not see the new desktop design, but act as a control group",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 7, 25)
+  sellByDate = new LocalDate(2017, 8, 24)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header")


### PR DESCRIPTION
## What does this change?
Extending some switches which expire tomorrow for another month.

New Header: We are working on v2 of the test which will address a few of the issues caught be user feedback.

Explore Template: We still don't know what is happening with this but @stephanfowler and @blongden73 are chasing people up on it so we can make the decision of keeping or killing. 

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
Tests continue and the switches don't turn off.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
n/a

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
