### PR TITLE
Update resize messenger and Advertisement label addition and placement.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -7,7 +7,6 @@ import { commercialFeatures } from 'commercial/modules/commercial-features';
 
 const shouldRenderLabel = adSlotNode =>
     !(
-        adSlotNode.classList.contains('ad-slot--fluid') ||
         adSlotNode.classList.contains('ad-slot--frame') ||
         adSlotNode.classList.contains('gu-style') ||
         adSlotNode.getAttribute('data-label') === 'false' ||

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -17,15 +17,8 @@ const normalise = (length: string): string => {
     return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
 };
 
-const resize = (
-    specs: Specs,
-    iframe: HTMLElement
-): ?Promise<any> => {
-    if (
-        !specs ||
-        !('height' in specs || 'width' in specs) ||
-        !iframe
-    ) {
+const resize = (specs: Specs, iframe: HTMLElement): ?Promise<any> => {
+    if (!specs || !('height' in specs || 'width' in specs) || !iframe) {
         return null;
     }
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -19,14 +19,12 @@ const normalise = (length: string): string => {
 
 const resize = (
     specs: Specs,
-    iframe: HTMLElement,
-    adSlot: HTMLElement
+    iframe: HTMLElement
 ): ?Promise<any> => {
     if (
         !specs ||
         !('height' in specs || 'width' in specs) ||
-        !iframe ||
-        !adSlot
+        !iframe
     ) {
         return null;
     }
@@ -42,7 +40,6 @@ const resize = (
     }
 
     return fastdom.write(() => {
-        Object.assign(adSlot.style, styles);
         Object.assign(iframe.style, styles);
     });
 };
@@ -50,8 +47,7 @@ const resize = (
 const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
-            const adSlot = iframe && iframe.closest('.js-ad-slot');
-            return resize(specs, iframe, adSlot);
+            return resize(specs, iframe);
         }
     });
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -57,23 +57,19 @@ describe('Cross-frame messenger: resize', () => {
 
     describe('resize function', () => {
         it('should resolve if the specs are empty', () => {
-            const fakeAdSlot = document.createElement('div');
             const fakeIframe = document.createElement('iframe');
-            const result = resize({}, fakeIframe, fakeAdSlot);
+            const result = resize({}, fakeIframe);
             expect(result).toBeNull();
         });
 
         it('should set width and height of the ad slot', () => {
             const fallback = document.createElement('div');
             const fakeIframe = document.getElementById('iframe01') || fallback;
-            const fakeAdSlot = document.getElementById('slot01') || fallback;
             return foolFlow(
-                resize({ width: '20', height: '10' }, fakeIframe, fakeAdSlot)
+                resize({ width: '20', height: '10' }, fakeIframe)
             ).then(() => {
                 expect(fakeIframe.style.height).toBe('10px');
                 expect(fakeIframe.style.width).toBe('20px');
-                expect(fakeAdSlot.style.height).toBe('10px');
-                expect(fakeAdSlot.style.width).toBe('20px');
             });
         });
     });

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -133,7 +133,6 @@
     margin: 0 auto;
     min-height: 90px;
     padding-bottom: $gs-row-height / 2;
-    padding-top: $gs-row-height / 2;
 
     @include mq($until: tablet) {
         display: none;
@@ -183,7 +182,9 @@
     }
 
     .ad-slot__label {
-        margin-top: (-1) * $gs-row-height / 2;
+        width: 100%;
+        margin: 0 auto;
+        max-width: 1300px;
     }
 }
 


### PR DESCRIPTION
## What does this change?
This PR covers a few changes:

1. The top-above-nav will now have the 'Advertisement' label added regardless of whether it is fluid or not. This means that the fluid creatives need not supply their own 'Advertisement' label, thus removing duplication of effort and eventual inconsistency i.e. when we add a 'Ad Feedback' button to the standard 'Advertisement' label. The additional CSS ensures that the label appears left-aligned on the ad slot.

2. When resizing an ad slot iframe using the resize messenger API, we currently resize both the iframe _and_ the ad slot container. This PR removes the resizing of the ad slot container. Given the iframe is being resized, the ad slot container can just expand to the size of the iframe.

3. There is padding on the top banner ad slot and then an equal negative margin on the ad label. I can't see the reason for this - it appears to entirely cancel out...so I've removed it.

**I assume that I shouldn't be specifying `1300px` directly; should I use `gs-span(16) + $gs-gutter*2` instead?**

## What is the value of this and can you measure success?
Less logic specific to fabric creatives and a removal of CSS rules.
