### PR TITLE
Extracting the video length from the video object rather than the DOM

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -142,7 +142,7 @@ const setupVideo = (
                     nextVideoAutoplay.triggerAutoplay.bind(
                         this,
                         player.currentTime.bind(player),
-                        parseInt(video.getAttribute('data-duration'), 10)
+                        parseInt(player.duration(), 10)
                     )
                 );
             } else {


### PR DESCRIPTION
Frontend is relying on the duration attribute being set, however for self hosted assets in the Media Atom we're currently not setting the duration [1], so frontend treats it as 0 and thus auto plays the next video before the video actually ends.

[1] This attribute is optional