### PR TITLE
Fix missing keyword issue in lib/page

### DIFF
--- a/static/src/javascripts/lib/page.js
+++ b/static/src/javascripts/lib/page.js
@@ -81,7 +81,7 @@ const belowArticleVisible = (yes: yesable, no: noable): boolean => {
 };
 
 const keywordExists = (keywordArr: Array<string>): boolean => {
-    const keywords = config.get('page.keywords', []).split(',');
+    const keywords = config.get('page.keywords', '').split(',');
     return keywordArr.some(kw => keywords.includes(kw));
 };
 

--- a/static/src/javascripts/lib/page.spec.js
+++ b/static/src/javascripts/lib/page.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import config from 'lib/config';
-import { isMatch, isClockwatch, isLiveClockwatch } from './page';
+import { isMatch, isClockwatch, isLiveClockwatch, keywordExists } from './page';
 
 jest.mock('lib/config', () => {
     const defaultConfig = {
@@ -143,5 +143,19 @@ describe('isLiveClockwatch', () => {
         isLiveClockwatch(yesable);
 
         expect(yesable).toHaveBeenCalled();
+    });
+});
+
+describe('keywordExists', () => {
+    it('should identify that given keywords are in config', () => {
+        config.page.keywords = 'foo,bar';
+
+        expect(keywordExists(['foo'])).toBe(true);
+    });
+
+    it('should return false when no given keywords are in config', () => {
+        config.page.keywords = undefined;
+
+        expect(keywordExists(['foo'])).toBe(false);
     });
 });


### PR DESCRIPTION
## What does this change?

If `config.page.keywords` is not defined (e.g. on [the profile reauthenticate page](https://profile.theguardian.com/reauthenticate)), the `keywordExists` function calls `split` on the default value (an empty array). Array doesn't have a `split` method, so this results in an error. 

I have updated the default value to be an empty string, which does have a `split` method. I have also added some tests that catch this problem.

## What is the value of this and can you measure success?

Fewer errors reported to Sentry

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
