### PR TITLE
Add campaign codes for support links

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -60,6 +60,10 @@ object UrlHelpers {
       case (Subscribe, SlimHeaderDropdown, _) => Some(s"NGW_TOPNAV_${editionId}_GU_SUBSCRIBE")
       case (Subscribe, Footer, _) => Some(s"NGW_FOOTER_${editionId}_GU_SUBSCRIBE")
 
+      case (Support, Footer, _) => Some("gdnwb_copts_memco_dotcom_footer")
+      case (Support, AmpHeader, _) => Some("gdnwb_copts_memco_header_amp")
+      case (Support, _, _) => Some("gdnwb_copts_memco_header")
+
       case (_, _, _) => None
     }
   }


### PR DESCRIPTION
We were missing campaign codes for header/footer links since switching to the S&C site. This doesn't actually matter for contributions since we're tracking those in the new Acquisitions table with all the info we used to put into the campaign code encoded in other fields. But subs aren't yet in the acquisitions table so we still need the campaign code for tracking