### PR TITLE
Warming up rendering actor at startup

### DIFF
--- a/common/app/rendering/core/JavascriptRendering.scala
+++ b/common/app/rendering/core/JavascriptRendering.scala
@@ -6,12 +6,10 @@ import java.nio.file.{Files, Paths}
 import javax.script.{CompiledScript, SimpleScriptContext}
 
 import common.Logging
-import model.ApplicationContext
-import play.api.Mode
 import play.api.libs.json.{JsValue, Json}
 import rendering.core.JavascriptEngine.EvalResult
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 
 trait JavascriptRendering extends Logging {
 
@@ -20,12 +18,11 @@ trait JavascriptRendering extends Logging {
   private implicit val scriptContext = createContext()
   private val memoizedJs: Try[EvalResult] = loadJavascript()
 
-  def render(props: Option[JsValue] = None)(implicit ac: ApplicationContext): Try[String] = for {
+  def render(props: Option[JsValue] = None, forceReload: Boolean = false): Try[String] = for {
     propsObject <- encodeProps(props)
-    js <- if(ac.environment.mode == Mode.Dev) loadJavascript() else memoizedJs // Reloading the javascript bundle every time when in dev mode
+    js <- if(forceReload) loadJavascript() else memoizedJs
     rendering <- JavascriptEngine.invoke(js, "render", propsObject)
   } yield rendering
-
 
   private def createContext(): SimpleScriptContext = {
     val context = new SimpleScriptContext()

--- a/common/app/rendering/core/Renderer.scala
+++ b/common/app/rendering/core/Renderer.scala
@@ -23,7 +23,8 @@ class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionCon
   implicit val timeout = Timeout(timeoutValue.seconds)
 
   def render[R <: Renderable](renderable: R): Future[Html] = {
-    (actor ? Rendering(renderable, ac))
+    val forceReload = ac.environment.mode == Mode.Dev
+    (actor ? Rendering(renderable, forceReload))
       .mapTo[Try[String]]
       .recover { case t => Try(throw t)}
       .map {

--- a/common/app/rendering/core/RenderingActor.scala
+++ b/common/app/rendering/core/RenderingActor.scala
@@ -1,11 +1,11 @@
 package rendering.core
 
 import akka.actor.Actor
-import model.ApplicationContext
+import common.StopWatch
 import rendering.Renderable
 import scala.util.Try
 
-case class Rendering(renderable: Renderable, ac: ApplicationContext)
+case class Rendering(renderable: Renderable, forceReload: Boolean = false)
 
 case class RenderingException(error: String) extends RuntimeException(error)
 
@@ -13,9 +13,18 @@ class RenderingActor extends Actor with JavascriptRendering {
 
   override def javascriptFile: String = "ui/dist/ui.bundle.server.js"
 
+  override def preStart: Unit = {
+    // Warming up the script engine
+    val stopWatch = new StopWatch
+    (1 to 25).foreach(_ => render(None))
+    log.info(s"Warming up rendering actor completed in ${stopWatch.elapsed}s")
+
+    super.preStart()
+  }
+
   override def receive: Receive = {
-    case Rendering(renderable, appContext) =>
-      sender ! render(renderable.props)(appContext)
+    case Rendering(renderable, forceReload) =>
+      sender ! render(renderable.props, forceReload)
     case  _ =>
       sender ! Try(throw new RenderingException("RenderingActor received an unknown message"))
   }

--- a/common/test/rendering/core/RenderingActorTest.scala
+++ b/common/test/rendering/core/RenderingActorTest.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success, Try}
     val component = new Renderable {
       override def props: Option[JsValue] = Some(Json.obj("title" -> "my title"))
     }
-    val f = (actor ? Rendering(component, testContext)).mapTo[Try[String]]
+    val f = (actor ? Rendering(component)).mapTo[Try[String]]
     Await.result(f, timeout.duration) match {
       case Success(s) => s should not be(empty)
       case Failure(e) => fail(s"A string should have been returned. Error: $e")


### PR DESCRIPTION
Nashorn script engine has quite a slow cold startup. To remedy the
problem we are warming it up by executing 25 empty renderings before a
rendering actor starts.

Eventually the healthcheck internal endpoints will be rendered using the javascript engine and therefore warming up will always happen before the instance receives any traffic. Not possible to ensure the same with the 404 page though.

## What is the value of this and can you measure success?
First rendering are not slow anymore

## Tested in CODE?
Yes