### PR TITLE
Use an arrow for the placeholder in the countdown timer of Hosted Videos

### DIFF
--- a/commercial/app/views/hosted/hostedVideoAutoplay.scala.html
+++ b/commercial/app/views/hosted/hostedVideoAutoplay.scala.html
@@ -19,7 +19,7 @@
         </div>
         <a href="@{trail.url}" class="hosted-next-autoplay__poster" data-link-name="Next Hosted Video Autoplay: @{trail.title}">
             <img class="hosted-next-autoplay__poster-img" src="@{trail.thumbnailUrl}">
-            <div class="hosted-next-autoplay__poster-timer hosted-tone-btn js-autoplay-timer" data-next-page="@{trail.url}">10s</div>
+            <div class="hosted-next-autoplay__poster-timer hosted-tone-btn js-autoplay-timer" data-next-page="@{trail.url}">@fragments.inlineSvg("arrow-right", "icon", List(""))</div>
         </a>
         <a href="@{trail.url}" class="hosted__next-video--mobile" data-link-name="Next Hosted Video @{trail.title}" target="_blank">
                             Watch now

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-video.scss
@@ -273,7 +273,8 @@
         position: absolute;
         bottom: 10px;
         left: 10px;
-        width: 22px;
+        width: 20px;
+        height: 20px;
         padding: 10px;
         color: #000000;
         border-radius: 100%;


### PR DESCRIPTION
## What does this change?

Changes the placeholder content of the next video icon from `10s` to an arrow, and sets the sizing.

## What is the value of this and can you measure success?

After removing the 'autoload next' from Hosted Videos (#17787), the content of the timer element does not update.

If we can resolve the bug, we should keep this placeholder swap anyway, since `nextVideoAutoplay.triggerAutoplay` can still update the element, therefore we do not need to hardcode the starting value in the template.

## Screenshots

BEFORE:

<img width="1287" alt="picture 1012" src="https://user-images.githubusercontent.com/8607683/30374433-da80fd08-987c-11e7-88ae-f4f51c14ffb1.png">

AFTER:

<img width="1159" alt="picture 1011" src="https://user-images.githubusercontent.com/8607683/30374460-f190e15c-987c-11e7-9731-6577a3918a9f.png">
