### PR TITLE
Extending membership tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -15,7 +15,7 @@ trait ABTestSwitches {
     s"Test effectiveness of engagement banners in the $edition edition for driving Membership & Contributions.",
     owners = Seq(Owner.withGithub("rtyley")),
     safeState = On,
-    sellByDate = new LocalDate(2017, 9, 8), // we'll be doing AB tests on this for a long time, don't want to break the build
+    sellByDate = new LocalDate(2017, 9, 12), // we'll be doing AB tests on this for a long time, don't want to break the build
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
Extending tests which expired on Friday

cc @rtyley @davidfurey @guardian/dotcom-platform 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
