### PR TITLE
Migrate au customers to au stripe

### DIFF
--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -50,7 +50,7 @@ export const display = (
     const $type = $('.js-manage-account-card-type', $parent);
     const $button = $('.js-manage-account-change-card', $parent);
     const $updating = $('.js-updating', $parent);
-    const stripePublicKey = maybeKey || config.get('page.stripePublicToken')
+    const stripePublicKey = maybeKey || config.get('page.stripePublicToken');
 
     /*  show/hide
      *   once we've sent the token, we don't want to change the state of the dots until we redisplay

--- a/static/src/javascripts/projects/membership/stripe.js
+++ b/static/src/javascripts/projects/membership/stripe.js
@@ -50,6 +50,7 @@ export const display = (
     const $type = $('.js-manage-account-card-type', $parent);
     const $button = $('.js-manage-account-change-card', $parent);
     const $updating = $('.js-updating', $parent);
+    const stripePublicKey = maybeKey || config.get('page.stripePublicToken')
 
     /*  show/hide
      *   once we've sent the token, we don't want to change the state of the dots until we redisplay
@@ -117,6 +118,7 @@ export const display = (
             },
             body: {
                 stripeToken: token.id,
+                publicKey: stripePublicKey,
             },
         })
             .then(resp => resp.json())
@@ -142,7 +144,6 @@ export const display = (
         return e => {
             e.preventDefault();
             fastdom.write(loading.showDots);
-            const key = maybeKey ? { key: maybeKey } : {};
             checkoutHandler.open({
                 email,
                 description: 'Update your card details',
@@ -151,7 +152,7 @@ export const display = (
                 closed() {
                     fastdom.write(loading.hideDots);
                 },
-                ...key,
+                key: stripePublicKey,
             });
             /*
              Nonstandard javascript alert:


### PR DESCRIPTION
## What does this change?
This change passes back to Members Data API the Stripe public key used to generate the Stripe card token. This lets Members Data API know, reliably, which Stripe account and Zuora settings to use to update the card details.

## What is the value of this and can you measure success?
The value of this (once the members-data-api change is also released) is that we have a way of resolving the issue for Australia customers who complain about having to pay an [international transaction fee](https://www.choice.com.au/shopping/online-shopping/buying-online/articles/foreign-transaction-fees-when-shopping-online) for their membership or digital pack subscription.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
Card update screen in profile.theguardian.com:

<img width="831" alt="picture 214" src="https://user-images.githubusercontent.com/1515970/32105627-0fc3f92c-bb21-11e7-94df-a6032187aed4.png">

## Tested in CODE?
Yes - 30 October 2017 @ 10:18am - before it posted no publicKey form data value.
![picture 215](https://user-images.githubusercontent.com/1515970/32165754-c0e5e7a6-bd5b-11e7-893a-bf4afaeca601.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @AWare @jfsoul 