### PR TITLE
Post merge hook

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -10,11 +10,11 @@ execa.shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
         const changedFiles = result.stdout.split(',');
 
         if (changedFiles.includes('.nvmrc')) {
-            const nodeVersion = fs.readFileSync('.nvmrc');
+            const nvmrcVersion = fs.readFileSync('.nvmrc');
 
-            console.log(`${chalk.red(`This application now uses Node.js v${nodeVersion}. Switch to the latest version using \`nvm use\` or download from nodejs.org. Then run \`make reinstall\``)}`);
+            console.log(`${chalk.red(`Frontend now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`)}`);
         } else if (changedFiles.includes('yarn.lock')) {
-            console.log(`${chalk.red('This application has new dependencies. Running \`make install\`')}`);
+            console.log(`${chalk.red('This application has new dependencies. Running \`make install\`...')}`);
 
             return execa('make', ['install'], {
                 stdio: 'inherit',

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const execa = require('execa');
+const chalk = require('chalk');
+const fs = require('fs');
+
+execa.shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
+    .then(result => {
+        const changedFiles = result.stdout.split(',');
+
+        if (changedFiles.includes('.nvmrc')) {
+            const nodeVersion = fs.readFileSync('.nvmrc');
+
+            console.log(`${chalk.red(`This application now uses Node.js v${nodeVersion}. Switch to the latest version using \`nvm use\` or download from nodejs.org. Then run \`make reinstall\``)}`);
+        } else if (changedFiles.includes('yarn.lock')) {
+            console.log(`${chalk.red('This application has new dependencies. Running \`make install\`')}`);
+
+            return execa('make', ['install'], {
+                stdio: 'inherit',
+            });
+        }
+    })
+    .catch(e => {
+        console.log(`\n${e}\n`);
+        process.exit(1);
+    });


### PR DESCRIPTION
## What does this change?

Adds a post merge hook to improve developer experience. When a developer pulls down the latest frontend changes, this hook:

- checks whether `.nvmrc`, and hence the required Node.js version has changed. If so, user is prompted to upgrade and run `make reinstall`. Sadly it is not possible to automate the Node.js upgrade within a JavaScript `child_process` and have that reflected in the user's terminal.
- checks whether `yarn.lock` has changed. If so, the hook runs `make install` to ensure the developer's environment is up to date.

## What is the value of this and can you measure success?

Fewer things a developer needs to think about
