### PR TITLE
Fix flashing elements checkbox for iPads

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -3,12 +3,14 @@
 @import play.api.Mode.Dev
 
 try {
-    ((document, window) => {
+    (function(document, window) {
         if (typeof window.getComputedStyle !== 'function') {
             // Old browsers not supporting getComputedStyle most likely won't have adBlockers
             return;
         }
+
         var ad = document.createElement('div');
+
         ad.style.position = 'absolute';
         ad.style.left = '0';
         ad.style.top = '0';
@@ -19,17 +21,18 @@ try {
 
         // avoid a forced sync layout, and open door to more accurate detection
         // e.g. detecting network behaviour
-        window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(function() {
             document.body.appendChild(ad);
 
             // avoid a forced layout, and be sure the element has been added to the DOM
-            window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(function() {
                 var adBlockers = window.guardian.adBlockers;
                 var adStyles = window.getComputedStyle(ad);
 
                 // Due to an update to AdblockPlus we now need an extra check for adblock being used on Firefox as the sacrificial ad check does not work.
-                var displayProp = adStyles.getPropertyValue('display');
-                var mozBindingProp = adStyles.getPropertyValue('-moz-binding');
+                var displayProp = adStyles && adStyles.getPropertyValue('display');
+                var mozBindingProp = adStyles && adStyles.getPropertyValue('-moz-binding');
+
                 adBlockers.active = displayProp === 'none' || (mozBindingProp && mozBindingProp.indexOf('about:') !== -1);
 
                 // Run each listener


### PR DESCRIPTION
## What does this change?

ES5ifies the file, since it doesn't get transpiled and adds a check around a getter, to confirm `adStyles` exists.

[Trello reference](https://trello.com/c/I8X4AlJK/325-allow-flashing-elements-checkbox-does-not-appear-on-ipad)

## What is the value of this and can you measure success?

Checkbox works again on iPads.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.