### PR TITLE
remove engagement banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -121,16 +121,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-membership-engagement-banner-digipack-price-test",
-    "Find the optimal price point for the digipack",
-    owners = Seq(Owner.withGithub("jranks123")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 3),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-acquisitions-epic-rebaseline-support-proposition",
     "Re-baseline the new support proposition against the old",
     owners = Seq(Owner.withGithub("Ap0c")),

--- a/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts-legacy/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -6,7 +6,6 @@ define([
     'lodash/utilities/template',
     'common/modules/commercial/contributions-utilities',
     'lib/mediator',
-    'lib/geolocation'
 ], function (
     bean,
     qwery,
@@ -14,8 +13,7 @@ define([
     storage,
     template,
     contributionsUtilities,
-    mediator,
-    geolocation) {
+    mediator) {
     var EditionTest = function (edition, id, start, expiry, campaignPrefix) {
 
         this.edition = edition;
@@ -76,77 +74,7 @@ define([
 
         return this.addMessageVariant(variantId, {contributions: variantParams});
     };
+    
+    return []
 
-    var MembershipEngagementBannerDigipackPriceTest = function() {
-        this.id = 'MembershipEngagementBannerDigipackPriceTest';
-        this.start = '2017-07-03';
-        this.expiry = '2017-08-03';
-        this.author = 'Jonathan Rankin';
-        this.description = 'Send ';
-        this.audience = 0.25;
-        this.audienceOffset = 0;
-        this.successMeasure = 'Each variant points to a different price point on the landing page. The success is measured' +
-            'by the click rate on th landing page';
-        this.audienceCriteria = 'UK';
-        this.idealOutcome = 'We are able to establish which price point is better for the digital edition';
-        this.canRun = function() {
-            return contributionsUtilities.shouldShowReaderRevenue() && geolocation.getSync() === 'GB';
-        };
-        this.variants = [];
-    };
-
-    // cta should be a function which returns the call-to-action which is placed after the message text.
-    MembershipEngagementBannerDigipackPriceTest.prototype.addVariant = function(variantId, messageText, cta, paypalClass) {
-
-        function createCampaignCode(variantId) {
-            // Campaign code follows convention. Talk to Alex for more information.
-            return 'BUNDLE_PRICE_TEST_1M_B_UK_' + variantId;
-        }
-
-        var engagementBannerParams = {
-            campaignCode: createCampaignCode(variantId),
-            buttonCaption: 'Support the Guardian',
-            linkUrl: 'https://membership.theguardian.com/bundles',
-            messageText: 'Unlike many others, we haven\'t put up a paywall &ndash; we want to keep our journalism as open as we can. Support us with a contribution or subscription',
-            pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found'
-        };
-
-        if (messageText) {
-
-            if (typeof cta === 'function') {
-                messageText = messageText + ' ' + cta()
-            }
-
-            engagementBannerParams.messageText = messageText;
-        }
-
-        if(paypalClass) {
-            engagementBannerParams.paypalClass = paypalClass;
-        }
-
-        this.variants.push({
-            id: variantId,
-
-            // We don't want to run any 'code' in this test, we just want a variant to be selected.
-            // All message display is performed in membership-engagement-banner.js,
-            // modifying the banner using the data in variantParams.
-            test: function () {},
-
-            success: this.completer,
-
-            // This allows a lot of the deriveBannerParams() logic (in membership-engagement-banner.js) to be by-passed.
-            // If that function has picked up a variant from the CopyTest test, call this method and be done with it.
-            engagementBannerParams : engagementBannerParams
-
-        });
-
-        return this;
-    };
-
-    return [
-        new MembershipEngagementBannerDigipackPriceTest()
-            .addVariant('A')
-            .addVariant('B')
-            .addVariant('C')
-    ]
 });


### PR DESCRIPTION
## What does this change?

removes the engagement banner digipack price test (introduced here https://github.com/guardian/frontend/pull/17350/files)  from the codebase

@guardian/contributions 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
