### PR TITLE
Revert poll

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -9,52 +9,63 @@
 }
 
 @if(!isAmp && !isClosed) {
-    <div class="js-view-tracking-component submeta user__question" data-atom-id="@storyquestions.id">
+    <div class="js-view-tracking-component submeta user__question">
+        <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
 
         @defining("test/test" == storyquestions.data.relatedStoryId && storyquestions.atom.labels.exists(_.length == 4)) { isEmailSubmissionReady =>
             <span class="is-hidden" id="js-storyquestion-is-email-submission-ready" data-is-email-submission-ready="@isEmailSubmissionReady"></span>
         }
 
-        <h2 class="user__question-title">
-            Ask us a question
-            <span class="user__question-title--secondary">We will answer the most popular question later today.</span>
-        </h2>
-
+        <h2 class="user__question-title">Need something explained?<span class="user__question-title--secondary">Let us know which of these questions we can answer for you.</span></h2>
         @for(questions <- storyquestions.data.editorialQuestions) {
             @for(qs <- questions) {
-                <div class="user__question-section">
+                <p>
+                    <div class="user__question-section"></div>
                     @for(question <- qs.questions) {
                         <div class="user__question-container">
-                            <label><input type="checkbox" name="checkbox" value="@question.questionId">@question.questionText</label>
+                            <div class="user__questions-text--wrapper js-ask-question-link">
+                                <div class="user__question-text">
+                                    <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
+                                    <span class="user__questions-text--inner">
+                                    @question.questionText
+                                    </span>
+                                </div>
+                                <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
+                                    Ask
+                                </button>
+                                <span id="js-final-thankyou-message-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ll send you the answer soon.
+                                </span>
+                                <span id="js-thankyou-message-no-submission-@question.questionId" class="user__question-response submeta__label is-hidden">
+                                    Thanks, we&rsquo;ve registered your vote.
+                                </span>
+                            </div>
+                            <div class="storyquestion-submission-container js-storyquestion-submission-container">
+                                <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
+                                    Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
+                                </span>
+                                @*********************
+                                * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
+
+                                * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
+                                * show the form allowing a user to submit their email address and receive an answer.
+                                *********************@
+
+                                @if("test/test" == storyquestions.data.relatedStoryId) {
+                                    @storyquestions.atom.labels.find(_.length == 4).map { listId =>
+                                        <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
+                                            <div class="form-field js-storyquestion-email-signup-input-container">
+                                                <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
+                                            </div>
+                                            <input class="" type="hidden" name="listId" value="@listId" />
+                                            <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+                                        </form>
+                                    }
+                                }
+                            </div>
                         </div>
                     }
-                </div>
-
-                <button type="submit" class="js-storyquestion-vote-button storyquestion-vote-button button button--primary">Vote</button>
-
-                @storyquestions.atom.labels.find(_.length == 4).map { listId =>
-
-                    <div class="is-hidden js-storyquestion-email-question storyquestion-email-question">We're working on the answer. Would you like to receive an email when we answer the most popular question?</div>
-
-                    <label for="#email-input-@listId" class="is-hidden js-storyquestion-email-enter storyquestion-email-enter">Enter your email</label>
-
-                    <div class="is-hidden js-storyquestion-email-done storyquestion-email-done">We will email you the answer to the most popular question as soon as it's ready.</div>
-
-                    <a href="#email-input-@listId" class="is-hidden js-storyquestion-email-question-button storyquestion-email-question-button button button--primary">Email me</a>
-
-                    <form action="#" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form">
-                        <div class="form-field js-storyquestion-email-signup-input-container">
-                            <input id="email-input-@listId" aria-describedby="no-spam-@qs.questionSetId" class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
-                        </div>
-                        <input class="" type="hidden" name="listId" value="@listId" />
-                        <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">
-                            @fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))
-                            Sign up
-                        </button>
-                    </form>
-                }
-
-                <div id="no-spam-@qs.questionSetId" class="is-hidden js-storyquestion-email-nospam">No spam, just one email</div>
+                </p>
             }
     </div>
 }

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -101,35 +101,26 @@ define([
                 bean.one(el, 'submit', submitSignUpForm);
             });
 
