### PR TITLE
Guard against config.page.keywordIds not existing

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -102,12 +102,20 @@ const defaultPageCheck = (page: Object): boolean =>
 
 const shouldShowReaderRevenue = (
     showToContributorsAndSupporters: boolean = false
-): boolean =>
-    (userShouldSeeReaderRevenue() || showToContributorsAndSupporters) &&
-    !config.page.keywordIds.includes(
-        'guardian-masterclasses/guardian-masterclasses'
-    ) &&
-    !config.page.shouldHideReaderRevenue;
+): boolean => {
+    const isMasterclassesPage =
+        config.page &&
+        config.page.keywordIds &&
+        config.page.keywordIds.includes(
+            'guardian-masterclasses/guardian-masterclasses'
+        );
+
+    return (
+        (userShouldSeeReaderRevenue() || showToContributorsAndSupporters) &&
+        !isMasterclassesPage &&
+        !config.page.shouldHideReaderRevenue
+    );
+};
 
 const defaultCanEpicBeDisplayed = (test: EpicABTest): boolean => {
     const worksWellWithPageTemplate = test.pageCheck(config.page);


### PR DESCRIPTION
## What does this change?
Fixes an error where `keywordId`s isn't set, which is apparently breaking comments in some instances.

## What is the value of this and can you measure success?
Comments work again 

## Does this affect other platforms - Amp, Apps, etc?
Nope 

@jfsoul 