### PR TITLE
Fix Option comparison for metadata.contentType

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -75,7 +75,7 @@ final case class Content(
   lazy val shortUrlId = fields.shortUrlId
   lazy val shortUrlPath = shortUrlId
   lazy val discussionId = Some(shortUrlId)
-  lazy val isGallery = metadata.contentType == DotcomContentType.Gallery
+  lazy val isGallery = metadata.contentType.exists(c => c == DotcomContentType.Gallery)
   lazy val isExplore = ExploreTemplateSwitch.isSwitchedOn && tags.isExploreSeries
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isExplore || isPhotoEssay
@@ -273,8 +273,7 @@ final case class Content(
     val canDisableStickyTopBanner =
       metadata.shouldHideHeaderAndTopAds ||
       isPaidContent ||
-      metadata.contentType == DotcomContentType.Interactive ||
-      metadata.contentType == DotcomContentType.Crossword
+      metadata.contentType.exists(c => c == DotcomContentType.Interactive || c == DotcomContentType.Crossword)
 
     // These conditions must always disable sticky banner.
     val alwaysDisableStickyTopBanner =

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -246,8 +246,7 @@ final case class MetaData (
   val hasSlimHeader: Boolean =
     contentWithSlimHeader ||
       sectionId == "identity" ||
-      contentType == DotcomContentType.Survey ||
-      contentType == DotcomContentType.Signup
+      contentType.exists(c => c == DotcomContentType.Survey || c == DotcomContentType.Signup)
 
   // this is here so it can be included in analytics.
   // Basically it helps us understand the impact of changes and needs

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -28,9 +28,11 @@
 // Ophan pageview ID and browser ID are needed by Google Analytics, which runs just after this script tag
 @InlineJs(ophanConfig().body, "ophanConfig.js")
 
-@if(page.metadata.contentType == DotcomContentType.Article ||
-    page.metadata.contentType == DotcomContentType.LiveBlog ||
-    page.metadata.contentType == DotcomContentType.Interactive
+@if(page.metadata.contentType.exists { c =>
+        c == DotcomContentType.Article ||
+        c == DotcomContentType.LiveBlog ||
+        c == DotcomContentType.Interactive
+    }
 ) {
     // provide CURL for interactives ASAP, and in perpetuity.
     // this config may or may not be needed. but it has been present


### PR DESCRIPTION
## What does this change?

Previously we were directly comparing an `Option(DotcomContentType)` to a `DotcomContentType`, which was always evaluating to `false`. This fix ensures we compare apples to apples.

## What is the value of this and can you measure success?

Fixes interactive iframes, and probably other things

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
