### PR TITLE
Do not recompile when ui/dist changes

### DIFF
--- a/common/app/rendering/core/JavascriptRendering.scala
+++ b/common/app/rendering/core/JavascriptRendering.scala
@@ -2,6 +2,7 @@ package rendering.core
 
 import java.io._
 import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 import javax.script.{CompiledScript, SimpleScriptContext}
 
 import common.Logging
@@ -95,11 +96,9 @@ trait JavascriptRendering extends Logging {
     new ByteArrayInputStream(pre.getBytes(StandardCharsets.UTF_8))
   }
 
-  private def loadFile(fileName: String): Try[InputStream] = {
-    Option(getClass.getClassLoader.getResourceAsStream(fileName)) match {
-      case Some(stream) => Success(stream)
-      case None => Failure(new FileNotFoundException(s"${this.getClass.getSimpleName}: Cannot find file '$fileName'. Have you run `make ui-compile`?"))
-    }
+  private def loadFile(file: String): Try[InputStream] = {
+    Try(Files.newInputStream(Paths.get(file)))
+      .recoverWith { case f => Failure(new FileNotFoundException(s"${f.getLocalizedMessage}. Have you run `make ui-compile`?")) }
   }
 
 }

--- a/common/app/rendering/core/RenderingActor.scala
+++ b/common/app/rendering/core/RenderingActor.scala
@@ -11,7 +11,7 @@ case class RenderingException(error: String) extends RuntimeException(error)
 
 class RenderingActor extends Actor with JavascriptRendering {
 
-  override def javascriptFile: String = "ui.bundle.server.js"
+  override def javascriptFile: String = "ui/dist/ui.bundle.server.js"
 
   override def receive: Receive = {
     case Rendering(renderable, appContext) =>

--- a/common/test/rendering/core/JavascriptRenderingTest.scala
+++ b/common/test/rendering/core/JavascriptRenderingTest.scala
@@ -19,8 +19,10 @@ class JavascriptRenderingTest
     override def javascriptFile = jsFile
   }
 
+  val baseDir = "common/test/resources/components"
+
   "Rendering" should "return correct HTML string" in {
-    val renderer = new TestJavascriptRendering("components/TestButtonComponent.js")
+    val renderer = new TestJavascriptRendering(s"$baseDir/TestButtonComponent.js")
     val state: Option[JsObject] = Some(JsObject(Seq("title" -> JsString("my title"))))
     renderer.render(state) should be (Try("<button type='button'>my title</button>"))
   }

--- a/common/test/rendering/core/RenderingActorTest.scala
+++ b/common/test/rendering/core/RenderingActorTest.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
   implicit lazy val timeout = new Timeout(2.seconds)
 
   class TestRenderingActor extends RenderingActor {
-    override def javascriptFile: String = "components/TestButtonComponent.js"
+    override def javascriptFile: String = "common/test/resources/components/TestButtonComponent.js"
   }
 
   lazy val actor = actorSystem.actorOf(Props(new TestRenderingActor))
@@ -36,7 +36,7 @@ import scala.util.{Failure, Success, Try}
     val f = (actor ? Rendering(component, testContext)).mapTo[Try[String]]
     Await.result(f, timeout.duration) match {
       case Success(s) => s should not be(empty)
-      case Failure(e) => fail("A string should have been returned")
+      case Failure(e) => fail(s"A string should have been returned. Error: $e")
     }
   }
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -36,8 +36,7 @@ trait Prototypes {
     cleanAll := Def.taskDyn {
       val allProjects = ScopeFilter(inAnyProject)
       clean.all(allProjects)
-    }.value,
-    unmanagedResourceDirectories in Compile += file("ui/dist")
+    }.value
   )
 
   val frontendIntegrationTestsSettings = Seq (
@@ -139,6 +138,9 @@ trait Prototypes {
     .settings(libraryDependencies ++= Seq(macwire, commonsIo))
     .settings(packageName in Universal := applicationName)
     .settingSets(settingSetsOrder)
+    .settings(
+      mappings in Universal ++= (file("ui/dist") ** "*").get.map { f => f.getAbsoluteFile -> f.toString }
+    )
   }
 
   def library(applicationName: String): Project = {


### PR DESCRIPTION
Dealing with ui/dir as an unmanagnedResourcesDirectory leads to sbt
watching any changes made to its content and requires recompiling which
is useless since it is a javascript file that is only read/processed at runtime.
This patch changes how we access the UI bundle file, as a file in the filesystem rather than a file added to the classpath

## What is the value of this and can you measure success?
Change of the ui bundle file doesn't require sbt compilation. (ie: faster dev feedback when only working on the UI)

## Tested in CODE?
Yes
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
