### PR TITLE
Create test for US recurring contributions (S&C test 3 - stars & pikes)

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -152,7 +152,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-acquisitions-support-us-recurring-contribution",
-    "Test demmand for recurrin contributions in the US offering across all channels",
+    "Test demand for recurring contributions in the US across all channels",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
     sellByDate = new LocalDate(2017, 10, 19),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -149,4 +149,14 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  Switch(
+    ABTests,
+    "ab-acquisitions-support-us-recurring-contribution",
+    "Test demmand for recurrin contributions in the US offering across all channels",
+    owners = Seq(Owner.withGithub("justinpinner")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 10, 19),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -123,7 +123,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         REFPVID: params.pageviewId,
         INTCMP: params.campaignCode,
     };
-    const linkUrl = `${params.linkUrl}?${constructQuery(urlParameters)}`;
+    const linkUrl = `${params.linkUrl}${params.linkUrl.indexOf('?') > 0 ? '&' : '?'}${constructQuery(urlParameters)}`;
     const buttonCaption = params.buttonCaption;
     const buttonSvg = inlineSvg('arrowWhiteRight');
     const renderedBanner = `

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -123,7 +123,9 @@ const showBanner = (params: EngagementBannerParams): void => {
         REFPVID: params.pageviewId,
         INTCMP: params.campaignCode,
     };
-    const linkUrl = `${params.linkUrl}${params.linkUrl.indexOf('?') > 0 ? '&' : '?'}${constructQuery(urlParameters)}`;
+    const linkUrl = `${params.linkUrl}${params.linkUrl.indexOf('?') > 0
+        ? '&'
+        : '?'}${constructQuery(urlParameters)}`;
     const buttonCaption = params.buttonCaption;
     const buttonSvg = inlineSvg('arrowWhiteRight');
     const renderedBanner = `

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -123,7 +123,8 @@ const showBanner = (params: EngagementBannerParams): void => {
         REFPVID: params.pageviewId,
         INTCMP: params.campaignCode,
     };
-    const linkUrl = `${params.linkUrl}${params.linkUrl.indexOf('?') > 0
+    const linkUrl = `${params.linkUrl}${params.linkUrl &&
+    params.linkUrl.indexOf('?') > 0
         ? '&'
         : '?'}${constructQuery(urlParameters)}`;
     const buttonCaption = params.buttonCaption;

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,6 +14,7 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsSupportBaseline } from 'common/modules/experiments/tests/acquisitions-support-baseline';
+import { acquisitionsSupportUSRecurringContribution } from 'common/modules/experiments/tests/acquisitions-support-us-recurring-contributions';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -22,6 +23,7 @@ const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     payInEpic,
     acquisitionsSupportBaseline,
+    acquisitionsSupportUSRecurringContribution,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -22,8 +22,8 @@ import { acquisitionsSupportUSRecurringContribution } from 'common/modules/exper
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     payInEpic,
-    acquisitionsSupportBaseline,
     acquisitionsSupportUSRecurringContribution,
+    acquisitionsSupportBaseline,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,7 +14,7 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsSupportBaseline } from 'common/modules/experiments/tests/acquisitions-support-baseline';
-import { acquisitionsSupportUSRecurringContribution } from 'common/modules/experiments/tests/acquisitions-support-us-recurring-contributions';
+import { acquisitionsSupportUsRecurringContribution } from 'common/modules/experiments/tests/acquisitions-support-us-recurring-contributions';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -22,7 +22,7 @@ import { acquisitionsSupportUSRecurringContribution } from 'common/modules/exper
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     payInEpic,
-    acquisitionsSupportUSRecurringContribution,
+    acquisitionsSupportUsRecurringContribution,
     acquisitionsSupportBaseline,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -124,7 +124,7 @@ const bindEpicInsertAndViewHandlers = (
 };
 
 export const acquisitionsSupportUSRecurringContribution = makeABTest({
-    id: 'AcquisitionsSupportUSRecurringContribution',
+    id: 'AcquisitionsSupportUsRecurringContribution',
     campaignId: 'sandc_support_us_recurring_contribution',
 
     start: '2017-08-31',
@@ -132,7 +132,7 @@ export const acquisitionsSupportUSRecurringContribution = makeABTest({
 
     author: 'justinpinner',
     description:
-        'Test the demand for recurring contributions in the US offering across all channels',
+        'Test demand for recurring contributions in the US across all channels',
     successMeasure: 'Annualised value',
     idealOutcome:
         'The new proposition delivers the same or greater annualised value',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -96,8 +96,12 @@ const changeLinks = (cssClass: string, link: string) => {
     });
 };
 
-const changeHeaderLinks = (becomeSupporterLink: string) => {
-    changeLinks('js-change-become-member-link', becomeSupporterLink);
+const changeHeaderLinks = (
+    becomeSupporterLinkDesktop: string,
+    makeContributionLinkMobile: string
+) => {
+    changeLinks('js-change-become-member-link', makeContributionLinkMobile);
+    changeLinks('js-become-member', becomeSupporterLinkDesktop);
 };
 
 const changeSideMenuLinks = (becomeSupporterLink: string) => {
@@ -194,6 +198,9 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                     }
 
                     changeHeaderLinks(
+                        makeBecomeSupporterURL(
+                            `${baseCampaignCode}_control_header_become_supporter`
+                        ),
                         makeContributionURL(
                             `${baseCampaignCode}_control_header_become_supporter`
                         )
@@ -248,6 +255,10 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                     }
 
                     changeHeaderLinks(
+                        makeSupportURL(
+                            `${baseCampaignCode}_support_header_become_supporter`,
+                            true
+                        ),
                         makeSupportURL(
                             `${baseCampaignCode}_support_header_become_supporter`,
                             true

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -14,7 +14,7 @@ import fastdom from 'lib/fastdom-promise';
 
 import config from 'lib/config';
 
-const baseCampaignCode = 'gdnwb_copts_memco_sandc_support_baseline';
+const baseCampaignCode = 'gdnwb_copts_memco_sandc_us_rec_cont';
 
 const getREFPVID = (): string =>
     (config.ophan && config.ophan.pageViewId) || 'not_found';
@@ -26,7 +26,7 @@ const makeSupportURL = (campaignCode: string): string =>
     buildURL('https://support.theguardian.com/us/contribute', campaignCode);
 
 const makeBecomeSupporterURL = (campaignCode: string): string =>
-    buildURL('https://membership.theguardian.com/uk/supporter', campaignCode);
+    buildURL('https://membership.theguardian.com/us/supporter', campaignCode);
 
 const buildButtonTemplate = ({ supportUrl }) =>
     `<div class="contributions__amount-field">
