### PR TITLE
Make the kickers of labs cards teal, to match the labs theme

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -378,6 +378,10 @@
         color: $neutral-1;
     }
 
+    .fc-item__kicker {
+        color: $paid-article-brand;
+    }
+
     .fc-item__content {
         display: flex !important;
         flex-direction: column;


### PR DESCRIPTION
## What does this change?

Labs cards in editorial containers should have teal kickers, this PR makes them teal

## What is the value of this and can you measure success?

Correct themes and tones for labs content

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

###### BEFORE:

<img width="1330" alt="picture 6" src="https://user-images.githubusercontent.com/8607683/30812862-cb6a5d56-a203-11e7-8924-ca3a80de9581.png">


###### AFTER:

<img width="1337" alt="picture 5" src="https://user-images.githubusercontent.com/8607683/30812804-a8af2864-a203-11e7-8df5-b19f463da125.png">
