### PR TITLE
UI: Delete stylesheet url

### DIFF
--- a/ui/src/components/head/index.js
+++ b/ui/src/components/head/index.js
@@ -16,7 +16,6 @@ export default (props: any, css: string) =>
         <meta name="format-detection" content="telephone=no"/>
         <meta name="HandheldFriendly" content="True"/>
         <meta name="viewport" content="width=device-width,initial-scale=1">
-        <link rel="stylesheet" href="${props.fontsUrl}">
         <style>${resetCSS}</style>
         <style>${fontsCSS}</style>
         ${css}


### PR DESCRIPTION
## What does this change?

In #17751, I erroneously added a link href that resolves to `undefined`. This was an experiment that was apparently only partially aborted 😅 

## What is the value of this and can you measure success?

No broken links on 404

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
