### PR TITLE
Extending switches keep-video-ad-slots-open and ab-glabs-traffic-driver-slot

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -125,7 +125,7 @@ trait ABTestSwitches {
     "Displays a new ad slot to drive traffic to GLabs content",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 23),
+    sellByDate = new LocalDate(2017, 8, 25),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -21,7 +21,7 @@ trait CommercialSwitches {
     "Deactivates the sizecallback for videos (620x1) that hides the slot.",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 23),
+    sellByDate = new LocalDate(2017, 8, 25),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the two switches `keep-video-ad-slots-open` and `ab-glabs-traffic-driver-slot` the time for Jon to be back :)

