### PR TITLE
Update big long banner test info

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-big-long.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-big-long.js
@@ -7,10 +7,9 @@ export const AcquisitionsBannerBigLong: AcquisitionsABTest = {
     id: 'AcquisitionsBannerBigLong',
     campaignId: 'banner_big_long',
     start: '2017-10-26',
-    expiry: '2018-11-12',
+    expiry: '2018-11-27',
     author: 'Jonathan Rankin',
-    description:
-        'This places the epic on all articles for all users, with a limit of 4 impressions in any given 30 days',
+    description: 'Tests 2 new banner variants',
     successMeasure: 'Conversion rate',
     idealOutcome: 'Acquires many Supporters',
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',


### PR DESCRIPTION
## What does this change?
Put the correct expiry date on the big long banner test

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
