### PR TITLE
yarn silence: move the ess

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,10 +17,10 @@ list: # PRIVATE
 
 # Install all 3rd party dependencies.
 install: check-node-env
-	@yarn install -s
-	@cd ui && yarn install -s
-	@cd dev/eslint-plugin-guardian-frontend && yarn install -s
-	@cd tools/amp-validation && yarn install -s
+	@yarn -s install
+	@cd ui && yarn -s install
+	@cd dev/eslint-plugin-guardian-frontend && yarn -s install
+	@cd tools/amp-validation && yarn -s install
 
 # Remove all 3rd party dependencies.
 uninstall: # PRIVATE
@@ -138,10 +138,10 @@ es6: install
 # *********************** UI ***********************
 
 ui-compile: install
-	@cd ui && yarn compile -s
+	@cd ui && yarn -s compile
 
 ui-watch-nashorn: install
-	@cd ui && yarn watch:nashorn -s
+	@cd ui && yarn -s watch:nashorn
 
 ui-watch: install
-	@cd ui && yarn watch -s
+	@cd ui && yarn -s watch


### PR DESCRIPTION
## What does this change?

When we upgraded Yarn to 1.1.x (#17935), it was necessary to move the `--silent` flag to the infix position between the call to `yarn` and the `command` argument. Why? Only Yarn knows.

## What is the value of this and can you measure success?

We can now run the `ui/` app.
