### PR TITLE
Javascript rendered 404 page

### DIFF
--- a/archive/app/ui/NotFound.scala
+++ b/archive/app/ui/NotFound.scala
@@ -1,0 +1,8 @@
+package ui
+
+import rendering.Renderable
+
+object NotFound extends Renderable {
+  override def props = None
+}
+

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -1,11 +1,16 @@
 package test
 
+import akka.actor.ActorSystem
+import common.ExecutionContexts
 import controllers.ArchiveController
+import model.{ApplicationContext, ApplicationIdentity}
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import play.api.Environment
+import rendering.core.Renderer
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import services.RedirectService
 import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
 
@@ -13,9 +18,13 @@ import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
   extends FlatSpec
   with Matchers
   with ConfiguredTestSuite
+  with ExecutionContexts
   with BeforeAndAfterAll {
 
-  lazy val archiveController = new ArchiveController(mockRedirects)
+  implicit lazy val appContext: ApplicationContext = ApplicationContext(Environment.simple(), ApplicationIdentity("archive"))
+  implicit lazy val actorSystem: ActorSystem = app.actorSystem
+  lazy val renderer = new Renderer
+  lazy val archiveController = new ArchiveController(mockRedirects, renderer)
   lazy val mockRedirects = new RedirectService {
     override def destinationFor(source: String) = Future.successful(None)
   }

--- a/common/app/controllers/DevComponentController.scala
+++ b/common/app/controllers/DevComponentController.scala
@@ -5,10 +5,12 @@ import play.api.mvc.{Action, Controller}
 import rendering.TestComponent
 import rendering.core.Renderer
 
-class DevComponentController(renderer: Renderer)(implicit ac: ApplicationContext) extends Controller {
+import scala.concurrent.ExecutionContext
+
+class DevComponentController(renderer: Renderer)(implicit ac: ApplicationContext, ec: ExecutionContext) extends Controller {
 
   def renderComponent() = Action.async { implicit request =>
-    renderer.render(TestComponent)
+    renderer.render(TestComponent).map(Ok(_).withHeaders("Content-Type" -> "text/html"))
   }
 
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -52,6 +52,30 @@ object ABNewDesktopHeaderControl extends TestDefinition(
   def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("control")
 }
 
+object ABJavascriptRenderingVariant extends TestDefinition(
+  name = "ab-javascript-rendering-variant",
+  description = "Users in this test will see pages rendered by the javascript renderer.",
+  owners = Seq(Owner.withName("dotcom.platform")),
+  sellByDate = new LocalDate(2017, 8, 29)
+) {
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-javascript-rendering")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
+}
+
+object ABJavascriptRenderingControl extends TestDefinition(
+  name = "ab-javascript-rendering-control",
+  description = "Users in this test will see pages rendered via twirl.",
+  owners = Seq(Owner.withName("dotcom.platform")),
+  sellByDate = new LocalDate(2017, 8, 29)
+) {
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-javascript-rendering")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("control")
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -77,7 +101,9 @@ object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     CommercialClientLoggingVariant,
     ABNewDesktopHeaderVariant,
-    ABNewDesktopHeaderControl
+    ABNewDesktopHeaderControl,
+    ABJavascriptRenderingVariant,
+    ABJavascriptRenderingControl
   )
 }
 

--- a/common/app/rendering/core/JavascriptRendering.scala
+++ b/common/app/rendering/core/JavascriptRendering.scala
@@ -98,7 +98,7 @@ trait JavascriptRendering extends Logging {
   private def loadFile(fileName: String): Try[InputStream] = {
     Option(getClass.getClassLoader.getResourceAsStream(fileName)) match {
       case Some(stream) => Success(stream)
-      case None => Failure(new FileNotFoundException(s"${this.getClass.getSimpleName}: Cannot find file '$fileName'"))
+      case None => Failure(new FileNotFoundException(s"${this.getClass.getSimpleName}: Cannot find file '$fileName'. Have you run `make ui-compile`?"))
     }
   }
 

--- a/common/app/rendering/core/Renderer.scala
+++ b/common/app/rendering/core/Renderer.scala
@@ -2,14 +2,13 @@ package rendering.core
 
 import akka.actor.{ActorSystem, Props}
 import model.ApplicationContext
-import play.api.mvc.Result
-import play.api.mvc.Results._
 import rendering.Renderable
 import akka.pattern.ask
 import akka.routing.RoundRobinPool
 import akka.util.Timeout
 import common.Logging
 import play.api.Mode
+import play.twirl.api.Html
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -23,17 +22,16 @@ class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionCon
   val timeoutValue: Int = if(ac.environment.mode == Mode.Dev) 10 else 1
   implicit val timeout = Timeout(timeoutValue.seconds)
 
-  def render[R <: Renderable](renderable: R): Future[Result] = {
+  def render[R <: Renderable](renderable: R): Future[Html] = {
     (actor ? Rendering(renderable, ac))
       .mapTo[Try[String]]
       .recover { case t => Try(throw t)}
       .map {
         _ match {
-          case Success(s) =>
-            Ok(s).withHeaders("Content-Type" -> "text/html")
+          case Success(s) => Html(s)
           case Failure(f) =>
             log.error(f.getLocalizedMessage)
-            InternalServerError(f.getLocalizedMessage)
+            throw f
         }
       }
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -37,8 +37,7 @@ trait Prototypes {
       val allProjects = ScopeFilter(inAnyProject)
       clean.all(allProjects)
     }.value,
-    unmanagedClasspath in Compile += file("ui/dist"),
-    unmanagedClasspath in Runtime ++= (unmanagedClasspath in Compile).value
+    unmanagedResourceDirectories in Compile += file("ui/dist")
   )
 
   val frontendIntegrationTestsSettings = Seq (

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -37,7 +37,8 @@ trait Prototypes {
       val allProjects = ScopeFilter(inAnyProject)
       clean.all(allProjects)
     }.value,
-    unmanagedClasspath in Runtime += file("ui/dist")
+    unmanagedClasspath in Compile += file("ui/dist"),
+    unmanagedClasspath in Runtime ++= (unmanagedClasspath in Compile).value
   )
 
   val frontendIntegrationTestsSettings = Seq (

--- a/tools/__tasks__/compile/index.js
+++ b/tools/__tasks__/compile/index.js
@@ -4,8 +4,7 @@ module.exports = {
         require('./conf/clean'),
         require('./css'),
         require('./javascript'),
-        // not quite yet...
-        // require('./ui'),
+        require('./ui'),
         require('./fonts'),
         require('./hash'),
         require('./conf'),

--- a/ui/src/components/head/index.js
+++ b/ui/src/components/head/index.js
@@ -17,6 +17,4 @@ export default (props: any, css: string) =>
         <meta name="viewport" content="width=device-width,initial-scale=1">
         <style>${resetCSS}</style>
         ${css}
-        <script>window.guardian = ${JSON.stringify(props)};</script>
-        <script src="/assets/javascripts/ui.bundle.browser.js" async defer></script>
     </head>`;

--- a/ui/src/views/404/NavigationItem/index.jsx
+++ b/ui/src/views/404/NavigationItem/index.jsx
@@ -2,7 +2,7 @@
 import styles from './style.js.scss';
 
 const NavigationItem = ({
-    zone = 'news',
+    zone = 'default',
     path,
     newWindow = false,
     children,

--- a/ui/src/views/404/NavigationItem/style.js.scss
+++ b/ui/src/views/404/NavigationItem/style.js.scss
@@ -13,6 +13,7 @@ nav_item {
 }
 
 $zones: (
+    default: #005689,
     news: #d61d00,
     sport: #008000,
     culture: #d1008b,


### PR DESCRIPTION
## What does this change?
Using the new javascript renderer to render the 404 page. It is for now behind a test

## What is the value of this and can you measure success?
The goal is to test how the app and server behaves while using javascript.

## Does this affect other platforms - Amp, Apps, etc?
No

Screenshots:

Before
![screen shot 2017-08-03 at 13 46 25](https://user-images.githubusercontent.com/233326/28922534-765a5526-7852-11e7-9677-b16c4df33447.png)

After
![screen shot 2017-08-03 at 13 46 41](https://user-images.githubusercontent.com/233326/28922539-7a301366-7852-11e7-8078-7744a65e1572.png)

## Tested in CODE?
Yes