### PR TITLE
Prevent blink/flashing icon on liveblog rich links

### DIFF
--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -12,7 +12,7 @@
         <span class="rich-link__kicker">Analysis</span>
     }
     @if(content.tags.isLiveBlog && content.fields.isLive) {
-        <span class="rich-link__kicker"><span class="rich-link__live live-pulse-icon js-flashing-image"></span>Live</span>
+        <span class="rich-link__kicker"><span class="rich-link__live live-pulse-icon flashing-image"></span>Live</span>
     }
     @if(content.tags.isPodcast) {
         @content.content.seriesTag.map { series => <span class="rich-link__kicker">@series.metadata.webTitle</span> }


### PR DESCRIPTION
## What does this change?

The flashing element in a liveblog rich link needs the class `flashing-image` on it. If it has this class when the class `disable-flashing-elements` is on the body then the element will be hidden.

The flashing element in the rich-link was still visible even when the `disable-flashing-elements` class was on the body. This was because the wrong class `js-flashing-image` was added, this class is not referenced anywhere in our JS/SCSS.

Trello: https://trello.com/c/UR7WDRAr/440-web-blinking-lights-on-articles-with-a-breaking-news-rich-link

## What is the value of this and can you measure success?

Accessibility improvements

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No