### PR TITLE
Give myself targeting-tool.js conversion

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -65,7 +65,9 @@
   "davidfurey": [],
   "jranks123": [],
   "shaundillon": [],
-  "Joseph Smith": [],
+  "Joseph Smith": [
+      "projects/common/modules/commercial/targeting-tool.js"
+  ],
   "Gideon Goldberg": [],
   "Matthew Walls": [],
   "Nicolas Long": [],


### PR DESCRIPTION
Ultimately I need to do this in order to fix the failing test in https://github.com/guardian/frontend/pull/17840, since due to changed dependencies a jest test now depends on `targeting-tool.js` which is still ES5

Weirdly it wasn't in anyone else's list in `es5to6.json`, not sure why

@sndrs 