### PR TITLE
enforce order of video sources on hosted pages

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedVideo.scala.html
@@ -65,7 +65,7 @@
                             Please <a href="http://whatbrowser.org/">upgrade</a> to a modern browser and try again.
                         </div>
                         @for(source <- page.video.sources) {
-                            <source type="@source.mimeType" src="@source.url">
+                            <source type="@source.format" src="@source.url">
                         }
                     </amp-video>
                 }

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -75,7 +75,7 @@
                         poster="@{page.video.posterUrl}"
                         class="vjs-hosted__video hosted__video gu-media--video vjs vjs-paused vjs-controls-enabled vjs_video_1-dimensions vjs-user-active">
                             @for(source <- page.video.sources) {
-                                <source type="@source.mimeType" src="@source.url">
+                                <source type="@source.format" src="@source.url">
                             }
                         </video>
                     }

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -5,7 +5,7 @@ import com.gu.contentatom.thrift.AtomData
 import common.Logging
 import common.commercial.hosted.ContentUtils.thumbnailUrl
 import common.commercial.hosted.LoggingUtils.getAndLog
-import model.MetaData
+import model.{Encoding, EncodingOrdering, MetaData}
 
 case class HostedVideoPage(
   override val id: String,
@@ -23,6 +23,7 @@ case class HostedVideoPage(
 }
 
 object HostedVideoPage extends Logging {
+  private implicit val ordering = EncodingOrdering
 
   def fromContent(content: Content): Option[HostedVideoPage] = {
     log.info(s"Building hosted video ${content.id} ...")
@@ -52,7 +53,7 @@ object HostedVideoPage extends Logging {
           duration = video.duration.map(_.toInt) getOrElse 0,
           posterUrl = video.posterUrl getOrElse "",
           youtubeId = videoVariants.find(_.platform.toString.contains("Youtube")).map(_.id),
-          sources = videoVariants.flatMap(asset => asset.mimeType map (mimeType => VideoSource(mimeType, asset.id)))
+          sources = videoVariants.flatMap(asset => asset.mimeType map (mimeType => Encoding(asset.id, mimeType))).sorted
         ),
         cta = HostedCallToAction.fromAtom(ctaAtom),
         socialShareText = content.fields.flatMap(_.socialShareText),
@@ -74,7 +75,5 @@ case class HostedVideo(
   duration: Int,
   posterUrl: String,
   youtubeId: Option[String] = None,
-  sources: Seq[VideoSource]
+  sources: Seq[Encoding]
 )
-
-case class VideoSource(mimeType: String, url: String)


### PR DESCRIPTION
## What does this change?
same as PR #14381, but for hosted pages

also, code reuse 🕺

## What is the value of this and can you measure success?
More performant hosted video pages.

## Does this affect other platforms - Amp, Apps, etc?
Yes - Amp.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Yes.

## Screenshots
before
![image](https://user-images.githubusercontent.com/836140/29968783-23a7c726-8f15-11e7-9a64-c60f8dedd35a.png)

after
![image](https://user-images.githubusercontent.com/836140/29968804-3de59d0c-8f15-11e7-9193-9b4ffe3e694d.png)


## Tested in CODE?
no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
