### PR TITLE
facebook Oauth login to referrer null

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -108,8 +108,9 @@
         }
         ga('@{trackerName}.set', 'dimension43', getExperienceValue()); @* 'Experience' dimension, for short-lived experiment values. *@
 
-        if(document.cookies.contain('GU_FB')) {
+        if(document.location.hash === '#fbLogin') {
             ga('@{trackerName}.set', 'referrer', null);
+            document.location.hash = '';
         }
     }
 

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -107,6 +107,10 @@
           ga('@{trackerName}.set', 'dimension42', '@brandingType.name');
         }
         ga('@{trackerName}.set', 'dimension43', getExperienceValue()); @* 'Experience' dimension, for short-lived experiment values. *@
+
+        if(document.cookies.contain('GU_FB')) {
+            ga('@{trackerName}.set', 'referrer', null);
+        }
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker(context).trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?
- Sets the Google Analytics referrer to null if the user has come via facebok Oauth. See https://github.com/guardian/identity-federation-api/pull/228 .
- This will stop us wrongly attributing facebook logins as facebook referrals in google analytics
- First commit is related to an attempt to achieve the same effect with a cookie in the identity-federation-api that was abandoned.   

## What is the value of this and can you measure success?
- Correct the google analytics data.

## Tested in CODE?
Not yet

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