@@ -125,7 +125,7 @@ const bindEpicInsertAndViewHandlers = (
 
 export const acquisitionsSupportUsRecurringContribution = makeABTest({
     id: 'AcquisitionsSupportUsRecurringContribution',
-    campaignId: 'sandc_support_us_recurring_contribution',
+    campaignId: 'sandc_support_us_rec_cont',
 
     start: '2017-08-31',
     expiry: '2017-10-19',
@@ -138,7 +138,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
         'The new proposition delivers the same or greater annualised value',
 
     audienceCriteria: 'US all devices',
-    audience: 1,
+    audience: 0.5,
     audienceOffset: 0,
     locations: ['US'],
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -202,7 +202,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                             `${baseCampaignCode}_control_header_become_supporter`
                         ),
                         makeContributionURL(
-                            `${baseCampaignCode}_control_header_become_supporter`
+                            `${baseCampaignCode}_control_header_make_contribution`
                         )
                     );
 
@@ -260,7 +260,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                             true
                         ),
                         makeSupportURL(
-                            `${baseCampaignCode}_support_header_become_supporter`,
+                            `${baseCampaignCode}_support_header_make_contribution`,
                             true
                         )
                     );

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -20,13 +20,16 @@ const getREFPVID = (): string =>
     (config.ophan && config.ophan.pageViewId) || 'not_found';
 
 const buildURL = (url: string, campaignCode: string): string =>
-    `${url}?INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
+    `${url}${url.indexOf('?') > 0 ? '&' : '?'}INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
 
-const makeSupportURL = (campaignCode: string): string =>
-    buildURL('https://support.theguardian.com/us/contribute', campaignCode);
+const makeSupportURL = (campaignCode: string, context: Boolean = false): string =>
+    buildURL(`https://support.theguardian.com/us/contribute${context ? '?context=true' : ''}`, campaignCode);
 
 const makeBecomeSupporterURL = (campaignCode: string): string =>
     buildURL('https://membership.theguardian.com/us/supporter', campaignCode);
