### PR TITLE
[WiP] Move the Carrot PoC slot to sit between the second and third paragraphs.

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -72,8 +72,6 @@
 
                         @fragments.contentMeta(article, model, amp = amp)
 
-                        <div class="js-carrot"></div>
-
                         @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
                             <hr class="content__hr hide-until-leftcol" />
                         }

--- a/static/src/javascripts/projects/commercial/modules/carrot-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-slot.js
@@ -6,15 +6,15 @@ import { commercialFeatures } from 'commercial/modules/commercial-features';
 
 const carrotSlotInit = () => {
     if (commercialFeatures.carrotSlot) {
-        const anchorSelector = '.js-carrot';
-        const anchor = document.querySelector(anchorSelector);
+        const secondArticleParagraph = '.js-article__body p:nth-of-type(2)';
+        const anchor = document.querySelector(secondArticleParagraph);
 
         const slot = createSlot('carrot');
 
         return fastdom
             .write(() => {
                 if (anchor) {
-                    anchor.insertAdjacentElement('beforebegin', slot);
+                    anchor.insertAdjacentElement('beforeend', slot);
                 }
             })
             .then(() => {

--- a/static/src/javascripts/projects/commercial/modules/carrot-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-slot.js
@@ -4,22 +4,43 @@ import { addSlot } from 'commercial/modules/dfp/add-slot';
 import createSlot from 'commercial/modules/dfp/create-slot';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 
+/*
+ The heuristic for adding a carrot slot into an article is as follows:
+ 1) it must be after the second paragraph and
+ 2) it must be after the 100th word in the article
+
+ This is to prevent it appearing after single word paragraphs that are encountered
+ at the top of some article. It still isn't perfect, but it is good enough for a test.
+ */
+const findSuitableCarrotPosition = (
+    paragraphs: Array<HTMLElement>
+): ?HTMLElement => {
+    let runningWordCount = 0;
+    let index = 0;
+
+    while (index < paragraphs.length) {
+        runningWordCount += paragraphs[index].textContent.split(' ').length;
+
+        if (runningWordCount >= 100 && index >= 1) return paragraphs[index];
+
+        index += 1;
+    }
+};
+
 const carrotSlotInit = () => {
     if (commercialFeatures.carrotSlot) {
-        const secondArticleParagraph = '.js-article__body p:nth-of-type(2)';
-        const anchor = document.querySelector(secondArticleParagraph);
+        const paragraphs = Array.from(
+            document.querySelectorAll('.js-article__body p')
+        );
+        const anchor: ?HTMLElement = findSuitableCarrotPosition(paragraphs);
 
-        const slot = createSlot('carrot');
+        if (anchor) {
+            const slot = createSlot('carrot');
 
-        return fastdom
-            .write(() => {
-                if (anchor) {
-                    anchor.insertAdjacentElement('beforeend', slot);
-                }
-            })
-            .then(() => {
-                addSlot(slot, true);
-            });
+            return fastdom
+                .write(() => anchor.insertAdjacentElement('beforeend', slot))
+                .then(() => addSlot(slot, true));
+        }
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -73,6 +73,11 @@ class CommercialFeatures {
 
         this.carrotSlot =
             this.articleBodyAdverts &&
+            config.hasTone('Features') &&
+            !config.page.isPaidContent &&
+            ['sport', 'lifeandstyle', 'fashion', 'food', 'travel'].includes(
+                config.page.section
+            ) &&
             getTestVariantId('CarrotSlot') === 'opt-in';
 
         this.videoPreRolls = this.dfpAdvertising && !this.adFree;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -441,7 +441,8 @@
 .ad-slot--carrot {
     min-height: 0;
     padding: 0;
-    margin-bottom: 16px
+    margin-top: 16px;
+    margin-bottom: 16px;
 }
 
 .ad-slot--fabric-v1 {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -441,8 +441,8 @@
 .ad-slot--carrot {
     min-height: 0;
     padding: 0;
-    margin-top: 16px;
-    margin-bottom: 16px;
+    margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
 }
 
 .ad-slot--fabric-v1 {


### PR DESCRIPTION
Changes the position of the carrot to before the article to between the second and third paragraphs.

To do:
- [x] Get design spec from design and implement.
- [x] Articulate the current criteria for placing the slot in a way that spacefiller can understand. This may require extending spacefiller.

![image](https://user-images.githubusercontent.com/1821099/28633627-6136e384-722c-11e7-901a-abf13e7f7948.png)
