### PR TITLE
Allow to embed atom with a vertical scrollbar

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -75,20 +75,20 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient)
       })
   }
 
-  def render(atomType: String, id: String, isJsEnabled: Boolean) = Action.async { implicit request =>
+  def render(atomType: String, id: String, isJsEnabled: Boolean, hasVerticalScrollbar: Boolean) = Action.async { implicit request =>
     lookup(s"atom/$atomType/$id") map {
       case Left(model: MediaAtom) =>
-        renderAtom(MediaAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(MediaAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: StoryQuestionsAtom) =>
-        renderAtom(StoryQuestionsAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(StoryQuestionsAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: GuideAtom) =>
-        renderAtom(GuideAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(GuideAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: ProfileAtom) =>
-        renderAtom(ProfileAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(ProfileAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: QandaAtom) =>
-        renderAtom(QandaAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(QandaAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: TimelineAtom) =>
-        renderAtom(TimelineAtomPage(model, withJavaScript = isJsEnabled))
+        renderAtom(TimelineAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(_) =>
         renderOther(NotFound)
       case Right(other) =>

--- a/applications/app/views/fragments/atomPageHead.scala.html
+++ b/applications/app/views/fragments/atomPageHead.scala.html
@@ -17,6 +17,11 @@
 
 <style>
   @Html(common.Assets.css.inlineAtom(page.atomType))
+  @if(page.withVerticalScrollbar) {
+    body {
+        overflow-y: scroll !important;
+    }
+  }
 </style>
 
 @if(page.withJavaScript) {

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -37,8 +37,9 @@ GET        /index/contributors                                                  
 GET        /index/contributors/*contributor                                     controllers.TagIndexController.contributor(contributor)
 
 GET        /embed/video/*path                                                   controllers.EmbedController.render(path)
-GET        /embed/atom/:atomType/:id                                            controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = true)
-GET        /embed/atom/:atomType/:id/nojs                                       controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false)
+GET        /embed/atom/:atomType/:id                                            controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = true, hasVerticalScrollbar: Boolean = false)
+GET        /embed/atom/:atomType/:id/nojs                                       controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false, hasVerticalScrollbar: Boolean = false)
+GET        /embed/atom/:atomType/:id/nojs/scroll-y                              controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false, hasVerticalScrollbar: Boolean = true)
 POST       /story-questions/answers/signup                                      controllers.AtomPageController.signup()
 OPTIONS    /story-questions/answers/signup                                      controllers.AtomPageController.options()
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -403,12 +403,14 @@ trait AtomPage extends Page {
   def atomType: String
   def body: Html
   def withJavaScript: Boolean
+  def withVerticalScrollbar: Boolean 
   def javascriptModule: String = atomType
 }
 
 case class MediaAtomPage(
   override val atom: MediaAtom,
-  override val withJavaScript: Boolean
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "media"
   override val body = views.html.fragments.atoms.media(atom, displayCaption = false, mediaWrapper = Some(MediaWrapper.EmbedPage))
@@ -422,7 +424,8 @@ case class MediaAtomPage(
 
 case class StoryQuestionsAtomPage(
   override val atom: StoryQuestionsAtom,
-  override val withJavaScript: Boolean
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "storyquestions"
   override val body = views.html.fragments.atoms.storyquestions(atom, isAmp = false)
@@ -435,7 +438,8 @@ case class StoryQuestionsAtomPage(
 
 case class GuideAtomPage(
   override val atom: GuideAtom,
-  override val withJavaScript: Boolean
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "guide"
   override val body = views.html.fragments.atoms.snippets.guide(atom, isAmp = false)
@@ -449,7 +453,8 @@ case class GuideAtomPage(
 
 case class ProfileAtomPage(
   override val atom: ProfileAtom,
-  override val withJavaScript: Boolean
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "profile"
   override val body = views.html.fragments.atoms.snippets.profile(atom, isAmp = false)
@@ -463,7 +468,8 @@ case class ProfileAtomPage(
 
 case class QandaAtomPage(
 override val atom: QandaAtom,
-override val withJavaScript: Boolean
+override val withJavaScript: Boolean,
+override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "qanda"
   override val body = views.html.fragments.atoms.snippets.qanda(atom, isAmp = false)
@@ -477,7 +483,8 @@ override val withJavaScript: Boolean
 
 case class TimelineAtomPage(
 override val atom: TimelineAtom,
-override val withJavaScript: Boolean
+override val withJavaScript: Boolean,
+override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "timeline"
   override val body = views.html.fragments.atoms.snippets.timeline(atom, isAmp = false)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -343,8 +343,9 @@ GET            /sharecount/*path.json                                           
 GET            /2015-06-24-manifest.json                                                                                         controllers.WebAppController.manifest()
 GET            /preferences                                                                                                      controllers.PreferencesController.indexPrefs()
 GET            /embed/video/*path                                                                                                controllers.EmbedController.render(path)
-GET            /embed/atom/:atomType/:id                                                                                         controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = true)
-GET            /embed/atom/:atomType/:id/nojs                                                                                    controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false)
+GET            /embed/atom/:atomType/:id                                                                                         controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = true, hasVerticalScrollbar: Boolean = false)
+GET            /embed/atom/:atomType/:id/nojs                                                                                    controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false, hasVerticalScrollbar: Boolean = false)
+GET            /embed/atom/:atomType/:id/nojs/scroll-y                                                                           controllers.AtomPageController.render(atomType: String, id: String, isJsEnabled: Boolean = false, hasVerticalScrollbar: Boolean = true)
 POST           /story-questions/answers/signup                                                                                   controllers.AtomPageController.signup()
 OPTIONS        /story-questions/answers/signup                                                                                   controllers.AtomPageController.options()
 


### PR DESCRIPTION
## What does this change?

This add a route to embed content atom with a vertical scrollbar when embedding without js support. 

## What is the value of this and can you measure success?
this allow to add a [preview of atom in composer](https://github.com/guardian/flexible-content/pull/2899) 

## Does this affect other platforms - Amp, Apps, etc?
no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
no


