### PR TITLE
Add OutsideInAmerica to email list, update naming and example URL

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -236,10 +236,10 @@ object EmailNewsletters {
 
   val documentaries = EmailNewsletter(
     name = "Guardian Documentaries",
-    theme = "feature",
+    theme = "features",
     teaser = "Find out about our new films and get background on our film-makers and the subjects that they cover",
     description = "Be the first to find out about our new documentary films, created by top international filmmakers and following unseen global stories. Discover our latest documentaries, get background on our film-makers and the subjects that they cover, and find out about live documentary screenings",
-    frequency = "Every four weeks",
+    frequency = "Whenever a new film is available",
     listId = 3745,
     tone = Some("media"),
     signupPage = Some("/info/2016/sep/02/sign-up-for-the-guardian-documentaries-update"),
@@ -248,7 +248,7 @@ object EmailNewsletters {
 
   val weekendReading = EmailNewsletter(
     name = "Weekend Reading",
-    theme = "feature",
+    theme = "features",
     teaser = "The best stuff you didn't have time to read during the week - from features and news analysis to lifestyle and culture",
     description = "The best stuff you didn't have time to read during the week - from features and news analysis to lifestyle and culture",
     frequency = "Every Saturday",
@@ -260,14 +260,27 @@ object EmailNewsletters {
 
   val theLongRead = EmailNewsletter(
     name = "The Long Read",
-    theme = "feature",
+    theme = "features",
     teaser = "Get lost in a great story; the Guardian’s award-winning long reads bring you the biggest ideas and the arguments that matter",
     description = "Get lost in a great story. From politics to fashion, international investigations to new thinking, culture to crime - we’ll bring you the biggest ideas and the arguments that matter. Sign up to have the Guardian’s award-winning long reads emailed to you every Saturday morning",
     frequency = "Every Saturday",
     listId = 3890,
     aliases = List(3322),
     tone = Some("feature"),
-    signupPage = Some("/news/2015/jul/20/sign-up-to-the-long-read-email")
+    signupPage = Some("/news/2015/jul/20/sign-up-to-the-long-read-email"),
+    exampleUrl = Some("/email/the-long-read")
+  )
+
+  val outsideInAmerica = EmailNewsletter(
+    name = "Outside in America",
+    theme = "features",
+    teaser = "Keep up with our Investigation of the homeless crisis in western US, focusing on those frontline and enabling readers to take action",
+    description = "Keep up with our year-long investigation of the homeless crisis in western US, focusing on those frontline and enabling readers to take action. Editor Alastair Gee rounds up the latest developments and provides a catch-up on the most compelling stories, both from the Guardian and around the web",
+    frequency = "Monthly",
+    listId = 3833,
+    tone = Some("feature"),
+    signupPage = Some("/us-news/2017/feb/16/outside-in-america-homeless-project"),
+    exampleUrl = Some("/us-news/series/outside-in-america-newsletter/latest/email")
   )
 
   val sleeveNotes = EmailNewsletter(
@@ -487,7 +500,8 @@ object EmailNewsletters {
   val featureEmails = List(
     documentaries,
     weekendReading,
-    theLongRead
+    theLongRead,
+    outsideInAmerica
   )
 
   val cultureEmails = List(

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -70,7 +70,7 @@
               <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
             }
             <div class="email-subscriptions">
-                @List("news", "feature", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
+                @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
                   @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), index == 0)
                 }
             </div>


### PR DESCRIPTION
## What does this change?

- Add Outside In America to the email list
- Update frequency of the Documentaries email
- Change 'Feature' to 'Features' on the email prefs page
- Add an example URL for The Long Read

## What is the value of this and can you measure success?

- Keeping email-prefs and newsletter page up-to-date
- Guardian Digital << ❤️ >> Editorial

## Does this affect other platforms - Amp, Apps, etc?

## Screenshots

##### Email-Prefs centre is changing Feature >> Features

<img width="830" alt="picture 861" src="https://user-images.githubusercontent.com/8607683/28571243-e16aa408-7139-11e7-8335-938306223b5b.png">

##### Newsletters page on desktop:

<img width="1326" alt="picture 865" src="https://user-images.githubusercontent.com/8607683/28571256-e9b71632-7139-11e7-9bb3-32eed27bcef4.png">

##### Newsletters page on tablet:

<img width="570" alt="picture 866" src="https://user-images.githubusercontent.com/8607683/28571299-3379f6a4-713a-11e7-8a74-df43459f749e.png">


## Tested in CODE?

YES! (Because it was quicker than trying to get Identity running locally so I could sign in to see the email preferences page)
