### PR TITLE
Correct Liveblog Microdata

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -16,6 +16,22 @@
         itemscope
         itemtype="http://schema.org/BlogPosting"
     >
+
+        <meta itemprop="headline" content="@block.title.getOrElse[String](article.trail.headline)" />
+
+        <span itemprop="author" itemscope itemtype="http://schema.org/Organization">
+            <meta itemprop="name" content="https://www.theguardian.com#publisher" />
+        </span>
+
+        <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+            <meta itemprop="name" content="https://www.theguardian.com#publisher" />
+            <span itemprop="logo" itemscope itemtype="http://schema.org/ImageObject">
+                <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png" />
+                <meta itemprop="width" content="300" />
+                <meta itemprop="height" content="60" />
+            </span>
+        </span>
+
         <p class="block-time published-time">
             @if(amp){
                 <a href="@LinkTo{/@article.metadata.id?page=with:block-@block.id#block-@block.id}" itemprop="url" class="block-time__link">
@@ -29,8 +45,9 @@
         </p>
 
         @block.title.map { title =>
-            <h2 class="block-title" itemprop="headline">@title</h2>
+            <h2 class="block-title">@title</h2>
         }
+
         @block.contributors.map { contributorId =>
             @article.tags.tags.find(_.id == s"profile/$contributorId").map{ contributorTag =>
                 @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
@@ -50,10 +67,6 @@
             article.metadata.contentType.getOrElse(DotcomContentType.Unknown),
             amp
         )
-
-        <span itemprop="author" itemscope itemtype="http://schema.org/Organization">
-            <span itemprop="name" value="https://www.theguardian.com#publisher"></span>
-        </span>
 
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -3,7 +3,6 @@
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
 @import model.DotcomContentType
-
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
@@ -51,5 +50,10 @@
             article.metadata.contentType.getOrElse(DotcomContentType.Unknown),
             amp
         )
+
+        <span itemprop="author" itemscope itemtype="http://schema.org/Organization">
+            <span itemprop="name" value="https://www.theguardian.com#publisher"></span>
+        </span>
+
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -53,6 +53,7 @@
                 @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
             }
         }
+
         <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
         @BodyCleaner(article, block.bodyHtml, amp)
         </div>

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -2,8 +2,8 @@
 @import model.Article
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
-
 @import model.DotcomContentType
+
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
@@ -13,6 +13,9 @@
         id="block-@block.id"
         data-sort-time="@block.publishedCreatedTimestamp()"
         class="block block--content@block.eventClass@block.attributes.membershipPlaceholder.map { _ => js-insert-epic-after}"
+        itemprop="liveBlogUpdate"
+        itemscope
+        itemtype="http://schema.org/BlogPosting"
     >
         <p class="block-time published-time">
             @if(amp){
@@ -25,6 +28,7 @@
                 </a>
             }
         </p>
+
         @block.title.map { title =>
             <h2 class="block-title" itemprop="headline">@title</h2>
         }

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -15,9 +15,14 @@
 <div class="js-notifications-blocked"></div>
 <div class="l-side-margins">
 
-    <article id="live-blog" data-test-id="live-blog"
+    <article
+        id="live-blog"
+        data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@toneClass(article) blog @if(article.fields.isLive){is-live} section-@article.trail.sectionName.toLowerCase"
-        role="main">
+        role="main"
+        itemscope
+        itemtype="http://schema.org/LiveBlogPosting"
+    >
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
         <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -15,15 +15,22 @@
                 </button>
             </div>
         </div>
+
         @if(model.currentPage.currentPage.isArchivePage) {
             @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
         }
-        <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
-            LatestBlock(article.blocks)
-        }" data-test-id="live-blog-blocks"
-        itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+
+        <div
+            class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}"
+            data-most-recent-block="block-@{LatestBlock(article.blocks)}"
+            data-test-id="live-blog-blocks"
+        >
+
             @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
+
         </div>
+
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+
     </div>
 }


### PR DESCRIPTION
## What does this change?

In some cases **the google carousel picks up the wrong title to display from our live blogs**. 

Although we have no way to be 100% sure of what's happening here, I believe this is because of some microdata issues on the liveblogs page.

This PR fixes some of those microdata problems.

Microdata is a way to add metadata properties to html directly, using "props" and "scopes". Here is an example

```
<div itemscope itemtype="WebPage">

    <span itemprop="heading">this property is part of WebPage</span>

    <div itemscope itemtype="LiveBlog">
        <span itemprop="heading">this property is part of WebPage->LiveBlog</span>
    </div>

</div>
```

On our liveblogs, we have an error in that we never have an itemscope to begin the LiveBlog, so all the microdata properties for stuff inside of the LiveBlog is being consumed into the WebPage, including duplicated headline properties. I believe this duplicated headline property is what's causing the carousel bug. (Note that we DO have proper/correct liveblog structured data in the json+ld format)

You can see a bunch of random duplicate properties being consumed into Webpage in the screenshot  of the structured data testing tool below (note the duplicated headline+dates):

![image](https://user-images.githubusercontent.com/1218561/30959320-afea3ea8-a437-11e7-81d8-02d0131e460c.png)
...
![image](https://user-images.githubusercontent.com/1218561/30959383-db62fa34-a437-11e7-9301-3532c6d628fd.png)

To correct this, I've just opened a scope for the LiveBlog on our article tag. In addition I've inserted missing mandatory microdata properties to ensure there is always a headline, publisher, etc properties.

A better solution for the future is just to desupport microdata, but it's still coming in from CAPI which makes this a more difficult problem.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

I ran the amp source for liveblogs through the structured data testing tool and it doesn't appear
to be an issue.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
