### PR TITLE
Remove calls to config.page.keywordIds

### DIFF
--- a/static/src/javascripts-legacy/.eslintrc.js
+++ b/static/src/javascripts-legacy/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         // our own rules for frontend
         // live in tools/eslint-plugin-guardian-frontend
         'guardian-frontend/global-config': 2,
-        'guardian-frontend/no-direct-access-config': 'error',
+        'guardian-frontend/no-direct-access-config': 'warn',
 
     },
     globals: {

--- a/static/src/javascripts-legacy/.eslintrc.js
+++ b/static/src/javascripts-legacy/.eslintrc.js
@@ -54,6 +54,8 @@ module.exports = {
         // our own rules for frontend
         // live in tools/eslint-plugin-guardian-frontend
         'guardian-frontend/global-config': 2,
+        'guardian-frontend/no-direct-access-config': 'error',
+
     },
     globals: {
         Promise: true

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -12,12 +12,14 @@ import { catchErrorsWithContext } from 'lib/robust';
 import storyQuestions from 'common/modules/atoms/story-questions';
 
 const affixTimeline = (): void => {
+    const keywordIds = config.get('page.keywordIds', '');
+
     if (
         isBreakpoint({
             min: 'desktop',
         }) &&
-        !config.page.keywordIds.includes('football/football') &&
-        !config.page.keywordIds.includes('sport/rugby-union')
+        !keywordIds.includes('football/football') &&
+        !keywordIds.includes('sport/rugby-union')
     ) {
         // eslint-disable-next-line no-new
         new Affix({
@@ -34,7 +36,7 @@ const affixTimeline = (): void => {
 };
 
 const createAutoUpdate = (): void => {
-    if (config.page.isLive) {
+    if (config.get('page.isLive')) {
         autoUpdate();
     }
 };

--- a/static/src/javascripts/lib/__mocks__/config.js
+++ b/static/src/javascripts/lib/__mocks__/config.js
@@ -1,0 +1,13 @@
+// @flow
+
+export default {
+    get(path: string, defaultValue: any): any {
+        return path.split('.').reduce((acc, prop) => {
+            if (acc[prop]) {
+                return acc[prop]
+            }
+
+            return defaultValue;
+        }, this);
+    }
+};

--- a/static/src/javascripts/lib/__mocks__/config.js
+++ b/static/src/javascripts/lib/__mocks__/config.js
@@ -2,7 +2,7 @@
 
 export default {
     get(path: string, defaultValue: any): any {
-        return path.split('.').reduce((acc, prop) => {
+        return path.split('.').reduce((acc: Object, prop: string): any => {
             if (acc[prop]) {
                 return acc[prop]
             }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -103,22 +103,19 @@ const defaultPageCheck = (page: Object): boolean =>
 const shouldShowReaderRevenue = (
     showToContributorsAndSupporters: boolean = false
 ): boolean => {
-    const isMasterclassesPage =
-        config.page &&
-        config.page.keywordIds &&
-        config.page.keywordIds.includes(
-            'guardian-masterclasses/guardian-masterclasses'
-        );
+    const isMasterclassesPage = config
+        .get('page.keywordIds', '')
+        .includes('guardian-masterclasses/guardian-masterclasses');
 
     return (
         (userShouldSeeReaderRevenue() || showToContributorsAndSupporters) &&
         !isMasterclassesPage &&
-        !config.page.shouldHideReaderRevenue
+        !config.get('page.shouldHideReaderRevenue')
     );
 };
 
 const defaultCanEpicBeDisplayed = (test: EpicABTest): boolean => {
-    const worksWellWithPageTemplate = test.pageCheck(config.page);
+    const worksWellWithPageTemplate = test.pageCheck(config.get('page'));
 
     const storedGeolocation = geolocationGetSync();
     const inCompatibleLocation = test.locations.length
@@ -159,7 +156,7 @@ const getCampaignCode = (
 
 const addTrackingCodesToUrl = (base: string, campaignCode: string) => {
     const params = {
-        REFPVID: (config.ophan && config.ophan.pageViewId) || 'not_found',
+        REFPVID: config.get('ophan.pageViewId') || 'not_found',
         INTCMP: campaignCode,
     };
 

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -18,7 +18,7 @@ const buildExpandable = (el: HTMLElement): void => {
 const popularInTagOverride = (): ?string | false => {
     /* whitelist of tags to override related story component with a
        popular-in-tag component */
-    if (!config.page.keywordIds) {
+    if (!config.get('page.keywordIds')) {
         return false;
     }
 
@@ -56,9 +56,9 @@ const popularInTagOverride = (): ?string | false => {
 
     const intersect = (a: Array<string>, b: Array<string>): Array<string> =>
         [...new Set(a)].filter(_ => new Set(b).has(_));
-    const pageTags = config.page.keywordIds.split(',');
+    const pageTags = config.get('page.keywordIds', '').split(',');
     // if this is an advertisement feature, use the page's keyword (there'll only be one)
-    const popularInTags = config.page.isPaidContent
+    const popularInTags = config.get('page.isPaidContent')
         ? pageTags
         : intersect(whitelistedTags, pageTags);
 
@@ -72,7 +72,7 @@ const related = (opts: Object): void => {
     let popularInTag;
     let componentName;
 
-    if (config.page && config.page.hasStoryPackage) {
+    if (config.get('page.hasStoryPackage')) {
         const expandable =
             document.body && document.body.querySelector('.related-trails');
 
@@ -80,8 +80,8 @@ const related = (opts: Object): void => {
             buildExpandable(expandable);
         }
     } else if (
-        config.switches.relatedContent &&
-        config.page.showRelatedContent
+        config.get('switches.relatedContent') &&
+        config.get('page.showRelatedContent')
     ) {
         const container =
             document.body && document.body.querySelector('.js-related');
@@ -94,7 +94,8 @@ const related = (opts: Object): void => {
 
             register.begin(componentName);
             container.setAttribute('data-component', componentName);
-            relatedUrl = popularInTag || `/related/${config.page.pageId}.json`;
+            relatedUrl =
+                popularInTag || `/related/${config.get('page.pageId')}.json`;
             const queryParams = opts.excludeTags.map(
                 tag => `exclude-tag=${tag}`
             );

--- a/static/src/javascripts/projects/common/modules/onward/related.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.spec.js
@@ -4,23 +4,12 @@ import config from 'lib/config';
 import Expandable from 'common/modules/ui/expandable';
 import { related } from './related';
 
-jest.mock('lib/config', () => ({
-    page: {
-        hasStoryPackage: false,
-        showRelatedContent: true,
-    },
-    switches: {
-        relatedContent: true,
-        ajaxRelatedContent: true,
-    },
-}));
-
+jest.mock('lib/config');
 jest.mock('common/modules/ui/expandable', () => {
     const Exp: any = (jest.fn(): any);
     Exp.prototype.init = jest.fn();
     return Exp;
 });
-
 jest.mock('common/modules/analytics/register', () => ({
     begin() {},
     end() {},
@@ -36,6 +25,14 @@ describe('onward/related', () => {
             `;
         }
 
+        config.page = {
+            hasStoryPackage: false,
+            showRelatedContent: true,
+        };
+        config.switches = {
+            relatedContent: true,
+            ajaxRelatedContent: true,
+        };
         jest.resetAllMocks();
         jest.resetModules();
     });
@@ -44,6 +41,7 @@ describe('onward/related', () => {
         const container: HTMLElement = (document.querySelector(
             '.js-related'
         ): any);
+
         config.switches.relatedContent = false;
 
         related({});

--- a/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
+++ b/static/test/javascripts-legacy/spec/common/experiments/ab-test-clash.spec.js
@@ -9,8 +9,18 @@ define([
 
             beforeEach(function (done) {
                 var injector = new Injector();
+                var fakeIsInVariant = {
+                    isInVariant: function() {
+                        return true;
+                    },
+                };
+                var fakeAcquisitionData = {
+                    abTestClashData: []
+                };
 
                 sandbox = sinon.sandbox.create();
+                injector.mock('common/modules/experiments/utils', fakeIsInVariant)
+                injector.mock('common/modules/experiments/acquisition-test-selector', fakeAcquisitionData)
                 injector.require([
                     'common/modules/experiments/ab-test-clash'
                 ], function (sut) {


### PR DESCRIPTION
## What does this change?

Several JS modules assume that `config.page.keywordIds` exists on every page on which they execute. This is generating errors on non-content pages such as Identity pages, for which `keywordIds` is undefined.

By using the `config.get()`, we can pass a default value if the property doesn't exist, hence guarding against non-existent properties throwing errors 

**Yak shaving**

- provided a mock for `config.get`
- fixed failing legacy tests that didn't provide sufficient mocking

## What is the value of this and can you measure success?

Fewer errors, safer software

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
