### PR TITLE
Refactor out membership engagement banner template into it's own file, use getSync for geolocaiton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ static/src/stylesheets/pasteup/.npmrc
 *.crt
 *.key
 .vscode/settings.json
+

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -4,14 +4,26 @@ declare type AcquisitionsEpicTemplateCopy = {
     p2: string,
 };
 
+declare type EngagementBannerTemplateParams = {
+    messageText: string,
+    ctaText: string,
+    paypalAndCreditCardImage: string,
+    colourClass: string,
+    linkUrl: string,
+    buttonCaption: string,
+    buttonSvg: string,
+}
+
 declare type EngagementBannerParams = {
     minArticles: number,
     campaignCode: string,
     buttonCaption: string,
     linkUrl: string,
     messageText: string,
+    ctaText: string,
     pageviewId: string,
     colourStrategy: () => string,
     products: OphanProduct[],
     paypalClass?: string,
+    template?: (templateParams: EngagementBannerTemplateParams) => string
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -10,8 +10,8 @@ const baseParams = {
     campaignCode: 'gdnwb_copts_memco_banner',
 };
 
-const engagementBannerCopy = (cta: string): string =>
-    `Unlike many others, we haven't put up a paywall &ndash; we want to keep our journalism as open as we can. ${cta}`;
+const engagementBannerCopy = (): string =>
+    `Unlike many others, we haven't put up a paywall &ndash; we want to keep our journalism as open as we can.`;
 
 // Prices taken from https://membership.theguardian.com/<region>/supporter
 const monthlySupporterCost = (location: string): string => {
@@ -61,20 +61,19 @@ const monthlySupporterCost = (location: string): string => {
     return payment || '£5';
 };
 
-const supporterEngagementBannerCopy = (location: string): string =>
-    engagementBannerCopy(
-        `Support us for ${monthlySupporterCost(location)} per month.`
-    );
+const supporterEngagementCtaCopy = (location: string): string =>
+    `Support us for ${monthlySupporterCost(location)} per month.`;
 
 const contributionEngagementBannerCopy = (): string =>
-    engagementBannerCopy(`Support us with a one-time contribution`);
+    `Support us with a one-time contribution`;
 
 const supporterParams = (location: string): EngagementBannerParams =>
     Object.assign({}, baseParams, {
         buttonCaption: 'Become a Supporter',
         linkUrl: 'https://membership.theguardian.com/supporter',
         products: ['MEMBERSHIP_SUPPORTER'],
-        messageText: supporterEngagementBannerCopy(location),
+        messageText: engagementBannerCopy(),
+        ctaText: supporterEngagementCtaCopy(location),
         pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found',
     });
 
@@ -83,7 +82,8 @@ const contributionParams = (): EngagementBannerParams =>
         buttonCaption: 'Make a Contribution',
         linkUrl: 'https://contribute.theguardian.com',
         products: ['CONTRIBUTION'],
-        messageText: contributionEngagementBannerCopy(),
+        messageText: engagementBannerCopy(),
+        ctaText: contributionEngagementBannerCopy(),
         pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found',
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -74,7 +74,7 @@ const supporterParams = (location: string): EngagementBannerParams =>
         products: ['MEMBERSHIP_SUPPORTER'],
         messageText: engagementBannerCopy(),
         ctaText: supporterEngagementCtaCopy(location),
-        pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found',
+        pageviewId: config.get('ophan.pageViewId', 'not_found'),
     });
 
 const contributionParams = (): EngagementBannerParams =>
@@ -84,7 +84,7 @@ const contributionParams = (): EngagementBannerParams =>
         products: ['CONTRIBUTION'],
         messageText: engagementBannerCopy(),
         ctaText: contributionEngagementBannerCopy(),
-        pageviewId: (config.ophan && config.ophan.pageViewId) || 'not_found',
+        pageviewId: config.get('ophan.pageViewId', 'not_found'),
     });
 
 export const engagementBannerParams = (

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -19,6 +19,7 @@ import {
     selectBaseUrl,
     selectEngagementBannerButtonCaption,
 } from 'common/modules/commercial/support-utilities';
+import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 
 // change messageCode to force redisplay of the message to users who already closed it.
 const messageCode = 'engagement-banner-2017-09-21';
@@ -118,13 +119,13 @@ const showBanner = (params: EngagementBannerParams): void => {
 
     const test = getUserTest();
     const variant = getUserVariant(test);
-
     const paypalAndCreditCardImage =
         config.get('images.acquisitions.paypal-and-credit-card') || '';
     const colourClass = params.colourStrategy();
     const messageText = Array.isArray(params.messageText)
         ? selectSequentiallyFrom(params.messageText)
         : params.messageText;
+    const ctaText = params.ctaText;
 
     const linkUrl = addTrackingCodesToUrl({
         base: selectBaseUrl(params.linkUrl),
@@ -136,23 +137,22 @@ const showBanner = (params: EngagementBannerParams): void => {
                 ? { name: test.id, variant: variant.id }
                 : undefined,
     });
-
     const buttonCaption = selectEngagementBannerButtonCaption(
         params.buttonCaption
     );
     const buttonSvg = inlineSvg('arrowWhiteRight');
-    const renderedBanner = `
-    <div id="site-message__message">
-        <div class="site-message__message site-message__message--membership">
-            <span class = "membership__message-text">${messageText}</span>
-            <span class="membership__paypal-container">
-                <img class="membership__paypal-logo" src="${paypalAndCreditCardImage}" alt="Paypal and credit card">
-                <span class="membership__support-button"><a class="message-button-rounded__cta ${colourClass}" href="${linkUrl}">${buttonCaption}${buttonSvg}</a></span>
-            </span>
-        </div>
-        <a class="u-faux-block-link__overlay js-engagement-message-link" target="_blank" href="${linkUrl}" data-link-name="Read more link"></a>
-    </div>`;
-
+    const templateParams = {
+        messageText,
+        ctaText,
+        paypalAndCreditCardImage,
+        colourClass,
+        linkUrl,
+        buttonCaption,
+        buttonSvg,
+    };
+    const renderedBanner: string = params.template
+        ? params.template(templateParams)
+        : acquisitionsBannerControlTemplate(templateParams);
     const messageShown = new Message(messageCode, {
         pinOnHide: false,
         siteMessageLinkName: 'membership message',

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-control.js
@@ -1,0 +1,14 @@
+// @flow
+export const acquisitionsBannerControlTemplate = (
+    params: EngagementBannerTemplateParams
+) =>
+    `<div id="site-message__message">
+        <div class="site-message__message site-message__message--membership">
+            <span class = "membership__message-text">${params.messageText} ${params.ctaText}</span>
+            <span class="membership__paypal-container">
+                <img class="membership__paypal-logo" src="${params.paypalAndCreditCardImage}" alt="Paypal and credit card">
+                <span class="membership__support-button"><a class="message-button-rounded__cta ${params.colourClass}" href="${params.linkUrl}">${params.buttonCaption}${params.buttonSvg}</a></span>
+            </span>
+        </div>
+        <a class="u-faux-block-link__overlay js-engagement-message-link" target="_blank" href="${params.linkUrl}" data-link-name="Read more link"></a>
+    </div>`;


### PR DESCRIPTION
## What does this change?
In order to create tests with new banner templates more easily, this change makes it simple for a test to provide an alternative engagement banner template.

Also, I am separating the message main text from the cta in the EngagementBannerParams; this is because in an upcoming test, one variant makes the main paragraph big and keeps the cta small, so in order to generalise across the tempaltes they need splitting out