### PR TITLE
Renaming from EFL Cup to Carabao Cup

### DIFF
--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -17,7 +17,7 @@ object PA extends Collections {
     ("123", "Scottish League Two"),
     ("300", "FA Cup"),
     ("320", "Scottish Cup"),
-    ("301", "EFL Cup"),
+    ("301", "Carabao Cup"),
     ("400", "Community Shield"),
     ("500", "Champions League"),
     ("510", "Europa League"),

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -70,7 +70,7 @@ class LeagueTableController(
         "Champions League",
         "Women's Euro 2017",
         "FA Cup",
-        "EFL Cup",
+        "Carabao Cup",
         "Community Shield",
         "Scottish Cup",
         "Scottish League Cup",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -114,7 +114,7 @@ object CompetitionsProvider {
     Competition("751", "/football/euro-2016-qualifiers", "Euro 2016 qualifying", "Euro 2016 qual.", "Internationals"),
     Competition("501", "/football/champions-league-qualifying", "Champions League qualifying", "Champions League qual.", "European"),
     Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
-    Competition("301", "/football/efl-cup", "EFL Cup", "EFL Cup", "English"),
+    Competition("301", "/football/carabao-cup", "Carabao Cup", "Carabao Cup", "English"),
     Competition("400", "/football/community-shield", "Community Shield", "Community Shield", "English", showInTeamsList = true),
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),


### PR DESCRIPTION
## What does this change?
Request from CP to rename EFL cup to Carabao cup.

## What is the value of this and can you measure success?
The correct name displays

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/32012810-0e38ca86-b9b1-11e7-8123-bf674a38363b.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
