### PR TITLE
Track page ID of clicked paid card in story package

### DIFF
--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -7,7 +7,8 @@
 
 @container(title: String, dataId: String, href: Option[String]) = {
     @containers.facia_cards.container(
-        FaciaContainer.forStoryPackage(dataId, related.faciaItems, title, href)
+        containerDefinition = FaciaContainer.forStoryPackage(dataId, related.faciaItems, title, href),
+        frontId = Some(request.path.stripPrefix("/"))
     )
 }
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -284,16 +284,16 @@ object Commercial {
       frontId: Option[String]
     )(implicit request: RequestHeader): String = {
 
-      val isContentPage = frontId.isEmpty && containerDisplayName.contains("related content")
+      val isContentPage =
+        containerDisplayName.contains("more on this story") ||
+          containerDisplayName.contains("related content")
 
       mkString(
         containerType =
           if (isContentPage) "Onward container"
           else "Front container",
         editionId = Edition(request).id,
-        frontId =
-          if (isContentPage) "none"
-          else frontId.getOrElse("unknown front id"),
+        frontId = frontId.getOrElse("unknown front id"),
         containerIndex = containerIndex,
         containerTitle = containerDisplayName.getOrElse("unknown container"),
         sponsorName = card.branding.map(_.sponsorName) getOrElse "unknown",


### PR DESCRIPTION
This will give the page ID in the data-component attribute.

Eg.
Before:
>data-component="Front container | UK | unknown front id | container-3 | more on this story | Nespresso | card-3 | What does it mean to buy something sustainable?"

After:
>data-component="Onward container | UK | environment/2017/apr/29/recycle-nespresso-coffee-pods-london | container-3 | more on this story | Nespresso | card-3 | What does it mean to buy something sustainable?"
