### PR TITLE
Enable Akka http as server engine backend

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -144,7 +144,7 @@ object Frontend extends Build with Prototypes {
 
   val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common)
 
-  val onward = application("onward").dependsOn(commonWithTests).aggregate(common)
+  val onward = applicationWithAkkaHttp("onward").dependsOn(commonWithTests).aggregate(common)
 
   val dev = application("dev-build")
     .dependsOn(

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -7,7 +7,7 @@ import sbt.Keys._
 import com.gu.riffraff.artifact.RiffRaffArtifact
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import Dependencies._
-import play.sbt.{PlayAkkaHttpServer, PlayScala}
+import play.sbt.{PlayAkkaHttpServer, PlayNettyServer, PlayScala}
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
 
@@ -126,13 +126,15 @@ trait Prototypes {
   )
 
   def root(): Project = Project("root", base = file("."))
-    .enablePlugins(PlayScala, RiffRaffArtifact)
+    .enablePlugins(PlayScala, RiffRaffArtifact, PlayNettyServer)
+    .disablePlugins(PlayAkkaHttpServer)
     .settings(frontendCompilationSettings)
     .settings(frontendRootSettings)
 
   def application(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
-      .enablePlugins(PlayScala, UniversalPlugin)
+      .enablePlugins(PlayScala, PlayNettyServer, UniversalPlugin)
+      .disablePlugins(PlayAkkaHttpServer)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)
@@ -147,7 +149,8 @@ trait Prototypes {
 
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
-      .enablePlugins(PlayScala)
+      .enablePlugins(PlayScala, PlayNettyServer)
+      .disablePlugins(PlayAkkaHttpServer)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -7,7 +7,7 @@ import sbt.Keys._
 import com.gu.riffraff.artifact.RiffRaffArtifact
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import Dependencies._
-import play.sbt.{PlayAkkaHttpServer, PlayNettyServer, PlayScala}
+import play.sbt.{PlayAkkaHttpServer, PlayScala}
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.packageName
 
@@ -126,15 +126,13 @@ trait Prototypes {
   )
 
   def root(): Project = Project("root", base = file("."))
-    .enablePlugins(PlayScala, RiffRaffArtifact, PlayNettyServer)
-    .disablePlugins(PlayAkkaHttpServer)
+    .enablePlugins(PlayScala, RiffRaffArtifact)
     .settings(frontendCompilationSettings)
     .settings(frontendRootSettings)
 
   def application(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
-      .enablePlugins(PlayScala, PlayNettyServer, UniversalPlugin)
-      .disablePlugins(PlayAkkaHttpServer)
+      .enablePlugins(PlayScala, UniversalPlugin)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)
@@ -149,8 +147,7 @@ trait Prototypes {
 
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
-      .enablePlugins(PlayScala, PlayNettyServer)
-      .disablePlugins(PlayAkkaHttpServer)
+      .enablePlugins(PlayScala)
       .settings(frontendDependencyManagementSettings)
       .settings(frontendCompilationSettings)
       .settings(frontendTestSettings)

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -147,6 +147,22 @@ trait Prototypes {
       )
   }
 
+  // TODO: Temporary Project definition to test Akka Http as backend server
+  def applicationWithAkkaHttp(applicationName: String): Project = {
+    Project(applicationName, file(applicationName))
+      .enablePlugins(PlayScala, UniversalPlugin)
+      .settings(frontendDependencyManagementSettings)
+      .settings(frontendCompilationSettings)
+      .settings(frontendTestSettings)
+      .settings(VersionInfo.settings)
+      .settings(libraryDependencies ++= Seq(macwire, commonsIo))
+      .settings(packageName in Universal := applicationName)
+      .settingSets(settingSetsOrder)
+      .settings(
+        mappings in Universal ++= (file("ui/dist") ** "*").get.map { f => f.getAbsoluteFile -> f.toString }
+      )
+  }
+
   def library(applicationName: String): Project = {
     Project(applicationName, file(applicationName))
       .enablePlugins(PlayScala, PlayNettyServer)


### PR DESCRIPTION
Play 2.6 introduces Akka http as the new default server engine backend

Because the PR migrating this repository to Play 2.6 was already quite
big I had decided not to introduce any additional changes that were not
absolutely necesseary and stick to Netty, the server engine which was
used in Play 2.5 https://github.com/guardian/frontend/commit/c098233a21

This patch disables Netty so Play is using the default Akka http as server engine backend

## What is the value of this and can you measure success?
No real value other than using the default Play components which I believe the Play team will focus on in priority in the future. 😬 

## Tested in CODE?
Yes