### PR TITLE
Pre-push hook: Check changed files not staged files

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -4,6 +4,7 @@
 const path = require('path');
 const execa = require('execa');
 const chalk = require('chalk');
+const getChangedFiles = require('../tools/__tasks__/lib/get-changed-files');
 
 const confirmIfMasterMessage = `${chalk.red(
     `${chalk.inverse(
@@ -35,11 +36,6 @@ const confirmIfMaster = execa
     )
     .catch(() => Promise.reject(new Error('Ok, stopping 😉')));
 
-const diff = () =>
-    execa
-        .stdout('git', ['diff', '--name-only', '--cached', '--diff-filter=AM'])
-        .then(staged => staged.split('\n'));
-
 const validate = () =>
     execa(
         './tools/task-runner/runner',
@@ -49,10 +45,10 @@ const validate = () =>
         }
     );
 
-const checkYarnLock = staged => {
+const checkYarnLock = changed => {
     if (
-        staged.some(file => file === 'package.json') &&
-        !staged.some(file => file === 'yarn.lock')
+        changed.some(file => file === 'package.json') &&
+        !changed.some(file => file === 'yarn.lock')
     ) {
         return Promise.reject(
             new Error(
@@ -68,26 +64,28 @@ const checkYarnLock = staged => {
             )
         );
     }
-    return staged;
+    return changed;
+};
+
+// make sure docs TOC stays up to date
+const updateTOC = changed => {
+    if (changed.some(file => file.includes('docs/'))) {
+        const docs = path.resolve('docs');
+        const readme = path.resolve(docs, 'README.md');
+        return execa(path.resolve(docs, 'generate-toc.sh'), ['>', readme], {
+            stdio: 'inherit',
+        })
+            .then(() => execa.sync('git', ['add', readme]))
+            .then(() => changed);
+    }
+    return changed;
 };
 
 confirmIfMaster
     .then(validate)
-    .then(diff)
+    .then(getChangedFiles)
     .then(checkYarnLock)
-    // make sure docs TOC stays up to date
-    .then(staged => {
-        if (staged.some(file => file.includes('docs/'))) {
-            const docs = path.resolve('docs');
-            const readme = path.resolve(docs, 'README.md');
-            return execa(path.resolve(docs, 'generate-toc.sh'), ['>', readme], {
-                stdio: 'inherit',
-            })
-                .then(() => execa.sync('git', ['add', readme]))
-                .then(() => staged);
-        }
-        return staged;
-    })
+    .then(updateTOC)
     .catch(e => {
         console.log(`\n${e}\n`);
         process.exit(1);


### PR DESCRIPTION
## What does this change?

Currently, the pre-push hook is checking staged files for changes to `package.json`. If staged changes were found, it was warning if `yarn.lock` had not also changed.

This functionality made sense when this hook was a pre-commit hook, however it was converted into a pre-push hook in #17647.

This change uses the existing `get-changed-files` module to check whether changes to `package.json` or the `docs` have been committed in this branch.

## What is the value of this and can you measure success?

Pre-push hook works as intended

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
