### PR TITLE
Update resize messenger to include the iframe container div

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -20,6 +20,7 @@ const normalise = (length: string): string => {
 const resize = (
     specs: Specs,
     iframe: HTMLElement,
+    iframeContainer: HTMLElement,
     adSlot: HTMLElement
 ): ?Promise<any> => {
     if (
@@ -44,14 +45,22 @@ const resize = (
     return fastdom.write(() => {
         Object.assign(adSlot.style, styles);
         Object.assign(iframe.style, styles);
+        Object.assign(iframeContainer.style, styles);
     });
 };
 
 const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
+            /* there are ultimately three containers that need resizing:
+                 1) the ad slot,
+                 2) the iframe container div (.ad-slot--content), and
+                 3) the iframe containing the creative
+             */
             const adSlot = iframe && iframe.closest('.js-ad-slot');
-            return resize(specs, iframe, adSlot);
+            const iframeContainer =
+                iframe && iframe.closest('.ad-slot__content');
+            return resize(specs, iframe, iframeContainer, adSlot);
         }
     });
 };
@@ -59,3 +68,5 @@ const init = (register: RegisterListeners) => {
 export const _ = { resize, normalise };
 
 export { init };
+
+// #${iframe.id}__container__

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -52,11 +52,6 @@ const resize = (
 const init = (register: RegisterListeners) => {
     register('resize', (specs, ret, iframe) => {
         if (iframe && specs) {
-            /* there are ultimately three containers that need resizing:
-                 1) the ad slot,
-                 2) the iframe container div (.ad-slot--content), and
-                 3) the iframe containing the creative
-             */
             const adSlot = iframe && iframe.closest('.js-ad-slot');
             const iframeContainer =
                 iframe && iframe.closest('.ad-slot__content');
@@ -68,5 +63,3 @@ const init = (register: RegisterListeners) => {
 export const _ = { resize, normalise };
 
 export { init };
-
-// #${iframe.id}__container__

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -10,15 +10,6 @@ describe('Cross-frame messenger: resize', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
-              <div id="slot01" class="js-ad-slot"><div id="iframe01" class="iframe" data-unit="ch"></div></div>
-              <div id="slot02" class="js-ad-slot"><div id="iframe02" class="iframe" data-unit="px"></div></div>
-              <div id="slot03" class="js-ad-slot"><div id="iframe03" class="iframe" data-unit="em"></div></div>
-              <div id="slot04" class="js-ad-slot"><div id="iframe04" class="iframe" data-unit="rem"></div></div>
-              <div id="slot05" class="js-ad-slot"><div id="iframe05" class="iframe" data-unit="vmin"></div></div>
-              <div id="slot06" class="js-ad-slot"><div id="iframe06" class="iframe" data-unit="vmax"></div></div>
-              <div id="slot07" class="js-ad-slot"><div id="iframe07" class="iframe" data-unit="vh"></div></div>
-              <div id="slot08" class="js-ad-slot"><div id="iframe08" class="iframe" data-unit="vw"></div></div>
-              <div id="slot09" class="js-ad-slot"><div id="iframe09" class="iframe" data-unit="ex"></div></div>
               </div>`;
         }
         expect.hasAssertions();

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -10,6 +10,10 @@ describe('Cross-frame messenger: resize', () => {
     beforeEach(() => {
         if (document.body) {
             document.body.innerHTML = `
+              <div id="slot01" class="js-ad-slot">
+                <div id="container01">
+                    <div id="iframe01" class="iframe" data-unit="ch"></div>
+                </div>
               </div>`;
         }
         expect.hasAssertions();
@@ -49,17 +53,30 @@ describe('Cross-frame messenger: resize', () => {
     describe('resize function', () => {
         it('should resolve if the specs are empty', () => {
             const fakeAdSlot = document.createElement('div');
+            const fakeIframeContainer = document.createElement('div');
             const fakeIframe = document.createElement('iframe');
-            const result = resize({}, fakeIframe, fakeAdSlot);
+            const result = resize(
+                {},
+                fakeIframe,
+                fakeIframeContainer,
+                fakeAdSlot
+            );
             expect(result).toBeNull();
         });
 
         it('should set width and height of the ad slot', () => {
             const fallback = document.createElement('div');
+            const fakeIframeContainer =
+                document.getElementById('container01') || fallback;
             const fakeIframe = document.getElementById('iframe01') || fallback;
             const fakeAdSlot = document.getElementById('slot01') || fallback;
             return foolFlow(
-                resize({ width: '20', height: '10' }, fakeIframe, fakeAdSlot)
+                resize(
+                    { width: '20', height: '10' },
+                    fakeIframe,
+                    fakeIframeContainer,
+                    fakeAdSlot
+                )
             ).then(() => {
                 expect(fakeIframe.style.height).toBe('10px');
                 expect(fakeIframe.style.width).toBe('20px');


### PR DESCRIPTION
## What does this change?
When ads post a message to the main page in a request to resize them, our `resize` module resizes the ad slot and the iframe itself.

However in some circumstances we also need to resize the iframe container and it doesn't hurt to do this in all cases, hence this PR enforces this behaviour.

The layout of a typical ad is:

```
<div class="ad-slot">
    <div class="iframe-container">
        <iframe class="iframe-ad">
        </iframe>
    </div>
</div>
```