### PR TITLE
Resolved spacing issue with series label

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -129,6 +129,8 @@
     overflow: hidden;
 
     @include mq($until: tablet) {
+        padding: 0;
+
         & > div:not(.content__series-label) {
             display: none;
         }
@@ -183,6 +185,7 @@
 
     @include mq($until: tablet) {
         @include fs-header(1);
+        padding-top: $gs-baseline / 3;
     }
 
     @include mq(leftCol) {


### PR DESCRIPTION
The introduction of the series label at mobile breakpoints meant there was increased padding above headlines even when there was no series label. I've changed the logic so that is no longer the case.


# Before
<img width="318" alt="screen shot 2017-10-10 at 11 39 57" src="https://user-images.githubusercontent.com/14570016/31382562-02b6c896-adb0-11e7-8946-7be9f06e1bdb.png">

# After
<img width="319" alt="screen shot 2017-10-10 at 11 39 25" src="https://user-images.githubusercontent.com/14570016/31382559-02568cd8-adb0-11e7-8155-009d7e03e0ed.png">

# Before
<img width="319" alt="screen shot 2017-10-10 at 11 39 37" src="https://user-images.githubusercontent.com/14570016/31382560-026c7980-adb0-11e7-8113-e66c6d297e42.png">

# After
<img width="319" alt="screen shot 2017-10-10 at 11 39 50" src="https://user-images.githubusercontent.com/14570016/31382561-02945176-adb0-11e7-8687-531d63ab93c9.png">




