### PR TITLE
reserve space for container toggle

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -101,6 +101,9 @@ object GetClasses {
     lazyLoad: Boolean,
     dynamicSlowMpu: Boolean
   ): String = {
+    // no toggle for Headlines container as it will be hosting the weather widget instead
+    val showToggle = !disableHide && !container.exists(!slices.Container.showToggle(_)) && !isFirst && hasTitle && !isHeadlines
+
     RenderClasses((Seq(
       ("fc-container", true),
       ("fc-container--first", isFirst),
@@ -110,9 +113,8 @@ object GetClasses {
       ("fc-container--lazy-load", lazyLoad),
       ("js-container--lazy-load", lazyLoad),
       ("fc-container--dynamic-slow-mpu", dynamicSlowMpu),
-      ("js-container--toggle",
-        // no toggle for Headlines container as it will be hosting the weather widget instead
-        !disableHide && !container.exists(!slices.Container.showToggle(_)) && !isFirst && hasTitle && !isHeadlines)
+      ("fc-container--will-have-toggle", showToggle),
+      ("js-container--toggle", showToggle)
     ) collect {
       case (kls, true) => kls
     }) ++ extraClasses: _*)

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -93,6 +93,7 @@ export class ContainerToggle {
             $containerHeader.append(this.$button);
             this.$container
                 .removeClass('js-container--toggle')
+                .removeClass('fc-container--will-have-toggle')
                 .addClass('fc-container--has-toggle');
 
             this.readPrefs(id);

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
@@ -34,7 +34,7 @@ describe('Container Toggle', () => {
 
     beforeEach(() => {
         container = bonzo.create(
-            `<section class="fc-container js-container--toggle" data-id="${containerId}">` +
+            `<section class="fc-container js-container--toggle fc-container__will-have-toggle" data-id="${containerId}">` +
                 `<div class="fc-container__header js-container__header">` +
                 `<h2>A container</h2>` +
                 `</div>` +
@@ -59,6 +59,18 @@ describe('Container Toggle', () => {
 
         fastdom.defer(1, () => {
             expect($container.hasClass('js-container--toggle')).toBeFalsy();
+            done();
+        });
+    });
+
+    it('should remove "fc-container--will-have-toggle" class from container', done => {
+        const toggle = new ContainerToggle(container);
+        toggle.addToggle();
+
+        fastdom.defer(1, () => {
+            expect(
+                $container.hasClass('fc-container--will-have-toggle')
+            ).toBeFalsy();
             done();
         });
     });

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -408,7 +408,7 @@ $header-image-size-desktop: 100px;
         clear: left;
     }
 
-    .js-container--toggle & , .fc-container--has-toggle & {
+    .fc-container--will-have-toggle &, .fc-container--has-toggle & {
         @include mq(leftCol, wide) {
             padding-top: gs-height(1);
         }

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -408,7 +408,7 @@ $header-image-size-desktop: 100px;
         clear: left;
     }
 
-    .fc-container--has-toggle & {
+    .js-container--toggle & , .fc-container--has-toggle & {
         @include mq(leftCol, wide) {
             padding-top: gs-height(1);
         }


### PR DESCRIPTION
## What does this change?

At the `leftcol` breakpoint, there is no space reserved for the "Hide" button at the top of some facia containers. When the button is added using JavaScript, there is some *yank* as the height of containers changes, pushing subsequent containers further down the viewport. 

This change reserves some space for the "Hide" button at this viewport width.

## What is the value of this and can you measure success?

Slightly less yank, a better user experience

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

Keep an eye on of the space at the top of the "In depth" container and how the "Hide" button appears at the top right

**Before**

![reserver-toggle-space-before](https://user-images.githubusercontent.com/5931528/30538629-ce541cfc-9c66-11e7-9b5a-4041aef67df7.gif)

**After**

![reserve-toggle-space-after](https://user-images.githubusercontent.com/5931528/30538635-d4203576-9c66-11e7-9658-6514390a06fe.gif)

## Tested in CODE?

No
