### PR TITLE
Add IAS targetting optimisations when defining ad slots.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -25,6 +25,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val IasOptimizations = Switch(
+    SwitchGroup.Commercial,
+    "ias-optimisation",
+    "Activates the IAS optimisation additional targeting when requesting ads.",
+    owners = Seq(Owner.withGithub("JonNorman")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 11, 9),
+    exposeClientSide = true
+  )
+
   val SurveySwitch = Switch(
     SwitchGroup.Commercial,
     "surveys",

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -96,7 +96,12 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slotReady = setHighMerchSlotTargeting(slot, slotTarget);
     }
 
-    if (config.switches.iasOptimisation) {
+    /*
+        The iasOptimisation implementation below is still a WiP, hence the
+        console.log statements and the dev-only execution.
+     */
+
+    if (config.switches.iasOptimisation && config.get('page.isDev', false)) {
         console.log(`Defining ${id}`);
         /* eslint-disable no-underscore-dangle, no-multi-assign */
         const iasPET = (window.__iasPET = window.__iasPET || {});

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -96,6 +96,56 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         slotReady = setHighMerchSlotTargeting(slot, slotTarget);
     }
 
+    if (config.switches.iasOptimisation) {
+        console.log(`Defining ${id}`);
+        /* eslint-disable no-underscore-dangle, no-multi-assign */
+        const iasPET = (window.__iasPET = window.__iasPET || {});
+        /* eslint-enable no-underscore-dangle, no-multi-assign */
+
+        iasPET.queue = iasPET.queue || [];
+        iasPET.pubId = '10249';
+
+        let loadedResolve;
+
+        const iasDataPromise = new Promise(resolve => {
+            loadedResolve = resolve;
+        });
+
+        const iasDataCallback = () => {
+            console.log(`Applying IAS targeting: ${id}`);
+            iasPET.setTargetingForGPT();
+            loadedResolve();
+        };
+
+        // IAS Optimization Targeting
+        const iasPETSlots = [
+            {
+                adSlotId: id,
+                size: sizes,
+                adUnitPath: adUnit(), // why do we have this method and not just slot.getAdUnitPath()?
+            },
+        ];
+
+        iasPET.queue.push({
+            adSlots: iasPETSlots,
+            dataHandler: iasDataCallback,
+        });
+
+        const iasTimeoutDuration = 10000;
+
+        const iasTimeout = () =>
+            new Promise(resolve => {
+                setTimeout(() => {
+                    console.log(`Timed out of IAS request: ${id}`);
+                    resolve();
+                }, iasTimeoutDuration);
+            });
+
+        slotReady = slotReady.then(() =>
+            Promise.race([iasTimeout(), iasDataPromise])
+        );
+    }
+
     if (slotTarget === 'im' && config.page.isbn) {
         slot.setTargeting('isbn', config.page.isbn);
     }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -16,6 +16,7 @@ import { remarketing } from 'commercial/modules/third-party-tags/remarketing';
 import { simpleReach } from 'commercial/modules/third-party-tags/simple-reach';
 import { tourismAustralia } from 'commercial/modules/third-party-tags/tourism-australia';
 import { krux } from 'commercial/modules/third-party-tags/krux';
+import { ias } from 'commercial/modules/third-party-tags/ias';
 import { initOutbrain } from 'commercial/modules/third-party-tags/outbrain';
 import { doubleClickAdFree } from 'commercial/modules/third-party-tags/doubleclick-ad-free';
 import plista from 'commercial/modules/third-party-tags/plista';
@@ -86,6 +87,7 @@ const loadOther = (): void => {
         simpleReach,
         tourismAustralia,
         krux,
+        ias,
         doubleClickAdFree,
     ].filter(_ => _.shouldRun);
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
@@ -1,0 +1,7 @@
+// @flow
+import config from 'lib/config';
+
+export const ias: ThirdPartyTag = {
+    shouldRun: config.switches.iasOptimisation,
+    url: '//cdn.adsafeprotected.com/iasPET.1.js',
+};


### PR DESCRIPTION
## What does this change?
IAS periodically scan our inventory and build models that describe the average viewability, brand safety and attention that various slots on various sections receive.

We can query their optimisation tool to request this information prior to requesting an ad from DFP. We can then use this information to add targeting to the ad slot beforehand.

Whilst IAS supports the batch requesting of ad slot information, we send a single request to IAS for _each_ slot that is to be defined. Because we lazy load and define slots all over the place at different times, there is no sensible bottleneck in which to insert this behaviour and thus we must do it on each creation of an `Advert` in `define-slot`.

**Note: this currently doesn't work. The timeout is always reached, however for IAS to debug this it needs to be present on a test page i.e. CODE. Instead of commandeering code for an interminable length of time, I plan to merge this and only enable the switch on CODE.**

## What is the value of this and can you measure success?
We can better target campaigns in DFP with richer information about the resultant, displayed ad.

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
