### PR TITLE
Fastdom User Account Refactor + fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -3,30 +3,26 @@
 import fastdom from 'lib/fastdom-promise';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 
-const updateCommentLink = (): void => {
-    fastdom
-        .read(() => [...document.querySelectorAll('.js-show-comment-activity')])
-        .then(commentItems => {
-            const user = getUserFromCookie();
+const updateCommentLink = (commentItems): void => {
+    const user = getUserFromCookie();
 
-            if (user) {
-                commentItems.forEach(commentItem => {
-                    const commentLink = commentItem.querySelector(
-                        '.js-add-comment-activity-link'
-                    );
-
-                    if (commentLink) {
-                        fastdom.write(() => {
-                            commentItem.classList.remove('u-h');
-                            commentLink.setAttribute(
-                                'href',
-                                `https://profile.theguardian.com/user/id/${user.id}`
-                            );
-                        });
-                    }
-                });
-            }
+    if (user) {
+        commentItems.forEach(commentItem => {
+            fastdom
+                .read(() =>
+                    commentItem.querySelector('.js-add-comment-activity-link')
+                )
+                .then(commentLink =>
+                    fastdom.write(() => {
+                        commentItem.classList.remove('u-h');
+                        commentLink.setAttribute(
+                            'href',
+                            `https://profile.theguardian.com/user/id/${user.id}`
+                        );
+                    })
+                );
         });
+    }
 };
 
 const showMyAccountIfNecessary = (): void => {
@@ -34,22 +30,33 @@ const showMyAccountIfNecessary = (): void => {
         return;
     }
 
-    const signIns = [...document.querySelectorAll('.js-navigation-sign-in')];
-    const accountActionsLists = [
-        ...document.querySelectorAll('.js-navigation-account-actions'),
-    ];
-
     fastdom
-        .write(() => {
-            signIns.forEach(signIn => {
-                signIn.classList.add('u-h');
-            });
+        .read(() => ({
+            signIns: [...document.querySelectorAll('.js-navigation-sign-in')],
+            accountActionsLists: [
+                ...document.querySelectorAll('.js-navigation-account-actions'),
+            ],
+            commentItems: [
+                ...document.querySelectorAll('.js-show-comment-activity'),
+            ],
+        }))
+        .then(els => {
+            const { signIns, accountActionsLists, commentItems } = els;
 
-            accountActionsLists.forEach(accountActions => {
-                accountActions.classList.remove('u-h');
-            });
-        })
-        .then(updateCommentLink);
+            return fastdom
+                .write(() => {
+                    signIns.forEach(signIn => {
+                        signIn.classList.add('u-h');
+                    });
+
+                    accountActionsLists.forEach(accountActions => {
+                        accountActions.classList.remove('u-h');
+                    });
+                })
+                .then(() => {
+                    updateCommentLink(commentItems);
+                });
+        });
 };
 
 export { showMyAccountIfNecessary };

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -1,6 +1,6 @@
 // @flow
 
-import fastdom from 'fastdom';
+import fastdom from 'lib/fastdom-promise';
 import { getUserFromCookie, isUserLoggedIn } from 'common/modules/identity/api';
 
 const updateCommentLink = (): void => {


### PR DESCRIPTION
## What does this change?
This file wasn't using fastdom promise, so this changes that (thus also fixing a 🐛 in prod) and refactors the file slightly.

## What is the value of this and can you measure success?
Less bugs?

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
