### PR TITLE
Make the labs cards have a grey standfirst, to match the paid-for badging

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -397,7 +397,7 @@
     }
 
     .fc-item__standfirst {
-        color: $neutral-1;
+        color: #757575;
     }
 
     .badge {


### PR DESCRIPTION
## What does this change?

- Makes the labs cards in editorial containers have a grey standfirst, to match the badge label

## What is the value of this and can you measure success?

- Approval of @blongden73 🙇 
- Correct themes and tones for labs content

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Screenshots

###### AFTER:

<img width="972" alt="picture 7" src="https://user-images.githubusercontent.com/8607683/30817074-b5eca784-a20f-11e7-8082-f4a38d1e59f6.png">

