### PR TITLE
Ask twitter not to track users

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -124,6 +124,9 @@
     }
     case _ => {}
 }
+    
+@* https://dev.twitter.com/web/overview/privacy *@
+<meta name="twitter:dnt" content="on">
 
 @page.metadata.openGraphImages.map{ case (imageUrl) =>
     <meta property="og:image" content="@Html(imageUrl)" />


### PR DESCRIPTION
## What does this change?

> When you view Twitter content or Twitter products integrated into other websites using Twitter for Websites, Twitter may receive information including the web page you visited, your IP address, browser type, operating system, and cookie information. This information helps us to improve our products and services, including personalized suggestions and personalized ads.

https://dev.twitter.com/web/overview/privacy

The meta tag turns on `do not track`.

It's probably only needed in pages that include tweet embeds (content) but I'm not sure how to implement that, I figured it wouldn't hurt much to have another meta on every page.

It might not be necessary if you guys are converting tweets to static html (atom?)

## What is the value of this and can you measure success?

More privacy for readers

## Does this affect other platforms - Amp, Apps, etc?

No amp

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
What's this?

## Screenshots

## Tested in CODE?

No