### PR TITLE
Increase Re-baseline Test Audience on Epic With New Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -171,6 +171,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-epic-rebaseline-support-proposition-two",
+    "Re-baseline the new support proposition against the old",
+    owners = Seq(Owner.withGithub("Ap0c")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 8, 15),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-carrot-slot",
     "Displays a new ad slot at the top of articles to drive traffic to GLabs content",
     owners = Seq(Owner.withGithub("JonNorman")),

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -15,6 +15,7 @@ import acquisitionsEpicAlwaysAskElection from 'common/modules/experiments/tests/
 import acquisitionsEpicThankYou from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import acquisitionsThisLandSeries from 'common/modules/experiments/tests/acquisitions-this-land-series';
 import { acquisitionsEpicRebaselineSupportProposition } from 'common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition';
+import { acquisitionsEpicRebaselineSupportPropositionTwo } from 'common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition-two';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -24,6 +25,7 @@ const tests = [
     acquisitionsThisLandSeries,
     bundlePriceTest1,
     acquisitionsEpicRebaselineSupportProposition,
+    acquisitionsEpicRebaselineSupportPropositionTwo,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition-two.js
@@ -1,0 +1,41 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import template from 'lodash/utilities/template';
+import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
+
+const buildButtonTemplate = ({ supportUrl }) =>
+    template(singleButtonTemplate, {
+        url: supportUrl,
+    });
+
+export const acquisitionsEpicRebaselineSupportPropositionTwo = makeABTest({
+    id: 'AcquisitionsEpicRebaselineSupportPropositionTwo',
+    campaignId: 'sandc_epic_rebaseline_support_proposition_two',
+
+    start: '2017-07-26',
+    expiry: '2017-08-15',
+
+    author: 'Ap0c',
+    description:
+        'This creates a single-button version of the epic that links off to the new support frontend bundles landing page',
+    successMeasure: 'Conversion rate',
+    idealOutcome:
+        'We get a baseline for conversion of the bundles landing page',
+
+    audienceCriteria: 'UK all devices',
+    audience: 0.58,
+    locations: ['GB'],
+    audienceOffset: 0.2,
+
+    variants: [
+        {
+            id: 'control',
+            useTailoredCopyForRegulars: true,
+        },
+        {
+            id: 'support_proposition',
+            buttonTemplate: buildButtonTemplate,
+            useTailoredCopyForRegulars: true,
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition-two.js
@@ -18,7 +18,7 @@ export const acquisitionsEpicRebaselineSupportPropositionTwo = makeABTest({
     author: 'Ap0c',
     description:
         'This creates a single-button version of the epic that links off to the new support frontend bundles landing page',
-    successMeasure: 'Conversion rate',
+    successMeasure: 'Annualised value',
     idealOutcome:
         'We get a baseline for conversion of the bundles landing page',
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-rebaseline-support-proposition.js
@@ -18,7 +18,7 @@ export const acquisitionsEpicRebaselineSupportProposition = makeABTest({
     author: 'Ap0c',
     description:
         'This creates a single-button version of the epic that links off to the new support frontend bundles landing page',
-    successMeasure: 'Conversion rate',
+    successMeasure: 'Annualised value',
     idealOutcome:
         'We get a baseline for conversion of the bundles landing page',
 


### PR DESCRIPTION
## What does this change?

This extends #17376 to a larger percentage of the audience.

It doesn't do it by simply increasing the audience size however, as in #17486, because we have subsequently realised this can cause issues with the `notintest` allocation. People who were allocated `notintest` when the first percentage was running will not be allocated to the test when the percentage changes, even if they are now in the right audience segment.

Instead, this PR creates a new test, identical to the old but under a different name. This test is then applied to the additional audience segment we want to include in the test, and the results will be aggregated later.

![percentage-changes](https://user-images.githubusercontent.com/5131341/28632974-1e2a40ec-722a-11e7-845c-c111016b544a.png)


## What is the value of this and can you measure success?

It should speed up the support re-baseline test.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Tested in CODE?

No.