### PR TITLE
Track more referrals to paid content

### DIFF
--- a/common/app/views/fragments/commercial/cards/itemLargeCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemLargeCard.scala.html
@@ -17,7 +17,8 @@
 <div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a class="@CssClassBuilder.linkFromLargeCard(item, optAdvertClassNames, useCardBranding)"
         href="@item.targetUrl"
-        data-link-name="@omnitureId">
+        data-link-name="@omnitureId"
+        data-component="@omnitureId">
         <div class="advert__text">
             <h2 class="advert__title">
                 @for(icon <- item.icon){@inlineSvg(icon, "icon")}

--- a/common/app/views/fragments/commercial/cards/itemSmallCard.scala.html
+++ b/common/app/views/fragments/commercial/cards/itemSmallCard.scala.html
@@ -11,7 +11,8 @@
 <div class="@CssClassBuilder.paidForContainer(optClassNames)">
     <a href="@item.targetUrl"
         class="@CssClassBuilder.linkFromSmallCard(item, optAdvertClassNames, useCardBranding)"
-        data-link-name="@omnitureId">
+        data-link-name="@omnitureId"
+        data-component="@omnitureId">
         <p class="advert__title">
             @for(icon <- item.icon){@inlineSvg(icon, "icon")}
             @item.headline

--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -18,7 +18,12 @@
     ){
         @containerModel.content.targetUrl match {
             case None => { <span tabindex="0">@containerModel.content.title</span> }
-            case Some(href) => { <a class="adverts__logo u-text-hyphenate" href="/@href">@containerModel.content.title</a> }
+            case Some(href) => {
+                <a
+                class="adverts__logo u-text-hyphenate"
+                href="/@href"
+                data-component="@mkInteractionTrackingCode(frontId, containerIndex,containerModel)">@containerModel.content.title</a>
+            }
         }
     }{
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -240,6 +240,24 @@ object Commercial {
     def mkInteractionTrackingCode(
       frontId: String,
       containerIndex: Int,
+      container: ContainerModel
+    )(implicit request: RequestHeader): String = mkString(
+      containerType = "Labs front container",
+      editionId = Edition(request).id,
+      frontId = frontId,
+      containerIndex = containerIndex,
+      containerTitle = container.content.title,
+      sponsorName = {
+        val containerSponsorName = container.branding collect { case b: Branding => b.sponsorName }
+        containerSponsorName getOrElse ""
+      },
+      cardIndex = -1,
+      cardTitle = container.content.title
+    )
+
+    def mkInteractionTrackingCode(
+      frontId: String,
+      containerIndex: Int,
       container: ContainerModel,
       card: PaidCard
     )(implicit request: RequestHeader): String =


### PR DESCRIPTION
This adds data-component attributes to more cards and containers, which will tell us more about the origin of traffic to paid campaigns.
