### PR TITLE
Remove inline style attribute when AMP

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -74,6 +74,7 @@ object BodyCleaner {
       ListIf(!amp)(ExplainerCleaner(article.atoms.map(_.explainers).getOrElse(Nil))) ++
       ListIf(!amp)(VideoEmbedCleaner(article)) ++
       ListIf(amp)(AmpEmbedCleaner(article)) ++
+      ListIf(amp)(AttributeCleaner("style")) ++ // The inline 'style' attribute is not allowed in AMP documents
       ListIf(amp && shouldShowAds && !article.isLiveBlog)(AmpAdCleaner(edition, request.uri, article))
 
     withJsoup(BulletCleaner(html))(cleaners :_*)

--- a/common/app/views/support/cleaner/AttributeCleaner.scala
+++ b/common/app/views/support/cleaner/AttributeCleaner.scala
@@ -1,0 +1,11 @@
+package views.support.cleaner
+
+import org.jsoup.nodes.Document
+import views.support.HtmlCleaner
+
+case class AttributeCleaner(attributeName: String) extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    document.select(s"[$attributeName]").removeAttr(attributeName)
+    document
+  }
+}

--- a/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
+++ b/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
@@ -1,38 +1,18 @@
 package views.support.cleaner
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 import org.scalatest.{FlatSpec, Matchers}
+import StringCleaner._
 
-import org.apache.commons.lang.StringEscapeUtils
 import views.support.CommercialMPUForFronts
 
 class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
-
-/*
- * The format we are using for the test data is treated as XML when toString()
- * is run on it. To parse it into a JSoup element, it is necessary to remove
- * all the XML character encodings that have been introduced.
- */
-  private def parseTestData(doc: String): Document = {
-    Jsoup.parse(StringEscapeUtils.unescapeXml(doc))
-  }
-
-  private def clean(document: Document): Document = {
-    val cleaner = CommercialMPUForFronts(true)
-    cleaner.clean(document)
-    document
-  }
 
   def getFileContent(filePath: String): String = {
     val source = scala.io.Source.fromInputStream(getClass.getResourceAsStream(filePath))
     try source.mkString finally source.close()
   }
 
-  val htmlFile = getFileContent("fixtures/CommercialMPUForFronts.html")
-
-  val htmlContent = parseTestData(htmlFile)
-  val body = clean(htmlContent)
+  val body = getFileContent("fixtures/CommercialMPUForFronts.html").cleanWith(CommercialMPUForFronts(true))
 
   it should "insert MPUs into applicable slices, and give them unique IDs" in {
     val desktopMPUs = body.getElementsByClass("fc-slice__item--mpu-candidate")

--- a/common/test/views/support/cleaner/StringCleaner.scala
+++ b/common/test/views/support/cleaner/StringCleaner.scala
@@ -1,0 +1,20 @@
+package views.support.cleaner
+
+import org.apache.commons.lang.StringEscapeUtils
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.support.HtmlCleaner
+
+object StringCleaner {
+
+  implicit class DocumentString(html: String) {
+    def cleanWith(cleaner: HtmlCleaner): Document = {
+      // The format we are using for the test data - while eminently readable - is treated as XML when toString() is run on it.
+      // To parse it into a JSoup element, it is necessary to remove all the XML character encodings that have been introduced.
+      val document = Jsoup.parse(StringEscapeUtils.unescapeXml(html))
+      cleaner.clean(document)
+      document
+    }
+  }
+
+}

--- a/common/test/views/support/cleaner/StyleCleanerTest.scala
+++ b/common/test/views/support/cleaner/StyleCleanerTest.scala
@@ -1,0 +1,38 @@
+package views.support.cleaner
+
+import org.scalatest.{FlatSpec, Matchers}
+import StringCleaner._
+
+class StyleCleanerTest extends FlatSpec with Matchers {
+
+  def ignoreWhiteSpaces(s: String): String = s.replaceAll("\\s", "")
+
+  lazy val styleCleaner = AttributeCleaner("style")
+
+  it should "remove inline style attribute" in {
+    val html: String = <html>
+      <head></head>
+      <body>
+        <h1 style="text-align:center">title</h1>
+          <p style="color:black">paragraph</p>
+        </body>
+      </html>.toString()
+
+    val cleanedStyles = html.cleanWith(styleCleaner).getElementsByAttribute("style")
+    cleanedStyles.size should be (0)
+  }
+
+  it should "do nothing if no style attribute" in {
+    val originalHtml: String = <html>
+      <head></head>
+      <body>
+        <h1>title</h1>
+        <p>paragraph</p>
+      </body>
+    </html>.toString()
+
+    val cleanedHtml = originalHtml.cleanWith(styleCleaner)
+    ignoreWhiteSpaces(cleanedHtml.html()) should be (ignoreWhiteSpaces(originalHtml))
+  }
+
+}


### PR DESCRIPTION
The inline 'style' attribute is not allowed in AMP documents.
https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages)

## What does this change?
This patch ensures that all `style` attribute are removed when rendering an amp page.
Also slightly refactored cleaner tests 😺 

## What is the value of this and can you measure success?
No more invalid AMP content in case CAPI/Composer is returning html with `style` attribute

## Does this affect other platforms - Amp, Apps, etc?
It only affects AMP

## Tested in CODE?
Yes