+
+const makeContributionURL = (campaignCode: string): string =>
+    buildURL('https://contribute.theguardian.com/us', campaignCode);
 
 const buildButtonTemplate = ({ supportUrl }) =>
     `<div class="contributions__amount-field">
@@ -181,7 +184,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                     }
 
                     changeHeaderLinks(
-                        makeBecomeSupporterURL(
+                        makeContributionURL(
                             `${baseCampaignCode}_control_header_become_supporter`
                         )
                     );
@@ -236,13 +239,13 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
 
                     changeHeaderLinks(
                         makeSupportURL(
-                            `${baseCampaignCode}_support_header_become_supporter`
+                            `${baseCampaignCode}_support_header_become_supporter`, true
                         )
                     );
 
                     changeSideMenuLinks(
                         makeSupportURL(
-                            `${baseCampaignCode}_support_side_menu_become_supporter`
+                            `${baseCampaignCode}_support_side_menu_become_supporter`, true
                         )
                     );
                 },
@@ -251,7 +254,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                 engagementBannerParams: {
                     buttonCaption: 'Support the Guardian',
                     campaignCode: `${baseCampaignCode}_support_banner`,
-                    linkUrl: `https://support.theguardian.com/us/contribute`,
+                    linkUrl: `https://support.theguardian.com/us/contribute?context=true`,
                 },
 
                 isUnlimited: true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -123,8 +123,8 @@ const bindEpicInsertAndViewHandlers = (
     });
 };
 
