### PR TITLE
Raven: Ignore "Fetch error:"

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -28,6 +28,7 @@ const sentryOptions = {
         /There is no space left matching rules from/gi,
         'Top comments failed to load:',
         /InvalidStateError/gi,
+        /Fetch error:/gi,
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?

Adds `Fetch error:` to the list of ignored Sentry errors. Again - this is something that should be done and handled in Kibana.

- https://sentry.io/the-guardian/client-side-prod/issues/388261213/
- https://sentry.io/the-guardian/client-side-prod/issues/388467374/

## What is the value of this and can you measure success?

Less errors in Sentry.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.