### PR TITLE
Byline cutouts in rich links to appear behind the text

### DIFF
--- a/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
+++ b/static/src/stylesheets/module/onward/_rich-links-enhanced.scss
@@ -90,7 +90,6 @@
 
 .rich-link__byline-img {
     height: $gs-baseline * 12;
-    z-index: 1;
     position: absolute;
     bottom: 0;
     margin: 0;


### PR DESCRIPTION
## What does this change?
Makes me a bit less of an asshole by trying to fix instead of, as per usual, suggesting to fix byline images overlapping Read more CTA on rich links.

## What is the value of this and can you measure success?
Not again!

## Does this affect other platforms - Amp, Apps, etc?
Most certainly probably not.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
Ditto?


## Screenshots
Before:
![z-index](https://user-images.githubusercontent.com/6032869/30665547-3e88845c-9e49-11e7-8830-e62aaa8f2c2a.PNG)
After:
![z-index aftermath](https://user-images.githubusercontent.com/6032869/30665553-43c295b6-9e49-11e7-9355-02a84415be97.PNG)

## Tested in CODE?
Are you ready to be run on Windows, dotcom?