### PR TITLE
Call initTrails method on trail bootstrap

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -171,7 +171,7 @@ const bootEnhanced = (): void => {
             require => {
                 bootstrapContext(
                     'media : trail',
-                    require('bootstraps/enhanced/trail')
+                    require('bootstraps/enhanced/trail').initTrails
                 );
             },
             'trail'
@@ -224,7 +224,7 @@ const bootEnhanced = (): void => {
                 );
                 bootstrapContext(
                     'image-content : trail',
-                    require('bootstraps/enhanced/trail')
+                    require('bootstraps/enhanced/trail').initTrails
                 );
             },
             'image-content'


### PR DESCRIPTION
## What does this change?

In #17727 we ES6-ified the trail bootstrap, updating its API by providing a named initialisation method instance of exposing a default function. This API change was not reflected in the main enhanced bootstrap. 

This PR fixes the discrepancy.

## What is the value of this and can you measure success?

This issue leads to discussion failing to load on `ImageContent` pages. It is likely other `trail`-related functionality is also unavailable.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
