### PR TITLE
Do not press more than 20 stories per collections

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -485,7 +485,7 @@ class GuardianConfiguration extends Logging {
 
   object facia {
     lazy val stage = configuration.getStringProperty("facia.stage").getOrElse(environment.stage)
-    lazy val collectionCap: Int = 35
+    lazy val collectionCap: Int = 20
   }
 
   object faciatool {


### PR DESCRIPTION
## What does this change?
Fronts editors have decided not to show more than 20 stories per container (including those hidden in `Show more`).
This patch ensures we don't press more than 20 stories per collection

## What is the value of this and can you measure success?
Putting a cap on a container size and prevent very big pressed fronts

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
No

cc @stephanfowler 
