### PR TITLE
Add YouTube ad free pixel

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -85,6 +85,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val DoubleClickYouTubeAdFree = Switch(
+    SwitchGroup.Commercial,
+    "doubleclick-youtube-ad-free",
+    "Enable DoubleClick Segment for YouTube for Ad Free Users",
+    owners = Seq(Owner.withName("commercial team")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val RemarketingSwitch = Switch(
     SwitchGroup.Commercial,
     "remarketing",

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -17,6 +17,7 @@ import { simpleReach } from 'commercial/modules/third-party-tags/simple-reach';
 import { tourismAustralia } from 'commercial/modules/third-party-tags/tourism-australia';
 import { krux } from 'commercial/modules/third-party-tags/krux';
 import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
+import { doubleClickAdFree } from 'commercial/modules/third-party-tags/doubleclick-ad-free';
 import plista from 'commercial/modules/third-party-tags/plista';
 
 const isLuckyBastard = (): boolean =>
@@ -85,6 +86,7 @@ const loadOther = (): void => {
         simpleReach,
         tourismAustralia,
         krux,
+        doubleClickAdFree,
     ].filter(_ => _.shouldRun);
 
     if (services.length) {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
@@ -3,9 +3,15 @@
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import config from 'lib/config';
 
+const doubleClickRandom = (): string => {
+    const axel = Math.random();
+    const a = axel * 10000000000000;
+    return a.toString();
+};
+
 export const doubleClickAdFree: ThirdPartyTag = {
     shouldRun: commercialFeatures.adFree,
     useImage: true,
     url: `//pubads.g.doubleclick.net/activity;dc_iu=/${config.page
-        .dfpAccountId}/;ord=1;af=T;dc_seg=482549580?`,
+        .dfpAccountId}/;ord=${doubleClickRandom()};af=T;dc_seg=482549580?`,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
@@ -10,7 +10,8 @@ const doubleClickRandom = (): string => {
 };
 
 export const doubleClickAdFree: ThirdPartyTag = {
-    shouldRun: commercialFeatures.adFree,
+    shouldRun:
+        commercialFeatures.adFree && config.switches.doubleclickYoutubeAdFree,
     useImage: true,
     url: `//pubads.g.doubleclick.net/activity;dc_iu=/${config.page
         .dfpAccountId}/;ord=${doubleClickRandom()};af=T;dc_seg=482549580?`,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
@@ -1,0 +1,11 @@
+// @flow
+
+import { commercialFeatures } from 'commercial/modules/commercial-features';
+import config from 'lib/config';
+
+export const doubleClickAdFree: ThirdPartyTag = {
+    shouldRun: commercialFeatures.adFree,
+    useImage: true,
+    url: `//pubads.g.doubleclick.net/activity;dc_iu=/${config.page
+        .dfpAccountId}/;ord=1;af=T;dc_seg=482549580?`,
+};


### PR DESCRIPTION
## What does this change?

Adds doubleclick segment for ad free users. This is the supported way to provide an ad-free* experience for YouTube PFP users.

(Due to restrictions of the YouTube player we cannot use PPID as we do in other places for more on this please talk to Tom Duffett.)

 *_Actually not ad-free but serves a fixed guardian bumper as a short ad_ 

Note: due to YouTube domain whitelisting we can only test this end-to-end on PROD but it is behind a switch, which we intend to turn on for a short time to validate it.

## What is the value of this and can you measure success?
Parity with existing video player for ad-free experience.

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
N/A

## Tested in CODE?
Yes (at least for the part that is testable)

CC @guardian/commercial-dev 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
