### PR TITLE
Listener and class are now on the correct element for Last modified/First published

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/last-modified.js
+++ b/static/src/javascripts/projects/common/modules/ui/last-modified.js
@@ -5,13 +5,13 @@ import fastdom from 'lib/fastdom-promise';
 const lastModified = (): void => {
     fastdom
         .read(() => ({
-            lastModifiedElm: document.getElementsByClassName('js-lm')[0],
-            webPublicationDateElm: document.getElementsByClassName('js-wpd')[0],
+            lastModifiedElm: document.querySelector('.js-lm'),
+            webPublicationDateElm: document.querySelector('.js-wpd'),
         }))
         .then(els => {
             const { lastModifiedElm, webPublicationDateElm } = els;
 
-            if (lastModifiedElm) {
+            if (lastModifiedElm && webPublicationDateElm) {
                 fastdom.write(() => {
                     webPublicationDateElm.classList.add(
                         'content__dateline-wpd--modified'

--- a/static/src/javascripts/projects/common/modules/ui/last-modified.js
+++ b/static/src/javascripts/projects/common/modules/ui/last-modified.js
@@ -4,14 +4,19 @@ import fastdom from 'lib/fastdom-promise';
 
 const lastModified = (): void => {
     fastdom
-        .read(() => document.getElementsByClassName('js-lm')[0])
-        .then(jsLm => {
+        .read(() => ({
+            jsLm: document.getElementsByClassName('js-lm')[0],
+            jsWpd: document.getElementsByClassName('js-wpd')[0],
+        }))
+        .then(els => {
+            const { jsLm, jsWpd } = els;
+
             if (jsLm) {
                 fastdom.write(() => {
-                    jsLm.classList.add('content__dateline-wpd--modified');
+                    jsWpd.classList.add('content__dateline-wpd--modified');
                 });
 
-                jsLm.addEventListener('click', () => {
+                jsWpd.addEventListener('click', () => {
                     fastdom.write(() => {
                         jsLm.classList.toggle('u-h');
                     });

--- a/static/src/javascripts/projects/common/modules/ui/last-modified.js
+++ b/static/src/javascripts/projects/common/modules/ui/last-modified.js
@@ -5,20 +5,22 @@ import fastdom from 'lib/fastdom-promise';
 const lastModified = (): void => {
     fastdom
         .read(() => ({
-            jsLm: document.getElementsByClassName('js-lm')[0],
-            jsWpd: document.getElementsByClassName('js-wpd')[0],
+            lastModifiedElm: document.getElementsByClassName('js-lm')[0],
+            webPublicationDateElm: document.getElementsByClassName('js-wpd')[0],
         }))
         .then(els => {
-            const { jsLm, jsWpd } = els;
+            const { lastModifiedElm, webPublicationDateElm } = els;
 
-            if (jsLm) {
+            if (lastModifiedElm) {
                 fastdom.write(() => {
-                    jsWpd.classList.add('content__dateline-wpd--modified');
+                    webPublicationDateElm.classList.add(
+                        'content__dateline-wpd--modified'
+                    );
                 });
 
-                jsWpd.addEventListener('click', () => {
+                webPublicationDateElm.addEventListener('click', () => {
                     fastdom.write(() => {
-                        jsLm.classList.toggle('u-h');
+                        lastModifiedElm.classList.toggle('u-h');
                     });
                 });
             }


### PR DESCRIPTION
## What does this change?
Fixing a bug reported by CP today (introduced 11 days ago in an ES6 conversion).

[In this conversion](https://github.com/guardian/frontend/pull/17976/files#diff-0ed46079c63fd6f30db7713fff483967L17) we introduced the problem, but this should fix it!

## What is the value of this and can you measure success?
🐛 

## Screenshots
![lmfix](https://user-images.githubusercontent.com/8774970/31817454-ee6b4d9c-b58b-11e7-9552-7ba5cfdb4d29.gif)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
