### PR TITLE
Football league table pages with commercial metadata

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -156,8 +156,8 @@ GET            /football/match-day/:year/:month/:day                            
 GET            /football/match-day/:competition/:year/:month/:day.json                                                           football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET            /football/match-day/:competition/:year/:month/:day                                                                football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
 
-GET            /football/tables                                                                                                  football.controllers.LeagueTableController.renderLeagueTable()
-GET            /football/tables.json                                                                                             football.controllers.LeagueTableController.renderLeagueTableJson()
+GET            /football/tables                                                                                                  football.controllers.LeagueTableController.renderLeagueTables()
+GET            /football/tables.json                                                                                             football.controllers.LeagueTableController.renderLeagueTablesJson()
 GET            /football/:competition/table                                                                                      football.controllers.LeagueTableController.renderCompetition(competition)
 GET            /football/:competition/table.json                                                                                 football.controllers.LeagueTableController.renderCompetitionJson(competition)
 GET            /football/:competition/:group/table                                                                               football.controllers.LeagueTableController.renderCompetitionGroup(competition, group)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -89,8 +89,8 @@ GET        /football/match-day/:year/:month/:day                                
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
 
-GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTable()
-GET        /football/tables.json                                                               football.controllers.LeagueTableController.renderLeagueTableJson()
+GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTables()
+GET        /football/tables.json                                                               football.controllers.LeagueTableController.renderLeagueTablesJson()
 GET        /football/:competition/table                                                        football.controllers.LeagueTableController.renderCompetition(competition)
 GET        /football/:competition/table.json                                                   football.controllers.LeagueTableController.renderCompetitionJson(competition)
 GET        /football/:competition/:group/table                                                 football.controllers.LeagueTableController.renderCompetitionGroup(competition, group)

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -53,8 +53,8 @@ class LeagueTableController(
 
   private def loadTables: Seq[Table] = sortedCompetitions.filter(_.hasLeagueTable).map { Table(_) }
 
-  def renderLeagueTableJson() = renderLeagueTable()
-  def renderLeagueTable() = Action { implicit request =>
+  def renderLeaguesTableJson() = renderLeagueTables()
+  def renderLeagueTables() = Action { implicit request =>
 
     val page = new FootballPage(
       "football/tables",

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -53,7 +53,7 @@ class LeagueTableController(
 
   private def loadTables: Seq[Table] = sortedCompetitions.filter(_.hasLeagueTable).map { Table(_) }
 
-  def renderLeaguesTableJson() = renderLeagueTables()
+  def renderLeagueTablesJson() = renderLeagueTables()
   def renderLeagueTables() = Action { implicit request =>
 
     val page = new FootballPage(

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -103,7 +103,7 @@ class LeagueTableController(
     table.map { table =>
 
       val page = new FootballPage(
-        "football/tables",
+        s"football/$competition/table",
         "football",
         s"${table.competition.fullName} table"
       )
@@ -132,7 +132,7 @@ class LeagueTableController(
       }
     } yield {
       val page = new FootballPage(
-        "football/tables",
+        s"football/$competition/$groupReference/table",
         "football",
         s"${table.competition.fullName} table"
       )

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -44,8 +44,8 @@ GET        /football/match-day/:year/:month/:day                                
 GET        /football/match-day/:competition/:year/:month/:day.json                             football.controllers.MatchDayController.competitionMatchesForJson(competition, year, month, day)
 GET        /football/match-day/:competition/:year/:month/:day                                  football.controllers.MatchDayController.competitionMatchesFor(competition, year, month, day)
 
-GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTable()
-GET        /football/tables.json                                                               football.controllers.LeagueTableController.renderLeagueTableJson()
+GET        /football/tables                                                                    football.controllers.LeagueTableController.renderLeagueTables()
+GET        /football/tables.json                                                               football.controllers.LeagueTableController.renderLeagueTablesJson()
 GET        /football/:competition/table                                                        football.controllers.LeagueTableController.renderCompetition(competition)
 GET        /football/:competition/table.json                                                   football.controllers.LeagueTableController.renderCompetitionJson(competition)
 GET        /football/:competition/:group/table                                                 football.controllers.LeagueTableController.renderCompetitionGroup(competition, group)

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
   lazy val leagueTableController = new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
 
   "League Table Controller" should "200 when content type is table" in {
-    val result = leagueTableController.renderLeagueTable()(TestRequest())
+    val result = leagueTableController.renderLeagueTables()(TestRequest())
     status(result) should be(200)
   }
 
@@ -29,7 +29,7 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
       .withHeaders("host" -> "localhost:9000")
       .withHeaders("Origin" -> "http://www.theorigin.com")
 
-    val result = leagueTableController.renderLeagueTableJson()(fakeRequest)
+    val result = leagueTableController.renderLeagueTablesJson()(fakeRequest)
     status(result) should be(200)
     contentType(result) shouldBe Some("application/json")
     contentAsString(result) should startWith("{\"config\"")


### PR DESCRIPTION
Adds metadata ids that are consistent with the page urls so that ad targeting works as expected. This affects competition table pages, eg. 

https://www.theguardian.com/football/premierleague/table
https://www.theguardian.com/football/world-cup-2018-qualifiers/group-b/table