### PR TITLE
Extend expired switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -75,7 +75,7 @@ trait ABTestSwitches {
     "Integrate Tailor with ab tests",
     owners = Seq(Owner.withGithub("oilnam"), Owner.withGithub("mike-ruane")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 8, 31),
+    sellByDate = new LocalDate(2017, 9, 5),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -363,7 +363,7 @@ trait FeatureSwitches {
     "When ON, articles specified in the badges file will have visual elements added",
     owners = Seq(Owner.withGithub("superfrank")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 8, 31),
+    sellByDate = new LocalDate(2017, 9, 5),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
## What does this change?

Extends a couple of expired switches

c/c @oilnam @superfrank @mike-ruane - I've extended the switch life until Tuesday, just to fix the failing build. Would you be able to extend these switches for a longer period of time, or delete them if they are no longer needed? Let me know if you need any help with this
