### PR TITLE
Amp snippets

### DIFF
--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -1,5 +1,5 @@
-@(className: String, label: String, headline: String, id: String)(body: Html)(implicit request: RequestHeader)
-
+@(className: String, label: String, headline: String, id: String, isAmp: Boolean)(body: Html)(implicit request: RequestHeader)
+@if(!isAmp) {
 <details data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
   <summary class="explainer-snippet__header">
     <span class="explainer-snippet__label">@label</span>
@@ -12,6 +12,7 @@
   <div class="explainer-snippet__body">
     @body
   </div>
+
   <footer class="explainer-snippet__footer">
     <div class="explainer-snippet__feedback">
       <div>Was this helpful?</div>
@@ -23,3 +24,28 @@
     </div>
   </footer>
 </details>
+} else {
+<div data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
+
+  <div class="explainer-snippet__header">
+    <span class="explainer-snippet__label">@label</span>
+    <h4 class="explainer-snippet__headline">@headline</h4>
+
+    <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility">
+      <span id="show-@id">
+        @fragments.inlineSvg("plus", "icon")
+        Show
+      </span>
+      <span hidden="" id="hide-@id">
+        @fragments.inlineSvg("minus", "icon")
+        Hide
+      </span>
+    </button>
+  </div>
+  <div hidden="" id="body-@id" class="explainer-snippet__body">
+  @body
+  </div>
+
+</div>
+}
+

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -27,11 +27,11 @@
 } else {
 <div data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
 
-  <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility">
+  <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
     <span class="explainer-snippet__label">@label</span>
     <h4 class="explainer-snippet__headline">@headline</h4>
 
-    <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility">
+    <button class="explainer-button explainer-snippet__handle" aria-hidden="true" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility" tabindex="0" role="header">
       <span id="show-@id">
         @fragments.inlineSvg("plus", "icon")
         Show

--- a/common/app/views/fragments/atoms/snippet.scala.html
+++ b/common/app/views/fragments/atoms/snippet.scala.html
@@ -27,7 +27,7 @@
 } else {
 <div data-snippet-id="@id" data-snippet-type="@className" class="clean explainer-snippet explainer-snippet--new explainer-snippet--light explainer-snippet--@className">
 
-  <div class="explainer-snippet__header">
+  <div class="explainer-snippet__header" on="tap:body-@{id}.toggleVisibility,show-@{id}.toggleVisibility,hide-@{id}.toggleVisibility">
     <span class="explainer-snippet__label">@label</span>
     <h4 class="explainer-snippet__headline">@headline</h4>
 

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -2,31 +2,31 @@
 
 @import views.html.fragments.image
 
-@if(!isAmp) {
-  @fragments.atoms.snippet(
-    className = "guide",
-    label = guide.data.typeLabel.getOrElse("Quick Guide"),
-    headline = guide.atom.title.getOrElse(""),
-    guide.id
-  ){
-    @for(img <- guide.image ) {
-      <div class="explainer-snippet__image">
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Guide",
-          isImmersiveMainMedia = true
-        )
-      </div>
-    }
+@fragments.atoms.snippet(
+  className = "guide",
+  label = guide.data.typeLabel.getOrElse("Quick Guide"),
+  headline = guide.atom.title.getOrElse(""),
+  guide.id,
+  isAmp
+){
+  @for(img <- guide.image ) {
+    <div class="explainer-snippet__image">
+      @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Guide",
+        isImmersiveMainMedia = true
+      )
+    </div>
+  }
 
-    @for(item <- guide.data.items) {
-      <div class="explainer-snippet__item">
-        @item.title.map { t =>
-          <div class="explainer-snippet__heading"><b>@t</b></div>
-        }
-        @Html(item.body)
-      </div>
-    }
+  @for(item <- guide.data.items) {
+    <div class="explainer-snippet__item">
+      @item.title.map { t =>
+        <div class="explainer-snippet__heading"><b>@t</b></div>
+      }
+      @Html(item.body)
+    </div>
   }
 }
+

--- a/common/app/views/fragments/atoms/snippets/guide.scala.html
+++ b/common/app/views/fragments/atoms/snippets/guide.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- guide.image ) {
     <div class="explainer-snippet__image">
-      @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Guide",
-        isImmersiveMainMedia = true
-      )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Guide")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Guide",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- profile.image ) {
     <div class="explainer-snippet__image">
-      @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Profile",
-        isImmersiveMainMedia = true
-      )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Profile")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Profile",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 

--- a/common/app/views/fragments/atoms/snippets/profile.scala.html
+++ b/common/app/views/fragments/atoms/snippets/profile.scala.html
@@ -2,31 +2,31 @@
 
 @import views.html.fragments.image
 
