### PR TITLE
Show liveblog updates on fronts

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -11,7 +11,6 @@ import template from 'lodash/utilities/template';
 import blockTemplate from 'raw-loader!facia/views/liveblog-block.html';
 import isUndefined from 'lodash/objects/isUndefined';
 import debounce from 'lodash/functions/debounce';
-import isEmpty from 'lodash/objects/isEmpty';
 
 const animateDelayMs = 2000;
 const animateAfterScrollDelayMs = 500;
@@ -189,7 +188,7 @@ const showUpdatesFromLiveBlog = (): Promise<void> =>
         .then(elementsById => {
             let oldBlockDates;
 
-            if (!isEmpty(elementsById)) {
+            if (elementsById.size) {
                 oldBlockDates = session.get(sessionStorageKey) || {};
 
                 elementsById.forEach((elements, articleId) => {


### PR DESCRIPTION
## What does this change?

Fixes issue where liveblog updates on fronts were not displaying. The cause of the bug was the use of the `lodash/isEmpty` to check whether a `Map` object was empty, `isEmpty` always returned true even if the map wasn't empty. I've changed to use the `size` property of the map which fixes the issue.

Trello: https://trello.com/c/wS8Vjeqb/422-web-liveblog-updates-on-fronts-no-longer-working

## What is the value of this and can you measure success?

Fixes a bug.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

Before...

<img width="457" alt="screen_shot_2017-08-31_at_16 57 06" src="https://user-images.githubusercontent.com/1590704/30272182-1eaad14a-96eb-11e7-9a36-2dab44566053.png">

After...

![picture 68](https://user-images.githubusercontent.com/1590704/30272190-2d7399fa-96eb-11e7-8c25-d561062dd14d.png)

## Tested in CODE?

No
