### PR TITLE
Fix wrong legacy function call

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
+++ b/static/src/javascripts/projects/common/modules/commercial/video-ad-url.js
@@ -7,9 +7,7 @@ const videoAdUrl = (): string => {
     const queryParams = {
         ad_rule: 1,
         correlator: new Date().getTime(),
-        cust_params: encodeURIComponent(
-            constructQuery(buildPageTargeting.buildPageTargeting())
-        ),
+        cust_params: encodeURIComponent(constructQuery(buildPageTargeting())),
         env: 'vp',
         gdfp_req: 1,
         impl: 's',


### PR DESCRIPTION
## What does this change?

Fixes a case, where a legacy function call wasn't properly converted. Broke e.g. https://www.theguardian.com/film/video/2015/aug/11/man-from-uncle-henry-cavill-armie-hammer-video-interview?adtest=tom

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

Nope.

## Tested in CODE?

No.