### PR TITLE
Update overlay to not contain '=='

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -133,7 +133,7 @@ object TwitterImage {
 
 object FacebookOpenGraphImage {
   val default = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n", FacebookShareImageLogoOverlay.isSwitchedOn)
-  val opinions = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNy8xMC8wNi9vcGluaW9uc19vdmVybGF5LWZhY2Vib29rLnBuZw==", FacebookShareImageLogoOverlay.isSwitchedOn)
+  val opinions = new ShareImage("blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNy8xMC8wNi9vcGluaW9uc19vdmVybGF5LWZhY2Vib29rLnBuZz90ZXN0", FacebookShareImageLogoOverlay.isSwitchedOn)
 }
 
 object EmailImage extends Profile(width = Some(580), autoFormat = false) {


### PR DESCRIPTION
In #17969 we added a new `overlay` for opinions pieces, unfortunately the overlay blended 64 contains `==` which prevent the [value parameter to be parsed correctly by facebook opengraph implementation](https://github.com/guardian/frontend/pull/17969#issuecomment-335220317)

## What does this change?

* previous value: `https://uploads.guim.co.uk/2017/10/06/opinions_overlay-facebook.png`
*  new value: `https://uploads.guim.co.uk/2017/10/06/opinions_overlay-facebook.png?test`

## What is the value of this and can you measure success?
allow opinion pieces to be shared as intended

## Does this affect other platforms - Amp, Apps, etc?
no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
no