### PR TITLE
Correct banner message

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-long.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-long.js
@@ -9,7 +9,7 @@ export const acquisitionsBannerLongTemplate = (
                     <strong>Unlike many news organisations, we haven't put up a paywall - we want to keep our journalism as open as we can.</strong>
                     The Guardian's independent, investigative journalism
                 takes a lot of time, money and hard work to produce. But the revenue we get from advertising is falling,
-                so we increasingly need our readers to fund us. If everyone who read our reporting, who likes it, helps
+                so we increasingly need our readers to fund us. If everyone who reads our reporting, who likes it, helps
                 fund it, our future would be much more secure. <strong>${params.ctaText}</strong></span>
             </div>
             <span class="membership__paypal-container">


### PR DESCRIPTION
## What does this change?
It should read "reads" rather than "read" on the banner

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
