### PR TITLE
Send UK engagement banner traffic to support.theguardian

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -502,4 +502,5 @@ export {
     makeABTest,
     defaultButtonTemplate,
     useSupportDomain,
+    selectBaseUrl,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -25,10 +25,7 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/templates/acquisitions-epic-testimonial-block';
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'commercial/modules/user-features';
-import {
-    useSupportDomain,
-    selectBaseUrl
-} from "./support-utilities";
+import { useSupportDomain, selectBaseUrl } from './support-utilities';
 
 type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
@@ -37,7 +34,6 @@ export type CtaUrls = {
     contributeUrl?: string,
     supportUrl?: string,
 };
-
 
 const membershipBaseURL = selectBaseUrl(
     'https://membership.theguardian.com/supporter'

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -25,6 +25,10 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/templates/acquisitions-epic-testimonial-block';
 import { shouldSeeReaderRevenue as userShouldSeeReaderRevenue } from 'commercial/modules/user-features';
+import {
+    useSupportDomain,
+    selectBaseUrl
+} from "./support-utilities";
 
 type EpicTemplate = (Variant, AcquisitionsEpicTemplateCopy) => string;
 
@@ -34,12 +38,6 @@ export type CtaUrls = {
     supportUrl?: string,
 };
 
-const supportBaseURL = 'https://support.theguardian.com/uk';
-const useSupportDomain = (): boolean =>
-    config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
-    geolocationGetSync() === 'GB';
-const selectBaseUrl = (defaultUrl: string): string =>
-    useSupportDomain() ? supportBaseURL : defaultUrl;
 
 const membershipBaseURL = selectBaseUrl(
     'https://membership.theguardian.com/supporter'
@@ -216,7 +214,7 @@ const makeABTestVariant = (
         }),
         supportCustomURL = null,
         supportURL = addTrackingCodesToUrl({
-            base: supportCustomURL || supportBaseURL,
+            base: supportCustomURL || selectBaseUrl(),
             componentType: parentTest.componentType,
             componentId: campaignCode,
             campaignCode,
@@ -501,6 +499,4 @@ export {
     getTestimonialBlock,
     makeABTest,
     defaultButtonTemplate,
-    useSupportDomain,
-    selectBaseUrl,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -16,6 +16,15 @@ import {
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
 
+const supportBaseURL = 'https://support.theguardian.com/uk';
+
+const useSupportDomain = (): boolean =>
+    config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
+    getGeoLocation() === 'GB';
+
+const getBaseUrl = (defaultUrl: string): string =>
+    useSupportDomain() ? supportBaseURL : defaultUrl;
+
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';
 
@@ -123,7 +132,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         : params.messageText;
 
     const linkUrl = addTrackingCodesToUrl({
-        base: params.linkUrl,
+        base: getBaseUrl(params.linkUrl),
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         componentId: params.campaignCode,
         campaignCode: params.campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -15,15 +15,7 @@ import {
     submitComponentEvent,
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
-
-const supportBaseURL = 'https://support.theguardian.com/uk';
-
-const useSupportDomain = (): boolean =>
-    config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
-    getGeoLocation() === 'GB';
-
-const getBaseUrl = (defaultUrl: string): string =>
-    useSupportDomain() ? supportBaseURL : defaultUrl;
+import { selectBaseUrl } from 'common/modules/commercial/contributions-utilities';
 
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';
@@ -132,7 +124,7 @@ const showBanner = (params: EngagementBannerParams): void => {
         : params.messageText;
 
     const linkUrl = addTrackingCodesToUrl({
-        base: getBaseUrl(params.linkUrl),
+        base: selectBaseUrl(params.linkUrl),
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         componentId: params.campaignCode,
         campaignCode: params.campaignCode,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -15,7 +15,10 @@ import {
     submitComponentEvent,
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
-import { selectBaseUrl, selectEngagementBannerButtonCaption } from 'common/modules/commercial/support-utilities';
+import {
+    selectBaseUrl,
+    selectEngagementBannerButtonCaption,
+} from 'common/modules/commercial/support-utilities';
 
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';
@@ -134,7 +137,9 @@ const showBanner = (params: EngagementBannerParams): void => {
                 : undefined,
     });
 
-    const buttonCaption = selectEngagementBannerButtonCaption(params.buttonCaption);
+    const buttonCaption = selectEngagementBannerButtonCaption(
+        params.buttonCaption
+    );
     const buttonSvg = inlineSvg('arrowWhiteRight');
     const renderedBanner = `
     <div id="site-message__message">

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -15,7 +15,7 @@ import {
     submitComponentEvent,
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
-import { selectBaseUrl } from 'common/modules/commercial/contributions-utilities';
+import { selectBaseUrl } from 'common/modules/commercial/support-utilities';
 
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -15,7 +15,7 @@ import {
     submitComponentEvent,
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
-import { selectBaseUrl } from 'common/modules/commercial/support-utilities';
+import { selectBaseUrl, selectEngagementBannerButtonCaption } from 'common/modules/commercial/support-utilities';
 
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';
@@ -134,7 +134,7 @@ const showBanner = (params: EngagementBannerParams): void => {
                 : undefined,
     });
 
-    const buttonCaption = params.buttonCaption;
+    const buttonCaption = selectEngagementBannerButtonCaption(params.buttonCaption);
     const buttonSvg = inlineSvg('arrowWhiteRight');
     const renderedBanner = `
     <div id="site-message__message">

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,0 +1,16 @@
+// @flow
+
+import config from 'lib/config';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+const supportBaseURL = 'https://support.theguardian.com/uk';
+const useSupportDomain = (): boolean =>
+    config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
+    geolocationGetSync() === 'GB';
+const selectBaseUrl = (defaultUrl: string = supportBaseURL): string =>
+    useSupportDomain() ? supportBaseURL : defaultUrl;
+
+export {
+    useSupportDomain,
+    selectBaseUrl,
+};

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -10,7 +10,4 @@ const useSupportDomain = (): boolean =>
 const selectBaseUrl = (defaultUrl: string = supportBaseURL): string =>
     useSupportDomain() ? supportBaseURL : defaultUrl;
 
-export {
-    useSupportDomain,
-    selectBaseUrl,
-};
+export { useSupportDomain, selectBaseUrl };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -4,10 +4,13 @@ import config from 'lib/config';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const supportBaseURL = 'https://support.theguardian.com/uk';
+const supportButtonCaption = 'Support the Guardian';
 const useSupportDomain = (): boolean =>
     config.get('switches.ukSupporterTrafficToNewSupportFrontend') &&
     geolocationGetSync() === 'GB';
 const selectBaseUrl = (defaultUrl: string = supportBaseURL): string =>
     useSupportDomain() ? supportBaseURL : defaultUrl;
+const selectEngagementBannerButtonCaption = (defaultCaption: string) =>
+    useSupportDomain() ? supportButtonCaption : defaultCaption;
 
-export { useSupportDomain, selectBaseUrl };
+export { useSupportDomain, selectBaseUrl, selectEngagementBannerButtonCaption };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -1,8 +1,5 @@
 // @flow
-import {
-    makeABTest,
-    useSupportDomain,
-} from 'common/modules/commercial/contributions-utilities';
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
 import $ from 'lib/$';
 import config from 'lib/config';
@@ -11,7 +8,7 @@ import { elementInView } from 'lib/element-inview';
 import fastdom from 'lib/fastdom-promise';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { liveblog as liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
-
+import { useSupportDomain } from 'common/modules/commercial/support-utilities';
 const pageId: string = config.get('page.pageId', '');
 
 let isAutoUpdateHandlerBound = false;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-liveblog.js
@@ -9,6 +9,7 @@ import fastdom from 'lib/fastdom-promise';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { liveblog as liveblogCopy } from 'common/modules/commercial/acquisitions-copy';
 import { useSupportDomain } from 'common/modules/commercial/support-utilities';
+
 const pageId: string = config.get('page.pageId', '');
 
 let isAutoUpdateHandlerBound = false;


### PR DESCRIPTION
## What does this change?
Follows up on changes made here: https://github.com/guardian/frontend/pull/17986

When the `uk-supporter-traffic-to-new-support-frontend` switch is ON and the reader is known to be UK-centric, we set the destination of traffic from the engagement banner to `support.theguardian.com`

## What is the value of this and can you measure success?
Getting ready to switch over everything. The switch remains OFF in PROD until we're all set.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
**Switch ON, user in GB**
![screen shot 2017-10-12 at 12 11 21](https://user-images.githubusercontent.com/690395/31494346-da8531ae-af4a-11e7-92a5-cbd7aa6744e2.png)

and re-checking the epic with the same configuration;
![screen shot 2017-10-12 at 12 12 01](https://user-images.githubusercontent.com/690395/31494359-e5d6cee6-af4a-11e7-9f4f-91f3ebb3884c.png)

and a liveblog epic, to be thorough;
![screen shot 2017-10-12 at 12 16 41](https://user-images.githubusercontent.com/690395/31494404-0d6a117a-af4b-11e7-9bc9-e817bfbb53e0.png)


**Switch ON, user in US**
![screen shot 2017-10-12 at 12 13 49](https://user-images.githubusercontent.com/690395/31494378-f4b870cc-af4a-11e7-9713-4d00345148f5.png)

**Switch OFF**
![screen shot 2017-10-12 at 12 20 27](https://user-images.githubusercontent.com/690395/31494468-4e1d6212-af4b-11e7-9dda-3cf3d40e2c9e.png)

**After updating the button caption**
Switch ON
![screen shot 2017-10-12 at 14 40 24](https://user-images.githubusercontent.com/690395/31499535-ff859c52-af5c-11e7-875c-c1507956846a.png)

Switch OFF
![screen shot 2017-10-12 at 14 41 38](https://user-images.githubusercontent.com/690395/31499562-093d6ffe-af5d-11e7-80df-b874a6ac815e.png)

(these were captured at a slightly narrow breakpoint, and the button and icons usually move around like this)

## Tested in CODE?
Yes

cc @rupertbates @Ap0c @svillafe @davidfurey 