### PR TITLE
Add fix for responsive video embeds

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -8,7 +8,10 @@ import views.support.{HtmlCleaner, Item640}
 
 import scala.collection.JavaConversions._
 
-case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 680) extends HtmlCleaner {
+/*
+ * maxEmbedHeight: 812px - full height on an iPhone X
+ */
+case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extends HtmlCleaner {
   val facebookVideoEmbedUrl = "https://www.facebook.com/v2.3/plugins/video.php?href="
   def facebookVideoEmbedUrlFor(url: String): String = s"$facebookVideoEmbedUrl${URLEncoder.encode(url, "UTF-8")}"
 

--- a/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
@@ -1,0 +1,72 @@
+package views.support.cleaner
+
+import com.gu.contentapi.client.model.v1.{Content => ApiContent}
+import model.{Article, Content}
+import org.jsoup.nodes.Element
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.{FlatSpec, Matchers}
+import scala.collection.JavaConversions._
+
+class VideoEmbedCleanerTest extends FlatSpec with Matchers {
+
+  val contentApi = ApiContent(
+    id = "foo/2012/jan/07/bar",
+    webTitle = "Some article",
+    webUrl = "http://www.guardian.co.uk/foo/2012/jan/07/bar",
+    apiUrl = "http://content.guardianapis.com/foo/2012/jan/07/bar"
+  )
+
+  val article = {
+    val contentApiItem = contentApi
+    val content = Content.make(contentApiItem)
+    Article.make(content)
+  }
+
+  def clean(doc: String): Document = {
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = VideoEmbedCleaner(article, 600).clean(document)
+    result
+  }
+
+  private def getStyle(styleString: String, property: String): String = {
+    val style = raw"${property}:\s*([^;]*)".r
+
+    val embeddedStyle = style.unanchored
+
+    styleString match {
+      case embeddedStyle(value) => value
+      case default => ""
+    }
+  }
+
+  "VideoEmbedCleaner" should "correctly sets max width" in {
+      val doc = s"""<html><body><figure class="element-video"><iframe src="test" height="800" width="400"></iframe></figure></body></html>"""
+      val result = clean(doc)
+
+      val alignerStyleString = result.getElementsByClass("u-responsive-aligner").attr("style")
+      val maxWidth = getStyle(alignerStyleString, "max-width")
+
+      val wrapperStyleString = result.getElementsByClass("embed-video-wrapper").attr("style")
+      val paddingBottom = getStyle(wrapperStyleString, "padding-bottom")
+
+      // values will always be a float
+      maxWidth should be("300.0px")
+      paddingBottom should be("200.0%")
+   }
+
+   "VideoEmbedCleaner" should "handles iframe with missing width and height" in {
+      val doc = s"""<html><body><figure class="element-video"><iframe src="test")></iframe></figure></body></html>"""
+      val result = clean(doc)
+      val responsiveElements = result.getElementsByClass("u-responsive-ratio--hd")
+      responsiveElements.size should be(1)
+   }
+
+   "VideoEmbedCleaner" should "work without an iframe in the embed" in {
+      val doc = s"""<html><body><figure class="element-video"><div class="some-other-embed"><script>alert('hi');</script></div></figure></body></html>"""
+      val result = clean(doc)
+      val responsiveElements = result.getElementsByClass("u-responsive-ratio--hd")
+      responsiveElements.size should be(1)
+   }
+
+}

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -158,6 +158,12 @@
     }
 }
 
+.u-responsive-aligner {
+    // to be overidden by inline max-width style for center-aligning
+    margin: 0 auto;
+    width: 100%;
+}
+
 .u-responsive-ratio--hd {
     padding-bottom: aspect-ratio-height(16, 9);
 }


### PR DESCRIPTION
## What does this change?
Fixes responsive video embeds that fall outside 16:9 ratio. It will also constrain iframe embeds with a width to their natural width rather than stretch them to the container width (although this could be changed).

## What is the value of this and can you measure success?
Initially allows reporters to post portrait live Facebook videos

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
