### PR TITLE
Update discussion switch to stop all requests from frontend

### DIFF
--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -11,7 +11,7 @@ import conf.Configuration
   feature("Analytics") {
 
 
-    conf.switches.Switches.CommentsVisibleOnArticleSwitch.switchOff()
+    conf.switches.Switches.EnableDiscussionSwitch.switchOff()
     // Feature
 
     info("In order understand how people are using the website and provide data for auditing")

--- a/common/app/conf/switches/DiscussionSwitches.scala
+++ b/common/app/conf/switches/DiscussionSwitches.scala
@@ -43,4 +43,14 @@ trait DiscussionSwitches {
     exposeClientSide = true
   )
 
+  val EnableDiscussionSwitch = Switch(
+    SwitchGroup.Discussion,
+    "enable-discussion-switch",
+    "When OFF, no requests will be possible from dotcom to DAPI and the comment UI will be removed",
+    owners = Seq(Owner.withGithub("Calum-Campbell")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -146,15 +146,6 @@ trait PerformanceSwitches {
     exposeClientSide = true
   )
 
-  val CommentsVisibleOnArticleSwitch = Switch(
-    SwitchGroup.Performance,
-    "comments-visible-on-article",
-    "If this switch is on, comments are displayed on articles on dotcom. This switch only show/hides the UI from dotcom and does not disable any underlying services/endpoints etc.",
-    owners = Seq(Owner.withGithub("Calum-Campbell")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true
-  )
 
   val DiscussionPageSizeSwitch = Switch(
     SwitchGroup.Performance,

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -83,7 +83,7 @@
 
 
 @if(isCommentable) {
-    @if(CommentsVisibleOnArticleSwitch.isSwitchedOn) {
+    @if(EnableDiscussionSwitch.isSwitchedOn) {
         <div id="comments" class="discussion discussion--not-staff discussion--loading js-comments
         @if(discussionClosed) {discussion--closed} else {discussion--open}
         u-cf"

--- a/discussion/app/discussion/api/DiscussionApiException.scala
+++ b/discussion/app/discussion/api/DiscussionApiException.scala
@@ -8,6 +8,7 @@ import play.api.mvc.Results.{InternalServerError, NotFound}
 sealed abstract class DiscussionApiException(msg: String) extends RuntimeException(msg)
 case class NotFoundException(msg: String) extends DiscussionApiException(msg)
 case class OtherException(msg: String) extends DiscussionApiException(msg)
+case class ServiceUnavailableException(msg:String) extends DiscussionApiException(msg)
 
 object DiscussionApiException {
 

--- a/static/src/javascripts-legacy/bootstraps/enhanced/common.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/common.js
@@ -225,7 +225,7 @@ define([
             },
 
             initDiscussion: function () {
-                if (config.switches.commentsVisibleOnArticle) {
+                if (config.switches.enableDiscussionSwitch) {
                     CommentCount.init();
                 }
             },

--- a/static/src/javascripts-legacy/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/trail.js
@@ -92,7 +92,7 @@ define([
     }
 
     function initDiscussion() {
-        if (config.switches.commentsVisibleOnArticle && config.page.commentable) {
+        if (config.switches.enableDiscussionSwitch && config.page.commentable) {
             var el = qwery('.discussion')[0];
             if (el) {
                 new DiscussionLoader().attachTo(el);

--- a/static/src/javascripts-legacy/projects/common/modules/crosswords/comments.js
+++ b/static/src/javascripts-legacy/projects/common/modules/crosswords/comments.js
@@ -8,7 +8,7 @@ define([
     qwery
 ) {
     return function () {
-        if (config.switches.commentsVisibleOnArticle && config.page.commentable) {
+        if (config.switches.enableDiscussionSwitch && config.page.commentable) {
             var el = qwery('.discussion')[0];
             if (el) {
                 new DiscussionLoader().attachTo(el);

--- a/static/src/javascripts-legacy/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts-legacy/projects/common/modules/discussion/api.js
@@ -26,22 +26,26 @@ define([
      * @return {Reqwest} a promise
      */
     Api.send = function (endpoint, method, data) {
-        data = data || {};
+        if (config.switches.enableDiscussionSwitch) {
+            data = data || {};
 
-        var request = ajax.ajax({
-            url: Api.root + endpoint,
-            type: (method === 'get') ? 'jsonp' : 'json',
-            method: method,
-            crossOrigin: true,
-            data: data,
-            headers: {
-                'D2-X-UID': Api.d2Uid,
-                'GU-Client': Api.clientHeader
-            },
-            withCredentials: true
-        });
+            var request = ajax.ajax({
+                url: Api.root + endpoint,
+                type: (method === 'get') ? 'jsonp' : 'json',
+                method: method,
+                crossOrigin: true,
+                data: data,
+                headers: {
+                    'D2-X-UID': Api.d2Uid,
+                    'GU-Client': Api.clientHeader
+                },
+                withCredentials: true
+            });
 
-        return request;
+            return request;
+        } else {
+            throw new Error('Discussion features have been disabled');
+        }
     };
 
     /**

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -101,7 +101,7 @@ class CommercialFeatures {
             this.dfpAdvertising &&
             !this.adFree &&
             !isMinuteArticle &&
-            config.switches.commentsVisibleOnArticle &&
+            config.switches.enableDiscussionSwitch &&
             config.page.commentable &&
             identityApi.isUserLoggedIn() &&
             (!isLiveBlog || isWidePage);

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
@@ -78,7 +78,7 @@ describe('Commercial features', () => {
         config.switches = {
             outbrain: true,
             commercial: true,
-            commentsVisibleOnArticle: true,
+            enableDiscussionSwitch: true,
             adFreeSubscriptionTrial: false,
         };
 

--- a/static/test/javascripts-legacy/spec/common/discussion/comment-box.spec.js
+++ b/static/test/javascripts-legacy/spec/common/discussion/comment-box.spec.js
@@ -7,7 +7,8 @@ define([
     'fixtures/discussion/api-post-comment-valid',
     'fixtures/discussion/api-post-comment-error-discussion-closed',
     'fixtures/discussion/api-post-comment-error-read-only-mode',
-    'common/modules/discussion/comment-box'
+    'common/modules/discussion/comment-box',
+    'lib/config'
 ], function (
     Id,
     bean,
@@ -17,7 +18,8 @@ define([
     apiPostValidCommentResp,
     apiPostValidCommentButDiscussionClosed,
     apiPostValidCommentButReadOnlyMode,
-    CommentBox
+    CommentBox,
+    config
 ) {
     describe('Comment box', function () {
         var server,
@@ -161,6 +163,7 @@ define([
 
             it('should error on discussion closed', function () {
                 expect(commentBox.getElem('error')).toBeUndefined();
+                config.switches.enableDiscussionSwitch = true;
                 commentBox.getElem('body').value = validCommentText;
                 server.respondWith('POST', /.*/, [409, { 'Content-Type': 'text/html', 'Content-Length': apiPostValidCommentButDiscussionClosed.length }, apiPostValidCommentButDiscussionClosed]);
                 bean.fire(commentBox.elem, 'submit');


### PR DESCRIPTION
## What does this change?
- Create new discussion-frontend switch that will completely kill requests to DAPI from Frontend (and consume the behaviour of the old UI switch into this one).
- Will also remove the comment and discussion UI from the site

## What is the value of this and can you measure success?
- Creates a single switch for the frontend to turn of commenting, discussion and requests to DAPI.
- This is clearer than the old switch which just turned off UI on web. 

## Does this affect other platforms - Amp, Apps, etc?
Shouldn't do

## Screenshots
 
![image](https://user-images.githubusercontent.com/14179210/29172814-12e12632-7dd9-11e7-9f50-550c91d2cdf9.png)

## Tested in CODE?
Not yet
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
