### PR TITLE
add referrer url to acquisition data

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -51,6 +51,7 @@ export const addTrackingCodesToUrl = ({
         componentId,
         componentType,
         referrerPageviewId: config.get('ophan.pageViewId') || undefined,
+        referrerUrl: window.location.href.split('?')[0],
         campaignCode,
         abTest,
     };


### PR DESCRIPTION
## What does this change?
Adds referrer url to the reader revenue links generated client side.

## What is the value of this and can you measure success?
Provides a canonical source for the referrer url field in acquisition events.

## Tested in CODE?
Tested locally.