-@if(!isAmp) {
-  @fragments.atoms.snippet(
-    className = "profile",
-    label = profile.data.typeLabel.getOrElse("Profile"),
-    headline = profile.atom.title.getOrElse(""),
-    profile.id
-  ){
-    @for(img <- profile.image ) {
-      <div class="explainer-snippet__image">
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Profile",
-          isImmersiveMainMedia = true
-        )
-      </div>
-    }
+@fragments.atoms.snippet(
+  className = "profile",
+  label = profile.data.typeLabel.getOrElse("Profile"),
+  headline = profile.atom.title.getOrElse(""),
+  profile.id,
+  isAmp
+){
+  @for(img <- profile.image ) {
+    <div class="explainer-snippet__image">
+      @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Profile",
+        isImmersiveMainMedia = true
+      )
+    </div>
+  }
 
-    @for(item <- profile.data.items) {
-      <div class="explainer-snippet__item">
-        @item.title.map { t =>
-          <div class="explainer-snippet__heading"><b>@t</b></div>
-        }
-        @Html(item.body)
-      </div>
-    }
+  @for(item <- profile.data.items) {
+    <div class="explainer-snippet__item">
+      @item.title.map { t =>
+        <div class="explainer-snippet__heading"><b>@t</b></div>
+      }
+      @Html(item.body)
+    </div>
   }
 }
