### PR TITLE
Don’t create npm 5 lockfile when quickly installing semver in node env check

### DIFF
--- a/tools/check-yarn.js
+++ b/tools/check-yarn.js
@@ -18,7 +18,7 @@ new Promise(resolve => {
         resolve();
     } catch (e) {
         childProcess
-            .spawn('npm', ['i', 'semver'], {
+            .spawn('npm', ['i', 'semver', '--no-save'], {
                 stdio: 'inherit',
             })
             .on('close', code => {


### PR DESCRIPTION
npm 5 adds a lockfile and saves by default. we only install this module temporarily if it doesn't exist (is installed by the app, but a fresh/re-install will mean it's not yet on disc)

this stops npm5 actually adding it as a dep