### PR TITLE
Discussion: Fix duplicated comments, when using "show more replies"

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -78,7 +78,7 @@ class Comments extends Component {
             li.innerHTML = 'Loading…';
         }
 
-        const source = target.getAttribute('data-source-comment');
+        const source = bonzo(target).data('source-comment');
         const commentId = currentTarget.getAttribute('data-comment-id');
 
         if (commentId) {
@@ -250,13 +250,13 @@ class Comments extends Component {
         );
         this.comments = qwery(this.getClass('comment'), this.elem);
 
-        this.on(
-            'click',
-            this.getClass('showRepliesButton'),
-            this.getMoreReplies
+        this.on('click', this.getClass('showRepliesButton'), (event: Event) =>
+            this.getMoreReplies(event)
         );
 
-        this.on('click', this.getClass('commentReport'), this.reportComment);
+        this.on('click', this.getClass('commentReport'), (event: Event) =>
+            this.reportComment(event)
+        );
 
         if (shouldMakeTimestampsRelative()) {
             window.setInterval(() => this.relativeDates(), 60000);


### PR DESCRIPTION
## What does this change?

In the [ES6 conversion](https://github.com/guardian/frontend/pull/17973) a bug was introduced, which lead to duplicated comment threads, once a user clicked "show more replies". This PR fixes the problem, by using bonzo again to access the data attribute.

## What is the value of this and can you measure success?

Proper discussion threads.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.