### PR TITLE
Load TargetingLifecycle in preview

### DIFF
--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -2,6 +2,7 @@ import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import commercial.CommercialLifecycle
 import commercial.controllers.CommercialControllers
+import commercial.targeting.TargetingLifecycle
 import common.Logback.LogstashLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
 import conf.{CachedHealthCheckLifeCycle, FootballLifecycle}
@@ -44,7 +45,8 @@ trait PreviewLifecycleComponents extends SportServices with CommercialServices w
     wire[SwitchboardLifecycle],
     wire[FootballLifecycle],
     wire[CricketLifecycle],
-    wire[RugbyLifecycle]
+    wire[RugbyLifecycle],
+    wire[TargetingLifecycle]
   )
 }
 


### PR DESCRIPTION
## What does this change?
TargetingLifecycle was not loaded in preview which means that targeting campaign were not loaded and features depending on them would not work (ex: Special Report)

## What is the value of this and can you measure success?
Making targeting campaigns based special report works on preview

## Does this affect other platforms - Amp, Apps, etc?
No

## Tested in CODE?
Yes