### PR TITLE
Add success callback to GLabs AB test

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -5,7 +5,7 @@ import fastdom from 'lib/fastdom-promise';
 import { spaceFiller } from 'common/modules/article/space-filler';
 import adSizes from 'commercial/modules/ad-sizes';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import createSlot from 'commercial/modules/dfp/create-slot';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.js
@@ -1,7 +1,5 @@
 // @flow
 import waitForAdvert from 'commercial/modules/dfp/wait-for-advert';
 
-const trackAdRender = (id: string) =>
+export const trackAdRender = (id: string) =>
     waitForAdvert(id).then(_ => _.whenRendered);
-
-export default trackAdRender;

--- a/static/src/javascripts/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts/projects/commercial/modules/high-merch.js
@@ -5,7 +5,7 @@ import { getTestVariantId } from 'common/modules/experiments/utils';
 import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import { addSlot } from 'commercial/modules/dfp/add-slot';
 import createSlot from 'commercial/modules/dfp/create-slot';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { paidContentVsOutbrain2 } from 'common/modules/experiments/tests/paid-content-vs-outbrain';
 

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -5,7 +5,7 @@ import { addEventListener } from 'lib/events';
 import config from 'lib/config';
 import { isBreakpoint } from 'lib/detect';
 import fastdom from 'lib/fastdom-promise';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { register, unregister } from 'commercial/modules/messenger';

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
@@ -12,9 +12,9 @@ jest.mock('lib/detect', () => ({
 jest.mock('commercial/modules/messenger', () => ({
     register: jest.fn(),
 }));
-jest.mock('commercial/modules/dfp/track-ad-render', () => () =>
-    Promise.resolve(true)
-);
+jest.mock('commercial/modules/dfp/track-ad-render', () => ({
+    trackAdRender: () => Promise.resolve(true),
+}));
 jest.mock('lib/events', () => ({
     addEventListener: jest.fn(),
 }));

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -4,7 +4,7 @@ import fastdom from 'fastdom';
 import $ from 'lib/$';
 import config from 'lib/config';
 import { adblockInUse as adblockInUse_ } from 'lib/detect';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { loadScript } from 'lib/load-script';
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
@@ -3,11 +3,13 @@ import config from 'lib/config';
 import { adblockInUse as adblockInUse_ } from 'lib/detect';
 import plista from 'commercial/modules/third-party-tags/plista';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 
 const adblockInUse: any = adblockInUse_;
 
-jest.mock('commercial/modules/dfp/track-ad-render', () => jest.fn());
+jest.mock('commercial/modules/dfp/track-ad-render', () => ({
+    trackAdRender: jest.fn(),
+}));
 
 jest.mock('commercial/modules/commercial-features', () => ({
     commercialFeatures: {

--- a/static/src/javascripts/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/common/modules/check-dispatcher.js
@@ -7,7 +7,7 @@ import {
     contributionsTests,
     userIsInAClashingAbTest,
 } from 'common/modules/experiments/ab-test-clash';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { checks } from './check-mediator-checks';
 import { resolveCheck, waitForCheck } from './check-mediator';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver-slots.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver-slots.js
@@ -1,4 +1,10 @@
 // @flow
+import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+
+const success = advertId => complete => trackAdRender(advertId).then(complete);
+
+const successLeft = success('dfp-ad--glabs-left');
+const successInline = success('dfp-ad--glabs-inline');
 
 export const glabsTrafficDriverSlots: ABTest = {
     id: 'GlabsTrafficDriverSlots',
@@ -20,10 +26,12 @@ export const glabsTrafficDriverSlots: ABTest = {
         {
             id: 'inline',
             test: () => {},
+            success: successInline,
         },
         {
             id: 'left',
             test: () => {},
+            success: successLeft,
         },
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver-slots.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver-slots.js
@@ -1,5 +1,5 @@
 // @flow
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 
 const success = advertId => complete => trackAdRender(advertId).then(complete);
 

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -6,7 +6,7 @@ import qwery from 'qwery';
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';
-import trackAdRender from 'commercial/modules/dfp/track-ad-render';
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import memoize from 'lodash/functions/memoize';
 
 type SpacefinderOptions = {


### PR DESCRIPTION
## What does this change?
When the GLabs slot is rendered, the `complete` callback will be fired, which will make the analysis of this test easier.

@guardian/commercial-dev 