### PR TITLE
Footer: Unify label for tech feedback across editions

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -198,7 +198,7 @@
 
                         <ul class="colophon__list">
                             <li class="colophon__item"><a data-link-name="us : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                                solve technical issue</a>
+                                ask for help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
                                 terms &amp; conditions</a>
@@ -292,7 +292,7 @@
                                 securedrop</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                                solve technical issue</a>
+                                ask for help</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
                                 information</a>
@@ -333,7 +333,7 @@
                                 securedrop</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="tech feedback" class="international : footer : js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                                solve technical issue</a>
+                                ask for help</a>
                             </li>
                         </ul>
 


### PR DESCRIPTION
## What does this change?

Unifies link label for tech feedback across editions in footer.

[Trello reference](https://trello.com/c/ko05H07m/555-p2-easy-ask-for-help-link-on-all-editions)

## What is the value of this and can you measure success?

Consistency.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.