### PR TITLE
Fix: pass content type value as config.page.contentType

### DIFF
--- a/common/app/common/commercial/hosted/HostedMetadata.scala
+++ b/common/app/common/commercial/hosted/HostedMetadata.scala
@@ -29,7 +29,7 @@ object HostedMetadata {
       url = Some(s"/${item.id}"),
       description = Some(description),
       contentType = contentType,
-      iosType = Some(contentType.toString),
+      iosType = contentType.map(_.name),
       isHosted = true,
       commercial = Some(CommercialProperties.fromContent(item)),
       javascriptConfigOverrides = Map(

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -263,7 +263,7 @@ final case class MetaData (
     ("buildNumber", JsString(buildNumber)),
     ("revisionNumber", JsString(revision)),
     ("isFront", JsBoolean(isFront)),
-    ("contentType", JsString(contentType.toString))
+    ("contentType", JsString(contentType.map(_.name).getOrElse("")))
   )
 
   def opengraphProperties: Map[String, String] = {


### PR DESCRIPTION
## What does this change?
pass content type value as config.page.contentType and not the Optional content type itself

## What is the value of this and can you measure success?
Fixing comments not loading

## Tested in CODE?
No