### PR TITLE
Remove whitespace from header links

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,22 +1,53 @@
 package navigation
 
 import conf.Configuration.id.membershipUrl
+import play.api.mvc.RequestHeader
 
 object UrlHelpers {
 
-  def getJobUrl(editionId: String): String = {
+  def getJobUrl(editionId: String): String =
     if (editionId == "au") {
       "https://jobs.theguardian.com/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"
     } else {
       s"https://jobs.theguardian.com?INTCMP=jobs_${editionId}_web_newheader"
     }
-  }
 
-  def getContributionOrSupporterUrl(editionId: String): String = {
+  def getContributionOrSupporterUrl(editionId: String): String =
     if(editionId == "us") {
       "https://contribute.theguardian.com/us?INTCMP=gdnwb_copts_co_dotcom_header"
     } else {
       s"${membershipUrl}/${editionId}/supporter?INTCMP=mem_${editionId}_web_newheader"
     }
+
+  object oldNav {
+    def jobsUrl(edition: String)(implicit request: RequestHeader): String =
+      if(mvt.ABNewDesktopHeaderControl.isParticipating) {
+        s"https://jobs.theguardian.com/?INTCMP=jobs_${edition}_web_newheader_control"
+      } else {
+        s"https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_${edition.toUpperCase}_GU_JOBS"
+      }
+
+    def soulmatesUrl(edition: String)(implicit request: RequestHeader): String =
+      if(mvt.ABNewDesktopHeaderControl.isParticipating) {
+        s"https://soulmates.theguardian.com/?INTCMP=soulmates_${edition}_web_newheader_control"
+      } else {
+        s"https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_${edition.toUpperCase}_GU_SOULMATES"
+      }
+
+    def holidaysUrl(implicit request: RequestHeader): String =
+      if(mvt.ABNewDesktopHeaderControl.isParticipating) {
+        "https://holidays.theguardian.com/?INTCMP=holidays_uk_web_newheader_control"
+      } else {
+        "https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav"
+      }
+
+    def masterclassesUrl(implicit request: RequestHeader): String =
+      if(mvt.ABNewDesktopHeaderControl.isParticipating) {
+        "https://www.theguardian.com/guardian-masterclasses?INTCMP=masterclasses_uk_web_newheader_control"
+      } else {
+        "https://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES"
+      }
+
   }
+
 }

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -5,6 +5,7 @@
 @import common.editions._
 @import views.support.RenderClasses
 @import views.html.fragments.topNav.editionMenu
+@import navigation.UrlHelpers.oldNav._
 
 @ellipsis() = {
     <a class="brand-bar__item--action popup__toggle"
@@ -18,38 +19,6 @@
         </span>
         <span class="control__info" data-test-id="sign-in-name">more</span>
     </a>
-}
-
-@jobsUrl(edition: String) = {
-    @if(mvt.ABNewDesktopHeaderControl.isParticipating) {
-        https://jobs.theguardian.com/?INTCMP=jobs_@{edition}_web_newheader_control
-    } else {
-        https://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_@{edition.toUpperCase}_GU_JOBS
-    }
-}
-
-@soulmatesUrl(edition: String) = {
-    @if(mvt.ABNewDesktopHeaderControl.isParticipating) {
-        https://soulmates.theguardian.com/?INTCMP=soulmates_@{edition}_web_newheader_control
-    } else {
-        https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_@{edition.toUpperCase}_GU_SOULMATES
-    }
-}
-
-@holidaysUrl = {
-    @if(mvt.ABNewDesktopHeaderControl.isParticipating) {
-        https://holidays.theguardian.com/?INTCMP=holidays_uk_web_newheader_control
-    } else {
-        https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav
-    }
-}
-
-@masterclassesUrl = {
-    @if(mvt.ABNewDesktopHeaderControl.isParticipating) {
-        https://www.theguardian.com/guardian-masterclasses?INTCMP=masterclasses_uk_web_newheader_control
-    } else {
-        https://www.theguardian.com/guardian-masterclasses?INTCMP=NGW_TOPNAV_UK_GU_MASTERCLASSES
-    }
 }
 
 <div class="brand-bar__item--right"


### PR DESCRIPTION
## What does this change?
Removes the unnecessary whitespace from a few more links in the header (the "old" one).  This was causing some errors from crawlers who don't trim the whitespace automatically.

## What is the value of this and can you measure success?
Less errors in our logs and better results for those random crawlers 🐌 

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
