### PR TITLE
Stop Showing Messaging for Recurring Contributors

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/user-features.js
+++ b/static/src/javascripts/projects/commercial/modules/user-features.js
@@ -32,7 +32,7 @@ const timeInDaysFromNow = (daysFromNow: number): string => {
 const persistResponse = (JsonResponse: () => void) => {
     const switches = config.switches;
     addCookie(USER_FEATURES_EXPIRY_COOKIE, timeInDaysFromNow(1));
-    addCookie(PAYING_MEMBER_COOKIE, !JsonResponse.adblockMessage);
+    addCookie(PAYING_MEMBER_COOKIE, JsonResponse.contentAccess.paidMember);
 
     if (adFreeDataIsPresent() && !JsonResponse.adFree) {
         removeCookie(AD_FREE_USER_COOKIE);
@@ -51,7 +51,7 @@ const deleteOldData = (): void => {
 };
 
 const requestNewData = (): Promise<void> =>
-    fetchJson(`${config.page.userAttributesApiUrl}/me/features`, {
+    fetchJson(`${config.page.userAttributesApiUrl}/me`, {
         mode: 'cors',
         credentials: 'include',
     })

--- a/static/src/javascripts/projects/commercial/modules/user-features.js
+++ b/static/src/javascripts/projects/commercial/modules/user-features.js
@@ -127,7 +127,9 @@ const isContributor = (): boolean => !!lastContributionDate;
 const isRecentContributor = (): boolean => daysSinceLastContribution <= 180;
 
 const isRecurringContributor = (): boolean =>
-    getCookie(RECURRING_CONTRIBUTOR_COOKIE) === 'true';
+    // If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
+    identity.isUserLoggedIn() &&
+    getCookie(RECURRING_CONTRIBUTOR_COOKIE) !== 'false';
 
 /*
     Whenever the checks are updated, please make sure to update


### PR DESCRIPTION
## What does this change?

It updates the rules for when we show reader revenue messaging for users, i.e. the epic, the banner and so on.

### Background

In general, if a user is supporting us, either through membership or with a one-off contribution, we don't want to continue to show them the asks for support. For membership, this means that as long as they are a member, and exist in the members-data-api, we drop the `gu_paying_member` cookie, which is used to hide the various reader revenue messages. For one-off contributions (made on contribute.theguardian.com), a 6-month cookie is dropped, which hides the reader revenue asks until it expires.

### Recurring Contributions

As part of S&C we've added a new product, called **recurring contributions**, for which we also want to hide reader revenue asks. Information about whether a user is a recurring contributor is available in the [members-data-api](https://github.com/guardian/members-data-api/pull/191), so we've taken a similar approach as is used for membership.

This PR adds a new `gu_recurring_contributor` cookie, that gets populated by a call to the members-data-api.

### New Members-Data-API Endpoint

Currently, dotcom hits the `/user-attributes/me/features` endpoint on the members-data-api to retrieve information about membership. However, information about recurring contributions is only available on the `/user-attributes/me` endpoint, which is due to supersede the 'features' and the 'membership' (`/user-attributes/me/membership`) endpoints at some point in the future. Therefore this PR also updates dotcom to make use of the new 'me' endpoint.

There are some differences between the 'features' and 'me' endpoints. If a user has no membership benefits the 'features' endpoint returns a 200, with api response fields signifying that no features are available. *However*, the 'me' endpoint returns a 404 in this situation. Unfortunately, dotcom's `fetchJson` method is not set up to handle 404s as anything else than an error case.

After discussion with the supporter experience team and @gustavpursche we decided that it would be easier to update the 'me' endpoint on the members-data-api, rather than to modify the `fetchJson` method that is used throughout dotcom. The work was done by @JustinPinner in [this PR](https://github.com/guardian/members-data-api/pull/230).

### Identity Frontend

A [small PR](https://github.com/guardian/identity-frontend/pull/225) was also needed in identity-frontend, to make it aware of the new `gu_recurring_contributor` cookie, which should be deleted on sign-out.

## What is the value of this and can you measure success?

People who have given us a recurring contribution, and who are therefore supporting us, will no longer see reader revenue messaging asking them to support us.

## Does this affect other platforms - Amp, Apps, etc?

Support, contributions and membership.

## Tested in CODE?

Not yet.

cc: @guardian/contributions @guardian/membership-and-subscriptions 