### PR TITLE
Update sbt-scalastyle to 0.9.0

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -81,7 +81,7 @@ trait Prototypes {
     testOptions in Test := Nil,
     concurrentRestrictions in Global := List(Tags.limit(Tags.Test, 4)),
 
-    checkScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Test).toTask("").value,
+    checkScalastyle := org.scalastyle.sbt.ScalastylePlugin.autoImport.scalastyle.in(Test).toTask("").value,
     (test in Test) := (test in Test).dependsOn(checkScalastyle).value,
 
     // Copy unit test resources https://groups.google.com/d/topic/play-framework/XD3X6R-s5Mc/discussion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,4 +28,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("org.jetbrains.teamcity.plugins" % "sbt-teamcity-logger" % "0.3.0")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")


### PR DESCRIPTION
I was trying to use this project to benchmark scalac via an sbt source
dependency, but sbt-scalastyle broke bincompat between 0.8.0 and 0.9.0, and
compiling the build failed in the existence of a more up-to-date version.

Thanks to this improvement, I can use guardian/frontend for profiling of
scalac. See work in progress
[here](https://github.com/scalacenter/scalac-profiling).