### PR TITLE
[WiP] Create the second iteration of GLabs Traffic Driver tests.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Displays an ad slot that will drive traffic to GLabs content",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 9, 7),
+    sellByDate = new LocalDate(2017, 9, 26),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -8,6 +8,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-glabs-traffic-driver",
+    "Displays an ad slot that will drive traffic to GLabs content",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 9, 7),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-snippet-four-variants",
     "Measure snippet open rate based on snippet design",
     owners = Seq(Owner.withGithub("regiskuckaertz")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Displays an ad slot that will drive traffic to GLabs content",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 9, 26),
+    sellByDate = new LocalDate(2017, 9, 29),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -6,6 +6,7 @@ import reportError from 'lib/report-error';
 import highMerch from 'commercial/modules/high-merch';
 import { articleAsideAdvertsInit } from 'commercial/modules/article-aside-adverts';
 import { articleBodyAdvertsInit } from 'commercial/modules/article-body-adverts';
+import { glabsTrafficDriverInit } from 'commercial/modules/glabs-traffic-driver';
 import { closeDisabledSlots } from 'commercial/modules/close-disabled-slots';
 import prepareGoogletag from 'commercial/modules/dfp/prepare-googletag';
 import prepareSonobiTag from 'commercial/modules/dfp/prepare-sonobi-tag';
@@ -44,7 +45,8 @@ if (!commercialFeatures.adFree) {
         ['cm-articleAsideAdverts', articleAsideAdvertsInit, true],
         ['cm-articleBodyAdverts', articleBodyAdvertsInit],
         ['cm-liveblogAdverts', initLiveblogAdverts, true],
-        ['cm-stickyTopBanner', initStickyTopBanner]
+        ['cm-stickyTopBanner', initStickyTopBanner],
+        ['cm-glabsTrafficDriver', glabsTrafficDriverInit, true]
     );
 }
 

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -5,6 +5,7 @@ import { isAdFreeUser } from 'commercial/modules/user-features';
 import identityApi from 'common/modules/identity/api';
 import userPrefs from 'common/modules/user-prefs';
 import { shouldShowReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import { getParticipations } from 'common/modules/experiments/utils';
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
@@ -12,6 +13,7 @@ class CommercialFeatures {
     stickyTopBannerAd: any;
     articleBodyAdverts: any;
     articleAsideAdverts: any;
+    glabsTrafficDriver: any;
     videoPreRolls: any;
     highMerch: any;
     thirdPartyTags: any;
@@ -68,6 +70,16 @@ class CommercialFeatures {
             !isLiveBlog &&
             !isHosted &&
             !newRecipeDesign;
+
+        this.glabsTrafficDriver =
+            this.articleBodyAdverts &&
+            switches.abGlabsTrafficDriver &&
+            config.hasTone('Features') &&
+            !config.page.isPaidContent &&
+            ['sport', 'lifeandstyle', 'fashion', 'football', 'travel'].includes(
+                config.page.section
+            ) &&
+            getParticipations().GlabsTrafficDriver !== undefined;
 
         this.videoPreRolls = this.dfpAdvertising && !this.adFree;
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
@@ -76,6 +76,15 @@ const adSlotDefinitions = {
             ],
         },
     },
+
+    'glabs-left': {
+        label: false,
+        refresh: false,
+        name: 'glabs-inline',
+        sizeMappings: {
+            mobile: [adSizes.fluid],
+        },
+    },
 };
 
 const createAdSlotElement = (

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.js
@@ -80,7 +80,7 @@ const adSlotDefinitions = {
     'glabs-left': {
         label: false,
         refresh: false,
-        name: 'glabs-inline',
+        name: 'glabs-left',
         sizeMappings: {
             mobile: [adSizes.fluid],
         },

--- a/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
@@ -1,0 +1,83 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import { addSlot } from 'commercial/modules/dfp/add-slot';
+import createSlot from 'commercial/modules/dfp/create-slot';
+import { commercialFeatures } from 'commercial/modules/commercial-features';
+import { spaceFiller } from 'common/modules/article/space-filler';
+
+/*
+ The heuristic for adding a glabs traffic driver slot into an article is as follows:
+ 1) it must be before the penultimate paragraph and
+ 2) it must be more than 100 words from the bottom of the article
+ This is a rough heuristic for ensuring that the slot isn't added to above
+ two very small paragraphs, which would look jarring.
+ */
+
+let runningWordCount = 0;
+
+const wordCount = (element: Element): number =>
+    element.textContent.split(' ').length;
+
+const rules = {
+    bodySelector: '.js-article__body',
+    slotSelector: ' > p',
+    minAbove: 200,
+    minBelow: 0,
+    clearContentMeta: 0,
+    selectors: {
+        ' .element-rich-link': {
+            minAbove: 200,
+            minBelow: 200,
+        },
+        ' .element-image': {
+            minAbove: 50,
+            minBelow: 50,
+        },
+        ' .player': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > h1': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > h2': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' > *:not(p):not(h2):not(blockquote)': {
+            minAbove: 0,
+            minBelow: 0,
+        },
+        ' .ad-slot': {
+            minAbove: 100,
+            minBelow: 100,
+        },
+    },
+    filter: (slot: Object, index: number): boolean => {
+        runningWordCount += wordCount(slot.element);
+        return index >= 2 && runningWordCount >= 200;
+    },
+    fromBottom: true,
+};
+
+const insertSlot = (paras: Element[]): Promise<void> => {
+    const slot = createSlot('glabs-left');
+    return fastdom
+        .write(() => paras[0].insertAdjacentElement('afterend', slot))
+        .then(() => addSlot(slot, true));
+};
+
+const glabsTrafficDriverInit = (): Promise<void> => {
+    if (commercialFeatures.glabsTrafficDriver) {
+        return spaceFiller.fillSpace(rules, insertSlot, {
+            waitForImages: false,
+            waitForLinks: false,
+            waitForInteractives: false,
+        });
+    }
+
+    return Promise.resolve();
+};
+
+export { glabsTrafficDriverInit };

--- a/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
@@ -5,24 +5,11 @@ import createSlot from 'commercial/modules/dfp/create-slot';
 import { commercialFeatures } from 'commercial/modules/commercial-features';
 import { spaceFiller } from 'common/modules/article/space-filler';
 
-/*
- The heuristic for adding a glabs traffic driver slot into an article is as follows:
- 1) it must be before the penultimate paragraph and
- 2) it must be more than 100 words from the bottom of the article
- This is a rough heuristic for ensuring that the slot isn't added to above
- two very small paragraphs, which would look jarring.
- */
-
-let runningWordCount = 0;
-
-const wordCount = (element: Element): number =>
-    element.textContent.split(' ').length;
-
 const rules = {
     bodySelector: '.js-article__body',
     slotSelector: ' > p',
-    minAbove: 200,
-    minBelow: 0,
+    minAbove: 400,
+    minBelow: 300,
     clearContentMeta: 0,
     selectors: {
         ' .element-rich-link': {
@@ -53,10 +40,6 @@ const rules = {
             minAbove: 100,
             minBelow: 100,
         },
-    },
-    filter: (slot: Object, index: number): boolean => {
-        runningWordCount += wordCount(slot.element);
-        return index >= 2 && runningWordCount >= 200;
     },
     fromBottom: true,
 };

--- a/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/glabs-traffic-driver.js
@@ -76,7 +76,6 @@ const glabsTrafficDriverInit = (): Promise<void> => {
             waitForInteractives: false,
         });
     }
-
     return Promise.resolve();
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,6 +6,7 @@ import { paidContentVsOutbrain2 } from 'common/modules/experiments/tests/paid-co
 import { outstreamFrequencyCapHoldback } from 'common/modules/experiments/tests/outstream-cap-holdback';
 import { acquisitionsEpicElectionInteractiveEnd } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
 import { acquisitionsEpicElectionInteractiveSlice } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-slice';
+import { glabsTrafficDriver } from 'common/modules/experiments/tests/glabs-traffic-driver';
 import { SnippetFourVariants } from 'common/modules/experiments/tests/snippet-a-a1-b-b1';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
@@ -15,6 +16,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     acquisitionsEpicElectionInteractiveSlice,
     outstreamFrequencyCapHoldback,
     SnippetFourVariants,
+    glabsTrafficDriver,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
@@ -5,8 +5,8 @@ const success = complete => trackAdRender('dfp-ad--glabs-left').then(complete);
 
 export const glabsTrafficDriver: ABTest = {
     id: 'GlabsTrafficDriver',
-    start: '2017-09-08',
-    expiry: '2017-09-25',
+    start: '2017-09-13',
+    expiry: '2017-09-28',
     author: 'Jon Norman',
     description:
         'Adds in a new ad slot to drive traffic to specific GLabs campaigns, served through DFP.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
@@ -6,7 +6,7 @@ const success = complete => trackAdRender('dfp-ad--glabs-left').then(complete);
 export const glabsTrafficDriver: ABTest = {
     id: 'GlabsTrafficDriver',
     start: '2017-09-08',
-    expiry: '2017-08-19',
+    expiry: '2017-09-25',
     author: 'Jon Norman',
     description:
         'Adds in a new ad slot to drive traffic to specific GLabs campaigns, served through DFP.',
@@ -21,7 +21,12 @@ export const glabsTrafficDriver: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'contextual',
+            id: 'contextual1',
+            test: () => {},
+            success,
+        },
+        {
+            id: 'contextual2',
             test: () => {},
             success,
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/glabs-traffic-driver.js
@@ -1,0 +1,34 @@
+// @flow
+import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';
+
+const success = complete => trackAdRender('dfp-ad--glabs-left').then(complete);
+
+export const glabsTrafficDriver: ABTest = {
+    id: 'GlabsTrafficDriver',
+    start: '2017-09-08',
+    expiry: '2017-08-19',
+    author: 'Jon Norman',
+    description:
+        'Adds in a new ad slot to drive traffic to specific GLabs campaigns, served through DFP.',
+    audience: 0.4,
+    audienceOffset: 0.05,
+    successMeasure:
+        'Higher clickthrough rates to specific campaigns targeted to the new GLabs slots',
+    audienceCriteria: 'Users who are browsing articles on web.',
+    dataLinkNames: '',
+    idealOutcome:
+        'Determine how much context matters when serving these traffic drivers.',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'contextual',
+            test: () => {},
+            success,
+        },
+        {
+            id: 'non-contextual',
+            test: () => {},
+            success,
+        },
+    ],
+};

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -415,7 +415,7 @@
     padding: 0;
     margin: 0;
 
-    &:not(.ad-slot--im) {
+    &:not(.ad-slot--im .ad-slot--glabs-left) {
         width: auto;
     }
 
@@ -435,6 +435,37 @@
         @include mq(mobileLandscape, $until: tablet) {
             margin-left: -$gs-gutter;
             margin-right: -$gs-gutter;
+        }
+    }
+}
+.ad-slot--glabs-left {
+    min-height: 0;
+    padding: 0;
+    float: left;
+    margin: 5px $gs-gutter $gs-baseline 0;
+    clear: both;
+
+    @include mq($until: mobileLandscape) {
+        width: $gs-gutter * 6.5;
+        margin-bottom: $gs-baseline / 2;
+        margin-right: $gs-gutter / 2;
+    }
+
+    @include mq(mobileLandscape) {
+        width: gs-span(3);
+    }
+
+    @include mq(leftCol) {
+        margin-left: -1 * (gs-span(2) + $gs-gutter);
+        &.element--supporting {
+            width: gs-span(4);
+        }
+    }
+
+    @include mq(wide) {
+        margin-left: -1 * (gs-span(3) + $gs-gutter);
+        &.element--supporting {
+            width: gs-span(5);
         }
     }
 }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -34,7 +34,7 @@
         .content__article-body {
             padding-right: gs-span(1) + $gs-gutter;
 
-            .ad-slot:not(.ad-slot--im) {
+            .ad-slot:not(.ad-slot--im .ad-slot--glabs-left) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }
 


### PR DESCRIPTION
## What does this change?
This follows up the previous test (#17683), with a new one.

## What is the value of this and can you measure success?
We can measure the difference that a contextual traffic driver has over a non-contextual traffic driver. This is achieved through the changes in this PR as well as the line items defined [here](https://www.google.com/dfp/59666047#delivery/OrderDetail/orderId=2107407035) (requires a DFP login).

To do:
- [x] Make it such that the `contextual` variant bucket is twice the size of the `non-contextual` variant. This probably requires just creating a third variant of the test i.e. `contextual2` rather than changing the AB test framework.
- [x] Ensure that the end dates allow for 2 weeks of testing before this gets merged.
- [x] Have a play around with the space-finder rules. It looks like some articles that should be eligible for a traffic driver slot are being ruled out because the min-above is too high.
- [x] The logic for ensuring that the traffic driver appears above the penultimate paragraph and is after 200 words is currently faulty as it runs on the candidates returned by the space-finder rather than ALL the paragraphs in the article.