-export const acquisitionsSupportUSRecurringContribution = makeABTest({
-    id: 'AcquisitionsSupportUSRecurringContribution',
+export const acquisitionsSupportUsRecurringContribution = makeABTest({
+    id: 'AcquisitionsSupportUsRecurringContribution',
     campaignId: 'sandc_support_us_recurring_contribution',
 
     start: '2017-08-31',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -20,10 +20,20 @@ const getREFPVID = (): string =>
     (config.ophan && config.ophan.pageViewId) || 'not_found';
 
 const buildURL = (url: string, campaignCode: string): string =>
-    `${url}${url.indexOf('?') > 0 ? '&' : '?'}INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
+    `${url}${url.indexOf('?') > 0
+        ? '&'
+        : '?'}INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
 
-const makeSupportURL = (campaignCode: string, context: Boolean = false): string =>
-    buildURL(`https://support.theguardian.com/us/contribute${context ? '?context=true' : ''}`, campaignCode);
+const makeSupportURL = (
+    campaignCode: string,
+    context: boolean = false
+): string =>
+    buildURL(
+        `https://support.theguardian.com/us/contribute${context
+            ? '?context=true'
+            : ''}`,
+        campaignCode
+    );
 
 const makeBecomeSupporterURL = (campaignCode: string): string =>
     buildURL('https://membership.theguardian.com/us/supporter', campaignCode);
@@ -239,13 +249,15 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
 
                     changeHeaderLinks(
                         makeSupportURL(
-                            `${baseCampaignCode}_support_header_become_supporter`, true
+                            `${baseCampaignCode}_support_header_become_supporter`,
+                            true
                         )
                     );
 
                     changeSideMenuLinks(
                         makeSupportURL(
-                            `${baseCampaignCode}_support_side_menu_become_supporter`, true
+                            `${baseCampaignCode}_support_side_menu_become_supporter`,
+                            true
                         )
                     );
                 },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -17,7 +17,7 @@ import config from 'lib/config';
 const baseCampaignCode = 'gdnwb_copts_memco_sandc_support_baseline';
 
 const getREFPVID = (): string =>
-(config.ophan && config.ophan.pageViewId) || 'not_found';
+    (config.ophan && config.ophan.pageViewId) || 'not_found';
 
 const buildURL = (url: string, campaignCode: string): string =>
     `${url}?INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
@@ -106,7 +106,7 @@ const changeSideMenuLinks = (becomeSupporterLink: string) => {
 };
 
 const shouldDisplayEpic = (test: EpicABTest): boolean =>
-isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
+    isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
 
 const bindEpicInsertAndViewHandlers = (
     test: EpicABTest,
@@ -131,7 +131,8 @@ export const acquisitionsSupportUSRecurringContribution = makeABTest({
     expiry: '2017-10-19',
 
     author: 'justinpinner',
-    description: 'Test demmand for recurrin contributions in the US offering across all channels',
+    description:
+        'Test the demand for recurring contributions in the US offering across all channels',
     successMeasure: 'Annualised value',
     idealOutcome:
         'The new proposition delivers the same or greater annualised value',
@@ -201,10 +202,7 @@ export const acquisitionsSupportUSRecurringContribution = makeABTest({
         },
         {
             id: 'support',
-            products: [
-                'CONTRIBUTION',
-                'RECURRING_CONTRIBUTION',
-            ],
+            products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
 
             // EPIC
             options: {
@@ -212,7 +210,8 @@ export const acquisitionsSupportUSRecurringContribution = makeABTest({
                 success: submitABTestComplete => submitABTestComplete(),
 
                 buttonTemplate: buildButtonTemplate,
-                supportCustomURL: 'https://support.theguardian.com/us/contribute',
+                supportCustomURL:
+                    'https://support.theguardian.com/us/contribute',
                 useTailoredCopyForRegulars: true,
 
                 test(renderArticleEpic, variant, test) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -155,7 +155,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
         'The new proposition delivers the same or greater annualised value',
 
     audienceCriteria: 'US all devices',
-    audience: 0.5,
+    audience: 1,
     audienceOffset: 0,
     locations: ['US'],
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -1,0 +1,262 @@
+// @flow
+import {
+    makeABTest,
+    defaultPageCheck as isEpicCompatibleWithPage,
+} from 'common/modules/commercial/contributions-utilities';
+import { setupEpicInLiveblog } from 'common/modules/experiments/tests/acquisitions-epic-liveblog';
+import { viewsInPreviousDays } from 'common/modules/commercial/acquisitions-view-log';
+import {
+    submitInsertEvent,
+    submitViewEvent,
+} from 'common/modules/commercial/acquisitions-ophan';
+import mediator from 'lib/mediator';
+import fastdom from 'lib/fastdom-promise';
+
+import config from 'lib/config';
+
+const baseCampaignCode = 'gdnwb_copts_memco_sandc_support_baseline';
+
+const getREFPVID = (): string =>
+(config.ophan && config.ophan.pageViewId) || 'not_found';
+
+const buildURL = (url: string, campaignCode: string): string =>
+    `${url}?INTCMP=${campaignCode}&REFPVID=${getREFPVID()}`;
+
+const makeSupportURL = (campaignCode: string): string =>
+    buildURL('https://support.theguardian.com/us/contribute', campaignCode);
+
+const makeBecomeSupporterURL = (campaignCode: string): string =>
+    buildURL('https://membership.theguardian.com/uk/supporter', campaignCode);
+
+const buildButtonTemplate = ({ supportUrl }) =>
+    `<div class="contributions__amount-field">
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button"
+               href="${supportUrl}"
+               target="_blank">
+                Support the Guardian
+            </a>
+        </div>
+    </div>`;
+
+const liveblogEpicTemplate = (ctaSentence: string) =>
+    `<div class="block block--content is-epic">
+        <p class="block-time published-time">
+            <a href="#" itemprop="url" class="block-time__link">
+                <time data-relativeformat="med" itemprop="datePublished" class="js-timestamp"></time>
+                <span class="block-time__absolute"></span>
+            </a>
+        </p>
+        <div class="block-elements block-elements--no-byline">
+            <p>
+                <em>
+                    Since you’re here &hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.
+                </em>
+            </p>
+            <p>
+                <em>
+                    If everyone who reads our reporting, who likes it, helps to support it, our future would be much more secure.
+                    ${ctaSentence}. - Guardian HQ
+                </em>
+            </p>
+        </div>
+    </div>`;
+
+const isEpicWithinViewLimit = (test: EpicABTest): boolean => {
+    const days = 30;
+    const count = 4;
+    const minDaysBetweenViews = 0;
+
+    const testId = test.useLocalViewLog ? test.id : undefined;
+
+    const withinViewLimit = viewsInPreviousDays(days, testId) < count;
+    const enoughDaysBetweenViews =
+        viewsInPreviousDays(minDaysBetweenViews, testId) === 0;
+    return withinViewLimit && enoughDaysBetweenViews;
+};
+
+const changeLinks = (cssClass: string, link: string) => {
+    [...document.getElementsByClassName(cssClass)].forEach(el => {
+        if (el instanceof HTMLAnchorElement) {
+            el.href = link;
+        }
+    });
+};
+
+const changeHeaderLinks = (becomeSupporterLink: string) => {
+    changeLinks('js-change-become-member-link', becomeSupporterLink);
+};
+
+const changeSideMenuLinks = (becomeSupporterLink: string) => {
+    const cssClass = 'js-change-membership-item';
+    fastdom.read(() => document.getElementsByClassName(cssClass)).then(els =>
+        fastdom.write(() => {
+            [...els].forEach(el => {
+                if (el instanceof HTMLAnchorElement) {
+                    if (
+                        el.innerText &&
+                        el.innerText.trim() === 'become a supporter'
+                    ) {
+                        el.href = becomeSupporterLink;
+                    }
+                }
+            });
+        })
+    );
+};
+
+const shouldDisplayEpic = (test: EpicABTest): boolean =>
+isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
+
+const bindEpicInsertAndViewHandlers = (
+    test: EpicABTest,
+    products: $ReadOnlyArray<OphanProduct>,
+    campaignCode: string
+) => {
+    // These should get fired when the epic is inserted & viewed
+    mediator.once(test.insertEvent, () => {
+        submitInsertEvent(test.componentType, products, campaignCode);
+    });
+
+    mediator.once(test.viewEvent, () => {
+        submitViewEvent(test.componentType, products, campaignCode);
+    });
+};
+
+export const acquisitionsSupportUSRecurringContribution = makeABTest({
+    id: 'AcquisitionsSupportUSRecurringContribution',
+    campaignId: 'sandc_support_us_recurring_contribution',
+
+    start: '2017-08-31',
+    expiry: '2017-10-19',
+
+    author: 'justinpinner',
+    description: 'Test demmand for recurrin contributions in the US offering across all channels',
+    successMeasure: 'Annualised value',
+    idealOutcome:
+        'The new proposition delivers the same or greater annualised value',
+
+    audienceCriteria: 'US all devices',
+    audience: 1,
+    audienceOffset: 0,
+    locations: ['US'],
+
+    campaignSuffix: 'epic',
+
+    // (epic & banner will not display.
+    pageCheck: () => true,
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            options: {
+                // These should get fired after the test runs, regardless of
+                // whether we display the epic, banner, or just header
+                impression: submitABTestImpression => submitABTestImpression(),
+                success: submitABTestComplete => submitABTestComplete(),
+
+                useTailoredCopyForRegulars: true,
+                test(renderArticleEpic, variant, test) {
+                    bindEpicInsertAndViewHandlers(
+                        test,
+                        variant.options.products,
+                        variant.options.campaignCode
+                    );
+
+                    if (config.get('page.contentType') === 'LiveBlog') {
+                        const membershipURL = variant.membershipURLBuilder(
+                            campaignCode => `${campaignCode}_liveblog`
+                        );
+                        const contributionsURL = variant.contributionsURLBuilder(
+                            campaignCode => `${campaignCode}_liveblog`
+                        );
+                        const ctaSentence = `You can give to the Guardian by <a href="${membershipURL}" target="_blank" class="u-underline">becoming a monthly supporter</a> or by making a <a href="${contributionsURL}" target="_blank" class="u-underline">one-off contribution</a>`;
+                        const epicHtml = liveblogEpicTemplate(ctaSentence);
+
+                        setupEpicInLiveblog(epicHtml, test);
+                    } else if (shouldDisplayEpic(test)) {
+                        renderArticleEpic();
+                    }
+
+                    changeHeaderLinks(
+                        makeBecomeSupporterURL(
+                            `${baseCampaignCode}_control_header_become_supporter`
+                        )
+                    );
+
+                    changeSideMenuLinks(
+                        makeBecomeSupporterURL(
+                            `${baseCampaignCode}_control_side_menu_become_supporter`
+                        )
+                    );
+                },
+
+                engagementBannerParams: {
+                    campaignCode: `${baseCampaignCode}_control_banner`,
+                },
+
+                isUnlimited: true,
+            },
+        },
+        {
+            id: 'support',
+            products: [
+                'CONTRIBUTION',
+                'RECURRING_CONTRIBUTION',
+            ],
+
+            // EPIC
+            options: {
+                impression: submitABTestImpression => submitABTestImpression(),
+                success: submitABTestComplete => submitABTestComplete(),
+
+                buttonTemplate: buildButtonTemplate,
+                supportCustomURL: 'https://support.theguardian.com/us/contribute',
+                useTailoredCopyForRegulars: true,
+
+                test(renderArticleEpic, variant, test) {
+                    bindEpicInsertAndViewHandlers(
+                        test,
+                        variant.options.products,
+                        variant.options.campaignCode
+                    );
+
+                    if (config.get('page.contentType') === 'LiveBlog') {
+                        const url = makeSupportURL(
+                            `${baseCampaignCode}_support_liveblog`
+                        );
+
+                        const ctaSentence = `You can give to the Guardian by <a href="${url}" target="_blank" class="u-underline">becoming a supporter</a>`;
+                        const epicHtml = liveblogEpicTemplate(ctaSentence);
+
+                        setupEpicInLiveblog(epicHtml, test);
+                    } else if (shouldDisplayEpic(test)) {
+                        renderArticleEpic();
+                    }
+
+                    changeHeaderLinks(
+                        makeSupportURL(
+                            `${baseCampaignCode}_support_header_become_supporter`
+                        )
+                    );
+
+                    changeSideMenuLinks(
+                        makeSupportURL(
+                            `${baseCampaignCode}_support_side_menu_become_supporter`
+                        )
+                    );
+                },
+
+                // ENGAGEMENT BANNER
+                engagementBannerParams: {
+                    buttonCaption: 'Support the Guardian',
+                    campaignCode: `${baseCampaignCode}_support_banner`,
+                    linkUrl: `https://support.theguardian.com/us/contribute`,
+                },
+
+                isUnlimited: true,
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,6 +1,7 @@
 // @flow
 import { acquisitionsSupportBaseline } from 'common/modules/experiments/tests/acquisitions-support-baseline';
+import { acquisitionsSupportUsRecurringContribution } from 'common/modules/experiments/tests/acquisitions-support-us-recurring-contributions';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [acquisitionsSupportBaseline];
+> = [acquisitionsSupportBaseline, acquisitionsSupportUsRecurringContribution];


### PR DESCRIPTION
## What does this change?
Prepare for US recurring contribution test.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?
No
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Conversions codes
####  Control

| Channel | Campaign Code | Goes to |
|---------|---------------|------------|
|**Header Become Supporter (Desktop)**|gdnwb_copts_memco_sandc_us_rec_cont_control_header_become_supporter |`membership-frontend`|
|**Header Make a Contribution (Tablet and Mobile)**|gdnwb_copts_memco_sandc_us_rec_cont_control_header_make_contribution|`contributions-frontend`|
|**Side Bar - Become Supporter**|gdnwb_copts_memco_sandc_us_rec_cont_control_side_menu_become_supporter|`membership-frontend`|
| **Engagement Banner** |gdnwb_copts_memco_sandc_us_rec_cont_control_banner |`contributions-frontend`|
| **Epic**  |gdnwb_copts_memco_sandc_support_us_rec_cont_control_epic|Contribution button to `contribute-frontend` and member button to `membership-frontend`|
| **Live Blog** |gdnwb_copts_memco_sandc_support_us_rec_cont_control_epic_liveblog|Contribution button to `contribute-frontend` and member button to `membership-frontend`|

#### Variant Support

| Channel | Campaign Code | Context |
|---------|---------------|-----------|
|**Header Become Supporter (Desktop)**|gdnwb_copts_memco_sandc_us_rec_cont_support_header_become_supporter|true|
|**Header Make a Contribution (Tablet and Mobile)**|gdnwb_copts_memco_sandc_us_rec_cont_support_header_make_contribution|true|
|**Side Bar - Become Supporter**|gdnwb_copts_memco_sandc_us_rec_cont_support_side_menu_become_supporter | true|
| **Engagement Banner** | gdnwb_copts_memco_sandc_us_rec_cont_support_banner | true |
| **Epic**  |gdnwb_copts_memco_sandc_support_us_rec_cont_support_epic|Not Present|
| **Liveblog** | gdnwb_copts_memco_sandc_us_rec_cont_support_liveblog |Not Present| 

## Screenshots
### Header and engagement banner (in-test):
![supportfrontendusheader engagementbanner-intest](https://user-images.githubusercontent.com/690395/29936012-9835566e-8e78-11e7-9620-a71cb4c89b5c.gif)

### Menu (in-test):
![supportfrontendusmenu-intest](https://user-images.githubusercontent.com/690395/29936027-a72b45b6-8e78-11e7-83bd-6df0f22d1830.gif)

### Epic (in-test):
![supportfrontendusepic-intest](https://user-images.githubusercontent.com/690395/29936037-b11184fa-8e78-11e7-9b26-30b1fd77c1e6.gif)

### Header and engagement banner (in-control):
![banner-control](https://user-images.githubusercontent.com/825398/29974639-75447730-8f2b-11e7-9232-4b8197d875a5.gif)

### Menu (in-control):
![sidemenu-control](https://user-images.githubusercontent.com/825398/29974785-f367998a-8f2b-11e7-9819-a93511015fd9.gif)

### Epic (in-control)
![epic-control](https://user-images.githubusercontent.com/825398/29975045-eb171606-8f2c-11e7-89f1-7e9207d0ff30.gif)



## Tested in CODE?
Yes
