### PR TITLE
Stop flow on teamcity

### DIFF
--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -28,9 +28,10 @@ set +x
 echo "##teamcity[progressFinish 'asset dist']"
 set -x
 
-cd ../../static/src/javascripts
-flow stop
+# cd ../../static/src/javascripts
+# flow stop
 
 set +x
+echo "$PWD"
 echo "Stop flow server"
 set -x

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-set -o xtrace
-set -o nounset
-set -o errexit
+# set -o xtrace
+# set -o nounset
+# set -o errexit
 
 set +x
 . ~/.nvm/nvm.sh
@@ -30,19 +30,15 @@ set -x
 
 cd static/src/javascripts
 
-set +x
-echo "*** $PWD ***"
-set -x
-
-set +x
-echo "Move to flow root directory static/src/javascripts"
-set -x
-
-# flow stop
-
 # set +x
-# echo "Stop flow server"
+# echo "Move to flow root directory $PWD"
 # set -x
+
+$(npm bin)/flow --help
+
+set +x
+echo "Stop flow server"
+set -x
 
 cd -
 

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# set -o xtrace
-# set -o nounset
-# set -o errexit
+set -o xtrace
+set -o nounset
+set -o errexit
 
 set +x
 . ~/.nvm/nvm.sh

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -28,7 +28,7 @@ set +x
 echo "##teamcity[progressFinish 'asset dist']"
 set -x
 
-pushd static/src/javascripts
+cd static/src/javascripts
 
 set +x
 echo "Move to flow root directory static/src/javascripts"
@@ -40,7 +40,7 @@ set +x
 echo "Stop flow server"
 set -x
 
-popd
+cd -
 
 set +x
 echo "Return to directory $PWD"

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -38,8 +38,6 @@ set +x
 echo "Move to flow root directory static/src/javascripts"
 set -x
 
-flow --help
-
 # flow stop
 
 # set +x
@@ -49,13 +47,8 @@ flow --help
 cd -
 
 set +x
-echo "*** $PWD ***"
+echo "Return to directory $PWD"
 set -x
-
-# set +x
-# echo "Return to directory $PWD"
-# set -x
-
 
 set +x
 echo "Exit "

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -30,9 +30,9 @@ set -x
 
 cd static/src/javascripts
 
-# set +x
-# echo "Move to flow root directory $PWD"
-# set -x
+set +x
+echo "Move to flow root directory $PWD"
+set -x
 
 $(npm bin)/flow --help
 

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -34,9 +34,11 @@ set +x
 echo "*** $PWD ***"
 set -x
 
-# set +x
-# echo "Move to flow root directory static/src/javascripts"
-# set -x
+set +x
+echo "Move to flow root directory static/src/javascripts"
+set -x
+
+flow --help
 
 # flow stop
 
@@ -44,7 +46,11 @@ set -x
 # echo "Stop flow server"
 # set -x
 
-# cd -
+cd -
+
+set +x
+echo "*** $PWD ***"
+set -x
 
 # set +x
 # echo "Return to directory $PWD"

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -11,6 +11,24 @@ set -x
 
 echo "Asset compilation"
 
+cd static/src/javascripts
+
+set +x
+echo "Moved to flow root directory $PWD"
+set -x
+
+$(npm bin)/flow stop
+
+set +x
+echo "Stopped flow server"
+set -x
+
+cd -
+
+set +x
+echo "Returned to directory $PWD"
+set -x
+
 set +x
 echo "##teamcity[progressStart 'asset validation and tests']"
 set -x
@@ -26,24 +44,6 @@ set -x
 
 set +x
 echo "##teamcity[progressFinish 'asset dist']"
-set -x
-
-cd static/src/javascripts
-
-set +x
-echo "Move to flow root directory $PWD"
-set -x
-
-$(npm bin)/flow stop
-
-set +x
-echo "Stop flow server"
-set -x
-
-cd -
-
-set +x
-echo "Return to directory $PWD"
 set -x
 
 set +x

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -34,7 +34,7 @@ set +x
 echo "Move to flow root directory $PWD"
 set -x
 
-$(npm bin)/flow --help
+$(npm bin)/flow stop
 
 set +x
 echo "Stop flow server"

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -31,20 +31,24 @@ set -x
 cd static/src/javascripts
 
 set +x
-echo "Move to flow root directory static/src/javascripts"
+echo "*** $PWD ***"
 set -x
 
-flow stop
+# set +x
+# echo "Move to flow root directory static/src/javascripts"
+# set -x
 
-set +x
-echo "Stop flow server"
-set -x
+# flow stop
 
-cd -
+# set +x
+# echo "Stop flow server"
+# set -x
 
-set +x
-echo "Return to directory $PWD"
-set -x
+# cd -
+
+# set +x
+# echo "Return to directory $PWD"
+# set -x
 
 
 set +x

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -27,3 +27,10 @@ set -x
 set +x
 echo "##teamcity[progressFinish 'asset dist']"
 set -x
+
+cd ../../static/src/javascripts
+flow stop
+
+set +x
+echo "Stop flow server"
+set -x

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -28,10 +28,25 @@ set +x
 echo "##teamcity[progressFinish 'asset dist']"
 set -x
 
-cd static/src/javascripts
-# flow stop
+pushd static/src/javascripts
 
 set +x
-echo "$PWD"
+echo "Move to flow root directory static/src/javascripts"
+set -x
+
+flow stop
+
+set +x
 echo "Stop flow server"
+set -x
+
+popd
+
+set +x
+echo "Return to directory $PWD"
+set -x
+
+
+set +x
+echo "Exit "
 set -x

--- a/dev/teamcity/dist-assets-tc
+++ b/dev/teamcity/dist-assets-tc
@@ -28,7 +28,7 @@ set +x
 echo "##teamcity[progressFinish 'asset dist']"
 set -x
 
-# cd ../../static/src/javascripts
+cd static/src/javascripts
 # flow stop
 
 set +x


### PR DESCRIPTION
## What does this change?

To quote @SiAdcock from Trello https://trello.com/c/Hns5LbUf/438-flow-state-issue-on-teamcity-agents

> When Flow runs on a TeamCity agent, the Flow server is not stopped. As a result, the next time Flow runs on this agent, even if the branch has changed, Flow validates the code in the new branch against the state of the file system of the old branch. Therefore any new modules added in the new branch will not exist from Flow's perspective.

This change stops Flow server, meaning the next time Flow runs on the Teamcity agent it will restart the server afresh.

## What is the value of this and can you measure success?

Prevent intermittent flow issue on Teamcity that results in a red build.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?
No