### PR TITLE
Extend Email ads switch until end of November

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -301,7 +301,7 @@ trait CommercialSwitches {
     "When ON, the Guardian Today US Email will contain Live Intent advertisements",
     owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 10, 3),
+    sellByDate = new LocalDate(2017, 11, 30),
     exposeClientSide = false
   )
 }


### PR DESCRIPTION
Extending the switch until end of November. Will need to chat to Brendan in the US about this one, @ScottPainterGNM 