### PR TITLE
Pa11y: Fix reporting, if there are now errors at all

### DIFF
--- a/tools/__tasks__/validate/a11y/a11y.js
+++ b/tools/__tasks__/validate/a11y/a11y.js
@@ -15,11 +15,17 @@ module.exports = {
                         reject(err);
                     }
 
-                    const messages = results.map(reporter);
-                    messages.forEach(message => ctx.messages.push(message));
+                    if (results) {
+                        const messages = results
+                            .map(reporter)
+                            .filter(item => item);
 
-                    if (results.length) {
-                        ctx.error = true;
+                        if (messages.length) {
+                            messages.forEach(message =>
+                                ctx.messages.push(message)
+                            );
+                            ctx.error = true;
+                        }
                     }
 
                     resolve();

--- a/tools/__tasks__/validate/a11y/config.js
+++ b/tools/__tasks__/validate/a11y/config.js
@@ -7,6 +7,7 @@ module.exports = {
     port,
     options: {
         level: 'error',
+        htmlcs: 'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js',
     },
     paths: ['politics/2013/oct/31/universal'],
     logLevel: 1, // 1: error, 2: warning, 3: notice

--- a/tools/__tasks__/validate/a11y/config.js
+++ b/tools/__tasks__/validate/a11y/config.js
@@ -7,6 +7,8 @@ module.exports = {
     port,
     options: {
         level: 'error',
+
+        // Issue: https://github.com/pa11y/pa11y/issues/335
         htmlcs: 'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js',
     },
     paths: ['politics/2013/oct/31/universal'],

--- a/tools/__tasks__/validate/a11y/reporter.js
+++ b/tools/__tasks__/validate/a11y/reporter.js
@@ -15,5 +15,5 @@ module.exports = result => {
         output = lines.join('\n');
     }
 
-    return output;
+    return output && output.length ? output : undefined;
 };

--- a/tools/__tasks__/validate/a11y/reporter.js
+++ b/tools/__tasks__/validate/a11y/reporter.js
@@ -9,11 +9,10 @@ module.exports = result => {
         `${chalk.underline('Context')}: ${context}`,
         `${chalk.underline('Selector')}: ${selector}`,
     ];
-    let output = '';
 
     if (typeCode <= logLevel) {
-        output = lines.join('\n');
+        return lines.join('\n');
     }
 
-    return output && output.length ? output : undefined;
+    return undefined;
 };


### PR DESCRIPTION
## What does this change?

We don't have any problematic errors anymore reported from pa11y. The code wasn't prepared for that and fell over, because `results` was undefined. This PR fixes the issue.

## What is the value of this and can you measure success?

Proper p11y reports! 💚 

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.