### PR TITLE
Snippet style improvements

### DIFF
--- a/static/src/stylesheets/module/atoms/_explainers.scss
+++ b/static/src/stylesheets/module/atoms/_explainers.scss
@@ -33,12 +33,12 @@
 }
 
 .explainer-snippet__label {
-    @include font-size(14, 18);
+    @include font-size(21, 24);
     display: block;
 }
 
 .explainer-snippet__headline {
-    @include font-size(20, 22);
+    @include font-size(21, 24);
 }
 
 .explainer-snippet__handle {

--- a/static/src/stylesheets/module/atoms/_snippets.scss
+++ b/static/src/stylesheets/module/atoms/_snippets.scss
@@ -23,20 +23,17 @@
 .explainer-snippet__item::before {
     content: '';
     display: flex;
-    width: 200px;
+    width: 100px;
     height: 0;
-    border-top: 1px dotted $neutral-2;
+    border-top: 1px dotted $neutral-3;
     @include mq($until: mobileLandscape) {
         width: 100px;
     }
 }
 
-.explainer-snippet__item+.explainer-snippet__item {
-    padding-top: $gs-baseline;
-}
-
 .explainer-snippet__heading {
     font-size: 18px;
+    padding-top: 2px;
 }
 
 .explainer-snippet__event-date::before {
@@ -45,12 +42,13 @@
     height: 16px;
     border-radius: 100%;
     float: left;
-    margin-left: -26px;
-    background-color: $neutral-2;
+    margin-left: -24px;
+    background-color: $news-main-2;
 }
 
 .explainer-snippet__event-date {
-    font-size: 18px;
+    font-size: 16px;
+    line-height: 24px;
 }
 
 .explainer-snippet--timeline {
@@ -61,7 +59,19 @@
 
     .explainer-snippet__item {
         padding-left: 17px;
-        border-left: 1px solid rgba($neutral-2, .5);
+
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    .explainer-snippet__item:not(:last-child) {
+        border-left: 1px solid rgba($neutral-3, .5);
+        padding-bottom: 16px;
+
+        .explainer-snippet__event-date::before {
+            margin-left: -25px;
+        }
     }
 }
 
@@ -107,6 +117,20 @@
 
     .explainer-snippet__heading {
         color: $news-support-5;
+    }
+
+    .explainer-snippet--timeline {
+        .explainer-snippet__item:not(:last-child) {
+            border-left: 1px solid rgba($news-support-2, .5);
+        }
+    }
+
+    .explainer-snippet__event-date::before {
+        background-color: #ffffff;
+    }
+
+    .explainer-snippet__item::before {
+        border-top: 1px dotted $news-support-1;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Some small style improvements for the "snippet" atoms.

- no line after the last bullet point in the timeline
- fixed gaps sometimes appearing in the timeline
- some general size/colour fixes, for both variants

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
![picture 1](https://user-images.githubusercontent.com/1513454/30206046-c0128d40-9482-11e7-960f-d19e2b470842.png)

![picture 2](https://user-images.githubusercontent.com/1513454/30206051-c521c47c-9482-11e7-80fa-9be8c6328c66.png)

![picture 3](https://user-images.githubusercontent.com/1513454/30206055-c8a516f8-9482-11e7-8217-9c23ff756b5a.png)

![picture 4](https://user-images.githubusercontent.com/1513454/30206060-cc9e0058-9482-11e7-9b10-4f809febb3c5.png)


## Tested in CODE?
Yes