### PR TITLE
Remove autoplay next from hosted videos to solve intermittent bug

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -1,5 +1,4 @@
 // @flow
-import { isBreakpoint } from 'lib/detect';
 import fastdom from 'fastdom';
 import deferToAnalytics from 'lib/defer-to-analytics';
 import reportError from 'lib/report-error';
@@ -9,8 +8,6 @@ import { fullscreener } from 'common/modules/media/videojs-plugins/fullscreener'
 import { initHostedYoutube } from 'commercial/modules/hosted/youtube';
 import nextVideoAutoplay from 'commercial/modules/hosted/next-video-autoplay';
 import loadingTmpl from 'raw-loader!common/views/ui/loading.html';
-
-const isDesktop = (): boolean => isBreakpoint({ min: 'desktop' });
 
 const initLoadingSpinner = (player: Object, loadingTemplate: string): void => {
     player.loadingSpinner.contentEl().innerHTML = loadingTemplate;
@@ -134,20 +131,7 @@ const setupVideo = (
 
     nextVideoAutoplay.init().then(() => {
         if (nextVideoAutoplay.canAutoplay()) {
-            // on desktop show the next video link 10 second before the end of the currently watching video
-            if (isDesktop()) {
-                nextVideoAutoplay.addCancelListener();
-                player.one(
-                    'timeupdate',
-                    nextVideoAutoplay.triggerAutoplay.bind(
-                        this,
-                        player.currentTime.bind(player),
-                        parseInt(player.duration(), 10)
-                    )
-                );
-            } else {
-                player.one('ended', nextVideoAutoplay.triggerEndSlate);
-            }
+            player.one('ended', nextVideoAutoplay.triggerEndSlate);
         }
     });
 };


### PR DESCRIPTION
## What does this change?

Remove auto-load next feature from HOSTED videos

This will mean that the 'next video' panel will not overlay in the final ten seconds, and on video end, the browser will not auto-redirect to the URL of the next video. However, the overlay screen showing the campaign, and the next video will still display when the video finishes.

## What is the value of this and can you measure success?

Solves intermittent but significant bug where the duration of the video does not set, so the next page loads immediately. This results in the user only seeing about 1 second of the video before the url redirect occurs. Even worse, if you encounter this bug, it will probably occur on the subsequent videos as well...

Trello card: https://trello.com/c/afyBKTLy/253-jumpy-video-atom

The next video screen will still load at the end of the video, so there is still a user onward journey:

<img width="1041" alt="picture 1006" src="https://user-images.githubusercontent.com/8607683/30323899-e75dedd6-97b6-11e7-8548-dbf1397aeb44.png">


## Does this affect other platforms - Amp, Apps, etc?

Nope - feature for desktop only

Hosted content only

## Screenshots

🐛 🐛 🐛 

![hosted-bug](https://user-images.githubusercontent.com/8607683/30322863-d05ab7bc-97b2-11e7-96c5-a1216f2a1984.gif)

😱 😱 😱

## Tested in CODE?
