### PR TITLE
[WiP] Fix right-hand ad slots on match reports.

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -169,7 +169,7 @@ define([
                     if (resp.hasStarted && $nav) {
                         var statsUrl = $('.tab--stats a', $nav).attr('href').replace(/^.*\/\/[^/]+/, '');
 
-                        $.create('<div class="match-stats__container"></div>').each(function (container) {
+                        $.create('<div class="match-stats__container js-match-stats"></div>').each(function (container) {
                             football.statsFor(statsUrl).fetch(container).then(function () {
                                 $('.js-chart', container).each(function (el) {
                                     new Doughnut.TableDoughnut().render(el);

--- a/static/src/javascripts-legacy/bootstraps/enhanced/sport.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/sport.js
@@ -83,8 +83,8 @@ define([
                     $('.score-container').after($scoreEventsTabletUp);
                 }
 
-                $('.match-stats__container').remove();
-                $.create('<div class="match-stats__container">' + resp.matchStat + '</div>').each(function (container) {
+                $('.js-match-stats').remove();
+                $.create('<div class="match-stats__container js-match-stats">' + resp.matchStat + '</div>').each(function (container) {
                     $('.js-chart', container).each(function (el) {
                         new Doughnut.TableDoughnut().render(el);
                     });

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -3,7 +3,6 @@ import $ from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
-import { commercialFeatures } from 'commercial/modules/commercial-features';
 
 import type { bonzo } from 'bonzo';
 
@@ -21,14 +20,8 @@ const articleAsideAdvertsInit = (
 
     const $col: bonzo = $('.js-secondary-column');
 
-    // are article aside ads disabled, or secondary column hidden?
-    if (
-        !(
-            commercialFeatures.articleAsideAdverts &&
-            $col.length &&
-            $col.css('display') !== 'none'
-        )
-    ) {
+    // article aside ads are added server-side if the container doesn't exist then stop.
+    if (!$col.length || $col.css('display') === 'none') {
         stop();
         return Promise.resolve(false);
     }

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -4,7 +4,6 @@ import qwery from 'qwery';
 import mediator from 'lib/mediator';
 import { noop } from 'lib/noop';
 import { articleAsideAdvertsInit } from 'commercial/modules/article-aside-adverts';
-import { commercialFeatures } from 'commercial/modules/commercial-features';
 import fastdom from 'lib/fastdom-promise';
 
 jest.mock('commercial/modules/commercial-features', () => ({
@@ -113,13 +112,5 @@ describe('Article Aside Adverts', () => {
             done();
         });
         articleAsideAdvertsInit(noop, noop);
-    });
-
-    it('should not do anything if disabled in commercial-feature-switches', done => {
-        commercialFeatures.articleAsideAdverts = false;
-        articleAsideAdvertsInit(noop, noop).then(returned => {
-            expect(returned).toBe(false);
-            done();
-        });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -37,7 +37,6 @@ class CommercialFeatures {
         const isInteractive = config.page.contentType === 'Interactive';
         const isLiveBlog = config.page.isLiveBlog;
         const isHosted = config.page.isHosted;
-        const isMatchReport = config.hasTone('Match reports');
         const isIdentityPage =
             config.page.contentType === 'Identity' ||
             config.page.section === 'identity'; // needed for pages under profile.* subdomain
@@ -75,14 +74,6 @@ class CommercialFeatures {
         this.carrotSlot =
             this.articleBodyAdverts &&
             getTestVariantId('CarrotSlot') === 'opt-in';
-
-        this.articleAsideAdverts =
-            this.dfpAdvertising &&
-            !this.adFree &&
-            !isMinuteArticle &&
-            !isMatchReport &&
-            !!(isArticle || isLiveBlog) &&
-            !newRecipeDesign;
 
         this.videoPreRolls = this.dfpAdvertising && !this.adFree;
 

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
@@ -160,67 +160,6 @@ describe('Commercial features', () => {
         });
     });
 
-    describe('Article aside adverts', () => {
-        it('Runs by default in articles', () => {
-            config.page.contentType = 'Article';
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(true);
-        });
-
-        it('Runs by default in liveblogs', () => {
-            config.page.contentType = 'LiveBlog';
-            config.page.isLiveBlog = true;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(true);
-        });
-
-        it('Doesn`t run in minute articles', () => {
-            config.page.isMinuteArticle = true;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-
-        it('Doesn`t run in non-article non-liveblog pages', () => {
-            config.page.contentType = 'Network Front';
-            config.page.isLiveBlog = false;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-    });
-
-    describe('Article aside adverts under ad-free', () => {
-        beforeEach(() => {
-            config.switches.adFreeSubscriptionTrial = true;
-            isAdFreeUser.mockReturnValue(true);
-        });
-
-        it('are disabled in articles', () => {
-            config.page.contentType = 'Article';
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-
-        it('are disabled in liveblogs', () => {
-            config.page.contentType = 'LiveBlog';
-            config.page.isLiveBlog = true;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-
-        it('are disabled in minute articles', () => {
-            config.page.isMinuteArticle = true;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-
-        it('are disabled in non-article non-liveblog pages (e.g. network front)', () => {
-            config.page.contentType = 'Network Front';
-            config.page.isLiveBlog = false;
-            const features = new CommercialFeatures();
-            expect(features.articleAsideAdverts).toBe(false);
-        });
-    });
-
     describe('Video prerolls', () => {
         it('Runs by default', () => {
             const features = new CommercialFeatures();


### PR DESCRIPTION
## What does this change?
We have logic in `articleAsideAdverts.js` that changes the sizes requested by the ad slot depending on whether there is space in the right hand column or not. The available space is especially affected on match reports due to the short nature of the articles and the 'match-stats' container in the right hand column.

This resizing logic is currently being short-circuited due to a flag in `commercial-features.js`: `articleAsideAdverts`. This would make sense if the ad slot was a) served client-side and b) defined in `articleAsideAdverts.js`...but it isn't.

The ad slot is added into the DOM server-side (in `articleAsideSlot.scala.html` from various article and liveblog templates) and so it makes no sense to have this client-side rule, since it only affects resizing, which we want to happen in every instance of the right hand ad existing.

## What is the value of this and can you measure success?
**Before (300x600 is requested**
![image](https://user-images.githubusercontent.com/1821099/28570617-d38328e0-7136-11e7-9a2a-654f298798c1.png)


**After (only 300x250 is requested)**:
![image](https://user-images.githubusercontent.com/1821099/28570552-8c77fe9e-7136-11e7-8b7c-f13d5eea8ef3.png)