### PR TITLE
Remove TagPageSize switch and set index page size to 20 for ever

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -25,16 +25,6 @@ trait PerformanceSwitches {
     exposeClientSide = true
   )
 
-  val TagPageSizeSwitch = Switch(
-    SwitchGroup.Performance,
-    "tag-page-size",
-    "If this switch is on then we will request more items for larger tag pages",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false
-  )
-
   val LongCacheSwitch = Switch(
     SwitchGroup.Performance,
     "long-cache-switch",

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -18,13 +18,7 @@ import scala.Function.const
 import scala.annotation.tailrec
 
 object IndexPagePagination {
-  def pageSize: Int = if (Switches.TagPageSizeSwitch.isSwitchedOn) {
-    35
-  } else {
-    20
-  }
-
-  def rssPageSize: Int = 20
+  def pageSize: Int = 20
 }
 
 case class MpuState(injected: Boolean)

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -66,7 +66,7 @@ trait Index extends ConciergeRepository with Collections {
     val promiseOfResponse = contentApiClient.getResponse(contentApiClient.search(edition)
       .tag(s"$firstTag,$secondTag")
       .page(page)
-      .pageSize(if (isRss) IndexPagePagination.rssPageSize else IndexPagePagination.pageSize)
+      .pageSize(IndexPagePagination.pageSize)
       .showFields(if (isRss) rssFields else QueryDefaults.trailFieldsWithMain)
     ).map {response =>
       val trails = response.results.map(IndexPageItem(_)).toList
@@ -110,7 +110,6 @@ trait Index extends ConciergeRepository with Collections {
   ))
 
   def index(edition: Edition, path: String, pageNum: Int, isRss: Boolean)(implicit request: RequestHeader): Future[Either[IndexPage, PlayResult]] = {
-    val pageSize = if (isRss) IndexPagePagination.rssPageSize else IndexPagePagination.pageSize
     val fields = if (isRss) rssFields else QueryDefaults.trailFieldsWithMain
 
     val maybeSection = sectionsLookUp.get(path)
@@ -126,7 +125,7 @@ trait Index extends ConciergeRepository with Collections {
     val queryPath = maybeSection.fold(path)(s => SectionTagLookUp.tagId(s.id))
 
     val promiseOfResponse = contentApiClient.getResponse(contentApiClient.item(queryPath, edition).page(pageNum)
-      .pageSize(pageSize)
+      .pageSize(IndexPagePagination.pageSize)
       .showFields(fields)
     ) map { response =>
       val page = maybeSection.map(s => section(s, response)) orElse


### PR DESCRIPTION
## What does this change?
Removing the TagPageSize switch. It has been disabled for more than a week now in order to relieve CAPI when fetching content for index pages.
The page size value is now 20. It doesn't seem to have been an issue when reduced from 35 to 20: we got not report of anybody noticing the change 🙈 

## What is the value of this and can you measure success?
Less CAPI slow down

## Tested in CODE?
No