### PR TITLE
Header v3 expanded dropdown styling

### DIFF
--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -2,6 +2,18 @@
 
 @import common.{Edition, LinkTo}
 
+@editionListItem(edition: Edition, isCurrentEdition: Boolean = false) = {
+    <li class="dropdown-menu__item">
+        <a data-link-name="nav2 : topbar : edition-picker: @edition.id"
+            href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
+            class="dropdown-menu__title @if(isCurrentEdition) {dropdown-menu__title--active}">
+
+            <span class="u-h">switch to the </span>
+            @edition.displayName
+        </a>
+    </li>
+}
+
 <div class="new-header__edition-container hide-until-desktop">
 
     <input type="checkbox"
@@ -14,32 +26,16 @@
         id="edition-dropdown-menu"
         aria-hidden="true">
 
-        @Edition.all.map { edition =>
-            @if((edition != Edition(request))) {
+        @editionListItem(Edition(request), true)
 
-                <li class="dropdown-menu__item">
-                    <a data-link-name="nav2 : topbar : edition-picker: @edition.id"
-                        href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
-                        class="dropdown-menu__title">
-
-                        <span class="u-h">switch to the </span>
-                        @edition.displayName
-                    </a>
-                </li>
-            }
-        }
+        @Edition.others(request).map(e => editionListItem(e))
     </ul>
 
     <label for="edition-picker-toggle"
             class="top-bar__item top-bar__item--dropdown js-edition-picker-trigger"
             data-link-name="nav2 : topnav : edition-picker: toggle">
 
-        <span class="u-h">Current Edition: </span>
-
         @Edition(request).displayName
     </label>
 
 </div>
-
-
-

--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -35,6 +35,7 @@
             class="top-bar__item top-bar__item--dropdown js-edition-picker-trigger"
             data-link-name="nav2 : topnav : edition-picker: toggle">
 
+        <span class="u-h">current edition: </span>
         @Edition(request).displayName
     </label>
 

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -113,7 +113,7 @@ from scrolling */
     @include mq(tablet) {
         height: calc(3 / 16 * 345px);
         margin-bottom: -5px;
-        margin-top: $gs-baseline + 3px;
+        margin-top: $gs-baseline + $gs-baseline / 4;
         width: 345px;
     }
 

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -113,7 +113,7 @@ from scrolling */
     @include mq(tablet) {
         height: calc(3 / 16 * 345px);
         margin-bottom: -5px;
-        margin-top: $gs-baseline + 2px;
+        margin-top: $gs-baseline + 3px;
         width: 345px;
     }
 

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -9,36 +9,36 @@
     display: none;
     position: absolute;
     top: $gs-baseline * 2.5;
-    right: -$gs-gutter / 4;
+    right: -8px;
     width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
     border-radius: $gs-baseline / 4;
     padding: $gs-baseline / 2 0;
     margin: 0;
-    box-shadow: 0 0 5px 0 rgba(0, 0, 0, .25);
-    z-index: 1;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .1);
+    z-index: $zindex-main-menu;
 
     // triangle
     &:before,
     &:after {
         content: '';
         position: absolute;
-        top: 0;
-        right: 12px;
-        transform: translateY(-100%);
+        right: $gs-gutter;
+        transform: translateX(50%) translateY(-100%);
     }
 
     &:before {
-        border-bottom: $gs-baseline / 2 + 1 solid $neutral-5;
-        border-left: $gs-baseline / 2 + 1 solid transparent;
-        border-right: $gs-baseline / 2 + 1 solid transparent;
-        margin-right: -1px;
+        top: -1px;
+        border-bottom: $gs-baseline / 1.5 solid rgba(0, 0, 0, .1);
+        border-left: $gs-baseline / 1.5 solid transparent;
+        border-right: $gs-baseline / 1.5 solid transparent;
     }
 
     &:after {
-        border-bottom: $gs-baseline / 2 solid #ffffff;
-        border-left: $gs-baseline / 2 solid transparent;
-        border-right: $gs-baseline / 2 solid transparent;
+        top: 0;
+        border-bottom: $gs-baseline / 1.5 - 1 solid #ffffff;
+        border-left: $gs-baseline / 1.5 - 1 solid transparent;
+        border-right: $gs-baseline / 1.5 - 1 solid transparent;
     }
 }
 
