### PR TITLE
Lint all head changes in one process

### DIFF
--- a/tools/__tasks__/lib/get-changed-files.js
+++ b/tools/__tasks__/lib/get-changed-files.js
@@ -7,12 +7,12 @@ const getRemoteBranches = () => execa.stdout('git', ['branch', '-r']);
 
 const diffAgainstRemote = branch =>
     execa
-        .stdout('git', ['diff', '--cached', '--name-only', `origin/${branch}`])
+        .stdout('git', ['diff', '--name-only', 'head', `origin/${branch}`])
         .then(diffs => diffs.split('\n'));
 
 const diffAgainstMaster = () =>
     execa
-        .stdout('git', ['diff', '--name-only', 'origin/master...'])
+        .stdout('git', ['diff', '--name-only', 'head', 'origin/master...'])
         .then(diffs => diffs.split('\n'));
 
 const getChangedFiles = () =>

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -9,23 +9,65 @@ module.exports = {
             description: 'Lint committed JS',
             task: () =>
                 getChangedFiles().then(files => {
-                    const jsFiles = files
-                        .filter(
-                            file =>
-                                file.endsWith('.js') ||
-                                file === 'git-hooks/pre-push'
-                        )
-                        .join(' ');
+                    const errors = [];
+                    const jsFiles = files.filter(
+                        file =>
+                            file.endsWith('.js') ||
+                            file === 'git-hooks/pre-push'
+                    );
+                    const lint = (proc, batchedFiles) =>
+                        proc.then(() =>
+                            Promise.all(
+                                batchedFiles.map(filePath =>
+                                    execa
+                                        .shell(
+                                            `git show HEAD:${filePath} | eslint --stdin --stdin-filename ${filePath}`
+                                        )
+                                        .catch(e => {
+                                            errors.push(e);
+                                        })
+                                )
+                            )
+                        );
+                    const batch = (arr, batchSize) => {
+                        const batchFold = (xss, x) => {
+                            if (!xss.length) {
+                                return [[x]];
+                            }
+                            if (xss[0].length < batchSize) {
+                                return [xss[0].concat(x), ...xss.slice(1)];
+                            }
 
-                    return execa.shell(`eslint ${jsFiles}`).catch(e => {
-                        e.stdout += `\n${chalk.red(
-                            `✋ Linting failed. You can attempt to fix lint errors by running ${chalk.underline(
-                                'make fix-commits'
-                            )}.\nYour changes have not been pushed`
-                        )}`;
+                            return [[x], ...xss];
+                        };
 
-                        return Promise.reject(e);
-                    });
+                        return arr.reduce(batchFold, []);
+                    };
+
+                    return batch(jsFiles, 10)
+                        .reduce(lint, Promise.resolve())
+                        .then(() => {
+                            if (errors.length) {
+                                const error = errors.reduce(
+                                    (acc, curr) => {
+                                        acc.stdout += curr.stdout;
+
+                                        return acc;
+                                    },
+                                    { stdout: '' }
+                                );
+
+                                error.stdout += `\n${chalk.red(
+                                    `✋ Linting failed. You can attempt to fix lint errors by running ${chalk.underline(
+                                        'make fix-commits'
+                                    )}.\nYour changes have not been pushed`
+                                )}`;
+
+                                return Promise.reject(error);
+                            }
+
+                            return Promise.resolve();
+                        });
                 }),
         },
         {

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -9,29 +9,23 @@ module.exports = {
             description: 'Lint committed JS',
             task: () =>
                 getChangedFiles().then(files => {
-                    const jsFiles = files.filter(
-                        file =>
-                            file.endsWith('.js') ||
-                            file === 'git-hooks/pre-push'
-                    );
-
-                    return Promise.all(
-                        jsFiles.map(filePath =>
-                            execa
-                                .shell(
-                                    `git show HEAD:${filePath} | eslint --stdin --stdin-filename ${filePath}`
-                                )
-                                .catch(e => {
-                                    e.stdout += `\n${chalk.red(
-                                        `✋ Linting failed. You can attempt to fix lint errors by running ${chalk.underline(
-                                            'make fix-commits'
-                                        )}.\nYour changes have not been pushed`
-                                    )}`;
-
-                                    return Promise.reject(e);
-                                })
+                    const jsFiles = files
+                        .filter(
+                            file =>
+                                file.endsWith('.js') ||
+                                file === 'git-hooks/pre-push'
                         )
-                    );
+                        .join(' ');
+
+                    return execa.shell(`eslint ${jsFiles}`).catch(e => {
+                        e.stdout += `\n${chalk.red(
+                            `✋ Linting failed. You can attempt to fix lint errors by running ${chalk.underline(
+                                'make fix-commits'
+                            )}.\nYour changes have not been pushed`
+                        )}`;
+
+                        return Promise.reject(e);
+                    });
                 }),
         },
         {

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -1,6 +1,9 @@
 const execa = require('execa');
 const chalk = require('chalk');
+const os = require('os');
 const getChangedFiles = require('../lib/get-changed-files');
+
+const getCpuCount = () => os.cpus().length;
 
 module.exports = {
     description: 'Validate committed JS',
@@ -44,7 +47,7 @@ module.exports = {
                         return arr.reduce(batchFold, []);
                     };
 
-                    return batch(jsFiles, 10)
+                    return batch(jsFiles, getCpuCount())
                         .reduce(lint, Promise.resolve())
                         .then(() => {
                             if (errors.length) {


### PR DESCRIPTION
## What does this change?

On pre-push, committed changes to files are linted concurrently by piping them them into `eslint`. The benefit of this approach is that it allows us to ignore uncommitted "dirty" changes, as these changes are not being pushed. 

The trouble with this approach is that a different process is generated for every file. If a lot of files have been changed, especially after a large rebase, it caused too many concurrent processes to spawn, and node to run out of memory.

This new approach is to lint all files in one process, avoiding the memory issue. However it does mean that uncommitted changes to _files that were previously changed and committed on the branch_ are linted. This introduces an edge case whereby changes that would not be pushed but fail linting prevent all code being pushed.  

I have tried several different approaches, this one having the least friction. I'm open to any ideas!

## What is the value of this and can you measure success?

Validation does not blow up and prevent user from pushing a branch