### PR TITLE
Replace comscorekw parameter with amp.

### DIFF
--- a/common/app/views/fragments/amp/analytics.scala.html
+++ b/common/app/views/fragments/amp/analytics.scala.html
@@ -27,8 +27,8 @@ are used to generate the confidence graphs on the frontend dashboard.
                     "c2": "6035250"
                 },
              "extraUrlParams": {
-                    "comscorekw": @Html(Json.toJson(content.tags.keywords.map{ tag: Tag => tag.id}).toString)
-                }
+                "comscorekw": "amp"
+             }
         }
     </script>
 </amp-analytics>


### PR DESCRIPTION
## What does this change?
Apparently this _should_ be the parameter for comscore on AMP. I am taking this entirely on the authority of a comscore point of contact. I have no idea why it is necessary or how it will help 😃.

## What is the value of this and can you measure success?
I think AMP content will be better indexed in ComScore's analytics.

## Does this affect other platforms - Amp, Apps, etc?
Only AMP
