### PR TITLE
Use GDPR compliant marketing consent model in Edit Profile

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -36,13 +36,17 @@ class AuthenticatedActions(
     SeeOther(identityUrlBuilder.buildUrl(signinUrl))
   }
 
-  def sendUserToSignin(request: RequestHeader): Result =  redirectWithReturn(request, "/signin")
+  def sendUserToSignin(request: RequestHeader): Result =
+    redirectWithReturn(request, "/signin")
 
-  def sendUserToReauthenticate(request: RequestHeader): Result = redirectWithReturn(request, "/reauthenticate")
+  def sendUserToReauthenticate(request: RequestHeader): Result =
+    redirectWithReturn(request, "/reauthenticate")
 
-  def authAction: AuthenticatedBuilder[AuthenticatedUser] = new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, sendUserToSignin)
+  def authAction: AuthenticatedBuilder[AuthenticatedUser] =
+    new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, sendUserToSignin)
 
-  def agreeAction(unAuthorizedCallback: (RequestHeader) => Result): AuthenticatedBuilder[AuthenticatedUser] = new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, unAuthorizedCallback)
+  def agreeAction(unAuthorizedCallback: (RequestHeader) => Result): AuthenticatedBuilder[AuthenticatedUser] =
+    new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, unAuthorizedCallback)
 
   def apiVerifiedUserRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
     override val executionContext = ec
@@ -63,12 +67,15 @@ class AuthenticatedActions(
 
   def recentlyAuthenticatedRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
     override val executionContext = ec
+
     def refine[A](request: AuthRequest[A]) = Future.successful {
       if (authService.recentlyAuthenticated(request)) Right(request) else Left(sendUserToReauthenticate(request))
     }
   }
 
-  def authActionWithUser: ActionBuilder[AuthRequest, AnyContent] = authAction andThen apiVerifiedUserRefiner
+  def authActionWithUser: ActionBuilder[AuthRequest, AnyContent] =
+    authAction andThen apiVerifiedUserRefiner
 
-  def recentlyAuthenticated: ActionBuilder[AuthRequest, AnyContent] = authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
+  def recentlyAuthenticated: ActionBuilder[AuthRequest, AnyContent] =
+    authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
 }

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -9,7 +9,7 @@ import idapiclient.responses.Error
 import idapiclient.IdApiClient
 import model._
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi, MessagesProvider}
+import play.api.i18n.{I18nSupport, MessagesProvider}
 import play.api.mvc._
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import services._
@@ -66,27 +66,30 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
       }
 
       val activePage = identityPageToEditProfilePage(page)
-      val user = request.user
-      val profileForms = ProfileForms(user, activePage).bindFromRequestWithAddressErrorHack(request) // Why are we binding from case class and then re-binding from request?
+      val userFromRequest = request.user
+      val profileForms =
+        ProfileForms(userFromRequest, activePage).bindFromRequestWithAddressErrorHack(request) // Why are we binding from case class and then re-binding from request?
+
+//    def error(formWithErrors: Form[UserFormData]) =
 
       profileForms.activeForm.value.map {
         case data: AccountFormData if (data.deleteTelephone) => {
-          identityApiClient.deleteTelephone(user.auth) map {
-            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), user)
+          identityApiClient.deleteTelephone(userFromRequest.auth) map {
+            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), userFromRequest)
 
             case Right(_) => {
-              val boundForms = profileForms.bindForms(user.user.copy(privateFields = user.user.privateFields.copy(telephoneNumber = None)))
-              profileFormsView(page, boundForms, user)
+              val boundForms = profileForms.bindForms(userFromRequest.user.copy(privateFields = userFromRequest.user.privateFields.copy(telephoneNumber = None)))
+              profileFormsView(page, boundForms, userFromRequest)
             }
           }
         }
 
         case data: UserFormData =>
-          identityApiClient.saveUser(user.id, data.toUserUpdate(user), user.auth) map {
-            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), user)
+          identityApiClient.saveUser(userFromRequest.id, data.toUserUpdate(userFromRequest), userFromRequest.auth) map {
+            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), userFromRequest)
             case Right(updatedUser) => profileFormsView(page, profileForms.bindForms(updatedUser), updatedUser)
           }
-      }.getOrElse(Future(profileFormsView(page, profileForms, user)))
+      }.getOrElse(Future(profileFormsView(page, profileForms, userFromRequest)))
     }
   }
 

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -47,35 +47,35 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
   def displayDigitalPackForm: Action[AnyContent] = displayForm(digitalPackPage)
   def displayPrivacyForm: Action[AnyContent] = displayForm(privacyPage)
 
+  def submitPublicProfileForm(): Action[AnyContent] = submitForm(publicPage)
+  def submitAccountForm(): Action[AnyContent] = submitForm(accountPage)
+  def submitPrivacyForm(): Action[AnyContent] = submitForm(privacyPage)
+
   private def displayForm(page: IdentityPage) = csrfAddToken {
     recentlyAuthenticated.async { implicit request =>
       Future(profileFormsView(page = page, forms = ProfileForms(request.user, PublicEditProfilePage), request.user))
     }
   }
 
