### PR TITLE
Fix Simple and Coherent a/b tests outbrain compliance

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
@@ -65,16 +65,14 @@ const liveblogEpicTemplate = (ctaSentence: string) =>
         </div>
     </div>`;
 
-const isEpicWithinViewLimit = (test: EpicABTest): boolean => {
+const isEpicWithinViewLimit = (): boolean => {
     const days = 30;
     const count = 4;
     const minDaysBetweenViews = 0;
 
-    const testId = test.useLocalViewLog ? test.id : undefined;
-
-    const withinViewLimit = viewsInPreviousDays(days, testId) < count;
+    const withinViewLimit = viewsInPreviousDays(days, undefined) < count;
     const enoughDaysBetweenViews =
-        viewsInPreviousDays(minDaysBetweenViews, testId) === 0;
+        viewsInPreviousDays(minDaysBetweenViews, undefined) === 0;
     return withinViewLimit && enoughDaysBetweenViews;
 };
 
@@ -120,8 +118,8 @@ const changeSideMenuLinks = (
     );
 };
 
-const shouldDisplayEpic = (test: EpicABTest): boolean =>
-    isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
+const shouldDisplayEpic = (): boolean =>
+    isEpicWithinViewLimit() && isEpicCompatibleWithPage(config.get('page'));
 
 const bindEpicInsertAndViewHandlers = (
     test: EpicABTest,
@@ -171,6 +169,8 @@ export const acquisitionsSupportBaseline = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
+                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+
                 useTailoredCopyForRegulars: true,
                 test(renderArticleEpic, variant, test) {
                     bindEpicInsertAndViewHandlers(
@@ -190,7 +190,7 @@ export const acquisitionsSupportBaseline = makeABTest({
                         const epicHtml = liveblogEpicTemplate(ctaSentence);
 
                         setupEpicInLiveblog(epicHtml, test);
-                    } else if (shouldDisplayEpic(test)) {
+                    } else if (shouldDisplayEpic()) {
                         renderArticleEpic();
                     }
 
@@ -234,6 +234,8 @@ export const acquisitionsSupportBaseline = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
+                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+
                 buttonTemplate: buildButtonTemplate,
                 supportCustomURL: 'https://support.theguardian.com/uk',
                 useTailoredCopyForRegulars: true,
@@ -254,7 +256,7 @@ export const acquisitionsSupportBaseline = makeABTest({
                         const epicHtml = liveblogEpicTemplate(ctaSentence);
 
                         setupEpicInLiveblog(epicHtml, test);
-                    } else if (shouldDisplayEpic(test)) {
+                    } else if (shouldDisplayEpic()) {
                         renderArticleEpic();
                     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-baseline.js
@@ -169,7 +169,9 @@ export const acquisitionsSupportBaseline = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
-                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+                isOutbrainCompliant:
+                    config.get('page.contentType') === 'LiveBlog' ||
+                    !shouldDisplayEpic(),
 
                 useTailoredCopyForRegulars: true,
                 test(renderArticleEpic, variant, test) {
@@ -234,7 +236,9 @@ export const acquisitionsSupportBaseline = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
-                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+                isOutbrainCompliant:
+                    config.get('page.contentType') === 'LiveBlog' ||
+                    !shouldDisplayEpic(),
 
                 buttonTemplate: buildButtonTemplate,
                 supportCustomURL: 'https://support.theguardian.com/uk',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -172,7 +172,9 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
-                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+                isOutbrainCompliant:
+                    config.get('page.contentType') === 'LiveBlog' ||
+                    !shouldDisplayEpic(),
 
                 useTailoredCopyForRegulars: true,
                 test(renderArticleEpic, variant, test) {
@@ -229,7 +231,9 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
-                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+                isOutbrainCompliant:
+                    config.get('page.contentType') === 'LiveBlog' ||
+                    !shouldDisplayEpic(),
 
                 buttonTemplate: buildButtonTemplate,
                 supportCustomURL:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-support-us-recurring-contributions.js
@@ -75,16 +75,14 @@ const liveblogEpicTemplate = (ctaSentence: string) =>
         </div>
     </div>`;
 
-const isEpicWithinViewLimit = (test: EpicABTest): boolean => {
+const isEpicWithinViewLimit = (): boolean => {
     const days = 30;
     const count = 4;
     const minDaysBetweenViews = 0;
 
-    const testId = test.useLocalViewLog ? test.id : undefined;
-
-    const withinViewLimit = viewsInPreviousDays(days, testId) < count;
+    const withinViewLimit = viewsInPreviousDays(days, undefined) < count;
     const enoughDaysBetweenViews =
-        viewsInPreviousDays(minDaysBetweenViews, testId) === 0;
+        viewsInPreviousDays(minDaysBetweenViews, undefined) === 0;
     return withinViewLimit && enoughDaysBetweenViews;
 };
 
@@ -122,8 +120,8 @@ const changeSideMenuLinks = (becomeSupporterLink: string) => {
     );
 };
 
-const shouldDisplayEpic = (test: EpicABTest): boolean =>
-    isEpicWithinViewLimit(test) && isEpicCompatibleWithPage(config.get('page'));
+const shouldDisplayEpic = (): boolean =>
+    isEpicWithinViewLimit() && isEpicCompatibleWithPage(config.get('page'));
 
 const bindEpicInsertAndViewHandlers = (
     test: EpicABTest,
@@ -174,6 +172,8 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
+                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+
                 useTailoredCopyForRegulars: true,
                 test(renderArticleEpic, variant, test) {
                     bindEpicInsertAndViewHandlers(
@@ -193,7 +193,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                         const epicHtml = liveblogEpicTemplate(ctaSentence);
 
                         setupEpicInLiveblog(epicHtml, test);
-                    } else if (shouldDisplayEpic(test)) {
+                    } else if (shouldDisplayEpic()) {
                         renderArticleEpic();
                     }
 
@@ -229,6 +229,8 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                 impression: submitABTestImpression => submitABTestImpression(),
                 success: submitABTestComplete => submitABTestComplete(),
 
+                isOutbrainCompliant: config.get('page.contentType') === 'LiveBlog' || !shouldDisplayEpic(),
+
                 buttonTemplate: buildButtonTemplate,
                 supportCustomURL:
                     'https://support.theguardian.com/us/contribute',
@@ -250,7 +252,7 @@ export const acquisitionsSupportUsRecurringContribution = makeABTest({
                         const epicHtml = liveblogEpicTemplate(ctaSentence);
 
                         setupEpicInLiveblog(epicHtml, test);
-                    } else if (shouldDisplayEpic(test)) {
+                    } else if (shouldDisplayEpic()) {
                         renderArticleEpic();
                     }
 


### PR DESCRIPTION
## What does this change?

We are taking control of the epic frequency capping, so we also need to
take control of the outbrain compliance

## What is the value of this and can you measure success?

This change should increase the number of compliant outbrain impressions (with no change to the total number of outbrain impressions)

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
