### PR TITLE
Add side bar buttons to S&C's test 4

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -108,7 +108,7 @@
                         data-edition="@{edition.id.toLowerCase}"
                         role="menuitem">
 
-                        <a class="menu-item__title"
+                        <a class="menu-item__title js-change-membership-item"
                            href="@item.url"
                            data-link-name="nav2 : @item.title">
                             @item.title

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
@@ -98,22 +98,20 @@ const changeSideMenuLinks = (
     subscribeLink: string
 ) => {
     const cssClass = 'js-change-membership-item';
-    debugger;
+
     [...document.getElementsByClassName(cssClass)].forEach(el => {
         if (el instanceof HTMLAnchorElement) {
-            if(el.innerText.trim() === 'become a supporter') {
+            if (el.innerText && el.innerText.trim() === 'become a supporter') {
                 el.href = becomeSupporterLink;
-            }else if(el.innerText.trim() === 'subscribe') {
+            } else if (el.innerText && el.innerText.trim() === 'subscribe') {
                 el.href = subscribeLink;
             }
         }
     });
-}
+};
 
 const shouldDisplayEpic = (test: EpicABTest): boolean =>
     isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
-
-// gdnwb_copts_memco_sandc_support_baseline_support_epic
 
 const bindEpicInsertAndViewHandlers = (
     test: EpicABTest,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
@@ -10,6 +10,7 @@ import {
     submitViewEvent,
 } from 'common/modules/commercial/acquisitions-ophan';
 import mediator from 'lib/mediator';
+import fastdom from 'lib/fastdom-promise';
 
 import config from 'lib/config';
 
@@ -98,16 +99,25 @@ const changeSideMenuLinks = (
     subscribeLink: string
 ) => {
     const cssClass = 'js-change-membership-item';
-
-    [...document.getElementsByClassName(cssClass)].forEach(el => {
-        if (el instanceof HTMLAnchorElement) {
-            if (el.innerText && el.innerText.trim() === 'become a supporter') {
-                el.href = becomeSupporterLink;
-            } else if (el.innerText && el.innerText.trim() === 'subscribe') {
-                el.href = subscribeLink;
-            }
-        }
-    });
+    fastdom.read(() => document.getElementsByClassName(cssClass)).then(els =>
+        fastdom.write(() => {
+            [...els].forEach(el => {
+                if (el instanceof HTMLAnchorElement) {
+                    if (
+                        el.innerText &&
+                        el.innerText.trim() === 'become a supporter'
+                    ) {
+                        el.href = becomeSupporterLink;
+                    } else if (
+                        el.innerText &&
+                        el.innerText.trim() === 'subscribe'
+                    ) {
+                        el.href = subscribeLink;
+                    }
+                }
+            });
+        })
+    );
 };
 
 const shouldDisplayEpic = (test: EpicABTest): boolean =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
@@ -93,6 +93,23 @@ const changeHeaderLinks = (
     changeLinks('js-change-subscribe-link', subscribeLink);
 };
 
+const changeSideMenuLinks = (
+    becomeSupporterLink: string,
+    subscribeLink: string
+) => {
+    const cssClass = 'js-change-membership-item';
+    debugger;
+    [...document.getElementsByClassName(cssClass)].forEach(el => {
+        if (el instanceof HTMLAnchorElement) {
+            if(el.innerText.trim() === 'become a supporter') {
+                el.href = becomeSupporterLink;
+            }else if(el.innerText.trim() === 'subscribe') {
+                el.href = subscribeLink;
+            }
+        }
+    });
+}
+
 const shouldDisplayEpic = (test: EpicABTest): boolean =>
     isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
 
@@ -177,6 +194,15 @@ export const acquisitionsSupportBaseline = makeABTest({
                             `${baseCampaignCode}_control_header_subscribe`
                         )
                     );
+
+                    changeSideMenuLinks(
+                        makeBecomeSupporterURL(
+                            `${baseCampaignCode}_control_side_menu_become_supporter`
+                        ),
+                        makeSubscribeURL(
+                            `${baseCampaignCode}_control_side_menu_subscribe`
+                        )
+                    );
                 },
 
                 engagementBannerParams: {
@@ -233,6 +259,15 @@ export const acquisitionsSupportBaseline = makeABTest({
                         ),
                         makeSupportURL(
                             `${baseCampaignCode}_support_header_subscribe`
+                        )
+                    );
+
+                    changeSideMenuLinks(
+                        makeSupportURL(
+                            `${baseCampaignCode}_support_side_menu_become_supporter`
+                        ),
+                        makeSupportURL(
+                            `${baseCampaignCode}_support_side_menu_subscribe`
                         )
                     );
                 },


### PR DESCRIPTION
## What does this change?
When we implemented S&C's test 4 (https://github.com/guardian/frontend/pull/17650) we didn't include the links from the side menu (only visible in the mobile and tablet view) as a channel. In this PR we add them.

### Support variant
| Channel | Campaign Code | 
|---------|-----------------|
|Side Menu - Become a Supporter | gdnwb_copts_memco_sandc_support_baseline_support_side_menu_become_supporter|
|Side menu - Subscribe |gdnwb_copts_memco_sandc_support_baseline_support_side_menu_subscribe|


### Control variant
| Channel | Campaign Code | 
|---------|-----------------|
|Side Menu - Become a Supporter | gdnwb_copts_memco_sandc_support_baseline_control_side_menu_become_supporter|
|Side menu - Subscribe |gdnwb_copts_memco_sandc_support_baseline_control_side_menu_subscribe|



## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots

<img width="481" alt="picture 392" src="https://user-images.githubusercontent.com/825398/29821579-54a53360-8cc0-11e7-964a-7f23d3848db8.png">


## Tested in CODE?
Not yet.