### PR TITLE
Warn against accessing properties on JS config

### DIFF
--- a/dev/eslint-plugin-guardian-frontend/__tests__/no-direct-access-config.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/no-direct-access-config.js
@@ -1,0 +1,23 @@
+const { RuleTester } = require('eslint');
+const rule = require('../rules/no-direct-access-config');
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+ruleTester.run('no-direct-access-config', rule, {
+    valid: [
+        'config',
+        'config.get()',
+    ],
+
+    invalid: [
+        'config.page',
+        'config.page.keywordIds',
+    ].map(code => ({
+        code,
+        errors: [
+            {
+                type: 'Identifier',
+            },
+        ],
+    })),
+});

--- a/dev/eslint-plugin-guardian-frontend/__tests__/no-direct-access-config.js
+++ b/dev/eslint-plugin-guardian-frontend/__tests__/no-direct-access-config.js
@@ -4,15 +4,9 @@ const rule = require('../rules/no-direct-access-config');
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 
 ruleTester.run('no-direct-access-config', rule, {
-    valid: [
-        'config',
-        'config.get()',
-    ],
+    valid: ['config', 'config.get()'],
 
-    invalid: [
-        'config.page',
-        'config.page.keywordIds',
-    ].map(code => ({
+    invalid: ['config.page', 'config.page.keywordIds'].map(code => ({
         code,
         errors: [
             {

--- a/dev/eslint-plugin-guardian-frontend/package.json
+++ b/dev/eslint-plugin-guardian-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-guardian-frontend",
   "main": "index.js",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "scripts": {
     "test": "jest"
   }

--- a/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
@@ -2,16 +2,14 @@ module.exports = {
     create(context) {
         const isDot = token =>
             token && token.type === 'Punctuator' && token.value === '.';
-        const isIdentifier = (token) =>
-            token && token.type === 'Identifier'
+        const isIdentifier = token => token && token.type === 'Identifier';
 
         return {
             Identifier: node => {
                 if (node.name === 'config') {
-                    const [
-                        dot,
-                        child,
-                    ] = context.getSourceCode().getTokensAfter(node, 2);
+                    const [dot, child] = context
+                        .getSourceCode()
+                        .getTokensAfter(node, 2);
 
                     if (
                         isDot(dot) &&
@@ -20,7 +18,8 @@ module.exports = {
                     ) {
                         context.report({
                             node,
-                            message: 'Prefer accessing properties on config using get() method',
+                            message:
+                                'Prefer accessing properties on config using get() method',
                         });
                     }
                 }

--- a/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-direct-access-config.js
@@ -1,0 +1,30 @@
+module.exports = {
+    create(context) {
+        const isDot = token =>
+            token && token.type === 'Punctuator' && token.value === '.';
+        const isIdentifier = (token) =>
+            token && token.type === 'Identifier'
+
+        return {
+            Identifier: node => {
+                if (node.name === 'config') {
+                    const [
+                        dot,
+                        child,
+                    ] = context.getSourceCode().getTokensAfter(node, 2);
+
+                    if (
+                        isDot(dot) &&
+                        isIdentifier(child) &&
+                        child.value !== 'get'
+                    ) {
+                        context.report({
+                            node,
+                            message: 'Prefer accessing properties on config using get() method',
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
         'guardian-frontend/no-multiple-classlist-parameters': 'error',
         'guardian-frontend/no-default-export': 'warn',
         'import/prefer-default-export': 'off',
+        'guardian-frontend/no-direct-access-config': 'error',
 
         // flow should take care of our return values
         'consistent-return': 'off',

--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         'import/extensions': 'off',
         'import/no-webpack-loader-syntax': 'off', // used for require plugins still
         'import/no-namespace': 2,
+        'import/prefer-default-export': 'off', // we explicitly warn against default export below
 
         // these are bad habits in react that we're already abusing.
         // if we go more [p]react we should look at them.
@@ -78,8 +79,7 @@ module.exports = {
         'guardian-frontend/global-config': 'error',
         'guardian-frontend/no-multiple-classlist-parameters': 'error',
         'guardian-frontend/no-default-export': 'warn',
-        'import/prefer-default-export': 'off',
-        'guardian-frontend/no-direct-access-config': 'error',
+        'guardian-frontend/no-direct-access-config': 'warn',
 
         // flow should take care of our return values
         'consistent-return': 'off',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,7 +2522,7 @@ eslint-plugin-flowtype@^2.35.0:
     lodash "^4.15.0"
 
 "eslint-plugin-guardian-frontend@file:dev/eslint-plugin-guardian-frontend":
-  version "4.0.0"
+  version "5.0.0"
 
 eslint-plugin-import@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
## What does this change?

There have been a number of errors introduced into production caused by us attempting to access properties on the `config` object that do not exist. It is simple to guard against this type of error by using the [`get` method](https://github.com/guardian/frontend/blob/master/static/src/javascripts/lib/config.js#L10-L14) that is provided by `config`.

This change introduces a lint rule to warn against direct access of properties on `config`, and to prefer the use of the `get` method instead.

## What is the value of this and can you measure success?

There are currently 71 occurrences of direct property access on the `config` object, which are a source of potential defects. In future PRs we can gradually eliminate theses accesses, and eventually disallow direct access entirely. For now it's useful to have visibility over where these property accesses are occurring.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No
