### PR TITLE
install UI deps as part of main install

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ list: # PRIVATE
 # Install all 3rd party dependencies.
 install: check-node check-yarn
 	@yarn install -s
+	@make ui-install
 
 # Remove all 3rd party dependencies.
 uninstall: # PRIVATE
@@ -135,3 +136,6 @@ ui-compile:
 
 ui-watch:
 	@cd ui && yarn watch -s
+
+ui-install:
+	@cd ui && yarn install -s


### PR DESCRIPTION
## What does this change?

installs UI deps as part of `make install`

## What is the value of this and can you measure success?

since we sticking with UI in frontend, this stops UI listing errors for people who've not touched UI