### PR TITLE
Add theResistanceNow email, and update the display order for newsEmails

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -166,6 +166,17 @@ object EmailNewsletters {
     exampleUrl = Some("/us-news/series/the-campaign-minute-2016/latest/email")
   )
 
+  val theResistanceNow = EmailNewsletter(
+    name = "The Resistance Now",
+    theme = "news",
+    teaser = "Grassroots activism is one of the defining stories of Trump's America. Get updates on the emerging campaigns, from climate change to reproductive rights",
+    description = "Grassroots activism is becoming one of the defining news stories of America's Trump era. Get updates on the emerging campaigns on climate change, reproductive rights, equality, immigration, racial justice and more",
+    frequency = "Weekly",
+    listId = 3830,
+    signupPage = Some("/us-news/2017/mar/07/the-resistance-now-email-sign-up-weekly-updates"),
+    exampleUrl = Some("/us-news/series/the-resistance-now-newsletter/latest/email")
+  )
+
   val australianPolitics = EmailNewsletter(
     name = "Australian Politics",
     theme = "news",
@@ -479,14 +490,15 @@ object EmailNewsletters {
   )
 
   val newsEmails = List(
-    businessToday,
-    mediaBriefing,
-    greenLight,
-    labNotes,
     globalDispatch,
     brexitBriefing,
     usPoliticsMinute,
-    australianPolitics
+    theResistanceNow,
+    australianPolitics,
+    businessToday,
+    mediaBriefing,
+    greenLight,
+    labNotes
   )
 
   val sportEmails = List(


### PR DESCRIPTION
## What does this change?

- Adds [The Resistance Now](https://www.theguardian.com/us-news/2017/jul/29/the-resistance-now-republican-healthcare-bill-failure/email) email to the emails list

- change the order of the emails in 'news by topic'/'news' section

## What is the value of this and can you measure success?

- Updates for Editorial! ❤️ 

- Email lists are accurate

- Users can manage their email preferences

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

#### BEFORE:

<img width="1322" alt="picture 899" src="https://user-images.githubusercontent.com/8607683/28925171-ffb85800-785b-11e7-8a32-9b75cc7ab9f7.png">

#### AFTER:

<img width="1333" alt="picture 900" src="https://user-images.githubusercontent.com/8607683/28925155-f3e1352e-785b-11e7-8023-45505c840a87.png">
