### PR TITLE
Extend "video slot close" switch until the end of the month

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -21,7 +21,7 @@ trait CommercialSwitches {
     "Deactivates the sizecallback for videos (620x1) that hides the slot.",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 9, 20),
+    sellByDate = new LocalDate(2017, 9, 29),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Extending this commercial switch until the end of quarter. Still haven't had confirmation the single-slot teads solution is up and running.