### PR TITLE
Update native style behaviour

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -20,20 +20,15 @@ const onLoad = (event: SlotOnloadEvent) => {
     if (!advert) {
         return;
     }
-    if (
-        advert.size &&
-        ((typeof advert.size === 'string' && advert.size === 'fluid') ||
-            (advert.size[0] === 0 && advert.size[1] === 0))
-    ) {
-        const iframe = advert.node.getElementsByTagName('iframe')[0];
-        postMessage(
-            {
-                id: iframe.id,
-                host,
-            },
-            iframe.contentWindow
-        );
-    }
+
+    const iframe = advert.node.getElementsByTagName('iframe')[0];
+    postMessage(
+        {
+            id: iframe.id,
+            host,
+        },
+        iframe.contentWindow
+    );
 };
 
 export default onLoad;

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -62,9 +62,22 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
     backgroundParent.appendChild(background);
 
     if (specs.scrollType === 'fixed') {
-        return fastdom.write(() => {
-            adSlot.insertBefore(backgroundParent, adSlot.firstChild);
-        });
+        return fastdom
+            .read(() => {
+                if (adSlot instanceof Element) {
+                    return adSlot.getBoundingClientRect();
+                }
+            })
+            .then(rect =>
+                fastdom.write(() => {
+                    if (rect) {
+                        background.style.left = `${rect.left}px`;
+                        background.style.right = `${rect.right}px`;
+                        background.style.width = `${rect.width}px`;
+                    }
+                    adSlot.insertBefore(backgroundParent, adSlot.firstChild);
+                })
+            );
     }
     let updateQueued = false;
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -207,9 +207,11 @@
     @include mq(tablet) {
         width: auto;
     }
-    .ad-slot__label {
-        background-color: transparent;
-    }
+}
+
+.ad-slot--liveblog-inline,
+.ad-slot--gallery-inline {
+    background-color: transparent;
 }
 
 .ad-slot--container-inline,


### PR DESCRIPTION
## What does this change?
1. Currently whenever an ad is rendered, if it is of size "fluid" then we post a message to it containing the id of the iframe for use by native styles (which are typically fluid). However, native styles can be of any size, so we should send the message to all ads regardless of size.

2. Adds some of the positioning of the ad slot to the background layer for a native ad. This secures the same behaviour for mobile-revealer templates (which are until now the only user of this `setBackground` callback) and for parallax MPUs that can appear anywhere in the page.

3. Keeps the transparency of the Advertisement label only on Liveblogs. Most of the time the label will have it's own grey colour that should be honoured.