### PR TITLE
Adding an extra parameter to the comscore analytics in amp

### DIFF
--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -18,5 +18,11 @@ are used to generate the confidence graphs on the frontend dashboard.
 @fragments.amp.googleAnalytics(content)
 
 <amp-analytics id="comscore" type="comscore">
-    <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
+    <script type="application/json">
+        {
+            "vars": { "c2": "6035250" },
+            "extraUrlParams": {"comscorekw": "amp"}
+        }
+
+    </script>
 </amp-analytics>


### PR DESCRIPTION
## What does this change?
Trello card: https://trello.com/c/6JaqQdEV/430-amp-add-parameter-to-the-comscore-analytics-config-easy

This is just so that in comscore you know this traffic is AMP.

## What is the value of this and can you measure success?
Able to tell the difference in comscore between AMP and other sources.

## Does this affect other platforms - Amp, Apps, etc?
Just AMP

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->


cc @guardian/dotcom-platform 