### PR TITLE
Use $ReadOnlyArray type for immutable covariant arrays

### DIFF
--- a/dev/flow-typed-guardian-frontend/ab-tests.js
+++ b/dev/flow-typed-guardian-frontend/ab-tests.js
@@ -24,7 +24,7 @@ declare type ABTest = {
     showForSensitive?: boolean,
     idealOutcome?: string,
     dataLinkNames?: string,
-    variants: Array<Variant>,
+    variants: $ReadOnlyArray<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,
 };
@@ -41,7 +41,7 @@ declare type EpicABTest = AcquisitionsABTest & {
     overrideCanRun: boolean,
     showToContributorsAndSupporters: boolean,
     pageCheck: (page: Object) => boolean,
-    locations: Array<string>,
+    locations: $ReadOnlyArray<string>,
     locationCheck: (location: string) => boolean,
     useTargetingTool: boolean,
     insertEvent: string,
@@ -50,7 +50,7 @@ declare type EpicABTest = AcquisitionsABTest & {
 
 declare type InitEpicABTestVariant = {
     id: string,
-    products: OphanProduct[],
+    products: $ReadOnlyArray<OphanProduct>,
     options: Object
 };
 
@@ -66,7 +66,7 @@ declare type InitEpicABTest = {
     audienceCriteria: string,
     idealOutcome: string,
     campaignId: string,
-    variants: InitEpicABTestVariant[],
+    variants: $ReadOnlyArray<InitEpicABTestVariant>,
 
     componentType?: OphanComponentType,
     // locations is a filter where empty is taken to mean 'all'

--- a/dev/flow-typed-guardian-frontend/ophan.js
+++ b/dev/flow-typed-guardian-frontend/ophan.js
@@ -6,7 +6,7 @@
 declare type OphanABEvent = {
     variantName: string,
     complete: string | boolean,
-    campaignCodes?: Array<string>,
+    campaignCodes?: $ReadOnlyArray<string>,
 };
 
 /**
@@ -49,9 +49,9 @@ declare type OphanComponentType =
 declare type OphanComponent = {|
     type: OphanComponentType,
     id?: string,
-    products: OphanProduct[],
+    products: $ReadOnlyArray<OphanProduct>,
     campaignCode?: string,
-    labels: string[]
+    labels: $ReadOnlyArray<string>
 |};
 
 declare type OphanComponentEvent = {|

--- a/static/src/javascripts/projects/admin/bootstraps/abtests.js
+++ b/static/src/javascripts/projects/admin/bootstraps/abtests.js
@@ -7,7 +7,7 @@ import { ABTestReportItem as ReportItem } from 'admin/modules/abtests/abtest-rep
 import { Audience } from 'admin/modules/abtests/audience';
 
 const renderTests = (
-    tests: Array<any>,
+    tests: $ReadOnlyArray<ABTest>,
     active: boolean,
     elem: ?Element
 ): Array<any> => {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -6,7 +6,7 @@ const submitComponentEvent = (componentEvent: OphanComponentEvent) => {
 };
 
 export const submitEpicInsertEvent = (
-    products: OphanProduct[],
+    products: $ReadOnlyArray<OphanProduct>,
     campaignCode: string,
     type: OphanComponentType = 'ACQUISITIONS_EPIC'
 ) => {
@@ -22,7 +22,7 @@ export const submitEpicInsertEvent = (
 };
 
 export const submitEpicViewEvent = (
-    products: OphanProduct[],
+    products: $ReadOnlyArray<OphanProduct>,
     campaignCode: string,
     type: OphanComponentType = 'ACQUISITIONS_EPIC'
 ) => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -177,7 +177,7 @@ const registerIframeListener = (iframeId: string) => {
 
 const makeABTestVariant = (
     id: string,
-    products: OphanProduct[],
+    products: $ReadOnlyArray<OphanProduct>,
     options: Object,
     parentTest: EpicABTest
 ): Variant => {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -4,7 +4,6 @@ import fakeConfig from 'lib/config';
 import fakeOphan from 'ophan/ng';
 import { commercialFeatures as fakeCommercialFeatures } from 'commercial/modules/commercial-features';
 import { engagementBannerParams as engagementBannerParams_ } from 'common/modules/commercial/membership-engagement-banner-parameters';
-import { membershipEngagementBannerTests as fakeMembershipEngagementTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import { membershipEngagementBannerInit } from 'common/modules/commercial/membership-engagement-banner';
 
 const engagementBannerParams: any = engagementBannerParams_;
@@ -27,6 +26,28 @@ jest.mock('common/views/svgs', () => ({
     inlineSvg: jest.fn(() => ''),
 }));
 jest.mock('common/modules/experiments/acquisition-test-selector', () => []);
+jest.mock(
+    'common/modules/experiments/tests/membership-engagement-banner-tests',
+    () => ({
+        membershipEngagementBannerTests: [
+            {
+                campaignId: 'fake-campaign-id',
+                id: 'fake-id',
+                start: '2017-01-01',
+                expiry: '2027-01-01',
+                author: 'fake-author',
+                description: 'fake-description',
+                audience: 1,
+                audienceOffset: 0,
+                successMeasure: 'fake success measure',
+                audienceCriteria: 'fake audience criteria',
+                variants: [],
+                canRun: () => true,
+                componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+            },
+        ],
+    })
+);
 jest.mock(
     'common/modules/commercial/membership-engagement-banner-parameters',
     () => ({
@@ -159,21 +180,6 @@ describe('Membership engagement banner', () => {
                 colourStrategy: jest.fn(() => 'fake-colour-class'),
                 interactionOnMessageShow: {},
             }));
-            fakeMembershipEngagementTests.push({
-                campaignId: 'fake-campaign-id',
-                id: 'fake-id',
-                start: '2017-01-01',
-                expiry: '2027-01-01',
-                author: 'fake-author',
-                description: 'fake-description',
-                audience: 1,
-                audienceOffset: 0,
-                successMeasure: 'fake success measure',
-                audienceCriteria: 'fake audience criteria',
-                variants: [],
-                canRun: () => true,
-                componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-            });
             fakeVariantFor.mockImplementationOnce(() => ({
                 id: 'fake-user-variant-id',
                 engagementBannerParams: {},
@@ -181,10 +187,6 @@ describe('Membership engagement banner', () => {
             showBanner = membershipEngagementBannerInit().then(() => {
                 fakeMediator.emit('modules:onwards:breaking-news:ready', false);
             });
-        });
-
-        afterEach(() => {
-            fakeMembershipEngagementTests.pop();
         });
 
         it('correct campaign code', () =>

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
@@ -91,10 +91,10 @@ const registerCompleteEvent = (complete: boolean) => (test: ABTest): void => {
     }
 };
 
-export const registerCompleteEvents = (tests: Array<ABTest>): void =>
+export const registerCompleteEvents = (tests: $ReadOnlyArray<ABTest>): void =>
     tests.forEach(registerCompleteEvent(true));
 
-export const registerImpressionEvents = (tests: Array<ABTest>): void =>
+export const registerImpressionEvents = (tests: $ReadOnlyArray<ABTest>): void =>
     tests.filter(defersImpression).forEach(registerCompleteEvent(false));
 
 export const buildOphanPayload = (): OphanABPayload => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-test-clash.js
@@ -2,18 +2,18 @@
 import { isInVariant } from 'common/modules/experiments/utils';
 import { abTestClashData as acquisitionsAbTestClashData } from 'common/modules/experiments/acquisition-test-selector';
 
-const emailTests: Object[] = [];
-const contributionsTests: Object[] = acquisitionsAbTestClashData;
+const emailTests: $ReadOnlyArray<ABTest> = [];
+const contributionsTests: $ReadOnlyArray<ABTest> = acquisitionsAbTestClashData;
 
-const potentiallyClashingTests: Object[] = contributionsTests.concat(
-    emailTests
-);
+const potentiallyClashingTests: $ReadOnlyArray<
+    ABTest
+> = contributionsTests.concat(emailTests);
 
 export { emailTests, contributionsTests };
 
 export const testABClash = (
     f: (test: ABTest, variant: Variant) => boolean,
-    tests: Object[]
+    tests: $ReadOnlyArray<ABTest>
 ): boolean =>
     tests.some(test =>
         test.variants
@@ -28,5 +28,5 @@ export const testABClash = (
     );
 
 export const userIsInAClashingAbTest = (
-    tests: Object[] = potentiallyClashingTests
+    tests: $ReadOnlyArray<ABTest> = potentiallyClashingTests
 ) => testABClash(isInVariant, tests);

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,7 +10,7 @@ import { tailorSurvey } from 'common/modules/experiments/tests/tailor-survey';
 import { acquisitionsEpicElectionInteractiveEnd } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
 import { acquisitionsEpicElectionInteractiveSlice } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-slice';
 
-export const TESTS: Array<ABTest> = [
+export const TESTS: $ReadOnlyArray<ABTest> = [
     paidContentVsOutbrain2,
     getAcquisitionTest(),
     tailorSurvey,
@@ -21,7 +21,7 @@ export const TESTS: Array<ABTest> = [
     .concat(membershipEngagementBannerTests)
     .filter(Boolean);
 
-export const getActiveTests = (): Array<ABTest> =>
+export const getActiveTests = (): $ReadOnlyArray<ABTest> =>
     TESTS.filter(test => {
         if (isExpired(test.expiry)) {
             removeParticipation(test);
@@ -30,7 +30,7 @@ export const getActiveTests = (): Array<ABTest> =>
         return true;
     });
 
-export const getExpiredTests = (): Array<ABTest> =>
+export const getExpiredTests = (): $ReadOnlyArray<ABTest> =>
     TESTS.filter(test => isExpired(test.expiry));
 
 export const getTest = (id: string): ?ABTest => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -55,7 +55,7 @@ export const shouldRunTest = (testId: string, variantName: string) => {
     );
 };
 
-export const segment = (tests: Array<ABTest>) =>
+export const segment = (tests: $ReadOnlyArray<ABTest>) =>
     tests.forEach(allocateUserToTest);
 
 export const forceSegment = (testId: string, variantName: string) => {
@@ -98,4 +98,4 @@ export const segmentUser = () => {
     cleanParticipations(TESTS);
 };
 
-export const run = (tests: Array<ABTest>) => tests.forEach(runTest);
+export const run = (tests: $ReadOnlyArray<ABTest>) => tests.forEach(runTest);

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -18,7 +18,7 @@ import { acquisitionsEpicRecurringContributionUkSupportProposition } from 'commo
 /**
  * acquisition tests in priority order (highest to lowest)
  */
-const tests: AcquisitionsABTest[] = [
+const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     payInEpic,
     acquisitionsEpicRecurringContributionUkSupportProposition,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,3 +1,5 @@
 // @flow
 
-export const membershipEngagementBannerTests: AcquisitionsABTest[] = [];
+export const membershipEngagementBannerTests: $ReadOnlyArray<
+    AcquisitionsABTest
+> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.js
@@ -25,7 +25,7 @@ export const removeParticipation = (toRemove: { id: string }): void => {
 
 // Removes any tests from localstorage that have been
 // renamed/deleted from the backend
-export const cleanParticipations = (tests: Array<ABTest>): void =>
+export const cleanParticipations = (tests: $ReadOnlyArray<ABTest>): void =>
     Object.keys(getParticipations()).forEach(k => {
         if (typeof config.switches[`ab${k}`] === 'undefined') {
             removeParticipation({ id: k });


### PR DESCRIPTION
Convert some `Array<T>` (aka `T[]`) types to `$ReadOnlyArray<T>`

This has the following advantages:
- Enforces immutability of these arrays, which reduces the likelihood of bugs
- Allows arrays to be covariant (thus fixing an issue in #17637 where I had to use `Object[]` to get around the fact that mutable arrays are not covariant)

The latter advantage only really applies where the parameterised type `T` is a subtype or supertype of another since otherwise the variance of higher-order types using `T` is irrelevant. So it's relevant for `ABTest` since we have subtypes `AcquisitionsABTest` and `EpicABTest`. It's less important for, say, `OphanProduct`