### PR TITLE
Non-compliant impression on JTBD survey

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -37,7 +37,9 @@ const getOutbrainPageConditions = (): Promise<OutbrainPageConditions> =>
         waitForCheck('isStoryQuestionsOnPage'),
         waitForCheck('isJTBDSurveyOnPage'),
     ]).then(
-        ([outbrainDisabled, noMerchSlots, contributions, email, story, jtbd]) => ({
+        (
+            [outbrainDisabled, noMerchSlots, contributions, email, story, jtbd]
+        ) => ({
             outbrainEnabled: !outbrainDisabled,
             noMerchSlotsExpected: noMerchSlots,
             contributionsTestVisible: contributions,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -9,6 +9,7 @@ type OutbrainPageConditions = {
     contributionsTestVisible: boolean,
     emailTestVisible: boolean,
     storyQuestionsVisible: boolean,
+    jtbdSurveyVisible: boolean,
 };
 
 type OutbrainDfpConditions = {
@@ -34,13 +35,15 @@ const getOutbrainPageConditions = (): Promise<OutbrainPageConditions> =>
         waitForCheck('isUserInContributionsAbTest'),
         waitForCheck('isUserInEmailAbTestAndEmailCanRun'),
         waitForCheck('isStoryQuestionsOnPage'),
+        waitForCheck('isJTBDSurveyOnPage'),
     ]).then(
-        ([outbrainDisabled, noMerchSlots, contributions, email, story]) => ({
+        ([outbrainDisabled, noMerchSlots, contributions, email, story, jtbd]) => ({
             outbrainEnabled: !outbrainDisabled,
             noMerchSlotsExpected: noMerchSlots,
             contributionsTestVisible: contributions,
             emailTestVisible: email,
             storyQuestionsVisible: story,
+            jtbdSurveyVisible: jtbd,
         })
     );
 
@@ -61,6 +64,7 @@ export const getOutbrainComplianceTargeting = (): Promise<
             pageConditions.contributionsTestVisible ||
             pageConditions.emailTestVisible ||
             pageConditions.storyQuestionsVisible ||
+            pageConditions.jtbdSurveyVisible ||
             !pageConditions.outbrainEnabled
         ) {
             // This key value should be read as "the outbrain load cannot be compliant"
@@ -98,7 +102,8 @@ export const initOutbrain = () =>
         const editorialTests =
             pageConditions.contributionsTestVisible ||
             pageConditions.emailTestVisible ||
-            pageConditions.storyQuestionsVisible;
+            pageConditions.storyQuestionsVisible ||
+            pageConditions.jtbdSurveyVisible;
 
         if (pageConditions.noMerchSlotsExpected) {
             if (editorialTests) {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -75,6 +75,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
+            resolveCheck('isJTBDSurveyOnPage', false);
 
             return initOutbrain().then(() => {
                 expect(load).not.toHaveBeenCalled();
@@ -89,7 +90,8 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
-
+            resolveCheck('isJTBDSurveyOnPage', false);
+            
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalled();
                 adblockInUse.mockReturnValue(false);
@@ -103,6 +105,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
+            resolveCheck('isJTBDSurveyOnPage', false);
             // isOutbrainBlockedByAds checks
             resolveCheck('isOutbrainBlockedByAds', true);
             resolveCheck('isOutbrainMerchandiseCompliant', false);
@@ -119,6 +122,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
+            resolveCheck('isJTBDSurveyOnPage', false);
             // isOutbrainBlockedByAds and isOutbrainMerchandiseCompliant checks
             resolveCheck('isOutbrainBlockedByAds', false);
             resolveCheck('isOutbrainMerchandiseCompliant', true);
@@ -138,7 +142,8 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', true);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
-
+            resolveCheck('isJTBDSurveyOnPage', false);
+            
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -154,7 +159,8 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', true);
             resolveCheck('isStoryQuestionsOnPage', false);
-
+            resolveCheck('isJTBDSurveyOnPage', false);
+            
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -170,7 +176,25 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', true);
+            resolveCheck('isJTBDSurveyOnPage', false);
+            
+            return initOutbrain().then(() => {
+                expect(load).toHaveBeenCalledWith('nonCompliant');
+            });
+        });
 
+        it('should load a non compliant component if jtbd survey on page', () => {
+            // isOutbrainDisabled check
+            resolveCheck('isOutbrainDisabled', false);
+            // isOutbrainBlockedByAds and isOutbrainMerchandiseCompliant checks
+            resolveCheck('isOutbrainBlockedByAds', false);
+            resolveCheck('isOutbrainMerchandiseCompliant', false);
+            // editorial tests
+            resolveCheck('isUserInContributionsAbTest', false);
+            resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
+            resolveCheck('isStoryQuestionsOnPage', false);
+            resolveCheck('isJTBDSurveyOnPage', true);
+            
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -186,7 +210,8 @@ describe('Outbrain', () => {
             resolveCheck('isUserInContributionsAbTest', false);
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
-
+            resolveCheck('isJTBDSurveyOnPage', false);
+            
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalled();
             });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.spec.js
@@ -91,7 +91,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
             resolveCheck('isJTBDSurveyOnPage', false);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalled();
                 adblockInUse.mockReturnValue(false);
@@ -143,7 +143,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
             resolveCheck('isJTBDSurveyOnPage', false);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -160,7 +160,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', true);
             resolveCheck('isStoryQuestionsOnPage', false);
             resolveCheck('isJTBDSurveyOnPage', false);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -177,7 +177,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', true);
             resolveCheck('isJTBDSurveyOnPage', false);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -194,7 +194,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
             resolveCheck('isJTBDSurveyOnPage', true);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalledWith('nonCompliant');
             });
@@ -211,7 +211,7 @@ describe('Outbrain', () => {
             resolveCheck('isUserInEmailAbTestAndEmailCanRun', false);
             resolveCheck('isStoryQuestionsOnPage', false);
             resolveCheck('isJTBDSurveyOnPage', false);
-            
+
             return initOutbrain().then(() => {
                 expect(load).toHaveBeenCalled();
             });

--- a/static/src/javascripts/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/common/modules/check-dispatcher.js
@@ -1,5 +1,6 @@
 // @flow
 import config from 'lib/config';
+import mediator from 'lib/mediator';
 import { allEmailCanRun, listCanRun } from 'common/modules/email/run-checks';
 import emailArticle from 'common/modules/email/email-article';
 import {
@@ -95,6 +96,14 @@ const checksToDispatch = {
         return Promise.resolve(
             document.querySelectorAll('.js-ask-question-link').length > 0
         );
+    },
+
+    isJTBDSurveyOnPage(): Promise<boolean> {
+        return config.page.contentType === 'Article' && !config.page.isMinuteArticle ?
+            new Promise((resolve) => {
+                mediator.on('journalism:modules:jtbd', resolve);
+            }) :
+            Promise.resolve(false);
     },
 
     isOutbrainBlockedByAds(): Promise<boolean> {

--- a/static/src/javascripts/projects/common/modules/check-dispatcher.js
+++ b/static/src/javascripts/projects/common/modules/check-dispatcher.js
@@ -99,11 +99,12 @@ const checksToDispatch = {
     },
 
     isJTBDSurveyOnPage(): Promise<boolean> {
-        return config.page.contentType === 'Article' && !config.page.isMinuteArticle ?
-            new Promise((resolve) => {
-                mediator.on('journalism:modules:jtbd', resolve);
-            }) :
-            Promise.resolve(false);
+        return config.page.contentType === 'Article' &&
+        !config.page.isMinuteArticle
+            ? new Promise(resolve => {
+                  mediator.on('journalism:modules:jtbd', resolve);
+              })
+            : Promise.resolve(false);
     },
 
     isOutbrainBlockedByAds(): Promise<boolean> {

--- a/static/src/javascripts/projects/common/modules/check-mediator-checks.js
+++ b/static/src/javascripts/projects/common/modules/check-mediator-checks.js
@@ -12,6 +12,7 @@ export const checks = [
     'hasLowPriorityAdLoaded',
     'hasLowPriorityAdNotLoaded',
     'isStoryQuestionsOnPage',
+    'isJTBDSurveyOnPage',
     'isOutbrainBlockedByAds',
     'isOutbrainMerchandiseCompliant',
     'isOutbrainMerchandiseCompliantOrBlockedByAds',

--- a/static/src/javascripts/projects/journalism/jtbd-survey.js
+++ b/static/src/javascripts/projects/journalism/jtbd-survey.js
@@ -138,7 +138,7 @@ const init = (): void => {
     }
 
     mediator.emit('journalism:modules:jtbd', true);
-    
+
     localStorage.setIfNotExists('gu.jtbd.questions', qs, {
         expires: endOfSurvey,
     });

--- a/static/src/javascripts/projects/journalism/jtbd-survey.js
+++ b/static/src/javascripts/projects/journalism/jtbd-survey.js
@@ -1,4 +1,5 @@
 // @flow
+import mediator from 'lib/mediator';
 import { session as sessionStorage, local as localStorage } from 'lib/storage';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { campaignsFor } from 'common/modules/commercial/targeting-tool';
@@ -120,6 +121,7 @@ const init = (): void => {
 
     // Should I stay or should I go?
     if (!campaign || shouldIGo()) {
+        mediator.emit('journalism:modules:jtbd', false);
         return;
     }
 
@@ -131,9 +133,12 @@ const init = (): void => {
     const q = selectQuestion(qs, as);
 
     if (q === -1) {
+        mediator.emit('journalism:modules:jtbd', false);
         return;
     }
 
+    mediator.emit('journalism:modules:jtbd', true);
+    
     localStorage.setIfNotExists('gu.jtbd.questions', qs, {
         expires: endOfSurvey,
     });


### PR DESCRIPTION
Make Outbrain non-compliant. @GHaberis this is because there's a survey being displayed on 1.5% of article PVs between 3pm and 4pm we will run for a few days.