### PR TITLE
Add SponsorName and BrandingType to GA params of AMP pages

### DIFF
--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -1,7 +1,7 @@
 @import play.api.Mode
 @import model.Tag
 @import play.api.libs.json.Json
-@(content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(content: model.Content, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.Configuration
 @import views.support.FBPixel
@@ -17,7 +17,7 @@ are used to generate the confidence graphs on the frontend dashboard.
 
 <amp-analytics config="https://ophan.theguardian.com/amp.json" @if(context.environment.mode != Mode.Dev) { data-credentials="include" }></amp-analytics>
 
-@fragments.amp.googleAnalytics(content)
+@fragments.amp.googleAnalytics(content, page)
 
 <amp-analytics id="comscore" type="comscore">
     <script type="application/json">

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,7 +1,7 @@
 @(content: model.Content, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.GoogleAnalyticsAccount
-@import views.support.Commercial.pageSponsorNames
+@import views.support.Commercial.{getSponsorForGA, getBrandingTypeForGA}
 @import conf.Configuration
 
 @* TODO: Abstract this out so its shared with the main GA tracking *@
@@ -9,7 +9,7 @@
     <script type="application/json">
             {
               "requests": {
-                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}&cd27=${userAgent}@pageSponsorNames(page, "cd31")"
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}&cd27=${userAgent}@getSponsorForGA(page, "cd31")@getBrandingTypeForGA(page, "cd42")"
               },
               "vars": {
                 "account": "@{GoogleAnalyticsAccount.editorialTracker(context).trackingId}"

--- a/common/app/views/fragments/amp/googleAnalytics.scala.html
+++ b/common/app/views/fragments/amp/googleAnalytics.scala.html
@@ -1,6 +1,7 @@
-@(content: model.Content)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(content: model.Content, page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import views.support.GoogleAnalyticsAccount
+@import views.support.Commercial.pageSponsorNames
 @import conf.Configuration
 
 @* TODO: Abstract this out so its shared with the main GA tracking *@
@@ -8,7 +9,7 @@
     <script type="application/json">
             {
               "requests": {
-                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}&cd27=${userAgent}"
+                "pageviewWithCustomDims": "${pageview}&cd3=${platform}&cd4=${sectionId}&cd5=${contentType}&cd6=${commissioningDesks}&cd7=${contentId}&cd8=${contributorIds}&cd9=${keywordIds}&cd10=${toneIds}&cd11=${seriesId}&cd26=${isHostedFlag}&cd29=${fullRequestUrl}&cd27=${userAgent}@pageSponsorNames(page, "cd31")"
               },
               "vars": {
                 "account": "@{GoogleAnalyticsAccount.editorialTracker(context).trackingId}"

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -9,7 +9,7 @@
 
     <body class="guardian-egyptian-loading">
 
-        @fragments.amp.analytics(content)
+        @fragments.amp.analytics(content, page)
 
         @fragments.amp.header()
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -3,12 +3,12 @@ package views.support
 import com.gu.commercial.branding._
 import common.Edition
 import common.commercial._
-import conf.switches.Switches
 import layout.{ColumnAndCards, ContentCard, FaciaContainer, PaidCard}
 import model.{Page, PressedPage}
 import org.apache.commons.lang.StringEscapeUtils._
 import play.api.libs.json.JsBoolean
 import play.api.mvc.RequestHeader
+import play.twirl.api.Html
 
 object Commercial {
   def isAdFree(request: RequestHeader): Boolean = {
@@ -87,6 +87,15 @@ object Commercial {
     }
 
     allSponsors map (_ map escapeJavaScript)
+  }
+
+  def pageSponsorNames(page: Page, key: String)(implicit request: RequestHeader): Html = Html {
+    if (isBrandedContent(page)) {
+      listSponsorLogosOnPage(page) match {
+        case Some(logos) => s"&$key=${logos.mkString("|")}"
+        case _ => ""
+      }
+    } else { "" }
   }
 
   def brandingType(page: Page)(implicit request: RequestHeader): Option[BrandingType] = for {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -89,13 +89,20 @@ object Commercial {
     allSponsors map (_ map escapeJavaScript)
   }
 
-  def pageSponsorNames(page: Page, key: String)(implicit request: RequestHeader): Html = Html {
+  def getSponsorForGA(page: Page, key: String)(implicit request: RequestHeader): Html = Html {
     if (isBrandedContent(page)) {
       listSponsorLogosOnPage(page) match {
         case Some(logos) => s"&$key=${logos.mkString("|")}"
         case _ => ""
       }
     } else { "" }
+  }
+
+  def getBrandingTypeForGA(page: Page, key: String)(implicit request: RequestHeader): Html = Html {
+    brandingType(page) match {
+      case Some(branding) => s"&$key=${branding.name}"
+      case _ => ""
+    }
   }
 
   def brandingType(page: Page)(implicit request: RequestHeader): Option[BrandingType] = for {


### PR DESCRIPTION
## What does this change?

- Gives AMP google-analytics a couple more conditional params on branded pages
- Adds the cd31 and cd42 values is the page has a sponsor name and branding type

## What is the value of this and can you measure success?

- Consistency in params sent to google-analytics between AMP and non-AMP pages.

## Does this affect other platforms - Amp, Apps, etc?

This affects AMP. On branded content (Hosted, Sponsored, Supported) there will be two extra query params added to the AMP google-analytics, to make it consistent with the non-AMP google-analytics.

Validation still passes 👍 

## Screenshots

###### BEFORE:

<img width="610" alt="picture 24" src="https://user-images.githubusercontent.com/8607683/31224694-e25f691e-a9c6-11e7-8d08-d321f7784eb4.png">

###### AFTER:

<img width="610" alt="picture 23" src="https://user-images.githubusercontent.com/8607683/31224700-e845915a-a9c6-11e7-8442-0ad98e85d989.png">

<img width="812" alt="picture 25" src="https://user-images.githubusercontent.com/8607683/31225373-b2422db8-a9c9-11e7-92d2-6dbc87233d41.png">




