### PR TITLE
always show play button on fronts

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -84,19 +84,15 @@
                             </div>
                         </div>
                     } else {
-                        @defining(!cardStyle.exists(c => c.toneString != "media" && !playable)) { showPlayButton: Boolean =>
-                            @if(showPlayButton) {
-                                <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
-                            }
-                        }
-                            @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {
-                                <div class="youtube-media-atom__bottom-bar">
-                                    <div class="youtube-media-atom__bottom-bar__icon">
-                                    @fragments.inlineSvg("video-icon", "icon")
-                                    </div>
-                                    <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
+                        <div class="youtube-media-atom__play-button vjs-control-text">Play Video</div>
+                        @for(duration <- media.formattedDuration.filter(_ => displayDuration)) {
+                            <div class="youtube-media-atom__bottom-bar">
+                                <div class="youtube-media-atom__bottom-bar__icon">
+                                @fragments.inlineSvg("video-icon", "icon")
                                 </div>
-                            }
+                                <div class="youtube-media-atom__bottom-bar__duration">@duration</div>
+                            </div>
+                        }
                     }
                 } else {
                     <div class="vjs-error-display vjs-modal-dialog">


### PR DESCRIPTION
Changes more easily viewed without whitespace - https://github.com/guardian/frontend/pull/17695/files?w=1

## What does this change?
Previously, we were not adding the play button to small cards when they had a Media Atom as main media. This is different from old style videos. In old style videos, they would have a play button and the video would play inline on fronts. Although Editorial accept that we cannot play YouTube videos inline on small cards*, they still want the play button to show as its a signal that there's video content; so much so in fact that, on occasion, they've burnt it into the image e.g.

![image](https://user-images.githubusercontent.com/836140/29689978-0500c226-891d-11e7-8c15-56f0d959a62e.png)

😱 🙈 

*because a [YouTube iframe cannot be less than 200px x 200px](https://developers.google.com/youtube/iframe_api_reference), additionally, pre-roll cannot be served in small players

## What is the value of this and can you measure success?
- Signal to Readers that there is (main media) video content in an article
- Keep Editorial happy
- Stop Editorial from burning play buttons into images!

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No.

## Screenshots
The following screengrabs have three different type of video articles:
- [Media Atom video page](https://www.theguardian.com/world/video/2017/aug/24/aerial-footage-switzerland-landslide-shows-trail-destruction-video) has the play button on all card sizes
- [Article with old style video as main media](https://www.theguardian.com/uk-news/2017/aug/24/shipping-forecast-marks-150-years-service-bbc-met-office) has play button and plays inline
- [Article with media atom as main media](https://www.theguardian.com/uk-news/2017/aug/08/police-search-for-jogger-who-knocked-woman-into-path-of-bus) this is changing. Before we didn't render the play button on small cards. Now we do 🎉

### Before
<img width="973" alt="screen shot 2017-08-24 at 22 24 50" src="https://user-images.githubusercontent.com/836140/29689582-9b96b56c-891b-11e7-892e-246f455b43de.png">

### After
<img width="954" alt="screen shot 2017-08-24 at 22 26 07" src="https://user-images.githubusercontent.com/836140/29689593-a39ed046-891b-11e7-8e90-a7bc3679877a.png">


## Tested in CODE?
Yes.
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
