### PR TITLE
Remove superfluous class styles and fix the cascade

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -26,10 +26,6 @@
 }
 
 .dumathoin--capi {
-    .dumathoin__title {
-        font-size: get-font-size(headline, 3);
-    }
-
     .dumathoin__row {
         @include mq($until: tablet) {
             flex-direction: column;

--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -74,7 +74,10 @@
 }
 
 .dumathoin__title {
+    @include fs-headline(4, true);
     @include f-headlineSans;
+    color: #ffffff;
+    font-size: get-font-size(headline, 3);
 }
 
 .dumathoin__blurb {
@@ -138,11 +141,6 @@
                 vertical-align: top;
             }
         }
-    }
-
-    .dumathoin__title {
-        @include fs-header(2);
-        color: #ffffff;
     }
 
     .adverts__logo {
@@ -337,10 +335,6 @@
     .paidfor-label .popup__toggle {
         border: 0;
     }
-}
-
-.dumathoin__title {
-    @include fs-headline(4, true);
 }
 
 .dumathoin__stamp {


### PR DESCRIPTION
## What does this change?

Recent overhaul of labs CSS changed the cascade, which mean the CSS properties of the container title were being applied in the wrong order, resulting in a serif font  🤕 

This PR consolidates the class styles, and restores the intended design 🛠 

## What is the value of this and can you measure success?

- Labs content looks like it should
- Less CSS

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Yup

## Screenshots

BEFORE:

<img width="722" alt="picture 945" src="https://user-images.githubusercontent.com/8607683/29325615-48ac1884-81e0-11e7-8c33-e35bb50efc25.png">

AFTER:

<img width="723" alt="picture 944" src="https://user-images.githubusercontent.com/8607683/29325583-2c591434-81e0-11e7-962a-4fe829c7c841.png">
