### PR TITLE
Ignore weatherapi/city.json 404s in raven

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -26,6 +26,9 @@ const sentryOptions = {
     ignoreErrors: [
         "Can't execute code from a freed script",
         'There is no space left matching rules from .js-article__body',
+
+        // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
+        'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',
     ],
 
     dataCallback(data: Object): Object {


### PR DESCRIPTION
## What does this change?

The call to [`weatherapi/city.json`](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/facia/modules/onwards/weather.js#L65-L67) frequently 404s, which `lib/fetch-json.js` treats as an error and reports to Sentry. It often clocks in at over 10,000 reports per day and we have reported this error 855,000 times in 6 months. It is unlikely we'll fix it, so simply to reduce the number of Sentry noise, this change ignores the error.

## What is the value of this and can you measure success?

Fewer noisy reports to Sentry, so more legitimate issues are reported

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No
