### PR TITLE
Add front ID to data components on tag pages

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -64,7 +64,10 @@
 
                 @defining(IndexPage.makeFront(index, Edition(request)).containers) { containers =>
                     @containers.map { containerDefinition =>
-                        @container(containerDefinition, empty)
+                        @container(
+                            containerDefinition = containerDefinition,
+                            frontId = Some(index.idWithoutEdition)
+                        )
                     }
                 }
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -254,9 +254,8 @@ object Commercial {
 
       mkString(
         containerType =
-          if (frontId.isDefined) "Curated front container"
-          else if (isContentPage) "Onward container"
-          else "Automated front container",
+          if (isContentPage) "Onward container"
+          else "Front container",
         editionId = Edition(request).id,
         frontId =
           if (isContentPage) "none"


### PR DESCRIPTION
This is to allow us to report referrals accurately in Campaign Central, using the pageview.referrer_component in the data lake.

Before:
`Automated front container | UK | `**unknown front id**` | container-1 | May 2017 | Canal & River Trust | card-1 | Emma Dabiri: 'A walk by the canal feels a world apart from the rest of London'`

After:
`Front container | UK | `**profile/emma-dabiri**` | container-1 | May 2017 | Canal & River Trust | card-1 | Emma Dabiri: 'A walk by the canal feels a world apart from the rest of London'`
