### PR TITLE
Header, new header, footer and side menu traffic for the new support US page

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -476,13 +476,23 @@ trait FeatureSwitches {
   )
 
   // Owner: Simple & Coherent
-  val SupportFrontendActive = Switch(
+  val UkSupportFrontendActive = Switch(
     SwitchGroup.Feature,
     "uk-supporter-traffic-to-new-support-frontend",
     "When ON, all UK membership/contribute/support links send traffic to support.theguardian.com",
     owners = Seq(Owner.withGithub("justinpinner")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 10, 17),
+    exposeClientSide = true
+  )
+
+  val UsSupportFrontendActive = Switch(
+    SwitchGroup.Feature,
+    "us-supporter-traffic-to-new-support-frontend",
+    "When ON, all US membership/contribute/support links send traffic to support.theguardian.com",
+    owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2018, 10, 17),
     exposeClientSide = true
   )
 }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,7 +1,7 @@
 package navigation
 
 import conf.Configuration
-import conf.switches.Switches.SupportFrontendActive
+import conf.switches.Switches.{UkSupportFrontendActive, UsSupportFrontendActive}
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
@@ -17,6 +17,9 @@ object UrlHelpers {
   }
   case object Membership extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.membershipUrl}/supporter"
+  }
+  case object SupportUsContribute extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/us/contribute"
   }
   case object Contribute extends ReaderRevenueSite {
     val url: String = Configuration.id.contributeUrl
@@ -118,37 +121,31 @@ object UrlHelpers {
       s"https://jobs.theguardian.com?INTCMP=jobs_${editionId}_web_newheader"
     }
 
-  def getContributionOrSupporterUrl(editionId: String)(implicit request: RequestHeader): String =
-    if (editionId == "us") {
-      getReaderRevenueUrl(Contribute, NewHeader)
-    } else if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
-      getReaderRevenueUrl(Support, NewHeader)
-    } else {
-      getReaderRevenueUrl(Membership, NewHeader)
+  def countryUrlLogic(editionId: String, position: Position, defaultDestination: ReaderRevenueSite)(implicit request: RequestHeader): String =
+    editionId match {
+      case "us" if UsSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(SupportUsContribute, position)
+      case "us" if !UsSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(Contribute, position)
+      case "uk" if UkSupportFrontendActive.isSwitchedOn => getReaderRevenueUrl(Support, position)
+      case _ => getReaderRevenueUrl(defaultDestination, position)
     }
+
+  def getContributionOrSupporterUrl(editionId: String)(implicit request: RequestHeader): String =
+    countryUrlLogic(editionId, NewHeader, Membership)
 
   // This methods can be reverted once we decide to deploy the new support site to the rest of the world.
   def getSupportOrMembershipUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
-    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
-      getReaderRevenueUrl(Support, position)
-    } else {
-      getReaderRevenueUrl(Membership, position)
-    }
+    countryUrlLogic(editionId, position, Membership)
   }
 
   def getSupportOrContribute(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
-    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
-      getReaderRevenueUrl(Support, position)
-    } else {
-      getReaderRevenueUrl(Contribute, position)
-    }
+    countryUrlLogic(editionId, position, Contribute)
   }
 
   def getSupportOrSubscriptionUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
-    if (editionId == "uk" && SupportFrontendActive.isSwitchedOn) {
+    if (editionId == "uk" && UkSupportFrontendActive.isSwitchedOn) {
       getReaderRevenueUrl(Support, position)
     } else {
       getReaderRevenueUrl(Subscribe, position)

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -168,10 +168,10 @@
                             <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                                 jobs</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">


### PR DESCRIPTION
## What does this change?
Change the traffic for the US to the new support site

## What is the value of this and can you measure success?
N/A
## Does this affect other platforms - Amp, Apps, etc?
N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
N/A

## Tested in CODE?
Not yet
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
