### PR TITLE
Update DFPAudiencePixel URL

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/doubleclick-ad-free.js
@@ -14,5 +14,5 @@ export const doubleClickAdFree: ThirdPartyTag = {
         commercialFeatures.adFree && config.switches.doubleclickYoutubeAdFree,
     useImage: true,
     url: `//pubads.g.doubleclick.net/activity;dc_iu=/${config.page
-        .dfpAccountId}/;ord=${doubleClickRandom()};af=T;dc_seg=482549580?`,
+        .dfpAccountId}/DFPAudiencePixel;ord=${doubleClickRandom()};dc_seg=482549580;af=T?`,
 };


### PR DESCRIPTION
## What does this change?

Update the doubleclick URL to include `DFPAudiencePixel` in the hope that this allows us to bucket users in DFP correctly.

## What is the value of this and can you measure success?

Maybe video splash works?
