### PR TITLE
Deps: Upgrade chalk to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-react": "^7.1.0",
     "execa": "^0.8.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.53.1",
+    "flow-bin": "^0.54.0",
     "flow-typed": "^2.1.5",
     "git-user-name": "^1.2.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "browser-sync": "^2.18.13",
     "bs-fullscreen-message": "^1.1.0",
     "btoa": "1.1.2",
-    "chalk": "^1.1.3",
+    "chalk": "^2.1.0",
     "chance": "^1.0.11",
     "chokidar": "^1.7.0",
     "cp-file": "^4.2.0",

--- a/static/src/javascripts/lib/__mocks__/fetch-json.js
+++ b/static/src/javascripts/lib/__mocks__/fetch-json.js
@@ -1,3 +1,3 @@
 // @flow
 /* eslint-disable guardian-frontend/no-default-export */
-export default () => Promise.resolve();
+export default (): Promise<void> => Promise.resolve();

--- a/static/src/javascripts/lib/fastdom-promise.js
+++ b/static/src/javascripts/lib/fastdom-promise.js
@@ -1,7 +1,7 @@
 // @flow
 import fastdom from 'fastdom';
 
-const promisify = fdaction => (fn: Function, ctx: ?Object) =>
+const promisify = fdaction => (fn: Function, ctx: ?Object): Promise<any> =>
     new Promise((resolve, reject) =>
         fdaction(
             /* this function needs to be bound to ctx - it therefore cannot

--- a/static/src/javascripts/lib/sha1.js
+++ b/static/src/javascripts/lib/sha1.js
@@ -46,7 +46,7 @@ const Sha1 = {
         // add length (in bits) into final pair of 32-bit integers (big-endian) [§5.1.1]
         // note: most significant word would be (len-1)*8 >>> 32, but since JS converts
         // bitwise-op args to 32 bits, we need to simulate this by arithmetic operators
-        M[N - 1][14] = (msg.length - 1) * 8 / 2 ** 32;
+        M[N - 1][14] = (msg.length - 1) * 8 / (2 ** 32);
         M[N - 1][14] = Math.floor(M[N - 1][14]);
         M[N - 1][15] = ((msg.length - 1) * 8) & 0xffffffff;
 

--- a/static/src/javascripts/lib/sha1.js
+++ b/static/src/javascripts/lib/sha1.js
@@ -46,7 +46,7 @@ const Sha1 = {
         // add length (in bits) into final pair of 32-bit integers (big-endian) [§5.1.1]
         // note: most significant word would be (len-1)*8 >>> 32, but since JS converts
         // bitwise-op args to 32 bits, we need to simulate this by arithmetic operators
-        M[N - 1][14] = (msg.length - 1) * 8 / (2 ** 32);
+        M[N - 1][14] = (msg.length - 1) * 8 / 2 ** 32;
         M[N - 1][14] = Math.floor(M[N - 1][14]);
         M[N - 1][15] = ((msg.length - 1) * 8) & 0xffffffff;
 

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -93,7 +93,7 @@ class ScrollableMpu {
         }
     }
 
-    create() {
+    create(): Promise<?boolean> {
         const templateOptions = {
             id: `scrollable-mpu-${Math.floor(Math.random() * 10000).toString(
                 16

--- a/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
@@ -120,7 +120,7 @@ const getAdvertIframe = (adSlot: Element): Promise<HTMLIFrameElement> =>
  * Not all adverts render themselves - some just provide data for templates that we implement in commercial.js.
  * This looks for any such data and, if we find it, renders the appropriate component.
  */
-const applyCreativeTemplate = (adSlot: Element) =>
+const applyCreativeTemplate = (adSlot: Element): Promise<boolean> =>
     getAdvertIframe(adSlot).then((iframe: HTMLIFrameElement) =>
         renderCreativeTemplate(adSlot, iframe)
     );

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-sonobi-tag.js
@@ -43,7 +43,7 @@ const setupSonobi: () => Promise<void> = once(() => {
     return Promise.resolve();
 });
 
-const init = (start: () => void, stop: () => void) => {
+const init = (start: () => void, stop: () => void): Promise<void> => {
     start();
     setupSonobi().then(stop);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -14,7 +14,7 @@ const shouldRenderLabel = adSlotNode =>
         adSlotNode.getElementsByClassName('ad-slot__label').length
     );
 
-const renderAdvertLabel = (adSlotNode: any) => {
+const renderAdvertLabel = (adSlotNode: any): Promise<null> => {
     if (shouldRenderLabel(adSlotNode)) {
         let feedbackPopup = '';
         let feedbackThanksMessage = '';
@@ -37,6 +37,7 @@ const renderAdvertLabel = (adSlotNode: any) => {
             adSlotNode.insertAdjacentHTML('afterbegin', labelDiv);
         });
     }
+
     return Promise.resolve(null);
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -152,7 +152,10 @@ const addContentClass = adSlotNode => {
  * @param slotRenderEvent - GPT slotRenderEndedEvent
  * @returns {Promise} - resolves once all necessary rendering is queued up
  */
-const renderAdvert = (advert: Advert, slotRenderEvent: any): Promise<boolean> => {
+const renderAdvert = (
+    advert: Advert,
+    slotRenderEvent: any
+): Promise<boolean> => {
     addContentClass(advert.node);
 
     return applyCreativeTemplate(advert.node)

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -122,8 +122,10 @@ sizeCallbacks[adSizes.portrait] = () => {
     // remove geo most popular
     geoMostPopular.whenRendered.then(popular =>
         fastdom.write(() => {
-            popular.elem.remove();
-            popular.elem = null;
+            if (popular && popular.elem) {
+                popular.elem.remove();
+                popular.elem = null;
+            }
         })
     );
 };
@@ -150,7 +152,7 @@ const addContentClass = adSlotNode => {
  * @param slotRenderEvent - GPT slotRenderEndedEvent
  * @returns {Promise} - resolves once all necessary rendering is queued up
  */
-const renderAdvert = (advert: Advert, slotRenderEvent: any) => {
+const renderAdvert = (advert: Advert, slotRenderEvent: any): Promise<boolean> => {
     addContentClass(advert.node);
 
     return applyCreativeTemplate(advert.node)

--- a/static/src/javascripts/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts/projects/commercial/modules/high-merch.js
@@ -36,7 +36,7 @@ const insertAlternativeSlot = isHiResLoaded => {
         });
 };
 
-const init = () => {
+const init = (): Promise<void> => {
     if (commercialFeatures.highMerch) {
         const anchorSelector = config.page.commentable
             ? '#comments + *'

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import fastdom from 'lib/fastdom-promise';
 
-const loadNextVideo = () => {
+const loadNextVideo = (): Promise<void> => {
     const placeholders = document.querySelectorAll('.js-autoplay-placeholder');
 
     if (placeholders.length) {
@@ -21,6 +21,7 @@ const loadNextVideo = () => {
             })
         );
     }
+
     return Promise.resolve();
 };
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/outbrain.js
@@ -95,7 +95,7 @@ export const getOutbrainComplianceTargeting = (): Promise<
   true              false               false             n/a              false         false      true      non-compliant
   true              false               false             n/a              false         false      false     compliant
 */
-export const initOutbrain = () =>
+export const initOutbrain = (): Promise<void> =>
     getOutbrainPageConditions().then(pageConditions => {
         if (!pageConditions.outbrainEnabled) {
             return;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -69,7 +69,7 @@ module.load = function() {
     });
 };
 
-module.init = function() {
+module.init = function(): Promise<false> {
     if (commercialFeatures.outbrain) {
         return loadInstantly().then(inUse => {
             if (inUse) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -72,7 +72,7 @@ export const initYoutubePlayer = (
     el: HTMLElement,
     handlers: Handlers,
     videoId: string
-) => {
+): Promise<void> => {
     loadYoutubeJs();
 
     return promise.then(() => {

--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -8,7 +8,7 @@ import Component from 'common/modules/component';
 import mediator from 'lib/mediator';
 import once from 'lodash/functions/once';
 
-const promise = new Promise((resolve, reject) => {
+const promise: Promise<void> = new Promise((resolve, reject) => {
     mediator.on('modules:onward:geo-most-popular:ready', resolve);
     mediator.on('modules:onward:geo-most-popular:cancel', resolve);
     mediator.on('modules:onward:geo-most-popular:error', reject);

--- a/ui/src/__flow__/preact.js
+++ b/ui/src/__flow__/preact.js
@@ -3,7 +3,7 @@
 // temporarily commit preact libdef,
 // pending https://github.com/developit/preact/pull/782
 
-import react from 'react';
+import * as react from 'react';
 import { render } from 'react-dom';
 
 declare module "preact" {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,9 +3301,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.53.1:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
+flow-bin@^0.54.0:
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.0.tgz#f2fb0478e9e99702b623c9ed84079a39903bba77"
 
 flow-typed@^2.1.5:
   version "2.1.5"


### PR DESCRIPTION
## What does this change?

Upgrades `chalk` to `2.1.0`. The [breaking changes from](https://github.com/chalk/chalk/releases/tag/v2.0.0) don't affect us, because the APIs aren't in use.

## What is the value of this and can you measure success?

Up to date dependencies.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.