### PR TITLE
Provide tracking for paid content cards in editorial containers.

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -1,5 +1,5 @@
 @import model.FrontProperties
-@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None)(implicit request: RequestHeader)
+@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None, containerDisplayName: Option[String] = None)(implicit request: RequestHeader)
 
 @import layout.{ColumnAndCards, SingleItem, Rows, SplitColumn, MPU}
 @import views.html.fragments.items.facia_cards.item
@@ -10,7 +10,7 @@
         @column match {
             case SingleItem(colSpan, _) => {
                 @cards.headOption.map { card =>
-                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties)
+                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
                 }
             }
 
@@ -19,7 +19,7 @@
                     <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
                         @if(cards.nonEmpty) {
                             @cards.map{ card =>
-                                @item(card, containerIndex, isList = true, frontProperties = frontProperties)
+                                @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
                             }
                         }
                     </ul>
@@ -30,7 +30,7 @@
                 <li class="fc-slice__item l-row__item l-row__item--span-@colSpan">
                     <ul class="u-unstyled l-list l-list--columns-1 l-list--rows-@(topItemRows + bottomItemRows)">
                         @cards.map { card =>
-                            @item(card, containerIndex, isList = true, frontProperties = frontProperties)
+                            @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
                         }
                     </ul>
                 </li>

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -39,7 +39,7 @@
          data-id="@containerDefinition.dataId">
 
         @for(sliceWithCards <- containerLayout.slices) {
-            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties))
+            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName)
         }
 
         @if(containerDefinition.hasShowMore && containerDefinition.hasShowMoreEnabled) {

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -1,5 +1,12 @@
 @import model.FrontProperties
-@(card: layout.FaciaCardAndIndex, containerIndex: Int, isRow: Boolean = true, isList: Boolean = false, colSpan: Int = 1, frontProperties: Option[FrontProperties] = None)(implicit request: RequestHeader)
+@(card: layout.FaciaCardAndIndex,
+    containerIndex: Int,
+    isRow: Boolean = true,
+    isList: Boolean = false,
+    colSpan: Int = 1,
+    frontProperties: Option[FrontProperties] = None,
+    containerDisplayName: Option[String] = None)(implicit request: RequestHeader)
+
 @import layout.{ContentCard, HtmlBlob, PaidCard}
 @import views.html.fragments.items.facia_cards.contentCard
 @import views.html.fragments.items.facia_cards.paidContentCard
@@ -22,7 +29,7 @@
         case paidContentOnEditorialPage: ContentCard if paidContentOnEditorialPage.branding.exists(_.isPaid) && !frontProperties.exists(_.isPaidContent) => {
             @paidContentCard(
                 item = paidContentOnEditorialPage,
-                omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage),
+                omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage, containerDisplayName),
                 containerIndex,
                 index,
                 isFirstContainer

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -224,8 +224,11 @@ object Commercial {
       ) mkString " | "
     }
 
-    def mkInteractionTrackingCode(containerIndex: Int, cardIndex: Int, card: ContentCard): String = Seq(
+    def mkInteractionTrackingCode(containerIndex: Int, cardIndex: Int, card: ContentCard, containerDisplayName: Option[String])(implicit request: RequestHeader): String = Seq(
+      containerDisplayName.getOrElse("unknown container"),
+      Edition(request).id,
       card.branding.map(_.sponsorName) getOrElse "unknown",
+      s"container-${containerIndex + 1}",
       s"card-${ cardIndex + 1 }",
       card.header.headline
     ).mkString(" | ")

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -225,10 +225,10 @@ object Commercial {
     }
 
     def mkInteractionTrackingCode(containerIndex: Int, cardIndex: Int, card: ContentCard, containerDisplayName: Option[String])(implicit request: RequestHeader): String = Seq(
-      containerDisplayName.getOrElse("unknown container"),
       Edition(request).id,
-      card.branding.map(_.sponsorName) getOrElse "unknown",
       s"container-${containerIndex + 1}",
+      containerDisplayName.getOrElse("unknown container"),
+      card.branding.map(_.sponsorName) getOrElse "unknown",
       s"card-${ cardIndex + 1 }",
       card.header.headline
     ).mkString(" | ")


### PR DESCRIPTION
## What does this change?
This changes the component-link-name on paid cards.

## What is the value of this and can you measure success?
Allows us to know when a paid content card has been rendered within an editorial container along with the position within that container.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots
![picture 125](https://user-images.githubusercontent.com/8861681/28966342-7afaea8a-790d-11e7-9214-03df5ab8e61a.png)

## Tested in CODE?
No.
