### PR TITLE
User account button should have a title attribute

### DIFF
--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -13,7 +13,7 @@
 
     <button class="u-h js-user-account-trigger"
         id="my-account-toggle"
-        name="user account toggle"
+        title="user account toggle"
         data-link-name="nav2 : topbar: my account"
         aria-expanded="false"
         aria-controls="my-account-dropdown"></button>


### PR DESCRIPTION
## What does this change?

Not understanding PR builds 🍏  -> 🍎  there is a button I added which doesn't have a title attribute 😱 . This should fix this.

Hopefully PR builds is happier now

## What is the value of this and can you measure success?
More accessible 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
