### PR TITLE
Update the location of the Sonobi Morpheus file.

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -226,7 +226,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object sonobi {
-    lazy val jsLocation = configuration.getStringProperty("sonobi.js.location").getOrElse("//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12917.js")
+    lazy val jsLocation = configuration.getStringProperty("sonobi.js.location").getOrElse("//mtrx.go.sonobi.com/morpheus.theguardian.12916.js")
   }
 
   object switch {


### PR DESCRIPTION
The current url for the Sonobi Morpheus file in PROD is `//api.nextgen.guardianapps.co.uk/morpheus.theguardian.12917.js`

The current url for CODE is `//mtrx.go.sonobi.com/morpheus.theguardian.12916.js` (if you look at the `eu-west-1-frontend.v41` front end config file, you will find the entry `sonobi.js.location="//mtrx.go.sonobi.com/morpheus.theguardian.12916_uk.js"`, but Fastly adds the suffix `_uk` automatically).

There isn't a config file entry for PROD. The PROD value is the default value of the Scala code `configuration.getStringProperty`. This PR pushes the value currently on CODE to PROD, by updating the default string in the Scala code.

## Tested in CODE?

Yes.