### PR TITLE
Misc import fixes (pre Play 2.6)

### DIFF
--- a/common/app/views/fragments/atoms/interactive.scala.html
+++ b/common/app/views/fragments/atoms/interactive.scala.html
@@ -1,6 +1,7 @@
 @import common.InlineJs
 @import model.content.InteractiveAtom
 @import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
+@import play.twirl.api.HtmlFormat
 
 @(interactive: InteractiveAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,7 +1,6 @@
 @import conf.Configuration.site.host
 @import conf.Configuration.Media
 @import views.support.{RenderClasses, Video700}
-@import views.html.fragments.atoms.mediaAtomCaption
 @import com.netaporter.uri.dsl._
 @import model.pressed.CardStyle
 

--- a/common/app/views/fragments/commercial/cardLogo.scala.html
+++ b/common/app/views/fragments/commercial/cardLogo.scala.html
@@ -1,5 +1,4 @@
 @import com.gu.commercial.branding.Branding
-@import views.html.fragments.commercial.logo
 @(branding: Branding, isStandardSizeCard: Boolean)(implicit request: RequestHeader)
 
 <div class="badge @if(isStandardSizeCard){badge--branded}">

--- a/common/app/views/fragments/commercial/containerLogo.scala.html
+++ b/common/app/views/fragments/commercial/containerLogo.scala.html
@@ -1,5 +1,4 @@
 @import com.gu.commercial.branding.Branding
-@import views.html.fragments.commercial.logo
 @(branding: Branding, isOnTheLeft: Boolean)(implicit request: RequestHeader)
 
 <div class="badge @if(isOnTheLeft){badge--alt}">

--- a/common/app/views/fragments/commercial/pageLogo.scala.html
+++ b/common/app/views/fragments/commercial/pageLogo.scala.html
@@ -1,5 +1,4 @@
 @import com.gu.commercial.branding.Branding
-@import views.html.fragments.commercial.logo
 @(branding: Branding,
   isInteractive: Boolean,
   onDarkBackground: Boolean = false

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -2,7 +2,6 @@
 @import common.commercial.ContainerModel
 @import common.{Edition, Localisation}
 @import views.html.fragments.commercial.containerLogo
-@import views.html.fragments.containers.facia_cards.{containerHeader, showMore, showMoreButton, slice}
 @import views.support.RenderClasses
 
 @(containerDefinition: layout.FaciaContainer,

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -3,6 +3,7 @@
 @import conf.Configuration
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._
+@import play.twirl.api.HtmlFormat
 
 @(page: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,7 +1,6 @@
 @import common.Edition
 @import model.ContentType
 @import views.support.{BulletCleaner, ContributorLinks, InBodyLinkCleaner, RenderClasses, withJsoup}
-@import views.html.fragments.langAttributes
 
 @(item: ContentType)(implicit request: RequestHeader)
 


### PR DESCRIPTION
## What does this change?
Tiny fixes:
- Explicitly import play.twirl.api.HtmlFormat where needed
- Remove unnecessary import in templates (Imports are in the same package. No need to import them)

## What is the value of this and can you measure success?
Preparing for 2.6 upgrade (Play 2.6 complaining about those issues)

## Tested in CODE?
No