### PR TITLE
Post-merge install script split char

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 execa.shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
     .then(result => {
-        const changedFiles = result.stdout.split(',');
+        const changedFiles = result.stdout.split('\n');
 
         if (changedFiles.includes('.nvmrc')) {
             const nvmrcVersion = fs.readFileSync('.nvmrc');


### PR DESCRIPTION
## What does this change?

split git output on `\n` rather than `,`

## What is the value of this and can you measure success?

should work?
