### PR TITLE
Fix various pa11y contrast issues

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -54,6 +54,7 @@ $c-guardian-services-action: #ffffff;
 }
 
 .logo-wrapper {
+    color: #ffffff;
     position: relative;
     float: right;
     margin: $gs-baseline/4 $gs-gutter/2 $gs-baseline 0;

--- a/static/src/stylesheets/layout/footer/_old-footer.scss
+++ b/static/src/stylesheets/layout/footer/_old-footer.scss
@@ -4,6 +4,7 @@
  ************************************/
 
 .guardian-logo-footer {
+    color: #ffffff;
     margin-top: $gs-baseline * .75;
     float: right;
     line-height: 0;

--- a/static/src/stylesheets/pasteup/buttons/_styles.scss
+++ b/static/src/stylesheets/pasteup/buttons/_styles.scss
@@ -248,12 +248,12 @@ $show-more-icon-spacing: $base-size + 1;
 .button--syndication-reprint {
     @include button-colour(
         transparent,
-        $news-main-2,
-        $news-main-2
+        $news-support-6,
+        rgba($news-support-6, .3)
     );
 
     @include button-hover-colour(
         transparent,
-        darken($news-main-2, 10%)
+        darken($news-support-6, 10%)
     );
 }


### PR DESCRIPTION
## What does this change?

Fixes various colo(u)r-contrast issues reported by pa11y. The only visible change is the "Reuse this content" button at the end of articles. The change was confirmed with @zeftilldeath.

[Trello reference](https://trello.com/c/cObLS1LH/367-accessibility-bug-on-article-page-low-contrast)

Before:

<img width="546" alt="screen shot 2017-10-16 at 16 27 00" src="https://user-images.githubusercontent.com/2244375/31620325-dd940702-b28e-11e7-9a47-24d309fa827d.png">

After:

<img width="622" alt="screen shot 2017-10-16 at 16 23 29" src="https://user-images.githubusercontent.com/2244375/31620299-c8138452-b28e-11e7-9e7f-03f99ca1be20.png">

## What is the value of this and can you measure success?

More relieable PRbuild reports. Better accessibility.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

...

## Tested in CODE?

No.
