### PR TITLE
Rebrand report technical issue as ask for help

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -115,7 +115,7 @@
                                 contact us</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                                report technical issue</a>
+                                ask for help</a>
                             </li>
                         </ul>
 

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -8,7 +8,7 @@
             <header class="content__head">
                 <div class="gs-container">
                     <div class="content__main-column">
-                        <h1 itemprop="headline" class="content__headline">Report a technical issue</h1>
+                        <h1 itemprop="headline" class="content__headline">Ask for help</h1>
                     </div>
                 </div>
             </header>

--- a/onward/app/views/feedbackSent.scala.html
+++ b/onward/app/views/feedbackSent.scala.html
@@ -6,7 +6,7 @@
             <header class="content__head">
                 <div class="gs-container">
                     <div class="content__main-column">
-                        <h1 itemprop="headline" class="content__headline">Report a technical issue</h1>
+                        <h1 itemprop="headline" class="content__headline">Ask for help</h1>
                     </div>
                 </div>
             </header>


### PR DESCRIPTION
## What does this change?

Change the link to the feedback form from 'report technical issue' to 'ask for help' as requested by Sally.

## What is the value of this and can you measure success?

no

## Does this affect other platforms - Amp, Apps, etc?

no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
