### PR TITLE
Do not show contributor byline if more than 1 contributors

### DIFF
--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -3,18 +3,21 @@
 @import views.support.{ImgSrc, Item300}
 @import common.RichRequestHeader
 
-@tags.contributors.headOption.map { profile =>
-    @profile.properties.contributorLargeImagePath.map{ src =>
-        <div class="byline-img">
-        @if(request.isAmp) {
-            @if(model.Tags(tags.tones.toList).isComment) {
-                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150"></amp-img>
-            } else {
-                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66"></amp-img>
-            }
-        } else {
-            <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
+@if(tags.contributors.length == 1) { @* Do not show byline if more than 1 contributor (or zero) *@
+    @tags.contributors.headOption.map { profile =>
+        @profile.properties.contributorLargeImagePath.map{ src =>
+            <div class="byline-img">
+                @if(request.isAmp) {
+                    @if(model.Tags(tags.tones.toList).isComment) {
+                        <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150"></amp-img>
+                    } else {
+                        <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66"></amp-img>
+                    }
+                } else {
+                    <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
+                }
+            </div>
         }
-        </div>
     }
+
 }


### PR DESCRIPTION
We currently show a picture for the first contributor.
This patch ensures we don't show any contributor image if more than 1
contributors. I guess not to highlight a specific author

## Tested in CODE?
No