-  def submitPublicProfileForm(): Action[AnyContent] = submitForm(publicPage)
-  def submitAccountForm(): Action[AnyContent] = submitForm(accountPage)
-  def submitPrivacyForm(): Action[AnyContent] = submitForm(privacyPage)
+  private def submitForm(page: IdentityPage): Action[AnyContent] = csrfCheck { authActionWithUser.async { implicit request =>
+    def identityPageToEditProfilePage(identityPage: IdentityPage): EditProfilePage =
+      identityPage match {
+        case `publicPage` => PublicEditProfilePage
+        case `accountPage` => AccountEditProfilePage
+        case _ => PrivacyEditProfilePage
+      }
 
-  def identifyActiveSubmittedForm(page: IdentityPage): EditProfilePage =
-    page match {
-      case `publicPage` => PublicEditProfilePage
-      case `accountPage` => AccountEditProfilePage
-      case _ => PrivacyEditProfilePage
-    }
-
-  def submitForm(page: IdentityPage): Action[AnyContent] = csrfCheck { authActionWithUser.async { implicit request =>
-      val activePage = identifyActiveSubmittedForm(page)
+      val activePage = identityPageToEditProfilePage(page)
       val user = request.user
-      val forms = ProfileForms(user, activePage).bindFromRequest(request)
+      val profileForms = ProfileForms(user, activePage).bindFromRequestWithAddressErrorHack(request) // Why are we binding from case class and then re-binding from request?
 
-      forms.activeForm.value.map {
+      profileForms.activeForm.value.map {
         case data: AccountFormData if (data.deleteTelephone) => {
           identityApiClient.deleteTelephone(user.auth) map {
-            case Left(errors) => profileFormsView(page, forms.withErrors(errors), user)
+            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), user)
 
             case Right(_) => {
-              val boundForms = forms.bindForms(user.user.copy(privateFields = user.user.privateFields.copy(telephoneNumber = None)))
+              val boundForms = profileForms.bindForms(user.user.copy(privateFields = user.user.privateFields.copy(telephoneNumber = None)))
               profileFormsView(page, boundForms, user)
             }
           }
@@ -83,10 +83,10 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
 
         case data: UserFormData =>
           identityApiClient.saveUser(user.id, data.toUserUpdate(user), user.auth) map {
-            case Left(errors) => profileFormsView(page, forms.withErrors(errors), user)
-            case Right(updatedUser) => profileFormsView(page, forms.bindForms(updatedUser), updatedUser)
+            case Left(errors) => profileFormsView(page, profileForms.withErrors(errors), user)
+            case Right(updatedUser) => profileFormsView(page, profileForms.bindForms(updatedUser), updatedUser)
           }
-      }.getOrElse(Future(profileFormsView(page, forms, user)))
+      }.getOrElse(Future(profileFormsView(page, profileForms, user)))
     }
   }
 
@@ -94,6 +94,15 @@ class EditProfileController(idUrlBuilder: IdentityUrlBuilder,
     NoCache(Ok(views.html.profileForms(page, user, forms, idRequestParser(request), idUrlBuilder)))
 }
 
+/**
+  * Holds all Edit Profile forms and designates which one is user currently viewing
+  *
+  * @param publicForm   /public/edit
+  * @param accountForm  /account/edit
+  * @param privacyForm  /privacy/edit
+  * @param activePage   which page is user currently viewing and hence which form
+  * @param profileFormsMapping Case class with mappings for all the forms
+  */
 case class ProfileForms(
     publicForm: Form[ProfileFormData],
     accountForm: Form[AccountFormData],
@@ -106,7 +115,23 @@ case class ProfileForms(
     case PrivacyEditProfilePage => privacyForm
   }
 
-  def bindFromRequest(implicit request: Request[_]): ProfileForms = update {
+  private lazy val activeMapping = activePage match {
+    case PublicEditProfilePage => profileFormsMapping.profileMapping
+    case AccountEditProfilePage => profileFormsMapping.accountDetailsMapping
+    case PrivacyEditProfilePage => profileFormsMapping.privacyMapping
+  }
+
+  /** Fills all Edit Profile forms (Public, Account, Privacy) with the provided User value */
+  def bindForms(user: User)(implicit messagesProvider: MessagesProvider): ProfileForms = {
+    copy(
+      publicForm = profileFormsMapping.profileMapping.bindForm(user),
+      accountForm = profileFormsMapping.accountDetailsMapping.bindForm(user),
+      privacyForm = profileFormsMapping.privacyMapping.bindForm(user)
+    )
+  }
+
+  /** Adds address hack error to the form */
+  def bindFromRequestWithAddressErrorHack(implicit request: Request[_]): ProfileForms = update {
     form =>
       // Hack to get the postcode error into the correct context.
       val boundForm = form.bindFromRequest()
@@ -116,14 +141,7 @@ case class ProfileForms(
       } getOrElse boundForm
   }
 
-  def bindForms(user: User)(implicit messagesProvider: MessagesProvider): ProfileForms = {
-    copy(
-      publicForm = profileFormsMapping.profileMapping.bindForm(user),
-      accountForm = profileFormsMapping.accountDetailsMapping.bindForm(user),
-      privacyForm = profileFormsMapping.privacyMapping.bindForm(user)
-    )
-  }
-
+  /** Adds errors to the form */
   def withErrors(errors: List[Error]): ProfileForms = {
     update{
       form =>
@@ -135,27 +153,43 @@ case class ProfileForms(
     }
   }
 
-  private lazy val activeMapping = activePage match {
-    case PublicEditProfilePage => profileFormsMapping.profileMapping
-    case AccountEditProfilePage => profileFormsMapping.accountDetailsMapping
-    case PrivacyEditProfilePage => profileFormsMapping.privacyMapping
-  }
-
-  private def update(change: (Form[_ <: UserFormData]) => Form[_ <: UserFormData]): ProfileForms = {
+  /**
+    * Create a copy of ProfileForms with applied change to the currently active form
+    *
+    * @param changeFunc function that takes currently active form and returns a modified version of the form
+    * @return copy of ProfileForms with applied change to the currently active form
+    */
+  private def update(changeFunc: (Form[_ <: UserFormData]) => Form[_ <: UserFormData]): ProfileForms = {
     activePage match {
-      case PublicEditProfilePage => copy(publicForm = change(publicForm).asInstanceOf[Form[ProfileFormData]])
-      case AccountEditProfilePage => copy(accountForm = change(accountForm).asInstanceOf[Form[AccountFormData]])
-      case PrivacyEditProfilePage => copy(privacyForm = change(privacyForm).asInstanceOf[Form[PrivacyFormData]])
+      case PublicEditProfilePage => copy(publicForm = changeFunc(publicForm).asInstanceOf[Form[ProfileFormData]])
+      case AccountEditProfilePage => copy(accountForm = changeFunc(accountForm).asInstanceOf[Form[AccountFormData]])
+      case PrivacyEditProfilePage => copy(privacyForm = changeFunc(privacyForm).asInstanceOf[Form[PrivacyFormData]])
     }
   }
 }
 
 object ProfileForms {
+  /**
+    * Creates a instance of ProfileForms by filling all the Edit Profile forms (Public, Account, Privacy)
+    * with the provided User value
+    *
+    * @param user User instance used as a form filler
+    * @param activePage Which page is user currently viewing
+    * @param profileFormsMapping Case class with mappings for all the forms
+    * @return instance of ProfileForms having all the forms bound to provided user value
+    */
+  def apply(
+      user: User,
+      activePage: EditProfilePage)
+      (implicit profileFormsMapping: ProfileFormsMapping, messagesProvider: MessagesProvider): ProfileForms = {
 
-  def apply(user: User, activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping, messagesProvider: MessagesProvider): ProfileForms = ProfileForms(
-    publicForm = profileFormsMapping.profileMapping.bindForm(user),
-    accountForm = profileFormsMapping.accountDetailsMapping.bindForm(user),
-    privacyForm = profileFormsMapping.privacyMapping.bindForm(user),
-    activePage = activePage
-  )
+    ProfileForms(
+      publicForm = profileFormsMapping.profileMapping.bindForm(user),
+      accountForm = profileFormsMapping.accountDetailsMapping.bindForm(user),
+      privacyForm = profileFormsMapping.privacyMapping.bindForm(user),
+      activePage = activePage
+    )
+
+  }
+
 }

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -17,10 +17,11 @@ import utils.SafeLogging
 
 import scala.concurrent.Future
 
-sealed trait EditProfilePage
-case object PublicEditProfilePage extends EditProfilePage
-case object AccountEditProfilePage extends EditProfilePage
-case object PrivacyEditProfilePage extends EditProfilePage
+object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
+object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
+object PrivacyEditProfilePage extends IdentityPage("/privacy/edit", "Privacy")
+object MembershipEditProfilePage extends IdentityPage("/membership/edit", "Membership")
+object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
 
 class EditProfileController(
     idUrlBuilder: IdentityUrlBuilder,
@@ -39,21 +40,15 @@ class EditProfileController(
 
   import authenticatedActions._
 
-  private val accountPage = IdentityPage("/account/edit", "Edit Account Details")
-  private val publicPage = IdentityPage("/public/edit", "Edit Public Profile")
-  private val membershipPage = IdentityPage("/membership/edit", "Membership")
-  private val digitalPackPage = IdentityPage("/digitalpack/edit", "Digital Pack")
-  private val privacyPage = IdentityPage("/privacy/edit", "Privacy")
+  def displayPublicProfileForm: Action[AnyContent] = displayForm(PublicEditProfilePage)
+  def displayAccountForm: Action[AnyContent] = displayForm(AccountEditProfilePage)
+  def displayMembershipForm: Action[AnyContent] = displayForm(MembershipEditProfilePage)
+  def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
+  def displayPrivacyForm: Action[AnyContent] = displayForm(PrivacyEditProfilePage)
 
-  def displayPublicProfileForm: Action[AnyContent] = displayForm(publicPage)
-  def displayAccountForm: Action[AnyContent] = displayForm(accountPage)
-  def displayMembershipForm: Action[AnyContent] = displayForm(membershipPage)
-  def displayDigitalPackForm: Action[AnyContent] = displayForm(digitalPackPage)
-  def displayPrivacyForm: Action[AnyContent] = displayForm(privacyPage)
-
-  def submitPublicProfileForm(): Action[AnyContent] = submitForm(publicPage)
-  def submitAccountForm(): Action[AnyContent] = submitForm(accountPage)
-  def submitPrivacyForm(): Action[AnyContent] = submitForm(privacyPage)
+  def submitPublicProfileForm(): Action[AnyContent] = submitForm(PublicEditProfilePage)
+  def submitAccountForm(): Action[AnyContent] = submitForm(AccountEditProfilePage)
+  def submitPrivacyForm(): Action[AnyContent] = submitForm(PrivacyEditProfilePage)
 
   private def displayForm(page: IdentityPage) = csrfAddToken {
     recentlyAuthenticated.async { implicit request =>
@@ -69,17 +64,9 @@ class EditProfileController(
   private def submitForm(page: IdentityPage): Action[AnyContent] =
     csrfCheck {
       authActionWithUser.async { implicit request =>
-        def identityPageToEditProfilePage(identityPage: IdentityPage): EditProfilePage =
-          identityPage match {
-            case `publicPage` => PublicEditProfilePage
-            case `accountPage` => AccountEditProfilePage
-            case _ => PrivacyEditProfilePage
-          }
-
-        val activePage = identityPageToEditProfilePage(page)
         val userDO = request.user
         val boundProfileForms =
-          ProfileForms(userDO, activePage).bindFromRequestWithAddressErrorHack(request) // NOTE: only active form is bound to request data
+          ProfileForms(userDO, activePage = page).bindFromRequestWithAddressErrorHack(request) // NOTE: only active form is bound to request data
 
         def processSuccessfulSubmission(userFormData: UserFormData): Future[Result] = {
           userFormData match {
@@ -133,7 +120,7 @@ case class ProfileForms(
     publicForm: Form[ProfileFormData],
     accountForm: Form[AccountFormData],
     privacyForm: Form[PrivacyFormData],
-    activePage: EditProfilePage)(implicit profileFormsMapping: ProfileFormsMapping) {
+    activePage: IdentityPage)(implicit profileFormsMapping: ProfileFormsMapping) {
 
   lazy val activeForm = activePage match {
     case PublicEditProfilePage => publicForm
@@ -210,7 +197,7 @@ object ProfileForms {
     */
   def apply(
       userDO: User,
-      activePage: EditProfilePage)
+      activePage: IdentityPage)
       (implicit profileFormsMapping: ProfileFormsMapping, messagesProvider: MessagesProvider): ProfileForms = {
 
     ProfileForms(

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -3,7 +3,7 @@ package form
 import model.Titles
 import play.api.data.Forms._
 import com.gu.identity.model.{PrivateFields, User, UserDates}
-import idapiclient.UserUpdate
+import idapiclient.UserUpdateDTO
 import play.api.i18n.MessagesProvider
 
 class AccountDetailsMapping extends UserFormMapping[AccountFormData] with AddressMapping with DateMapping with TelephoneNumberMapping {
@@ -25,9 +25,9 @@ class AccountDetailsMapping extends UserFormMapping[AccountFormData] with Addres
     )(AccountFormData.apply)(AccountFormData.unapply _)
   }
 
-  protected def fromUser(user: User) = AccountFormData(user)
+  protected def toUserFormData(user: User) = AccountFormData(user)
 
-  protected lazy val contextMap = Map(
+  protected lazy val idapiErrorContextToFormFieldKeyMap = Map(
     ("privateFields.title", "title"),
     ("privateFields.firstName", "firstName"),
     ("privateFields.secondName", "secondName"),
@@ -62,7 +62,7 @@ case class AccountFormData(
   deleteTelephone: Boolean = false
 ) extends UserFormData {
 
-  def toUserUpdate(currentUser: User): UserUpdate = UserUpdate(
+  def toUserUpdate(currentUser: User): UserUpdateDTO = UserUpdateDTO(
     primaryEmailAddress = toUpdate(primaryEmailAddress, Some(currentUser.primaryEmailAddress)),
     dates = Some(UserDates(birthDate = birthDate.dateTime)),
     privateFields = Some(PrivateFields(

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -4,7 +4,7 @@ import com.gu.identity.model.User
 import idapiclient.UserUpdate
 import play.api.data.Forms._
 import play.api.data.Mapping
-import play.api.i18n.{MessagesApi, MessagesProvider}
+import play.api.i18n.MessagesProvider
 
 class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
@@ -24,10 +24,9 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 }
 
 case class PrivacyFormData(
-                            receiveGnmMarketing: Boolean,
-                            receive3rdPartyMarketing: Boolean,
-                            allowThirdPartyProfiling: Boolean
-                            ) extends UserFormData{
+    receiveGnmMarketing: Boolean,
+    receive3rdPartyMarketing: Boolean,
+    allowThirdPartyProfiling: Boolean) extends UserFormData{
 
   def toUserUpdate(currentUser: User): UserUpdate = {
     val statusFields = currentUser.statusFields
@@ -39,7 +38,6 @@ case class PrivacyFormData(
       ))
     )
   }
-
 }
 
 object PrivacyFormData {

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -66,6 +66,5 @@ object PrivacyFormData {
     List(
       Consent("user", "firstParty", false),
       Consent("user", "thirdParty", false),
-      Consent("user", "thirdPartyProfiling", false)
-    )
+      Consent("user", "thirdPartyProfiling", false))
 }

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -42,16 +42,15 @@ case class PrivacyFormData(
     allowThirdPartyProfiling: Boolean,
     consents: Seq[Consent]) extends UserFormData{
 
-  def toUserUpdate(currentUser: User): UserUpdate = {
-    val statusFields = currentUser.statusFields
+  def toUserUpdate(oldUser: User): UserUpdate =
     UserUpdate(
-      statusFields = Some(statusFields.copy(
+      statusFields = Some(oldUser.statusFields.copy(
         receive3rdPartyMarketing = Some(receive3rdPartyMarketing),
         receiveGnmMarketing = Some(receiveGnmMarketing),
         allowThirdPartyProfiling = Some(allowThirdPartyProfiling)
-      ))
+      )),
+      consents = Some(consents.toSet)
     )
-  }
 }
 
 object PrivacyFormData {

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -49,7 +49,7 @@ case class PrivacyFormData(
         receiveGnmMarketing = Some(receiveGnmMarketing),
         allowThirdPartyProfiling = Some(allowThirdPartyProfiling)
       )),
-      consents = Some(consents.toSet)
+      consents = Some(consents)
     )
 }
 
@@ -58,6 +58,6 @@ object PrivacyFormData {
     receiveGnmMarketing = user.statusFields.receiveGnmMarketing.getOrElse(false),
     receive3rdPartyMarketing = user.statusFields.receive3rdPartyMarketing.getOrElse(false),
     allowThirdPartyProfiling = user.statusFields.allowThirdPartyProfiling.getOrElse(true),
-    consents = user.consents.toList
+    consents = user.consents
   )
 }

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -13,9 +13,6 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
   protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] =
     mapping(
-      "receiveGnmMarketing" -> boolean,
-      "receive3rdPartyMarketing" -> boolean,
-      "allowThirdPartyProfiling" -> boolean,
       "consents" -> list(
         mapping(
           "actor" -> text,
@@ -42,20 +39,10 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
   * Form specific DTO representing marketing consent subset of User model
   */
 case class PrivacyFormData(
-    receiveGnmMarketing: Boolean,
-    receive3rdPartyMarketing: Boolean,
-    allowThirdPartyProfiling: Boolean,
     consents: List[Consent]) extends UserFormData{
 
   def toUserUpdate(oldUserFromApi: User): UserUpdateDTO =
-    UserUpdateDTO(
-      statusFields = Some(oldUserFromApi.statusFields.copy(
-        receive3rdPartyMarketing = Some(receive3rdPartyMarketing),
-        receiveGnmMarketing = Some(receiveGnmMarketing),
-        allowThirdPartyProfiling = Some(allowThirdPartyProfiling)
-      )),
-      consents = Some(consents)
-    )
+    UserUpdateDTO(consents = Some(consents))
 }
 
 object PrivacyFormData {
@@ -67,11 +54,7 @@ object PrivacyFormData {
     */
   def apply(userFromApi: User): PrivacyFormData =
     PrivacyFormData(
-      receiveGnmMarketing = userFromApi.statusFields.receiveGnmMarketing.getOrElse(false),
-      receive3rdPartyMarketing = userFromApi.statusFields.receive3rdPartyMarketing.getOrElse(false),
-      allowThirdPartyProfiling = userFromApi.statusFields.allowThirdPartyProfiling.getOrElse(true),
-      consents = if (userFromApi.consents.isEmpty) defaultConsents else userFromApi.consents
-    )
+      consents = if (userFromApi.consents.isEmpty) defaultConsents else userFromApi.consents)
 
   private val defaultConsents =
     List(

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -15,7 +15,7 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
     "receiveGnmMarketing" -> boolean,
     "receive3rdPartyMarketing" -> boolean,
     "allowThirdPartyProfiling" -> boolean,
-    "consents" -> seq(
+    "consents" -> list(
       mapping(
         "actor" -> text,
         "consentIdentifier" -> text,
@@ -40,7 +40,7 @@ case class PrivacyFormData(
     receiveGnmMarketing: Boolean,
     receive3rdPartyMarketing: Boolean,
     allowThirdPartyProfiling: Boolean,
-    consents: Seq[Consent]) extends UserFormData{
+    consents: List[Consent]) extends UserFormData{
 
   def toUserUpdate(oldUser: User): UserUpdate =
     UserUpdate(

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -54,10 +54,18 @@ case class PrivacyFormData(
 }
 
 object PrivacyFormData {
-  def apply(user: User): PrivacyFormData = PrivacyFormData(
-    receiveGnmMarketing = user.statusFields.receiveGnmMarketing.getOrElse(false),
-    receive3rdPartyMarketing = user.statusFields.receive3rdPartyMarketing.getOrElse(false),
-    allowThirdPartyProfiling = user.statusFields.allowThirdPartyProfiling.getOrElse(true),
-    consents = user.consents
-  )
+  def apply(user: User): PrivacyFormData =
+    PrivacyFormData(
+      receiveGnmMarketing = user.statusFields.receiveGnmMarketing.getOrElse(false),
+      receive3rdPartyMarketing = user.statusFields.receive3rdPartyMarketing.getOrElse(false),
+      allowThirdPartyProfiling = user.statusFields.allowThirdPartyProfiling.getOrElse(true),
+      consents = if (user.consents.isEmpty) defaultConsents else user.consents
+    )
+
+  private val defaultConsents =
+    List(
+      Consent("user", "firstParty", false),
+      Consent("user", "thirdParty", false),
+      Consent("user", "thirdPartyProfiling", false)
+    )
 }

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -9,7 +9,7 @@ import play.api.i18n.MessagesProvider
 
 class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
-  val DateTimeFormat: String = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  private val dateTimeFormatISO8601: String = "yyyy-MM-dd'T'HH:mm:ssZZ"
 
   protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] = mapping(
     "receiveGnmMarketing" -> boolean,
@@ -21,7 +21,7 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
         "consentIdentifier" -> text,
         "consentIdentifierVersion" -> number,
         "hasConsented" -> boolean,
-        "timestamp" -> jodaDate(DateTimeFormat),
+        "timestamp" -> jodaDate(dateTimeFormatISO8601),
         "privacyPolicy" -> number
       )(Consent.apply)(Consent.unapply)
     )

--- a/identity/app/form/ProfileMapping.scala
+++ b/identity/app/form/ProfileMapping.scala
@@ -2,7 +2,7 @@ package form
 
 import play.api.data.Forms._
 import com.gu.identity.model.{PublicFields, User}
-import idapiclient.UserUpdate
+import idapiclient.UserUpdateDTO
 import play.api.data.Mapping
 import play.api.i18n.{MessagesApi, MessagesProvider}
 
@@ -15,9 +15,9 @@ class ProfileMapping extends UserFormMapping[ProfileFormData] {
     "username" -> textField
   )(ProfileFormData.apply)(ProfileFormData.unapply)
 
-  protected def fromUser(user: User) = ProfileFormData(user)
+  protected def toUserFormData(user: User) = ProfileFormData(user)
 
-  protected lazy val contextMap =  Map(
+  protected lazy val idapiErrorContextToFormFieldKeyMap =  Map(
     "publicFields.location" -> "location",
     "publicFields.aboutMe" -> "aboutMe",
     "publicFields.interests" -> "interests",
@@ -32,7 +32,7 @@ case class ProfileFormData(
   username: String
 ) extends UserFormData{
 
-  def toUserUpdate(currentUser: User): UserUpdate = UserUpdate(
+  def toUserUpdate(currentUser: User): UserUpdateDTO = UserUpdateDTO(
     publicFields = Some(PublicFields(
       location = toUpdate(location, currentUser.publicFields.location),
       aboutMe = toUpdate(aboutMe, currentUser.publicFields.aboutMe),

--- a/identity/app/form/UserFormMapping.scala
+++ b/identity/app/form/UserFormMapping.scala
@@ -7,9 +7,8 @@ import play.api.i18n.MessagesProvider
 
 trait UserFormMapping[T <: UserFormData] extends Mappings {
 
-  private def form(implicit messagesProvider: MessagesProvider): Form[T] = Form(formMapping)
-
-  def bindForm(user: User)(implicit messagesProvider: MessagesProvider): Form[T] = form fill fromUser(user)
+  def bindForm(user: User)(implicit messagesProvider: MessagesProvider): Form[T] =
+    Form(formMapping) fill fromUser(user)
 
   def mapContext(context: String): String = contextMap.getOrElse(context, context)
 

--- a/identity/app/form/UserFormMapping.scala
+++ b/identity/app/form/UserFormMapping.scala
@@ -2,25 +2,57 @@ package form
 
 import play.api.data.{Form, Mapping}
 import com.gu.identity.model.User
-import idapiclient.UserUpdate
+import idapiclient.UserUpdateDTO
 import play.api.i18n.MessagesProvider
 
 trait UserFormMapping[T <: UserFormData] extends Mappings {
 
-  def bindForm(user: User)(implicit messagesProvider: MessagesProvider): Form[T] =
-    Form(formMapping) fill fromUser(user)
+  type IdapiErrorContext = String
+  type FormFieldKey = String
 
-  def mapContext(context: String): String = contextMap.getOrElse(context, context)
+  /**
+    * Returns a Form filled with existing UserFormData DTO value (as opposed to binding data from request)
+    * which is in turn created from User DO from IDAPI.
+    *
+    * @param userFromApi User from IDAPI defined in identity-model library
+    * @param messagesProvider
+    * @return Form filled with UserFormData DTO
+    */
+  def fillForm(userFromApi: User)(implicit messagesProvider: MessagesProvider): Form[T] =
+    Form(formMapping) fill toUserFormData(userFromApi) // note the indirection where userFromApi is converted to UserFormData
+
+  /**
+    * Returns Form field key given IDAPI error context
+    */
+  def formFieldKeyBy(idapiErrorContext: IdapiErrorContext): String =
+    idapiErrorContextToFormFieldKeyMap.getOrElse(idapiErrorContext, default = idapiErrorContext)
 
   protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[T]
 
-  protected def fromUser(user: User): T
+  /**
+    * Converts User from IDAPI to form processing DTO
+    *
+    * @param userFromApi
+    * @return form processing DTO
+    */
+  protected def toUserFormData(userFromApi: User): T
 
-  protected def contextMap: Map[String, String]
+  /**
+    * Mapping from IDAPI error context to Form field key
+    */
+  protected def idapiErrorContextToFormFieldKeyMap: Map[IdapiErrorContext, FormFieldKey]
 }
 
+/**
+  * Trait to represent form specific Data Transfer Objects used for form data binding.
+  * These DTOs are meant to represent parts of User Domain Object form
+  */
 trait UserFormData {
-  def toUserUpdate(currentUser: User): UserUpdate
+
+  /**
+    * Converts User DO to UserUpdate DTO used for serialisation over wire
+    */
+  def toUserUpdate(oldUserDO: User): UserUpdateDTO
 
   protected def toUpdate[T](newValue: T, current: Option[T]): Option[T] = (newValue, current) match {
     case ("", None) => None

--- a/identity/app/formstack/FormstackApi.scala
+++ b/identity/app/formstack/FormstackApi.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class FormstackApi(httpClient: WsFormstackHttp) extends SafeLogging {
 
-  implicit val formats = LiftJsonConfig.formats + new JodaJsonSerializer
+  implicit val formats = LiftJsonConfig.formats + JodaJsonSerializer
 
   def formstackUrl(formId: String): String = {
     val formstackUrl = Configuration.formstack.url

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -57,119 +57,14 @@ class IdApiClient(
     response map extractUser
   }
 
-  def saveUser(userId: String, user: UserUpdateDTO, auth: Auth): Future[Response[User]] = {
-    println("Saving user!!!")
-    println(write(user))
-//    mockUserResponseV2Consent
+  def saveUser(userId: String, user: UserUpdateDTO, auth: Auth): Future[Response[User]] =
     post(urlJoin("user", userId), Some(auth), body = Some(write(user))) map extractUser
-  }
 
   def me(auth: Auth): Future[Response[User]] = {
     val apiPath = urlJoin("user", "me")
     val params = buildParams(Some(auth))
     val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(Some(auth)))
-    response.map { _.fold(
-        error => println(error.toString()),
-        httpResponse => println(httpResponse.body)
-      )
-    }
-
     response map extractUser
-//    mockUserResponseV2Consent
-  }
-
-  private def mockUserResponseV2Consent = {
-
-    val httpResponseBody =
-      """
-        |{
-        |	"status": "ok",
-        |	"user": {
-        |		"id": "10000052",
-        |		"primaryEmailAddress": "tgtz4grdot0hgc4mfec@gu.com",
-        |		"publicFields": {
-        |			"username": "ratatat11",
-        |			"usernameLowerCase": "ratatat11",
-        |			"displayName": "ratatat11"
-        |		},
-        |		"privateFields": {
-        |			"firstName": "tGtZ4grdot0HGC4mFEc1-mock",
-        |			"secondName": "tGtZ4grdot0HGC4mFEc1",
-        |			"gender": "Male",
-        |			"registrationIp": "",
-        |			"address1": "Moon311",
-        |			"registrationType": "guardian",
-        |			"registrationPlatform": "identity-frontend",
-        |			"title": "Mr",
-        |			"legacyPackages": "CRE,RCO",
-        |			"legacyProducts": "CRE,RCO"
-        |		},
-        |		"statusFields": {
-        |			"receive3rdPartyMarketing": true,
-        |			"receiveGnmMarketing": false,
-        |			"allowThirdPartyProfiling": false
-        |			"userEmailValidated": true,
-        |		},
-        |		"dates": {
-        |			"accountCreatedDate": "2017-07-14T13:57:59Z"
-        |		},
-        |		"userGroups": [{
-        |			"path": "/sys/policies/basic-identity",
-        |			"packageCode": "CRE"
-        |		}, {
-        |			"path": "/sys/policies/basic-community",
-        |			"packageCode": "RCO"
-        |		}],
-        |		"socialLinks": [],
-        |		"adData": {},
-        |		"consents": [{
-        |				"actor": "user",
-        |				"consentIdentifier": "firstParty",
-        |				"consentIdentifierVersion": 3,
-        |				"hasConsented": true,
-        |				"timestamp": "2017-07-14T13:57:59Z",
-        |				"privacyPolicy": 1
-        |			},
-        |			{
-        |				"actor": "user",
-        |				"consentIdentifier": "thirdParty",
-        |				"consentIdentifierVersion": 2,
-        |				"hasConsented": false,
-        |				"timestamp": "2017-07-14T13:57:59Z",
-        |				"privacyPolicy": 1
-        |			}
-        |		]
-        |	}
-        |}
-      """.stripMargin
-
-    val response = Future(Right(HttpResponse(httpResponseBody, 200, "OK")))
-
-    //    response.map { _.fold(
-    //        error => println(error.toString()),
-    //        httpResponse => println(httpResponse.body)
-    //      )
-    //    }
-
-    val deserializedUserWithConsentsResponse = response map extractUser
-    println("the new model ta da da da!")
-
-    deserializedUserWithConsentsResponse.map { deserializedUserWithConsents =>
-      println("i am here")
-      deserializedUserWithConsents.fold(
-        error => {
-          println("ererrrerw")
-          println(error.toString())
-        },
-        userWithConsents => {
-          println("I am in right")
-          userWithConsents.consents.toList.foreach(println)
-        }
-      )
-    }
-
-    deserializedUserWithConsentsResponse
-
   }
 
   /**

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -57,7 +57,7 @@ class IdApiClient(
     response map extractUser
   }
 
-  def saveUser(userId: String, user: UserUpdate, auth: Auth): Future[Response[User]] = {
+  def saveUser(userId: String, user: UserUpdateDTO, auth: Auth): Future[Response[User]] = {
     println("Saving user!!!")
     println(write(user))
 //    mockUserResponseV2Consent

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -57,18 +57,28 @@ class IdApiClient(
     response map extractUser
   }
 
-  def saveUser(userId: String, user: UserUpdate, auth: Auth): Future[Response[User]] =
+  def saveUser(userId: String, user: UserUpdate, auth: Auth): Future[Response[User]] = {
+    println("Saving user!!!")
+    println(write(user))
+//    mockUserResponseV2Consent
     post(urlJoin("user", userId), Some(auth), body = Some(write(user))) map extractUser
+  }
 
   def me(auth: Auth): Future[Response[User]] = {
     val apiPath = urlJoin("user", "me")
     val params = buildParams(Some(auth))
-//    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(Some(auth)))
-//    response.map { _.fold(
-//        error => println(error.toString()),
-//        httpResponse => println(httpResponse.body)
-//      )
-//    }
+    val response = httpClient.GET(apiUrl(apiPath), None, params, buildHeaders(Some(auth)))
+    response.map { _.fold(
+        error => println(error.toString()),
+        httpResponse => println(httpResponse.body)
+      )
+    }
+
+    response map extractUser
+//    mockUserResponseV2Consent
+  }
+
+  private def mockUserResponseV2Consent = {
 
     val httpResponseBody =
       """
@@ -135,11 +145,11 @@ class IdApiClient(
 
     val response = Future(Right(HttpResponse(httpResponseBody, 200, "OK")))
 
-//    response.map { _.fold(
-//        error => println(error.toString()),
-//        httpResponse => println(httpResponse.body)
-//      )
-//    }
+    //    response.map { _.fold(
+    //        error => println(error.toString()),
+    //        httpResponse => println(httpResponse.body)
+    //      )
+    //    }
 
     val deserializedUserWithConsentsResponse = response map extractUser
     println("the new model ta da da da!")
@@ -147,20 +157,18 @@ class IdApiClient(
     deserializedUserWithConsentsResponse.map { deserializedUserWithConsents =>
       println("i am here")
       deserializedUserWithConsents.fold(
-          error => {
-            println("ererrrerw")
-            println(error.toString())
-          },
-          userWithConsents => {
-            println("I am in right")
-            userWithConsents.consents.toList.foreach(println)
-          }
-        )
-      }
+        error => {
+          println("ererrrerw")
+          println(error.toString())
+        },
+        userWithConsents => {
+          println("I am in right")
+          userWithConsents.consents.toList.foreach(println)
+        }
+      )
+    }
 
     deserializedUserWithConsentsResponse
-
-//    response map extractUser
 
   }
 

--- a/identity/app/idapiclient/UserUpdate.scala
+++ b/identity/app/idapiclient/UserUpdate.scala
@@ -12,5 +12,5 @@ case class UserUpdate (
   userGroups: Option[Set[GroupMembership]] = None,
   socialLinks: Option[Set[SocialLink]] = None,
   adData: Option[Map[String, AnyRef]] = None,
-  consents: Option[Set[Consent]] = None
+  consents: Option[Seq[Consent]] = None
 )

--- a/identity/app/idapiclient/UserUpdate.scala
+++ b/identity/app/idapiclient/UserUpdate.scala
@@ -11,5 +11,6 @@ case class UserUpdate (
   password: Option[String] = None,
   userGroups: Option[Set[GroupMembership]] = None,
   socialLinks: Option[Set[SocialLink]] = None,
-  adData: Option[Map[String, AnyRef]] = None
-);
+  adData: Option[Map[String, AnyRef]] = None,
+  consents: Option[Set[Consent]] = None
+)

--- a/identity/app/idapiclient/UserUpdate.scala
+++ b/identity/app/idapiclient/UserUpdate.scala
@@ -12,5 +12,5 @@ case class UserUpdate (
   userGroups: Option[Set[GroupMembership]] = None,
   socialLinks: Option[Set[SocialLink]] = None,
   adData: Option[Map[String, AnyRef]] = None,
-  consents: Option[Seq[Consent]] = None
+  consents: Option[List[Consent]] = None
 )

--- a/identity/app/idapiclient/UserUpdateDTO.scala
+++ b/identity/app/idapiclient/UserUpdateDTO.scala
@@ -4,15 +4,11 @@ import com.gu.identity.model._
 
 /**
   * Represents up-to-date user data DTO that is serialised and posted to IDAPI
-  *
-  * Note that this is not the User model from identity-model library, although
-  * it seems to have one-to-one mapping to User DO fields.
   */
 case class UserUpdateDTO (
   primaryEmailAddress: Option[String] = None,
   publicFields: Option[PublicFields] = None,
   privateFields: Option[PrivateFields] = None,
-  statusFields: Option[StatusFields] = None,
   dates: Option[UserDates] = None,
   password: Option[String] = None,
   userGroups: Option[Set[GroupMembership]] = None,

--- a/identity/app/idapiclient/UserUpdateDTO.scala
+++ b/identity/app/idapiclient/UserUpdateDTO.scala
@@ -2,7 +2,13 @@ package idapiclient
 
 import com.gu.identity.model._
 
-case class UserUpdate (
+/**
+  * Represents up-to-date user data DTO that is serialised and posted to IDAPI
+  *
+  * Note that this is not the User model from identity-model library, although
+  * it seems to have one-to-one mapping to User DO fields.
+  */
+case class UserUpdateDTO (
   primaryEmailAddress: Option[String] = None,
   publicFields: Option[PublicFields] = None,
   privateFields: Option[PrivateFields] = None,

--- a/identity/app/idapiclient/parser/IdApiJsonBodyParser.scala
+++ b/identity/app/idapiclient/parser/IdApiJsonBodyParser.scala
@@ -6,7 +6,7 @@ import net.liftweb.json.JsonAST.JValue
 import utils.SafeLogging
 
 class IdApiJsonBodyParser extends JsonBodyParser with SafeLogging {
-  override implicit val formats = LiftJsonConfig.formats + new JodaJsonSerializer
+  override implicit val formats = LiftJsonConfig.formats + JodaJsonSerializer
 
   override def extractErrorFromResponse(json: JValue, statusCode: Int): List[Error] = {
     try {

--- a/identity/app/idapiclient/parser/JodaJsonSerializer.scala
+++ b/identity/app/idapiclient/parser/JodaJsonSerializer.scala
@@ -5,18 +5,21 @@ import net.liftweb.json.{MappingException, TypeInfo, Formats, Serializer}
 import org.joda.time.format.ISODateTimeFormat
 import net.liftweb.json.JsonAST.JString
 
-class JodaJsonSerializer extends Serializer[DateTime]{
+/**
+  * ISO 8601 date and time format: 2017-10-16T16:14:23Z
+  */
+object JodaJsonSerializer extends Serializer[DateTime]{
   private val DateTimeClass = classOf[DateTime]
-  val formatter = ISODateTimeFormat.dateTimeNoMillis
+  val dateTimeFormatISO8601 = ISODateTimeFormat.dateTimeNoMillis
 
   def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, _root_.net.liftweb.json.JValue), DateTime] = {
     case (TypeInfo(DateTimeClass, _), json) => json match {
-      case JString(s) => formatter.parseDateTime(s)
+      case JString(s) => dateTimeFormatISO8601.parseDateTime(s)
       case x => throw new MappingException("Can't convert " + x + " to DateTime")
     }
   }
 
   def serialize(implicit format: Formats): PartialFunction[Any, _root_.net.liftweb.json.JValue] = {
-    case dt: DateTime => JString(formatter.print(dt))
+    case dt: DateTime => JString(dateTimeFormatISO8601.print(dt))
   }
 }

--- a/identity/app/idapiclient/parser/JsonBodyParser.scala
+++ b/identity/app/idapiclient/parser/JsonBodyParser.scala
@@ -12,23 +12,32 @@ trait JsonBodyParser extends Logging {
 
   def extractErrorFromResponse(json: JValue, statusCode: Int): List[Error]
 
-  def extract[T](extractJsonObj: JValue => JValue = {json => json})(httpResponseResponse: Response[HttpResponse])(implicit successType: Manifest[T]): Response[T] = {
+  def extract[T]
+      (extractJsonObj: JValue => JValue = identity)
+      (httpResponseResponse: Response[HttpResponse])
+      (implicit successType: Manifest[T]): Response[T] = {
+
     httpResponseResponse.right.flatMap { httpResponse =>
       try {
         httpResponse match {
           case HttpResponse(body, status, message) if status == 502 =>
             logger.error("API unavailable, 502")
             Left(List(Error("Bad gateway", "The server was not available", 502)))
+
           case HttpResponse(body, status, message) if status == 503 =>
             logger.error("API unavailable, 503")
             Left(List(Error("Service unavailable", "The service was not available", 503)))
+
           case HttpResponse(body, status, message) if status == 504 =>
             logger.error("API unavailable, 504")
             Left(List(Error("Gateway timeout", "The service did not respond", 504)))
+
           case HttpResponse(body, status, message) if status > 299 =>
             Left(extractErrorFromResponse(parse(body), httpResponse.statusCode))
+
           case HttpResponse(body, status, message) if successType == manifest[Unit] =>
             Right(()).asInstanceOf[Right[List[Error], T]]
+
           case HttpResponse(body, status, message) =>
             Right(extractJsonObj(parse(body)).extract[T])
         }
@@ -48,7 +57,6 @@ trait JsonBodyParser extends Logging {
   def extractUnit(httpResponseResponse: Response[HttpResponse]): Response[Unit] = {
     extract[Unit](_ => JNothing)(httpResponseResponse)
   }
-}
-object JsonBodyParser {
+
   def jsonField(field: String)(json: JValue): JValue = json \ field
 }

--- a/identity/app/idapiclient/responses/Error.scala
+++ b/identity/app/idapiclient/responses/Error.scala
@@ -1,3 +1,8 @@
 package idapiclient.responses
 
+/**
+  * FIXME:
+  *   This seems to be exactly the same as com.gu.identity.model.Error from identity-request library.
+  *   Is this only representing IDAPI errors?
+  */
 case class Error(message: String, description: String, statusCode: Int = 500, context: Option[String] = None)

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -34,7 +34,7 @@
 
 @getCurrentTime = {
     @(DateTimeFormat
-        .forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        .forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
         .withZone(DateTimeZone.UTC)
         .print(new DateTime()))
 }
@@ -45,7 +45,9 @@
       <input type="hidden" name=@(consent.name + ".actor") value='user'>
       <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
       <input type="hidden" name=@(consent.name + ".consentIdentifierVersion") value=@(user.consents.toList(consentIndex).consentIdentifierVersion)>
-      <input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>
+      @*<input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>*@
+      <input type="hidden" name="testing time" value=@getCurrentTime>
+      <input type="hidden" name=@(consent.name + ".timestamp") value="bad time format">
       <input type="hidden" name=@(consent.name + ".privacyPolicy") value=@(user.consents.toList(consentIndex).privacyPolicy)>
 
       @checkboxField(
@@ -61,14 +63,12 @@
     @views.html.helper.CSRF.formField
 
     @* Make this beautiful *@
+    @* This also displays globalErrors *@
     @if(privacyForm.hasErrors) {
-        @privacyForm.errors.size
-        @privacyForm.errors(0).message
-        @privacyForm.errors(0).key
-    }
-
-    @if(privacyForm.globalError.isDefined) {
-        <div class="form__error">@privacyForm.globalErrors.map(_.message).mkString(", ")</div>
+        <div class="form__error">
+          Error processing the form. Your changes have not been saved:
+          <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
+        </div>
     }
 
     <fieldset class="fieldset">

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -1,12 +1,11 @@
 @(idUrlBuilder: services.IdentityUrlBuilder,
   idRequest: services.IdentityRequest,
   user: com.gu.identity.model.User,
-  privacyForm: Form[form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+  privacyForm: Form[_root_.form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import views.html.fragments.form.checkboxField
 @import views.html.fragments.registrationFooter
-@import form.IdFormHelpers.{Checkbox, nonInputFields}
-@import helper._
+@import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
 @import org.joda.time.DateTime
 @import idapiclient.parser.JodaJsonSerializer
 @import com.gu.identity.model.ConsentData

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -7,44 +7,32 @@
 @import views.html.fragments.registrationFooter
 @import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
 @import org.joda.time.DateTime
-@import idapiclient.parser.JodaJsonSerializer
+@import org.joda.time.format.ISODateTimeFormat
 @import com.gu.identity.model.ConsentData
 
-@v2ConsentCheckbox(index: Int, consentIdentifier: String, consentIdentifierVersion: Int) = {
+@v2ConsentCheckbox(consentField: Field) = {
 
-    <input type="hidden" name=@("consents[" + index + "].actor") value='user'>
-    <input type="hidden" name=@("consents[" + index + "].consentIdentifier") value=@consentIdentifier>
-    <input type="hidden" name=@("consents[" + index + "].consentIdentifierVersion") value=@consentIdentifierVersion>
-    <input type="hidden" name=@("consents[" + index + "].timestamp") value=@getCurrentTime>
-    <input type="hidden" name=@("consents[" + index + "].privacyPolicy") value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
+    @* hidden input fields *@
+    @helper.inputText(consentField("actor"), 'type -> "hidden")(nonInputFields, messages)
+    @helper.inputText(consentField("consentIdentifier"), 'type -> "hidden")(nonInputFields, messages)
+    @helper.inputText(consentField("consentIdentifierVersion"), 'type -> "hidden")(nonInputFields, messages)
+    @helper.inputText(consentField("timestamp"), 'type -> "hidden", 'value -> getCurrentTime)(nonInputFields, messages)
+    @helper.inputText(consentField("privacyPolicy"), 'type -> "hidden", 'value -> ConsentData.privacyPolicyVersion)(nonInputFields, messages)
 
     @checkboxField(
         Checkbox(
-            privacyForm("consents[" + index + "].hasConsented"),
-            '_label -> ConsentData.allConsents(consentIdentifier)(consentIdentifierVersion)
+            consentField("hasConsented"),
+            '_label -> ConsentData.allConsents(consentField("consentIdentifier").value.get)(consentField("consentIdentifierVersion").value.get.toInt)
         )
     )(nonInputFields, messages)
 }
 
 @getCurrentTime = {
-    @JodaJsonSerializer.dateTimeFormatISO8601.print(new DateTime)
+    @ISODateTimeFormat.dateTimeNoMillis.withZoneUTC().print(new DateTime)
 }
 
-@* If the user has not yet set V2 consent *@
-@v2consentCheckboxesOnboarding = {
-    @v2ConsentCheckbox(0, "firstParty", ConsentData.allConsents("firstParty").indices.last)
-    @v2ConsentCheckbox(1, "thirdParty", ConsentData.allConsents("thirdParty").indices.last)
-    @v2ConsentCheckbox(2, "thirdPartyProfiling", ConsentData.allConsents("thirdPartyProfiling").indices.last)
-}
-
-@* If user has set V2 consent before *@
-@v2consentCheckboxesFromApiUser = {
-  @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consent, consentIndex) =>
-    @v2ConsentCheckbox(
-        consentIndex,
-        user.consents(consentIndex).consentIdentifier,
-        user.consents(consentIndex).consentIdentifierVersion)
-  }
+@v2consentCheckboxes = {
+  @helper.repeat(privacyForm("consents"), min=1) { consentField => @v2ConsentCheckbox(consentField) }
 }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
@@ -87,11 +75,7 @@
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">
-                        @if(user.consents.isEmpty) {
-                            @v2consentCheckboxesOnboarding
-                        } else {
-                            @v2consentCheckboxesFromApiUser
-                        }
+                        @v2consentCheckboxes
                     </div>
                 </li>
             </ul>

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -3,12 +3,12 @@
   user: com.gu.identity.model.User,
   privacyForm: Form[form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
-@import views.html.fragments.form.{checkboxField}
+@import views.html.fragments.form.checkboxField
 @import form.IdFormHelpers._
 @import helper._
 @import views.html.fragments.registrationFooter
-@import org.joda.time.{DateTime, LocalDate, DateTimeZone}
-@import org.joda.time.format.DateTimeFormat
+@import org.joda.time.DateTime
+@import idapiclient.parser.JodaJsonSerializer
 
 
 
@@ -33,10 +33,7 @@
 }
 
 @getCurrentTime = {
-    @(DateTimeFormat
-        .forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ")
-        .withZone(DateTimeZone.UTC)
-        .print(new DateTime()))
+    @JodaJsonSerializer.dateTimeFormatISO8601.print(new DateTime)
 }
 
 
@@ -45,9 +42,7 @@
       <input type="hidden" name=@(consent.name + ".actor") value='user'>
       <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
       <input type="hidden" name=@(consent.name + ".consentIdentifierVersion") value=@(user.consents.toList(consentIndex).consentIdentifierVersion)>
-      @*<input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>*@
-      <input type="hidden" name="testing time" value=@getCurrentTime>
-      <input type="hidden" name=@(consent.name + ".timestamp") value="bad time format">
+      <input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>
       <input type="hidden" name=@(consent.name + ".privacyPolicy") value=@(user.consents.toList(consentIndex).privacyPolicy)>
 
       @checkboxField(

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -10,15 +10,6 @@
 @import idapiclient.parser.JodaJsonSerializer
 @import com.gu.identity.model.ConsentData
 
-@*
-    WARNING!!
-
-    Make sure you are testing bounds
-
-    [IndexOutOfBoundsException: 0]
-    <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
-*@
-
 @v2ConsentCheckbox(index: Int, consentIdentifier: String, consentIdentifierVersion: Int) = {
 
     <input type="hidden" name=@("consents[" + index + "].actor") value='user'>
@@ -59,7 +50,7 @@
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
 
-    @* This also displays globalErrors *@
+    @* This displays both global and key-bound errors *@
     @if(privacyForm.hasErrors) {
         <div class="form__error">
           Error processing the form. Your changes have not been saved:

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -7,16 +7,47 @@
 @import form.IdFormHelpers._
 @import helper._
 @import views.html.fragments.registrationFooter
+@import org.joda.time.{DateTime, LocalDate, DateTimeZone}
+@import org.joda.time.format.DateTimeFormat
+
+
+
+@*
+    WARNING!!
+
+    Make sure you are testing bounds
+
+    [IndexOutOfBoundsException: 0]
+    <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
+*@
 
 @getConsentText(index: Int) = {
-  @com.gu.identity.model.Consent.getText(
-    user.consents.toList(index).consentIdentifier,
-    user.consents.toList(index).consentIdentifierVersion
-  )
+    @if(user.consents.toList.isEmpty) {
+        "Unknown consent text"
+    } else {
+        @com.gu.identity.model.Consent.getText(
+            user.consents.toList(index).consentIdentifier,
+            user.consents.toList(index).consentIdentifierVersion
+        )
+    }
 }
+
+@getCurrentTime = {
+    @(DateTimeFormat
+        .forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        .withZone(DateTimeZone.UTC)
+        .print(new DateTime()))
+}
+
 
 @consentCheckboxes = {
   @helper.repeatWithIndex(privacyForm("consents"), min=1) {(consent, consentIndex) =>
+      <input type="hidden" name=@(consent.name + ".actor") value='user'>
+      <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
+      <input type="hidden" name=@(consent.name + ".consentIdentifierVersion") value=@(user.consents.toList(consentIndex).consentIdentifierVersion)>
+      <input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>
+      <input type="hidden" name=@(consent.name + ".privacyPolicy") value=@(user.consents.toList(consentIndex).privacyPolicy)>
+
       @checkboxField(
           Checkbox(
               privacyForm(consent.name + ".hasConsented"),
@@ -28,6 +59,13 @@
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
+
+    @* Make this beautiful *@
+    @if(privacyForm.hasErrors) {
+        @privacyForm.errors.size
+        @privacyForm.errors(0).message
+        @privacyForm.errors(0).key
+    }
 
     @if(privacyForm.globalError.isDefined) {
         <div class="form__error">@privacyForm.globalErrors.map(_.message).mkString(", ")</div>

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -6,7 +6,7 @@
 @import views.html.fragments.form.checkboxField
 @import views.html.fragments.registrationFooter
 @import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
-@import com.gu.identity.model.ConsentData
+@import com.gu.identity.model.ConsentText
 
 @v2ConsentCheckbox(consentField: Field) = {
 
@@ -30,7 +30,7 @@
 }
 
 @getConsentText(consentField: Field) = {
-    @ConsentData.getText(
+    @ConsentText.getText(
         consentField("consentIdentifier").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
         consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
 }

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -4,11 +4,12 @@
   privacyForm: Form[form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import views.html.fragments.form.checkboxField
-@import form.IdFormHelpers._
-@import helper._
 @import views.html.fragments.registrationFooter
+@import form.IdFormHelpers.{Checkbox, nonInputFields}
+@import helper._
 @import org.joda.time.DateTime
 @import idapiclient.parser.JodaJsonSerializer
+@import com.gu.identity.model.ConsentData
 
 @*
     WARNING!!
@@ -19,114 +20,46 @@
     <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
 *@
 
-@getConsentText(index: Int) = {
-    @if(user.consents.toList.isEmpty) {
-        "Unknown consent text"
-    } else {
-        @com.gu.identity.model.ConsentData.getText(
-            user.consents.toList(index).consentIdentifier,
-            user.consents.toList(index).consentIdentifierVersion
+@v2ConsentCheckbox(index: Int, consentIdentifier: String, consentIdentifierVersion: Int) = {
+
+    <input type="hidden" name=@("consents[" + index + "].actor") value='user'>
+    <input type="hidden" name=@("consents[" + index + "].consentIdentifier") value=@consentIdentifier>
+    <input type="hidden" name=@("consents[" + index + "].consentIdentifierVersion") value=@consentIdentifierVersion>
+    <input type="hidden" name=@("consents[" + index + "].timestamp") value=@getCurrentTime>
+    <input type="hidden" name=@("consents[" + index + "].privacyPolicy") value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
+
+    @checkboxField(
+        Checkbox(
+            privacyForm("consents[" + index + "].hasConsented"),
+            '_label -> ConsentData.allConsents(consentIdentifier)(consentIdentifierVersion)
         )
-    }
+    )(nonInputFields, messages)
 }
 
 @getCurrentTime = {
     @JodaJsonSerializer.dateTimeFormatISO8601.print(new DateTime)
 }
 
-@v2consentCheckboxes = {
-  @helper.repeatWithIndex(privacyForm("consents"), min=1) {(consent, consentIndex) =>
-      <input type="hidden" name=@(consent.name + ".actor") value='user'>
-      <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
-      <input type="hidden" name=@(consent.name + ".consentIdentifierVersion") value=@(user.consents.toList(consentIndex).consentIdentifierVersion)>
-      <input type="hidden" name=@(consent.name + ".timestamp") value=@getCurrentTime>
-      <input type="hidden" name=@(consent.name + ".privacyPolicy") value=@(user.consents.toList(consentIndex).privacyPolicy)>
+@* If the user has not yet set V2 consent *@
+@v2consentCheckboxesOnboarding = {
+    @v2ConsentCheckbox(0, "firstParty", ConsentData.allConsents("firstParty").indices.last)
+    @v2ConsentCheckbox(1, "thirdParty", ConsentData.allConsents("thirdParty").indices.last)
+    @v2ConsentCheckbox(2, "thirdPartyProfiling", ConsentData.allConsents("thirdPartyProfiling").indices.last)
+}
 
-      @checkboxField(
-          Checkbox(
-              privacyForm(consent.name + ".hasConsented"),
-              '_label -> getConsentText(consentIndex)
-          )
-      )(nonInputFields, messages)
+@* If user has set V2 consent before *@
+@v2consentCheckboxesFromApiUser = {
+  @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consent, consentIndex) =>
+    @v2ConsentCheckbox(
+        consentIndex,
+        user.consents(consentIndex).consentIdentifier,
+        user.consents(consentIndex).consentIdentifierVersion)
   }
 }
-
-@v1consentCheckboxes = {
-    @checkboxField(Checkbox(
-        privacyForm("receiveGnmMarketing"),
-        '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
-
-    @checkboxField(Checkbox(
-        privacyForm("receive3rdPartyMarketing"),
-        '_label -> "Receive email from other organisations"))(nonInputFields, messages)
-}
-
-@v1profilingConsetCheckbox = {
-    @checkboxField(Checkbox(
-        privacyForm("allowThirdPartyProfiling"),
-        '_label -> "Allow matching with third party data")
-    )(nonInputFields, messages)
-}
-
-@v2consentCheckboxesOnboarding = {
-
-    @* FIRST PARTY *@
-
-    <input type="hidden" name="consents[0].actor" value='user'>
-    <input type="hidden" name="consents[0].consentIdentifier" value="firstParty">
-    <input type="hidden" name="consents[0].consentIdentifierVersion" value="0">
-    <input type="hidden" name="consents[0].timestamp" value=@getCurrentTime>
-    <input type="hidden" name="consents[0].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
-
-    @checkboxField(
-        Checkbox(
-            privacyForm("consents[0].hasConsented"),
-            '_label -> com.gu.identity.model.ConsentData.currentConsents("firstParty")
-        )
-    )(nonInputFields, messages)
-
-    @* THIRD PARTY *@
-
-    <input type="hidden" name="consents[1].actor" value='user'>
-    <input type="hidden" name="consents[1].consentIdentifier" value="thirdParty">
-    <input type="hidden" name="consents[1].consentIdentifierVersion" value="0">
-    <input type="hidden" name="consents[1].timestamp" value=@getCurrentTime>
-    <input type="hidden" name="consents[1].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
-
-    @checkboxField(
-        Checkbox(
-            privacyForm("consents[1].hasConsented"),
-            '_label -> com.gu.identity.model.ConsentData.currentConsents("thirdParty")
-        )
-    )(nonInputFields, messages)
-}
-
-
-@v2consentProfilingCheckboxOnboarding  = {
-
-    @* PROFILING *@
-
-    <input type="hidden" name="consents[2].actor" value='user'>
-    <input type="hidden" name="consents[2].consentIdentifier" value="thirdPartyProfiling">
-    <input type="hidden" name="consents[2].consentIdentifierVersion" value="0">
-    <input type="hidden" name="consents[2].timestamp" value=@getCurrentTime>
-    <input type="hidden" name="consents[2].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
-
-    @checkboxField(
-        Checkbox(
-            privacyForm("consents[2].hasConsented"),
-            '_label -> com.gu.identity.model.ConsentData.currentConsents("thirdPartyProfiling")
-        )
-    )(nonInputFields, messages)
-}
-
-
-@noV2Consents = { @user.consents.toList.isEmpty }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
 
-    @* Make this beautiful *@
     @* This also displays globalErrors *@
     @if(privacyForm.hasErrors) {
         <div class="form__error">
@@ -135,19 +68,22 @@
         </div>
     }
 
+    @* Newsletters *@
     <fieldset class="fieldset">
         <div class="fieldset__heading">
-            <h2 class="form__heading">Guardian & Observer newsletters</h2>
+            <h2 class="form__heading">Newsletters</h2>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">
-                    <label class="label">Click <a href=@idUrlBuilder.buildUrl("/email-prefs")>here</a> to manage your email subscriptions.</label>
+                    <label class="label">Click <a href=@idUrlBuilder.buildUrl("/email-prefs")>here</a> to manage your email subscriptions to editorial newsletters.</label>
                 </li>
             </ul>
         </div>
     </fieldset>
+
+    @* Marketing Consent *@
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
@@ -161,28 +97,18 @@
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">
-                        @v2consentCheckboxesOnboarding
+                        @if(user.consents.isEmpty) {
+                            @v2consentCheckboxesOnboarding
+                        } else {
+                            @v2consentCheckboxesFromApiUser
+                        }
                     </div>
                 </li>
             </ul>
         </div>
     </fieldset>
-    <fieldset class="fieldset">
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Profiling</h2>
-        </div>
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
-                <li class="form-field">
-                    <label class="label">In addition to the data that you provide to us, we may also match profiling data from third parties with your registration details.</label>
 
-                    <div class="form-fields-group">
-                        @v2consentProfilingCheckboxOnboarding
-                    </div>
-                </li>
-            </ul>
-        </div>
-     </fieldset>
+    @* Submit button *@
     <fieldset class="fieldset">
         <div class="fieldset__heading"></div>
         <div class="fieldset__fields">

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -10,8 +10,6 @@
 @import org.joda.time.DateTime
 @import idapiclient.parser.JodaJsonSerializer
 
-
-
 @*
     WARNING!!
 
@@ -25,7 +23,7 @@
     @if(user.consents.toList.isEmpty) {
         "Unknown consent text"
     } else {
-        @com.gu.identity.model.Consent.getText(
+        @com.gu.identity.model.ConsentData.getText(
             user.consents.toList(index).consentIdentifier,
             user.consents.toList(index).consentIdentifierVersion
         )
@@ -36,8 +34,7 @@
     @JodaJsonSerializer.dateTimeFormatISO8601.print(new DateTime)
 }
 
-
-@consentCheckboxes = {
+@v2consentCheckboxes = {
   @helper.repeatWithIndex(privacyForm("consents"), min=1) {(consent, consentIndex) =>
       <input type="hidden" name=@(consent.name + ".actor") value='user'>
       <input type="hidden" name=@(consent.name + ".consentIdentifier") value=@(user.consents.toList(consentIndex).consentIdentifier)>
@@ -53,6 +50,78 @@
       )(nonInputFields, messages)
   }
 }
+
+@v1consentCheckboxes = {
+    @checkboxField(Checkbox(
+        privacyForm("receiveGnmMarketing"),
+        '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
+
+    @checkboxField(Checkbox(
+        privacyForm("receive3rdPartyMarketing"),
+        '_label -> "Receive email from other organisations"))(nonInputFields, messages)
+}
+
+@v1profilingConsetCheckbox = {
+    @checkboxField(Checkbox(
+        privacyForm("allowThirdPartyProfiling"),
+        '_label -> "Allow matching with third party data")
+    )(nonInputFields, messages)
+}
+
+@v2consentCheckboxesOnboarding = {
+
+    @* FIRST PARTY *@
+
+    <input type="hidden" name="consents[0].actor" value='user'>
+    <input type="hidden" name="consents[0].consentIdentifier" value="firstParty">
+    <input type="hidden" name="consents[0].consentIdentifierVersion" value="0">
+    <input type="hidden" name="consents[0].timestamp" value=@getCurrentTime>
+    <input type="hidden" name="consents[0].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
+
+    @checkboxField(
+        Checkbox(
+            privacyForm("consents[0].hasConsented"),
+            '_label -> com.gu.identity.model.ConsentData.currentConsents("firstParty")
+        )
+    )(nonInputFields, messages)
+
+    @* THIRD PARTY *@
+
+    <input type="hidden" name="consents[1].actor" value='user'>
+    <input type="hidden" name="consents[1].consentIdentifier" value="thirdParty">
+    <input type="hidden" name="consents[1].consentIdentifierVersion" value="0">
+    <input type="hidden" name="consents[1].timestamp" value=@getCurrentTime>
+    <input type="hidden" name="consents[1].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
+
+    @checkboxField(
+        Checkbox(
+            privacyForm("consents[1].hasConsented"),
+            '_label -> com.gu.identity.model.ConsentData.currentConsents("thirdParty")
+        )
+    )(nonInputFields, messages)
+}
+
+
+@v2consentProfilingCheckboxOnboarding  = {
+
+    @* PROFILING *@
+
+    <input type="hidden" name="consents[2].actor" value='user'>
+    <input type="hidden" name="consents[2].consentIdentifier" value="thirdPartyProfiling">
+    <input type="hidden" name="consents[2].consentIdentifierVersion" value="0">
+    <input type="hidden" name="consents[2].timestamp" value=@getCurrentTime>
+    <input type="hidden" name="consents[2].privacyPolicy" value=@com.gu.identity.model.ConsentData.privacyPolicyVersion>
+
+    @checkboxField(
+        Checkbox(
+            privacyForm("consents[2].hasConsented"),
+            '_label -> com.gu.identity.model.ConsentData.currentConsents("thirdPartyProfiling")
+        )
+    )(nonInputFields, messages)
+}
+
+
+@noV2Consents = { @user.consents.toList.isEmpty }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
@@ -92,7 +161,7 @@
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">
-                        @consentCheckboxes
+                        @v2consentCheckboxesOnboarding
                     </div>
                 </li>
             </ul>
@@ -108,7 +177,7 @@
                     <label class="label">In addition to the data that you provide to us, we may also match profiling data from third parties with your registration details.</label>
 
                     <div class="form-fields-group">
-                        @checkboxField(Checkbox(privacyForm("allowThirdPartyProfiling"), '_label -> "Allow matching with third party data"))(nonInputFields, messages)
+                        @v2consentProfilingCheckboxOnboarding
                     </div>
                 </li>
             </ul>

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -6,8 +6,6 @@
 @import views.html.fragments.form.checkboxField
 @import views.html.fragments.registrationFooter
 @import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
-@import org.joda.time.DateTime
-@import org.joda.time.format.ISODateTimeFormat
 @import com.gu.identity.model.ConsentData
 
 @v2ConsentCheckbox(consentField: Field) = {
@@ -16,8 +14,8 @@
     @helper.inputText(consentField("actor"), 'type -> "hidden")(nonInputFields, messages)
     @helper.inputText(consentField("consentIdentifier"), 'type -> "hidden")(nonInputFields, messages)
     @helper.inputText(consentField("consentIdentifierVersion"), 'type -> "hidden")(nonInputFields, messages)
-    @helper.inputText(consentField("timestamp"), 'type -> "hidden", 'value -> getCurrentTime)(nonInputFields, messages)
-    @helper.inputText(consentField("privacyPolicy"), 'type -> "hidden", 'value -> ConsentData.privacyPolicyVersion)(nonInputFields, messages)
+    @helper.inputText(consentField("timestamp"), 'type -> "hidden")(nonInputFields, messages)
+    @helper.inputText(consentField("privacyPolicy"), 'type -> "hidden")(nonInputFields, messages)
 
     @checkboxField(
         Checkbox(
@@ -25,10 +23,6 @@
             '_label -> ConsentData.allConsents(consentField("consentIdentifier").value.get)(consentField("consentIdentifierVersion").value.get.toInt)
         )
     )(nonInputFields, messages)
-}
-
-@getCurrentTime = {
-    @ISODateTimeFormat.dateTimeNoMillis.withZoneUTC().print(new DateTime)
 }
 
 @v2consentCheckboxes = {

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -20,13 +20,19 @@
     @checkboxField(
         Checkbox(
             consentField("hasConsented"),
-            '_label -> ConsentData.allConsents(consentField("consentIdentifier").value.get)(consentField("consentIdentifierVersion").value.get.toInt)
+            '_label -> getConsentText(consentField)
         )
     )(nonInputFields, messages)
 }
 
 @v2consentCheckboxes = {
   @helper.repeat(privacyForm("consents"), min=1) { consentField => @v2ConsentCheckbox(consentField) }
+}
+
+@getConsentText(consentField: Field) = {
+    @ConsentData.getText(
+        consentField("consentIdentifier").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
+        consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
 }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -8,6 +8,23 @@
 @import helper._
 @import views.html.fragments.registrationFooter
 
+@getConsentText(index: Int) = {
+  @com.gu.identity.model.Consent.getText(
+    user.consents.toList(index).consentIdentifier,
+    user.consents.toList(index).consentIdentifierVersion
+  )
+}
+
+@consentCheckboxes = {
+  @helper.repeatWithIndex(privacyForm("consents"), min=1) {(consent, consentIndex) =>
+      @checkboxField(
+          Checkbox(
+              privacyForm(consent.name + ".hasConsented"),
+              '_label -> getConsentText(consentIndex)
+          )
+      )(nonInputFields, messages)
+  }
+}
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
     @views.html.helper.CSRF.formField
@@ -42,8 +59,7 @@
                     <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
 
                     <div class="form-fields-group">
-                        @checkboxField(Checkbox(privacyForm("receiveGnmMarketing"), '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
-                        @checkboxField(Checkbox(privacyForm("receive3rdPartyMarketing"), '_label -> "Receive email from other organisations"))(nonInputFields, messages)
+                        @consentCheckboxes
                     </div>
                 </li>
             </ul>

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -101,14 +101,14 @@ import scala.concurrent.Future
             displayName = Some(username)
           )
         )
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitPublicProfileForm().apply(fakeRequest)
 
         status(result) should be(200)
 
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
 
@@ -138,14 +138,14 @@ import scala.concurrent.Future
             receive3rdPartyMarketing = Some(receive3rdPartyMarketing)
           )
         )
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitPrivacyForm().apply(fakeRequest)
 
         status(result) should be(200)
 
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
 
@@ -278,7 +278,7 @@ import scala.concurrent.Future
       "return 200 if called with a valid CSRF request" in new EditProfileFixture {
         val fakeRequest = createFakeRequestWithBillingAddress
 
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(user)))
 
         val result = controller.submitAccountForm().apply(fakeRequest)
@@ -305,12 +305,12 @@ import scala.concurrent.Future
           )
         )
 
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitAccountForm().apply(fakeRequest)
         status(result) should be(200)
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
 
@@ -358,13 +358,13 @@ import scala.concurrent.Future
           )
         )
 
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitAccountForm().apply(fakeRequest)
         status(result) should be(200)
 
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
 
@@ -407,13 +407,13 @@ import scala.concurrent.Future
           )
         )
 
-        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdate], MockitoMatchers.any[Auth]))
+        when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(updatedUser)))
 
         val result = controller.submitAccountForm().apply(fakeRequest)
         status(result) should be(200)
 
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
         val userUpdate = userUpdateCapture.getValue
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -4,9 +4,10 @@ import actions.AuthenticatedActions
 import idapiclient.Auth
 import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model._
-import form.{AccountDetailsMapping, PrivacyMapping, ProfileFormsMapping, ProfileMapping}
+import form._
 import idapiclient.{TrackingData, _}
 import model.{Countries, PhoneNumbers}
+import org.joda.time.format.ISODateTimeFormat
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
 import org.scalatest.{DoNotDiscover, Matchers, OptionValues, WordSpec}
@@ -119,39 +120,34 @@ import scala.concurrent.Future
     }
 
 
-    "submitPrivacyForm method is called with a valid CSRF request" should {
-      val receive3rdPartyMarketing = false
-      val receiveGnmMarketing = true
-      val allowThirdPartyProfiling = false
+    "submitPrivacyForm method is called with valid CSRF request" should {
+      "post UserUpdateDTO with consent to IDAPI" in new EditProfileFixture {
+        val consent = Consent("user", "firstParty", false)
 
-      "then the user should be saved on the ID API" in new EditProfileFixture {
         val fakeRequest = FakeCSRFRequest(csrfAddToken)
           .withFormUrlEncodedBody(
-            "receiveGnmMarketing" -> receiveGnmMarketing.toString,
-            "receive3rdPartyMarketing" -> receive3rdPartyMarketing.toString,
-            "allowThirdPartyProfiling" -> allowThirdPartyProfiling.toString
+            "consents[0].actor" -> consent.actor,
+            "consents[0].consentIdentifier" -> consent.consentIdentifier,
+            "consents[0].hasConsented" -> consent.hasConsented.toString,
+            "consents[0].privacyPolicy" -> consent.privacyPolicy.toString,
+            "consents[0].timestamp" -> consent.timestamp.toString(ISODateTimeFormat.dateTimeNoMillis.withZoneUTC()),
+            "consents[0].consentIdentifierVersion" -> consent.consentIdentifierVersion.toString
           )
 
-        val updatedUser = user.copy(
-          statusFields = StatusFields(
-            receiveGnmMarketing = Some(receiveGnmMarketing),
-            receive3rdPartyMarketing = Some(receive3rdPartyMarketing)
-          )
-        )
         when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
-          .thenReturn(Future.successful(Right(updatedUser)))
+          .thenReturn(Future.successful(Right(user.copy(consents = List(consent)))))
 
         val result = controller.submitPrivacyForm().apply(fakeRequest)
 
         status(result) should be(200)
 
-        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
-        verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
-        val userUpdate = userUpdateCapture.getValue
+        val userUpdateDTOCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
+        verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateDTOCapture.capture(), MockitoMatchers.eq(testAuth))
+        val userUpdateDTO = userUpdateDTOCapture.getValue
 
-        userUpdate.statusFields.value.receive3rdPartyMarketing.value should equal(receive3rdPartyMarketing)
-        userUpdate.statusFields.value.receiveGnmMarketing.value should equal(receiveGnmMarketing)
-        userUpdate.statusFields.value.allowThirdPartyProfiling.value should equal(allowThirdPartyProfiling)
+        userUpdateDTO.consents.value.head.actor should equal(consent.actor)
+        userUpdateDTO.consents.value.head.consentIdentifier should equal(consent.consentIdentifier)
+        userUpdateDTO.consents.value.head.hasConsented should equal(consent.hasConsented)
       }
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.80"
+//  val identityLibVersion = "3.80"
+  val identityLibVersion = "3.81-SNAPSHOT"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.4"
   val capiVersion = "11.33"

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -62,6 +62,7 @@ object ProjectSettings {
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases"),
       Resolver.sonatypeRepo("releases"),
+      Resolver.sonatypeRepo("snapshots"), // FIXME: Is it OK to keep this?
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Guardian Editorial Tools Bintray" at "https://dl.bintray.com/guardian/editorial-tools",


### PR DESCRIPTION
## What does this change?

_NOTE: Do not merge! This PR might be open for a long time as requirements are evolving, however I would like to collect some initial feedback._

Use new GDPR compliant marketing consent model on the Edit Profile Privacy Tab:
https://github.com/guardian/identity/pull/696

This PR also attempts to rediscover how Edit Profile was originally architected so there is quite a bit of added comments and renaming of methods to hopefully make intent clearer.

Main changes are in:
* `EditProfileController.scala`
* `PrivacyMapping.scala`
* `privacyForm.scala.html`
* `UserFormMapping.scala`


## What is the value of this and can you measure success?

GDPR compliance. 

## Does this affect other platforms - Amp, Apps, etc?

No

## Screenshots

TODO

## Tested in CODE?

Yes


