### PR TITLE
Reinstate main content div

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -9,7 +9,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent, mainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -54,6 +54,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         content,
         footer(),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -10,7 +10,7 @@ import crosswords.{AccessibleCrosswordPage, CrosswordPage, CrosswordPageWithSvg,
 import views.html.fragments._
 import crosswords.{accessibleCrosswordContent, crosswordContent, crosswordSearch, printableCrosswordBody, crosswordNoResult}
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -50,6 +50,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         content,
         footer(),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -11,7 +11,7 @@ import views.IndexCleaner
 import views.html.all
 import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -48,6 +48,7 @@ object IndexHtml {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         bodyContent,
         footer(),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -8,7 +8,7 @@ import model.{ApplicationContext, Page}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -54,6 +54,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         interactiveBody(page),
         footer(),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -8,7 +8,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -51,6 +51,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         content,
         footer(),

--- a/applications/app/views/fragments/galleryTop.scala.html
+++ b/applications/app/views/fragments/galleryTop.scala.html
@@ -4,5 +4,6 @@
 
 <div class="immersive-header-container">
     @guardianHeaderHtml()
+    @fragments.page.body.mainContent()
     @fragments.immersiveGalleryMainMedia()
 </div>

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -10,7 +10,7 @@ import play.twirl.api.Html
 import views.html.fragments._
 import views.html.fragments.commercial.{pageSkin, survey}
 import views.html.fragments.page._
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent, twentyFourSevenTraining}
+import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 
@@ -52,6 +52,7 @@ object StoryHtmlPage {
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         survey() when SurveySwitch.isSwitchedOn,
         header,
+        mainContent(),
         breakingNewsDiv(),
         content,
         twentyFourSevenTraining(),

--- a/article/app/views/fragments/exploreHeader.scala.html
+++ b/article/app/views/fragments/exploreHeader.scala.html
@@ -9,6 +9,6 @@
     ("explore-video-container", page.item.content.elements.hasMainVideo)))">
 
     @guardianHeaderHtml()
-
+    @fragments.page.body.mainContent()
     @fragments.exploreSeries()
 </div>

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -27,16 +27,7 @@ object HtmlPageHelpers {
       commercial.topBanner() when showTop && showAds,
       header() when showTop
     )
-    if(model.Page.getContent(page).exists(_.tags.hasSuperStickyBanner))
-      stacked(
-        headerContent,
-        mainContent() when !page.metadata.shouldHideHeaderAndTopAds
-      )
-    else
-      stacked(
-      bannerAndHeaderDiv(headerContent),
-      mainContent() when !page.metadata.shouldHideHeaderAndTopAds
-    )
+    if(model.Page.getContent(page).exists(_.tags.hasSuperStickyBanner)) headerContent else bannerAndHeaderDiv(headerContent)
   }
 
   def defaultBodyClasses()(implicit page: model.Page, request: RequestHeader, applicationContext: ApplicationContext): Map[String, Boolean] = {

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -27,7 +27,16 @@ object HtmlPageHelpers {
       commercial.topBanner() when showTop && showAds,
       header() when showTop
     )
-    if(model.Page.getContent(page).exists(_.tags.hasSuperStickyBanner)) headerContent else bannerAndHeaderDiv(headerContent)
+    if(model.Page.getContent(page).exists(_.tags.hasSuperStickyBanner))
+      stacked(
+        headerContent,
+        mainContent() when !page.metadata.shouldHideHeaderAndTopAds
+      )
+    else
+      stacked(
+      bannerAndHeaderDiv(headerContent),
+      mainContent() when !page.metadata.shouldHideHeaderAndTopAds
+    )
   }
 
   def defaultBodyClasses()(implicit page: model.Page, request: RequestHeader, applicationContext: ApplicationContext): Map[String, Boolean] = {

--- a/common/app/views/fragments/page/body/mainContent.scala.html
+++ b/common/app/views/fragments/page/body/mainContent.scala.html
@@ -1,0 +1,1 @@
+<div id="maincontent" tabindex="0"></div>

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -8,7 +8,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments._
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -52,6 +52,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
         guardianHeaderHtml(),
+        mainContent(),
         breakingNewsDiv(),
         cleanedFrontBody(),
         footer(),


### PR DESCRIPTION
## What does this change?

Currently the div with [`id="maincontent"`](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html#L24) is not being displayed. It appears to have been omitted during the Great Template Fragment Extraction of 2017. This means the ["Skip to main content" link doesn't do anything](https://twitter.com/forzagaribaldi/status/919846654710370304), rendering our pages less accessible.

## What is the value of this and can you measure success?

Reinstates this div, so that clicking the "Skip to main content" link skips past the ads and header.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
