### PR TITLE
Sentry: Add null check around "getEntriesByName"

### DIFF
--- a/static/src/javascripts/lib/capture-perf-timings.js
+++ b/static/src/javascripts/lib/capture-perf-timings.js
@@ -5,13 +5,15 @@ import performanceAPI from 'lib/window-performance';
 
 const capturePerfTimings = (): void => {
     const supportsPerformanceProperties =
-        'navigation' in performanceAPI && 'timing' in performanceAPI;
+        performanceAPI &&
+        'navigation' in performanceAPI &&
+        'timing' in performanceAPI;
 
     if (!supportsPerformanceProperties) {
         return;
     }
 
-    const timing = performanceAPI && performanceAPI.timing;
+    const timing = performanceAPI.timing;
 
     const marks = [
         'standard boot',

--- a/static/src/javascripts/lib/user-timing.js
+++ b/static/src/javascripts/lib/user-timing.js
@@ -6,7 +6,7 @@ const timings = {};
 const startDate = new Date().getTime();
 
 const getCurrentTime = (): number => {
-    if ('now' in performanceAPI) {
+    if (performanceAPI && 'now' in performanceAPI) {
         return performanceAPI.now();
     }
 
@@ -14,7 +14,7 @@ const getCurrentTime = (): number => {
 };
 
 const markTime = (label: string): void => {
-    if ('mark' in performanceAPI) {
+    if (performanceAPI && 'mark' in performanceAPI) {
         performanceAPI.mark(label);
     } else {
         timings[label] = getCurrentTime();
@@ -23,7 +23,7 @@ const markTime = (label: string): void => {
 
 // Returns the ms time when the mark was made.
 const getMarkTime = (label: string): ?number => {
-    if ('getEntriesByName' in performanceAPI) {
+    if (performanceAPI && 'getEntriesByName' in performanceAPI) {
         const perfMark = performanceAPI.getEntriesByName(label, 'mark');
 
         if (perfMark && 'startTime' in perfMark[0]) {

--- a/static/src/javascripts/lib/user-timing.js
+++ b/static/src/javascripts/lib/user-timing.js
@@ -24,10 +24,10 @@ const markTime = (label: string): void => {
 // Returns the ms time when the mark was made.
 const getMarkTime = (label: string): ?number => {
     if ('getEntriesByName' in performanceAPI) {
-        const perfMark = performanceAPI.getEntriesByName(label, 'mark')[0];
+        const perfMark = performanceAPI.getEntriesByName(label, 'mark');
 
-        if (perfMark && 'startTime' in perfMark) {
-            return perfMark.startTime;
+        if (perfMark && 'startTime' in perfMark[0]) {
+            return perfMark[0].startTime;
         }
     } else if (label in timings) {
         return timings[label];

--- a/static/src/javascripts/lib/window-performance.js
+++ b/static/src/javascripts/lib/window-performance.js
@@ -1,36 +1,8 @@
 // @flow
 
-import { noop } from 'lib/noop';
-
 const api = window.performance ||
     window.msPerformance ||
     window.webkitPerformance ||
-    window.mozPerformance || {
-        getEntriesByName: noop,
-
-        navigation: {
-            redirectCount: 0,
-            type: '',
-        },
-
-        mark: noop,
-        now: noop,
-
-        timing: {
-            connectStart: 0,
-            connectEnd: 0,
-
-            domainLookupEnd: 0,
-            domainLookupStart: 0,
-
-            domContentLoadedEventStart: 0,
-
-            loadEventStart: 0,
-            loadEventEnd: 0,
-
-            responseStart: 0,
-            responseEnd: 0,
-        },
-    };
+    window.mozPerformance;
 
 export default api;

--- a/static/src/javascripts/lib/window-performance.js
+++ b/static/src/javascripts/lib/window-performance.js
@@ -1,6 +1,7 @@
 // @flow
 
-const api = window.performance ||
+const api =
+    window.performance ||
     window.msPerformance ||
     window.webkitPerformance ||
     window.mozPerformance;


### PR DESCRIPTION
## What does this change?

This is an attempt to fix [`undefined is not an object (evaluating 'n.default.getEntriesByName(t,"mark")[0]')`](https://sentry.io/the-guardian/client-side-prod/issues/395953933/) and [`undefined is not an object (evaluating 'n.default.getEntriesByName(t,"mark")')`](https://sentry.io/the-guardian/client-side-prod/issues/388260708/), by executing the null check before accessing array properties.

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.
