### PR TITLE
Opinions social overlay

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -107,13 +107,12 @@ object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 1
 object Video1280 extends VideoProfile(width = Some(1280), height = Some(720)) // 16:9
 object GoogleStructuredData extends Profile(width = Some(300), height = Some(300)) // 1:1
 
-abstract class ShareImage(shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
+class ShareImage(blendImageParam: String, shouldIncludeOverlay: Boolean) extends Profile(width = Some(1200)) {
   override val heightParam = "h=630"
   override val fitParam = "fit=crop"
   val cropParam = "crop=faces%2Centropy"
   val blendModeParam = "bm=normal"
   val blendOffsetParam = "ba=bottom%2Cleft"
-  val blendImageParam: String
 
   override def resizeString: String = {
     if(shouldIncludeOverlay) {
@@ -125,12 +124,14 @@ abstract class ShareImage(shouldIncludeOverlay: Boolean) extends Profile(width =
   }
 }
 
-object TwitterImage extends ShareImage(TwitterShareImageLogoOverlay.isSwitchedOn) {
-  override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNi8wNy9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
+object TwitterImage {
+  val default = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n", TwitterShareImageLogoOverlay.isSwitchedOn)
+  val opinions = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNy8wOS8wOC9vcGluaW9uc19vdmVybGF5LnBuZw==", TwitterShareImageLogoOverlay.isSwitchedOn)
 }
 
-object FacebookOpenGraphImage extends ShareImage(FacebookShareImageLogoOverlay.isSwitchedOn) {
-  override val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
+object FacebookOpenGraphImage {
+  val default = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n", FacebookShareImageLogoOverlay.isSwitchedOn)
+  val opinions = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNy8wOS8wOC9vcGluaW9uc19vdmVybGF5LnBuZw==", FacebookShareImageLogoOverlay.isSwitchedOn)
 }
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {


### PR DESCRIPTION
Our 🌎 famous social cards have a branded overlay. Articles from the opinion section now have an "opinions" overlay to keep the strong branding but differentiate/highlight that these are "opinions" and not our "opinion" as a publisher.

## Before
![5184 1](https://user-images.githubusercontent.com/14570016/31233875-73364638-a9e5-11e7-8c5e-dcb648132ee2.jpg)

## After
![5184](https://user-images.githubusercontent.com/14570016/31233877-74804d5e-a9e5-11e7-8587-3e5289f2fe6f.jpg)

Thanks @TBonnin for writing **all** the scala

@katebee is there anything we need to do with regards to cache etc, now some articles will have updated images?