### PR TITLE
Alternative to using Regex to determine what to strip from the rich-link URL

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -49,9 +49,8 @@ const upgradeRichLink = (el: Element): Promise<void> => {
     if (!link) return Promise.resolve();
 
     const href: string = link.href;
-    const matches: ?(string[]) = href.match(
-        /(?:^https?:\/\/(?:www\.|m\.code\.dev-)theguardian\.com)?(\/.*)/
-    );
+    const host: string = config.get('page.host');
+    const matches: ?(string[]) = href.split(host);
     const isOnMobile: boolean = isBreakpoint({
         max: 'mobileLandscape',
     });


### PR DESCRIPTION
...so rich-link upgrading works when running locally

## What does this change?

The rich-links enhancing JS is responsible for fetching the image. This works on CODE and PROD, but the regex non-capturing group is specific enough that not enough of the string gets stripped locally, leaving `//m.thegulocal.com` or equivalent in place if the project is running elsewhere:

>/embed/card//m.thegulocal.com/science/2016/nov/22/scientists-to-reset-blood-proteins-in-attempt-to-slow-ageing-process-calico.json

For those running dev-build, this prevents the rich-links in articles from ever showing with images, and also results in console errors:

<img width="1652" alt="picture 1025" src="https://user-images.githubusercontent.com/8607683/30650728-97363d48-9e1b-11e7-86c8-ac014d17c5fe.png">

This PR switches to using the `config.page.host` to deduce the string that need to be stripped from the url before it is used.

## What is the value of this and can you measure success?

- Removes some console errors when running frontend locally
- Developers now get to see the enhanced rich-links 🚀

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

###### BEFORE (LOCALHOST):
<img width="1000" alt="picture 1024" src="https://user-images.githubusercontent.com/8607683/30650750-a2e57ff0-9e1b-11e7-887e-1c1bcaabfbd5.png">

###### BEFORE (LOCALHOST):
<img width="970" alt="picture 1023" src="https://user-images.githubusercontent.com/8607683/30650759-aab4b836-9e1b-11e7-913e-53546a943752.png">

If anything visibly changes in PROD something has go wrong....