### PR TITLE
Increasing rendering actor test timeout

### DIFF
--- a/common/test/rendering/core/RenderingActorTest.scala
+++ b/common/test/rendering/core/RenderingActorTest.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success, Try}
   with ExceptionMatcher {
 
   lazy val actorSystem: ActorSystem = app.actorSystem
-  implicit lazy val timeout = new Timeout(2.seconds)
+  implicit lazy val timeout = new Timeout(10.seconds)
 
   class TestRenderingActor extends RenderingActor {
     override def javascriptFile: String = "common/test/resources/components/TestButtonComponent.js"


### PR DESCRIPTION
We have seen test failure (timeout) when testing rendering actor.
It might be due to the fact actor needs more than 2 seconds to be
initialized and eventually respond.
This patch is increasing the timeout to 10 seconds to give enough time
to the akka actor to setup and respond

## What is the value of this and can you measure success?
No flacky test 😸 