### PR TITLE
Remove call to forsee function

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/common.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/common.js
@@ -326,7 +326,6 @@ define([
                 ['c-history', modules.updateHistory],
                 ['c-id-cookie-refresh', modules.idCookieRefresh],
                 ['c-history-nav', modules.showHistoryInMegaNav],
-                ['c-forsee', modules.runForseeSurvey],
                 ['c-start-register', modules.startRegister],
                 ['c-smart-banner', customSmartAppBanner.init],
                 ['c-adblock', modules.showAdblockMessage],


### PR DESCRIPTION
## What does this change?

When forsee was removed in #17636, there was one reference that was missed. This change removes a call to the now-removed `runForseeSurvey` function.

## What is the value of this and can you measure success?

Fewer Sentry errors

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
