### PR TITLE
Fix Flow validation on push

### DIFF
--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -44,7 +44,7 @@ module.exports = {
                     );
 
                     if (jsFiles.length) {
-                        return execa('flow');
+                        return execa('yarn flow');
                     }
 
                     return Promise.resolve();


### PR DESCRIPTION
## What does this change?

There is a task that runs on push when JS files have changed. This task ensures that Flow compile passes. 

Currently this task is broken as it attempts to run Flow compile in the root directory. This change explicitly runs the `flow` script defined in `package.json`, that runs Flow compile in `static/src/javascripts/`

## What is the value of this and can you measure success?

Working validation mean developers can push JavaScript changes 🛠 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
