### PR TITLE
[Applications] add test route for interactive test

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -97,6 +97,9 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)+>/$file<interactive(-service)?-worker.js> 
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    controllers.InteractiveController.renderInteractiveJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>         controllers.InteractiveController.renderInteractive(path)
 
+# Interactive test (removing ng-interactive in the url)
+GET        /$path<info/2017/jul/26/interactive-test>                            controllers.InteractiveController.renderInteractive(path)
+
 # Short urls with campaign codes
 GET        /$shortCode<p/[\w]+>                                                 controllers.ShortUrlsController.redirectShortUrl(shortCode)
 GET        /$shortCode<p/[\w]+>/:campaignCode                                   controllers.ShortUrlsController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)


### PR DESCRIPTION
Initial test removing ng-interactive in interactive's url

Requires https://github.com/guardian/platform/pull/1222

## What is the value of this and can you measure success?
Testing a single interactive without `ng-interactive` in the url

## Tested in CODE?
Yes https://code.dev-theguardian.com/info/2017/jul/26/interactive-test