### PR TITLE
ES6 module reassignments

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -1,9 +1,9 @@
 {
   "Regis Kuckaertz": [
+    "projects/common/modules/atoms/quiz.js",
     "bootstraps/enhanced/accessibility.js",
     "bootstraps/enhanced/common.js",
     "bootstraps/enhanced/crosswords.js",
-    "lib/atob.js",
     "projects/common/modules/article/rich-links.js",
     "projects/common/modules/article/twitter.js",
     "projects/common/modules/asyncCallMerger.js",
@@ -90,7 +90,6 @@
   "Calum Campbell": [],
   "GHaberis": [],
   "Unassigned": [
-    "projects/common/modules/atoms/quiz.js",
     "projects/common/modules/atoms/story-questions.js",
     "projects/common/modules/atoms/youtube-tracking.js",
     "projects/common/modules/component.js",

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -1,102 +1,100 @@
 {
-  "Francis Carr": [],
-  "Jon Norman": [],
   "Regis Kuckaertz": [
-    "projects/common/modules/discussion/comment-count.js",
-    "projects/common/modules/discussion/comments.js",
-    "projects/common/modules/discussion/discussion-frontend.js"
-  ],
-  "Richard Nguyen": [],
-  "Kate Whalen": [],
-  "sndrs": [
     "bootstraps/enhanced/accessibility.js",
     "bootstraps/enhanced/common.js",
     "bootstraps/enhanced/crosswords.js",
-    "bootstraps/enhanced/facia.js",
-    "bootstraps/enhanced/football.js",
-    "projects/common/modules/preferences/main.js",
-    "bootstraps/enhanced/gallery.js"
-  ],
-  "Simon Adcock": [
-    "projects/common/modules/experiments/tests/paid-content-vs-outbrain.js",
-    "projects/common/modules/ui/clickstream.js",
-    "projects/common/modules/discussion/user-avatars.js",
-    "projects/common/modules/discussion/whole-discussion.js"
-  ],
-  "Nicolas Long": [
-    "projects/common/modules/ui/selection-sharing.js",
-    "bootstraps/enhanced/profile.js",
-    "bootstraps/enhanced/recipe-article.js",
-    "bootstraps/enhanced/sport.js",
-    "bootstraps/enhanced/trail.js",
-    "bootstraps/enhanced/youtube.js",
-    "bootstraps/video-embed.js",
-    "bootstraps/youtube-embed.js",
     "lib/atob.js",
-    "projects/common/modules/component.js"
-  ],
-  "Calum Campbell": [
-    "lib/picturefill.js",
-    "lib/proximity-loader.js",
-    "projects/common/modules/video/metadata.js"
-  ],
-  "GHaberis": [
-    "projects/common/modules/discussion/activity-stream.js",
-    "projects/common/modules/discussion/api.js",
-    "projects/common/modules/discussion/comment-box.js"
-  ],
-  "Gustav Pursche": [
-    "projects/common/modules/discussion/comment-box.js"
-  ],
-  "NataliaLKB": [
     "projects/common/modules/article/rich-links.js",
     "projects/common/modules/article/twitter.js",
     "projects/common/modules/asyncCallMerger.js",
-    "projects/common/modules/atoms/quiz.js",
-    "projects/common/modules/atoms/story-questions.js",
-    "projects/common/modules/atoms/youtube-tracking.js"
+    "projects/common/modules/ui/clickstream.js",
+    "projects/common/modules/ui/expandable.js",
+    "projects/common/modules/ui/faux-block-link.js"
   ],
-  "Gideon Goldberg": [],
-  "Matthew Walls": [
+  "sndrs": [
+    "bootstraps/enhanced/facia.js",
+    "bootstraps/enhanced/football.js",
+    "bootstraps/enhanced/gallery.js",
     "projects/common/modules/crosswords/cell.js",
     "projects/common/modules/crosswords/classNames.js",
     "projects/common/modules/crosswords/clues.js",
     "projects/common/modules/crosswords/comments.js",
     "projects/common/modules/crosswords/confirm-button.js",
+    "projects/common/modules/discussion/activity-stream.js",
+    "projects/common/modules/discussion/api.js"
+  ],
+  "Simon Adcock": [
+    "bootstraps/enhanced/recipe-article.js",
+    "lib/picturefill.js",
     "projects/common/modules/crosswords/constants.js",
     "projects/common/modules/crosswords/controls.js",
     "projects/common/modules/crosswords/crossword.js",
     "projects/common/modules/crosswords/grid.js",
-    "projects/common/modules/crosswords/helpers.js"
+    "projects/common/modules/crosswords/helpers.js",
+    "projects/common/modules/discussion/discussion-frontend.js",
+    "projects/common/modules/email/email.js",
+    "projects/common/modules/email/run-checks.js"
   ],
-  "Sam Desborough": [],
-  "Akash A": [
+  "Gustav Pursche": [
+    "bootstraps/enhanced/sport.js",
+    "bootstraps/enhanced/trail.js",
+    "bootstraps/enhanced/youtube.js",
     "projects/common/modules/crosswords/hidden-input.js",
     "projects/common/modules/crosswords/keycodes.js",
     "projects/common/modules/crosswords/main.js",
     "projects/common/modules/crosswords/persistence.js",
-    "projects/common/modules/crosswords/series.js"
+    "projects/common/modules/crosswords/series.js",
+    "projects/common/modules/discussion/user-avatars.js",
+    "projects/common/modules/discussion/whole-discussion.js"
   ],
-  "dominickendrick": [
-    "projects/common/modules/email/email-article.js",
-    "projects/common/modules/email/email.js",
-    "projects/common/modules/email/run-checks.js",
-    "projects/common/modules/ui/expandable.js",
-    "projects/common/modules/ui/faux-block-link.js",
-    "projects/common/modules/ui/full-height.js",
-    "projects/common/modules/experiments/affix.js"
+  "Sam Desborough": [
+    "projects/common/modules/experiments/affix.js",
+    "projects/common/modules/experiments/tests/paid-content-vs-outbrain.js"
   ],
-  "davidfurey": [],
-  "jranks123": [
+  "Akash A": [
+    "projects/common/modules/video/metadata.js",
+    "projects/common/modules/video/onward-container.js"
+  ],
+  "jfsoul": [
+    "bootstraps/video-embed.js",
+    "bootstraps/youtube-embed.js"
+  ],
+  "Philip Wills": [
     "projects/common/modules/gallery/lightbox.js",
-    "projects/common/modules/identity/account-profile.js",
-    "projects/common/modules/identity/api.js",
-    "projects/common/modules/identity/cookierefresh.js",
-    "projects/common/modules/identity/email-preferences.js",
-    "bootstraps/enhanced/notifications.js"
+    "projects/common/modules/identity/account-profile.js"
   ],
-  "shaundillon": [
-    "projects/common/modules/identity/forms.js",
+  "Santiago Villa Fernandez": [
+    "projects/common/modules/identity/api.js",
+    "projects/common/modules/identity/cookierefresh.js"
+  ],
+  "Richard Nguyen": [
+    "projects/common/modules/identity/email-preferences.js",
+    "projects/common/modules/identity/forms.js"
+  ],
+  "NataliaLKB": [
+    "lib/proximity-loader.js",
+    "projects/common/modules/email/email-article.js"
+  ],
+  "Jamie Byers": [],
+  "Francis Carr": [],
+  "Jon Norman": [],
+  "Kate Whalen": [],
+  "dominickendrick": [],
+  "davidfurey": [],
+  "jranks123": [],
+  "shaundillon": [],
+  "Joseph Smith": [],
+  "Gideon Goldberg": [],
+  "Matthew Walls": [],
+  "Nicolas Long": [],
+  "Calum Campbell": [],
+  "GHaberis": [],
+  "Unassigned": [
+    "projects/common/modules/atoms/quiz.js",
+    "projects/common/modules/atoms/story-questions.js",
+    "projects/common/modules/atoms/youtube-tracking.js",
+    "projects/common/modules/component.js",
+    "projects/common/modules/discussion/comment-count.js",
     "projects/common/modules/identity/formstack-iframe-embed.js",
     "projects/common/modules/identity/formstack-iframe.js",
     "projects/common/modules/identity/formstack.js",
@@ -104,17 +102,12 @@
     "projects/common/modules/identity/validation-email.js",
     "projects/common/modules/navigation/membership.js",
     "projects/common/modules/navigation/navigation.js",
-    "projects/common/modules/navigation/profile.js"
-  ],
-  "jfsoul": [
-    "projects/common/modules/navigation/search.js"
-  ],
-  "Joseph Smith": [
-    "projects/common/modules/experiments/affix.js",
+    "projects/common/modules/navigation/profile.js",
+    "projects/common/modules/navigation/search.js",
+    "projects/common/modules/preferences/main.js",
+    "projects/common/modules/ui/full-height.js",
     "projects/common/modules/ui/notification-counter.js",
-    "projects/common/modules/ui/relativedates.js"
-  ],
-  "Philip Wills": [],
-  "Santiago Villa Fernandez": [],
-  "Jamie Byers": []
+    "projects/common/modules/ui/relativedates.js",
+    "projects/common/modules/ui/selection-sharing.js"
+  ]
 }

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -28,12 +28,12 @@
     "lib/picturefill.js",
     "projects/common/modules/crosswords/constants.js",
     "projects/common/modules/crosswords/controls.js",
-    "projects/common/modules/crosswords/crossword.js",
-    "projects/common/modules/crosswords/grid.js",
     "projects/common/modules/crosswords/helpers.js",
     "projects/common/modules/crosswords/series.js",
     "projects/common/modules/email/email.js",
-    "projects/common/modules/email/run-checks.js"
+    "projects/common/modules/email/run-checks.js",
+    "projects/common/modules/gallery/lightbox.js",
+    "projects/common/modules/atoms/youtube-tracking.js"
   ],
   "Gustav Pursche": [
     "projects/common/modules/discussion/user-avatars.js",
@@ -60,7 +60,8 @@
     "bootstraps/youtube-embed.js"
   ],
   "Philip Wills": [
-    "projects/common/modules/gallery/lightbox.js",
+    "projects/common/modules/crosswords/crossword.js",
+    "projects/common/modules/crosswords/grid.js",
     "projects/common/modules/identity/account-profile.js"
   ],
   "Santiago Villa Fernandez": [
@@ -90,7 +91,6 @@
   "Calum Campbell": [],
   "GHaberis": [],
   "Unassigned": [
-    "projects/common/modules/atoms/youtube-tracking.js",
     "projects/common/modules/component.js",
     "projects/common/modules/discussion/comment-count.js",
     "projects/common/modules/identity/formstack-iframe-embed.js",

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -20,8 +20,8 @@
     "projects/common/modules/crosswords/clues.js",
     "projects/common/modules/crosswords/comments.js",
     "projects/common/modules/crosswords/confirm-button.js",
-    "projects/common/modules/discussion/activity-stream.js",
-    "projects/common/modules/discussion/api.js"
+    "projects/common/modules/crosswords/hidden-input.js",
+    "projects/common/modules/crosswords/keycodes.js"
   ],
   "Simon Adcock": [
     "bootstraps/enhanced/recipe-article.js",
@@ -31,21 +31,21 @@
     "projects/common/modules/crosswords/crossword.js",
     "projects/common/modules/crosswords/grid.js",
     "projects/common/modules/crosswords/helpers.js",
-    "projects/common/modules/discussion/discussion-frontend.js",
+    "projects/common/modules/crosswords/series.js",
     "projects/common/modules/email/email.js",
     "projects/common/modules/email/run-checks.js"
   ],
   "Gustav Pursche": [
+    "projects/common/modules/discussion/user-avatars.js",
+    "projects/common/modules/discussion/whole-discussion.js",
+    "projects/common/modules/discussion/activity-stream.js",
+    "projects/common/modules/discussion/api.js",
+    "projects/common/modules/discussion/discussion-frontend.js",
     "bootstraps/enhanced/sport.js",
     "bootstraps/enhanced/trail.js",
     "bootstraps/enhanced/youtube.js",
-    "projects/common/modules/crosswords/hidden-input.js",
-    "projects/common/modules/crosswords/keycodes.js",
     "projects/common/modules/crosswords/main.js",
-    "projects/common/modules/crosswords/persistence.js",
-    "projects/common/modules/crosswords/series.js",
-    "projects/common/modules/discussion/user-avatars.js",
-    "projects/common/modules/discussion/whole-discussion.js"
+    "projects/common/modules/crosswords/persistence.js"
   ],
   "Sam Desborough": [
     "projects/common/modules/experiments/affix.js",
@@ -53,7 +53,7 @@
   ],
   "Akash A": [
     "projects/common/modules/video/metadata.js",
-    "projects/common/modules/video/onward-container.js"
+    "projects/common/modules/atoms/story-questions.js"
   ],
   "jfsoul": [
     "bootstraps/video-embed.js",
@@ -90,7 +90,6 @@
   "Calum Campbell": [],
   "GHaberis": [],
   "Unassigned": [
-    "projects/common/modules/atoms/story-questions.js",
     "projects/common/modules/atoms/youtube-tracking.js",
     "projects/common/modules/component.js",
     "projects/common/modules/discussion/comment-count.js",


### PR DESCRIPTION
## What does this change?

Reassigns ES6 modules based on what people have the bandwidth to complete.

I have removed entries for modules that have outstanding Pull Requests, so this may cause conflicts for those lucky people (mainly @gustavpursche). Sorry about this.

For those that requested a bunch of modules ( @regiskuckaertz, @sndrs, @gustavpursche), I've assigned 10 modules. If anybody wants any more, you can pull them from the `Unassigned` section at the bottom. There are currently ~18~ 16 unassigned modules.

Thanks for all your help with this epic task!

@desbo @akash1810 @jfsoul @philwills @svillafe @rich-nguyen @NataliaLKB 

## What is the value of this and can you measure success?

ES6 all the things ✨ 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
