### PR TITLE
Add url to GA for external link clicks

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -3,7 +3,8 @@
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 
-const trackerName = config.googleAnalytics.trackers.editorial;
+const trackerName = config.get('googleAnalytics.trackers.editorial');
+
 const send = `${trackerName}.send`;
 
 const getTextContent = (el: HTMLElement): string =>
@@ -25,7 +26,7 @@ const trackSamePageLinkClick = (target: HTMLElement, tag: string): void => {
 const trackExternalLinkClick = (target: HTMLElement, tag: string): void => {
     const data: {
         dimension13: string,
-        dimension48?: string
+        dimension48?: string,
     } = {
         dimension13: getTextContent(target),
     };
@@ -77,7 +78,7 @@ const sendPerformanceEvent = (event: Object): void => {
        send performance events as normal events too,
        so we can avoid the 0.1% sampling that affects timing events
     */
-    if (config.switches.boostGaUserTimingFidelity) {
+    if (config.get('switches.boostGaUserTimingFidelity')) {
         // these are our own metrics that map to our timing events
         const metric = boostGaUserTimingFidelityMetrics[event.timingVar];
 
@@ -128,7 +129,7 @@ const trackPerformance = (
             sendPerformanceEvent(event);
         } else {
             mediator.on('modules:ga:ready', sendDeferredEventQueue);
-            config.googleAnalytics.timingEvents.push(event);
+            config.get('googleAnalytics.timingEvents').push(event);
         }
     }
 };

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -23,9 +23,20 @@ const trackSamePageLinkClick = (target: HTMLElement, tag: string): void => {
 };
 
 const trackExternalLinkClick = (target: HTMLElement, tag: string): void => {
-    window.ga(send, 'event', 'click', 'external', tag, {
+    const data: {
+        dimension13: string,
+        dimension48?: string
+    } = {
         dimension13: getTextContent(target),
-    });
+    };
+
+    const targetURL = target.getAttribute('href');
+
+    if (targetURL) {
+        data.dimension48 = targetURL;
+    }
+
+    window.ga(send, 'event', 'click', 'external', tag, data);
 };
 
 const trackSponsorLogoLinkClick = (target: Object): void => {


### PR DESCRIPTION
## What does this change?

Adds the property dimension48 to GA data for external link clicks as requested here: https://trello.com/c/EFPSyoZU/411-web-add-url-property-to-ga-external-link-tracking

Also updates a few direct references to config properties to use `config.get` as enforced by new lint rules. 

## What is the value of this and can you measure success?

Better tracking

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No