### PR TITLE
Now You See Me: Remove overloaded word from GLabs cards

### DIFF
--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -160,12 +160,12 @@ object Commercial {
       useCardBranding: Boolean
     ): String = {
       val classes: Seq[String] = Seq(
-        "advert",
+        "vergadain",
         sizeClass getOrElse "",
-        "advert--capi",
-        cardContent.icon map (_ => "advert--media") getOrElse "advert--text",
-        adClasses.map(_.map(c => s"advert--$c").mkString(" ")).getOrElse(""),
-        if (useCardBranding) "advert--branded" else ""
+        "vergadain--capi",
+        cardContent.icon map (_ => "vergadain--media") getOrElse "vergadain--text",
+        adClasses.map(_.map(c => s"vergadain--$c").mkString(" ")).getOrElse(""),
+        if (useCardBranding) "vergadain--branded" else ""
       )
       classes mkString " "
     }
@@ -183,7 +183,7 @@ object Commercial {
       adClasses: Option[Seq[String]],
       useCardBranding: Boolean
     ): String = {
-      cardLink(cardContent, adClasses, sizeClass = Some("advert--small"), useCardBranding)
+      cardLink(cardContent, adClasses, sizeClass = Some("vergadain--small"), useCardBranding)
     }
 
     def linkFromLargeCard(
@@ -191,7 +191,7 @@ object Commercial {
       adClasses: Option[Seq[String]],
       useCardBranding: Boolean
     ): String = {
-      cardLink(cardContent, adClasses, sizeClass = Some("advert--large"), useCardBranding)
+      cardLink(cardContent, adClasses, sizeClass = Some("vergadain--large"), useCardBranding)
     }
 
     def paidForContainer(otherClasses: Option[Seq[String]]): String =

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -1,4 +1,4 @@
-.advert {
+.vergadain {
     box-sizing: border-box;
     display: block;
     display: flex;
@@ -22,13 +22,13 @@
         color: inherit;
     }
 
-    .has-no-flex &:not(.advert--small):not(.advert--landscape) {
+    .has-no-flex &:not(.vergadain--small):not(.vergadain--landscape) {
         padding-top: 11 * $gs-baseline;
         position: relative;
     }
 }
 
-.advert--landscape {
+.vergadain--landscape {
     .has-no-flex & {
         overflow: hidden;
 
@@ -48,7 +48,7 @@
     }
 }
 
-.advert--inverse {
+.vergadain--inverse {
     .has-no-flex & {
         > .advert__image-container {
             float: left;
@@ -60,13 +60,13 @@
     }
 }
 
-.advert--manual {
+.vergadain--manual {
     .advert__image-container {
         height: auto;
     }
 }
 
-.advert--single {
+.vergadain--single {
     @include mq(375px, $until: mobileLandscape) {
         flex-direction: row;
 
@@ -170,12 +170,12 @@
     margin-top: $gs-baseline / 2;
 }
 
-.advert--small > .advert__title {
+.vergadain--small > .advert__title {
     padding-top: $gs-baseline / 2;
 }
 
 @include mq(tablet) {
-    .advert--large {
+    .vergadain--large {
         flex-direction: row;
         align-items: stretch;
         padding-bottom: 0;
@@ -207,7 +207,7 @@
         }
     }
 
-    .advert--inverse {
+    .vergadain--inverse {
         flex-direction: row-reverse;
 
         .advert__text {
@@ -220,7 +220,7 @@
         }
     }
 
-    .advert--thumbnail {
+    .vergadain--thumbnail {
         .advert__image-container {
             $line-height: 20px;
             $image-height: $line-height * 4 + $gs-baseline;
@@ -233,28 +233,28 @@
         }
     }
 
-    .advert--large--1x3 > .advert__image-container {
+    .vergadain--large--1x3 > .advert__image-container {
         flex-basis: calc(75% - #{$gs-gutter / 2});
     }
 
-    .advert--large--1x2 > .advert__image-container {
+    .vergadain--large--1x2 > .advert__image-container {
         flex-basis: calc(66.67% - #{$gs-gutter / 2});
     }
 
     .has-no-flex {
-        .advert--large--1x3 > .advert__image-container {
+        .vergadain--large--1x3 > .advert__image-container {
             width:  calc(75% - #{$gs-gutter / 2});
         }
 
-        .advert--large--1x2 > .advert__image-container {
+        .vergadain--large--1x2 > .advert__image-container {
             width:  calc(66.67% - #{$gs-gutter / 2});
         }
 
-        .advert--large--1x3 > .advert__text {
+        .vergadain--large--1x3 > .advert__text {
             width:  calc(25% - #{$gs-gutter / 2});
         }
 
-        .advert--large--1x2 > .advert__text {
+        .vergadain--large--1x2 > .advert__text {
             width:  calc(33.33% - #{$gs-gutter / 2});
         }
     }

--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -54,8 +54,10 @@
     }
 }
 
+/* [1] Prevents brand logos floating out the bounds if the cards are hidden */
 .paidfor-container {
     margin: 0 $gs-gutter / 2;
+    min-height: 80px; /* [1] */
 
     @include mq($until: tablet) {
 

--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -1,4 +1,4 @@
-.advert--branded {
+.vergadain--branded {
     padding-bottom: $gs-baseline * 8;
 }
 
@@ -38,8 +38,8 @@
                 margin-top: $gs-baseline;
             }
 
-            & > * + .advert,
-            & > * + * > .advert {
+            & > * + .vergadain,
+            & > * + * > .vergadain {
                 padding-top: $gs-baseline / 2;
             }
 
@@ -49,7 +49,7 @@
         }
     }
 
-    .advert > :last-child {
+    .vergadain > :last-child {
         margin-bottom: 0;
     }
 }
@@ -63,7 +63,7 @@
             min-height: $gs-row-height;
         }
 
-        &:first-child > .advert {
+        &:first-child > .vergadain {
             padding-bottom: $gs-baseline / 2;
         }
 
@@ -73,7 +73,7 @@
             max-width: 520px;
         }
 
-        &:not(:first-child) > .advert {
+        &:not(:first-child) > .vergadain {
             padding-right: 80px;
             padding-bottom: 0;
             min-height: 80px;
@@ -215,7 +215,7 @@
     }
 }
 
-.advert--capi {
+.vergadain--capi {
     border-top: 1px solid;
     transition: background .1s;
 
@@ -247,7 +247,7 @@
         }
     }
 
-    &:not(.advert--landscape) {
+    &:not(.vergadain--landscape) {
         > .advert__image-container {
             width: 100%;
         }
@@ -265,7 +265,7 @@
         }
     }
 
-    .has-page-skin &:not(.advert--landscape) {
+    .has-page-skin &:not(.vergadain--landscape) {
         .advert__image {
             @include mq(desktop) {
                 min-height: 0;
@@ -277,7 +277,7 @@
         height: auto;
     }
 
-    .has-no-flex &:not(.advert--small):not(.advert--landscape) {
+    .has-no-flex &:not(.vergadain--small):not(.vergadain--landscape) {
         padding-top: 0;
 
         > :first-child {
@@ -286,7 +286,7 @@
     }
 }
 
-.advert--paidfor {
+.vergadain--paidfor {
     @include f-textSans;
     background: $paid-article-card-bg;
     border-top-color: $paid-article-brand;
@@ -317,8 +317,8 @@
     }
 }
 
-.advert--supported {
-    &.advert--text {
+.vergadain--supported {
+    &.vergadain--text {
         border-top-color: $news-main-2;
         background: $neutral-8;
 
@@ -328,7 +328,7 @@
         }
     }
 
-    &.advert--media {
+    &.vergadain--media {
         border-top-color: $multimedia-main-2;
         background: $multimedia-main-1;
         color: #ffffff;

--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -288,22 +288,22 @@
 }
 
 .dumathoin--legacy-single {
-    .advert {
+    .vergadain {
         flex-basis: calc(100% - #{$gs-gutter});
     }
 
     @include mq(mobileLandscape) {
-        .advert {
+        .vergadain {
             flex-basis: calc(75% - #{$gs-gutter});
             flex-grow: 0;
         }
 
-        .advert--inverse > .advert__image-container {
+        .vergadain--inverse > .advert__image-container {
             flex-basis: calc(33.33% - #{$gs-gutter / 2});
             margin-right: 0;
         }
 
-        .dumathoin__row > .advert::after {
+        .dumathoin__row > .vergadain::after {
             @include separator($neutral-4, 100%, $gs-gutter / 2);
         }
 
@@ -318,11 +318,11 @@
     }
 
     .has-no-flex & {
-        .advert {
+        .vergadain {
             width: calc(75% - #{$gs-gutter});
         }
 
-        .advert--landscape > .advert__image-container {
+        .vergadain--landscape > .advert__image-container {
             width: calc(33.33% - #{$gs-gutter / 2});
         }
     }


### PR DESCRIPTION
## What does this change?

Vergadain joins Dumathoin in frontend! Follow up to #17625 to catch some potential edge cases.

Switches labs cards to use classnames that would have zero chance of appearing on an adblock list, or elsewhere in our codebase, ever. The choice of `advert` for labs content is unfortunate since it is too generic.

- Remove overloaded word adverts from usage in Labs containers
- Add a min-height to their ancestor element, to stop branded badges from escaping 

For those wondering the choice of names, studying your D&D lore has never been such fun.

> The truly blessed are those whose enterprise and zeal brings both wealth and good luck. Work hard, be clever, seek the best bargain, and the Merchant King will shower you with gold. Treat others with respect, but shirk not your responsibility to try to strike a deal better for you than for them.

## What is the value of this and can you measure success?

By special request of @paperboyo 🤗

Reports of layout issues in Firefox... so fixing the suspected causes

At the very least this will stop the brand badges from overflowing into other containers, at the best it will bring back Labs cards for an indeterminate number of users

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

100% 😈 😈

## Screenshots

#### BEFORE:

![pbbefore](https://user-images.githubusercontent.com/8607683/29416026-c573d2f8-835c-11e7-9cde-95f9339766f1.PNG)

#### AFTER:

<img width="1058" alt="picture 950" src="https://user-images.githubusercontent.com/8607683/29415851-4289cea6-835c-11e7-983b-9af4f18055b3.png">

<img width="1047" alt="picture 951" src="https://user-images.githubusercontent.com/8607683/29415889-64695f1e-835c-11e7-86cb-50d1dc2e5834.png">

