### PR TITLE
Initialize more than one rendering actor

### DIFF
--- a/common/app/rendering/core/Renderer.scala
+++ b/common/app/rendering/core/Renderer.scala
@@ -6,6 +6,7 @@ import play.api.mvc.Result
 import play.api.mvc.Results._
 import rendering.Renderable
 import akka.pattern.ask
+import akka.routing.RoundRobinPool
 import akka.util.Timeout
 import common.Logging
 import play.api.Mode
@@ -16,7 +17,8 @@ import scala.util.{Failure, Success, Try}
 
 class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionContext, ac: ApplicationContext) extends Logging {
 
-  val actor = actorSystem.actorOf(Props[RenderingActor]) //TODO: initialize several actors
+  val renderingActorCount = 3
+  val actor = actorSystem.actorOf(Props[RenderingActor].withRouter(RoundRobinPool(renderingActorCount)))
 
   val timeoutValue: Int = if(ac.environment.mode == Mode.Dev) 10 else 1
   implicit val timeout = Timeout(timeoutValue.seconds)


### PR DESCRIPTION
The current number of account (3) has been chosen quite arbitrarily.
We will need to benchmark what is the best value depending on the
performance of the rendering. We might also want to set a different
count based on the kind of requests (ie: different app could have
different amount of rendering actors)

## What is the value of this and can you measure success?
Better throughput. Each rendering actor processes request sequentially. Increasing the number of actor improves the amount of rendering requests an app can handle

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No