### PR TITLE
Correct api for execa

### DIFF
--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -44,7 +44,7 @@ module.exports = {
                     );
 
                     if (jsFiles.length) {
-                        return execa('yarn flow');
+                        return execa('yarn', ['flow']);
                     }
 
                     return Promise.resolve();


### PR DESCRIPTION
## What does this change?

The API for `execa` does not work the way I thought it did (#17658). This change fixes the error introduced

## What is the value of this and can you measure success?

Fix validation (again)
