### PR TITLE
Deps: Upgrade flow-bin to 0.51.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-react": "^7.1.0",
     "execa": "^0.7.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.50.0",
+    "flow-bin": "^0.51.1",
     "flow-typed": "^2.1.2",
     "git-user-name": "^1.2.0",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,9 +3090,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
+flow-bin@^0.51.1:
+  version "0.51.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.51.1.tgz#7929c6f0a94e765429fcb2ee6e468278faa9c732"
 
 flow-typed@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Upgrades `flow-bin` to `0.51.1`. Includes [`flow 51`](https://github.com/facebook/flow/releases/tag/v0.51.0).
