### PR TITLE
strip terminal colors from rendering errors message

### DIFF
--- a/common/app/rendering/core/Renderer.scala
+++ b/common/app/rendering/core/Renderer.scala
@@ -14,6 +14,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
+case class RenderingException(error: String) extends RuntimeException(error)
+
 class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionContext, ac: ApplicationContext) extends Logging {
 
   val renderingActorCount = 3
@@ -30,8 +32,9 @@ class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionCon
         _ match {
           case Success(s) => Html(s)
           case Failure(f) =>
-            log.error(f.getLocalizedMessage)
-            throw f
+            val errorMessage = f.getLocalizedMessage.replaceAll("\u001B\\[[0-9]*m", "") // stripping terminal colors
+            log.error(errorMessage)
+            throw new RenderingException(errorMessage)
         }
       }
 

--- a/common/app/rendering/core/RenderingActor.scala
+++ b/common/app/rendering/core/RenderingActor.scala
@@ -10,8 +10,6 @@ import scala.util.Try
 
 case class Rendering(renderable: Renderable)
 
-case class RenderingException(error: String) extends RuntimeException(error)
-
 class RenderingActor(ac: ApplicationContext) extends Actor with JavascriptRendering {
 
   override def javascriptFile: String = "ui/dist/ui.bundle.server.js"


### PR DESCRIPTION
BEFORE:
![screen shot 2017-08-25 at 12 02 38](https://user-images.githubusercontent.com/233326/29714883-ed6d8ae2-899c-11e7-98b6-edf1936e1791.png)

AFTER:
![screen shot 2017-08-25 at 13 54 59](https://user-images.githubusercontent.com/233326/29714916-053658c0-899d-11e7-8de6-641a51857959.png)

I could have instead disable highlighting in babel but colors is quite useful in the terminal