### PR TITLE
Renaming the header used for the desktop test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -35,7 +35,7 @@ object ABNewDesktopHeaderVariant extends TestDefinition(
   sellByDate = new LocalDate(2017, 8, 24)
 ) {
 
-  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header")
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header-v2")
 
   def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
 }
@@ -47,7 +47,7 @@ object ABNewDesktopHeaderControl extends TestDefinition(
   sellByDate = new LocalDate(2017, 8, 24)
 ) {
 
-  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header")
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header-v2")
 
   def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("control")
 }


### PR DESCRIPTION
## What does this change?

Renaming the header used for the new desktop header test. 

 Corresponding fastly test is: https://github.com/guardian/fastly-edge-cache/pull/789

## What is the value of this and can you measure success?
"Reseting" the test so uses who were bucketed should no longer see v1 for the desktop header. But those who were opted in should continue to see it.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Screenshots
n/a

## Tested in CODE?
nope


cc @guardian/dotcom-platform 
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
