### PR TITLE
Desktop Header: signup dropdown

### DIFF
--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -20,7 +20,7 @@
             id="edition-picker-toggle"
             aria-controls="edition-dropdown-menu"
             class="u-h dropdown-menu-fallback js-enhance-checkbox"
-            data-link-name="nav2 : topnav : edition-picker: toggle">
+            data-link-name="nav2 : topbar : edition-picker: toggle">
 
     <ul class="dropdown-menu js-edition-dropdown-menu"
         id="edition-dropdown-menu"

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -13,6 +13,7 @@
 
     <button class="u-h js-user-account-trigger"
         id="my-account-toggle"
+        name="user account toggle"
         data-link-name="nav2 : topbar: my account"
         aria-expanded="false"
         aria-controls="my-account-dropdown"></button>

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -1,0 +1,71 @@
+@()(implicit request: RequestHeader)
+
+@import conf.Configuration
+
+<div class="new-header__user-account-container hide-until-desktop">
+
+    <a class="top-bar__item hide-until-desktop js-navigation-sign-in"
+        data-link-name="nav2 : topbar : signin"
+        href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN">
+
+        sign in
+    </a>
+
+    <button class="u-h js-user-account-trigger"
+        id="my-account-toggle"
+        data-link-name="nav2 : topbar: my account"
+        aria-expanded="false"
+        aria-controls="my-account-dropdown"></button>
+
+    <label class="top-bar__item top-bar__item--dropdown u-h js-navigation-account-actions"
+        for="my-account-toggle"
+        data-link-name="nav2 : topbar: my account">
+
+        my account
+    </label>
+
+    <ul class="dropdown-menu js-user-account-dropdown-menu"
+        id="my-account-dropdown"
+        aria-hidden="true">
+
+        <li class="dropdown-menu__item u-h js-show-comment-activity">
+            <a data-link-name="nav2 : topbar : comment activity"
+                class="dropdown-menu__title js-add-comment-activity-link">
+
+                Comment activity
+            </a>
+        </li>
+        <li class="dropdown-menu__item">
+            <a href="@Configuration.id.url/public/edit"
+                data-link-name="nav2 : topbar : edit profile"
+                class="dropdown-menu__title">
+
+                Edit profile
+            </a>
+        </li>
+        <li class="dropdown-menu__item">
+            <a href="@Configuration.id.url/email-prefs"
+                data-link-name="nav2 : topbar : email preferences"
+                class="dropdown-menu__title">
+
+                Email preferences
+            </a>
+        </li>
+        <li class="dropdown-menu__item">
+            <a href="@Configuration.id.url/password/change"
+                data-link-name="nav2 : topbar : change password"
+                class="dropdown-menu__title">
+
+                Change password
+            </a>
+        </li>
+        <li class="dropdown-menu__item">
+            <a href="@Configuration.id.url/signout"
+                data-link-name="nav2 : topbar : sign out"
+                class="dropdown-menu__title">
+
+                Sign out
+            </a>
+        </li>
+    </ul>
+</div>

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -4,23 +4,12 @@
 @import conf.switches.Switches.IdentityProfileNavigationSwitch
 
 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-    <li class="menu-item js-navigation-sign-in">
+    <li class="menu-item js-navigation-sign-in hide-on-desktop">
         <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN"
            data-link-name="nav2 : sign in"
            class="menu-item__title">
             Sign in/up
         </a>
-    </li>
-
-    <li class="menu-item menu-item--user-detail u-h hide-until-desktop js-navigation-account-details">
-        <div class="menu-user">
-            @fragments.inlineSvg("profile", "icon", List("menu-user__avatar-fallback", "js-navigation-account-avatar-fallback"))
-
-            <img src=""
-                 class="menu-user__avatar u-h js-navigation-account-avatar" alt="user avatar"/>
-
-            <p class="menu-user__name js-navigation-account-username"></p>
-        </div>
     </li>
 
     <li class="menu-item menu-item--membership u-h js-navigation-account-actions">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -1,10 +1,10 @@
 @(page: model.Page)(implicit request: RequestHeader)
 
-@import conf.Configuration
 @import common.{LinkTo, Edition}
 @import views.support.RenderClasses
 @import navigation.{NewNavigation, NavigationHelpers}
-@import navigation.UrlHelpers.{getReaderRevenueUrl, getJobUrl, getContributionOrSupporterUrl, NewHeader, Subscribe, getSupportOrSubscriptionUrl}
+@import navigation.UrlHelpers.{getJobUrl, getContributionOrSupporterUrl, NewHeader, getSupportOrSubscriptionUrl}
+@import conf.switches.Switches.IdentityProfileNavigationSwitch
 
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> mvt.ABNewDesktopHeaderVariant.isParticipating,
@@ -65,12 +65,9 @@
                                 <span class="hide-from-tablet">jobs</span>
                             </a>
 
