### PR TITLE
Component event update

### DIFF
--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -17,11 +17,12 @@ declare type OphanABPayload = {
 };
 
 declare type OphanProduct =
-    | 'ONE_OFF_CONTRIBUTION'
+    | 'CONTRIBUTION'
     | 'RECURRING_CONTRIBUTION'
     | 'MEMBERSHIP_SUPPORTER'
-    | 'DIGITAL_SUBSCRIPTION'
-    | 'PAPER_SUBSCRIPTION';
+    | 'MEMBERSHIP_PATRON'
+    | 'MEMBERSHIP_PARTNER'
+    | 'DIGITAL_SUBSCRIPTION';
 
 declare type OphanAction =
     | 'INSERT'
@@ -44,10 +45,10 @@ declare type OphanComponentType =
     | 'SURVEYS_QUESTIONS'
     | 'ACQUISITIONS_EPIC'
     | 'ACQUISITIONS_ENGAGEMENT_BANNER'
-    | 'THANK_YOU_EPIC';
+    | 'ACQUISITIONS_THANK_YOU_EPIC';
 
 declare type OphanComponent = {|
-    type: OphanComponentType,
+    componentType: OphanComponentType,
     id?: string,
     products: $ReadOnlyArray<OphanProduct>,
     campaignCode?: string,
@@ -57,5 +58,6 @@ declare type OphanComponent = {|
 declare type OphanComponentEvent = {|
     component: OphanComponent,
     action: OphanAction,
-    value?: string
+    value?: string,
+    id?: string
 |};

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -8,11 +8,11 @@ const submitComponentEvent = (componentEvent: OphanComponentEvent) => {
 export const submitEpicInsertEvent = (
     products: $ReadOnlyArray<OphanProduct>,
     campaignCode: string,
-    type: OphanComponentType = 'ACQUISITIONS_EPIC'
+    componentType: OphanComponentType = 'ACQUISITIONS_EPIC'
 ) => {
     submitComponentEvent({
         component: {
-            type,
+            componentType,
             labels: [],
             products,
             campaignCode,
@@ -24,11 +24,11 @@ export const submitEpicInsertEvent = (
 export const submitEpicViewEvent = (
     products: $ReadOnlyArray<OphanProduct>,
     campaignCode: string,
-    type: OphanComponentType = 'ACQUISITIONS_EPIC'
+    componentType: OphanComponentType = 'ACQUISITIONS_EPIC'
 ) => {
     submitComponentEvent({
         component: {
-            type,
+            componentType,
             labels: [],
             products,
             campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -87,7 +87,7 @@ const contributionParams = (): EngagementBannerParams =>
     Object.assign({}, baseParams, {
         buttonCaption: 'Make a Contribution',
         linkUrl: 'https://contribute.theguardian.com',
-        products: ['ONE_OFF_CONTRIBUTION'],
+        products: ['CONTRIBUTION'],
         messageText: contributionEngagementBannerCopy(),
         pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found',
     });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-election.js
@@ -22,7 +22,7 @@ export const acquisitionsEpicAlwaysAskElection = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -22,7 +22,7 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-end.js
@@ -41,7 +41,7 @@ export const acquisitionsEpicElectionInteractiveEnd = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-election-interactive-slice.js
@@ -32,7 +32,7 @@ export const acquisitionsEpicElectionInteractiveSlice = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -132,7 +132,7 @@ export const acquisitionsEpicLiveblog: EpicABTest = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paypal-pay-in-epic.js
@@ -50,7 +50,7 @@ const pageContext = (campaignCode, amounts) => {
 const createVariant = (id, amounts) => ({
     id,
 
-    products: ['ONE_OFF_CONTRIBUTION'],
+    products: ['CONTRIBUTION'],
 
     options: {
         template(variant) {
@@ -96,7 +96,7 @@ const createVariant = (id, amounts) => ({
 const createControl = () => ({
     id: 'control',
 
-    products: ['ONE_OFF_CONTRIBUTION'],
+    products: ['CONTRIBUTION'],
 
     options: {
         template(variant) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-recurring-contribution-uk-support-proposition.js
@@ -31,7 +31,7 @@ export const acquisitionsEpicRecurringContributionUkSupportProposition = makeABT
         variants: [
             {
                 id: 'control',
-                products: ['ONE_OFF_CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
+                products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
                 options: {
                     buttonTemplate: buildButtonTemplate,
                     supportCustomURL:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -24,7 +24,7 @@ const isTargetPage = () =>
 export const acquisitionsEpicThankYou = makeABTest({
     id: 'AcquisitionsEpicThankYou',
     campaignId: 'epic_thank_you',
-    componentType: 'THANK_YOU_EPIC',
+    componentType: 'ACQUISITIONS_THANK_YOU_EPIC',
 
     start: '2017-06-01',
     expiry: '2017-09-05',
@@ -49,7 +49,7 @@ export const acquisitionsEpicThankYou = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 maxViews: {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-always-ask-strategy.js
@@ -34,7 +34,7 @@ export const alwaysAsk: EpicABTest = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 test() {},
@@ -44,7 +44,7 @@ export const alwaysAsk: EpicABTest = makeABTest({
 
         {
             id: 'alwaysAsk',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 test(render, variant, parentTest) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -21,7 +21,7 @@ export const askFourEarning: EpicABTest = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['ONE_OFF_CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
 
             options: {
                 maxViews: {


### PR DESCRIPTION
## What does this change?

Updates the work in #17596 based on the initial version of component event merged into ophan master (pull request [here](https://github.com/guardian/ophan/pull/2344)).

## What is the value of this and can you measure success?

Component events are sent to Ophan in the correct format.
