### PR TITLE
Provide new messenger API point to retrieve page level ad targeting.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -24,6 +24,7 @@ import { init as initMessenger } from 'commercial/modules/messenger';
 
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as getStyles } from 'commercial/modules/messenger/get-stylesheet';
+import { init as getPageTargeting } from 'commercial/modules/messenger/get-page-targeting';
 import { init as hide } from 'commercial/modules/messenger/hide';
 import { init as resize } from 'commercial/modules/messenger/resize';
 import { init as scroll } from 'commercial/modules/messenger/scroll';
@@ -34,6 +35,7 @@ import { init as background } from 'commercial/modules/messenger/background';
 initMessenger(
     type,
     getStyles,
+    getPageTargeting,
     resize,
     hide,
     scroll,

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-page-targeting.js
@@ -1,0 +1,9 @@
+// @flow
+import type { RegisterListeners } from 'commercial/modules/messenger';
+import config from 'lib/config';
+
+const init = (register: RegisterListeners) => {
+    register('get-page-targeting', () => config.get('page.sharedAdTargeting'));
+};
+
+export { init };


### PR DESCRIPTION
## What does this change?
This provides a method for the messenger API to respond to requests for the ad targeting on the page.

## What is the value of this and can you measure success?
This allows for ads to be served into SafeFrame whilst retaining the ability to define a passback.