@@ -47,6 +47,7 @@
 
     & ~ .top-bar__item--dropdown {
         color: #ffffff;
+        background-color: $guardian-brand-dark;
 
         &:after {
             transform: translateY(0) rotate(45deg);

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -3,6 +3,15 @@
     & ~ .dropdown-menu {
         display: block;
     }
+
+    & ~ .top-bar__item--dropdown {
+        color: #ffffff;
+        background-color: $guardian-brand-dark;
+
+        &:after {
+            transform: translateY(0) rotate(45deg);
+        }
+    }
 }
 
 .dropdown-menu {

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -9,7 +9,7 @@
     display: none;
     position: absolute;
     top: $gs-baseline * 2 + $gs-baseline / 2;
-    right: -8px;
+    right: -$gs-gutter / 4;
     width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
     border-radius: $gs-baseline / 4;
@@ -23,22 +23,21 @@
     &:after {
         content: '';
         position: absolute;
-        right: $gs-gutter;
-        transform: translateX(50%) translateY(-100%);
+        right: $gs-gutter / 2;
+        border-left: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
+        border-right: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
+        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 solid;
+        transform: translateY(-100%);
     }
 
     &:before {
         top: -1px;
-        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 solid rgba(0, 0, 0, .1);
-        border-left: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
-        border-right: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
+        border-bottom-color: rgba(0, 0, 0, .1);
     }
 
     &:after {
         top: 0;
-        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid #ffffff;
-        border-left: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid transparent;
-        border-right: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid transparent;
+        border-bottom-color: #ffffff;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -8,33 +8,34 @@
 .dropdown-menu {
     display: none;
     position: absolute;
-    top: 29px; //visually this sits right under the text
-    left: -($gs-gutter / 2);
-    width: $gs-column-width * 3;
+    top: $gs-baseline * 2.5;
+    right: -$gs-gutter / 4;
+    width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
-    border-radius: 3px;
+    border-radius: $gs-baseline / 4;
     padding: $gs-baseline / 2 0;
     margin: 0;
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, .25);
+    z-index: 1;
 
     // triangle
     &:before,
     &:after {
         content: '';
         position: absolute;
+        top: 0;
+        right: 12px;
+        transform: translateY(-100%);
     }
 
     &:before {
-        top: -( $gs-baseline / 2 + 1);
-        left: $gs-gutter - 2;
         border-bottom: $gs-baseline / 2 + 1 solid $neutral-5;
         border-left: $gs-baseline / 2 + 1 solid transparent;
         border-right: $gs-baseline / 2 + 1 solid transparent;
+        margin-right: -1px;
     }
 
     &:after {
-        top: -( $gs-baseline / 2);
-        left: $gs-gutter - 1;
         border-bottom: $gs-baseline / 2 solid #ffffff;
         border-left: $gs-baseline / 2 solid transparent;
         border-right: $gs-baseline / 2 solid transparent;
@@ -43,6 +44,14 @@
 
 .dropdown-menu--open {
     display: block;
+
+    & ~ .top-bar__item--dropdown {
+        color: #ffffff;
+
+        &:after {
+            transform: translateY(0) rotate(45deg);
+        }
+    }
 }
 
 .dropdown-menu__title {
@@ -50,10 +59,12 @@
     color: $neutral-1;
     cursor: pointer;
     display: block;
+    letter-spacing: .01em;
     outline: none;
-    padding: $gs-baseline + 1 $gs-gutter $gs-baseline;
+    padding: ($gs-baseline / 2 + 1) $gs-gutter ($gs-baseline + $gs-baseline / 4) ($gs-baseline * 2 + $gs-baseline / 2);
     position: relative;
     box-sizing: border-box;
+    // Hides border on hover
     margin-top: -1px;
 
     &:hover,
@@ -69,15 +80,35 @@
         display: block;
         position: absolute;
         top: 0;
-        left: $gs-gutter;
+        left: $gs-gutter * 1.5;
         right: 0;
     }
 
-    .dropdown-menu__item:first-child &:before {
-        content: none;
+    .dropdown-menu__item:first-child & {
+        &:before {
+            content: none;
+        }
     }
 
     @include mq(desktop) {
         font-size: 15px;
+    }
+}
+
+.dropdown-menu__title--active {
+    font-weight: bold;
+
+    &:after {
+        // Tick icon
+        content: '';
+        border: 2px solid $news-main-2;
+        border-top: 0;
+        border-right: 0;
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        width: 10px;
+        height: 4px;
+        transform: rotate(-45deg);
     }
 }

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -68,7 +68,7 @@
     color: $neutral-1;
     cursor: pointer;
     display: block;
-    letter-spacing: .01em;
+    letter-spacing: .01rem;
     outline: none;
     padding: ($gs-baseline / 2 + 1) $gs-gutter ($gs-baseline + $gs-baseline / 4) ($gs-baseline * 2 + $gs-baseline / 2);
     position: relative;

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -8,7 +8,7 @@
 .dropdown-menu {
     display: none;
     position: absolute;
-    top: $gs-baseline * 2.5;
+    top: $gs-baseline * 2 + $gs-baseline / 2;
     right: -8px;
     width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
@@ -29,16 +29,16 @@
 
     &:before {
         top: -1px;
-        border-bottom: $gs-baseline / 1.5 solid rgba(0, 0, 0, .1);
-        border-left: $gs-baseline / 1.5 solid transparent;
-        border-right: $gs-baseline / 1.5 solid transparent;
+        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 solid rgba(0, 0, 0, .1);
+        border-left: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
+        border-right: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
     }
 
     &:after {
         top: 0;
-        border-bottom: $gs-baseline / 1.5 - 1 solid #ffffff;
-        border-left: $gs-baseline / 1.5 - 1 solid transparent;
-        border-right: $gs-baseline / 1.5 - 1 solid transparent;
+        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid #ffffff;
+        border-left: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid transparent;
+        border-right: $gs-baseline / 2 + $gs-baseline / 4 - 1 solid transparent;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -46,6 +46,11 @@
         border-top: transparent;
         margin-left: 2px;
         vertical-align: middle;
+        transition: transform 250ms ease-out;
+    }
+
+    &:hover:after {
+        transform: translateY(0) rotate(45deg);
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -2,7 +2,7 @@
     @include fs-textSans(2);
     color: $news-support-1;
     float: left;
-    font-weight: 300;
+    font-weight: normal;
     letter-spacing: .01rem;
     line-height: 1;
     position: relative;

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -3,13 +3,16 @@
     color: $news-support-1;
     float: left;
     font-weight: 300;
-    letter-spacing: .01rem;
+    letter-spacing: .01em;
     line-height: 1;
     padding: ($gs-baseline / 1.5) ($gs-gutter / 2);
     position: relative;
     // Prevents a strange 1px shift on hover
     backface-visibility: hidden;
     transition: color 80ms ease-out;
+    border-radius: 99999px;
+    padding: ($gs-baseline / 2) ($gs-gutter / 2);
+    margin: ($gs-baseline / 4) 0;
 
     &:nth-child(2) {
         padding-left: $gs-gutter / 1.5;
@@ -59,6 +62,7 @@
     font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
     font-weight: 800;
     padding: 0;
+    margin: 0;
 
     @include mq($until: mobileLandscape) {
         margin-left: -$gs-gutter / 2;

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -3,9 +3,8 @@
     color: $news-support-1;
     float: left;
     font-weight: 300;
-    letter-spacing: .01em;
+    letter-spacing: .01rem;
     line-height: 1;
-    padding: ($gs-baseline / 1.5) ($gs-gutter / 2);
     position: relative;
     // Prevents a strange 1px shift on hover
     backface-visibility: hidden;
@@ -15,7 +14,7 @@
     margin: ($gs-baseline / 4) 0;
 
     &:nth-child(2) {
-        padding-left: $gs-gutter / 1.5;
+        padding-left: $gs-gutter / 2 + $gs-gutter / 4;
     }
 
     .is-paying-member &:nth-child(2),
@@ -101,7 +100,7 @@
 .top-bar__item--cta--text {
     box-sizing: border-box;
     display: block;
-    padding: ($gs-baseline / 1.5) ($gs-gutter) ($gs-baseline / 4);
+    padding: ($gs-baseline / 2 + $gs-baseline / 4) ($gs-gutter) ($gs-baseline / 4);
     position: relative;
 
     @include mq($until: mobileMedium) {


### PR DESCRIPTION
I've been working on improving the styling of the dropdowns in the nav.

# They now look like this:
<img width="365" alt="screen shot 2017-10-20 at 15 49 49" src="https://user-images.githubusercontent.com/14570016/31827113-e31b2a52-b5ae-11e7-9f68-1bd88295a6ff.png">

![interaction](https://user-images.githubusercontent.com/14570016/31829107-3d8673fc-b5b4-11e7-8d5a-fa546bf83292.gif)


**Some notes on what I've done**
1. Dividing lines with top aligned text 
2. An active state for your chosen edition (Thank you @NataliaLKB) 
3. Slight hover on dropdown
4. Lots of spacing adjustments
5. Removed drop shadow and added opacity 1px border 

Currently, the selected item will always be at the top, I'm not sure if that's the best option?
