### PR TITLE
UI: Expose web fonts

### DIFF
--- a/ui/src/components/head/fonts.css
+++ b/ui/src/components/head/fonts.css
@@ -1,0 +1,26 @@
+@font-face {
+    font-family: "Guardian Text Egyptian Web";
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.eot");
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.eot?#iefix") format("embedded-opentype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff2") format("woff2"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff") format("woff"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.ttf") format("truetype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.svg#GuardianTextEgyptianWeb-Regular") format("svg");
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal
+}
+
+@font-face {
+    font-family: "Guardian Egyptian Web";
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot");
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot?#iefix") format("embedded-opentype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff2") format("woff2"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff") format("woff"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.ttf") format("truetype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.svg#GuardianEgyptianWeb-Regular") format("svg");
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal
+}
+
+@font-face {
+    font-family: "Guardian Text Sans Web";
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot");
+    src: url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.eot?#iefix") format("embedded-opentype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff2") format("woff2"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.woff") format("woff"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.ttf") format("truetype"), url("//pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-on/original/GuardianTextSansWeb/GuardianTextSansWeb-Regular.svg#GuardianTextSansWeb-Regular") format("svg");
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal
+}

--- a/ui/src/components/head/index.js
+++ b/ui/src/components/head/index.js
@@ -5,6 +5,7 @@
 // - https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice
 
 import resetCSS from './reset.css';
+import fontsCSS from './fonts.css';
 
 export default (props: any, css: string) =>
     `<head lang="en" data-page-path="/uk">
@@ -15,6 +16,8 @@ export default (props: any, css: string) =>
         <meta name="format-detection" content="telephone=no"/>
         <meta name="HandheldFriendly" content="True"/>
         <meta name="viewport" content="width=device-width,initial-scale=1">
+        <link rel="stylesheet" href="${props.fontsUrl}">
         <style>${resetCSS}</style>
+        <style>${fontsCSS}</style>
         ${css}
     </head>`;

--- a/ui/src/views/404/style.js.scss
+++ b/ui/src/views/404/style.js.scss
@@ -22,7 +22,7 @@ topBarLink {
 }
 
 heading {
-    font-family: georgia, serif;
+    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web", Georgia, serif;
     font-size: 24px;
     font-weight: normal;
     line-height: 30px;


### PR DESCRIPTION
## What does this change?

Make web fonts available to UI via pasteup. Obviously nothing clever with cacheing or UA detection going on here, we can address this later.

## What is the value of this and can you measure success?

This PR is to unblock @zeftilldeath so he can continue work on his 404 page redesign using real fonts. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
