### PR TITLE
Add required classes and css for Labs styling on PhotoEssays

### DIFF
--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -19,8 +19,7 @@
     <div class="@RenderClasses(Map(
             "content--minute-article" -> isTheMinuteArticle,
             "content--immersive-article-without-main-media" -> !hasMainMedia,
-            "immersive-main-media" -> hasMainMedia,
-            "immersive-main-media__advertisment" -> isPaidContent
+            "immersive-main-media" -> hasMainMedia
         ),
         "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -8,15 +8,17 @@
 @defining((
     page.item.elements.hasMainEmbed,
     page.item.fields.main.nonEmpty,
-    page.item.elements.hasMainVideo
-)) { case (hasEmbed, hasMainMedia, hasVideo) =>
+    page.item.elements.hasMainVideo,
+    page.item.tags.isPaidContent
+)) { case (hasEmbed, hasMainMedia, hasVideo, isPaidContent) =>
   <style>
     @Html(common.Assets.css.inlinePhotoEssay)
   </style>
 
     <div class="content--photo-essay @RenderClasses(Map(
             "immersive-main-media" -> hasMainMedia,
-            "photo-essay--video" -> hasVideo
+            "photo-essay--video" -> hasVideo,
+            "immersive-main-media__advertisment" -> isPaidContent
         ),
         "content", "tonal", s"tonal--${toneClass(page.item)}")
     ">
@@ -60,7 +62,7 @@
               <div class="gs-container">
                 <div class="content__main-column">
                     @fragments.meta.metaInline(page.item)
-                    <h1 class="@if(hasMainMedia){content__headline--immersive--with-main-media} content__headline content__headline--immersive content__headline--immersive-article">
+                    <h1 class="@if(hasMainMedia){content__headline--immersive--with-main-media} @if(isPaidContent){content__headline--advertisement} content__headline content__headline--immersive content__headline--immersive-article">
                         @Html(page.item.trail.headline)
                     </h1>
                     @if(page.item.fields.standfirst.isDefined) {

--- a/common/app/views/fragments/photoEssay.scala.html
+++ b/common/app/views/fragments/photoEssay.scala.html
@@ -17,8 +17,7 @@
 
     <div class="content--photo-essay @RenderClasses(Map(
             "immersive-main-media" -> hasMainMedia,
-            "photo-essay--video" -> hasVideo,
-            "immersive-main-media__advertisment" -> isPaidContent
+            "photo-essay--video" -> hasVideo
         ),
         "content", "tonal", s"tonal--${toneClass(page.item)}")
     ">

--- a/static/src/stylesheets/inline/article-photo-essay.scss
+++ b/static/src/stylesheets/inline/article-photo-essay.scss
@@ -171,6 +171,19 @@
     color: #ffffff;
 }
 
+.content__section-label--advertisement {
+    @include f-textSans;
+    font-size: 20px;
+    line-height: 24px;
+    font-weight: 900;
+    margin: 0;
+    padding-top: $gs-baseline / 2;
+
+    .content__section-label__link--advertisement {
+        color: $paid-article-brand;
+    }
+}
+
 .from-content-api ul {
     display: inline-block;
     width: 98%;


### PR DESCRIPTION
## What does this change?

- Adds CSS to the photo essay to target the `content__section-label--advertisement` to apply the same styling as found in `_article-immersive.scss` ([link](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/content/_article-immersive.scss#L251))

- Labs headlines always use the sans-serif styling

- Labs section labels are always large, teal and sans-serif 

- Removes an unused class from the templates (see comments)

<img width="764" alt="picture 901" src="https://user-images.githubusercontent.com/8607683/28927110-99c37286-7861-11e7-8ccd-f9ee2ecae5b6.png">




## What is the value of this and can you measure success?

**PhotoEssays** are a subset of **Immersives**, however, they use a separate template that does not apply the same classes is the article `isPaidForContent`. This PR applies the missing classes and styles to the template. [Here is an example](https://www.theguardian.com/cricket-has-no-boundaries/2017/jun/20/wicket-maidens-the-surprising-history-of-womens-cricket) immersive where the styling is correct.

- Labs content looks correct and consistent across different article types

- No delays to publication of scheduled content

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

#### STYLES BEFORE:

<img width="777" alt="picture 891" src="https://user-images.githubusercontent.com/8607683/28920856-77f3fd9e-784b-11e7-8bb0-ba6c0584647e.png">

#### STYLES AFTER:

<img width="816" alt="picture 890" src="https://user-images.githubusercontent.com/8607683/28920864-803c168a-784b-11e7-8164-fae8d5674b6e.png">

##### CLASSES BEFORE: 

<img width="1278" alt="picture 903" src="https://user-images.githubusercontent.com/8607683/28927164-c1a9494c-7861-11e7-9346-84d8cea5981a.png">

##### CLASSES AFTER: 

<img width="1279" alt="picture 902" src="https://user-images.githubusercontent.com/8607683/28927180-c7e2275c-7861-11e7-800c-ce46e3cc63db.png">

