### PR TITLE
onward/related: Replace lodash.intersection with inlined function

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
                     'lodash/objects/isArray',
                     'lodash/arrays/indexOf',
                     'lodash/arrays/compact',
+                    'lodash/arrays/intersection',
                     'Promise',
                 ],
                 patterns: ['!lodash/*'],

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -6,7 +6,6 @@ import fetchJSON from 'lib/fetch-json';
 import fastdom from 'lib/fastdom-promise';
 import register from 'common/modules/analytics/register';
 import Expandable from 'common/modules/ui/expandable';
-import intersection from 'lodash/arrays/intersection';
 
 const buildExpandable = (el: HTMLElement): void => {
     new Expandable({
@@ -55,11 +54,13 @@ const popularInTagOverride = (): ?string | false => {
         'football/liverpool',
     ];
 
+    const intersect = (a: Array<string>, b: Array<string>): Array<string> =>
+        [...new Set(a)].filter(_ => new Set(b).has(_));
     const pageTags = config.page.keywordIds.split(',');
     // if this is an advertisement feature, use the page's keyword (there'll only be one)
     const popularInTags = config.page.isPaidContent
         ? pageTags
-        : intersection(whitelistedTags, pageTags);
+        : intersect(whitelistedTags, pageTags);
 
     if (popularInTags.length) {
         return `/popular-in-tag/${popularInTags[0]}.json`;


### PR DESCRIPTION
## What does this change?

`lodash.intersection` seems to [be quite heavy (1Kb)](http://cost-of-modules.herokuapp.com/?p=lodash.intersection@2.4.1), so let's replace it with the power of ES6!

## What is the value of this and can you measure success?

Less code.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.