### PR TITLE
lib/page: Fix null access in isMatch()

### DIFF
--- a/static/src/javascripts/lib/page.js
+++ b/static/src/javascripts/lib/page.js
@@ -40,12 +40,17 @@ const isMatch = (yes: yesable, no: noable): boolean => {
         pageType: pageTypes.find(type => type[1] === true),
     });
 
+    /* if you think about this long enough, you will come to the conclusion:
+       match.pageType can't be anything different than an array (because there
+       is a fallback in pageTypes). Unfortunately flow isn't clever enough and
+       forces us to add this check and re-assign the value.
+    */
     if (Array.isArray(match.pageType)) {
         match.pageType = match.pageType[0];
     }
 
     return isit(
-        match.id || (match.pageType[0] && match.teams.length === 2),
+        match.id || (match.pageType && match.teams.length === 2),
         yes,
         no,
         match


### PR DESCRIPTION
## What does this change?

Fixes a null reference error, seen e.g. [here](https://www.theguardian.com/football/blog/2017/aug/03/championship-2017-18-season-preview). (Thanks @SiAdcock) I decided against writing a new spec, because it was just a dumb error on my side, which can't really be triggered from the outside.

## What is the value of this and can you measure success?

Less errors are good, right?

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No, but jest is happy.