### PR TITLE
Fix duplicate validation messages on pre-push

### DIFF
--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -87,9 +87,7 @@ module.exports = {
                     );
 
                     if (jsFiles.length) {
-                        return execa('yarn', ['flow'], {
-                            stdout: 'inherit',
-                        });
+                        return execa('yarn', ['flow']);
                     }
 
                     return Promise.resolve();


### PR DESCRIPTION
## What does this change?

In my zeal to plug all the ESLint gaps (#17897), I also attempted to fix a problem with the formatting of Flow validation messages on pre-push. In doing so, I introduced a bug whereby all validation messages originating from the pre-push hook are repeated.

![picture 300](https://user-images.githubusercontent.com/5931528/31228870-dc300f7a-a9d6-11e7-97a3-90e31cc19772.png)

Looks great, right?

This fix reverts the change, so the validation messages are no longer doubled up, but Flow validation messages have once more lost their nice formatting.

If anyone can think of a to retain Flow's nice formatting, I'd be happy to implement it

## What is the value of this and can you measure success?

Slightly less noise

## Screenshots

**Before**

![picture 297](https://user-images.githubusercontent.com/5931528/31222241-62e629be-a9be-11e7-8526-a5bbd48734f1.png)

**After**

![picture 298](https://user-images.githubusercontent.com/5931528/31222236-5f9820fa-a9be-11e7-8e67-d075c71b0a4f.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
