### PR TITLE
Add more context in football client error messages

### DIFF
--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -89,9 +89,9 @@ class FootballClient(wsClient: WSClient)(implicit executionContext: ExecutionCon
 
   lazy val apiKey = SportConfiguration.pa.footballKey
 
-  def logErrors[T]: PartialFunction[Throwable, T] = {
+  def logErrorsWithMessage[T](message: String): PartialFunction[Throwable, T] = {
     case e: PaClientErrorsException =>
-      log.error(s"Football Client errors: ${e.getMessage}")
+      log.error(s"Football Client errors: $message (${e.getMessage})")
       throw e
   }
 

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -66,7 +66,7 @@ class MatchController(
 
   private def render(maybeMatch: Option[FootballMatch]): Action[AnyContent] = Action.async { implicit request =>
     val response = maybeMatch map { theMatch =>
-      val lineup: Future[LineUp] = competitionsService.footballClient.lineUp(theMatch.id).recover(competitionsService.footballClient.logErrors)
+      val lineup: Future[LineUp] = competitionsService.getLineup(theMatch)
       val page: Future[MatchPage] = lineup map { MatchPage(theMatch, _) }
 
       page map { page =>

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -128,6 +128,7 @@ object CompetitionsProvider {
 class CompetitionsService(val footballClient: FootballClient, competitionDefinitions: Seq[Competition])
   extends Competitions
     with LiveMatches
+    with Lineups
     with Logging
     with implicits.Collections
     with implicits.Football {
@@ -176,7 +177,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
           }
         }
       }
-    }.recover(footballClient.logErrors)
+    }.recover(footballClient.logErrorsWithMessage("Failed refreshing competitions data"))
   }
 
   def refreshMatchDay()(implicit executionContext: ExecutionContext): Future[immutable.Iterable[Competition]] = {

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -11,8 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait Lineups extends Logging {
   def footballClient: FootballClient
-  def competitions: Competitions
-  def teamNameBuilder: TeamNameBuilder = new TeamNameBuilder(competitions)
+  def teamNameBuilder: TeamNameBuilder
   def getLineup(theMatch: FootballMatch)(implicit executionContext: ExecutionContext): Future[LineUp] =
     footballClient
       .lineUp(theMatch.id)
@@ -21,7 +20,7 @@ trait Lineups extends Logging {
         val awayTeam = m.awayTeam.copy(name = teamNameBuilder.withTeam(m.awayTeam))
         LineUp(homeTeam, awayTeam, m.homeTeamPossession)
       }
-      .recover(footballClient.logErrors)
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting line-up for match ${theMatch.id}"))
 }
 
 trait LiveMatches extends Logging {
@@ -30,7 +29,8 @@ trait LiveMatches extends Logging {
   def teamNameBuilder: TeamNameBuilder
 
   def getLiveMatches()(implicit executionContext: ExecutionContext): Future[Map[String, Seq[MatchDay]]] =
-    footballClient.matchDay(LocalDate.now)
+    footballClient
+      .matchDay(LocalDate.now)
       .map { todaysMatches: List[MatchDay] =>
 
         val matchesWithCompetitions = todaysMatches.filter(_.competition.isDefined)
@@ -44,7 +44,7 @@ trait LiveMatches extends Logging {
         // we have checked above that the competition does exist for these matches
         matchesWithCleanedTeams.groupBy(_.competition.head.id)
       }
-      .recover(footballClient.logErrors)
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting live matches"))
 }
 
 trait LeagueTables extends Logging {
@@ -60,7 +60,7 @@ trait LeagueTables extends Logging {
         t.copy(team = team)
       }
     }
-      .recover(footballClient.logErrors)
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting league table for competition: ${competition.id}"))
   }
 }
 
@@ -78,7 +78,7 @@ trait Fixtures extends Logging {
         f.copy(homeTeam = homeTeam, awayTeam = awayTeam)
       }
     }
-      .recover(footballClient.logErrors)
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting fixtures for competition: ${competition.id}"))
   }
 }
 
@@ -98,7 +98,7 @@ trait Results extends Logging with implicits.Collections {
         r.copy(homeTeam = homeTeam, awayTeam = awayTeam)
       }
     }
-      .recover(footballClient.logErrors)
+      .recover(footballClient.logErrorsWithMessage(s"Failed getting results for competition: ${competition.id}"))
   }
 }
 


### PR DESCRIPTION
## What does this change?
Add more context in football client error messages

## What is the value of this and can you measure success?
Sport app is throwing a bunch of errors on a regular basis. However the `Football Client` library's error message are not very usefule (ex: `Football Client errors: No data available` or `Football Client errors: Access to season is denied by client configuration`)

This patch adds more context to error message

## Tested in CODE?
Yes