### PR TITLE
Media.js should be loaded in if media atoms are on the page

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -1,5 +1,5 @@
 // @flow
-import fastdom from 'fastdom';
+import fastdom from 'lib/fastdom-promise';
 import qwery from 'qwery';
 import raven from 'lib/raven';
 import $ from 'lib/$';
@@ -178,24 +178,24 @@ const bootEnhanced = (): void => {
         );
     }
 
-    fastdom.read(() => {
-        if (
-            (config.isMedia ||
-                qwery('video, audio, .youtube-media-atom').length) &&
-            !config.page.isHosted
-        ) {
-            require.ensure(
-                [],
-                require => {
-                    bootstrapContext(
-                        'media',
-                        require('bootstraps/enhanced/media/main').init
+    if (!config.page.isHosted) {
+        fastdom
+            .read(() => qwery('video, audio, .youtube-media-atom'))
+            .then(els => {
+                if (config.isMedia || els.length) {
+                    require.ensure(
+                        [],
+                        require => {
+                            bootstrapContext(
+                                'media',
+                                require('bootstraps/enhanced/media/main').init
+                            );
+                        },
+                        'media'
                     );
-                },
-                'media'
-            );
-        }
-    });
+                }
+            });
+    }
 
     if (config.page.contentType === 'Gallery') {
         require.ensure(

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -178,21 +178,24 @@ const bootEnhanced = (): void => {
         );
     }
 
-    if (
-        (config.isMedia || qwery('video, audio').length) &&
-        !config.page.isHosted
-    ) {
-        require.ensure(
-            [],
-            require => {
-                bootstrapContext(
-                    'media',
-                    require('bootstraps/enhanced/media/main').init
-                );
-            },
-            'media'
-        );
-    }
+    fastdom.read(() => {
+        if (
+            (config.isMedia ||
+                qwery('video, audio, .youtube-media-atom').length) &&
+            !config.page.isHosted
+        ) {
+            require.ensure(
+                [],
+                require => {
+                    bootstrapContext(
+                        'media',
+                        require('bootstraps/enhanced/media/main').init
+                    );
+                },
+                'media'
+            );
+        }
+    });
 
     if (config.page.contentType === 'Gallery') {
         require.ensure(


### PR DESCRIPTION
## What does this change?
Trello card: https://trello.com/c/Yc5YBuSa/397-web-load-mediajs-if-media-atoms-or-carousel-are-in-the-page

Media JS is loaded if there are video elements on the page, but it also has to be loaded if there are youtube atoms on the page. 

## What is the value of this and can you measure success?
Video carousels will work on sport fronts now (sport uses entirely youtube now)

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
N/A

## Tested in CODE?
Tested on a code front locally

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
