### PR TITLE
Track page ID of clicked paid card in related container

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -45,6 +45,8 @@ trait Requests {
     lazy val campaignCode: Option[String] = r.getQueryString("CMP")
 
     lazy val isAdFree: Boolean = r.headers.keys.exists(_ equalsIgnoreCase "X-Gu-Commercial-Ad-Free")
+
+    lazy val referrer: Option[String] = r.headers.get("referer")
   }
 }
 

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.net.URI
+
 import common._
 import containers.Containers
 import contentapi.ContentApiClient
@@ -15,6 +17,8 @@ class PopularInTag(
 )(implicit context: ApplicationContext)
   extends BaseController with Related with Containers with Logging with ImplicitControllerExecutionContext {
 
+  import implicits.Requests._
+
   def render(tag: String): Action[AnyContent] = Action.async { implicit request =>
     val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
@@ -29,8 +33,8 @@ class PopularInTag(
     // to aesthetic issues with the second slice when there are only 5 or 6 results in related content (7 looks fine).
     val numberOfCards = if (trails.faciaItems.length == 5 || trails.faciaItems.length == 6) 4 else 8
     val html = views.html.fragments.containers.facia_cards.container(
-      onwardContainer("related content", trails.faciaItems take numberOfCards),
-      FrontProperties.empty
+      containerDefinition = onwardContainer("related content", trails.faciaItems take numberOfCards),
+      frontId = request.referrer.map(new URI(_).getPath.stripPrefix("/"))
     )
 
     JsonComponent(html)

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -1,11 +1,14 @@
 package controllers
 
+import java.net.URI
+
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.facia.client.models.Backfill
 import common._
 import contentapi.ContentApiClient
 import implicits.Requests
+import layout.slices.Fixed
 import layout.{CollectionEssentials, DescriptionMetaHeader, FaciaContainer}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
@@ -13,7 +16,6 @@ import model.pressed.CollectionConfig
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc._
 import services.CollectionConfigWithId
-import layout.slices.Fixed
 import views.support.FaciaToMicroFormat2Helpers._
 
 import scala.concurrent.Future
@@ -100,16 +102,19 @@ class SeriesController(
       href = Some(series.id)
     )
 
-    val response = () => views.html.fragments.containers.facia_cards.container(
-      FaciaContainer(
-        1,
-        Fixed(visuallyPleasingContainerForStories(math.min(series.trails.faciaItems.length, 4))),
-        CollectionConfigWithId(dataId, config),
-        CollectionEssentials(series.trails.faciaItems take 4, Nil, displayName, None, None, None),
-        componentId
-      ).withTimeStamps
-       .copy(customHeader = header),
-      properties
+    val response = () =>
+      views.html.fragments.containers.facia_cards.container(
+        containerDefinition = FaciaContainer(
+          1,
+          Fixed(visuallyPleasingContainerForStories(math.min(series.trails.faciaItems.length, 4))),
+          CollectionConfigWithId(dataId, config),
+          CollectionEssentials(series.trails.faciaItems take 4, Nil, displayName, None, None, None),
+          componentId
+        )
+          .withTimeStamps
+          .copy(customHeader = header),
+        frontProperties = properties,
+        frontId = request.referrer.map(new URI(_).getPath.stripPrefix("/"))
     )
 
     renderFormat(response, response, 900)


### PR DESCRIPTION
Following on from #18044, this change will give enough information to track referrals from related containers in other sections.

Eg.
Before:
> Onward container | UK | unknown front id | container-2 | related content | NAB | card-8 | A bug’s life for sustainability? It’s only natural, says top wine executive

After:
> Onward container | UK | nab-more-that-matters/2017/jun/27/shared-value-how-business-is-stepping-up | container-2 | related content | NAB | card-8 | A bug’s life for sustainability? It’s only natural, says top wine executive
