### PR TITLE
Revert "Comment out failing amp validation tests"

### DIFF
--- a/article/test/ArticleAmpValidityTest.scala
+++ b/article/test/ArticleAmpValidityTest.scala
@@ -14,8 +14,8 @@ import org.scalatest.DoNotDiscover
     "/commentisfree/2016/aug/09/jeremy-corbyn-supporters-voters-labour-leader-politics", // Comment tone
     "/books/2011/aug/24/jorge-luis-borges-google-doodle", // More on this story
     "/uk-news/2016/aug/09/southern-rail-strike-war-of-words-heats-up-on-second-day", // Story package / tone news
-    "/football/2016/jul/10/france-portugal-euro-2016-match-report" // Match summary
-//    "/us-news/live/2016/aug/12/donald-trump-republicans-hillary-clinton-us-election-live", // Live blog
-//    "/sport/live/2016/aug/20/rio-2016-olympics-day-15-mo-farah-relays-tom-daley-nicola-adams-football-live" // Sport live blog
+    "/football/2016/jul/10/france-portugal-euro-2016-match-report", // Match summary
+    "/us-news/live/2016/aug/12/donald-trump-republicans-hillary-clinton-us-election-live", // Live blog
+    "/sport/live/2016/aug/20/rio-2016-olympics-day-15-mo-farah-relays-tom-daley-nicola-adams-football-live" // Sport live blog
   ).foreach(testAmpPageValidity)
 }


### PR DESCRIPTION
Reverts guardian/frontend#18033

AMP validation should work now so we can restore these tests.

@guardian/dotcom-platform 