### PR TITLE
Revert "Only reinstall on nvmrc change"

### DIFF
--- a/dev/teamcity/dist-npm-tc
+++ b/dev/teamcity/dist-npm-tc
@@ -11,9 +11,4 @@ set -x
 
 echo "Install dependencies"
 
-git diff HEAD~1 --name-only | if grep .nvmrc
-then
-    make reinstall
-else
-    make install
-fi
+make reinstall

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ uninstall: # PRIVATE
 	@rm -rf node_modules
 	@rm -rf ui/node_modules
 	@rm -rf dev/eslint-plugin-guardian-frontend/node_modules
-	@rm -rf tools/amp-validation/node_modules
+	@rm -rf tools/amp-validation/node_module
 	@echo 'All 3rd party dependencies have been uninstalled.'
 
 # Reinstall all 3rd party dependencies from scratch.

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ uninstall: # PRIVATE
 	@rm -rf node_modules
 	@rm -rf ui/node_modules
 	@rm -rf dev/eslint-plugin-guardian-frontend/node_modules
-	@rm -rf tools/amp-validation/node_module
+	@rm -rf tools/amp-validation/node_modules
 	@echo 'All 3rd party dependencies have been uninstalled.'
 
 # Reinstall all 3rd party dependencies from scratch.


### PR DESCRIPTION
Reverts guardian/frontend#17878

On second thoughts, this is a dangerous change, prone to false negatives

```
git diff HEAD~1 --name-only | if grep .nvmrc
```

This will determine whether `.nvmrc` was changed in the most recent merge commit. However the following flow would create a false negative:

1) Alice makes change to `.nvmrc`. Merges into `master`
2) Bob installs new JavaScript dependency. Merges into `master`
3) Alice's and Bob's changes are bundled into the same build on TeamCity
4) Since `HEAD~1` resolves to Bob's merge commit, Alice's change to `.nvmrc` is missed

We could _potentially_ resolve this problem by comparing `HEAD` with the previous entry in [`git reflog`](https://git-scm.com/docs/git-reflog):

```
git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD
```

But there is still a problem. Since TeamCity agents are shared between branches, it is possible that the state (i.e. the Node.js version and hence the `node_modules`) of one branch would inadvertently be picked up in another branch. There is no way to guarantee the state of the TeamCity agent without reinstalling all dependencies every time we build.

Any other suggestions would be welcome