### PR TITLE
Ensure paid cards respect kickers from fronts.

### DIFF
--- a/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/paidContentCard.scala.html
@@ -14,10 +14,7 @@
         ))
         <div class="fc-item__content">
             <div class="fc-item__header">
-                <div class="fc-item__title">
-                    @item.paidIcon.map(icon => fragments.inlineSvg(icon, "icon"))
-                    @item.header.headline
-                </div>
+                @title(item.header, index, containerIndex, snapType = item.snapStuff.map(_.snapType))
             </div>
 
             @item.trailText.filter(const(item.showStandfirst)).map { text =>


### PR DESCRIPTION
## What does this change?
Ensures kickers can be shown on paid content cards when configured in fronts.

## What is the value of this and can you measure success?
In keeping with design of editorial cards.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Yes.

## Screenshots
<img width="247" alt="picture 133" src="https://user-images.githubusercontent.com/8861681/29919038-a2ac06a8-8e3f-11e7-9c05-335c382b8f82.png">
<img width="245" alt="picture 135" src="https://user-images.githubusercontent.com/8861681/29919040-a2c7dafe-8e3f-11e7-9e0d-4b59f53dc018.png">
