### PR TITLE
Improve pre-push hook

### DIFF
--- a/tools/__tasks__/lib/get-changed-files.js
+++ b/tools/__tasks__/lib/get-changed-files.js
@@ -7,12 +7,18 @@ const getRemoteBranches = () => execa.stdout('git', ['branch', '-r']);
 
 const diffAgainstRemote = branch =>
     execa
-        .stdout('git', ['diff', '--name-only', 'head', `origin/${branch}`])
+        .stdout('git', [
+            'diff',
+            '--name-only',
+            'HEAD',
+            `origin/${branch}`,
+            '^origin/master', // excluding changes already in origin/master
+        ])
         .then(diffs => diffs.split('\n'));
 
 const diffAgainstMaster = () =>
     execa
-        .stdout('git', ['diff', '--name-only', 'head', 'origin/master...'])
+        .stdout('git', ['diff', '--name-only', 'HEAD', 'origin/master'])
         .then(diffs => diffs.split('\n'));
 
 const getChangedFiles = () =>


### PR DESCRIPTION
## What does this change?
Exclude changes from origin/master when diff'ing between local HEAD and origin branch

## What is the value of this and can you measure success?
Less unnecessary linting when rebasing master into your current branch 