### PR TITLE
Fix scrollDepth test spec async issue

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
@@ -3,6 +3,12 @@
 import mediator from 'lib/mediator';
 import { ScrollDepth } from 'common/modules/analytics/scrollDepth';
 
+jest.mock('lodash/functions/debounce', (): void => fn => {
+    fn();
+});
+
+jest.mock('lib/mediator');
+
 describe('Scroll depth', () => {
     it('should log page depth on scroll.', done => {
         if (document.body) {

--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
@@ -3,7 +3,7 @@
 import mediator from 'lib/mediator';
 import { ScrollDepth } from 'common/modules/analytics/scrollDepth';
 
-jest.mock('lodash/functions/debounce', (): void => fn => {
+jest.mock('lodash/functions/debounce', (): Function => fn => {
     fn();
 });
 


### PR DESCRIPTION
## What does this change?

Mocks debounce and mediator in scrollDepth test spec to mitigate against async code failing to execute within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL

## What is the value of this and can you measure success?

Tests run consistently on Teamcity

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No