### PR TITLE
New prbuilds microdata configuration

### DIFF
--- a/.prbuilds/config.yml
+++ b/.prbuilds/config.yml
@@ -12,6 +12,12 @@ checks:
   loadtest:
     url: http://localhost:9000/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism
   microdata:
-    urls: 
-      - http://localhost:9000/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism
-      - http://localhost:9000/business/live/2017/oct/09/nobel-prize-in-economics-due-to-be-unveiled-business-live
+    endpoints:
+      - url: http://localhost:9000/business/live/2017/oct/09/nobel-prize-in-economics-due-to-be-unveiled-business-live
+        expected:
+          - WebPage
+          - LiveBlogPosting
+      - url: http://localhost:9000/books/2014/may/21/guardian-journalists-jonathan-freedland-ghaith-abdul-ahad-win-orwell-prize-journalism
+        expected:
+           - WebPage
+           - NewsArticle 


### PR DESCRIPTION
## What does this change?

Changes the prbuilds configuration to support the [updated microdata validation module](https://github.com/guardian/prbuilds/pull/7)

This is not backward compatible. PRBuilds will I think fail for old PRs but that should be a small window and it's not super vital.

## What is the value of this and can you measure success?

Prbuilds will become able to signal when expected microdata elements are missing

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
