### PR TITLE
Storyquestions: Update the height on any DOM change

### DIFF
--- a/static/src/javascripts/bootstraps/atoms/storyquestions.js
+++ b/static/src/javascripts/bootstraps/atoms/storyquestions.js
@@ -13,6 +13,18 @@ import { send } from 'commercial/modules/messenger/send';
 // eslint-disable-next-line camelcase,no-undef
 __webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
+const updateHeight = () => {
+    fastdom
+        .read(
+            () =>
+                document.documentElement &&
+                document.documentElement.getBoundingClientRect().height
+        )
+        .then(height => {
+            send('resize', { height });
+        });
+};
+
 Promise.all([
     window.guardian.polyfilled
         ? Promise.resolve()
@@ -23,13 +35,15 @@ Promise.all([
     new Promise(comready),
 ]).then(() => {
     init();
-    fastdom
-        .read(
-            () =>
-                document.documentElement &&
-                document.documentElement.getBoundingClientRect().height
-        )
-        .then(height => {
-            send('resize', { height });
+    updateHeight();
+
+    // Brittle but will work
+    [...document.getElementsByClassName('user__question')]
+        .slice(0, 1)
+        .forEach((sq: Element) => {
+            new MutationObserver(updateHeight).observe(sq, {
+                childList: true,
+                subtree: true,
+            });
         });
 });


### PR DESCRIPTION
This will fix the bug where storyquestions appear "cut" in apps when the user interacts with a question. Because changes in height are done via class additions/removals, we know that DOM mutation will catch these events and we just propagate them upstream to the parent window.