### PR TITLE
Import relativedates named export

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -17,7 +17,7 @@ import {
 } from 'common/modules/discussion/api';
 import { CommentBox } from 'common/modules/discussion/comment-box';
 import { WholeDiscussion } from 'common/modules/discussion/whole-discussion';
-import relativedates from 'common/modules/ui/relativedates';
+import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import userPrefs from 'common/modules/user-prefs';
 import { inlineSvg } from 'common/views/svgs';
 
@@ -549,7 +549,7 @@ class Comments extends Component {
     // eslint-disable-next-line class-methods-use-this
     relativeDates(): void {
         if (shouldMakeTimestampsRelative()) {
-            relativedates.init();
+            initRelativeDates();
         }
     }
 


### PR DESCRIPTION
## What does this change?

`discussion/comments.js` is erroneously importing the `realtivedates` default object. This change imports the named `init` method instead.

## What is the value of this and can you measure success?

Fixes everything

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
