### PR TITLE
UI: Support style attribute on SVGs

### DIFF
--- a/common/app/rendering/core/JavascriptRendering.scala
+++ b/common/app/rendering/core/JavascriptRendering.scala
@@ -63,6 +63,7 @@ trait JavascriptRendering extends Logging {
         |var logger = function(type) {
         |  return function () {
         |    for (var i = 0, len = arguments.length; i < len; i++) {
+        |      print(arguments[i]);
         |      __play_webpack_logger[type](arguments[i]);
         |    }
         |  }

--- a/ui/__tools__/svg-loader.js
+++ b/ui/__tools__/svg-loader.js
@@ -32,7 +32,13 @@ module.exports = function loadSVG(source) {
                     node.children.forEach(setBlockStyles);
                 }
 
-                if (props['svg-styles']) setStyle(svg, props['svg-styles']);
+                if (props.className) {
+                    if (svg.attributes['class']) {
+                        svg.attributes['class'] += props.className;
+                    } else {
+                        svg.attributes['class'] = props.className;
+                    }
+                }
                 if (props['block-styles']) setBlockStyles(svg);
 
                 return svg;

--- a/ui/src/views/404/index.jsx
+++ b/ui/src/views/404/index.jsx
@@ -15,7 +15,7 @@ import {
     logo,
 } from './style.js.scss';
 
-export default ({ beaconUrl }: Object) =>
+export default ({ beaconUrl }: Object) => (
     <div style={fluidWrap}>
         <div style={topBar}>
             <a href="/" style={topBarLink}>
@@ -24,7 +24,7 @@ export default ({ beaconUrl }: Object) =>
         </div>
         <Logo
             block-styles={{ guardian: { fill: colour.brandBlueDark } }}
-            svg-styles={logo}
+            style={logo}
         />
         <h1 style={heading}>
             Sorry - we haven’t been able to serve the page you asked for.
@@ -80,4 +80,5 @@ export default ({ beaconUrl }: Object) =>
             style={{ display: 'none' }}
             rel="nofollow"
         />
-    </div>;
+    </div>
+);


### PR DESCRIPTION
## What does this change?

There was an omission in the svg-loader that prevented classNames applied to the SVG Preact component from being added as classes to the SVG element.

This fix passes the classes correctly. We can hence do away with the bespoke prop `svg-styles`, which was previously used to add inline styles to the SVG element.

## What is the value of this and can you measure success?

Cleaner, more intuitive developer experience, fewer hacks.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
