### PR TITLE
Remove some unused deps from yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,6 @@
 # yarn lockfile v1
 
 
-"@guardian/guui@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/guui/-/guui-1.3.1.tgz#0c5235571bf214ff20774334181d7feca999aa25"
-  dependencies:
-    babel-plugin-emotion "7.3.2"
-    emotion "^7.3.2"
-    emotion-server "^7.3.2"
-    htmltojsx "^0.3.0"
-    preact "^8.2.5"
-    preact-render-to-string "^3.7.0"
-    styletron-client "^2.5.7"
-    styletron-preact "^2.5.9"
-    styletron-server "^2.5.7"
-    svgo "^0.7.2"
-
 "@guardian/guui@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/guui/-/guui-1.4.0.tgz#aa6a865bb5b03b330b549daaeb6be92c27923b8f"
@@ -1494,10 +1479,6 @@ boom@5.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
   dependencies:
     hoek "4.x.x"
-
-bowser@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.8.0.tgz#889d46ac922ec5db8297672747362ef836781ba7"
 
 boxen@^1.2.1:
   version "1.2.1"
@@ -4939,10 +4920,6 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-hyphenate-style-name@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.13, iconv-lite@^0.4.5:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -5043,13 +5020,6 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
-  dependencies:
-    bowser "^1.0.0"
-    hyphenate-style-name "^1.0.1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -9697,36 +9667,6 @@ stylelint@^8.0.0:
     sugarss "^1.0.0"
     svg-tags "^1.0.0"
     table "^4.0.1"
-
-styletron-client@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/styletron-client/-/styletron-client-2.5.7.tgz#104fa4dc564cd3fe78eb92488e5ef9039c9e242f"
-  dependencies:
-    styletron-core "^2.5.7"
-
-styletron-core@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/styletron-core/-/styletron-core-2.5.7.tgz#2c4a1fae537b42235462e438c24ab619bbf8993e"
-
-styletron-preact@^2.5.9:
-  version "2.5.9"
-  resolved "https://registry.yarnpkg.com/styletron-preact/-/styletron-preact-2.5.9.tgz#148985c148d8137bdbc8323a43f719f00136870f"
-  dependencies:
-    styletron-client "^2.5.7"
-    styletron-server "^2.5.7"
-    styletron-utils "^2.5.4"
-
-styletron-server@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/styletron-server/-/styletron-server-2.5.7.tgz#f3d0e86e1b8540cde10f25bfa08c40dc0df3851f"
-  dependencies:
-    styletron-core "^2.5.7"
-
-styletron-utils@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/styletron-utils/-/styletron-utils-2.5.4.tgz#f08cca7d58ee0338ce85e408cb32900e65620240"
-  dependencies:
-    inline-style-prefixer "^2.0.1"
 
 sugarss@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What does this change?

#17599 removed a number of dependencies from our application, but these were erroneously left in the `yarn.lock`. This change removes them

## What is the value of this and can you measure success?

Up-to-date `yarn.lock`

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