-                            <a class="top-bar__item top-bar__item--dropdown hide-until-desktop"
-                                data-link-name=""
-                                data-edition=""
-                                href="">
-                                sign in
-                            </a>
+                            @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
+                                @fragments.nav.userAccountDropdown()
+                            }
                         }
                     }
                 </div>

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -188,7 +188,7 @@ const toggleMenu = (): void => {
     fastdom.write(update);
 };
 
-const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls) => {
+const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     const openClass = 'dropdown-menu--open';
 
     fastdom.read(() => menuAndTriggerEls).then(els => {

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -8,11 +8,10 @@ import fastdom from 'lib/fastdom-promise';
 import { local } from 'lib/storage';
 import { scrollToElement } from 'lib/scroller';
 import { addEventListener } from 'lib/events';
-import { showMyAccountIfNecessary, enhanceAvatar } from './user-account';
+import { showMyAccountIfNecessary } from './user-account';
 
 const enhanced = {};
 const SEARCH_STORAGE_KEY = 'gu.recent.search';
-let avatarIsEnhanced = false;
 
 const getMenu = (): ?HTMLElement =>
     document.getElementsByClassName('js-main-menu')[0];
@@ -178,11 +177,6 @@ const toggleMenu = (): void => {
             closeAllMenuSections();
         } else {
             focusFirstMenuSection();
-
-            if (!avatarIsEnhanced) {
-                enhanceAvatar();
-                avatarIsEnhanced = true;
-            }
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -4,23 +4,27 @@ import fastdom from 'fastdom';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 
 const updateCommentLink = (): void => {
-    const commentItem = document.querySelector('.js-show-comment-activity');
-    const commentLink =
-        commentItem &&
-        commentItem.querySelector('.js-add-comment-activity-link');
+    const commentItems = [
+        ...document.querySelectorAll('.js-show-comment-activity'),
+    ];
+    const user = getUserFromCookie();
 
-    if (commentItem && commentLink) {
-        const user = getUserFromCookie();
+    if (user) {
+        commentItems.forEach(commentItem => {
+            const commentLink = commentItem.querySelector(
+                '.js-add-comment-activity-link'
+            );
 
-        if (user) {
-            fastdom.write(() => {
-                commentItem.classList.remove('u-h');
-                commentLink.setAttribute(
-                    'href',
-                    `https://profile.theguardian.com/user/id/${user.id}`
-                );
-            });
-        }
+            if (commentLink) {
+                fastdom.write(() => {
+                    commentItem.classList.remove('u-h');
+                    commentLink.setAttribute(
+                        'href',
+                        `https://profile.theguardian.com/user/id/${user.id}`
+                    );
+                });
+            }
+        });
     }
 };
 
@@ -29,20 +33,21 @@ const showMyAccountIfNecessary = (): void => {
         return;
     }
 
-    const signIn = document.querySelector('.js-navigation-sign-in');
-    const accountActions = document.querySelector(
-        '.js-navigation-account-actions'
-    );
+    const signIns = [...document.querySelectorAll('.js-navigation-sign-in')];
+    const accountActionsLists = [
+        ...document.querySelectorAll('.js-navigation-account-actions'),
+    ];
 
     fastdom.write(() => {
-        if (signIn) {
+        signIns.forEach(signIn => {
             signIn.classList.add('u-h');
-        }
+        });
 
-        if (accountActions) {
+        accountActionsLists.forEach(accountActions => {
             accountActions.classList.remove('u-h');
-            updateCommentLink();
-        }
+        });
+
+        updateCommentLink();
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -2,7 +2,6 @@
 
 import fastdom from 'fastdom';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
-import avatarAPI from 'common/modules/avatar/api';
 
 const updateCommentLink = (): void => {
     const commentItem = document.querySelector('.js-show-comment-activity');
@@ -12,6 +11,7 @@ const updateCommentLink = (): void => {
 
     if (commentItem && commentLink) {
         const user = getUserFromCookie();
+
         if (user) {
             fastdom.write(() => {
                 commentItem.classList.remove('u-h');
@@ -24,68 +24,14 @@ const updateCommentLink = (): void => {
     }
 };
 
-const enhanceAvatar = (): Promise<void> => {
-    const fallbackEl = document.querySelector(
-        '.js-navigation-account-avatar-fallback'
-    );
-    const avatarEl = document.querySelector('.js-navigation-account-avatar');
-
-    const preloadAvatar = (src: string): Promise<void> => {
-        const image = new Image();
-        image.src = src;
-
-        return new Promise(resolve => {
-            image.onload = resolve;
-        });
-    };
-
-    const swapFallback = (
-        fallback: ?HTMLElement,
-        avatar: ?HTMLElement,
-        src: string
-    ) => {
-        fastdom.write(() => {
-            if (fallback) {
-                fallback.classList.add('u-h');
-            }
-
-            if (avatar) {
-                avatar.setAttribute('src', src);
-                avatar.classList.remove('u-h');
-            }
-        });
-    };
-
-    if (!isUserLoggedIn() || !avatarEl) {
-        return Promise.resolve();
-    }
-
-    return avatarAPI.getActive().then(res => {
-        const src = res && res.data && res.data.avatarUrl;
-
-        if (src) {
-            preloadAvatar(src).then(() =>
-                swapFallback(fallbackEl, avatarEl, src)
-            );
-        }
-    });
-};
-
 const showMyAccountIfNecessary = (): void => {
     if (!isUserLoggedIn()) {
         return;
     }
 
     const signIn = document.querySelector('.js-navigation-sign-in');
-    const accountDetails = document.querySelector(
-        '.js-navigation-account-details'
-    );
     const accountActions = document.querySelector(
         '.js-navigation-account-actions'
-    );
-    const user = getUserFromCookie();
-    const userNameEl = document.querySelector(
-        '.js-navigation-account-username'
     );
 
     fastdom.write(() => {
@@ -93,19 +39,11 @@ const showMyAccountIfNecessary = (): void => {
             signIn.classList.add('u-h');
         }
 
-        if (accountDetails) {
-            accountDetails.classList.remove('u-h');
-        }
-
         if (accountActions) {
             accountActions.classList.remove('u-h');
             updateCommentLink();
         }
-
-        if (userNameEl && user && user.displayName) {
-            userNameEl.innerText = user.displayName;
-        }
     });
 };
 
-export { showMyAccountIfNecessary, enhanceAvatar };
+export { showMyAccountIfNecessary };

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -4,28 +4,29 @@ import fastdom from 'fastdom';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 
 const updateCommentLink = (): void => {
-    const commentItems = [
-        ...document.querySelectorAll('.js-show-comment-activity'),
-    ];
-    const user = getUserFromCookie();
+    fastdom
+        .read(() => [...document.querySelectorAll('.js-show-comment-activity')])
+        .then(commentItems => {
+            const user = getUserFromCookie();
 
-    if (user) {
-        commentItems.forEach(commentItem => {
-            const commentLink = commentItem.querySelector(
-                '.js-add-comment-activity-link'
-            );
-
-            if (commentLink) {
-                fastdom.write(() => {
-                    commentItem.classList.remove('u-h');
-                    commentLink.setAttribute(
-                        'href',
-                        `https://profile.theguardian.com/user/id/${user.id}`
+            if (user) {
+                commentItems.forEach(commentItem => {
+                    const commentLink = commentItem.querySelector(
+                        '.js-add-comment-activity-link'
                     );
+
+                    if (commentLink) {
+                        fastdom.write(() => {
+                            commentItem.classList.remove('u-h');
+                            commentLink.setAttribute(
+                                'href',
+                                `https://profile.theguardian.com/user/id/${user.id}`
+                            );
+                        });
+                    }
                 });
             }
         });
-    }
 };
 
 const showMyAccountIfNecessary = (): void => {
@@ -38,17 +39,17 @@ const showMyAccountIfNecessary = (): void => {
         ...document.querySelectorAll('.js-navigation-account-actions'),
     ];
 
-    fastdom.write(() => {
-        signIns.forEach(signIn => {
-            signIn.classList.add('u-h');
-        });
+    fastdom
+        .write(() => {
+            signIns.forEach(signIn => {
+                signIn.classList.add('u-h');
+            });
 
-        accountActionsLists.forEach(accountActions => {
-            accountActions.classList.remove('u-h');
-        });
-
-        updateCommentLink();
-    });
+            accountActionsLists.forEach(accountActions => {
+                accountActions.classList.remove('u-h');
+            });
+        })
+        .then(updateCommentLink);
 };
 
 export { showMyAccountIfNecessary };

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -47,60 +47,13 @@
 
 .menu-group--membership,
 .menu-group--editions {
-    @include mq($until: desktop) {
-        color: $guardian-brand-dark;
-        background-color: $news-main-2;
-    }
+    color: $guardian-brand-dark;
+    background-color: $news-main-2;
 }
 
 .menu-group--membership {
     padding-bottom: 0;
     position: relative;
-
-    @include mq($from: desktop, $until: leftCol) {
-        border-top: 1px solid $guardian-brand;
-        flex-wrap: nowrap;
-        width: 100%;
-    }
-
-    @include mq(desktop) {
-        flex-direction: row;
-        order: 3;
-        padding-bottom: 0;
-        padding-top: $gs-baseline;
-        width: 100%;
-    }
-
-    @include mq(leftCol) {
-        border-left: 2px solid $guardian-brand;
-        flex-direction: column;
-        margin-left: 0;
-        padding-left: $gs-gutter / 2 - 1;
-        // substracting the border-width, otherwise it breaks in Safari
-        width: gs-span(2) + $gs-gutter / 2 - 2;
-        position: absolute;
-        right: 0;
-        top: 0;
-
-        @supports(display: flex) {
-            position: relative;
-            right: auto;
-            top: auto;
-        }
-    }
-
-    @include mq(wide) {
-        width: gs-span(3) + $gs-gutter / 2 - 2;
-
-        .has-page-skin & {
-            border-top: 1px solid $guardian-brand;
-            border-left-width: 0;
-            flex-wrap: nowrap;
-            flex-direction: row;
-            width: 100%;
-            padding-left: 0;
-        }
-    }
 }
 
 .menu-group--editions {
@@ -113,16 +66,8 @@
 }
 
 .menu-group--membership-actions {
-    @include mq($until: desktop) {
-        background-color: darken($news-main-2, 10%);
-        color: $guardian-brand-dark;
-    }
-
-    @include mq(desktop) {
-        color: #ffffff;
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
+    background-color: darken($news-main-2, 10%);
+    color: $guardian-brand-dark;
 }
 
 .menu-group--footer {

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -31,20 +31,6 @@
             margin-top: $gs-baseline / 4;
         }
     }
-
-    .menu-group--membership-actions & {
-        @include mq($from: desktop, $until: leftCol) {
-            margin-left: $gs-gutter / 2;
-            width: gs-span(2) + $gs-gutter / 2;
-        }
-
-        .has-page-skin & {
-            @include mq(wide) {
-                margin-left: $gs-gutter / 2;
-                width: gs-span(2) + $gs-gutter / 2;
-            }
-        }
-    }
 }
 
 .menu-item--home {
@@ -65,22 +51,6 @@
     .has-page-skin & {
         @include mq(wide) {
             width: gs-span(4) + $gs-gutter / 2;
-        }
-    }
-}
-
-.menu-item--membership {
-    @include mq($from: desktop, $until: leftCol) {
-        width: gs-span(6) + $gs-gutter;
-    }
-
-    @include mq(leftCol) {
-        width: 100%;
-    }
-
-    .has-page-skin & {
-        @include mq(wide) {
-            width: gs-span(6) + $gs-gutter;
         }
     }
 }
@@ -182,17 +152,6 @@
 
         &[aria-expanded='true'] {
             margin-bottom: 0;
-        }
-    }
-
-    .menu-group--membership & {
-        @include mq(desktop) {
-            color: #ffffff;
-
-            &:hover,
-            &:focus {
-                color: $highlight-blue;
-            }
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -61,6 +61,12 @@ from scrolling */
     }
 }
 
+.new-header__user-account-container {
+    float: left;
+    position: relative;
+    z-index: $zindex-main-menu + 2;
+}
+
 .new-header__top-bar {
     left: 0;
     position: absolute;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -54,6 +54,7 @@ from scrolling */
     position: absolute;
     top: 0;
     transform: translateX(100%);
+    // Needs to sit above the menu, and the veggie burger
     z-index: $zindex-main-menu + 2;
 
     @include mq(tablet) {
@@ -64,6 +65,7 @@ from scrolling */
 .new-header__user-account-container {
     float: left;
     position: relative;
+    // Needs to sit above the menu, and the veggie burger
     z-index: $zindex-main-menu + 2;
 }
 


### PR DESCRIPTION
## What does this change?
Implementing the dropdown for my account and the link for signin after this PR: https://github.com/guardian/frontend/pull/17996

This is for the new desktop header design.

## What is the value of this and can you measure success?
Adds functionality!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
If you are not signed in, then the header looks like this:
![image](https://user-images.githubusercontent.com/8774970/31815465-a84313d8-b584-11e7-93a2-491dbd4f7911.png)

If you are, then `signin` changes to `my account`. If you click on my account:
![image](https://user-images.githubusercontent.com/8774970/31815438-9833543a-b584-11e7-9747-5c4a89a58e00.png)

Mobile should look and behave the exact same

ps. @zeftilldeath will be updating the styling in a separate PR

## Tested in CODE?
Yes!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
