### PR TITLE
Fix to remove Snippet & Explainer styling from AMP liveblogs

### DIFF
--- a/static/src/stylesheets/_head.amp-common.scss
+++ b/static/src/stylesheets/_head.amp-common.scss
@@ -31,6 +31,3 @@
 @import 'module/_icons.head';
 @import 'module/_rounded-icon';
 @import 'module/_main-media-captions';
-
-@import 'amp/atoms/_explainers';
-@import 'amp/atoms/_snippets';

--- a/static/src/stylesheets/head.amp.scss
+++ b/static/src/stylesheets/head.amp.scss
@@ -1,3 +1,6 @@
 @import 'head.amp-common';
 
 @import 'amp/_article-tones';
+@import 'amp/atoms/_explainers';
+@import 'amp/atoms/_snippets';
+


### PR DESCRIPTION
## What does this change?
Removes explainers and snippets from AMP liveblogs to not hit `css` edge.

@NataliaLKB 