### PR TITLE
Bump config for magento.domain

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -67,7 +67,7 @@ object GuardianConfiguration extends Logging {
   lazy val configuration = {
     // This is version number of the config file we read from s3,
     // increment this if you publish a new version of config
-    val s3ConfigVersion = 48
+    val s3ConfigVersion = 49
 
     lazy val userPrivate = FileConfigurationSource(s"${System.getProperty("user.home")}/.gu/frontend.conf")
     lazy val runtimeOnly = FileConfigurationSource("/etc/gu/frontend.conf")


### PR DESCRIPTION
## What does this change?

This bumps the configuration from `48` to `49`, which contains the change for the key in `DEV` and `CODE/PROD` for `magento.domain` from `guardianbookshop.com` to `www.guardianbookshop.com`.

The reason for this change is that the site operates off of `www`; but when we reference a feed on the site without the `www` prefix, we get directed to the root of the site without the path we originally requested.

Auth works on both `www` and without `www`.

@JonNorman 