### PR TITLE
Only reinstall on nvmrc change

### DIFF
--- a/dev/teamcity/dist-npm-tc
+++ b/dev/teamcity/dist-npm-tc
@@ -11,4 +11,9 @@ set -x
 
 echo "Install dependencies"
 
-make reinstall
+git diff HEAD~1 --name-only | if grep .nvmrc
+then
+    make reinstall
+else
+    make install
+fi

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ uninstall: # PRIVATE
 	@rm -rf node_modules
 	@rm -rf ui/node_modules
 	@rm -rf dev/eslint-plugin-guardian-frontend/node_modules
-	@rm -rf tools/amp-validation/node_module
+	@rm -rf tools/amp-validation/node_modules
 	@echo 'All 3rd party dependencies have been uninstalled.'
 
 # Reinstall all 3rd party dependencies from scratch.


### PR DESCRIPTION
## What does this change?

Currently on TeamCity we always reinstall all `node_modules` on every build. We do this just in case we have upgraded the version of Node.js we use by editing the `.nvmrc`.

Since this doesn't happen very often, this change introduces a check to see if the `.nvmrc` was changed in the most recent merge commit. 

- If `.nvmrc` has changed, TeamCity runs `make reinstall`
- If `.nvrmc` hasn't changed, Team City runs `make install`

## What is the value of this and can you measure success?

This is an attempt to address the intermittent segmentation faults we have seen on TeamCity that began on 18/09/2017. 

```
[17:40:28][Step 1/5] + make reinstall
[17:40:29][Step 1/5] All 3rd party dependencies have been uninstalled.
[17:40:31][Step 1/5] + chalk@2.1.0
[17:40:31][Step 1/5] + semver@5.4.1
[17:40:31][Step 1/5] added 8 packages in 1.15s
[17:40:31][Step 1/5] ✔ Node 8.5.0
[17:40:31][Step 1/5] ✔ Yarn 1.0.2
[17:40:33][Step 1/5] warning Pattern ["chalk"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v1/npm-chalk-1.1.3-a8115c55e4a702fe4d150abd3872822a7e09fc98" as pattern ["chalk@^1.1.1","chalk@^1.1.0","chalk@^1.1.3","chalk@^1.0.0"]. This could result in a non deterministic behavior, skipping.
[17:40:33][Step 1/5] warning Pattern ["figures"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v1/npm-figures-2.0.0-3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962" as pattern ["figures@^2.0.0"]. This could result in a non deterministic behavior, skipping.
[17:40:33][Step 1/5] warning Pattern ["uglify-js"] is trying to unpack in the same destination "/home/ubuntu/.cache/yarn/v1/npm-uglify-js-2.7.4-a295a0de12b6a650c031c40deb0dc40b14568bd2" as pattern ["uglify-js@^2.6.1"]. This could result in a non deterministic behavior, skipping.
[17:40:34][Step 1/5] warning "babel-loader@7.1.2" has incorrect peer dependency "babel-core@6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc".
[17:40:34][Step 1/5] warning "ajv-keywords@1.5.1" has incorrect peer dependency "ajv@>=4.10.0".
[17:40:34][Step 1/5] warning "ajv-keywords@2.1.0" has incorrect peer dependency "ajv@>=5.0.0".
[17:40:34][Step 1/5] warning "react-dom@0.14.8" has incorrect peer dependency "react@^0.14.8".
[17:40:37][Step 1/5] warning The case-insensitive file /home/ubuntu/buildAgent/work/67274da68ba418cc/node_modules/jspm-npm/node_modules shouldn't be copied twice in one bulk copy
[17:41:04][Step 1/5] make: *** [install] Segmentation fault (core dumped)
[17:41:04][Step 1/5] makefile:20: recipe for target 'install' failed
[17:41:04][Step 1/5] Process exited with code 2
[17:41:04][Step 1/5] Step npm (Command Line) failed
```

It is my suspicion that one of the dependencies we reinstall is causing the `make reinstall` command to segmentation fault. 

The change to run `make reinstall` instead of simply `make install` (#17802) was introduced on 14/09/2017.

Following this logic, while this change will not eliminate the possibility of the segmentation fault reappearing, it will dramatically reduce the number of builds that could _potentially_ segmentation fault