### PR TITLE
Storyquestions list

### DIFF
--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -8,6 +8,24 @@
     }
 }
 
+@getListId() = @{
+    if ("test/test" == storyquestions.data.relatedStoryId) {
+        /**
+          * TODO - remove this workaround once we've migrated to using the listId in the model.
+          *
+          * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
+          * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
+          * show the form allowing a user to submit their email address and receive an answer.
+          */
+        storyquestions.atom.labels.find(_.length == 4)
+    } else {
+        for {
+            notifications <- storyquestions.data.notifications
+            email <- notifications.email
+        } yield email.listId
+    }
+}
+
 @if(!isAmp && !isClosed) {
     <div class="js-view-tracking-component submeta user__question">
         <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
@@ -44,23 +62,15 @@
                                 <span id="js-question-thankyou-@question.questionId" class="user__question-response is-hidden">
                                     Thank you, we&rsquo;ve registered your vote. Sign up and we will email you an answer.
                                 </span>
-                                @*********************
-                                * This workaround enables us to run a test for demand of receiving the answers commissioned to questions by email.
 
-                                * If the story questions atom belongs to the test/test tag and has a label 4 characters long (an email list id) then
-                                * show the form allowing a user to submit their email address and receive an answer.
-                                *********************@
-
-                                @if("test/test" == storyquestions.data.relatedStoryId) {
-                                    @storyquestions.atom.labels.find(_.length == 4).map { listId =>
-                                        <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
-                                            <div class="form-field js-storyquestion-email-signup-input-container">
-                                                <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
-                                            </div>
-                                            <input class="" type="hidden" name="listId" value="@listId" />
-                                            <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-                                        </form>
-                                    }
+                                @for(listId <- getListId) {
+                                    <form id="js-storyquestion-email-signup-form-@question.questionId" class="is-hidden storyquestion-email-signup-form js-storyquestion-email-signup-form form" data-question-id="@question.questionId">
+                                        <div class="form-field js-storyquestion-email-signup-input-container">
+                                            <input class="text-input js-storyquestion-email-signup-input" type="email" name="email" placeholder="Email address" required />
+                                        </div>
+                                        <input class="" type="hidden" name="listId" value="@listId" />
+                                        <button type="submit" class="js-storyquestion-email-signup-button button button--primary button--with-input">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+                                    </form>
                                 }
                             </div>
                         </div>


### PR DESCRIPTION
## What does this change?
Currently, storyquestions atoms are associated with an email listId using the label field, and the atom must have the tag `test/test`.
The model has been updated to hold a listId (set using atom-workshop), so this hack is now being replaced. For now the code will support both methods of setting the listId.

## What is the value of this and can you measure success?
Email signups for these atoms will continue as normal.

## Tested in CODE?
Yes

<img width="635" alt="picture 7" src="https://user-images.githubusercontent.com/1513454/30421858-008f8302-9936-11e7-913c-ff25be76468a.png">
