### PR TITLE
'Fix' paypal view on edit profile recurring contribution tab

### DIFF
--- a/identity/app/views/fragments/profile/contributionForm/recurringDetails.scala.html
+++ b/identity/app/views/fragments/profile/contributionForm/recurringDetails.scala.html
@@ -1,17 +1,6 @@
 @(user: com.gu.identity.model.User)
 <div class="is-hidden js-contribution-info">
     <ul class="details-list u-unstyled js-contribution-details">
-        <li class="details-list__item is-hidden js-contribution-subscription-number-container">
-            <div class="fieldset__heading">
-                <h2 class="form__heading">
-                    Contributor ref
-                </h2>
-            </div>
-
-            <div class="fieldset__fields">
-                <div class="form-field js-contribution-subscription-number"></div>
-            </div>
-        </li>
         <li class="details-list__item">
             <div class="fieldset__heading">
                 <h2 class="form__heading">

--- a/static/src/javascripts/projects/membership/contributions-recurring-tab.js
+++ b/static/src/javascripts/projects/membership/contributions-recurring-tab.js
@@ -1,5 +1,4 @@
 // @flow
-import bean from 'bean';
 import $ from 'lib/$';
 import fetch from 'lib/fetch';
 import config from 'lib/config';

--- a/static/src/javascripts/projects/membership/contributions-recurring-tab.js
+++ b/static/src/javascripts/projects/membership/contributions-recurring-tab.js
@@ -10,10 +10,7 @@ import { display } from 'membership/stripe';
 const CARD_DETAILS = '.js-contribution-card-details';
 const PAYPAL = '.js-contribution-paypal';
 const MANAGE_CARD_LAST4 = '.js-manage-account-card-last4';
-const PAYPAL_EMAIL_ADDRESS = '.js-paypal-email';
 const PAYPAL_SHOW_EMAIL_BUTTON = '.js-show-paypal-button';
-const PAYPAL_HIDE_EMAIL_BUTTON = '.js-hide-paypal-button';
-const PAYPAL_SHOW_EMAIL_MESSAGE = '.js-paypal-email-message';
 const CONTRIBUTION_PERIOD_START_CONTAINER =
     '.js-contribution-period-start-container';
 const CONTRIBUTION_PERIOD_START = '.js-contribution-period-start';
@@ -30,18 +27,6 @@ const ERROR = '.js-contribution-error';
 
 const hideLoader = (): void => {
     $(LOADER).addClass(IS_HIDDEN_CLASSNAME);
-};
-
-const hidePayPalAccountName = (): void => {
-    $(PAYPAL_SHOW_EMAIL_MESSAGE).addClass(IS_HIDDEN_CLASSNAME);
-    $(PAYPAL_SHOW_EMAIL_BUTTON).removeClass(IS_HIDDEN_CLASSNAME);
-    $(PAYPAL_HIDE_EMAIL_BUTTON).addClass(IS_HIDDEN_CLASSNAME);
-};
-
-const showPayPalAccountName = (): void => {
-    $(PAYPAL_SHOW_EMAIL_MESSAGE).removeClass(IS_HIDDEN_CLASSNAME);
-    $(PAYPAL_HIDE_EMAIL_BUTTON).removeClass(IS_HIDDEN_CLASSNAME);
-    $(PAYPAL_SHOW_EMAIL_BUTTON).addClass(IS_HIDDEN_CLASSNAME);
 };
 
 const displayContributionInfo = (): void => {
@@ -69,10 +54,6 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
         contributorDetails.subscription.card.last4;
     if (cardTail) {
         $(MANAGE_CARD_LAST4).text(cardTail);
-    } else if (contributorDetails.subscription.payPalEmail) {
-        $(PAYPAL_EMAIL_ADDRESS).text(
-            contributorDetails.subscription.payPalEmail
-        );
     }
 
     if (contributorDetails.subscription.nextPaymentDate) {
@@ -112,9 +93,8 @@ const populateUserDetails = (contributorDetails: ContributorDetails): void => {
         );
     } else if (contributorDetails.subscription.payPalEmail) {
         // if the user hasn't changed their subscription and has PayPal as a payment method
+        $(PAYPAL_SHOW_EMAIL_BUTTON).addClass(IS_HIDDEN_CLASSNAME);
         $(PAYPAL).removeClass(IS_HIDDEN_CLASSNAME);
-        bean.on($(PAYPAL_SHOW_EMAIL_BUTTON)[0], 'click', showPayPalAccountName);
-        bean.on($(PAYPAL_HIDE_EMAIL_BUTTON)[0], 'click', hidePayPalAccountName);
     }
 };
 export const recurringContributionTab = (): void => {


### PR DESCRIPTION
## What does this change?
Hides the 'Show account name' button on the Contributions tab when a contributor is paying by PayPal. It also removes the contributor reference html, the JS end of that was previously pulled in the initial PR (https://github.com/guardian/frontend/pull/18091)

## What is the value of this and can you measure success?
PayPal users are still guided towards changing their contribution within the PayPal site, we just don't add an interactive 'helper' button to show their PayPal email address. We're actively building the Contributions tab, and in the short term just want to get it deployed with minimal overhead but this feature may well return in the near future.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
*Before*
<img width="839" alt="screen shot 2017-10-31 at 16 41 45" src="https://user-images.githubusercontent.com/690395/32241082-1ede77d6-be67-11e7-9a13-faad68a42906.png">

*After*
![screen shot 2017-10-31 at 17 58 34](https://user-images.githubusercontent.com/690395/32241089-2582c592-be67-11e7-9c1d-130c4d2cc914.png)

## Tested in CODE?
Not yet, only locally.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
