### PR TITLE
Security fix for identity-cookie library

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.78"
+  val identityLibVersion = "3.80"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.3"
   val capiVersion = "11.23"


### PR DESCRIPTION
## What does this change?

Addresses security issue flagged by [Synk](https://snyk.io/org/the-guardian-cuu/project/5c9ca119-45de-4476-a177-b87e8a62d463?tab=issues#SNYK-JAVA-ORGBOUNCYCASTLE-31049)  in `identity-cookie` library:

```
com.gu:identity_2.11@0.1-SNAPSHOT › com.gu.identity:identity-cookie_2.11@3.78 › com.gu.identity:identity-crypto_2.11@3.78 › org.bouncycastle:bcprov-jdk16@1.46

org.bouncycastle:bcprov-jdk16 The Bouncy Castle Java library before 1.51 does not validate a point is withing the elliptic curve, which makes it easier for remote attackers to obtain private keys via a series of crafted elliptic curve Diffie Hellman (ECDH) key exchanges, aka an "invalid curve attack."
```

Related PR: https://github.com/guardian/identity/pull/692

