### PR TITLE
Fix error preventing Preferences page JS from loading, and gimme it to ES6 convert

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/preferences/main.js
+++ b/static/src/javascripts-legacy/projects/common/modules/preferences/main.js
@@ -13,76 +13,78 @@ define([
     reduce,
     isEmpty
 ) {
-    return function () {
-        var placeholder = document.getElementById('preferences-history-tags'),
+    return {
+        init: function () {
+            var placeholder = document.getElementById('preferences-history-tags'),
 
-            initialiseSummaryTagsSettings = function () {
-                var SummaryTagsList = React.createClass({
-                    getInitialState: function () {
-                        return {popular: history.getPopularFiltered()};
-                    },
-                    handleRemove: function (tag) {
-                        history.deleteFromSummary(tag);
-                        this.setState({popular: history.getPopularFiltered({flush: true})});
-                        history.showInMegaNav();
-                    },
-                    render: function () {
-                        var self = this,
-                            tags = reduce(this.state.popular, function (obj, tag) {
-                                obj[tag[0]] = React.DOM.span({className: 'button button--small button--tag button--secondary'},
-                                    React.DOM.button({
-                                        onClick: self.handleRemove.bind(self, tag[0]),
-                                        'data-link-name': 'remove | ' + tag[1]
-                                    }, 'X'),
-                                    React.DOM.a({
-                                        href: '/' + tag[0]
-                                    }, tag[1])
-                                );
-                                return obj;
-                            }, {}),
-                            helperText;
+                initialiseSummaryTagsSettings = function () {
+                    var SummaryTagsList = React.createClass({
+                        getInitialState: function () {
+                            return {popular: history.getPopularFiltered()};
+                        },
+                        handleRemove: function (tag) {
+                            history.deleteFromSummary(tag);
+                            this.setState({popular: history.getPopularFiltered({flush: true})});
+                            history.showInMegaNav();
+                        },
+                        render: function () {
+                            var self = this,
+                                tags = reduce(this.state.popular, function (obj, tag) {
+                                    obj[tag[0]] = React.DOM.span({className: 'button button--small button--tag button--secondary'},
+                                        React.DOM.button({
+                                            onClick: self.handleRemove.bind(self, tag[0]),
+                                            'data-link-name': 'remove | ' + tag[1]
+                                        }, 'X'),
+                                        React.DOM.a({
+                                            href: '/' + tag[0]
+                                        }, tag[1])
+                                    );
+                                    return obj;
+                                }, {}),
+                                helperText;
 
-                        if (isEmpty(tags)) {
-                            helperText = '(You don\'t have any recently visited topics.)';
-                        } else {
-                            helperText = 'Remove individual topics by clicking \'X\' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.';
+                            if (isEmpty(tags)) {
+                                helperText = '(You don\'t have any recently visited topics.)';
+                            } else {
+                                helperText = 'Remove individual topics by clicking \'X\' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.';
+                            }
+                            tags.helperText = React.DOM.p(null, helperText);
+                            return React.DOM.div(null, tags);
                         }
-                        tags.helperText = React.DOM.p(null, helperText);
-                        return React.DOM.div(null, tags);
-                    }
-                });
+                    });
 
-                var SummaryTagsSettings = React.createClass({
-                    getInitialState: function () {
-                        return {enabled: history.showInMegaNavEnabled()};
-                    },
-                    handleToggle: function () {
-                        var isEnabled = !this.state.enabled;
+                    var SummaryTagsSettings = React.createClass({
+                        getInitialState: function () {
+                            return {enabled: history.showInMegaNavEnabled()};
+                        },
+                        handleToggle: function () {
+                            var isEnabled = !this.state.enabled;
 
-                        this.setState({enabled: isEnabled});
-                        history.showInMegaNavEnable(isEnabled);
-                    },
-                    render: function () {
-                        var self = this,
-                            toggleAction = this.state.enabled ? 'OFF' : 'ON';
+                            this.setState({enabled: isEnabled});
+                            history.showInMegaNavEnable(isEnabled);
+                        },
+                        render: function () {
+                            var self = this,
+                                toggleAction = this.state.enabled ? 'OFF' : 'ON';
 
-                        return React.DOM.div({'data-link-name': 'suggested links'}, [
-                            React.DOM.p(null, 'These are based on the topics you visit most. You can access them at any time by opening the "all sections” menu.'),
-                            this.state.enabled ? React.createElement(SummaryTagsList) : null,
-                            React.DOM.button({
-                                onClick: self.handleToggle,
-                                className: 'button button--medium button--primary',
-                                'data-link-name': toggleAction
-                            }, 'Switch recently visited links ' + toggleAction)
-                        ]);
-                    }
-                });
+                            return React.DOM.div({'data-link-name': 'suggested links'}, [
+                                React.DOM.p(null, 'These are based on the topics you visit most. You can access them at any time by opening the "all sections” menu.'),
+                                this.state.enabled ? React.createElement(SummaryTagsList) : null,
+                                React.DOM.button({
+                                    onClick: self.handleToggle,
+                                    className: 'button button--medium button--primary',
+                                    'data-link-name': toggleAction
+                                }, 'Switch recently visited links ' + toggleAction)
+                            ]);
+                        }
+                    });
 
-                React.render(React.createElement(SummaryTagsSettings), placeholder);
-            };
+                    React.render(React.createElement(SummaryTagsSettings), placeholder);
+                };
 
-        if (placeholder) {
-            initialiseSummaryTagsSettings();
+            if (placeholder) {
+                initialiseSummaryTagsSettings();
+            }
         }
     };
 });

--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -84,7 +84,9 @@
   "Jamie Byers": [],
   "Francis Carr": [],
   "Jon Norman": [],
-  "Kate Whalen": [],
+  "Kate Whalen": [
+      "projects/common/modules/preferences/main.js"
+  ],
   "dominickendrick": [],
   "davidfurey": [],
   "jranks123": [],
@@ -96,7 +98,6 @@
   "Calum Campbell": [],
   "Unassigned": [
     "projects/common/modules/navigation/search.js",
-    "projects/common/modules/preferences/main.js",
     "projects/common/modules/ui/full-height.js",
     "projects/common/modules/ui/notification-counter.js",
     "projects/common/modules/ui/relativedates.js",


### PR DESCRIPTION
## What does this change?

- makes the return an object, and name the function `init` so that [Enhanced Main](https://github.com/guardian/frontend/blob/7c46b367474d872acc76985a5e7a08c54e4796e1/static/src/javascripts/bootstraps/enhanced/main.js#L265) can find it when it tries to `require('common/modules/preferences/main').init`

- Gives me the unassigned ES6 conversion for this file

## What is the value of this and can you measure success?

- Fixes JS error being thrown on https://www.theguardian.com/preferences that is preventing the content from loading, and users from being able to modify their recent links

- Goodbye Raven error

- More ES6 conversions assigned

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

#### Before:

<img width="1680" alt="picture 972" src="https://user-images.githubusercontent.com/8607683/29824317-250d90da-8cc9-11e7-9c3a-37278f448734.png">

#### After:

<img width="1679" alt="picture 973" src="https://user-images.githubusercontent.com/8607683/29824359-45f39d30-8cc9-11e7-978f-01adb8d80c42.png">
