### PR TITLE
Header, footer and Side Menu traffic for support

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,7 +1,7 @@
 package navigation
 
 import conf.Configuration
-import conf.switches.Switches
+import conf.switches.Switches.SupportFrontendActive
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
@@ -117,15 +117,15 @@ object UrlHelpers {
   def getContributionOrSupporterUrl(editionId: String)(implicit request: RequestHeader): String =
     if (editionId == "us") {
       getReaderRevenueUrl(Contribute, NewHeader)
-    } else if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+    } else if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
       getReaderRevenueUrl(Support, NewHeader)
     } else {
       getReaderRevenueUrl(Membership, NewHeader)
     }
 
   def getSupportOrMembershipUrl(position: Position)(implicit request: RequestHeader): String = {
-    val editionId = Edition (request).id.toLowerCase()
-    if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+    val editionId = Edition(request).id.toLowerCase()
+    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
       getReaderRevenueUrl (Support, position)
     } else {
       getReaderRevenueUrl (Membership, position)
@@ -134,7 +134,7 @@ object UrlHelpers {
 
   def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
-    if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
       getReaderRevenueUrl (Support, position)
     } else {
       getReaderRevenueUrl (Subscribe, position)

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,6 +1,7 @@
 package navigation
 
 import conf.Configuration
+import conf.switches.Switches
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
@@ -10,6 +11,9 @@ import ophan.thrift.event.AcquisitionSource
 object UrlHelpers {
   sealed trait ReaderRevenueSite {
     val url: String
+  }
+  case object Support extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/uk"
   }
   case object Membership extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.membershipUrl}/supporter"
@@ -113,9 +117,29 @@ object UrlHelpers {
   def getContributionOrSupporterUrl(editionId: String)(implicit request: RequestHeader): String =
     if (editionId == "us") {
       getReaderRevenueUrl(Contribute, NewHeader)
+    } else if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+      getReaderRevenueUrl(Support, NewHeader)
     } else {
       getReaderRevenueUrl(Membership, NewHeader)
     }
+
+  def getSupportOrMembershipUrl(position: Position)(implicit request: RequestHeader): String = {
+    val editionId = Edition (request).id.toLowerCase()
+    if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+      getReaderRevenueUrl (Support, position)
+    } else {
+      getReaderRevenueUrl (Membership, position)
+    }
+  }
+
+  def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
+    val editionId = Edition(request).id.toLowerCase()
+    if (editionId == "uk" && Switches.SupportFrontendActive.isSwitchedOn) {
+      getReaderRevenueUrl (Support, position)
+    } else {
+      getReaderRevenueUrl (Subscribe, position)
+    }
+  }
 
   object oldNav {
     def jobsUrl(edition: String)(implicit request: RequestHeader): String =

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -123,6 +123,7 @@ object UrlHelpers {
       getReaderRevenueUrl(Membership, NewHeader)
     }
 
+  // This methods can be reverted once we decide to deploy the new support site to the rest of the world.
   def getSupportOrMembershipUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
     if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -126,18 +126,18 @@ object UrlHelpers {
   def getSupportOrMembershipUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
     if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
-      getReaderRevenueUrl (Support, position)
+      getReaderRevenueUrl(Support, position)
     } else {
-      getReaderRevenueUrl (Membership, position)
+      getReaderRevenueUrl(Membership, position)
     }
   }
 
   def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
     if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
-      getReaderRevenueUrl (Support, position)
+      getReaderRevenueUrl(Support, position)
     } else {
-      getReaderRevenueUrl (Subscribe, position)
+      getReaderRevenueUrl(Subscribe, position)
     }
   }
 

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -133,6 +133,15 @@ object UrlHelpers {
     }
   }
 
