### PR TITLE
Remove remaining references to Foresee

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -27,7 +27,6 @@ class DevParametersHttpRequestHandler(
     "view",
     "_edition", //allows us to spoof edition in tests
     "c", // used for counts in the Diagnostics server
-    "build", // used by Forsee surveys
     "shortUrl", // Used by series component in onwards journeys
     "switchesOn", // turn switches on for non-prod, http requests
     "switchesOff", // turn switches off for non-prod, http requests

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -312,10 +312,6 @@ There are five projects in the Javascript architecture:
 - [Facia](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/facia) - Contains JS modules and views for the weather, snaps and fronts containers
 - [Membership](https://github.com/guardian/frontend/tree/master/static/src/javascripts/projects/membership) - Contains the formatters, payment and stripe javascripts
 
-### Components
-
-[Here be 3rd-party JS](https://github.com/guardian/frontend/tree/master/static/vendor/javascripts/components) such as bean, bonzo and fastdom.
-
 ### Vendor
 
-Contains [vendor JS](https://github.com/guardian/frontend/tree/master/static/vendor/javascripts) from the likes of forsee, formstack and stripe.
+Contains [vendor JS](https://github.com/guardian/frontend/tree/master/static/vendor/javascripts) from the likes of formstack and the polyfill.io fallback.


### PR DESCRIPTION
## What does this change?

Removes a couple more references to Foresee (thanks to @sndrs [eagle eyes](https://github.com/guardian/frontend/pull/17644#issuecomment-322426912))

The build param doesn't look like it is being used elsewhere, it was introduced in #3341 specifically for Foresee integration in development.

## What is the value of this and can you measure success?

Kills a few lingering references to long dead features.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No
