### PR TITLE
[WIP] Cache assets using service worker

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -63,15 +63,15 @@ var handleAssetRequest = function (event) {
                 // Workaround Firefox bug which drops cookies
                 // https://github.com/guardian/frontend/issues/12012
                 if (response) {
-                    console.log('woooop ' + event.request.url + ' retrieved from cache :)');
                     return response;
                 } else {
-                    console.log('booooo ' + event.request.url + ' not in cache :(');
-
                     return fetch(event.request, needCredentialsWorkaround(event.request.url) ? {
                         credentials: 'include'
                     } : {}).then(function(response) {
-                        console.log('yeaaaaah ' + event.request.url + ' retrieved from network');
+                        // Check if we received a valid response
+                        if(!response || response.status !== 200 || response.type !== 'basic') {
+                            return response;
+                        }
 
                         // IMPORTANT: Clone the response. A response is a stream
                         // and because we want the browser to consume the response
@@ -80,8 +80,6 @@ var handleAssetRequest = function (event) {
                         var responseToCache = response.clone();
                        
                         caches.open('graun').then(function(cache) {
-                            console.log('oooh yeaaaaah ' + event.request.url + ' cached');
-
                             cache.put(event.request, responseToCache);
                         });
 
@@ -117,13 +115,7 @@ this.addEventListener('fetch', function (event) {
     }
 });
 
-this.addEventListener('install', function() {
-    console.log('**** install ****');
-});
-
 this.addEventListener('activate', function() {
-    console.log('*** activate ***');
-
     caches.delete('graun').then(function() { 
         console.log('graun cache successfully deleted'); 
     });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -116,7 +116,5 @@ this.addEventListener('fetch', function (event) {
 });
 
 this.addEventListener('activate', function() {
-    caches.delete('graun').then(function() { 
-        console.log('graun cache successfully deleted'); 
-    });
+    caches.delete('graun');
 });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -78,8 +78,24 @@ var handleAssetRequest = function (event) {
                         // as well as the cache consuming the response, we need
                         // to clone it so we have two streams.
                         var responseToCache = response.clone();
-                       
+                        
+                        // get filename of request we're going to cached
+                        var responseUrl = response.url;
+                        var responseFileName = responseUrl.substring(responseUrl.lastIndexOf("/") + 1, responseUrl.length);
+
                         caches.open('graun').then(function(cache) {
+                            // check cache for matching filename, if match found then delete old cached item
+                            cache.keys().then(function(keys) {
+                                keys.forEach(function(request, index, array) {
+                                    var requestUrl = request.url;
+                                    var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
+                                    
+                                    if (requestUrl === responseUrl) {
+                                        cache.delete(request);
+                                    }
+                                });
+                            });
+                            // save response to cache
                             cache.put(event.request, responseToCache);
                         });
 

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -136,6 +136,6 @@ this.addEventListener('fetch', function (event) {
 });
 
 this.addEventListener('activate', function() {
-    console.log('*** graun cache deleted ***');
+    console.log('**** graun cache deleted ****');
     caches.delete('graun');
 });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -85,23 +85,23 @@ var handleAssetRequest = function (event) {
                         // var responseUrl = responseToCache.url;
                         // var responseFileName = responseUrl.substring(responseUrl.lastIndexOf("/") + 1, responseUrl.length);
 
-                        // caches.open('graun').then(function(cache) {
-                        //     // check cache for matching filename, if match found then delete old cached item
-                        //     cache.keys().then(function(keys) {
-                        //         keys.forEach(function(request, index, array) {
-                        //             var requestUrl = request.url;
-                        //             var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
-                                    
-                        //             if (requestUrl === responseUrl) {
-                        //                 console.log('*** delete old cache ***', request);
-                        //                 cache.delete(request);
-                        //             }
-                        //         });
-                        //     });
-                        //     // save response to cache
+                        caches.open('graun').then(function(cache) {
+                            // check cache for matching filename, if match found then delete old cached item
+                            //     cache.keys().then(function(keys) {
+                            //         keys.forEach(function(request, index, array) {
+                            //             var requestUrl = request.url;
+                            //             var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
+                                        
+                            //             if (requestUrl === responseUrl) {
+                            //                 console.log('*** delete old cache ***', request);
+                            //                 cache.delete(request);
+                            //             }
+                            //         });
+                            //     });
+                            // save response to cache
                             console.log('*** save to cache ***', responseToCache);
                             cache.put(event.request, responseToCache);
-                        // });
+                        });
 
                         return fetchedResponse;
                     });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -63,6 +63,7 @@ var handleAssetRequest = function (event) {
                 // Workaround Firefox bug which drops cookies
                 // https://github.com/guardian/frontend/issues/12012
                 if (response) {
+                    console.log('*** return cache ***', response);
                     return response;
                 } else {
                     return fetch(event.request, needCredentialsWorkaround(event.request.url) ? {
@@ -91,11 +92,13 @@ var handleAssetRequest = function (event) {
                                     var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
                                     
                                     if (requestUrl === responseUrl) {
+                                        console.log('*** delete old cache ***', request);
                                         cache.delete(request);
                                     }
                                 });
                             });
                             // save response to cache
+                            console.log('*** save to cache ***', responseToCache);
                             cache.put(event.request, responseToCache);
                         });
 
@@ -132,5 +135,6 @@ this.addEventListener('fetch', function (event) {
 });
 
 this.addEventListener('activate', function() {
+    console.log('*** graun cache deleted ***');
     caches.delete('graun');
 });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -67,11 +67,14 @@ var handleAssetRequest = function (event) {
                     return cachedResponse;
                 } else {
                     return fetch(event.request, needCredentialsWorkaround(event.request.url) ? {
-                        credentials: 'include'
-                    } : {}).then(function(fetchedResponse) {
+                        credentials: 'include',
+                        mode: 'no-cors'
+                    } : {
+                        mode: 'no-cors'
+                    }).then(function(fetchedResponse) {
                         console.log('*** fetchedResponse ***', fetchedResponse);
                         // Check if we received a valid response
-                        if(!fetchedResponse || fetchedResponse.status !== 200) {
+                        if(!fetchedResponse || fetchedResponse.status !== 200 || fetchedResponse.type !== 'basic') {
                             return fetchedResponse;
                         }
 
@@ -87,17 +90,17 @@ var handleAssetRequest = function (event) {
 
                         caches.open('graun').then(function(cache) {
                             // check cache for matching filename, if match found then delete old cached item
-                                cache.keys().then(function(keys) {
-                                    keys.forEach(function(request, index, array) {
-                                        var requestUrl = request.url;
-                                        var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
+                            //     cache.keys().then(function(keys) {
+                            //         keys.forEach(function(request, index, array) {
+                            //             var requestUrl = request.url;
+                            //             var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
                                         
-                                        if (requestUrl === responseUrl) {
-                                            console.log('*** delete old cache ***', request);
-                                            cache.delete(request);
-                                        }
-                                    });
-                                });
+                            //             if (requestUrl === responseUrl) {
+                            //                 console.log('*** delete old cache ***', request);
+                            //                 cache.delete(request);
+                            //             }
+                            //         });
+                            //     });
                             // save response to cache
                             console.log('*** save to cache ***', responseToCache);
                             cache.put(event.request, responseToCache);

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -71,7 +71,7 @@ var handleAssetRequest = function (event) {
                     } : {}).then(function(fetchedResponse) {
                         console.log('*** fetchedResponse ***', fetchedResponse);
                         // Check if we received a valid response
-                        if(!fetchedResponse || fetchedResponse.status !== 200 || fetchedResponse.type !== 'basic') {
+                        if(!fetchedResponse || fetchedResponse.status !== 200) {
                             return fetchedResponse;
                         }
 
@@ -87,17 +87,17 @@ var handleAssetRequest = function (event) {
 
                         caches.open('graun').then(function(cache) {
                             // check cache for matching filename, if match found then delete old cached item
-                            //     cache.keys().then(function(keys) {
-                            //         keys.forEach(function(request, index, array) {
-                            //             var requestUrl = request.url;
-                            //             var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
+                                cache.keys().then(function(keys) {
+                                    keys.forEach(function(request, index, array) {
+                                        var requestUrl = request.url;
+                                        var requestFileName = requestUrl.substring(requestUrl.lastIndexOf("/") + 1, requestUrl.length);
                                         
-                            //             if (requestUrl === responseUrl) {
-                            //                 console.log('*** delete old cache ***', request);
-                            //                 cache.delete(request);
-                            //             }
-                            //         });
-                            //     });
+                                        if (requestUrl === responseUrl) {
+                                            console.log('*** delete old cache ***', request);
+                                            cache.delete(request);
+                                        }
+                                    });
+                                });
                             // save response to cache
                             console.log('*** save to cache ***', responseToCache);
                             cache.put(event.request, responseToCache);
@@ -136,6 +136,6 @@ this.addEventListener('fetch', function (event) {
 });
 
 this.addEventListener('activate', function() {
-    console.log('**** graun cache deleted ****');
+    console.log('** graun cache deleted **');
     caches.delete('graun');
 });


### PR DESCRIPTION
## What does this change?

This PR creates a named cache in our service worker for cacheing responses to requests for assets served from `assets.guim.co.uk`.

Why? After debugging the service worker running for the www.theguardian.com I came to the conclusion that the fetch requests intercepted by the service worker were always falling back to network requests rather than returning cached responses. The screen shots below demonstrate this. Note I turned off the browser cache for these tests...

**Prod / 1st load / No service worker running / assets retrieved from network**

![prod-1st-load](https://user-images.githubusercontent.com/1590704/30539225-5d188d0e-9c69-11e7-95eb-ce151f63f969.png)
 
**Prod / 2nd load / Service worker active / assets retrieved from network via service worker**

The service worker is active and now intercepts requests for assets, however if they don't exist in the cache it fallback to a network request. We'd expect to see this happening on 2nd load as this is the first time the service worker has intercepted the `fetch` requests so no assets will be cached yet. Network requests via the service worker are denoted by the gear icon in the network panel.

![prod-2nd-load](https://user-images.githubusercontent.com/1590704/30539361-f52e621c-9c69-11e7-8b0c-7c9fe6a3e8ac.png)

**Prod / 3rd load / Service worker active / assets should be retrieved from service worker cache**

Assets requests intercepted in the 2nd load should now be cached and the service worker should return this cached response rather than going to the network. **The problem is the requests still go to the network via the service worker, as denoted by the gear icon in the network panel.**

![prod-3rd-load](https://user-images.githubusercontent.com/1590704/30539744-ca05ba84-9c6b-11e7-8b96-1f4ed2e6bc59.png)

To address this issue I have created a named cache, in which I explicitly add responses when they have been retrieved from the network. This appears to fix the issue as show in the screen shots below... 

**gh-service-worker-cache / 1st load / No service worker running / assets retrieved from network**

As expected asset requests go to the network on first load as the service worker has not activated...

![pr-1st-load](https://user-images.githubusercontent.com/1590704/30539519-bb57904e-9c6a-11e7-9064-3faf7dab6fb9.png)

**gh-service-worker-cache / 2nd load / Service worker active / assets retrieved from network via service worker**

The service worker is now running and the cache has been set-up. Requests go to the network via the service worker but now the service worker is explicitly adding responses to the cache.

![pr-2nd-load](https://user-images.githubusercontent.com/1590704/30539563-ff67db36-9c6a-11e7-9cf7-5d7bc23e491f.png)

**gh-service-worker-cache / 3rd load / Service worker active / assets retrieved from service worker cache**

![pr-3rd-load](https://user-images.githubusercontent.com/1590704/31508655-aed22acc-af76-11e7-9ae0-1829d6d4b814.png)


Now the service worker intercepts requests and returns the cached response. **The gear icon is no longer visible on 3rd load and the response times are much less than on the Prod 3rd load eg. 36ms for `graun.enhanced.js compared to 525ms.**

## What is the value of this and can you measure success?

This should speed up response time for assets served from `assets.guim.co.uk`.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

Yes