### PR TITLE
Extend explore and header tests

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -21,7 +21,7 @@ trait FeatureSwitches {
     "If this switch is on, Explore template will be applied to explore articles. This template is part of a Membership Explore test",
     owners = Seq(Owner.withGithub("NataliaLKB"), Owner.withGithub("blongden73")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 24),
+    sellByDate = new LocalDate(2017, 10, 24),
     exposeClientSide = true
   )
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -32,7 +32,7 @@ object ABNewDesktopHeaderVariant extends TestDefinition(
   name = "ab-new-desktop-header-variant",
   description = "Users in this test will see the new desktop design.",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 8, 24)
+  sellByDate = new LocalDate(2017, 10, 24)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header-v2")
@@ -44,7 +44,7 @@ object ABNewDesktopHeaderControl extends TestDefinition(
   name = "ab-new-desktop-header-control",
   description = "Users in this test will not see the new desktop design, but act as a control group",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2017, 8, 24)
+  sellByDate = new LocalDate(2017, 10, 24)
 ) {
 
   def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-new-desktop-header-v2")


### PR DESCRIPTION
## What does this change?
Extending three switches which will expire on Thursday.

## What is the value of this and can you measure success?
Build doesn't break, uninterrupted viewing of these features.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
