### PR TITLE
Exclude masterclasses pages from Reader Revenue targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -104,6 +104,9 @@ const shouldShowReaderRevenue = (
     showToContributorsAndSupporters: boolean = false
 ): boolean =>
     (userShouldSeeReaderRevenue() || showToContributorsAndSupporters) &&
+    !config.page.keywordIds.includes(
+        'guardian-masterclasses/guardian-masterclasses'
+    ) &&
     !config.page.shouldHideReaderRevenue;
 
 const defaultCanEpicBeDisplayed = (test: EpicABTest): boolean => {


### PR DESCRIPTION
## What does this change?
Prevents Masterclasses-tagged pages showing the Epic/Engagement banner, as requested by Mark Jarvis.

## What is the value of this and can you measure success?
Improved UX – people on these pages are already in the process of supporting the guardian through event attendance, so shouldn't see these requests for support.