### PR TITLE
Give paidFor cards the option for higher resolution images

### DIFF
--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -9,7 +9,8 @@
     <div class="fc-item__container">
         @item.paidImage.map(image => itemImage(
             image,
-            inlineImage = containerIndex == 0 && index < 4
+            inlineImage = containerIndex == 0 && index < 4,
+            widthsByBreakpoint = Some(item.mediaWidthsByBreakpoint)
         ))
         <div class="fc-item__content">
             <div class="fc-item__header">


### PR DESCRIPTION
## What does this change?

Adds suggested fix from @ScottPainterGNM to paidFor content cards, giving them widthsByBreakpoint.

## What is the value of this and can you measure success?

When `paidForCards` become larger, the image resolution is noticeably poor, examples 
[can be found here](https://www.theguardian.com/profile/timhayward).

This issue does not affect `contentCards`, so this PR will allow paidForCards to be just as pretty as contentCards! 💅 

## Does this affect other platforms - Amp, Apps, etc?

Noipe

## Screenshots

#### BEFORE:

<img width="1295" alt="picture 880" src="https://user-images.githubusercontent.com/8607683/28785760-34399c3c-760f-11e7-95ff-1916b6f16dbd.png">

<img width="1210" alt="picture 882" src="https://user-images.githubusercontent.com/8607683/28786166-5355556a-7610-11e7-8b87-7a03d7ec0f0d.png">

#### AFTER:

<img width="1296" alt="picture 881" src="https://user-images.githubusercontent.com/8607683/28785750-2dea4d68-760f-11e7-9100-68f6ece60837.png">


