### PR TITLE
Update Fashion Statement day of send to match Editorial schedule

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -391,7 +391,7 @@ object EmailNewsletters {
     theme = "lifestyle",
     teaser = "A weekly hit of style with substance. The best of the week’s fashion brought to you with expertise, humour and irreverence",
     description = "A weekly hit of style with substance. Smart fashion writing and chic shopping galleries delivered straight to your inbox. Sign up for our Friday email for the best of the week’s fashion brought to you with expertise, humour and irreverence",
-    frequency = "Every Monday",
+    frequency = "Every Friday",
     listId = 3947,
     aliases = List(105),
     tone = Some("feature"),


### PR DESCRIPTION
## What does this change?

Every Monday >>> Every Friday

## What is the value of this and can you measure success?

Fashion Statement actually goes on a Friday now... The email prefs centre and newsletters page needed to be updated. 
