### PR TITLE
Reserve space below crossword grid for clue

### DIFF
--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -7,11 +7,13 @@ $stickyClueHeight: $stickyClueVerticalPadding * 2 + ($stickyClueLineHeight * $st
     position: relative;
     // Placeholder for sticky clue
     padding-top: $stickyClueHeight;
+    padding-bottom: $stickyClueHeight;
 
     @include mq(tablet) {
         float: left;
         // Unset
         padding-top: 0;
+        padding-bottom: 0;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Adds space below the crossword grid for the clue, so that the grid is not hidden when a clue is selected at small breakpoints. 

This probably isn't the optimal fix, but it stops the immediate issue and doesn't seem to heinous.

## What is the value of this and can you measure success?
Fewer people contacting userhelp.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
Live (before):

![image](https://user-images.githubusercontent.com/68329/31168518-82e263da-a8ed-11e7-9b83-a52fae07fb98.png)

Local (after):
![image](https://user-images.githubusercontent.com/68329/31169266-f1e1d250-a8ef-11e7-960f-c99dfc6e23b9.png)



## Tested in CODE?
Not yet
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
