### PR TITLE
Change 2nd opening <head> tag to be closing </head> tag

### DIFF
--- a/common/app/views/fragments/page/head/headTag.scala.html
+++ b/common/app/views/fragments/page/head/headTag.scala.html
@@ -1,4 +1,4 @@
 @(fragments: Html*)
 <head>
 @stacked(fragments:_*)
-<head>
+</head>


### PR DESCRIPTION
## What does this change?

Fixes issue where the closing `</head>` tag is actually an opening `<head>` tag leaving 2 opening tags.

## Does this affect other platforms - Amp, Apps, etc?

Unsure :)