### PR TITLE
Fix post delete lift-json serialization error

### DIFF
--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -8,7 +8,7 @@ import idapiclient.parser.{JodaJsonSerializer, JsonBodyParser}
 import net.liftweb.json.JsonAST.JValue
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
-import idapiclient.requests.{PasswordUpdate, TokenPassword}
+import idapiclient.requests.{DeletionBody, PasswordUpdate, TokenPassword}
 import play.api.libs.ws.WSClient
 
 class IdApiClient(
@@ -161,7 +161,6 @@ class IdApiClient(
   }
 
   def executeAccountDeletionStepFunction(userId: String, email: String, reason: Option[String], auth: Auth): Future[Response[AccountDeletionResult]] = {
-    case class DeletionBody(identityId: String, email: String, reason: Option[String])
     httpClient.POST(
         s"${conf.accountDeletionApiRoot}/delete",
         Some(write(DeletionBody(userId, email, reason))),

--- a/identity/app/idapiclient/requests/DeletionBody.scala
+++ b/identity/app/idapiclient/requests/DeletionBody.scala
@@ -1,0 +1,3 @@
+package idapiclient.requests
+
+case class DeletionBody(identityId: String, email: String, reason: Option[String])


### PR DESCRIPTION
## What does this change?

Moves `DeletionBody` case class outside `IdApiClient` class so that lift-json can pick it up.

## What is the value of this and can you measure success?

Fixes the following exception when posting to `/delete`:

```
scala.MatchError: (class akka.actor.BootstrapSetup,akka.actor.BootstrapSetup@44f78efa) (of class scala.Tuple2)
	at net.liftweb.json.Extraction$$anonfun$decompose$1.apply(Extraction.scala:82)
	at net.liftweb.json.Extraction$$anonfun$decompose$1.apply(Extraction.scala:82)
	...
	at net.liftweb.json.Serialization$.write(Serialization.scala:38)
	at idapiclient.IdApiClient.executeAccountDeletionStepFunction(IdApiClient.scala:167)
```
