### PR TITLE
Ignore uninteresting JS errors in Sentry

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -11,7 +11,7 @@ let adblockBeingUsed = false;
 
 const sentryOptions = {
     whitelistUrls: [
-        // loaclhost will not log errors, but call `shouldSendCallback`
+        // localhost will not log errors, but call `shouldSendCallback`
         /localhost/,
         /assets\.guim\.co\.uk/,
         /ophan\.co\.uk/,
@@ -22,6 +22,11 @@ const sentryOptions = {
         contentType: config.page.contentType,
         revisionNumber: config.page.revisionNumber,
     },
+
+    ignoreErrors: [
+        "Can't execute code from a freed script",
+        'There is no space left matching rules from .js-article__body',
+    ],
 
     dataCallback(data: Object): Object {
         const { culprit = false } = data;


### PR DESCRIPTION
## What does this change?

Adds a couple of uninteresting errors to Sentry's [ignore list](https://blog.sentry.io/2017/03/27/tips-for-reducing-javascript-error-noise#ignore-troublesome-errors).

There have been literally millions of occurrences of these errors, adding a lot of noise to Sentry but also masking genuine errors that cannot be logged as we hit our error reporting quota (60 events per minute).

### Can't execute code from a freed script

Introduced when we upgraded from Raven v1 to v3 (#16346). We have attempted to investigate, to no avail. It is very unlikely we'll be able to fix it, if it is even a problem we can fix. This event occurs on Windows mobile devices. According to Ben Vinegar at Sentry, this event is caused by an internal browser issue and is [probably safe to ignore](https://twitter.com/SiAdcock/status/847131315849904128).

### There is no space left matching rules from `.js-article__body`

This is an error internal to our application generated by [spacefinder](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/spacefinder.js#L267). From what I understand, this is a perfectly acceptable error, generated when there is no space for a particular candidate inside the `.js-article__body` element. The error shouldn't be reported as it doesn't relate to a bug that needs to be fixed.

## What is the value of this and can you measure success?

Fewer errors reported to Sentry, less noise, more genuine errors get reported.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
