### PR TITLE
Redesign storyquestions with checkboxes

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -9,63 +9,52 @@
 }
 
 @if(!isAmp && !isClosed) {
-    <div class="js-view-tracking-component submeta user__question">
-        <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
+    <div class="js-view-tracking-component submeta user__question" data-atom-id="@storyquestions.id">
 
         @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
             <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
         }
 
-        <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
+        <h2 class="user__question-title">
+            Ask us a question
+            <span class="user__question-title--secondary">We will answer the most popular question later today.</span>
+        </h2>
+
         @for(questions <- storyquestions.data.editorialQuestions) {
             @for(qs <- questions) {
-                <p>
-                    <div class="user__question-section"></div>
+                <div class="user__question-section">
                     @for(question <- qs.questions) {
                         <div class="user__question-container">
-                            <div class="user__questions-text--wrapper js-ask-question-link">
-                                <div class="user__question-text">
-                                    <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
-                                    <span class="user__questions-text--inner">
-                                    @question.questionText
-                                    </span>
-                                </div>
-                                <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
-                                    Ask
-                                </button>
-                                <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ll send you the answer soon.
-                                </span>
-                                <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
-                                    Thanks, we&rsquo;ve registered your vote.
-                                </span>
-                            </div>
-                            <div class="storyquestion-submission-container js-storyquestion-submission-container">
-                                <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
-                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
-                                </span>
-                                @*********************
-                                * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
-
-                                * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
-                                * show the form allowing a user to submit their email address and receive an answer.
-                                *********************@
-
-                                @if("test/test" == storyquestions.data.relatedStoryId) {
-                                    @storyquestions.atom.labels.find(_.length == 4).map { listId =>
-                                        <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                            <div class="form-field js-storyquestion-email-signup-input-container">
-                                                <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
-                                            </div>
-                                            <input class="" type="hidden" name="listId" value="@listId" />
-                                            <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-                                        </form>
-                                    }
-                                }
-                            </div>
+                            <label><input type="checkbox" name="checkbox" value="@question.questionId">@question.questionText</label>
                         </div>
                     }
-                </p>
+                </div>
+
+                <button type="submit" class="js-storyquestion-vote-button storyquestion-vote-button button button--primary">Vote</button>
+
+                @storyquestions.atom.labels.find(_.length == 4).map { listId =>
+
+                    <div class="is-hidden js-storyquestion-email-question storyquestion-email-question">We're working on the answer. Would you like to receive an email when we answer the most popular question?</div>
+
+                    <label for="#email-input-@listId" class="is-hidden js-storyquestion-email-enter storyquestion-email-enter">Enter your email</label>
+
+                    <div class="is-hidden js-storyquestion-email-done storyquestion-email-done">We will email you the answer to the most popular question as soon as it's ready.</div>
+
+                    <a href="#email-input-@listId" class="is-hidden js-storyquestion-email-question-button storyquestion-email-question-button button button--primary">Email me</a>
+
+                    <form action="#" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form">
+                        <div class="form-field js-storyquestion-email-signup-input-container">
+                            <input id="email-input-@listId" aria-describedby="no-spam-@qs.questionSetId" class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
+                        </div>
+                        <input class="" type="hidden" name="listId" value="@listId" />
+                        <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">
+                            @fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))
+                            Sign up
+                        </button>
+                    </form>
+                }
+
+                <div id="no-spam-@qs.questionSetId" class="is-hidden js-storyquestion-email-nospam">No spam, just one email</div>
             }
     </div>
 }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -19,53 +19,50 @@ define([
     Id,
     fastdom
 ) {
+    function vote(event, signedIn) {
+        var component = event.currentTarget.closest('.js-view-tracking-component');
+        var votes = $('.user__question-container input:checked', component);
 
-    function askQuestion(event, isEmailSubmissionReady) {
-        event.preventDefault();
+        if (votes.length > 0) {
 
-        var askQuestionBtn = event.currentTarget.querySelector('.user__question-upvote');
-        var atomIdElement = $('.js-storyquestion-atom-id');
+            var atomId = component.dataset.atomId;
 
-        if (askQuestionBtn && atomIdElement) {
-            var questionId = askQuestionBtn.dataset.questionId;
-            var atomId = atomIdElement.attr('id');
+            $('.user__question-title', component).text('Thank you for voting');
+            $('.user__question-section, .user__question-title--secondary, .js-storyquestion-vote-button', component)
+                .addClass('is-hidden');
 
-            var question = document.querySelector("meta[name=js-notranslate-" + questionId + "]");
+            if (signedIn) {
+                $('.js-storyquestion-email-signup-form', component).removeClass('is-hidden');
+            } else {
+                $('.js-storyquestion-email-question-button', component).removeClass('is-hidden');
+            }
 
-            if (question) {
-                var questionText = question.content;
+            $('.js-storyquestion-email-question, .js-storyquestion-email-nospam', component)
+                .removeClass('is-hidden');
 
-                if (questionText && atomId) {
+            //Send votes to ophan
+            votes.each(function (question) {
+                var questionText = $(question).parent().text();
 
-                    if (askQuestionBtn) {
-                        askQuestionBtn.classList.add('is-hidden');
-                    }
-
-                    if (isEmailSubmissionReady === "true") {
-                        var signupForm = document.forms['js-storyquestion-email-signup-form-' + questionId];
-                        var thankYouMessageForEmailSubmission = document.getElementById('js-question-thankyou-' + questionId);
-
-                        if (thankYouMessageForEmailSubmission && signupForm) {
-                            thankYouMessageForEmailSubmission.classList.remove('is-hidden');
-                            signupForm.classList.remove('is-hidden');
-                        }
-
-                    } else {
-                        var thankYouMessageNoEmailSubmission = document.getElementById('js-thankyou-message-no-submission-' + questionId);
-
-                        if (thankYouMessageNoEmailSubmission) {
-                            thankYouMessageNoEmailSubmission.classList.remove('is-hidden');
-                        }
-                    }
-
+                if (questionText) {
                     ophan.record({
                         atomId: atomId.trim(),
                         component: questionText.trim(),
                         value: 'question_asked'
                     });
                 }
-            }
+            });
         }
+    }
+
+    function emailMe(event) {
+        var component = event.currentTarget.closest('.js-view-tracking-component');
+
+        $('.js-storyquestion-email-question, .js-storyquestion-email-question-button, .js-storyquestion-email-nospam', component)
+            .addClass('is-hidden');
+
+        $('.js-storyquestion-email-enter, .js-storyquestion-email-signup-form', component)
+            .removeClass('is-hidden');
     }
 
     function submitSignUpForm(event) {
@@ -74,10 +71,8 @@ define([
         var answersEmailSignupForm = event.currentTarget;
         var email = answersEmailSignupForm.elements['email'];
         var listId = answersEmailSignupForm.listId;
-        var questionId = answersEmailSignupForm.dataset.questionId;
 
-        if (email && listId && questionId) {
-
+        if (email && listId) {
             fetch(config.page.ajaxUrl + '/story-questions/answers/signup', {
                 mode: 'cors',
                 method: 'POST',
@@ -85,13 +80,11 @@ define([
             })
             .then(function (response) {
                 if (response.ok) {
-                    var submissionContainerEl = answersEmailSignupForm.parentElement;
-                    var thankyouMessage = document.getElementById('js-final-thankyou-message-' + questionId);
+                    var component = event.currentTarget.closest('.js-view-tracking-component');
+                    $('.js-storyquestion-email-done', component).removeClass('is-hidden');
 
-                    if (submissionContainerEl && thankyouMessage) {
-                        submissionContainerEl.classList.add('is-hidden');
-                        thankyouMessage.classList.remove('is-hidden');
-                    }
+                    $('.js-storyquestion-email-question, .js-storyquestion-email-signup-form, .js-storyquestion-email-enter, .js-storyquestion-email-nospam', component)
+                        .addClass('is-hidden');
                 }
             });
         }
@@ -99,47 +92,40 @@ define([
 
     return {
         init: function() {
-            var askQuestionLinks = $('.js-ask-question-link');
-            var isEmailSubmissionReadyElement = document.getElementById('js-storyquestion-is-email-submission-ready');
 
-            var isEmailSubmissionReady = false;
-
-            if (isEmailSubmissionReadyElement) {
-                isEmailSubmissionReady = isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady ? isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady : false;
-            }
-
-            askQuestionLinks.each(function (el) {
-                bean.on(el, 'click', function(event) {
-                    askQuestion(event, isEmailSubmissionReady)
-                    this.classList.add('is-clicked')
-                });
+            $('.js-storyquestion-email-question-button').each(function(el) {
+                bean.one(el, 'click', emailMe);
             });
 
-            var answersEmailSignupForms = $('.js-storyquestion-email-signup-form');
-
-            answersEmailSignupForms.each(function (el) {
-                bean.on(el, 'submit', submitSignUpForm);
+            $('.js-storyquestion-email-signup-form').each(function(el) {
+                bean.one(el, 'submit', submitSignUpForm);
             });
-
 
             Id.getUserFromApi(function (userFromId) {
-                if (userFromId && userFromId.primaryEmailAddress) {
+                var signedIn = (userFromId && userFromId.primaryEmailAddress) != null;
+
+                if (signedIn) {
                     fastdom.write(function () {
                         $('.js-storyquestion-email-signup-form').each(function(form) {
-                            $('.js-storyquestion-email-signup-button', form).removeClass('button--with-input');
+                            $('.button--with-input', form).removeClass('button--with-input');
                             $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
                             $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
                             $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
                         });
                     });
                 }
+
+                $('.js-storyquestion-vote-button').each(function(el) {
+                    bean.on(el, 'click', function(event) {
+                        vote(event, signedIn);
+                    });
+                });
             });
 
 
             var storyQuestionsComponent = document.querySelector('.js-view-tracking-component');
-            var atomElement = $('.js-storyquestion-atom-id');
 
-            if (storyQuestionsComponent && atomElement) {
+            if (storyQuestionsComponent) {
 
                 mediator.on('window:throttledScroll', function onScroll() {
                     var height = detect.getViewport().height;
@@ -147,7 +133,7 @@ define([
                     var isStoryQuestionsInView = 0 <= coords.top && coords.bottom <= height;
 
                     if (isStoryQuestionsInView) {
-                        var atomId = atomElement.attr('id');
+                        var atomId = storyQuestionsComponent.dataset.atomId;
 
                         if (atomId) {
                             ophan.record({

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -20,67 +20,35 @@
 }
 
 .user__question-title--secondary {
-    color: $neutral-1;
     display: block;
-    font-size: 18px;
-    font-weight: 400;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+    margin-bottom: $gs-baseline/2;
+    color: $neutral-2;
+    font-weight: normal;
 }
 
-.user__questions-text--wrapper {
-    position: relative;
-    overflow: hidden;
-    background-color: $neutral-8;
-    margin-bottom: 0;
-    padding-top: $gs-baseline / 2;
-    padding-bottom: $gs-baseline;
-    padding-left: 8px;
-
-    &.is-clicked {
-        background-color: $news-support-5;
-        padding-bottom: 0;
-    }
-
-    &.is-clicked + .storyquestion-submission-container {
-        background-color: $news-support-5;
-    }
-
-    &:hover {
-        background-color: $news-support-5;
-
-        .user__question-upvote {
-            background-color: $news-main-1;
-            color: #ffffff;
-        }
-        cursor: pointer;
-    }
+.storyquestion-email-question, .storyquestion-email-done, .storyquestion-email-enter {
+    display: block;
+    font-weight: bold;
+    padding-bottom: 1rem;
+    padding-top: 1rem;
 }
 
 .user__question-section {
-    border-top: 1px dotted $neutral-6;
     margin-top: $gs-baseline * 2;
+    font-size: 1.25rem;
+    font-weight: bold;
 
     h3 {
         @include fs-textSans(2);
         color: $neutral-2;
         font-weight: 200;
     }
-}
 
-.user__question-text {
-    @include fs-headline(2);
-    font-weight: 900;
-    display: block;
-    //used to avoid fixed width across multiple break points.
-    max-width: 77%;
-    color: $news-main-1;
-    position: relative;
-    margin-bottom: $gs-baseline;
-
-    @include mq($from: tablet) {
-        @include fs-headline(3);
-        line-height: $gs-baseline * 2;
-        max-width: 80%;
-        font-weight: 900;
+    input {
+        margin-left: 0;
+        margin-right: $gs-baseline;
     }
 }
 
@@ -88,48 +56,17 @@
     margin-bottom: 12px;
 }
 
-.user__question-response {
-    @include fs-textSans(3);
-    clear: both;
-    margin-top: $gs-baseline;
-    margin-bottom: $gs-baseline;
-    font-size: 14px;
-    line-height: 18px;
-    width: 90%;
-    display: block;
-    color: $neutral-1;
-
-    @include mq($from: tablet) {
-        clear: none;
-        margin-top: 0;
-        font-size: 16px;
-        line-height: 20px;
-    }
+.storyquestion-vote-button, .storyquestion-email-question-button {
+    font-size: 1.125rem;
+    padding: 0 1rem;
+    height: 2.25rem;
 }
 
-.user__question-upvote {
-    @include fs-textSans(3);
-    right: $gs-gutter - 2;
-    bottom: $gs-gutter;
-    position: absolute;
-    color: $news-main-1;
-    font-weight: 900;
-    border: 1px solid $news-main-1;
-    padding-top: $gs-baseline / 3;
-    float: right;
-    outline: 0;
-    padding-left: $gs-baseline;
-    padding-right: $gs-baseline;
-    border-radius: $gs-gutter * 2;
-    background-color: transparent;
-
-    &:hover {
-        text-decoration: none;
-    }
-}
-.storyquestion-submission-container {
-    overflow: hidden;
-    padding-left: 8px;
+.storyquestion-email-question-button {
+    color: #ffffff;
+    text-decoration: inherit;
+    display: inline-flex;
+    align-items: center;
 }
 
 .storyquestion-email-signup-form.form {
@@ -160,4 +97,10 @@
     .storyquestion-email-signup-button-envelope {
         display: inline;
     }
+}
+
+.js-storyquestion-email-nospam {
+    font-size: .875rem;
+    font-weight: bold;
+    padding-top: .5rem;
 }


### PR DESCRIPTION
## What does this change?
The old design looks like this:
![picture 25](https://user-images.githubusercontent.com/1513454/28975999-19787f58-7934-11e7-9db0-023eb2b5b3c4.png)
UX research has revealed that this is misleading users. Some users expect to be given the answer immediately. Talk to George Green if you'd like to know more about this research :)
The conclusion was to make it look more like a poll, using checkboxes and a single 'Vote' button.

## What is the value of this and can you measure success?
This should make it clearer to users what will happen when they interact with the atom.

## Does this affect other platforms - Amp, Apps, etc?
Rendered in iframes in app

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
...

## Screenshots
### As a signed in user:
1.
![picture 0](https://user-images.githubusercontent.com/1513454/28976199-e8756ad2-7934-11e7-98a6-8cc3ecf08240.png)
2.
![picture 1](https://user-images.githubusercontent.com/1513454/28976198-e870c75c-7934-11e7-85ca-41b31b45ec6b.png)
3.
![picture 2](https://user-images.githubusercontent.com/1513454/28976197-e8704584-7934-11e7-825c-fd6db41e0a27.png)

### For other users, step 2 is replaced with:
2a.
![picture 3](https://user-images.githubusercontent.com/1513454/28976444-d09fbf4c-7935-11e7-8d51-e0a629eb1f10.png)
2b.
![picture 4](https://user-images.githubusercontent.com/1513454/28976445-d0af0a4c-7935-11e7-91e9-6d987cf2cc29.png)

## Tested in CODE?
Yes