### PR TITLE
Provide page keywords to comscore on AMP.

### DIFF
--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -1,4 +1,6 @@
 @import play.api.Mode
+@import model.Tag
+@import play.api.libs.json.Json
 @(content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.Configuration
@@ -18,5 +20,13 @@ are used to generate the confidence graphs on the frontend dashboard.
 @fragments.amp.googleAnalytics(content)
 
 <amp-analytics id="comscore" type="comscore">
-    <script type="application/json">{ "vars": { "c2": "6035250" } }</script>
+    <script type="application/json">
+        {
+            "vars":
+                {
+                    "c2": "6035250",
+                    "comscorekw": @Html(Json.toJson(content.tags.keywords.map{ tag: Tag => tag.id}).toString)
+                }
+        }
+    </script>
 </amp-analytics>

--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -24,7 +24,9 @@ are used to generate the confidence graphs on the frontend dashboard.
         {
             "vars":
                 {
-                    "c2": "6035250",
+                    "c2": "6035250"
+                },
+             "extraUrlParams": {
                     "comscorekw": @Html(Json.toJson(content.tags.keywords.map{ tag: Tag => tag.id}).toString)
                 }
         }


### PR DESCRIPTION
## What does this change?
This PR provides the page keywords to ComScore on AMP. This is already the case for non-AMP so this brings AMP into line.

## What is the value of this and can you measure success?
ComScore should be able to analyse our AMP traffic properly. We have a login for ComScore and should see it coming through on a number of dashboards.

This is what the payload now looks like:
![image](https://user-images.githubusercontent.com/1821099/30913730-180f15d0-a389-11e7-958b-9fcc0ad3e1d1.png) on http://localhost:3000/business/2017/sep/27/ryanair-cancel-flights-passengers-stansted-edinburgh?amp.

@stephanfowler can you please confirm that this is how the keywords should be passed in? On [Natalia's PR](https://github.com/guardian/frontend/pull/17818) there was use of an `extraUrlParams` key, but I can't see this in the docs I've read.