### PR TITLE
Unregistering service-workers when hitting preview login page

### DIFF
--- a/preview/app/views/previewAuth.scala.html
+++ b/preview/app/views/previewAuth.scala.html
@@ -12,6 +12,16 @@
 
         <link href="/assets/internal/javascripts/components/bootstrap.css/css/bootstrap.css" rel="stylesheet">
         <link href="/assets/internal/css/style.css" rel="stylesheet">
+        <script type="text/javascript">
+            var navigator = window.navigator;
+            if (navigator && navigator.serviceWorker) {
+                navigator.serviceWorker.getRegistrations().then(function(registrations) {
+                    registrations.forEach(function (registration) {
+                        registration.unregister();
+                    });
+                });
+            }
+        </script>
     </head>
     <body>
         <header>


### PR DESCRIPTION
Google auth redirection in preview is handled by writing in a cookie the last
requested urls. If a service worker is installed the browser might try
to refresh it and therefore save in the cookie the url of the
service-worker itself. When the user presses login they are then
redirected to service-worker.js :(
This patch ensured no service worker is registered when the user is not
logged in preview.

## What is the value of this and can you measure success?
No redirection to `service-worker.js` after logging into preview

## Does this affect other platforms - Amp, Apps, etc?
No