### PR TITLE
move useFakeTimers before test

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.spec.js
@@ -9,6 +9,8 @@ jest.mock('lodash/functions/debounce', (): Function => fn => {
 
 jest.mock('lib/mediator');
 
+jest.useFakeTimers();
+
 describe('Scroll depth', () => {
     it('should log page depth on scroll.', done => {
         if (document.body) {
@@ -26,8 +28,6 @@ describe('Scroll depth', () => {
             });
 
             window.scrollTo(0, 50);
-
-            jest.useFakeTimers();
 
             mediator.emit('window:throttledScroll');
 


### PR DESCRIPTION
## What does this change?

Moves useFakeTimers before test, this hopefully ensures jest has swapped out timer functions when test runs and fixes intermittent async test failures.

## What is the value of this and can you measure success?

scrollDepth tests run on Teamcity without async failures

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No