### PR TITLE
Add AB switch to commercial features.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -49,6 +49,7 @@ class CommercialFeatures {
         const newRecipeDesign =
             config.page.showNewRecipeDesign && config.tests.abNewRecipeDesign;
         const glabsTrafficDriverSlots =
+            switches.abGlabsTrafficDriverSlots &&
             config.hasTone('Features') &&
             !config.page.isPaidContent &&
             ['sport', 'lifeandstyle', 'fashion', 'football', 'travel'].includes(


### PR DESCRIPTION
The AB switch should be checked before running the GLabs test. This was there previously, but must have fallen out during a merge...