### PR TITLE
Fix sbt warnings

### DIFF
--- a/project/VersionInfo.scala
+++ b/project/VersionInfo.scala
@@ -41,10 +41,18 @@ object VersionInfo extends Plugin {
         commitHash
       }).getOrElse("DEV")
     }).value,
-    resourceGenerators in Compile <+= (resourceManaged in Compile, branch, buildNumber, vcsNumber, streams) map buildFile
+    resourceGenerators in Compile += Def.task {
+      buildFile(
+        (resourceManaged in Compile).value,
+        branch.value,
+        buildNumber.value,
+        vcsNumber.value,
+        streams.value
+      )
+    }
   )
 
-  def buildFile(outDir: File, branch: String, buildNum: String, vcsNum: String, s: TaskStreams) = {
+  def buildFile(outDir: File, branch: String, buildNum: String, vcsNum: String, s: TaskStreams): Seq[File] = {
     val versionInfo = Map(
       "Revision" -> vcsNum,
       "Branch" -> branch,


### PR DESCRIPTION
Fixing following sbt warnigns:

```
[warn]
.../frontend/project/VersionInfo.scala:44:
`<+=` operator is deprecated. Try `lhs += { x.value  }`
[warn]   or see
http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html.
[warn]     resourceGenerators in Compile <+= (resourceManaged in
Compile, branch, buildNumber, vcsNumber, streams) map buildFile
[warn]                                   ^
[warn]
.../frontend/project/VersionInfo.scala:44:
method t5ToTable5 in object Scoped is deprecated: The sbt 0.10 style DSL
is deprecated: '(k1, k2) map { (x, y) => ...  }' should now be '{ val x
= k1.value; val y = k2.value  }'.
[warn] See
http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
[warn]     resourceGenerators in Compile <+= (resourceManaged in
Compile, branch, buildNumber, vcsNumber, streams) map buildFile
[warn]                                       ^
```

## Tested in CODE?
No