### PR TITLE
Remove Fashion Statement email AB test artefact

### DIFF
--- a/common/app/model/EmailNewsletters.scala
+++ b/common/app/model/EmailNewsletters.scala
@@ -392,8 +392,7 @@ object EmailNewsletters {
     teaser = "A weekly hit of style with substance. The best of the week’s fashion brought to you with expertise, humour and irreverence",
     description = "A weekly hit of style with substance. Smart fashion writing and chic shopping galleries delivered straight to your inbox. Sign up for our Friday email for the best of the week’s fashion brought to you with expertise, humour and irreverence",
     frequency = "Every Friday",
-    listId = 3947,
-    aliases = List(105),
+    listId = 105,
     tone = Some("feature"),
     signupPage = Some("/fashion/2016/aug/18/sign-up-for-the-guardians-fashion-email")
   )


### PR DESCRIPTION
## What does this change?

Email list IDs!

## What is the value of this and can you measure success?

Always subscribe people to the right list!


## N.B. 
I've changed and redeployed the interactive and am about to open a PR there too

Everyone in 3947 has been moved to 105, and we will only send to 105 from tomorrow onwards