### PR TITLE
Update IAS Optimisation integration

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -60,7 +60,8 @@ class DevParametersHttpRequestHandler(
     "seg", // user segments in commercial component requests
     "t", // specific item targetting
     "0p19G", // Google AMP AB test parameter
-    "dll" // Disable lazy loading of ads
+    "dll", // Disable lazy loading of ads
+    "iasdebug" // IAS troubleshooting
   )
 
   val playBugs = Seq("") // (Play 2.5 bug?) request.queryString is returning an empty string when empty

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -148,7 +148,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
             dataHandler: iasDataCallback,
         });
 
-        const iasTimeoutDuration = 20000;
+        const iasTimeoutDuration = 2000;
 
         const iasTimeout = () =>
             new Promise(resolve => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -97,9 +97,6 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
     }
 
     /*
-        The iasOptimisation implementation below is still a WiP, hence the
-        console.log statements and the dev-only execution.
-
         For each ad slot defined, we request information from IAS, based
         on slot name, ad unit and sizes. We then add this targeting to the
         slot prior to requesting it from DFP.
@@ -109,7 +106,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         without the additional IAS data.
      */
 
-    if (config.switches.iasOptimisation && config.get('page.isDev', false)) {
+    if (config.switches.iasOptimisation) {
         /* eslint-disable no-underscore-dangle */
         // this should all have been instantiated by commercial/modules/third-party-tags/ias.js
         window.__iasPET = window.__iasPET || {};

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -104,6 +104,8 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         We race the request to IAS with a Timeout of 2 seconds. If the
         timeout resolves before the request to IAS then the slot is defined
         without the additional IAS data.
+
+        To see debugging output from IAS add the URL param `&iasdebug=true` to the page URL
      */
 
     if (config.get('switches.iasOptimisation', false)) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -106,7 +106,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         without the additional IAS data.
      */
 
-    if (config.switches.iasOptimisation) {
+    if (config.get('switches.iasOptimisation', false)) {
         /* eslint-disable no-underscore-dangle */
         // this should all have been instantiated by commercial/modules/third-party-tags/ias.js
         window.__iasPET = window.__iasPET || {};


### PR DESCRIPTION
## What does this change?
This PR updates the way we marshall the sizes when passing our requests to IAS, which results in the integration actually working, which is nice. The timeout is now reduced from 10 seconds to 2 seconds, as suggested by IAS.

This PR also adds the `iasDebug` flag to the allowed list of dev flags, for running locally.
