### PR TITLE
Remove idApiJsClientToken

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 42
+    val s3ConfigVersion = 43
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -61,7 +61,6 @@ guardian.page.omnitureAmpAccount=guardiangudev-code
 guardian.page.omnitureAccount=guardiangudev-code
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=202314643182694
-guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
 guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -192,11 +192,6 @@ export const updateUsername = (username: string): any => {
         contentType: 'application/json; charset=utf-8',
         data: JSON.stringify(data),
         withCredentials: true,
-        headers: {
-            'X-GU-ID-Client-Access-Token': `Bearer ${config.get(
-                'page.idApiJsClientToken'
-            )}`,
-        },
     });
 
     return request;


### PR DESCRIPTION
## What does this change?

Removes publicly accessible client access token used by [identity JavaScript module](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/identity/api.js)

The value of this token was publicly exposed via JS as:
`guardian.config.page.idApiJsClientToken`

## What is the value of this and can you measure success?

Client access token is not needed for JS because sending along `SC_GU_U` cookie is sufficient for user authentication for the [endpoints currently being hit via JS](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/identity/api.js)

This client token could be misused, for example, by easily registering an account by directly hitting the IDAPI.

Note that client access token for server-side Scala is still needed and is correctly stored as a secret.
