### PR TITLE
Change button text and set single-button style when using support domain

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -13,7 +13,7 @@ export const epicButtonsTemplate = (
              Make a contribution
             </a>
         </div>`;
-    const supportButton = `
+    const supportButtonBecome = `
         <div>
             <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top"
               href="${membershipUrl}"
@@ -21,10 +21,18 @@ export const epicButtonsTemplate = (
               Become a supporter
             </a>
         </div>`;
+    const supportButtonSupport = `
+        <div>
+            <a class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-member-top contributions__contribute--epic-single-button"
+              href="${membershipUrl}"
+              target="_blank">
+              Support the Guardian
+            </a>
+        </div>`;
 
     return `
         <div class="contributions__amount-field">
-            ${supportButton}
+            ${!useSupportDomain ? supportButtonBecome : supportButtonSupport}
             ${!useSupportDomain ? contribButton : ''}
         </div>`;
 };


### PR DESCRIPTION
## What does this change?
Fixes the button text on epics when we're running on support.theguardian.com

## What is the value of this and can you measure success?
Keep the caption consistent with that used in test 4

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Screenshots
**Switch ON**
![screen shot 2017-10-12 at 14 17 26](https://user-images.githubusercontent.com/690395/31498002-ba53349a-af58-11e7-9f5d-f2dfb36a714a.png)

**Switch OFF**
![screen shot 2017-10-12 at 14 16 11](https://user-images.githubusercontent.com/690395/31497987-acc765bc-af58-11e7-8cbe-1d77a4d7089a.png)

## Tested in CODE?
No, tested locally.

cc @joelochlann @mandr8 @svillafe @Ap0c 