### PR TITLE
Fix timeline description field

### DIFF
--- a/common/app/views/fragments/atoms/snippets/timeline.scala.html
+++ b/common/app/views/fragments/atoms/snippets/timeline.scala.html
@@ -10,7 +10,7 @@
     isAmp
 ){
     @for(description <- timeline.data.description) {
-      <div class="explainer-snippet__description">description</div>
+      <div class="explainer-snippet__description">@Html(description)</div>
     }
     @for(item <- timeline.data.events) {
       <div class="explainer-snippet__item">


### PR DESCRIPTION
it currently displays the word "description"

<img width="639" alt="picture 8" src="https://user-images.githubusercontent.com/1513454/31905923-917d550a-b827-11e7-8b05-75ca5d6edd46.png">
@annebyrne 