### PR TITLE
[Journalism - Story Questions] 404 Demand Test for reader's preferred delivery of answers

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -493,7 +493,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withGithub("annebyrne")),
     safeState = On,
     sellByDate = new LocalDate(2018, 10, 24),
-    exposeClientSide = true
+    exposeClientSide = false
   )
 
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,4 +484,16 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 10, 17),
     exposeClientSide = true
   )
+
+  // Owner: Journalism
+  val ReaderAnswersDeliveryMechanism = Switch(
+    SwitchGroup.Feature,
+    "reader-answers-preferred-delivery-mechanism",
+    "When ON, story questions will give readers the option to indicate their preferred answer delivery medium",
+    owners = Seq(Owner.withGithub("annebyrne")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 10, 24),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -427,7 +427,7 @@ case class StoryQuestionsAtomPage(
   override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "storyquestions"
-  override val body = views.html.fragments.atoms.storyquestions(atom, isAmp = false, isDemandTest = false)
+  override val body = views.html.fragments.atoms.storyquestions(atom, isAmp = false)
   override val metadata = MetaData.make(
     id = atom.id,
     webTitle = atom.atom.title.getOrElse("Story questions"),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -427,7 +427,7 @@ case class StoryQuestionsAtomPage(
   override val withVerticalScrollbar: Boolean
 )(implicit request: RequestHeader) extends AtomPage {
   override val atomType = "storyquestions"
-  override val body = views.html.fragments.atoms.storyquestions(atom, isAmp = false)
+  override val body = views.html.fragments.atoms.storyquestions(atom, isAmp = false, isDemandTest = false)
   override val metadata = MetaData.make(
     id = atom.id,
     webTitle = atom.atom.title.getOrElse("Story questions"),

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,5 +1,5 @@
 @import model.content.MediaWrapper
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper], demandTest: Boolean)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom}
@@ -9,7 +9,7 @@
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
         case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
-        case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp)
+        case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp, isDemandTest = demandTest)
         case qanda: QandaAtom => views.html.fragments.atoms.snippets.qanda(qanda, isAmp = amp)
         case timeline: TimelineAtom => views.html.fragments.atoms.snippets.timeline(timeline, isAmp = amp)
         case guide: GuideAtom => views.html.fragments.atoms.snippets.guide(guide, isAmp = amp)

--- a/common/app/views/fragments/atoms/atom.scala.html
+++ b/common/app/views/fragments/atoms/atom.scala.html
@@ -1,5 +1,5 @@
 @import model.content.MediaWrapper
-@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper], demandTest: Boolean)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
+@(model: _root_.model.content.Atom, shouldFence: Boolean, amp: Boolean, mediaWrapper: Option[MediaWrapper])(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import _root_.model.ShareLinkMeta
 @import _root_.model.content.{InteractiveAtom, MediaAtom, Quiz, StoryQuestionsAtom, TimelineAtom, GuideAtom, ProfileAtom, QandaAtom}
@@ -9,7 +9,7 @@
         case quiz: Quiz => views.html.fragments.atoms.quiz(quiz, maybeResults = None, showResults = false, sharelinks = quiz.shareLinks)
         case media: MediaAtom => views.html.fragments.atoms.media(media = media, amp = amp, displayCaption = true, displayEndSlate = mediaWrapper.contains(MediaWrapper.MainMedia), mediaWrapper = mediaWrapper)
         case interactive: InteractiveAtom => views.html.fragments.atoms.interactive(interactive, shouldFence)
-        case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp, isDemandTest = demandTest)
+        case storyquestions: StoryQuestionsAtom => views.html.fragments.atoms.storyquestions(storyquestions, isAmp = amp)
         case qanda: QandaAtom => views.html.fragments.atoms.snippets.qanda(qanda, isAmp = amp)
         case timeline: TimelineAtom => views.html.fragments.atoms.snippets.timeline(timeline, isAmp = amp)
         case guide: GuideAtom => views.html.fragments.atoms.snippets.guide(guide, isAmp = amp)

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -27,7 +27,7 @@
     }
 }
 
