### PR TITLE
Add cloudwatch metrics to monitor fronts pressing

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -138,6 +138,7 @@ object FaciaPressMetrics {
   val AuPressLatencyMetric = DurationMetric("au-press-latency", StandardUnit.Milliseconds)
   val AllFrontsPressLatencyMetric = DurationMetric("front-press-latency", StandardUnit.Milliseconds)
   val FrontPressContentSize = SamplerMetric("front-press-content-size", StandardUnit.Bytes)
+  val FrontDecodingLatency = DurationMetric("front-decoding-latency", StandardUnit.Milliseconds)
 }
 
 object EmailSubsciptionMetrics {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -137,6 +137,7 @@ object FaciaPressMetrics {
   val UsPressLatencyMetric = DurationMetric("us-press-latency", StandardUnit.Milliseconds)
   val AuPressLatencyMetric = DurationMetric("au-press-latency", StandardUnit.Milliseconds)
   val AllFrontsPressLatencyMetric = DurationMetric("front-press-latency", StandardUnit.Milliseconds)
+  val FrontPressContentSize = SamplerMetric("front-press-content-size", StandardUnit.Bytes)
 }
 
 object EmailSubsciptionMetrics {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -148,32 +148,17 @@ object S3FrontsApi extends S3 {
   val namespace = "frontsapi"
   lazy val location = s"$stage/$namespace"
 
-  def getLivePressedKeyForPath(path: String): String =
-    s"$location/pressed/live/$path/pressed.json"
-
-  def getDraftPressedKeyForPath(path: String): String =
-    s"$location/pressed/draft/$path/pressed.json"
-
   def getLiveFapiPressedKeyForPath(path: String): String =
     s"$location/pressed/live/$path/fapi/pressed.json"
 
   def getDraftFapiPressedKeyForPath(path: String): String =
     s"$location/pressed/draft/$path/fapi/pressed.json"
 
-  def putLivePressedJson(path: String, json: String): Unit =
-    putPrivateGzipped(getLivePressedKeyForPath(path), json, "application/json")
-
-  def putDraftPressedJson(path: String, json: String): Unit =
-    putPrivateGzipped(getDraftPressedKeyForPath(path), json, "application/json")
-
   def putLiveFapiPressedJson(path: String, json: String): Unit =
     putPrivateGzipped(getLiveFapiPressedKeyForPath(path), json, "application/json")
 
   def putDraftFapiPressedJson(path: String, json: String): Unit =
     putPrivateGzipped(getDraftFapiPressedKeyForPath(path), json, "application/json")
-
-  def getPressedLastModified(path: String): Option[String] =
-    getLastModified(getLiveFapiPressedKeyForPath(path)).map(_.toString)
 }
 
 class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -55,6 +55,7 @@ trait AppComponents extends FrontendComponents {
     FaciaPressMetrics.UsPressLatencyMetric,
     FaciaPressMetrics.AuPressLatencyMetric,
     FaciaPressMetrics.AllFrontsPressLatencyMetric,
-    FaciaPressMetrics.FrontPressContentSize
+    FaciaPressMetrics.FrontPressContentSize,
+    FaciaPressMetrics.FrontDecodingLatency
   )
 }

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -54,6 +54,7 @@ trait AppComponents extends FrontendComponents {
     FaciaPressMetrics.UkPressLatencyMetric,
     FaciaPressMetrics.UsPressLatencyMetric,
     FaciaPressMetrics.AuPressLatencyMetric,
-    FaciaPressMetrics.AllFrontsPressLatencyMetric
+    FaciaPressMetrics.AllFrontsPressLatencyMetric,
+    FaciaPressMetrics.FrontPressContentSize
   )
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -130,7 +130,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
 
     pressFuture.onComplete {
       case Success(_) =>
-        log.info(s"Succesfully pressed $path in ${stopWatch.elapsed} ms")
+        log.info(s"Successfully pressed $path in ${stopWatch.elapsed} ms")
         FaciaPressMetrics.AllFrontsPressLatencyMetric.recordDuration(stopWatch.elapsed)
         /** We record separate metrics for each of the editions' network fronts */
         val metricsByPath = Map(

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -130,8 +130,9 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
 
     pressFuture.onComplete {
       case Success(_) =>
-        log.info(s"Successfully pressed $path in ${stopWatch.elapsed} ms")
-        FaciaPressMetrics.AllFrontsPressLatencyMetric.recordDuration(stopWatch.elapsed)
+        val pressDuration: Long = stopWatch.elapsed
+        log.info(s"Successfully pressed $path in $pressDuration ms")
+        FaciaPressMetrics.AllFrontsPressLatencyMetric.recordDuration(pressDuration)
         /** We record separate metrics for each of the editions' network fronts */
         val metricsByPath = Map(
           "uk" -> FaciaPressMetrics.UkPressLatencyMetric,
@@ -140,7 +141,7 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
         )
         if (Edition.all.map(_.id.toLowerCase).contains(path)) {
           metricsByPath.get(path).foreach { metric =>
-            metric.recordDuration(stopWatch.elapsed)
+            metric.recordDuration(pressDuration)
           }
         }
       case Failure(error) =>

--- a/facia-press/app/frontpress/FrontPressCron.scala
+++ b/facia-press/app/frontpress/FrontPressCron.scala
@@ -2,13 +2,12 @@ package frontpress
 
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient
-import common.FaciaPressMetrics.{FrontPressCronSuccess, AllFrontsPressLatencyMetric}
-import common.{Edition, JsonMessageQueue, SNSNotification, StopWatch}
+import common.FaciaPressMetrics.FrontPressCronSuccess
+import common.{JsonMessageQueue, SNSNotification}
 import conf.switches.Switches.FrontPressJobSwitch
 import conf.Configuration
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
 
 class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorker: ToolPressQueueWorker) extends JsonQueueWorker[SNSNotification] {
   lazy val queueUrl: Option[String] = Configuration.faciatool.frontPressCronQueue
@@ -30,28 +29,16 @@ class FrontPressCron(liveFapiFrontPress: LiveFapiFrontPress, toolPressQueueWorke
 
     if (FrontPressJobSwitch.isSwitchedOn) {
       log.info(s"Cron pressing path $path")
-      val stopWatch: StopWatch = new StopWatch
+      val pressFuture = liveFapiFrontPress
+        .pressByPathId(path)
+        .map(Function.const(()))
 
-      val pressFuture: Future[Unit] = liveFapiFrontPress.pressByPathId(path)
-
-      pressFuture.onComplete {
-        case Success(_) =>
-          if (Edition.all.map(_.id.toLowerCase).contains(path)) {
-            toolPressQueueWorker.metricsByPath.get(path) foreach { metric =>
-              metric.recordDuration(stopWatch.elapsed)
-            }
-          } else {
-            AllFrontsPressLatencyMetric.recordDuration(stopWatch.elapsed)
-          }
-
-          log.info(s"Succesfully pressed $path in ${stopWatch.elapsed} ms")
-
-          FrontPressCronSuccess.increment()
-        case Failure(error) =>
-          log.warn(s"Error pressing $path:", error)
+      pressFuture.onSuccess {
+        case _ => FrontPressCronSuccess.increment()
       }
 
-      pressFuture.map(Function.const(()))
+      pressFuture
+
     } else {
       log.info(s"Ignoring message $message in Facia Press cron as cron is turned OFF")
       Future.successful(())

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -1,6 +1,6 @@
 package controllers.front
 
-import common.{ExecutionContexts, Logging}
+import common.{ExecutionContexts, FaciaPressMetrics, Logging, StopWatch}
 import conf.Configuration
 import model.PressedPage
 import play.api.libs.json._
@@ -18,14 +18,19 @@ trait FrontJsonFapi extends Logging with ExecutionContexts {
 
   private def getAddressForPath(path: String): String = s"$bucketLocation/${path.replaceAll("""\+""","%2B")}/fapi/pressed.json"
 
-  private def parsePressedJson(j: String): Option[PressedPage] = {
-    val json = Json.parse(j)
-    json.validate[PressedPage] match {
+  private def parsePressedJson(json: String): Option[PressedPage] = {
+    val stopWatch: StopWatch = new StopWatch
+
+    val pressedPage = Json
+      .parse(json)
+      .validate[PressedPage] match {
       case JsSuccess(page, _) => Option(page)
       case JsError(errors) =>
         log.warn("Could not parse JSON in FrontJson")
         None
     }
+    FaciaPressMetrics.FrontDecodingLatency.recordDuration(stopWatch.elapsed)
+    pressedPage
   }
 
   def getRaw(path: String): Future[Option[String]] = {


### PR DESCRIPTION
## What does this change?
Adding 2 metrics (pressed front json size and front decoding time) as well as refactoring front-press-latency metric so it happens in a single place.

## What is the value of this and can you measure success?
I am working on lowering the size of the pressed front files. Those metrics will allow us to monitor the impact of the changes.

## Tested in CODE?
Yes
