### PR TITLE
Flashing elements

### DIFF
--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -74,7 +74,7 @@ object FixedContainers {
 
   val footballTeamFixtures = slices(TTT)
 
-  val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher"))
+  val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher", "flashing-image"))
 
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -23,6 +23,7 @@ import { videojs } from 'bootstraps/enhanced/media/video-player';
 import loadingTmpl from 'raw-loader!common/views/ui/loading.html';
 import { isAdFreeUser } from 'commercial/modules/user-features';
 import { loadScript } from 'lib/load-script';
+import accessibility from 'common/modules/accessibility/main';
 
 const initLoadingSpinner = (player: any): void => {
     player.loadingSpinner.contentEl().innerHTML = loadingTmpl;
@@ -293,7 +294,10 @@ const enhanceVideo = (
                     });
 
                     playerSetupComplete.then(() => {
-                        if (autoplay) {
+                        if (
+                            autoplay &&
+                            accessibility.isOn('flashing-elements')
+                        ) {
                             player.play();
                         }
                     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -7,6 +7,7 @@ import $ from 'lib/$';
 import config from 'lib/config';
 import { isIOS, isAndroid, isBreakpoint } from 'lib/detect';
 import debounce from 'lodash/functions/debounce';
+import accessibility from 'common/modules/accessibility/main';
 
 const players = {};
 
@@ -116,11 +117,15 @@ const shouldAutoplay = (atomId: string): boolean => {
             )) ||
         false;
 
+    const flashingElementsAllowed = () =>
+        accessibility.isOn('flashing-elements');
+
     return (
         config.page.contentType === 'Video' &&
         isInternalReferrer() &&
         !isAutoplayBlockingPlatform() &&
-        isMainVideo()
+        isMainVideo() &&
+        flashingElementsAllowed()
     );
 };
 


### PR DESCRIPTION
## What does this change?

If 'flashing-elements' accessibility pref is disabled:

* hide thrashers
* prevents video autoplay

Note, this does not cover commercial videos or ads.

(Pre-existing) code which actually toggles display is here: https://github.com/guardian/frontend/blob/master/static/src/stylesheets/module/_accessibility.scss

## What is the value of this and can you measure success?

Better UX/accessibility.

## Does this affect other platforms - Amp, Apps, etc?

-
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No.

## Screenshots

## Tested in CODE?

Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
