### PR TITLE
Use correct proximity-loader function name

### DIFF
--- a/static/src/javascripts-legacy/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts-legacy/projects/facia/modules/ui/snaps.js
@@ -146,7 +146,7 @@ define([
     }
 
     function initStandardSnap(el) {
-        proximityLoader.add(el, 1500, function () {
+        proximityLoader.addProximityLoader(el, 1500, function () {
             fastdom.write(function () {
                 bonzo(el).addClass('facia-snap-embed');
             });


### PR DESCRIPTION
## What does this change?

In #17908, after renaming `proximityLoader.add()` to `proximityLoader.addProximityLoader()` we missed one instance. This change fixes this omission 

## What is the value of this and can you measure success?

No broken facia snap initialisation. This should allow us to run thrashers locally.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
