### PR TITLE
Raven: Generalize "There is no space left matching" ignore rule

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -25,7 +25,7 @@ const sentryOptions = {
 
     ignoreErrors: [
         "Can't execute code from a freed script",
-        'There is no space left matching rules from .js-article__body',
+        /There is no space left matching rules from/gi,
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?

Generalizes a raven ignore rule, to also ignore [other spacefinder issues](https://sentry.io/the-guardian/client-side-prod/issues/388268129/).

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.
