### PR TITLE
Outstream frequency cap holdback

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -129,4 +129,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-outstream-frequency-cap",
+    "Test adds a hold-back variant which keeps a frequency cap on outstream video format ads.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 11, 1),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -121,7 +121,8 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
 
     if (
         getTestVariantId('OutstreamFrequencyCap') === 'frequency-cap' &&
-        id === 'dfp-ad--inline1'
+        id === 'dfp-ad--inline1' &&
+        config.switches.abOutstreamFrequencyCap
     ) {
         slot.setTargeting('outstream', 'cap');
     }

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -119,8 +119,10 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slot.setTargeting('ad_h', new Date().getUTCHours().toString());
     }
 
-    if (getTestVariantId('OutstreamFrequencyCap') === 'frequency-cap' &&
-        id === 'dfp-ad--inline1') {
+    if (
+        getTestVariantId('OutstreamFrequencyCap') === 'frequency-cap' &&
+        id === 'dfp-ad--inline1'
+    ) {
         slot.setTargeting('outstream', 'cap');
     }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -7,6 +7,7 @@ import flatten from 'lodash/arrays/flatten';
 import once from 'lodash/functions/once';
 import prepareSwitchTag from 'commercial/modules/dfp/prepare-switch-tag';
 import { getOutbrainComplianceTargeting } from 'commercial/modules/third-party-tags/outbrain';
+import { getTestVariantId } from 'common/modules/experiments/utils';
 
 const adUnit = once(() => {
     const urlVars = getUrlVars();
@@ -116,6 +117,11 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
     if (config.switches.adomik) {
         slot.setTargeting('ad_group', adomikClassify());
         slot.setTargeting('ad_h', new Date().getUTCHours().toString());
+    }
+
+    if (getTestVariantId('OutstreamFrequencyCap') === 'frequency-cap' &&
+        id === 'dfp-ad--inline1') {
+        slot.setTargeting('outstream', 'cap');
     }
 
     slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,7 +5,7 @@ import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquis
 import { membershipEngagementBannerTests } from 'common/modules/experiments/tests/membership-engagement-banner-tests';
 import { paidContentVsOutbrain2 } from 'common/modules/experiments/tests/paid-content-vs-outbrain';
 import { tailorSurvey } from 'common/modules/experiments/tests/tailor-survey';
-
+import { outstreamFrequencyCapHoldback } from 'common/modules/experiments/tests/outstream-cap-holdback';
 import { acquisitionsEpicElectionInteractiveEnd } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
 import { acquisitionsEpicElectionInteractiveSlice } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-slice';
 
@@ -15,6 +15,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     tailorSurvey,
     acquisitionsEpicElectionInteractiveEnd,
     acquisitionsEpicElectionInteractiveSlice,
+    outstreamFrequencyCapHoldback,
 ]
     .concat(membershipEngagementBannerTests)
     .filter(Boolean);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
@@ -7,9 +7,9 @@ const videoInlineimpression = complete => {
     const advertId = 'dfp-ad--inline1';
 
     trackAdRender(advertId).then(() => {
-        const inlineAdvert: Advert = getAdvertById(advertId);
+        const inlineAdvert: ?Advert = getAdvertById(advertId);
         if (inlineAdvert) {
-            const loadedSize = inlineAdvert.size;
+            const loadedSize = inlineAdvert.size || [];
             if (
                 (loadedSize[0] === 620 && loadedSize[1] === 350) ||
                 (loadedSize[0] === 620 && loadedSize[1] === 1)

--- a/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
@@ -3,15 +3,17 @@ import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { Advert } from 'commercial/modules/dfp/Advert';
 
-const videoInlineimpression = (complete) => {
+const videoInlineimpression = complete => {
     const advertId = 'dfp-ad--inline1';
 
-    trackAdRender(advertId).then( () => {
-        const inlineAdvert : Advert = getAdvertById(advertId);
+    trackAdRender(advertId).then(() => {
+        const inlineAdvert: Advert = getAdvertById(advertId);
         if (inlineAdvert) {
             const loadedSize = inlineAdvert.size;
-            if ( (loadedSize[0] === 620 && loadedSize[1] === 350) ||
-                 (loadedSize[0] === 620 && loadedSize[1] === 1)) {
+            if (
+                (loadedSize[0] === 620 && loadedSize[1] === 350) ||
+                (loadedSize[0] === 620 && loadedSize[1] === 1)
+            ) {
                 // Notify ab-ophan module that a video impression was completed.
                 // Teads and outstream formats can be either 620x350 or 620x1 size.
                 complete();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/outstream-cap-holdback.js
@@ -1,0 +1,51 @@
+// @flow
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
+import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
+import { Advert } from 'commercial/modules/dfp/Advert';
+
+const videoInlineimpression = (complete) => {
+    const advertId = 'dfp-ad--inline1';
+
+    trackAdRender(advertId).then( () => {
+        const inlineAdvert : Advert = getAdvertById(advertId);
+        if (inlineAdvert) {
+            const loadedSize = inlineAdvert.size;
+            if ( (loadedSize[0] === 620 && loadedSize[1] === 350) ||
+                 (loadedSize[0] === 620 && loadedSize[1] === 1)) {
+                // Notify ab-ophan module that a video impression was completed.
+                // Teads and outstream formats can be either 620x350 or 620x1 size.
+                complete();
+            }
+        }
+    });
+};
+
+export const outstreamFrequencyCapHoldback: ABTest = {
+    id: 'OutstreamFrequencyCap',
+    start: '2017-08-24',
+    expiry: '2017-11-01',
+    author: 'Richard Nguyen',
+    description:
+        'This test adds a hold-back variant which retains a frequency cap on outstream video format ads.',
+    audience: 0.4,
+    audienceOffset: 0.6,
+    successMeasure:
+        'No change in user engagement; average page views per session, page views per user over a sustained test period',
+    audienceCriteria: 'All web traffic.',
+    dataLinkNames: '',
+    idealOutcome:
+        'We discover that removing the frequency cap on outstream ads has no significant impact on user engagement',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'frequency-cap',
+            test: () => {},
+            impression: videoInlineimpression,
+        },
+        {
+            id: 'control',
+            test: () => {},
+            impression: videoInlineimpression,
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?
Adding a long-term holdback test to see whether the effect of having a frequency cap on outstream format videos has an effect on user engagement.
