### PR TITLE
Deps: Upgrade prettier to 1.6.1

### DIFF
--- a/dev/eslint-plugin-guardian-frontend/rules/global-config.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/global-config.js
@@ -8,12 +8,7 @@ module.exports = {
         return {
             Identifier: node => {
                 if (node.name === 'config') {
-                    const [
-                        dot1,
-                        parent,
-                        dot2,
-                        grandparent,
-                    ] = context
+                    const [dot1, parent, dot2, grandparent] = context
                         .getSourceCode()
                         .getTokensBefore(node, 4)
                         .reverse();

--- a/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
+++ b/dev/eslint-plugin-guardian-frontend/rules/no-multiple-classlist-parameters.js
@@ -10,10 +10,7 @@ module.exports = {
         return {
             Identifier: node => {
                 if (node.name === 'add') {
-                    const [
-                        dot,
-                        parent,
-                    ] = context
+                    const [dot, parent] = context
                         .getSourceCode()
                         .getTokensBefore(node, 2)
                         .reverse();

--- a/dev/webpack-loaders/svg-loader/index.js
+++ b/dev/webpack-loaders/svg-loader/index.js
@@ -3,7 +3,10 @@ const path = require('path');
 module.exports = function svgLoader(content) {
     const match = content.match(/<svg([^>]+)+>([\s\S]+)<\/svg>/i);
     const prefix = 'inline-';
-    const imageType = path.dirname(this.resourcePath).split('/').pop();
+    const imageType = path
+        .dirname(this.resourcePath)
+        .split('/')
+        .pop();
     const fileName = path.basename(this.resourcePath, '.svg');
     const svg = match ? match[0].replace(/\n/g, ' ').trim() : '';
     const markup = `<span class="${prefix}${fileName} ${imageType !== ''

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "pify": "^3.0.0",
     "postcss": "^6.0.1",
     "postcss-pxtorem": "^4.0.1",
-    "prettier": "^1.5.3",
+    "prettier": "^1.6.1",
     "prettysize": "^0.1.0",
     "raw-loader": "^0.5.1",
     "request": "^2.81.0",

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -62,8 +62,16 @@ const createVideoPlayer = (el: HTMLElement, options: Object): any => {
         player.guAutoplay = $(el).attr('data-auto-play') === 'true';
 
         // need to explicitly set the dimensions for the ima plugin.
-        player.height(bonzo(player.el()).parent().dim().height);
-        player.width(bonzo(player.el()).parent().dim().width);
+        player.height(
+            bonzo(player.el())
+                .parent()
+                .dim().height
+        );
+        player.width(
+            bonzo(player.el())
+                .parent()
+                .dim().width
+        );
     });
 
     return player;
@@ -316,7 +324,9 @@ const initPlayButtons = (root: ?HTMLElement): void => {
         $('.js-video-play-button', root).each(el => {
             const $el = bonzo(el);
             bean.on(el, 'click', () => {
-                const container = bonzo(el).parent().parent();
+                const container = bonzo(el)
+                    .parent()
+                    .parent();
                 const placeholder = $('.js-video-placeholder', container);
                 const player = $('.js-video-player', container);
 

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -73,7 +73,9 @@ const showSignupForm = (buttonEl: HTMLButtonElement): void => {
     const form = buttonEl.form;
     const meta = $.ancestor(buttonEl, 'js-newsletter-meta');
     fastdom.write(() => {
-        $(`.${classes.textInput}`, form).removeClass('is-hidden').focus();
+        $(`.${classes.textInput}`, form)
+            .removeClass('is-hidden')
+            .focus();
         $(`.${classes.signupButton}`, form).addClass(classes.styleSignup);
         $(`.${classes.previewButton}`, meta).addClass('is-hidden');
         subscribeToEmail(buttonEl);

--- a/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/build-page-targeting.js
@@ -16,7 +16,11 @@ const format = (keyword: string): string =>
     keyword.replace(/[+\s]+/g, '-').toLowerCase();
 
 const formatTarget = (target: ?string): ?string =>
-    target ? format(target).replace(/&/g, 'and').replace(/'/g, '') : null;
+    target
+        ? format(target)
+              .replace(/&/g, 'and')
+              .replace(/'/g, '')
+        : null;
 
 const abParam = (): Array<string> => {
     const abParticipations: Object = getParticipations();

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -226,7 +226,9 @@ describe('DFP', () => {
     });
 
     it('should not get hidden ad slots', () => {
-        $('.js-ad-slot').first().css('display', 'none');
+        $('.js-ad-slot')
+            .first()
+            .css('display', 'none');
         return new Promise(resolve => {
             prepareGoogletag.init(noop, resolve);
         }).then(() => {
@@ -323,7 +325,9 @@ describe('DFP', () => {
     });
 
     it('should be able to create "out of page" ad slot', () => {
-        $('.js-ad-slot').first().attr('data-out-of-page', true);
+        $('.js-ad-slot')
+            .first()
+            .attr('data-out-of-page', true);
         return new Promise(resolve => {
             prepareGoogletag.init(noop, resolve);
         }).then(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -104,7 +104,9 @@ const init = (start: () => void, stop: () => void): Promise<void> => {
 
     if (commercialFeatures.dfpAdvertising) {
         if (commercialFeatures.adFree) {
-            setupAdvertising().then(adFreeSlotRemove).catch(removeAdSlots);
+            setupAdvertising()
+                .then(adFreeSlotRemove)
+                .catch(removeAdSlots);
             return Promise.resolve();
         }
         // A promise error here, from a failed module load,

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
@@ -144,15 +144,17 @@ describe('Sticky ad banner', () => {
             topSlot.style.paddingBottom = `${paddingBottom}px`;
         }
 
-        return initStickyTopBanner().then(() => update(height)).then(() => {
-            if (!stickyBanner) {
-                throw Error('missing sticky banner element');
-            } else {
-                expect(stickyBanner.style.height).toBe(
-                    `${height + padingTop + paddingBottom}px`
-                );
-            }
-        });
+        return initStickyTopBanner()
+            .then(() => update(height))
+            .then(() => {
+                if (!stickyBanner) {
+                    throw Error('missing sticky banner element');
+                } else {
+                    expect(stickyBanner.style.height).toBe(
+                        `${height + padingTop + paddingBottom}px`
+                    );
+                }
+            });
     });
 
     it('should reset the banner position and top styles at the top of the page', () =>
@@ -168,13 +170,15 @@ describe('Sticky ad banner', () => {
     it('should position the banner absolutely past the header', () => {
         window.pageYOffset = 501;
 
-        return initStickyTopBanner().then(onScroll).then(() => {
-            if (!stickyBanner) {
-                throw Error('missing header or sticky banner element');
-            } else {
-                expect(stickyBanner.style.position).toBe('absolute');
-                expect(stickyBanner.style.top).toBe('500px');
-            }
-        });
+        return initStickyTopBanner()
+            .then(onScroll)
+            .then(() => {
+                if (!stickyBanner) {
+                    throw Error('missing header or sticky banner element');
+                } else {
+                    expect(stickyBanner.style.position).toBe('absolute');
+                    expect(stickyBanner.style.top).toBe('500px');
+                }
+            });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain-load.spec.js
@@ -50,10 +50,16 @@ describe('Outbrain Load', () => {
             config.page.section = 'uk-news';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'AR_12'
-                );
-                expect($('.OUTBRAIN').last().data('widgetId')).toEqual('AR_14');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('AR_12');
+                expect(
+                    $('.OUTBRAIN')
+                        .last()
+                        .data('widgetId')
+                ).toEqual('AR_14');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'AR_12',
                 });
@@ -66,10 +72,16 @@ describe('Outbrain Load', () => {
             config.page.section = 'football';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'AR_13'
-                );
-                expect($('.OUTBRAIN').last().data('widgetId')).toEqual('AR_15');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('AR_13');
+                expect(
+                    $('.OUTBRAIN')
+                        .last()
+                        .data('widgetId')
+                ).toEqual('AR_15');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'AR_13',
                 });
@@ -82,9 +94,11 @@ describe('Outbrain Load', () => {
             config.page.edition = 'AU';
 
             load('merchandising').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'AR_28'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('AR_28');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'AR_28',
                 });
@@ -97,9 +111,11 @@ describe('Outbrain Load', () => {
             config.page.edition = 'AU';
 
             load('nonCompliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'AR_28'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('AR_28');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'AR_28',
                 });
@@ -118,8 +134,16 @@ describe('Outbrain Load', () => {
             config.page.section = 'uk-news';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual('MB_6');
-                expect($('.OUTBRAIN').last().data('widgetId')).toEqual('MB_8');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_6');
+                expect(
+                    $('.OUTBRAIN')
+                        .last()
+                        .data('widgetId')
+                ).toEqual('MB_8');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_6',
                 });
@@ -132,8 +156,16 @@ describe('Outbrain Load', () => {
             config.page.section = 'football';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual('MB_7');
-                expect($('.OUTBRAIN').last().data('widgetId')).toEqual('MB_9');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_7');
+                expect(
+                    $('.OUTBRAIN')
+                        .last()
+                        .data('widgetId')
+                ).toEqual('MB_9');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_7',
                 });
@@ -146,9 +178,11 @@ describe('Outbrain Load', () => {
             config.page.edition = 'AU';
 
             load('merchandising').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'MB_11'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_11');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_11',
                 });
@@ -159,9 +193,11 @@ describe('Outbrain Load', () => {
         // non-compliant
         it('should create one container for tablet with correct IDs for nonCompliant', done => {
             load('nonCompliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'MB_11'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_11');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_11',
                 });
@@ -180,7 +216,11 @@ describe('Outbrain Load', () => {
             config.page.section = 'uk-news';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual('MB_4');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_4');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_4',
                 });
@@ -193,7 +233,11 @@ describe('Outbrain Load', () => {
             config.page.section = 'football';
 
             load('compliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual('MB_5');
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_5');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_5',
                 });
@@ -206,9 +250,11 @@ describe('Outbrain Load', () => {
             config.page.edition = 'AU';
 
             load('merchandising').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'MB_10'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_10');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_10',
                 });
@@ -219,9 +265,11 @@ describe('Outbrain Load', () => {
         // non-compliant
         it('should create one container for mobile with correct IDs for nonCompliant', done => {
             load('nonCompliant').then(() => {
-                expect($('.OUTBRAIN').first().data('widgetId')).toEqual(
-                    'MB_10'
-                );
+                expect(
+                    $('.OUTBRAIN')
+                        .first()
+                        .data('widgetId')
+                ).toEqual('MB_10');
                 expect(tracking).toHaveBeenCalledWith({
                     widgetId: 'MB_10',
                 });

--- a/static/src/javascripts/projects/common/modules/charts/doughnut.js
+++ b/static/src/javascripts/projects/common/modules/charts/doughnut.js
@@ -127,12 +127,14 @@ const Doughnut = (data: Object, o: Object): bonzo => {
             inner.end.y,
             'Z',
         ];
-        $g = svgEl('g').attr('class', 'chart__arc').append(
-            svgEl('path').attr({
-                d: d.join(' '),
-                fill: datum.color,
-            })
-        );
+        $g = svgEl('g')
+            .attr('class', 'chart__arc')
+            .append(
+                svgEl('path').attr({
+                    d: d.join(' '),
+                    fill: datum.color,
+                })
+            );
 
         // labels
         $t = svgEl('text').attr('class', 'chart__label');
@@ -174,10 +176,13 @@ const Doughnut = (data: Object, o: Object): bonzo => {
 
     // Unit of measurement
     return $svg.append(
-        svgEl('text').attr('class', 'chart__unit').text(obj.unit).attr({
-            transform: translate(c),
-            dy: '0.4em',
-        })
+        svgEl('text')
+            .attr('class', 'chart__unit')
+            .text(obj.unit)
+            .attr({
+                transform: translate(c),
+                dy: '0.4em',
+            })
     );
 };
 

--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/main.js
@@ -47,21 +47,28 @@ const AnagramHelper = React.createClass({
             .sort();
 
         return shuffle(
-            word.trim().split('').sort().reduce((acc, letter) => {
-                const [head, ...tail] = acc.entries;
-                const entered = head === letter.toLowerCase();
+            word
+                .trim()
+                .split('')
+                .sort()
+                .reduce(
+                    (acc, letter) => {
+                        const [head, ...tail] = acc.entries;
+                        const entered = head === letter.toLowerCase();
 
-                return {
-                    letters: acc.letters.concat({
-                        value: letter,
-                        entered,
-                    }),
-                    entries: entered ? tail : acc.entries,
-                };
-            }, {
-                letters: [],
-                entries: wordEntries,
-            }).letters
+                        return {
+                            letters: acc.letters.concat({
+                                value: letter,
+                                entered,
+                            }),
+                            entries: entered ? tail : acc.entries,
+                        };
+                    },
+                    {
+                        letters: [],
+                        entries: wordEntries,
+                    }
+                ).letters
         );
     },
 

--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -37,7 +37,9 @@ class ActivityStream extends Component {
             // Blur so that when pressing forward/back the focus is not retained on
             // the old tab Note, without the focus first, the blur doesn't seem to
             // work for some reason
-            $('.js-activity-stream-change').focus().blur();
+            $('.js-activity-stream-change')
+                .focus()
+                .blur();
 
             $('.tabs__tab--selected').removeClass('tabs__tab--selected');
 

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -51,7 +51,10 @@ const addToShareCount = (val: number): void => {
         icon: shareSvg,
     });
 
-    $shareCountEls.removeClass('u-h').html(html).css('display', '');
+    $shareCountEls
+        .removeClass('u-h')
+        .html(html)
+        .css('display', '');
 
     $shortValueEls = $('.sharecount__value--short', $shareCountEls[0]);
     $fullValueEls = $('.sharecount__value--full', $shareCountEls[0]);

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -169,7 +169,9 @@ const onInteractivesLoaded = memoize((rules: SpacefinderRules): Promise<
 const onAdsLoaded = memoize(
     (rules: SpacefinderRules): Promise<boolean[]> =>
         Promise.all(
-            qwery('.js-ad-slot', rules.body).map(ad => ad.id).map(trackAdRender)
+            qwery('.js-ad-slot', rules.body)
+                .map(ad => ad.id)
+                .map(trackAdRender)
         ),
     getFuncId
 );

--- a/static/src/javascripts/projects/common/modules/tailor/fetch-data.js
+++ b/static/src/javascripts/projects/common/modules/tailor/fetch-data.js
@@ -67,10 +67,12 @@ const fetchData = (
         return Promise.resolve(tailorData[url]);
     }
 
-    return fetchJson(url).then(data => handleResponse(url, data)).catch(err => {
-        handleError(url, err);
-        return Promise.resolve({});
-    });
+    return fetchJson(url)
+        .then(data => handleResponse(url, data))
+        .catch(err => {
+            handleError(url, err);
+            return Promise.resolve({});
+        });
 };
 
 export { fetchData };

--- a/static/src/javascripts/projects/common/modules/ui/rhc.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/rhc.spec.js
@@ -31,7 +31,11 @@ describe('rhc', () => {
         setFixture('<div class="js-components-container"></div>');
         addComponent(content, importance);
 
-        expect($(selector).first().data('importance')).toEqual(importance);
+        expect(
+            $(selector)
+                .first()
+                .data('importance')
+        ).toEqual(importance);
     });
 
     test('prepends component in non-empty rhc container before inferior components', () => {
@@ -58,7 +62,15 @@ describe('rhc', () => {
         `);
         addComponent(content, importance);
 
-        expect($(selector).first().get(0).id).toEqual(id);
-        expect($(selector).last().get(0).id).toEqual(inferiorId);
+        expect(
+            $(selector)
+                .first()
+                .get(0).id
+        ).toEqual(id);
+        expect(
+            $(selector)
+                .last()
+                .get(0).id
+        ).toEqual(inferiorId);
     });
 });

--- a/tools/__tasks__/compile/images/icons.js
+++ b/tools/__tasks__/compile/images/icons.js
@@ -101,7 +101,12 @@ module.exports = {
 
             return Promise.all(iconPaths.map(getSVG))
                 .then(sortSVGs)
-                .then(svgs => svgs.map(generateSassForSVG).join('').trim())
+                .then(svgs =>
+                    svgs
+                        .map(generateSassForSVG)
+                        .join('')
+                        .trim()
+                )
                 .then(sass => saveSass(sass, destPath, fileName));
         },
     })),

--- a/tools/es5to6.js
+++ b/tools/es5to6.js
@@ -59,7 +59,10 @@ git
         const unique = `${Date.now()}`.slice(-4);
         const es5Module = path.join(legacyPath, moduleId);
         const es6Module = path.join('static', 'src', 'javascripts', moduleId);
-        const es6Name = moduleId.split(path.sep).join('_').replace('.js', '');
+        const es6Name = moduleId
+            .split(path.sep)
+            .join('_')
+            .replace('.js', '');
         const branchName = `es6-${es6Name}`;
 
         const steps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6239,9 +6239,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+prettier@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
## What does this change?

Upgrades `prettier` to `1.6.1`. Look how beautiful! [Changelog](https://github.com/prettier/prettier/releases/tag/1.6.0).

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.
