### PR TITLE
Deps: Upgrade webpack to 3.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "svgo": "^0.7.2",
     "uglify-js": "^2.7.4",
     "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
-    "webpack": "^3.5.5",
+    "webpack": "^3.5.6",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-merge": "^4.1.0",
     "webpack-visualizer-plugin": "^0.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8409,9 +8409,9 @@ webpack-visualizer-plugin@^0.1.11:
     react "^0.14.0"
     react-dom "^0.14.0"
 
-webpack@^3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+webpack@^3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
## What does this change?

Minor upgrade. Why bother? [Sourcemaps performance improvements](https://github.com/webpack/webpack/releases/tag/v3.5.6)

## What is the value of this and can you measure success?

DX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.
