### PR TITLE
Removing alternative network front lists

### DIFF
--- a/common/app/common/NewNavigation.scala
+++ b/common/app/common/NewNavigation.scala
@@ -54,15 +54,6 @@ object NewNavigation {
     case "life" => Life
   }
 
-  case object MostPopular extends EditionalisedNavigationSection {
-    val name = "news"
-
-    val uk = NavLinkLists(List(headlines, ukNews, world, business, environment, tech, football))
-    val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, environment, football))
-    val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, environment, soccer))
-    val int = NavLinkLists(List(headlines, world, ukNews, business, science, globalDevelopment, football))
-  }
-
   case object News extends EditionalisedNavigationSection {
     val name = "news"
 
@@ -292,10 +283,10 @@ object NewNavigation {
 
     val sectionLinks = List(
 
-      SectionsLink("uk", headlines, MostPopular),
-      SectionsLink("us", headlines, MostPopular),
-      SectionsLink("au", headlines, MostPopular),
-      SectionsLink("international", headlines, MostPopular),
+      SectionsLink("uk", headlines, News),
+      SectionsLink("us", headlines, News),
+      SectionsLink("au", headlines, News),
+      SectionsLink("international", headlines, News),
       SectionsLink("uk-news", ukNews, News),
       SectionsLink("world", world, News),
       SectionsLink("world/europe-news", europe, News),


### PR DESCRIPTION
## What does this change?

The network front currently has a different subnav then the News list. This makes it the same.

_Please note_, this will be changed for all mobile users as well as those in the desktop test.


## What is the value of this and can you measure success?
* More consistency for users
* More links on the network front

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/8774970/28785338-05ca834e-760e-11e7-9a4f-d035dd314ab5.png)

**After**
![image](https://user-images.githubusercontent.com/8774970/28785372-1f7bc078-760e-11e7-9d60-e56d2fa8dd96.png)

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
