### PR TITLE
ES6: assign missing modules

### DIFF
--- a/tools/es5to6.json
+++ b/tools/es5to6.json
@@ -51,5 +51,10 @@
     "projects/common/modules/ui/last-modified.js",
     "projects/common/modules/analytics/interaction-tracking.js",
     "projects/common/modules/analytics/media-listener.js"
+  ],
+  "Alex Ware": [
+    "projects/membership/digitalpack-tab.js",
+    "projects/membership/membership-tab.js",
+    "projects/membership/stripe.js"
   ]
 }


### PR DESCRIPTION
## What does this change?

Assigns a few missing modules relating to profile / membership / identity to @AWare for ES6 conversion

## What is the value of this and can you measure success?

Total. ES6. Domination.
