### PR TITLE
Add open graph image dimensions to content

### DIFF
--- a/common/app/implicits/Booleans.scala
+++ b/common/app/implicits/Booleans.scala
@@ -1,0 +1,9 @@
+package implicits
+
+object Booleans extends Booleans
+
+trait Booleans {
+  implicit class RichBoolean(b: Boolean) {
+    def toOption[A](value: => A): Option[A] = if (b) Some(value) else None
+  }
+}


### PR DESCRIPTION
## What does this change?
Adds open graph image dimensions to our metadata.  As per the Facebook docs (https://developers.facebook.com/docs/sharing/best-practices#images) they will render share images correctly on the first share if dimensions are specified.

The actual dimensions are actually surprisingly hard to know for sure because it depends on imgix behaviour (and whether we have imgix turned on!).  I have gone for a fairly simple calculation, that will be correct nearly all the time.

## What is the value of this and can you measure success?
Audience team don't have to use the fb debugger to pre-cache images so often.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
