### PR TITLE
use Akka Http in some apps

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -83,25 +83,25 @@ object Frontend extends Build with Prototypes {
     .dependsOn(commonWithTests)
     .aggregate(common)
 
-  val archive = application("archive").dependsOn(commonWithTests).aggregate(common).settings(
+  val archive = applicationWithAkkaHttp("archive").dependsOn(commonWithTests).aggregate(common).settings(
   )
 
-  val sport = application("sport").dependsOn(commonWithTests).aggregate(common).settings(
+  val sport = applicationWithAkkaHttp("sport").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(
       paClient,
       akkaContrib
     )
   )
 
-  val discussion = application("discussion").dependsOn(commonWithTests).aggregate(common)
+  val discussion = applicationWithAkkaHttp("discussion").dependsOn(commonWithTests).aggregate(common)
 
-  val diagnostics = application("diagnostics").dependsOn(commonWithTests).aggregate(common).settings(
+  val diagnostics = applicationWithAkkaHttp("diagnostics").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(
       redisClient
     )
   )
 
-  val admin = application("admin").dependsOn(commonWithTests).aggregate(common).settings(
+  val admin = applicationWithAkkaHttp("admin").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(
       paClient,
       dfpAxis,
@@ -142,7 +142,7 @@ object Frontend extends Build with Prototypes {
     )
   )
 
-  val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common)
+  val commercial = applicationWithAkkaHttp("commercial").dependsOn(commonWithTests).aggregate(common)
 
   val onward = applicationWithAkkaHttp("onward").dependsOn(commonWithTests).aggregate(common)
 
@@ -165,7 +165,7 @@ object Frontend extends Build with Prototypes {
       javaOptions in Runtime += "-Dconfig.file=dev-build/conf/dev-build.application.conf"
     )
 
-  val preview = application("preview").dependsOn(
+  val preview = applicationWithAkkaHttp("preview").dependsOn(
     commonWithTests,
     article,
     facia,
@@ -180,7 +180,7 @@ object Frontend extends Build with Prototypes {
     .settings(frontendCompilationSettings:_*)
     .settings(frontendIntegrationTestsSettings:_*)
 
-  val rss = application("rss")
+  val rss = applicationWithAkkaHttp("rss")
     .dependsOn(commonWithTests)
     .aggregate(common)
 


### PR DESCRIPTION
Onward was [moved yesterday](https://github.com/guardian/frontend/pull/17797) to use Akka http as backend and metrics ([cpu/memory](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(view~'timeSeries~stacked~false~metrics~(~(~'Application~'used-heap-memory~'ApplicationName~'onward~'Stage~'PROD)~(~'AWS*2fEC2~'CPUUtilization~'AutoScalingGroupName~'frontend-PROD-OnwardStack-1WBRIBDSACKQL-AutoscalingGroup-1PZU7S81QUBTQ~(yAxis~'right)))~region~'eu-west-1~start~'-P3D~end~'P0D);search=onward;namespace=AWS/EC2;dimensions=AutoScalingGroupName) and [latency](https://kibana.gu-web.net/goto/da7932147d573deb5c09c12f1a738518)) don't show any decrease in performance.

This PR is moving more apps to use Akka http (archive, sport, discussion, diagnostics, commercial, sport and preview).

I will keep monitoring those apps today and move the remaining apps if no problem arises
