### PR TITLE
Fix liveblog epic timestamp link

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -31,14 +31,15 @@ const getLiveblogEntryTimeData = (el: Element): Promise<TimeData> =>
 
         if (timeEl && absoluteTimeEl) {
             const link = timeEl.parentNode;
-            const blockHref = (link instanceof HTMLAnchorElement) ? link.href : '';
+            const blockHref =
+                link instanceof HTMLAnchorElement ? link.href : '';
 
             return {
                 datetime: timeEl.getAttribute('datetime'),
                 title: timeEl.getAttribute('title'),
                 date: timeEl.innerHTML,
                 time: absoluteTimeEl.innerHTML,
-                blockHref
+                blockHref,
             };
         }
     });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -17,6 +17,7 @@ let isAutoUpdateHandlerBound = false;
 const INSERT_EPIC_AFTER_CLASS = 'js-insert-epic-after';
 
 type TimeData = {
+    blockHref: string,
     datetime: string,
     title: string,
     date: string,
@@ -29,11 +30,15 @@ const getLiveblogEntryTimeData = (el: Element): Promise<TimeData> =>
         const absoluteTimeEl = el.querySelector('.block-time__absolute');
 
         if (timeEl && absoluteTimeEl) {
+            const link = timeEl.parentNode;
+            const blockHref = (link instanceof HTMLAnchorElement) ? link.href : '';
+
             return {
                 datetime: timeEl.getAttribute('datetime'),
                 title: timeEl.getAttribute('title'),
                 date: timeEl.innerHTML,
                 time: absoluteTimeEl.innerHTML,
+                blockHref
             };
         }
     });
@@ -72,6 +77,11 @@ const setEpicLiveblogEntryTimeData = (
     const epicAbsoluteTimeEl = el.querySelector('.block-time__absolute');
 
     if (epicTimeEl && epicAbsoluteTimeEl) {
+        const epicTimeLink = epicTimeEl.parentNode;
+        if (epicTimeLink instanceof HTMLAnchorElement) {
+            epicTimeLink.href = timeData.blockHref;
+        }
+
         epicTimeEl.setAttribute('datetime', timeData.datetime);
         epicTimeEl.setAttribute('title', timeData.title);
         epicTimeEl.innerHTML = timeData.date;


### PR DESCRIPTION
The timestamp link in the top left of the epic liveblog block (see image below) didn't work the same as on other blocks. On others, it can be used as a link to the specific block in question. On liveblog epics, it's just a `#` placeholder so it takes the user back to the top of the page.

![picture 30](https://user-images.githubusercontent.com/5122968/29570677-0747cfb8-874f-11e7-850d-1efdd6fccbef.png)


This PR fixes the issue by copying the link of the adjacent block (we can't link to the epic itself because it's not guaranteed that the epic will be in that place, or there at all, on subsequent page loads)

@svillafe 
@gustavpursche 