+

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -11,12 +11,16 @@
 ){
   @for(img <- qa.image ) {
     <div class="explainer-snippet__image">
-      @image(
-        picture = img,
-        classes = Nil,
-        imageAltText = "Q&amp;A",
-        isImmersiveMainMedia = true
-      )
+      @if(isAmp) {
+        @fragments.amp.ampImage(img, "Q&amp;A")
+      } else {
+        @image(
+          picture = img,
+          classes = Nil,
+          imageAltText = "Q&amp;A",
+          isImmersiveMainMedia = true
+        )
+      }
     </div>
   }
 

--- a/common/app/views/fragments/atoms/snippets/qanda.scala.html
+++ b/common/app/views/fragments/atoms/snippets/qanda.scala.html
@@ -2,24 +2,24 @@
 
 @import views.html.fragments.image
 
-@if(!isAmp) {
-  @fragments.atoms.snippet(
-    className = "qanda",
-    label = qa.data.typeLabel.getOrElse("Q&amp;A"),
-    headline = qa.atom.title.getOrElse(""),
-    qa.id
-  ){
-    @for(img <- qa.image ) {
-      <div class="explainer-snippet__image">
-        @image(
-          picture = img,
-          classes = Nil,
-          imageAltText = "Q&amp;A",
-          isImmersiveMainMedia = true
-        )
-      </div>
-    }
-
-    @Html(qa.data.item.body)
+@fragments.atoms.snippet(
+  className = "qanda",
+  label = qa.data.typeLabel.getOrElse("Q&amp;A"),
+  headline = qa.atom.title.getOrElse(""),
+  qa.id,
+  isAmp
+){
+  @for(img <- qa.image ) {
+    <div class="explainer-snippet__image">
+      @image(
+        picture = img,
+        classes = Nil,
+        imageAltText = "Q&amp;A",
+        isImmersiveMainMedia = true
+      )
+    </div>
   }
+
+  @Html(qa.data.item.body)
 }
+

--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -2,19 +2,19 @@
 
 @import org.joda.time.format.DateTimeFormat
 
-@if(!isAmp) {
-  @fragments.atoms.snippet(
-    className = "timeline",
-    label = timeline.data.typeLabel.getOrElse("Timeline"),
-    headline = timeline.atom.title.getOrElse(""),
-    timeline.id
-  ){
-    @for(item <- timeline.data.events) {
-      <div class="explainer-snippet__item">
-        <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.forPattern("d MMMM yyyy").print(item.date)</time>
-        <div class="explainer-snippet__heading"><b>@item.title</b></div>
-        @item.body.map { body => @Html(body) }
-      </div>
-    }
+@fragments.atoms.snippet(
+  className = "timeline",
+  label = timeline.data.typeLabel.getOrElse("Timeline"),
+  headline = timeline.atom.title.getOrElse(""),
+  timeline.id,
+  isAmp
+){
+  @for(item <- timeline.data.events) {
+    <div class="explainer-snippet__item">
+      <time class="explainer-snippet__event-date" datetime="">@DateTimeFormat.forPattern("d MMMM yyyy").print(item.date)</time>
+      <div class="explainer-snippet__heading"><b>@item.title</b></div>
+      @item.body.map { body => @Html(body) }
+    </div>
   }
 }
+

--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -31,3 +31,6 @@
 @import 'module/_icons.head';
 @import 'module/_rounded-icon';
 @import 'module/_main-media-captions';
+
+@import 'amp/atoms/_explainers';
+@import 'amp/atoms/_snippets';

--- a/static/src/stylesheets/amp/atoms/_explainers.scss
+++ b/static/src/stylesheets/amp/atoms/_explainers.scss
@@ -1,0 +1,147 @@
+@mixin clean($element) {
+    #{$element}.clean {
+        @content;
+    }
+}
+
+@include clean(details) {
+    > summary {
+        outline: none;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+    }
+}
+
+.explainer-snippet {
+    position: relative;
+    padding: $gs-baseline / 3 $gs-gutter / 4 $gs-baseline / 2;
+    margin: $gs-baseline * 4 / 3 0 $gs-baseline * 3;
+
+    font-family: $f-sans-serif-text;
+}
+
+.explainer-snippet__header {
+    margin: 0 0 $gs-baseline * 4 / 3;
+    font-weight: bold;
+}
+
+.explainer-snippet__label {
+    @include font-size(21, 24);
+    display: block;
+}
+
+.explainer-snippet__headline {
+    @include font-size(21, 24);
+}
+
+.explainer-snippet__handle {
+    position: absolute;
+    bottom: 0;
+    transform: translate(0, 50%);
+    border: 0;
+    padding: 0 15px 0 7px;
+
+    > span,
+    .inline-icon {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        margin-right: $gs-gutter / 2;
+    }
+}
+
+.explainer-snippet__body {
+    overflow: hidden;
+    padding-bottom: 10px;
+}
+
+.explainer-snippet__footer {
+    @include font-size(13, 16);
+
+    display: flex;
+    justify-content: flex-end;
+}
+
+
+
+.explainer-button {
+    @include fs-textSans(2);
+    @include button-colour(
+        $news-main-2,
+        #ffffff,
+        $news-main-1
+    );
+    display: inline-block;
+    vertical-align: top;
+    width: auto;
+    height: 2.25rem;
+    font-weight: bold;
+    text-decoration: none;
+    border-radius: 1000px;
+    box-sizing: border-box;
+
+    &:hover,
+    &:focus,
+    &:active {
+        text-decoration: none;
+    }
+
+    .i-left {
+        margin-right: 0;
+        float: left;
+    }
+    .i-right {
+        margin-left: 0;
+        float: right;
+    }
+
+    line-height: 2.375rem;
+}
+
+/** THEMING */
+
+.explainer-snippet--light {
+    background: #f1f1f1;
+    color: $neutral-1;
+
+    .explainer-snippet__label {
+        color: $news-support-2;
+    }
+
+    .explainer-snippet__handle {
+        background: $news-support-2;
+        color: #ffffff;
+
+        &:hover,
+        &:focus {
+            background-color: darken($news-support-2, 10%);
+        }
+    }
+
+    .explainer-snippet__body > p {
+        &::before {
+            background-color: $news-support-2;
+        }
+    }
+
+    .explainer-snippet__feedback .button {
+        background: $news-main-1;
+        color: #ffffff;
+
+        &:hover,
+        &:focus {
+            background: darken($news-main-1, 10%);
+        }
+    }
+
+    a {
+        color: $news-main-1;
+        border-bottom-color: $neutral-3;
+    }
+}

--- a/static/src/stylesheets/amp/atoms/_snippets.scss
+++ b/static/src/stylesheets/amp/atoms/_snippets.scss
@@ -1,0 +1,73 @@
+.explainer-snippet__image {
+    float: left;
+    margin-right: $gs-gutter / 2;
+
+    display: inline-block;
+    position: relative;
+    width: 33%;
+    height: 0;
+    overflow: hidden;
+    border-radius: 50%;
+    padding-top: 33%;
+}
+
+.explainer-snippet__image img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    object-fit: cover;
+}
+
+.explainer-snippet__item::before {
+    content: '';
+    display: flex;
+    width: 100px;
+    height: 0;
+    border-top: 1px dotted $neutral-3;
+}
+
+.explainer-snippet__heading {
+    font-size: 18px;
+    padding-top: 2px;
+}
+
+.explainer-snippet__event-date::before {
+    content: '';
+    width: 16px;
+    height: 16px;
+    border-radius: 100%;
+    float: left;
+    margin-left: -24px;
+    background-color: $news-main-2;
+}
+
+.explainer-snippet__event-date {
+    font-size: 16px;
+    line-height: 24px;
+}
+
+.explainer-snippet--timeline {
+    .explainer-snippet__body {
+        margin-left: 8px;
+        overflow: visible;
+    }
+
+    .explainer-snippet__item {
+        padding-left: 17px;
+        padding-bottom: 16px;
+
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    .explainer-snippet__item:not(:last-child) {
+        border-left: 1px solid rgba($neutral-3, .5);
+
+        .explainer-snippet__event-date::before {
+            margin-left: -25px;
+        }
+    }
+}

--- a/static/src/stylesheets/amp/atoms/_snippets.scss
+++ b/static/src/stylesheets/amp/atoms/_snippets.scss
@@ -11,13 +11,16 @@
     padding-top: 33%;
 }
 
-.explainer-snippet__image img {
+.explainer-snippet__image amp-img {
     width: 100%;
     height: 100%;
     position: absolute;
     top: 0;
     left: 0;
-    object-fit: cover;
+
+    img {
+        object-fit: cover;
+    }
 }
 
 .explainer-snippet__item::before {


### PR DESCRIPTION
## What does this change?
Adds support for snippet atoms in AMP. Currently they are not displayed.

For now I have largely copied the old explainer/snippet css into `/stylesheets/amp/atoms/`. However, in future we should be able to use the style provided by the atom-renderer library (integration of this is a WIP - see https://github.com/guardian/frontend/pull/17968).

TODO:
- [ ] Track interactions with ophan.

![picture 7](https://user-images.githubusercontent.com/1513454/31395773-73dbbdfa-add9-11e7-86d6-e8057766986d.png)
