### PR TITLE
Make Labs cards on Fronts correct colour after visit, and ensure sans-serif standfirst

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs-capi.scss
+++ b/static/src/stylesheets/module/commercial/_labs-capi.scss
@@ -378,6 +378,13 @@
         color: $neutral-1;
     }
 
+    .fc-item__link,
+    .fc-sublink__link {
+        &:visited {
+            color: #5c5c5c;
+        }
+    }
+
     .fc-item__kicker {
         color: $paid-article-brand;
     }
@@ -397,6 +404,7 @@
     }
 
     .fc-item__standfirst {
+        @include f-textSans;
         color: #757575;
     }
 


### PR DESCRIPTION
## What does this change?

- Labs cards in Editorial containers will use sans-serif font for the standfirst
- Visited labs links will go a more aesthetically pleasing and readable tone

## What is the value of this and can you measure success?

- Fixing display issues 🔨 
- Making @blongden73 happy 🌤 
- Pretty pages 💅 

## Does this affect other platforms - Amp, Apps, etc?

Nah

## Screenshots

###### VISITED LINK BEFORE:

<img width="317" alt="picture 19" src="https://user-images.githubusercontent.com/8607683/31085440-0659ae04-a78f-11e7-8673-2203b46e3979.png">

###### VISITED LINK AFTER:

<img width="315" alt="picture 20" src="https://user-images.githubusercontent.com/8607683/31085462-168724aa-a78f-11e7-9a09-501f1faf871f.png">

