### PR TITLE
Added A/B test logic for the recurring contribution test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,9 +135,11 @@ trait ABTestSwitches {
     owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("desbo")),
     safeState = On,
     sellByDate = new LocalDate(2017, 9, 11),
+    exposeClientSide = true
   )
 
   Switch(
+    ABTests,
     "ab-acquisitions-epic-recurring-contribution-uk-support-proposition",
     "Add recurring contribution uk for support proposition",
     owners = Seq(Owner.withGithub("svillafe")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -140,7 +140,7 @@ trait ABTestSwitches {
   Switch(
     "ab-acquisitions-epic-recurring-contribution-uk-support-proposition",
     "Add recurring contribution uk for support proposition",
-    owners = Seq(Owner.withGithub("svillafe"), Owner.withGithub("Ap0c")),
+    owners = Seq(Owner.withGithub("svillafe")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 9, 13),
     exposeClientSide = true

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,7 +135,14 @@ trait ABTestSwitches {
     owners = Seq(Owner.withGithub("Mullefa"), Owner.withGithub("desbo")),
     safeState = On,
     sellByDate = new LocalDate(2017, 9, 11),
-    exposeClientSide = true
   )
 
+  Switch(
+    "ab-acquisitions-epic-recurring-contribution-uk-support-proposition",
+    "Add recurring contribution uk for support proposition",
+    owners = Seq(Owner.withGithub("svillafe"), Owner.withGithub("Ap0c")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 9, 13),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -201,7 +201,11 @@ const makeABTestVariant = (
             campaignCode
         ),
         membershipURL = addTrackingCodesToUrl(membershipBaseURL, campaignCode),
-        supportURL = addTrackingCodesToUrl(supportBaseURL, campaignCode),
+        supportCustomURL = null,
+        supportURL = addTrackingCodesToUrl(
+            supportCustomURL || supportBaseURL,
+            campaignCode
+        ),
         template = controlTemplate,
         buttonTemplate = defaultButtonTemplate,
         testimonialBlock = getTestimonialBlock(

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,12 +14,15 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 
+import { acquisitionsEpicRecurringContributionUkSupportProposition } from 'common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition';
+
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests = [
     alwaysAsk,
     payInEpic,
+    acquisitionsEpicRecurringContributionUkSupportProposition,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,7 +13,6 @@ import { acquisitionsEpicLiveblog } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
-
 import { acquisitionsEpicRecurringContributionUkSupportProposition } from 'common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition';
 
 /**

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
@@ -3,6 +3,11 @@ import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import template from 'lodash/utilities/template';
 import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
 
+const buildButtonTemplate = ({ supportUrl }) =>
+    template(singleButtonTemplate, {
+        url: supportUrl,
+    });
+
 export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABTest(
     {
         id: 'AcquisitionsEpicRecurringContributionUkSupportProposition',
@@ -19,8 +24,8 @@ export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABT
             'We see an uplift in annualised value when recurring contributions are available.',
 
         audienceCriteria: 'UK all devices',
-        audience: 0.58, // TODO: Needs definition
-        audienceOffset: 0.2, // TODO: Needs definition
+        audience: 1,
+        audienceOffset: 0,
         locations: ['GB'],
 
         variants: [
@@ -30,12 +35,9 @@ export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABT
             },
             {
                 id: 'variant',
-
-                buttonTemplate({ supportUrl }) {
-                    template(singleButtonTemplate, {
-                        url: supportUrl,
-                    });
-                },
+                buttonTemplate: buildButtonTemplate,
+                supportCustomURL:
+                    'https://support.theguardian.com/uk/contribute',
                 useTailoredCopyForRegulars: true,
             },
         ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
@@ -26,6 +26,10 @@ export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABT
         variants: [
             {
                 id: 'control',
+                useTailoredCopyForRegulars: true,
+            },
+            {
+                id: 'variant',
 
                 buttonTemplate({ supportUrl }) {
                     template(singleButtonTemplate, {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
@@ -31,14 +31,20 @@ export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABT
         variants: [
             {
                 id: 'control',
-                useTailoredCopyForRegulars: true,
+                products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+                options: {
+                    useTailoredCopyForRegulars: true,
+                },
             },
             {
                 id: 'variant',
-                buttonTemplate: buildButtonTemplate,
-                supportCustomURL:
-                    'https://support.theguardian.com/uk/contribute',
-                useTailoredCopyForRegulars: true,
+                products: ['ONE_OFF_CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
+                options: {
+                    buttonTemplate: buildButtonTemplate,
+                    supportCustomURL:
+                        'https://support.theguardian.com/uk/contribute',
+                    useTailoredCopyForRegulars: true,
+                },
             },
         ],
     }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
@@ -1,0 +1,39 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import template from 'lodash/utilities/template';
+import singleButtonTemplate from 'raw-loader!common/views/acquisitions-epic-single-button.html';
+
+export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABTest(
+    {
+        id: 'AcquisitionsEpicRecurringContributionUkSupportProposition',
+        campaignId: 'sandc_epic_recurring_contribution_uk_support_proposition',
+
+        start: '2017-08-07',
+        expiry: '2017-09-13',
+
+        author: 'svillafe',
+        description:
+            'This creates a two button version of the epic that links off to the new support frontend contribution landing page',
+        successMeasure: 'Annualised value',
+        idealOutcome:
+            'We see an uplift in annualised value when recurring contributions are available.',
+
+        audienceCriteria: 'UK all devices',
+        audience: 0.58, // TODO: Needs definition
+        audienceOffset: 0.2, // TODO: Needs definition
+        locations: ['GB'],
+
+        variants: [
+            {
+                id: 'control',
+
+                buttonTemplate({ supportUrl }) {
+                    template(singleButtonTemplate, {
+                        url: supportUrl,
+                    });
+                },
+                useTailoredCopyForRegulars: true,
+            },
+        ],
+    }
+);


### PR DESCRIPTION
## What does this change?
We are introducing a new AB test which tests if by adding recurring contributions, we increase the annualised value or not. 

This PR should be merged after we remove test 1.

## Campaign codes:

### Variant
INTCMP=gdnwb_copts_memco_sandc_epic_recurring_contribution_uk_support_proposition_variant

### Control
INTCMP=gdnwb_copts_memco_sandc_epic_recurring_contribution_uk_support_proposition_control

## Variants

**Control:** we should have 50% control identical to that provided in Test1, with calls to action leading to membership.theguardian.com and contribute.theguardian.com:

<img width="456" alt="picture 337" src="https://user-images.githubusercontent.com/825398/29022410-12a7cf2e-7b61-11e7-9804-73e31ad1d3c3.png">

**Variant:** 50% should receive a simpler “support the guardian” call to action, which leads to support.theguardian.com:
<img width="421" alt="picture 338" src="https://user-images.githubusercontent.com/825398/29022418-1b38bfc2-7b61-11e7-8173-7cae6cb307bd.png">


## Does this affect other platforms - Amp, Apps, etc?
No
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screencasts

### Test Variant
![testvariant](https://user-images.githubusercontent.com/825398/29036295-cdc99bf4-7b96-11e7-963d-2e5a9a9ca0c0.gif)

### Test Control Membership Button
![testcontrol1](https://user-images.githubusercontent.com/825398/29036347-ff7c4296-7b96-11e7-8f89-13c787ade2d4.gif)

### Test Control Contribution Button
![testcontrol2](https://user-images.githubusercontent.com/825398/29036400-35469b24-7b97-11e7-8fd9-545e8c484429.gif)


## Tested in CODE?
Yes.

