### PR TITLE
Snippets: Update height on DOMReady

### DIFF
--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -40,8 +40,7 @@ Promise.all([
         .slice(0, 1)
         .forEach(details => {
             new MutationObserver(updateHeight).observe(details, {
-                childList: true,
-                subtree: true,
+                attributes: true,
             });
         });
 });

--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -13,6 +13,18 @@ import { SnippetFeedback } from 'journalism/snippet-feedback';
 // eslint-disable-next-line camelcase,no-undef
 __webpack_public_path__ = `${config.page.assetsPath}javascripts/`;
 
+const updateHeight = () => {
+    fastdom
+        .read(
+            () =>
+                document.documentElement &&
+                document.documentElement.getBoundingClientRect().height
+        )
+        .then(height => {
+            send('resize', { height });
+        });
+};
+
 Promise.all([
     window.guardian.polyfilled
         ? Promise.resolve()
@@ -23,22 +35,13 @@ Promise.all([
     new Promise(comready),
 ]).then(() => {
     SnippetFeedback({ scroll: false });
+    updateHeight();
     [...document.getElementsByTagName('details')]
         .slice(0, 1)
         .forEach(details => {
-            new MutationObserver((changes: MutationRecord[]) => {
-                changes.forEach((change: MutationRecord) => {
-                    if (change.attributeName !== 'open') return;
-                    fastdom
-                        .read(
-                            () =>
-                                (document.documentElement &&
-                                    document.documentElement.getBoundingClientRect()
-                                        .height) ||
-                                0
-                        )
-                        .then(height => send('resize', { height }));
-                });
-            }).observe(details, { attributes: true });
+            new MutationObserver(updateHeight).observe(details, {
+                childList: true,
+                subtree: true,
+            });
         });
 });


### PR DESCRIPTION
The height of the iframe needs to be set not only when the widget is opened, but also as soon as the first paint has occurred.