-            if (window.location.hostname.includes("api.nextgen.guardianapps.co.uk")) {
-                //User details not available
-                $('.js-storyquestion-vote-button').each(function (el) {
-                    bean.on(el, 'click', function (event) {
-                        vote(event, false);
-                    });
-                });
-            } else {
-                Id.getUserFromApi(function (userFromId) {
-                    var signedIn = (userFromId && userFromId.primaryEmailAddress) != null;
+            Id.getUserFromApi(function (userFromId) {
+                var signedIn = (userFromId && userFromId.primaryEmailAddress) != null;
 
-                    if (signedIn) {
-                        fastdom.write(function () {
-                            $('.js-storyquestion-email-signup-form').each(function (form) {
-                                $('.button--with-input', form).removeClass('button--with-input');
-                                $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
-                                $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
-                                $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
-                            });
-                        });
-                    }
-
-                    $('.js-storyquestion-vote-button').each(function (el) {
-                        bean.on(el, 'click', function (event) {
-                            vote(event, signedIn);
+                if (signedIn) {
+                    fastdom.write(function () {
+                        $('.js-storyquestion-email-signup-form').each(function(form) {
+                            $('.button--with-input', form).removeClass('button--with-input');
+                            $('.js-storyquestion-email-signup-input-container', form).addClass('is-hidden');
+                            $('.js-storyquestion-email-signup-input', form).val(userFromId.primaryEmailAddress);
+                            $('.inline-envelope', form).addClass('storyquestion-email-signup-button-envelope');
                         });
                     });
+                }
+
+                $('.js-storyquestion-vote-button').each(function(el) {
+                    bean.on(el, 'click', function(event) {
+                        vote(event, signedIn);
+                    });
                 });
-            }
+            });
 
 
             var storyQuestionsComponent = document.querySelector('.js-view-tracking-component');

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -20,35 +20,67 @@
 }
 
 .user__question-title--secondary {
+    color: $neutral-1;
     display: block;
-    font-size: 1.125rem;
-    line-height: 1.375rem;
-    margin-bottom: $gs-baseline/2;
-    color: $neutral-2;
-    font-weight: normal;
+    font-size: 18px;
+    font-weight: 400;
 }
 
-.storyquestion-email-question, .storyquestion-email-done, .storyquestion-email-enter {
-    display: block;
-    font-weight: bold;
-    padding-bottom: 1rem;
-    padding-top: 1rem;
+.user__questions-text--wrapper {
+    position: relative;
+    overflow: hidden;
+    background-color: $neutral-8;
+    margin-bottom: 0;
+    padding-top: $gs-baseline / 2;
+    padding-bottom: $gs-baseline;
+    padding-left: 8px;
+
+    &.is-clicked {
+        background-color: $news-support-5;
+        padding-bottom: 0;
+    }
+
+    &.is-clicked + .storyquestion-submission-container {
+        background-color: $news-support-5;
+    }
+
+    &:hover {
+        background-color: $news-support-5;
+
+        .user__question-upvote {
+            background-color: $news-main-1;
+            color: #ffffff;
+        }
+        cursor: pointer;
+    }
 }
 
 .user__question-section {
+    border-top: 1px dotted $neutral-6;
     margin-top: $gs-baseline * 2;
-    font-size: 1.25rem;
-    font-weight: bold;
 
     h3 {
         @include fs-textSans(2);
         color: $neutral-2;
         font-weight: 200;
     }
+}
 
-    input {
-        margin-left: 0;
-        margin-right: $gs-baseline;
+.user__question-text {
+    @include fs-headline(2);
+    font-weight: 900;
+    display: block;
+    //used to avoid fixed width across multiple break points.
+    max-width: 77%;
+    color: $news-main-1;
+    position: relative;
+    margin-bottom: $gs-baseline;
+
+    @include mq($from: tablet) {
+        @include fs-headline(3);
+        line-height: $gs-baseline * 2;
+        max-width: 80%;
+        font-weight: 900;
     }
 }
 
@@ -56,17 +88,48 @@
     margin-bottom: 12px;
 }
 
-.storyquestion-vote-button, .storyquestion-email-question-button {
-    font-size: 1.125rem;
-    padding: 0 1rem;
-    height: 2.25rem;
+.user__question-response {
+    @include fs-textSans(3);
+    clear: both;
+    margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
+    font-size: 14px;
+    line-height: 18px;
+    width: 90%;
+    display: block;
+    color: $neutral-1;
+
+    @include mq($from: tablet) {
+        clear: none;
+        margin-top: 0;
+        font-size: 16px;
+        line-height: 20px;
+    }
 }
 
-.storyquestion-email-question-button {
-    color: #ffffff;
-    text-decoration: inherit;
-    display: inline-flex;
-    align-items: center;
+.user__question-upvote {
+    @include fs-textSans(3);
+    right: $gs-gutter - 2;
+    bottom: $gs-gutter;
+    position: absolute;
+    color: $news-main-1;
+    font-weight: 900;
+    border: 1px solid $news-main-1;
+    padding-top: $gs-baseline / 3;
+    float: right;
+    outline: 0;
+    padding-left: $gs-baseline;
+    padding-right: $gs-baseline;
+    border-radius: $gs-gutter * 2;
+    background-color: transparent;
+
+    &:hover {
+        text-decoration: none;
+    }
+}
+.storyquestion-submission-container {
+    overflow: hidden;
+    padding-left: 8px;
 }
 
 .storyquestion-email-signup-form.form {
@@ -97,10 +160,4 @@
     .storyquestion-email-signup-button-envelope {
         display: inline;
     }
-}
-
-.js-storyquestion-email-nospam {
-    font-size: .875rem;
-    font-weight: bold;
-    padding-top: .5rem;
 }


### PR DESCRIPTION
Reverting https://github.com/guardian/frontend/pull/17594 and subsequent attempt at a fix https://github.com/guardian/frontend/pull/17604.
This works fine on the web, but breaks the behaviour in the app. It's extremely hard to debug the behaviour of these atoms in iframes in the app at the moment. This redesign will probably have to wait for the new solution (without iframes).