### PR TITLE
Explicitly hide show-more button when javascript is disabled

### DIFF
--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -40,7 +40,7 @@
 
         @if(containerModel.content.showMoreCards.nonEmpty){
             <details class="dumathoin-more">
-                <summary class="button button--medium button--primary button--show-more dumathoin-more__button" data-text="@containerModel.content.title">
+                <summary class="button button--medium button--primary button--show-more dumathoin-more__button modern-visible" data-text="@containerModel.content.title">
                     @fragments.inlineSvg("plus", "icon")
                     @fragments.inlineSvg("minus", "icon")
                     <span class="js-button__label">More @containerModel.content.title</span>

--- a/common/app/views/fragments/containers/facia_cards/showMoreButton.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/showMoreButton.scala.html
@@ -8,7 +8,8 @@
     ("button--show-more", true),
     ("button--primary", true),
     ("collection__show-more", true),
-    ("js-show-more-button", true)
+    ("js-show-more-button", true),
+    ("modern-visible", true)
 ))"
         data-test-id="show-more"
         data-link-name="more">

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -120,7 +120,7 @@
 
                         <div class="discussion__comment-box discussion__comment-box--bottom discussion__comment-box--bottom--hidden js-discussion-comment-box--bottom"></div>
 
-                        <button class="discussion__show-button button--show-more button button--large button--primary js-discussion-show-button" data-link-name="more-comments">
+                        <button class="discussion__show-button button--show-more button button--large button--primary js-discussion-show-button modern-visible" data-link-name="more-comments">
                             @fragments.inlineSvg("plus", "icon")
                             View more comments
                         </button>

--- a/sport/app/football/views/matchList/matchesPage.scala.html
+++ b/sport/app/football/views/matchList/matchesPage.scala.html
@@ -66,7 +66,7 @@
                     @if( matchesList.nextPage.isDefined) {
                         <div class="matches-nav" data-link-name="@matchesList.pageType nav">
                             @matchesList.nextPage.map{url =>
-                                <a href="@url" class="football-matches__show-more js-show-more-football-matches button button--medium button--primary"
+                                <a href="@url" class="football-matches__show-more js-show-more-football-matches button--show-more button button--medium button--primary"
                                    data-shows-more=".football-matches__day"
                                    data-puts-more-into="football-matches"
                                    data-new-url="next"

--- a/static/src/stylesheets/module/facia/_facia-show-more.scss
+++ b/static/src/stylesheets/module/facia/_facia-show-more.scss
@@ -25,10 +25,6 @@
     opacity: 0;
 }
 
-.is-not-modern .button--show-more {
-    display: none;
-}
-
 /**
  *  Everything below is pure magic. Trying to even out the different baseline of Guardian font.
  */

--- a/static/src/stylesheets/module/football/_matches.scss
+++ b/static/src/stylesheets/module/football/_matches.scss
@@ -141,25 +141,9 @@
     cursor: pointer;
 }
 
-$show-more-icon-size: $base-size * 3;
-$show-more-icon-spacing: $base-size + 1;
-
 .football-matches__show-more {
     margin-top: $gs-baseline/2;
     outline: none;
-    position: relative;
-    padding-left: $show-more-icon-size + $show-more-icon-spacing * 2;
-
-    .i, svg {
-        width: $show-more-icon-size;
-        height: $show-more-icon-size;
-        vertical-align: middle;
-        margin: auto;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: $show-more-icon-spacing;
-    }
 }
 
 /* Footnotes */


### PR DESCRIPTION
## What does this change?
Not all `show-more` button needs to be hidden when javascript is disabled
(ex: www.theguardian.com/football/fixtures)
This patch:
- reverts workaround to make the football `show-more button` visible when javascript is off 
- removes the css that hides the `show-more` button when js is disabled and explicitly adds a class to the buttons that needs to be hidden

`StoryQuiz` atom is also using the `show-more` button but I checked with @regiskuckaertz and it doesn't need to be hidden when no js

## What is the value of this and can you measure success?
Less workaround, more explicit behaviour

## Tested in CODE?
Yes
