### PR TITLE
Remove width constraint on video embeds

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -140,7 +140,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
 
   private def wrapCustom(container: Element, width: Float, height: Float) {
     val aspectRatio = width / height
-    val maxWidth =  Math.min(maxEmbedHeight * aspectRatio, width)
+    val maxWidth =  maxEmbedHeight * aspectRatio
     val paddingBottom = (1 / aspectRatio) * 100
     container.wrap(s"""<div class="u-responsive-aligner" style="max-width: ${maxWidth}px;"><div class="embed-video-wrapper u-responsive-ratio" style="padding-bottom: ${paddingBottom}%;"></div></div>""")
   }


### PR DESCRIPTION
The previous width constraint on video embeds (by their iframe width attribute) has been removed

## What does this change?
Allows video embeds to appear full width regardless of their iframe size

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?
Yes

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots

## Tested in CODE?
Yes
