### PR TITLE
Raven: Ignore InvalidStateError

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -27,6 +27,7 @@ const sentryOptions = {
         "Can't execute code from a freed script",
         /There is no space left matching rules from/gi,
         'Top comments failed to load:',
+        /InvalidStateError/gi,
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?

Adds [`InvalidStateError`](https://sentry.io/the-guardian/client-side-prod/issues/220577772/) to the list of ignored Sentry errors.

The errors occurs in ophan for a long time and is hard to fix. Once someone works on a fix in Ophan, the ignore can be removed.

## What is the value of this and can you measure success?

Less errors in Sentry.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.