### PR TITLE
Add frontId to paid content card promotion tracking.

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -53,7 +53,7 @@
 
                     case _: Dynamic | _: Fixed => {
                         <div class="fc-container__inner">
-                            @standardContainer(containerDefinition, frontProperties, maybeContainerModel, showFrontBranding)
+                            @standardContainer(containerDefinition, frontProperties, maybeContainerModel, showFrontBranding, frontId)
                         </div>
                     }
 

--- a/common/app/views/fragments/containers/facia_cards/slice.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/slice.scala.html
@@ -1,5 +1,5 @@
 @import model.FrontProperties
-@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None, containerDisplayName: Option[String] = None)(implicit request: RequestHeader)
+@(slice: layout.SliceWithCards, containerIndex: Int, frontProperties: Option[FrontProperties] = None, containerDisplayName: Option[String] = None, frontId: Option[String] = None)(implicit request: RequestHeader)
 
 @import layout.{ColumnAndCards, SingleItem, Rows, SplitColumn, MPU}
 @import views.html.fragments.items.facia_cards.item
@@ -10,7 +10,7 @@
         @column match {
             case SingleItem(colSpan, _) => {
                 @cards.headOption.map { card =>
-                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
+                    @item(card, containerIndex, colSpan = colSpan, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
                 }
             }
 
@@ -19,7 +19,7 @@
                     <ul class="u-unstyled l-list l-list--columns-@columns l-list--rows-@rows">
                         @if(cards.nonEmpty) {
                             @cards.map{ card =>
-                                @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
+                                @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
                             }
                         }
                     </ul>
@@ -30,7 +30,7 @@
                 <li class="fc-slice__item l-row__item l-row__item--span-@colSpan">
                     <ul class="u-unstyled l-list l-list--columns-1 l-list--rows-@(topItemRows + bottomItemRows)">
                         @cards.map { card =>
-                            @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName)
+                            @item(card, containerIndex, isList = true, frontProperties = frontProperties, containerDisplayName = containerDisplayName, frontId = frontId)
                         }
                     </ul>
                 </li>

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -8,7 +8,8 @@
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties,
   maybeContainerModel: Option[ContainerModel],
-  showFrontBranding: Boolean)(implicit request: RequestHeader)
+  showFrontBranding: Boolean,
+  frontId: Option[String])(implicit request: RequestHeader)
 
 @containerHeader(containerDefinition, frontProperties)
 
@@ -39,7 +40,7 @@
          data-id="@containerDefinition.dataId">
 
         @for(sliceWithCards <- containerLayout.slices) {
-            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName)
+            @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName, frontId)
         }
 
         @if(containerDefinition.hasShowMore && containerDefinition.hasShowMoreEnabled) {

--- a/common/app/views/fragments/items/facia_cards/item.scala.html
+++ b/common/app/views/fragments/items/facia_cards/item.scala.html
@@ -5,7 +5,8 @@
     isList: Boolean = false,
     colSpan: Int = 1,
     frontProperties: Option[FrontProperties] = None,
-    containerDisplayName: Option[String] = None)(implicit request: RequestHeader)
+    containerDisplayName: Option[String] = None,
+    frontId: Option[String] = None)(implicit request: RequestHeader)
 
 @import layout.{ContentCard, HtmlBlob, PaidCard}
 @import views.html.fragments.items.facia_cards.contentCard
@@ -29,7 +30,7 @@
         case paidContentOnEditorialPage: ContentCard if paidContentOnEditorialPage.branding.exists(_.isPaid) && !frontProperties.exists(_.isPaidContent) => {
             @paidContentCard(
                 item = paidContentOnEditorialPage,
-                omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage, containerDisplayName),
+                omnitureId = mkInteractionTrackingCode(containerIndex, index, paidContentOnEditorialPage, containerDisplayName, frontId),
                 containerIndex,
                 index,
                 isFirstContainer

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -224,8 +224,9 @@ object Commercial {
       ) mkString " | "
     }
 
-    def mkInteractionTrackingCode(containerIndex: Int, cardIndex: Int, card: ContentCard, containerDisplayName: Option[String])(implicit request: RequestHeader): String = Seq(
+    def mkInteractionTrackingCode(containerIndex: Int, cardIndex: Int, card: ContentCard, containerDisplayName: Option[String], frontId: Option[String])(implicit request: RequestHeader): String = Seq(
       Edition(request).id,
+      frontId.getOrElse("unknown front id"),
       s"container-${containerIndex + 1}",
       containerDisplayName.getOrElse("unknown container"),
       card.branding.map(_.sponsorName) getOrElse "unknown",


### PR DESCRIPTION
## What does this change?
Adds the frontId to paid content card tracking.

## What is the value of this and can you measure success?
Consistent format between cards from a glabs container and paid cards in editorial container.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
N/A

## Tested in CODE?
No.
