### PR TITLE
Adding sbt-dependency-graph plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,3 +29,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 addSbtPlugin("org.jetbrains.teamcity.plugins" % "sbt-teamcity-logger" % "0.3.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")


### PR DESCRIPTION
## What is the value of this and can you measure success?
I am evaluating snyk.io to monitor dependencies vulnerabilities.
Snyk.io depends on the `sbt-dependency-graph` plugin

`sbt-dependency-graph` is also a very cool way to visualize dependency graph