### PR TITLE
Thank You Epic extended

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -105,7 +105,7 @@ trait ABTestSwitches {
     "Bootstrap the AB test framework to use the Epic to thank readers who have already supported the Guardian",
     owners = Seq(Owner.withGithub("Mullefa")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 9, 5),
+    sellByDate = new LocalDate(2018, 9, 5),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -27,7 +27,7 @@ export const acquisitionsEpicThankYou = makeABTest({
     componentType: 'ACQUISITIONS_THANK_YOU_EPIC',
 
     start: '2017-06-01',
-    expiry: '2017-09-05',
+    expiry: '2018-09-05',
 
     author: 'Guy Dawson',
     description:


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Extends the thank you Epic.

## What is the value of this and can you measure success?

Continues to thank readers who support the Guardian financially.

