### PR TITLE
Bind the onScroll method to the instance when passing to event handler.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
@@ -154,12 +154,13 @@ class FabricVideo {
             })
             .then(() => {
                 this.layer2 = qwery('.creative__layer2', this.adSlot);
+                const boundOnScroll = this.onScroll.bind(this);
 
-                addEventListener(window, 'scroll', this.onScroll, {
+                addEventListener(window, 'scroll', boundOnScroll, {
                     passive: true,
                 });
                 addEventListener(this.adSlot, 'animationend', () => {
-                    window.removeEventListener('scroll', this.onScroll);
+                    window.removeEventListener('scroll', boundOnScroll);
                 });
 
                 if (this.hasVideo) {


### PR DESCRIPTION
## What does this change?
Currently when the `onScroll` method is called by the `window` EventListeners, the `this` used in `onScroll` is bound to the window object, rather than the `FabricVideo` instance.

This change ensures that the `this` works correctly.

As a side note, we have to keep a reference to the bound function so that we can remove the event listener later on.

