### PR TITLE
Deps: Update flow-bin to 0.54.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-react": "^7.1.0",
     "execa": "^0.8.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.54.0",
+    "flow-bin": "^0.54.1",
     "flow-typed": "^2.1.5",
     "git-user-name": "^1.2.0",
     "glob": "^7.1.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,6 +48,7 @@
         "coveralls": "^2.13.0",
         "css-loader": "^0.28.4",
         "emotion": "^7.2.2",
+        "emotion-server": "^7.3.2",
         "express": "^4.15.4",
         "flow-bin": "^0.51.1",
         "gzip-size-cli": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,9 +3148,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.0.tgz#f2fb0478e9e99702b623c9ed84079a39903bba77"
+flow-bin@^0.54.1:
+  version "0.54.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.1.tgz#7101bcccf006dc0652714a8aef0c72078a760510"
 
 flow-typed@^2.1.5:
   version "2.1.5"


### PR DESCRIPTION
## What does this change?

`flow-bin@0.54.0` keeps crashing on my machine, which seems to be fixed in `0.54.1`.

## What is the value of this and can you measure success?

DX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

<img src="https://media.giphy.com/media/QH6ucBcRFK1wY/giphy.gif">

## Tested in CODE?

No.