### PR TITLE
Fix hidden share toggle

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/hidden-share-toggle.js
+++ b/static/src/javascripts/projects/common/modules/social/hidden-share-toggle.js
@@ -41,8 +41,12 @@ const hiddenShareToggle = (): void => {
         const toggleVisibility = (event: Event): void => {
             const target: HTMLElement = (event.target: any);
             const listItem: HTMLElement = (target.parentNode: any);
-            const targetIsMore = listItem.matches(MORE_SELECTOR);
-            const targetIsClose = listItem.matches(CLOSE_SELECTOR);
+            const targetIsMore =
+                listItem.matches(MORE_SELECTOR) ||
+                !!listItem.closest(MORE_SELECTOR);
+            const targetIsClose =
+                listItem.matches(CLOSE_SELECTOR) ||
+                !!listItem.closest(CLOSE_SELECTOR);
 
             if (targetIsMore || targetIsClose) {
                 event.preventDefault();


### PR DESCRIPTION
## What does this change?

Because events are trappend inside of SVGs on Chrome, the toggle buttons stopped working in that browser [after a recent refactoring](https://github.com/guardian/frontend/pull/17686). This PRs restores the proper behavoir.

## What is the value of this and can you measure success?

Less bugs, happier users. :crossed_fingers: 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.