### PR TITLE
Send through campaign code to component id in acquisition component events

### DIFF
--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -71,3 +71,11 @@ declare type OphanComponentEvent = {
         variant: string
     }
 };
+
+declare type AcquisitionLinkParams = {
+    base: string,
+    componentType: OphanComponentType,
+    componentId: string,
+    campaignCode?: string,
+    abTest?: { name: string, variant: string}
+}

--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -72,10 +72,3 @@ declare type OphanComponentEvent = {
     }
 };
 
-declare type AcquisitionLinkParams = {
-    base: string,
-    componentType: OphanComponentType,
-    componentId: string,
-    campaignCode?: string,
-    abTest?: { name: string, variant: string}
-}

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -35,15 +35,9 @@ export const addTrackingCodesToUrl = ({
     base,
     componentType,
     componentId,
-    campaignCode = '',
+    campaignCode,
     abTest,
-}: {
-    base: string,
-    componentType: OphanComponentType,
-    componentId: string,
-    campaignCode?: string,
-    abTest?: { name: string, variant: string },
-}) => {
+}: AcquisitionLinkParams) => {
     const acquisitionData = {
         source: 'GUARDIAN_WEB',
         componentId,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -13,6 +13,14 @@ type ComponentEventWithoutAction = {
     },
 };
 
+type AcquisitionLinkParams = {
+    base: string,
+    componentType: OphanComponentType,
+    componentId: string,
+    campaignCode?: string,
+    abTest?: { name: string, variant: string },
+};
+
 export const submitComponentEvent = (componentEvent: OphanComponentEvent) => {
     ophan.record({ componentEvent });
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -31,15 +31,22 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
         action: 'VIEW',
     });
 
