### PR TITLE
Comments: Fix various bugs

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -307,6 +307,11 @@ class Comments extends Component {
     addComment(comment: CommentType, parent: HTMLElement): void {
         const commentElem = bonzo.create(this.postedCommentEl)[0];
         const $commentElem = bonzo(commentElem);
+        const replyButton =
+            commentElem &&
+            commentElem.getElementsByClassName(
+                this.getClass('commentReply', true)
+            )[0];
         const map: Object = {
             username: 'd-comment__author',
             timestamp: 'js-timestamp',
@@ -348,6 +353,10 @@ class Comments extends Component {
             $commentElem.addClass(this.getClass('commentStaff', true));
         }
 
+        if (replyButton) {
+            replyButton.setAttribute('data-comment-id', comment.id);
+        }
+
         if (!parent) {
             $(this.getClass('newComments'), this.elem).prepend(commentElem);
         } else {
@@ -363,7 +372,12 @@ class Comments extends Component {
         e.preventDefault();
 
         const replyLink: HTMLElement = (e.currentTarget: any);
-        const replyToId = replyLink.getAttribute('data-comment-id') || '';
+        const replyToId = replyLink.getAttribute('data-comment-id');
+
+        if (!replyToId) {
+            return;
+        }
+
         const replyTo = document.getElementById(`reply-to-${replyToId}`);
 
         // There is already a comment box for this on the page

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -435,7 +435,7 @@ class Comments extends Component {
                 bonzo(parentCommentEl).append(responses);
             }
 
-            this.destroy();
+            commentBox.destroy();
             this.addComment(comment, responses);
         });
     }


### PR DESCRIPTION
## What does this change?

#### Bug 1: Comments: Fix disappeared comments after a reply 

After a reply the whole comment thread was destroyed. This bug was introduced as part of the ES6 conversion in https://github.com/guardian/frontend/pull/18016.

Who would have spotted the context switch?

https://github.com/guardian/frontend/blob/bcbcdd0e3aa1b53b3e0b189b1a9ffd7cf7ac5fac/static/src/javascripts-legacy/projects/common/modules/discussion/comments.js#L411-L419

#### Bug 2: Comments: Fix reply-to if comment was created dynamically 

Once a user posted a comment and wanted to reply to it again (without reloading the page) the JS would run into an error. I believe this never worked but is fixed now.

## What is the value of this and can you measure success?

Less complaints about comments, because less bugs and better UX.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

Nope.

## Tested in CODE?

Nope.