### PR TITLE
Youtube Atom: Add various null checks

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -77,14 +77,14 @@ const onPlayerPlaying = (atomId: string): void => {
         (player.iframe && player.iframe.closest('.immersive-main-media')) ||
         null;
     const parentNode = player.overlay && player.overlay.parentNode;
-    const containsEndSlateContainer =
+    const endSlateContainer =
         parentNode && parentNode.querySelector('.end-slate-container');
 
     if (mainMedia) {
         mainMedia.classList.add('atom-playing');
     }
 
-    if (player.endSlate && !containsEndSlateContainer) {
+    if (player.endSlate && !endSlateContainer) {
         player.endSlate.fetch(parentNode, 'html');
     }
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -12,15 +12,15 @@ import { isIOS, isAndroid, isBreakpoint } from 'lib/detect';
 import debounce from 'lodash/functions/debounce';
 import { isOn as accessibilityIsOn } from 'common/modules/accessibility/main';
 
-class YoutubePlayerTarget extends Event {
+class YoutubePlayerTarget extends EventTarget {
     playVideo: () => void;
 }
 
 // This is imcomplete; see https://developers.google.com/youtube/iframe_api_reference#Events
-declare type YoutubePlayerEvent = {
-    data: -1 | 0 | 1 | 2 | 3 | 4 | 5,
-    target: YoutubePlayerTarget,
-};
+class YoutubePlayerEvent {
+    data: -1 | 0 | 1 | 2 | 3 | 4 | 5;
+    target: YoutubePlayerTarget;
+}
 
 const players = {};
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -12,6 +12,16 @@ import { isIOS, isAndroid, isBreakpoint } from 'lib/detect';
 import debounce from 'lodash/functions/debounce';
 import { isOn as accessibilityIsOn } from 'common/modules/accessibility/main';
 
+class YoutubePlayerTarget extends Event {
+    playVideo: () => void;
+}
+
+// This is imcomplete; see https://developers.google.com/youtube/iframe_api_reference#Events
+declare type YoutubePlayerEvent = {
+    data: -1 | 0 | 1 | 2 | 3 | 4 | 5,
+    target: YoutubePlayerTarget,
+};
+
 const players = {};
 
 // retrieves actual id of atom without appended index
@@ -102,7 +112,7 @@ const STATES = {
     PAUSED: onPlayerPaused,
 };
 
-const checkState = (atomId, state, status): void => {
+const checkState = (atomId: string, state: number, status: string): void => {
     if (state === window.YT.PlayerState[status] && STATES[status]) {
         STATES[status](atomId);
     }
@@ -178,7 +188,12 @@ const updateImmersiveButtonPos = (): void => {
     }
 };
 
-const onPlayerReady = (atomId, overlay, iframe, event): void => {
+const onPlayerReady = (
+    atomId: string,
+    overlay: ?HTMLElement,
+    iframe: ?HTMLElement,
+    event: YoutubePlayerEvent
+): void => {
     players[atomId] = {
         player: event.target,
         pendingTrackingCalls: [25, 50, 75],
@@ -211,7 +226,7 @@ const onPlayerReady = (atomId, overlay, iframe, event): void => {
     }
 };
 
-const onPlayerStateChange = (atomId, event): void =>
+const onPlayerStateChange = (atomId: string, event: YoutubePlayerEvent): void =>
     Object.keys(STATES).forEach(checkState.bind(null, atomId, event.data));
 
 const checkElemForVideo = (elem: ?HTMLElement): void => {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -74,7 +74,7 @@ const onPlayerPlaying = (atomId: string): void => {
         mainMedia.classList.add('atom-playing');
     }
 
-    if (player && player.endSlate && !containsEndSlateContainer) {
+    if (player.endSlate && !containsEndSlateContainer) {
         player.endSlate.fetch(parentNode, 'html');
     }
 };


### PR DESCRIPTION
## What does this change?

After the [conversion of `component.js`](https://github.com/guardian/frontend/pull/18037) new Sentry issues started to show up:

- https://sentry.io/the-guardian/client-side-prod/issues/395778564/
- https://sentry.io/the-guardian/client-side-prod/issues/395430513/

The both seem to go back to `atoms/youtube.js`. This PRs tries to resolve the issues by adding more null checks.

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.