### PR TITLE
Set maximum number of concurrent tasks

### DIFF
--- a/tools/task-runner/runner
+++ b/tools/task-runner/runner
@@ -5,6 +5,7 @@
 process.env.FORCE_COLOR = true;
 
 const path = require('path');
+const os = require('os');
 
 const yargs = require('yargs');
 const Listr = require('listr');
@@ -86,6 +87,8 @@ const exec = (task, onError, ctx) => {
         });
 };
 
+const getCpuCount = () => os.cpus().length;
+
 // turn a list of our tasks into objects listr can use
 function listrify(steps, { concurrent = false } = {}) {
     const listrTasks = steps
@@ -104,7 +107,7 @@ function listrify(steps, { concurrent = false } = {}) {
                         if (_task.task) return _task;
                         if (typeof _task === 'string') return { title, task: ctx => exec(_task, onError, ctx), skip };
                         return { title, task: _task, skip };
-                    }), { concurrent: VERBOSE ? false : isConcurrent }),
+                    }), { concurrent: VERBOSE ? false : (isConcurrent ? getCpuCount() : false) }),
                     skip,
                 };
             }
@@ -133,7 +136,11 @@ function listrify(steps, { concurrent = false } = {}) {
     if (IS_TEAMCITY) renderer = require('./run-task-tc-formater');
     if (IS_VERBOSE) renderer = require('./run-task-verbose-formater');
 
-    return new Listr(listrTasks, { concurrent, collapse: true, renderer });
+    return new Listr(listrTasks, {
+        concurrent: concurrent ? getCpuCount() : false,
+        collapse: true,
+        renderer,
+    });
 }
 
 // resolve the tasks from yargs to actual files


### PR DESCRIPTION
## What does this change?

Talking to @gustavpursche earlier, he noticed that concurrently running Listr tasks were bottlenecked by the number of CPU cores:

<img width="533" alt="picture 275" src="https://user-images.githubusercontent.com/5931528/29326427-58f6d564-81e3-11e7-97a2-377d3b138275.png">

This change limits the number of concurrently-executing tasks to prevent this performance bottleneck

## What is the value of this and can you measure success?

Faster build and git hooks

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
