### PR TITLE
config.get should return falsy values

### DIFF
--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -7,11 +7,18 @@ const config: Object = window.guardian.config;
 
 // allows you to safely get items from config using a query of
 // dot or bracket notation, with optional default fallback
-const get = (path: string = '', defaultValue: any) =>
-    path
+const get = (path: string = '', defaultValue: any): any => {
+    const value = path
         .replace(/\[(.+?)\]/g, '.$1')
         .split('.')
-        .reduce((o, key) => o[key], config) || defaultValue;
+        .reduce((o, key) => o[key], config);
+
+    if (typeof value !== 'undefined') {
+        return value;
+    }
+
+    return defaultValue;
+};
 
 const hasTone = (name: string): boolean =>
     (config.page.tones || '').includes(name);

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -14,6 +14,7 @@ Object.assign(window.guardian.config, {
                 z: 'z',
             },
         },
+        falsyValue: false,
     },
 });
 
@@ -67,5 +68,11 @@ describe('Config', () => {
         expect(config.get('page.qwert', ['I am the default'])).toEqual([
             'I am the default',
         ]);
+    });
+
+    it('`get` should return falsy value for defined key with a default', () => {
+        expect(config.get('page.falsyValue', 'I am the default')).toEqual(
+            false
+        );
     });
 });


### PR DESCRIPTION
## What does this change?

Currently if the value of a property in `config` is falsy, it is ignored by `config.get(...)`, and the `defaultValue` is returned instead. This is not great for properties which could legitimately return falsy values (e.g. `config.switches`)

## What is the value of this and can you measure success?

`config.get(...)` allows falsy values

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

No 

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
