### PR TITLE
Raven: Ignore "Top comments failed to load" error

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -18,14 +18,15 @@ const sentryOptions = {
     ],
 
     tags: {
-        edition: config.page.edition,
-        contentType: config.page.contentType,
-        revisionNumber: config.page.revisionNumber,
+        edition: config.get('page.edition'),
+        contentType: config.get('page.contentType'),
+        revisionNumber: config.get('page.revisionNumber'),
     },
 
     ignoreErrors: [
         "Can't execute code from a freed script",
         'There is no space left matching rules from .js-article__body',
+        'Top comments failed to load:',
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',
@@ -46,10 +47,10 @@ const sentryOptions = {
     },
 
     shouldSendCallback(data: Object): boolean {
-        const { isDev } = config.page;
+        const { isDev } = config.get('page');
         const isIgnored =
             typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
-        const { enableSentryReporting } = config.switches;
+        const { enableSentryReporting } = config.get('switches');
         const isInSample = Math.random() < 0.1;
 
         if (isDev && !isIgnored) {


### PR DESCRIPTION
## What does this change?

Ignores a [popular Sentry error](https://sentry.io/the-guardian/client-side-prod/issues/125081729/), because we shouldn't abuse Sentry as a logging service for problems in the backend. In case discussion API returns something else than a `2xx` or `3xx` response, these should be loggend in Kibana.



## What is the value of this and can you measure success?

Less useless errors logged.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.