### PR TITLE
Onward: Add null check for geo-most-popular-front

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -32,7 +32,6 @@ export class GeoMostPopularFront extends Component {
     isVideoFront: boolean;
     isInternational: boolean;
     parent: ?bonzo;
-    tab: ?bonzo;
 
     prerender(): void {
         this.elem = qwery('.headline-list', this.elem)[0];
@@ -50,8 +49,11 @@ export class GeoMostPopularFront extends Component {
                 // hide the tabs
                 hideTabs(this.parent);
             } else {
-                this.tab = qwery(tabSelector, this.parent)[0];
-                this.fetch(this.tab, 'html');
+                const tab = this.parent.querySelector(tabSelector);
+
+                if (tab) {
+                    this.fetch(tab, 'html');
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this change?

After the [ES6 conversion of `component.js`](https://github.com/guardian/frontend/pull/18037) another small issue appeared in Sentry:

- https://sentry.io/the-guardian/client-side-prod/issues/395823127/

This PR is an attempt to fix it, by adding null checks.

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.