### PR TITLE
Story questions vote event fix for app

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -101,26 +101,35 @@ define([
                 bean.one(el, 'submit', submitSignUpForm);
             });
 
-            Id.getUserFromApi(function (userFromId) {
-                var signedIn = (userFromId && userFromId.primaryEmailAddress) != null;
-
-                if (signedIn) {
-                    fastdom.write(function () {
-                        $('.js-storyquestion-email-signup-form').each(function(form) {
-                            $('.button--with-input', form).removeClass('button--with-input');
-                            $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
-                            $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
-                            $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
-                        });
-                    });
-                }
-
-                $('.js-storyquestion-vote-button').each(function(el) {
-                    bean.on(el, 'click', function(event) {
-                        vote(event, signedIn);
+            if (window.location.hostname.includes("api.nextgen.guardianapps.co.uk")) {
+                //User details not available
+                $('.js-storyquestion-vote-button').each(function (el) {
+                    bean.on(el, 'click', function (event) {
+                        vote(event, false);
                     });
                 });
-            });
+            } else {
+                Id.getUserFromApi(function (userFromId) {
+                    var signedIn = (userFromId && userFromId.primaryEmailAddress) != null;
+
+                    if (signedIn) {
+                        fastdom.write(function () {
+                            $('.js-storyquestion-email-signup-form').each(function (form) {
+                                $('.button--with-input', form).removeClass('button--with-input');
+                                $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
+                                $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
+                                $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
+                            });
+                        });
+                    }
+
+                    $('.js-storyquestion-vote-button').each(function (el) {
+                        bean.on(el, 'click', function (event) {
+                            vote(event, signedIn);
+                        });
+                    });
+                });
+            }
 
 
             var storyQuestionsComponent = document.querySelector('.js-view-tracking-component');


### PR DESCRIPTION
The app displays the `storyquestions` atom in an iframe, using `api.nextgen.guardianapps.co.uk`.
The event handler for the 'Vote' button isn't working in the app, possibly because it's being bound in the callback for `getUserFromApi`. This was introduced by https://github.com/guardian/frontend/pull/17594.

Avoid calling `getUserFromApi` when the hostname is api.nextgen.

I've tested it still works in CODE with the website.