### PR TITLE
Render only active media asset in emails

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -132,7 +132,7 @@
                     case ContentAtomBlockElement(atomId) => {
                         @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
                             @atom.posterImage.flatMap(EmailVideoImage.bestSrcFor).map { imageUrl =>
-                                @atom.assets.map { asset =>
+                                @atom.activeAssets.headOption.map { asset =>
                                     @row(Seq("padded")) {
                                         @asset.platform match {
                                             case MediaAssetPlatform.Youtube => {


### PR DESCRIPTION
## What does this change?
Renders only the active media asset from atoms in email body.

## What is the value of this and can you measure success?
Avoids multiple versions of the same media asset being rendered in emails and moves closer to the way standard articles render atoms.

## Does this affect other platforms - Amp, Apps, etc?
Email only.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
