### PR TITLE
Update GLabs Traffic Driver targeting (and spacefinder rules)

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -51,7 +51,7 @@ class CommercialFeatures {
         const glabsTrafficDriverSlot =
             config.hasTone('Features') &&
             !config.page.isPaidContent &&
-            ['sport', 'lifeandstyle', 'fashion', 'food', 'travel'].includes(
+            ['sport', 'lifeandstyle', 'fashion', 'football', 'travel'].includes(
                 config.page.section
             );
 

--- a/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver-slot.js
@@ -26,7 +26,36 @@ const rules = {
     minAbove: 0,
     minBelow: 0,
     clearContentMeta: 0,
-    selectors: null,
+    selectors: {
+        ' .element-rich-link': {
+            minAbove: 200,
+            minBelow: 200,
+        },
+        ' .element-image': {
+            minAbove: 50,
+            minBelow: 50,
+        },
+        ' .player': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > h1': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > h2': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > *:not(p):not(h2):not(blockquote)': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' .ad-slot': {
+            minAbove: 100,
+            minBelow: 100,
+        },
+    },
     filter: (slot: Object, index: number): boolean => {
         runningWordCount += wordCount(slot.element);
         return index >= 2 && runningWordCount >= 200;


### PR DESCRIPTION
## What does this change?
The sections on which this slot should be active have been altered slightly. Food is out (as it isn't a section *sigh*) and Fashion is in.

In addition to the targeting changes, I've added in more prescriptive spacefinder rules so that the traffic drivers won't clash with other inline/left elements such as rich-links.

@guardian/commercial-dev 