### PR TITLE
Update list ids

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -392,7 +392,8 @@ object EmailNewsletters {
     teaser = "A weekly hit of style with substance. The best of the week’s fashion brought to you with expertise, humour and irreverence",
     description = "A weekly hit of style with substance. Smart fashion writing and chic shopping galleries delivered straight to your inbox. Sign up for our Friday email for the best of the week’s fashion brought to you with expertise, humour and irreverence",
     frequency = "Every Monday",
-    listId = 105,
+    listId = 3947,
+    aliases = List(105),
     tone = Some("feature"),
     signupPage = Some("/fashion/2016/aug/18/sign-up-for-the-guardians-fashion-email")
   )

--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -276,7 +276,6 @@ object EmailNewsletters {
     description = "Get lost in a great story. From politics to fashion, international investigations to new thinking, culture to crime - we’ll bring you the biggest ideas and the arguments that matter. Sign up to have the Guardian’s award-winning long reads emailed to you every Saturday morning",
     frequency = "Every Saturday",
     listId = 3322,
-    aliases = List(3890),
     tone = Some("feature"),
     signupPage = Some("/news/2015/jul/20/sign-up-to-the-long-read-email"),
     exampleUrl = Some("/email/the-long-read")


### PR DESCRIPTION
## What does this change?

Changes to email lists:

1) Remove long reads alias
- All subscribers have been migrated from 3890 to 3322

2) Change fashion statement id to 3947 and add 105 as alias

A new version of the email will be sent to this list id.  Users can also sign up using
https://www.theguardian.com/info/ng-interactive/2017/jul/25/sign-up-for-the-fashion-statement-email

## What is the value of this and can you measure success?

Tidying up from previous testing and also allows testing of fashion statement email

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
