### PR TITLE
UI: ignore Flow error in dev server

### DIFF
--- a/ui/__tools__/dev-server.js
+++ b/ui/__tools__/dev-server.js
@@ -21,8 +21,8 @@ app.use(webpackHotMiddleware(compiler));
 app.get('/', (req, res) => {
     delete require.cache[require.resolve('../dist/ui.bundle.server')];
 
-    // eslint-disable-next-line global-require
-    const { frontend } = require('../dist/ui.bundle.server');
+    // $FlowFixMe
+    const { frontend } = require('../dist/ui.bundle.server'); // eslint-disable-line global-require, import/no-unresolved
 
     // TODO: pass props from response to UI dev API endpoint
     res.send(


### PR DESCRIPTION
## What does this change?

If a developer has not run `make ui-watch` or `make ui-compile`, they will receive a Flow error in `dev-server.js`, notifying them that the server bundle doesn't exist. This change tells Flow to ignore this problem, as the server bundle will be built at runtime.

Thanks to @philwills for spotting this issue

## What is the value of this and can you measure success?

No Flow errors

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