+  def getSupportOrContribute(position: Position)(implicit request: RequestHeader): String = {
+    val editionId = Edition(request).id.toLowerCase()
+    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
+      getReaderRevenueUrl(Support, position)
+    } else {
+      getReaderRevenueUrl(Contribute, position)
+    }
+  }
+
   def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
     if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {

--- a/common/app/navigation/helpers/helpers.scala
+++ b/common/app/navigation/helpers/helpers.scala
@@ -16,8 +16,9 @@ object NavigationHelpers {
     val editionId = edition.id.toLowerCase()
 
     NavLinkLists(List(
-      NavLink("become a supporter", getReaderRevenueUrl(Membership, SideMenu)),
-      NavLink("subscribe", getReaderRevenueUrl(Subscribe, SideMenu))
+      // This methods can be reverted once we decide to deploy the new support site to the rest of the world.
+      NavLink("become a supporter", getSupportOrMembershipUrl(SideMenu)),
+      NavLink("subscribe", getSupportOrSubscriptionUrl(SideMenu))
     ))
   }
 

--- a/common/app/navigation/helpers/helpers.scala
+++ b/common/app/navigation/helpers/helpers.scala
@@ -7,7 +7,7 @@ import SectionLinks._
 import NewNavigation._
 import SubSectionLinks._
 import NavLinks._
-import UrlHelpers.{Membership, SideMenu, Subscribe, getReaderRevenueUrl}
+import UrlHelpers.{Membership, SideMenu, Subscribe, getReaderRevenueUrl, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl}
 import play.api.mvc.RequestHeader
 
 object NavigationHelpers {

--- a/common/app/navigation/helpers/helpers.scala
+++ b/common/app/navigation/helpers/helpers.scala
@@ -16,7 +16,6 @@ object NavigationHelpers {
     val editionId = edition.id.toLowerCase()
 
     NavLinkLists(List(
-      // This methods can be reverted once we decide to deploy the new support site to the rest of the world.
       NavLink("become a supporter", getSupportOrMembershipUrl(SideMenu)),
       NavLink("subscribe", getSupportOrSubscriptionUrl(SideMenu))
     ))

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 @import common.Edition
 @import common.LinkTo
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrContribute}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
 @import conf.switches.Switches.EmailInlineInFooterSwitch
@@ -91,10 +91,10 @@
                             <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
                                 dating</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
@@ -168,10 +168,10 @@
                             <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                                 jobs</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
@@ -242,10 +242,10 @@
 
                     case Au => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
@@ -323,10 +323,10 @@
 
                     case International => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 @import common.Edition
 @import common.LinkTo
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrContribute}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContribute}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
 @import conf.switches.Switches.EmailInlineInFooterSwitch
@@ -157,7 +157,7 @@
                             <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                                 Twitter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="@getReaderRevenueUrl(Subscribe, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="@getSupportOrSubscriptionUrl(Footer)">
                                 subscribe</a>
                             </li>
                         </ul>
@@ -168,10 +168,10 @@
                             <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                                 jobs</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
@@ -242,10 +242,10 @@
 
                     case Au => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
@@ -323,10 +323,10 @@
 
                     case International => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -2,7 +2,7 @@
 @import common.{Edition, LinkTo}
 @import conf.Configuration
 @import conf.switches.Switches._
-@import navigation.UrlHelpers.{Membership, OldHeader, Subscribe, getReaderRevenueUrl}
+@import navigation.UrlHelpers.{Membership, OldHeader, Subscribe, getReaderRevenueUrl, getSupportOrSubscriptionUrl, getSupportOrMembershipUrl}
 @import views.support.RenderClasses
 
 @* TODO: When implementing the desktop design, aim to consolidate the html *@
@@ -81,7 +81,7 @@
                                     hide-on-slim-header hide-on-tablet"
                             data-component="subscribe">
                             @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
-                            <a href="@getReaderRevenueUrl(Membership, OldHeader)"
+                            <a href="@getSupportOrMembershipUrl(OldHeader)"
                             data-link-name="Register link"
                             class="brand-bar__item--action brand-bar__item--split--first js-become-member">
                                 <span class="control__info js-control-info control__info--supporting">
@@ -89,7 +89,7 @@
                                 </span>
                             </a>
 
-                            <a href="@getReaderRevenueUrl(Subscribe, OldHeader)"
+                            <a href="@getSupportOrSubscriptionUrl(OldHeader)"
                                class="brand-bar__item--action brand-bar__item--split--last js-subscribe js-change-subscribe-link"
                                data-link-name="@Edition(request).id.toLowerCase : topNav : subscribe">
                                 <span class="control__info js-control-info">subscribe</span>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,7 +4,7 @@
 @import common.{LinkTo, Edition}
 @import views.support.RenderClasses
 @import navigation.{NewNavigation, NavigationHelpers}
-@import navigation.UrlHelpers.{getReaderRevenueUrl, getJobUrl, getContributionOrSupporterUrl, NewHeader, Subscribe}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, getJobUrl, getContributionOrSupporterUrl, NewHeader, Subscribe, getSupportOrSubscriptionUrl}
 
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> mvt.ABNewDesktopHeaderVariant.isParticipating,
@@ -48,7 +48,7 @@
                             <a class="header-cta-item hide-until-tablet header-cta-item--secondary js-change-subscribe-link"
                                 data-link-name="nav2 : subscribe-cta"
                                 data-edition="@{editionId}"
-                                href="@getReaderRevenueUrl(Subscribe, NewHeader)">
+                                href="@getSupportOrSubscriptionUrl(NewHeader)">
                                 <span class="header-cta-item__label">
                                     subscribe
                                 </span>


### PR DESCRIPTION
## What does this change?
We want to drive traffic to the news site, if and only if the switch is on and the reader is on the UK.

## What is the value of this and can you measure success?
N/A

## Does this affect other platforms - Amp, Apps, etc?
N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Tested in CODE?
Not yet
