### PR TITLE
Deps: Upgrade flow-bin to 0.53.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-react": "^7.1.0",
     "execa": "^0.7.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.51.1",
+    "flow-bin": "^0.53.1",
     "flow-typed": "^2.1.2",
     "git-user-name": "^1.2.0",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,9 +3090,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.51.1:
-  version "0.51.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.51.1.tgz#7929c6f0a94e765429fcb2ee6e468278faa9c732"
+flow-bin@^0.53.1:
+  version "0.53.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
 
 flow-typed@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## What does this change?

Upgrades `flow-bin` to 0.53.1. No changes, which affect us - I just don't want to fall too far behind. [Changelog](https://github.com/facebook/flow/releases/tag/v0.53.0).