### PR TITLE
Use 3322 as the default id for the long read

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -264,8 +264,8 @@ object EmailNewsletters {
     teaser = "Get lost in a great story; the Guardian’s award-winning long reads bring you the biggest ideas and the arguments that matter",
     description = "Get lost in a great story. From politics to fashion, international investigations to new thinking, culture to crime - we’ll bring you the biggest ideas and the arguments that matter. Sign up to have the Guardian’s award-winning long reads emailed to you every Saturday morning",
     frequency = "Every Saturday",
-    listId = 3890,
-    aliases = List(3322),
+    listId = 3322,
+    aliases = List(3890),
     tone = Some("feature"),
     signupPage = Some("/news/2015/jul/20/sign-up-to-the-long-read-email"),
     exampleUrl = Some("/email/the-long-read")


### PR DESCRIPTION
## What does this change?

The default list id for the newsletter signup from 3890 to 3322.  We were running a/b tests on emails but are now merging the lists and reverting to the younger list id.

## What is the value of this and can you measure success?

Tidying up old a/b test

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