-export const addTrackingCodesToUrl = (
+export const addTrackingCodesToUrl = ({
+    base,
+    componentType,
+    componentId,
+    campaignCode = '',
+    abTest,
+}: {
     base: string,
     componentType: OphanComponentType,
-    campaignCode: string,
-    abTest?: { name: string, variant: string }
-) => {
+    componentId: string,
+    campaignCode?: string,
+    abTest?: { name: string, variant: string },
+}) => {
     const acquisitionData = {
         source: 'GUARDIAN_WEB',
-        componentId: campaignCode,
+        componentId,
         componentType,
         referrerPageviewId: config.get('ophan.pageViewId') || undefined,
         campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -183,34 +183,34 @@ const makeABTestVariant = (
     const {
         maxViews = defaultMaxViews,
         isUnlimited = false,
-        contributeURL = addTrackingCodesToUrl(
-            contributionsBaseURL,
-            parentTest.componentType,
-            campaignCode,
-            {
+        contributeURL = addTrackingCodesToUrl({
+            base: contributionsBaseURL,
+            componentType: parentTest.componentType,
+            componentId: campaignCode,
+            abTest: {
                 name: parentTest.id,
                 variant: id,
-            }
-        ),
-        membershipURL = addTrackingCodesToUrl(
-            membershipBaseURL,
-            parentTest.componentType,
-            campaignCode,
-            {
+            },
+        }),
+        membershipURL = addTrackingCodesToUrl({
+            base: membershipBaseURL,
+            componentType: parentTest.componentType,
+            componentId: campaignCode,
+            abTest: {
                 name: parentTest.id,
                 variant: id,
-            }
-        ),
+            },
+        }),
         supportCustomURL = null,
-        supportURL = addTrackingCodesToUrl(
-            supportCustomURL || supportBaseURL,
-            parentTest.componentType,
-            campaignCode,
-            {
+        supportURL = addTrackingCodesToUrl({
+            base: supportCustomURL || supportBaseURL,
+            componentType: parentTest.componentType,
+            componentId: campaignCode,
+            abTest: {
                 name: parentTest.id,
                 variant: id,
-            }
-        ),
+            },
+        }),
         template = controlTemplate,
         buttonTemplate = defaultButtonTemplate,
         testimonialBlock = getTestimonialBlock(
@@ -373,27 +373,27 @@ const makeABTestVariant = (
         success,
 
         contributionsURLBuilder(codeModifier) {
-            return addTrackingCodesToUrl(
-                contributionsBaseURL,
-                parentTest.componentType,
-                codeModifier(campaignCode),
-                {
+            return addTrackingCodesToUrl({
+                base: contributionsBaseURL,
+                componentType: parentTest.componentType,
+                componentId: codeModifier(campaignCode),
+                abTest: {
                     name: parentTest.id,
                     variant: id,
-                }
-            );
+                },
+            });
         },
 
         membershipURLBuilder(codeModifier) {
-            return addTrackingCodesToUrl(
-                membershipBaseURL,
-                parentTest.componentType,
-                codeModifier(campaignCode),
-                {
+            return addTrackingCodesToUrl({
+                base: membershipBaseURL,
+                componentType: parentTest.componentType,
+                componentId: codeModifier(campaignCode),
+                abTest: {
                     name: parentTest.id,
                     variant: id,
-                }
-            );
+                },
+            });
         },
     };
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -187,6 +187,7 @@ const makeABTestVariant = (
             base: contributionsBaseURL,
             componentType: parentTest.componentType,
             componentId: campaignCode,
+            campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -196,6 +197,7 @@ const makeABTestVariant = (
             base: membershipBaseURL,
             componentType: parentTest.componentType,
             componentId: campaignCode,
+            campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -206,6 +208,7 @@ const makeABTestVariant = (
             base: supportCustomURL || supportBaseURL,
             componentType: parentTest.componentType,
             componentId: campaignCode,
+            campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -234,6 +237,7 @@ const makeABTestVariant = (
                         componentType: parentTest.componentType,
                         products,
                         campaignCode,
+                        id: campaignCode,
                     },
                     abTest: {
                         name: parentTest.id,
@@ -250,6 +254,7 @@ const makeABTestVariant = (
                         componentType: parentTest.componentType,
                         products,
                         campaignCode,
+                        id: campaignCode,
                     },
                     abTest: {
                         name: parentTest.id,
@@ -377,6 +382,7 @@ const makeABTestVariant = (
                 base: contributionsBaseURL,
                 componentType: parentTest.componentType,
                 componentId: codeModifier(campaignCode),
+                campaignCode: codeModifier(campaignCode),
                 abTest: {
                     name: parentTest.id,
                     variant: id,
@@ -389,6 +395,7 @@ const makeABTestVariant = (
                 base: membershipBaseURL,
                 componentType: parentTest.componentType,
                 componentId: codeModifier(campaignCode),
+                campaignCode: codeModifier(campaignCode),
                 abTest: {
                     name: parentTest.id,
                     variant: id,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -126,6 +126,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         base: params.linkUrl,
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         componentId: params.campaignCode,
+        campaignCode: params.campaignCode,
         abTest:
             test && variant
                 ? { name: test.id, variant: variant.id }
@@ -162,6 +163,7 @@ const showBanner = (params: EngagementBannerParams): void => {
                     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
                     products: params.products,
                     campaignCode: params.campaignCode,
+                    id: params.campaignCode,
                 },
                 action,
                 ...(test && variant

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -122,12 +122,15 @@ const showBanner = (params: EngagementBannerParams): void => {
         ? selectSequentiallyFrom(params.messageText)
         : params.messageText;
 
-    const linkUrl = addTrackingCodesToUrl(
-        params.linkUrl,
-        'ACQUISITIONS_ENGAGEMENT_BANNER',
-        params.campaignCode,
-        test && variant ? { name: test.id, variant: variant.id } : undefined
-    );
+    const linkUrl = addTrackingCodesToUrl({
+        base: params.linkUrl,
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        componentId: params.campaignCode,
+        abTest:
+            test && variant
+                ? { name: test.id, variant: variant.id }
+                : undefined,
+    });
 
     const buttonCaption = params.buttonCaption;
     const buttonSvg = inlineSvg('arrowWhiteRight');

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -178,6 +178,7 @@ describe('Membership engagement banner', () => {
                         component: {
                             componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
                             products: ['CONTRIBUTION'],
+                            id: 'fake-campaign-code',
                             campaignCode: 'fake-campaign-code',
                         },
                         action: 'INSERT',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -58,15 +58,15 @@ export const acquisitionsEpicThankYou = makeABTest({
                 template(variant) {
                     return acquisitionsEpicThankYouTemplate({
                         componentName: variant.options.componentName,
-                        membershipUrl: addTrackingCodesToUrl(
-                            'https://www.theguardian.com/membership',
-                            'ACQUISITIONS_EPIC',
-                            variant.options.campaignCode,
-                            {
+                        membershipUrl: addTrackingCodesToUrl({
+                            base: 'https://www.theguardian.com/membership',
+                            componentType: 'ACQUISITIONS_EPIC',
+                            componentId: variant.options.campaignCode,
+                            abTest: {
                                 name: 'AcquisitionsEpicThankYou',
                                 variant: variant.id,
-                            }
-                        ),
+                            },
+                        }),
                     });
                 },
             },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-thank-you.js
@@ -62,6 +62,7 @@ export const acquisitionsEpicThankYou = makeABTest({
                             base: 'https://www.theguardian.com/membership',
                             componentType: 'ACQUISITIONS_EPIC',
                             componentId: variant.options.campaignCode,
+                            campaignCode: variant.options.campaignCode,
                             abTest: {
                                 name: 'AcquisitionsEpicThankYou',
                                 variant: variant.id,


### PR DESCRIPTION
## What does this change?

Previously, we were using the campaign code to encode the channel, description and instance of a component. In the new world, we want to use campaign code for what it more literally means: a code to group together instances of components in the same campaign.

Rather confusingly, this means that we want to start storing what we now call the `campaign_code` in a field called `component_id`. We are not ready to fully switch over yet, so in the meantime, we want to store what is currently the `campaign_code` in both `campaign_code` and `component_id` in both the `component_event` field of the `pageview` table, and in the entries of the new `acquisitions` table.

This was already implemented for the `acquisitions` table, this PR just makes a slight adjustment to how we call the tracking funciton, making it explicit what parameters we are sending through.

In addition, this PR does start sending through the `campaign_code` to the `id` field of the `component_event` in the `pageview` table (as discussed prior)



## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
