### PR TITLE
Adding FrontDecodingLatency to facia appMetrics

### DIFF
--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -52,6 +52,10 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
 
   lazy val appIdentity = ApplicationIdentity("facia")
 
+  override lazy val appMetrics = ApplicationMetrics(
+    FaciaPressMetrics.FrontDecodingLatency
+  )
+
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters
   override lazy val httpRequestHandler: HttpRequestHandler = wire[DevParametersHttpRequestHandler]
 }


### PR DESCRIPTION
## What does this change?
I forgot to add the FrontDecodingLatency metrics to facia apploader so the metric is uploaded to cloudwatch 😊  in https://github.com/guardian/frontend/pull/17542

## What is the value of this and can you measure success?
Metric is actually uploaded to cloudwatch

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
