### PR TITLE
Revert "Merge pull request #17555 from guardian/remove-mobile-revealer"

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/revealer.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/revealer.js
@@ -1,0 +1,70 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import template from 'lodash/utilities/template';
+import { getViewport } from 'lib/detect';
+import { addTrackingPixel } from 'commercial/modules/creatives/add-tracking-pixel';
+import addViewabilityTracker from 'commercial/modules/creatives/add-viewability-tracker';
+import revealerStr from 'raw-loader!commercial/views/creatives/revealer.html';
+
+class Revealer {
+    adSlot: HTMLElement;
+    params: Object;
+
+    constructor(adSlot: HTMLElement, params: Object) {
+        params.id = `revealer-${Math.floor(Math.random() * 10000).toString(
+            16
+        )}`;
+        this.adSlot = adSlot;
+        this.params = params;
+    }
+
+    create() {
+        const revealerTpl = template(revealerStr);
+        const markup = revealerTpl(this.params);
+
+        return fastdom
+            .write(() => {
+                this.adSlot.insertAdjacentHTML('beforeend', markup);
+                // #? `classList.add` takes multiple arguments, but we are using it
+                // here with arity 1 because polyfill.io has incorrect support with IE 10 and 11.
+                // One may revert to adSlot.classList.add('ad-slot--revealer', 'ad-slot--fabric', 'content__mobile-full-width');
+                // When support is correct or when we stop supporting IE <= 11
+                this.adSlot.classList.add('ad-slot--revealer');
+                this.adSlot.classList.add('ad-slot--fabric');
+                this.adSlot.classList.add('content__mobile-full-width');
+                if (this.params.trackingPixel) {
+                    addTrackingPixel(
+                        this.params.trackingPixel + this.params.cacheBuster
+                    );
+                }
+                if (this.params.researchPixel) {
+                    addTrackingPixel(
+                        this.params.researchPixel + this.params.cacheBuster
+                    );
+                }
+                if (this.params.viewabilityTracker) {
+                    addViewabilityTracker(
+                        this.adSlot,
+                        this.params.id,
+                        this.params.viewabilityTracker
+                    );
+                }
+            })
+            .then(() => fastdom.read(getViewport))
+            .then(viewport =>
+                fastdom.write(() => {
+                    const background = this.adSlot.getElementsByClassName(
+                        'creative__background'
+                    )[0];
+                    // for the height, we need to account for the height of the location bar, which
+                    // may or may not be there. 70px padding is not too much.
+                    if (background) {
+                        background.style.height = `${viewport.height + 70}px`;
+                    }
+                    return true;
+                })
+            );
+    }
+}
+
+export { Revealer };

--- a/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
@@ -4,6 +4,7 @@ import fastdom from 'lib/fastdom-promise';
 import reportError from 'lib/report-error';
 
 import { Frame } from 'commercial/modules/creatives/frame';
+import { Revealer } from 'commercial/modules/creatives/revealer';
 import { FabricV1 } from 'commercial/modules/creatives/fabric-v1';
 import fabricExpand from 'commercial/modules/creatives/fabric-expanding-v1';
 import { fabricExpandVideo } from 'commercial/modules/creatives/fabric-expandable-video-v2';
@@ -12,6 +13,7 @@ import { ScrollableMpu } from 'commercial/modules/creatives/scrollable-mpu-v2';
 
 const creativeLookup: Object = {
     frame: Frame,
+    revealer: Revealer,
     'fabric-v1': FabricV1,
     'fabric-expanding-v1': fabricExpand,
     'fabric-expandable-video-v2': fabricExpandVideo,

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -72,6 +72,8 @@ sizeCallbacks[adSizes.fluid] = (renderSlotEvent: any, advert: Advert) =>
 sizeCallbacks[adSizes.mpu] = (_, advert) => {
     if (advert.node.classList.contains('js-sticky-mpu')) {
         stickyMpu(advert.node);
+    } else {
+        return addFluid(['ad-slot--revealer'])(_, advert);
     }
 };
 

--- a/static/src/javascripts/projects/commercial/views/creatives/revealer.html
+++ b/static/src/javascripts/projects/commercial/views/creatives/revealer.html
@@ -1,0 +1,6 @@
+<aside id="<%= id %>" class="creative creative--revealer">
+    <a class="creative__cta" href="<%=clickMacro%><%=link%>" target="_blank">
+        <div class="creative__background" style="background-image: url('<%=backgroundImage%>')"></div>
+        <img class="creative__button creative__button--<%=buttonVPos%> creative__button--<%=buttonHPos%>" src="<%=button%>" alt>
+    </a>
+</div>

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -448,6 +448,11 @@
     min-height: 250px;
 }
 
+.ad-slot--revealer {
+    min-width: 300px;
+    width: auto;
+}
+
 .ad-slot--fabric {
     overflow: hidden;
     width: auto;

--- a/static/src/stylesheets/module/commercial/_commercial.scss
+++ b/static/src/stylesheets/module/commercial/_commercial.scss
@@ -12,6 +12,7 @@
 /* Creative styles */
 @import '_creatives';
 @import 'creatives/_fabric-video';
+@import 'creatives/_revealer';
 
 /* GU styled commercial content */
 @import 'gustyle/_gu-comlabel';

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -1,0 +1,45 @@
+.creative--revealer {
+    height: 250px;
+    position: relative;
+
+    .creative__cta {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        clip: rect(0, auto, auto, 0);
+        overflow: hidden;
+
+        /* promoting the button up the layer stack will improve
+           perfs on Android devices */
+        z-index: 1;
+    }
+
+    .creative__background {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        background-position: center center;
+        background-size: cover;
+        backface-visibility: hidden;
+
+        /* promote to GPU layer hack: this is needed by older versions of iOS */
+        -webkit-transform: translate3d(0, 0, 0);
+    }
+
+    .creative__button {
+        position: absolute;
+    }
+
+    .creative__button--left    { left: 0; }
+    .creative__button--center  { left: 50%; transform: translate(-50%, 0); }
+    .creative__button--right   { right: 0; }
+
+    .creative__button--top     { top: 0; }
+    .creative__button--middle  { top: 50%; transform: translate(0, -50%); }
+    .creative__button--bottom  { bottom: 0; }
+
+    .creative__button--center.creative__button--middle {
+        transform: translate(-50%, -50%);
+    }
+}


### PR DESCRIPTION
Reverts the removal of mobile revealer, since some test-only creatives are still using it.