### PR TITLE
Tc reinstall

### DIFF
--- a/dev/teamcity/dist-npm-tc
+++ b/dev/teamcity/dist-npm-tc
@@ -9,4 +9,4 @@ nvm install
 
 echo "Install dependencies"
 
-make install
+make reinstall

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ install: check-node check-yarn
 
 # Remove all 3rd party dependencies.
 uninstall: # PRIVATE
-	@rm -rf node_modules
+	@rm -rf node_modules **/node_modules
 	@echo 'All 3rd party dependencies have been uninstalled.'
 
 # Reinstall all 3rd party dependencies from scratch.


### PR DESCRIPTION
## What does this change?

- ensures TC completely reinstalls node dips each time
- deletes all `node_modules` dirs (not just top level one) in `make uninstall`

## What is the value of this and can you measure success?

- if deps have been installed with a different node version, they may be the wrong ones. with yarn's caching completely reinstalling each time is only a neglible hit on TC but ensures they're the correct ones

