### PR TITLE
Update Magento auth details (and use HTTPS).

### DIFF
--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -65,7 +65,7 @@ class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends Loggi
         consumerKey = ConsumerKey(consumerKey, consumerSecret),
         token = RequestToken(token, tokenSecret)
       ),
-      urlPrefix = s"http://$domain/$path"
+      urlPrefix = s"https://$domain/$path"
     )
   }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 46
+    val s3ConfigVersion = 47
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")

--- a/dev-build/app/controllers/commercial/magento/AccessTokenGenerator.scala
+++ b/dev-build/app/controllers/commercial/magento/AccessTokenGenerator.scala
@@ -18,9 +18,9 @@ class AccessTokenGenerator(val controllerComponents: ControllerComponents) exten
     authorizationPath <- Configuration.commercial.magento.authorizationPath
   } yield {
     OAuth(ServiceInfo(
-      requestTokenURL = s"http://$domain/oauth/initiate",
-      accessTokenURL = s"http://$domain/oauth/token",
-      authorizationURL = s"http://$domain/$authorizationPath",
+      requestTokenURL = s"https://$domain/oauth/initiate",
+      accessTokenURL = s"https://$domain/oauth/token",
+      authorizationURL = s"https://$domain/$authorizationPath",
       key = ConsumerKey(consumerKey, consumerSecret)),
       use10a = true)
   }


### PR DESCRIPTION
## What does this change?
Bumps the config up to version 47 in order to set new access keys for the Magento, also upgrades the links to HTTPS. 

## What is the value of this and can you measure success?
Magento works again, which is nice. We get cool little book inline components on our books articles!