### PR TITLE
Into the ESLint wormhole

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -45,3 +45,6 @@ coverage
 
 # tools
 !/tools
+
+# git-hooks
+!/git-hooks

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -5,21 +5,32 @@ const execa = require('execa');
 const chalk = require('chalk');
 const fs = require('fs');
 
-execa.shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
+execa
+    .shell('git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD')
     .then(result => {
         const changedFiles = result.stdout.split('\n');
 
         if (changedFiles.includes('.nvmrc')) {
             const nvmrcVersion = fs.readFileSync('.nvmrc');
 
-            console.log(`${chalk.red(`Frontend now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`)}`);
+            console.log(
+                `${chalk.red(
+                    `Frontend now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
+                )}`
+            );
         } else if (changedFiles.includes('yarn.lock')) {
-            console.log(`${chalk.red('This application has new dependencies. Running \`make install\`...')}`);
+            console.log(
+                `${chalk.red(
+                    'This application has new dependencies. Running `make install`...'
+                )}`
+            );
 
             return execa('make', ['install'], {
                 stdio: 'inherit',
             });
         }
+
+        return Promise.resolve();
     })
     .catch(e => {
         console.log(`\n${e}\n`);

--- a/tools/__tasks__/validate-head/javascript-fix.js
+++ b/tools/__tasks__/validate-head/javascript-fix.js
@@ -9,8 +9,7 @@ module.exports = {
                 file =>
                     file.endsWith('.js') ||
                     file.endsWith('.jsx') ||
-                    file === 'git-hooks/pre-push' ||
-                    file === 'git-hooks/post-merge'
+                    file.startsWith('git-hooks')
             );
 
             return execa('eslint', [...jsFiles, '--quiet', '--color', '--fix']);

--- a/tools/__tasks__/validate-head/javascript-fix.js
+++ b/tools/__tasks__/validate-head/javascript-fix.js
@@ -6,7 +6,7 @@ module.exports = {
     task: () =>
         getChangedFiles().then(files => {
             const jsFiles = files.filter(
-                file => file.endsWith('.js') || file === 'git-hooks/pre-push'
+                file => file.endsWith('.js') || file === 'git-hooks/pre-push' || file === 'git-hooks/post-merge'
             );
 
             return execa('eslint', [...jsFiles, '--quiet', '--color', '--fix']);

--- a/tools/__tasks__/validate-head/javascript-fix.js
+++ b/tools/__tasks__/validate-head/javascript-fix.js
@@ -6,7 +6,11 @@ module.exports = {
     task: () =>
         getChangedFiles().then(files => {
             const jsFiles = files.filter(
-                file => file.endsWith('.js') || file === 'git-hooks/pre-push' || file === 'git-hooks/post-merge'
+                file =>
+                    file.endsWith('.js') ||
+                    file.endsWith('.jsx') ||
+                    file === 'git-hooks/pre-push' ||
+                    file === 'git-hooks/post-merge'
             );
 
             return execa('eslint', [...jsFiles, '--quiet', '--color', '--fix']);

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -16,6 +16,7 @@ module.exports = {
                     const jsFiles = files.filter(
                         file =>
                             file.endsWith('.js') ||
+                            file.endsWith('.jsx') ||
                             file === 'git-hooks/pre-push' ||
                             file === 'git-hooks/post-merge'
                     );

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -76,12 +76,15 @@ module.exports = {
                 }),
         },
         {
-            description: 'Run Flowtype checks on static/src/javascripts/',
+            description: 'Run Flowtype checks',
             task: () =>
                 getChangedFiles().then(files => {
                     const jsFiles = files.filter(
                         file =>
-                            file.endsWith('.js') && file.startsWith('static')
+                            (file.endsWith('.js') &&
+                                file.startsWith('static')) ||
+                            ((file.endsWith('.js') || file.endsWith('.jsx')) &&
+                                file.startsWith('ui'))
                     );
 
                     if (jsFiles.length) {

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -16,7 +16,8 @@ module.exports = {
                     const jsFiles = files.filter(
                         file =>
                             file.endsWith('.js') ||
-                            file === 'git-hooks/pre-push'
+                            file === 'git-hooks/pre-push' ||
+                            file === 'git-hooks/post-merge'
                     );
                     const lint = (proc, batchedFiles) =>
                         proc.then(() =>

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -87,7 +87,9 @@ module.exports = {
                     );
 
                     if (jsFiles.length) {
-                        return execa('yarn', ['flow']);
+                        return execa('yarn', ['flow'], {
+                            stdout: 'inherit',
+                        });
                     }
 
                     return Promise.resolve();

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -17,8 +17,7 @@ module.exports = {
                         file =>
                             file.endsWith('.js') ||
                             file.endsWith('.jsx') ||
-                            file === 'git-hooks/pre-push' ||
-                            file === 'git-hooks/post-merge'
+                            file.startsWith('git-hooks')
                     );
                     const lint = (proc, batchedFiles) =>
                         proc.then(() =>

--- a/tools/__tasks__/validate/javascript-fix.js
+++ b/tools/__tasks__/validate/javascript-fix.js
@@ -37,7 +37,12 @@ module.exports = {
             task: ctx =>
                 execa(
                     'eslint',
-                    ['*.js', 'tools/**/*.js', 'dev/**/*.js'].concat(config)
+                    [
+                        '*.js',
+                        'tools/**/*.js',
+                        'dev/**/*.js',
+                        'git-hooks/*',
+                    ].concat(config)
                 ).then(handleSuccess.bind(null, ctx)),
         },
     ],

--- a/tools/__tasks__/validate/javascript-fix.js
+++ b/tools/__tasks__/validate/javascript-fix.js
@@ -1,6 +1,7 @@
 const execa = require('execa');
 
 const config = ['--quiet', '--color', '--fix'];
+const uiConfig = config.concat(['--ext', '.js,.jsx']);
 
 const handleSuccess = ctx => {
     ctx.messages.push("Don't forget to commit any fixes...");
@@ -21,6 +22,13 @@ module.exports = {
             description: 'Fix static/src',
             task: ctx =>
                 execa('eslint', ['static/src/**/*.js'].concat(config)).then(
+                    handleSuccess.bind(null, ctx)
+                ),
+        },
+        {
+            description: 'Fix ui',
+            task: ctx =>
+                execa('eslint', ['ui'].concat(uiConfig)).then(
                     handleSuccess.bind(null, ctx)
                 ),
         },

--- a/tools/__tasks__/validate/javascript-fix.js
+++ b/tools/__tasks__/validate/javascript-fix.js
@@ -1,7 +1,6 @@
 const execa = require('execa');
 
 const config = ['--quiet', '--color', '--fix'];
-const uiConfig = config.concat(['--ext', '.js,.jsx']);
 
 const handleSuccess = ctx => {
     ctx.messages.push("Don't forget to commit any fixes...");
@@ -28,9 +27,9 @@ module.exports = {
         {
             description: 'Fix ui',
             task: ctx =>
-                execa('eslint', ['ui'].concat(uiConfig)).then(
-                    handleSuccess.bind(null, ctx)
-                ),
+                execa
+                    .shell('cd ui && yarn lint:js:fix')
+                    .then(handleSuccess.bind(null, ctx)),
         },
         {
             description: 'Fix everything else',

--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -43,7 +43,7 @@ module.exports = {
         },
         {
             description: 'UI',
-            task: `eslint ui ${config}`,
+            task: `eslint ui ${config} --ext .js,.jsx`,
             onError: error,
         },
         {

--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -57,9 +57,14 @@ module.exports = {
             onError: error,
         },
         {
-            description: `Flow`,
+            description: 'Flow',
             task: () => execa('flow'),
             onError: flowError,
+        },
+        {
+            description: 'Git hooks',
+            task: `eslint git-hooks/* ${config}`,
+            onError: error,
         },
     ],
     concurrent: true,

--- a/tools/__tasks__/validate/javascript.js
+++ b/tools/__tasks__/validate/javascript.js
@@ -43,7 +43,7 @@ module.exports = {
         },
         {
             description: 'UI',
-            task: `eslint ui ${config} --ext .js,.jsx`,
+            task: () => execa.shell('cd ui && yarn lint:js'),
             onError: error,
         },
         {

--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -1,0 +1,15 @@
+# for perf reasons, exclude all files by default
+/*
+
+# since we'll opting their parents back in, we need to explicitly exclude these
+node_modules
+__flow__
+flow-type*
+__snapshots__
+dist
+
+# generic options
+!.eslintrc.js
+
+# include src
+!/src

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,8 +6,8 @@
     "scripts": {
         "lint:scss": "stylelint 'src/**/*.*css'",
         "lint:scss:fix": "stylelint 'src/**/*.*css' --fix",
-        "lint:js": "eslint .",
-        "lint:js:fix": "eslint . --fix",
+        "lint:js": "eslint . --ext .js,.jsx",
+        "lint:js:fix": "eslint . --ext .js,.jsx --fix",
         "lint": "yarn lint:js -s && yarn lint:scss",
         "lint:fix": "yarn lint:js:fix -s && yarn lint:scss:fix -s",
         "test": "jest",

--- a/ui/src/.eslintrc.js
+++ b/ui/src/.eslintrc.js
@@ -49,5 +49,6 @@ module.exports = {
     env: {
         browser: true,
         nashorn: true,
+        jest: true,
     },
 };

--- a/ui/src/utils/test-render.jsx
+++ b/ui/src/utils/test-render.jsx
@@ -7,9 +7,7 @@ const styletron = new StyletronServer();
 
 export default (content: any) => {
     const html = renderToString(
-        <StyletronProvider styletron={styletron}>
-            {content}
-        </StyletronProvider>
+        <StyletronProvider styletron={styletron}>{content}</StyletronProvider>
     );
 
     it('generates the expected markup', () => {

--- a/ui/src/views/404/Footer/index.jsx
+++ b/ui/src/views/404/Footer/index.jsx
@@ -14,7 +14,7 @@ const footerLinks = [
     { href: '/help/privacy-policy', text: 'Privacy policy' },
 ];
 
-const FooterLink = ({ text, ...props }) =>
+const FooterLink = ({ text, ...props }) => (
     <li
         style={{
             display: 'inline',
@@ -30,9 +30,10 @@ const FooterLink = ({ text, ...props }) =>
             }}>
             {text}
         </a>
-    </li>;
+    </li>
+);
 
-const Footer = () =>
+const Footer = () => (
     <div
         style={{
             borderTopWidth: '3px',
@@ -44,9 +45,7 @@ const Footer = () =>
             margin: '15px 0',
             clear: 'both',
         }}>
-        <ul style={{ fontFamily: 'arial' }}>
-            {footerLinks.map(FooterLink)}
-        </ul>
+        <ul style={{ fontFamily: 'arial' }}>{footerLinks.map(FooterLink)}</ul>
         <p style={{ fontFamily: 'arial' }}>
             <small>
                 &copy; Guardian News and Media Limited or its affiliated
@@ -55,6 +54,7 @@ const Footer = () =>
                 York Way, London N1P 2AP
             </small>
         </p>
-    </div>;
+    </div>
+);
 
 export default Footer;

--- a/ui/src/views/404/Navigation/index.jsx
+++ b/ui/src/views/404/Navigation/index.jsx
@@ -2,9 +2,10 @@
 
 import NavigationItems from '../NavigationItems';
 
-const Navigation = () =>
+const Navigation = () => (
     <nav>
         <NavigationItems />
-    </nav>;
+    </nav>
+);
 
 export default Navigation;

--- a/ui/src/views/404/NavigationItems/index.jsx
+++ b/ui/src/views/404/NavigationItems/index.jsx
@@ -3,13 +3,12 @@
 import NavigationItem from '../NavigationItem';
 import navItems from './nav-items';
 
-const NavigationItems = () =>
+const NavigationItems = () => (
     <ul role="navigation">
-        {navItems.map(({ link, ...props }) =>
-            <NavigationItem {...props}>
-                {link}
-            </NavigationItem>
-        )}
-    </ul>;
+        {navItems.map(({ link, ...props }) => (
+            <NavigationItem {...props}>{link}</NavigationItem>
+        ))}
+    </ul>
+);
 
 export default NavigationItems;


### PR DESCRIPTION
## What does this change?

This is an attempt to cover some of the gaps in client side code validation:

- Includes `git-hooks` in our validate and fix make tasks
- Includes `ui` linting in our validate and fix make tests
- Includes `ui` flow type checking in our validate tasks
- Excludes flow types folder from `ui` linting
- Includes files with the JSX extension in `ui` linting
- Preserves error colours and formatting in pre-push validation

## What is the value of this and can you measure success?

More type safety, code style consistency

## Discussion

Should we define a make task specifically for `ui` validation (e.g. `make ui-validate` and `make ui-fix`) rather than including it in the application's main `make validate` and `make fix` tasks?

## Tested in CODE?

No
