### PR TITLE
Fix DotcomContentType equal comparison

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -145,10 +145,10 @@ object TrailsToRss extends implicits.Collections {
         .distinctBy(faciaContent => faciaContent.properties.maybeContentId.getOrElse(faciaContent.card.id))
         .flatMap(_.properties.maybeContent)
 
-    val webTitle = if (pressedPage.metadata.contentType != DotcomContentType.NetworkFront) {
-      s"${pressedPage.metadata.webTitle} | The Guardian"
-    } else {
+    val webTitle = if(pressedPage.metadata.contentType.contains(DotcomContentType.NetworkFront)) {
       "The Guardian"
+    } else {
+      s"${pressedPage.metadata.webTitle} | The Guardian"
     }
 
     fromFaciaContent(webTitle, faciaContentList, pressedPage.metadata.url, pressedPage.metadata.description)

--- a/common/app/model/DotcomContentType.scala
+++ b/common/app/model/DotcomContentType.scala
@@ -27,22 +27,22 @@ sealed trait DotcomContentType {
 }
 object DotcomContentType {
 
-  case object Unknown extends DotcomContentType { override val name = "Unknown" }
-  case object Article extends DotcomContentType { override val name = "Article" }
-  case object NetworkFront extends DotcomContentType { override val name = "Network Front" }
-  case object Section extends DotcomContentType { override val name = "Section" }
-  case object ImageContent extends DotcomContentType { override val name = "ImageContent" }
-  case object Interactive extends DotcomContentType { override val name = "Interactive" }
-  case object Gallery extends DotcomContentType { override val name = "Gallery" }
-  case object Video extends DotcomContentType { override val name = "Video" }
-  case object Audio extends DotcomContentType { override val name = "Audio" }
-  case object LiveBlog extends DotcomContentType { override val name = "LiveBlog" }
-  case object Tag extends DotcomContentType { override val name = "Tag" }
-  case object TagIndex extends DotcomContentType { override val name = "Index" }
-  case object Crossword extends DotcomContentType { override val name = "Crossword" }
-  case object Survey extends DotcomContentType { override val name = "Survey" }
-  case object Signup extends DotcomContentType { override val name = "Signup" }
-  case object Identity extends DotcomContentType { override val name = "userid" }
+  object Unknown extends DotcomContentType { override val name = "Unknown" }
+  object Article extends DotcomContentType { override val name = "Article" }
+  object NetworkFront extends DotcomContentType { override val name = "Network Front" }
+  object Section extends DotcomContentType { override val name = "Section" }
+  object ImageContent extends DotcomContentType { override val name = "ImageContent" }
+  object Interactive extends DotcomContentType { override val name = "Interactive" }
+  object Gallery extends DotcomContentType { override val name = "Gallery" }
+  object Video extends DotcomContentType { override val name = "Video" }
+  object Audio extends DotcomContentType { override val name = "Audio" }
+  object LiveBlog extends DotcomContentType { override val name = "LiveBlog" }
+  object Tag extends DotcomContentType { override val name = "Tag" }
+  object TagIndex extends DotcomContentType { override val name = "Index" }
+  object Crossword extends DotcomContentType { override val name = "Crossword" }
+  object Survey extends DotcomContentType { override val name = "Survey" }
+  object Signup extends DotcomContentType { override val name = "Signup" }
+  object Identity extends DotcomContentType { override val name = "userid" }
 
   implicit val format: Format[DotcomContentType] = new Format[DotcomContentType] {
     override def reads(json: JsValue): JsResult[DotcomContentType] = json match {

--- a/common/app/model/Pillars.scala
+++ b/common/app/model/Pillars.scala
@@ -7,11 +7,11 @@ sealed trait Pillar {
 }
 object Pillar {
 
-  case object News extends Pillar { override val name = "News" }
-  case object Opinion extends Pillar { override val name = "Opinion" }
-  case object Sport extends Pillar { override val name = "Sport" }
-  case object Arts extends Pillar { override val name = "Arts" }
-  case object Lifestyle extends Pillar { override val name = "Lifestyle" }
+  object News extends Pillar { override val name = "News" }
+  object Opinion extends Pillar { override val name = "Opinion" }
+  object Sport extends Pillar { override val name = "Sport" }
+  object Arts extends Pillar { override val name = "Arts" }
+  object Lifestyle extends Pillar { override val name = "Lifestyle" }
 
   implicit val format: Format[Pillar] = new Format[Pillar] {
     override def reads(json: JsValue): JsResult[Pillar] = json match {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -75,7 +75,7 @@ final case class Content(
   lazy val shortUrlId = fields.shortUrlId
   lazy val shortUrlPath = shortUrlId
   lazy val discussionId = Some(shortUrlId)
-  lazy val isGallery = metadata.contentType.exists(c => c == DotcomContentType.Gallery)
+  lazy val isGallery = metadata.contentType.contains(DotcomContentType.Gallery)
   lazy val isExplore = ExploreTemplateSwitch.isSwitchedOn && tags.isExploreSeries
   lazy val isPhotoEssay = fields.displayHint.contains("photoEssay")
   lazy val isImmersive = fields.displayHint.contains("immersive") || isGallery || tags.isTheMinuteArticle || isExplore || isPhotoEssay
@@ -96,7 +96,7 @@ final case class Content(
   lazy val hasTonalHeaderByline: Boolean = {
     (cardStyle == Comment || cardStyle == Editorial || (cardStyle == SpecialReport && tags.isComment)) &&
       hasSingleContributor &&
-      metadata.contentType != DotcomContentType.ImageContent
+      !metadata.contentType.contains(DotcomContentType.ImageContent)
   }
 
   lazy val hasBeenModified: Boolean =

--- a/common/app/views/fragments/amp/customStyles.scala.html
+++ b/common/app/views/fragments/amp/customStyles.scala.html
@@ -17,7 +17,7 @@
     @if(page.metadata.isHosted) {
         @Html(common.Assets.css.hostedAmp)
     } else {
-        @if(page.metadata.contentType == model.DotcomContentType.LiveBlog) {
+        @if(page.metadata.contentType.contains(model.DotcomContentType.LiveBlog)) {
             @Html(common.Assets.css.liveblogAmp)
         } else {
             @Html(common.Assets.css.amp)
@@ -34,7 +34,7 @@
     @if(page.metadata.isHosted) {
         <link rel="stylesheet" id="head-css" data-reload="head.hosted-amp" type="text/css" href="@Static("stylesheets/head.hosted-amp.css")" />
     } else {
-        @if(page.metadata.contentType == model.DotcomContentType.LiveBlog){
+        @if(page.metadata.contentType.contains(model.DotcomContentType.LiveBlog)){
             <link rel="stylesheet" id="head-css" data-reload="head.amp-liveblog" type="text/css" href="@Static("stylesheets/head.amp-liveblog.css")" />
         } else {
             <link rel="stylesheet" id="head-css" data-reload="head.amp" type="text/css" href="@Static("stylesheets/head.amp.css")" />


### PR DESCRIPTION
```
case object A
Option(something) == A
```
Code above doesn't lead to compilation warning
This commit fixes issues with DotcomContentType equality as well as make
case object for Pillars and DotcomContentType simple object until I
figure out why the behavior described above happens

## What is the value of this and can you measure success?
Fixing bug in production

## Tested in CODE?
No
