### PR TITLE
Remove extra switch from carrot slot - covered by AB switch.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -25,16 +25,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val CarrotSlotSwitch = Switch(
-    SwitchGroup.Commercial,
-    "carrot-slot",
-    "Allows the serving of a new type of slot: the carrot",
-    owners = Seq(Owner.withGithub("JonNorman")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 23),
-    exposeClientSide = true
-  )
-
   val SurveySwitch = Switch(
     SwitchGroup.Commercial,
     "surveys",

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -74,7 +74,6 @@ class CommercialFeatures {
 
         this.carrotSlot =
             this.articleBodyAdverts &&
-            switches.carrotSlot &&
             getTestVariantId('CarrotSlot') === 'opt-in';
 
         this.articleAsideAdverts =


### PR DESCRIPTION
It's overkill to have two switches, so I'm removing the feature switch.