### PR TITLE
Update human leavers

### DIFF
--- a/facia/public/humans.txt
+++ b/facia/public/humans.txt
@@ -1,14 +1,5 @@
 /* CURRENT TEAM */
 
-Head of User Experience: Nick Haley
-Twitter: @twobobswerver
-From: London, England
-
-Product Manager: Chris Mulholland
-LinkedIn: chrismulholland
-Twitter: @crifmulholland
-From: Glasgow, Scotland
-
 Development Manager: Dominic Kendrick
 Twitter: @dominickendrick
 From: London, UK
@@ -41,10 +32,6 @@ Location: London, UK
 Developer: Josh Holder
 Twitter: @Josh_H
 Location: London, UK
-
-Developer: Jenny Sivapalan
-Twitter: @jenny_sivapalan
-From: London, UK
 
 Developer: Natalia Baltazar
 Twitter: @NataliaLKB
@@ -134,13 +121,6 @@ Developer: Anne Byrne
 Twitter: @aycenne
 From: Cork, Ireland
 Location: London, UK
-
-Software Engineer in Test: Gideon Goldberg
-Twitter: @gidsg
-From: London, UK, Earth, the Universe
-
-Software Architect/Hacker: Phil Wills
-Twitter: @philwills
 
 Developer: Mariot Chauvin
 Twitter: @mchv
@@ -302,3 +282,24 @@ Engineer (Tech lead, Commercial): Ken Lim
 Twitter: @kenlim
 From: Kuala Lumpur, Malaysia
 Location: London, UK
+
+Head of User Experience: Nick Haley
+Twitter: @twobobswerver
+From: London, England
+
+Product Manager: Chris Mulholland
+LinkedIn: chrismulholland
+Twitter: @crifmulholland
+From: Glasgow, Scotland
+
+Developer: Jenny Sivapalan
+Twitter: @jenny_sivapalan
+From: London, UK
+
+Software Engineer in Test: Gideon Goldberg
+Twitter: @gidsg
+From: London, UK, Earth, the Universe
+
+Software Architect/Hacker: Phil Wills
+Twitter: @philwills
+


### PR DESCRIPTION
## What does this change?
I just noticed a few recent (and not so recent) leaver's names are still in the 'current' group.

## What is the value of this and can you measure success?
Nothing practical. Just housekeeping.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

## Screenshots
N/A

## Tested in CODE?
No.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