-@if(ReaderAnswersDeliveryMechanism.isSwitchedOn) {
+@if(!isAmp && !isClosed && ReaderAnswersDeliveryMechanism.isSwitchedOn) {
     <div id="user__question-atom-@storyquestions.id" class="js-view-tracking-component submeta user__question">
 
         <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
@@ -92,7 +92,7 @@
 }
 
 
-@if(!isAmp && !isClosed) {
+@if(!isAmp && !isClosed && !ReaderAnswersDeliveryMechanism.isSwitchedOn) {
     <div class="js-view-tracking-component submeta user__question">
         <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
 

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -35,23 +35,22 @@
 
         @for(questions <- storyquestions.data.editorialQuestions) {
             @for(qs <- questions) {
-                <h2 id="js-question-set-header-@storyquestions.id" class="user__question-title">
+                <h2 id="js-question-set-header-@storyquestions.id" class="user__question-title user__question-title-test">
                     Need something explained?
                         <span class="user__question-title--secondary">Pick a question: We'll publish an answer to the most popular question shortly</span>
                 </h2>
-                <h2 id="js-delivery-selection-header-@storyquestions.id" class="user__question-title is-hidden">
+                <h2 id="js-delivery-selection-header-@storyquestions.id" class="user__question-title user__question-title-test is-hidden">
                     Thank you for participating
                     <span class="user__question-title--secondary">
                     We'll publish an answer to the most popular question shortly. How would you like to get notified when it's ready?
                     </span>
                 </h2>
-                <h2 id="js-final-thank-you-header-@storyquestions.id" class="user__question-title is-hidden">
+                <h2 id="js-final-thank-you-header-@storyquestions.id" class="user__question-title user__question-final-thanks is-hidden">
                     Thank you for your interest
                     <span class="user__question-title--secondary">
                     We're actively developing these notification features but they are not yet built. We're using your feedback to understand how you would like to be notified of the answers. Thanks again.
                     </span>
                 </h2>
-            <div class="user__question-section"></div>
                 @for(question <- qs.questions) {
                     <div id="js-question-set-body-@question.questionId" class="user__question-container js-question-set-body-@storyquestions.id">
                         <div class="user__questions-text--wrapper js-ask-question-link">
@@ -68,20 +67,20 @@
                     </div>
                 }
 
-                <div id="js-delivery-selection-body-@storyquestions.id" class="storyquestion-submission-container js-storyquestion-submission-container js-delivery-selection-body is-hidden">
-                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="email">
+                <div id="js-delivery-selection-body-@storyquestions.id" class="storyquestion-submission-container delivery-selection-container js-storyquestion-submission-container js-delivery-selection-body is-hidden">
+                    <button class="button button--primary-inverse button--large user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="email">
                                     Email
                     </button>
-                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="browser-notification">
-                                    Onsite notification
+                    <button class="button button--primary-inverse button--large user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="browser-notification">
+                                    Browser notification
                     </button>
-                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="facebook-messenger">
+                    <button class="button button--primary-inverse button--large user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="facebook-messenger">
                                     Facebook Messenger
                     </button>
                 </div>
 
                 <div id="js-final-thank-you-body-@storyquestions.id" class="user__question-container user__answer-delivery-container final-thank-you-body is-hidden">
-                    <button id="js-final-thankyou-message-@storyquestions.id" class="user__question-response submeta__label">
+                    <button id="js-final-thankyou-message-@storyquestions.id" class="button button--primary-inverse button--medium">
                                     Close
                     </button>
                 </div>

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -1,4 +1,4 @@
-@(storyquestions: model.content.StoryQuestionsAtom, isAmp: Boolean)(implicit request: RequestHeader)
+@(storyquestions: model.content.StoryQuestionsAtom, isAmp: Boolean, isDemandTest: Boolean)(implicit request: RequestHeader)
 
 @import org.joda.time.{DateTime, DateTimeZone}
 
@@ -25,6 +25,71 @@
         } yield email.listId
     }
 }
+
+@if(isDemandTest) {
+    <div class="js-view-tracking-component submeta user__question">
+
+        <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
+        <span class="is-hidden" id="js-storyquestion-is-answer-delivery-test-ready" data-is-answer-delivery-test-ready="@isDemandTest"></span>
+
+        @for(questions <- storyquestions.data.editorialQuestions) {
+            @for(qs <- questions) {
+                <h2 id="js-ASK-ACTION-header-@storyquestions.id" class="user__question-title ASK-ACTION-body">
+                    Need something explained?
+                        <span class="user__question-title--secondary">Pick a question: We'll publish an answer to the most popular question shortly</span>
+                </h2>
+                <h2 id="js-SUBMIT-ACTION-header-@storyquestions.id" class="user__question-title SUBMIT-ACTION-body is-hidden">
+                    Thank you for participating
+                    <span class="user__question-title--secondary">
+                    We'll publish an answer to the most popular question shortly. How would you like to get notified when it's ready?
+                    </span>
+                </h2>
+                <h2 id="js-FINAL-ACTION-header-@storyquestions.id" class="user__question-title FINAL-ACTION-body is-hidden">
+                    Thank you for your interest
+                    <span class="user__question-title--secondary">
+                    We're actively developing these notification features but they are not yet built. We're using your feedback to understand how you would like to be notified of the answers. Thanks again.
+                    </span>
+                </h2>
+                <p>
+            <div class="user__question-section"></div>
+                @for(question <- qs.questions) {
+                    <div id="js-ASK-ACTION-body-@question.questionId" class="user__question-container js-ASK-ACTION-body-@storyquestions.id">
+                        <div class="user__questions-text--wrapper js-ask-question-link">
+                            <div class="user__question-text">
+                                <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
+                                <span class="user__questions-text--inner">
+                                @question.questionText
+                                </span>
+                            </div>
+                            <button id="btn-ask-question-@question.questionId" class="user__question-upvote" data-question-id="@question.questionId">
+                                    Ask
+                            </button>
+                        </div>
+                    </div>
+                }
+                <div id="js-SUBMIT-ACTION-body-@storyquestions.id" class="storyquestion-submission-container js-storyquestion-submission-container js-SUBMIT-ACTION-body is-hidden">
+                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="email">
+                                    Email
+                    </button>
+                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="browser-notification">
+                                    Onsite notification
+                    </button>
+                    <button  class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="facebook-messenger">
+                                    Facebook Messenger
+                    </button>
+                </div>
+
+                <div id="js-FINAL-ACTION-body-@storyquestions.id" class="user__question-container user__answer-delivery-container FINAL-ACTION-body is-hidden">
+                    <button id="js-final-thankyou-message-@storyquestions.id" class="user__question-response submeta__label"">
+                                    Close
+                    </button>
+                </div>
+                </p>
+            }
+        </div>
+}
+}
+
 
 @if(!isAmp && !isClosed) {
     <div class="js-view-tracking-component submeta user__question">

--- a/common/app/views/fragments/atoms/storyquestions.scala.html
+++ b/common/app/views/fragments/atoms/storyquestions.scala.html
@@ -1,6 +1,7 @@
-@(storyquestions: model.content.StoryQuestionsAtom, isAmp: Boolean, isDemandTest: Boolean)(implicit request: RequestHeader)
+@(storyquestions: model.content.StoryQuestionsAtom, isAmp: Boolean)(implicit request: RequestHeader)
 
 @import org.joda.time.{DateTime, DateTimeZone}
+@import conf.switches.Switches.ReaderAnswersDeliveryMechanism
 
 @isClosed() = @{
     storyquestions.data.closeDate.exists { closeDate =>
@@ -26,34 +27,33 @@
     }
 }
 
-@if(isDemandTest) {
-    <div class="js-view-tracking-component submeta user__question">
+@if(ReaderAnswersDeliveryMechanism.isSwitchedOn) {
+    <div id="user__question-atom-@storyquestions.id" class="js-view-tracking-component submeta user__question">
 
         <span class="js-storyquestion-atom-id is-hidden" id="@storyquestions.id"></span>
-        <span class="is-hidden" id="js-storyquestion-is-answer-delivery-test-ready" data-is-answer-delivery-test-ready="@isDemandTest"></span>
+        <span class="is-hidden" id="js-storyquestion-is-answer-delivery-test-ready" data-is-answer-delivery-test-ready="@ReaderAnswersDeliveryMechanism.isSwitchedOn"></span>
 
         @for(questions <- storyquestions.data.editorialQuestions) {
             @for(qs <- questions) {
-                <h2 id="js-ASK-ACTION-header-@storyquestions.id" class="user__question-title ASK-ACTION-body">
+                <h2 id="js-question-set-header-@storyquestions.id" class="user__question-title">
                     Need something explained?
                         <span class="user__question-title--secondary">Pick a question: We'll publish an answer to the most popular question shortly</span>
                 </h2>
-                <h2 id="js-SUBMIT-ACTION-header-@storyquestions.id" class="user__question-title SUBMIT-ACTION-body is-hidden">
+                <h2 id="js-delivery-selection-header-@storyquestions.id" class="user__question-title is-hidden">
                     Thank you for participating
                     <span class="user__question-title--secondary">
                     We'll publish an answer to the most popular question shortly. How would you like to get notified when it's ready?
                     </span>
                 </h2>
-                <h2 id="js-FINAL-ACTION-header-@storyquestions.id" class="user__question-title FINAL-ACTION-body is-hidden">
+                <h2 id="js-final-thank-you-header-@storyquestions.id" class="user__question-title is-hidden">
                     Thank you for your interest
                     <span class="user__question-title--secondary">
                     We're actively developing these notification features but they are not yet built. We're using your feedback to understand how you would like to be notified of the answers. Thanks again.
                     </span>
                 </h2>
-                <p>
             <div class="user__question-section"></div>
                 @for(question <- qs.questions) {
-                    <div id="js-ASK-ACTION-body-@question.questionId" class="user__question-container js-ASK-ACTION-body-@storyquestions.id">
+                    <div id="js-question-set-body-@question.questionId" class="user__question-container js-question-set-body-@storyquestions.id">
                         <div class="user__questions-text--wrapper js-ask-question-link">
                             <div class="user__question-text">
                                 <meta class="notranslate" name="js-notranslate-@question.questionId" content="@question.questionText">
@@ -67,27 +67,28 @@
                         </div>
                     </div>
                 }
-                <div id="js-SUBMIT-ACTION-body-@storyquestions.id" class="storyquestion-submission-container js-storyquestion-submission-container js-SUBMIT-ACTION-body is-hidden">
+
+                <div id="js-delivery-selection-body-@storyquestions.id" class="storyquestion-submission-container js-storyquestion-submission-container js-delivery-selection-body is-hidden">
                     <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="email">
                                     Email
                     </button>
                     <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="browser-notification">
                                     Onsite notification
                     </button>
-                    <button  class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="facebook-messenger">
+                    <button class="user_answer-delivery btn-answer-delivery-@storyquestions.id" data-delivery-method="facebook-messenger">
                                     Facebook Messenger
                     </button>
                 </div>
 
-                <div id="js-FINAL-ACTION-body-@storyquestions.id" class="user__question-container user__answer-delivery-container FINAL-ACTION-body is-hidden">
-                    <button id="js-final-thankyou-message-@storyquestions.id" class="user__question-response submeta__label"">
+                <div id="js-final-thank-you-body-@storyquestions.id" class="user__question-container user__answer-delivery-container final-thank-you-body is-hidden">
+                    <button id="js-final-thankyou-message-@storyquestions.id" class="user__question-response submeta__label">
                                     Close
                     </button>
                 </div>
-                </p>
             }
-        </div>
-}
+
+        }
+    </div>
 }
 
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -679,15 +679,9 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
           atomContainer.addClass("element-atom--media")
         }
 
-        if (ReaderAnswersDeliveryMechanism.isSwitchedOn) {
-          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper, true).toString()
+          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper).toString()
           bodyElement.remove()
           atomContainer.append(html)
-        } else {
-          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper, false).toString()
-          bodyElement.remove()
-          atomContainer.append(html)
-        }
       }
     }
     document

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -678,9 +678,16 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
         if(atomData.isInstanceOf[MediaAtom]){
           atomContainer.addClass("element-atom--media")
         }
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper).toString()
-        bodyElement.remove()
-        atomContainer.append(html)
+
+        if (ReaderAnswersDeliveryMechanism.isSwitchedOn) {
+          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper, true).toString()
+          bodyElement.remove()
+          atomContainer.append(html)
+        } else {
+          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper, false).toString()
+          bodyElement.remove()
+          atomContainer.append(html)
+        }
       }
     }
     document

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -22,16 +22,6 @@ define([
     componentEvent
 ) {
 
-    // TODO:
-    // clear atom on close button event
-    // check ophan events are being processed correctly
-    // sensible renaming
-    // tidy up class list
-    // styling
-    // clean up javascript
-    // sense-check feature test is the right way to test this.
-
-
     function sendOldStyleInteraction(atomId, component, value) {
         ophan.record({
             atomId: atomId,
@@ -73,7 +63,7 @@ define([
 
                 if (questionText && atomId) {
 
-                    if (isDeliveryTestReady === "true") {
+                    if (isDeliveryTestReady) {
 
                         var askActionHeader = document.getElementById('js-question-set-header-' + atomId);
                         var submitActionHeader = document.getElementById('js-delivery-selection-header-' + atomId);
@@ -98,7 +88,7 @@ define([
                             askQuestionBtn.classList.add('is-hidden');
                         }
 
-                        if (isEmailSubmissionReady === "true") {
+                        if (isEmailSubmissionReady) {
                             var signupForm = document.forms['js-storyquestion-email-signup-form-' + questionId];
                             var thankYouMessageForEmailSubmission = document.getElementById('js-question-thankyou-' + questionId);
 
@@ -165,7 +155,7 @@ define([
 
         event.preventDefault();
 
-        var prefAnswerDeliveryBtn = event.currentTarget;
+        var prefAnswerDeliveryBtn = event.target;
         var prefAnswerDelivery = prefAnswerDeliveryBtn.dataset.deliveryMethod;
 
         var atomIdElement = $('.js-storyquestion-atom-id');
@@ -195,27 +185,19 @@ define([
 
             var atomId = $('.js-storyquestion-atom-id').attr('id');
 
-            var askQuestionLinks = $('.js-ask-question-link');
             var isEmailSubmissionReadyElement = document.getElementById('js-storyquestion-is-email-submission-ready');
             var isDeliveryTestReadyElement = document.getElementById('js-storyquestion-is-answer-delivery-test-ready');
 
-            var isEmailSubmissionReady = false;
-            var isDeliveryTestReady = false;
+            var isEmailSubmissionReady = isEmailSubmissionReadyElement && isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady === 'true';
+            var isDeliveryTestReady = isDeliveryTestReadyElement && isDeliveryTestReadyElement.dataset.isAnswerDeliveryTestReady === 'true';
 
-            if (isDeliveryTestReadyElement) {
-                isDeliveryTestReady = isDeliveryTestReadyElement.dataset.isAnswerDeliveryTestReady ? isDeliveryTestReadyElement.dataset.isAnswerDeliveryTestReady : false;
-            }
+            var readerQuestionsContainer = document.getElementById('user__question-atom-' + atomId);
+            var askQuestionLinks = Array.from(document.querySelectorAll('.js-ask-question-link'));
 
-            if (isEmailSubmissionReadyElement) {
-                isEmailSubmissionReady = isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady ? isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady : false;
-            }
-
-            askQuestionLinks.each(function (el) {
-                bean.on(el, 'click', function(event) {
-                    askQuestion(event, isEmailSubmissionReady, isDeliveryTestReady)
-                    this.classList.add('is-clicked')
+            bean.one(readerQuestionsContainer, 'click', askQuestionLinks, function (event) {
+                    askQuestion(event, isEmailSubmissionReady, isDeliveryTestReady);
+                    this.classList.add('is-clicked');
                 });
-            });
 
             var answersEmailSignupForms = $('.js-storyquestion-email-signup-form');
 
@@ -223,18 +205,17 @@ define([
                 bean.on(el, 'submit', submitSignUpForm);
             });
 
-            var answersDeliveryPreferences = $('.btn-answer-delivery-' + atomId);
+            var answerDeliveryPrefContainer = document.getElementById('js-delivery-selection-body-' + atomId);
+            var answersDeliveryPreferences = Array.from(document.querySelectorAll('.btn-answer-delivery-' + atomId));
 
-            answersDeliveryPreferences.each(function (el) {
-                bean.on(el, 'click', function(event) {
-                    submitDeliveryPreference(event)
-                    this.classList.add('is-clicked')
+            bean.one(answerDeliveryPrefContainer, 'click', answersDeliveryPreferences, function (event) {
+                submitDeliveryPreference(event);
+                this.classList.add('is-clicked');
                 });
-            });
 
             var finalCloseBtn = document.getElementById('js-final-thankyou-message-' + atomId);
 
-            bean.on(finalCloseBtn, 'click', function(event) {
+            bean.one(finalCloseBtn, 'click', function(event) {
                 event.preventDefault();
                 var storyQuestionAtom = document.getElementById('user__question-atom-' + atomId);
                 storyQuestionAtom.classList.add('is-hidden');

--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -75,11 +75,11 @@ define([
 
                     if (isDeliveryTestReady === "true") {
 
-                        var askActionHeader = document.getElementById('js-ASK-ACTION-header-' + atomId);
-                        var submitActionHeader = document.getElementById('js-SUBMIT-ACTION-header-' + atomId);
+                        var askActionHeader = document.getElementById('js-question-set-header-' + atomId);
+                        var submitActionHeader = document.getElementById('js-delivery-selection-header-' + atomId);
 
-                        var questionList = Array.from(document.querySelectorAll('.js-ASK-ACTION-body-' + atomId));
-                        var answerDeliveryOptions = document.getElementById('js-SUBMIT-ACTION-body-' + atomId);
+                        var questionList = Array.from(document.querySelectorAll('.js-question-set-body-' + atomId));
+                        var answerDeliveryOptions = document.getElementById('js-delivery-selection-body-' + atomId);
 
                         if (askActionHeader && questionList && submitActionHeader && answerDeliveryOptions) {
                             submitActionHeader.classList.remove('is-hidden');
@@ -162,22 +162,22 @@ define([
     }
 
     function submitDeliveryPreference(event) {
+
         event.preventDefault();
 
         var prefAnswerDeliveryBtn = event.currentTarget;
         var prefAnswerDelivery = prefAnswerDeliveryBtn.dataset.deliveryMethod;
-        var questionId = prefAnswerDeliveryBtn.dataset.questionId;
 
         var atomIdElement = $('.js-storyquestion-atom-id');
         var atomId = atomIdElement.attr('id');
 
         if (prefAnswerDelivery) {
 
-            var thankyouMessageHeader = document.getElementById('js-FINAL-ACTION-header-' + atomId);
-            var thankyouMessageBody = document.getElementById('js-FINAL-ACTION-body-' + atomId);
+            var thankyouMessageHeader = document.getElementById('js-final-thank-you-header-' + atomId);
+            var thankyouMessageBody = document.getElementById('js-final-thank-you-body-' + atomId);
 
-            var submitContainer = document.getElementById('js-SUBMIT-ACTION-header-' + atomId);
-            var submitHeader = document.getElementById('js-SUBMIT-ACTION-body-' + atomId);
+            var submitHeader = document.getElementById('js-delivery-selection-header-' + atomId);
+            var submitContainer = document.getElementById('js-delivery-selection-body-' + atomId);
 
             if (thankyouMessageHeader && thankyouMessageBody && submitContainer && submitHeader) {
                 submitContainer.classList.add('is-hidden');
@@ -185,9 +185,9 @@ define([
                 thankyouMessageHeader.classList.remove('is-hidden');
                 thankyouMessageBody.classList.remove('is-hidden');
             }
-
-            sendNewStyleInteraction(atomId.trim(), 'SUBSCRIBE', prefAnswerDelivery.value, questionId);
         }
+
+        sendNewStyleInteraction(atomId.trim(), 'SUBSCRIBE', prefAnswerDelivery.value);
     }
 
     return {
@@ -231,6 +231,17 @@ define([
                     this.classList.add('is-clicked')
                 });
             });
+
+            var finalCloseBtn = document.getElementById('js-final-thankyou-message-' + atomId);
+
+            bean.on(finalCloseBtn, 'click', function(event) {
+                event.preventDefault();
+                var storyQuestionAtom = document.getElementById('user__question-atom-' + atomId);
+                storyQuestionAtom.classList.add('is-hidden');
+                this.classList.add('is-clicked')
+            });
+
+
 
             Id.getUserFromApi(function (userFromId) {
                 if (userFromId && userFromId.primaryEmailAddress) {

--- a/static/src/stylesheets/module/atoms/_storyquestions.scss
+++ b/static/src/stylesheets/module/atoms/_storyquestions.scss
@@ -45,7 +45,7 @@
     }
 
     &:hover {
-        background-color: $news-support-5;
+        background-color: $news-support-1;
 
         .user__question-upvote {
             background-color: $news-main-1;
@@ -160,5 +160,33 @@
 
     .storyquestion-email-signup-button-envelope {
         display: inline;
+    }
+}
+
+
+.user__question-title-test {
+    margin-bottom: $gs-baseline * 2;
+}
+
+.user__question-final-thanks {
+    margin-bottom: $gs-baseline;
+}
+
+.delivery-selection-container {
+    display: flex;
+    justify-content: space-between;
+
+    @include mq($until: desktop) {
+        flex-direction: column;
+    }
+}
+
+.user_answer-delivery {
+    flex: 1;
+
+    @include mq($until: desktop) {
+        & + & {
+            margin-top: $gs-baseline;
+        }
     }
 }

--- a/static/src/stylesheets/pasteup/buttons/_styles.scss
+++ b/static/src/stylesheets/pasteup/buttons/_styles.scss
@@ -45,6 +45,21 @@
     );
 }
 
+.button--primary-inverse {
+    @include button-colour(
+        transparent,
+        $news-main-1,
+        $news-main-1
+    );
+
+    &:hover,
+    &:focus,
+    &:active {
+        background-color: $news-main-1;
+        color: #ffffff;
+    }
+}
+
 .button--secondary {
     @include button-colour(
         $neutral-7,


### PR DESCRIPTION
A very rough PR for a demand test to understand reader's preferences for how answers to their questions are delivered to them.

This adds a 404 test to story questions via a Feature Switch. I'm unsure whether this is the appropriate way to deliver the 404 test but for now this works.

- [x] Tested on `CODE`
- [x] Styling

The code is rather verbose and can probably be mightily refined so please add comments. 

Video of current behaviour (no styling added): 
![graun_404_demandtest](https://user-images.githubusercontent.com/14946184/32112624-aa112900-bb35-11e7-9608-f22d94e2d710.gif)



