### PR TITLE
PR Template - addition of GLabs Paid Content checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Does this affect other platforms - Amp, Apps, etc?
 
-## Does this affect GLabs Paid Content Pages?
+## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
 
 ## Screenshots
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 ## Does this affect other platforms - Amp, Apps, etc?
 
+## Does this affect GLabs Paid Content Pages?
+
 ## Screenshots
 
 ## Tested in CODE?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@
 ## Does this affect other platforms - Amp, Apps, etc?
 
 ## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
+<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
+<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
+
 
 ## Screenshots
 


### PR DESCRIPTION
We often find that changes to templates/content pages have an adverse impact on Labs paid pages which can cause issues for that team when clients complain.

Suggestion to add this check to the PR template to remind people to think about it.