### PR TITLE
Raven: Ignore "Comments failed to load:"

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -27,6 +27,7 @@ const sentryOptions = {
         "Can't execute code from a freed script",
         /There is no space left matching rules from/gi,
         'Top comments failed to load:',
+        'Comments failed to load:',
         /InvalidStateError/gi,
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error


### PR DESCRIPTION
## What does this change?

Similar to "[Raven: Ignore "Top comments failed to load" error](https://github.com/guardian/frontend/pull/18101)", but for all comments instead of top comments only.

- https://sentry.io/the-guardian/client-side-prod/issues/125122391/

## What is the value of this and can you measure success?

Less errors in Sentry.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.