### PR TITLE
Hide account links on desktop

### DIFF
--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -12,7 +12,7 @@
         </a>
     </li>
 
-    <li class="menu-item menu-item--membership u-h js-navigation-account-actions">
+    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-on-desktop">
         <button class="menu-item__title hide-on-desktop js-navigation-toggle"
                 data-link-name="nav2 : my account"
                 aria-haspopup="true"


### PR DESCRIPTION
## What does this change?
Missed out on a classname in https://github.com/guardian/frontend/pull/18039 hide menu on desktop 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
