### PR TITLE
ArticleBody: Fix hairline between mainEmbed and content

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -72,7 +72,7 @@
 
                         @fragments.contentMeta(article, model, amp = amp)
 
-                        @if(article.tags.isNews && !article.elements.hasMainEmbed && article.elements.elements("main").isEmpty) {
+                        @if(article.tags.isNews && !article.elements.hasMainEmbed && (article.elements.elements("main") && article.elements.elements("main").isEmpty)) {
                             <hr class="content__hr hide-until-leftcol" />
                         }
 


### PR DESCRIPTION
## What does this change?

Fixes a bug, where a thin line appeared under the main embed, where it shouldn't.

Correct: http://theguardian.com/world/2017/jul/06/g20-police-and-demonstrators-clash-at-protest-in-hamburg

Incorrect: http://theguardian.com/politics/2017/jul/06/frictionless-trade-impossible-if-uk-leaves-eu-single-market-says-barnier

[Trello reference](https://trello.com/c/z3WRLQnN/554-a-thin-rule-under-main-media-atoms-on-dotcom).

## What is the value of this and can you measure success?

Proper layout.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

(Note: the youtube play icon difference is not connected to the changes)

Before

<img width="640" alt="screen shot 2017-10-16 at 17 43 44" src="https://user-images.githubusercontent.com/2244375/31624143-954c54ee-b299-11e7-917e-c41a64cf3231.png">


After

<img width="640" alt="screen shot 2017-10-16 at 17 43 15" src="https://user-images.githubusercontent.com/2244375/31624128-89c016b0-b299-11e7-81ac-34d9a6f868f1.png">


## Tested in CODE?

No.