### PR TITLE
Football: Add Women's Euro competition

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -36,6 +36,7 @@ class LeagueTableController(val competitionsService: CompetitionsService)(implic
         "Champions League qualifying",
         "Europa League",
         "Champions League",
+        "Women's Euro 2017",
         "FA Cup",
         "EFL Cup",
         "Community Shield",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -119,7 +119,8 @@ object CompetitionsProvider {
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
     Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2)),
-    Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true, tableDividers = List(2))
+    Competition("701", "/football/world-cup-2018-qualifiers", "World Cup 2018 Qualifiers", "World Cup 2018 qual.", "Internationals", showInTeamsList = true, tableDividers = List(2)),
+    Competition("423", "/football/women-euro-2017", "Women's Euro 2017", "Women's Euro", "Internationals", showInTeamsList = true, tableDividers = List(2))
   )
 }
 


### PR DESCRIPTION
## What does this change?
Add Women's Euro competition

Note: This is a bit ridiculous we have to update a few different places to fully add a competition.
I didn't even update the admin endpoint because PA doesn't seem to return the competition when calling`/competitions/competitions/`

## Tested in CODE?
No