### PR TITLE
Make banner get synchronous geolocation rather than async

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-workspaces-experimental true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -204,6 +204,7 @@ const membershipEngagementBannerInit = (): Promise<void> => {
             }
         );
     }
+    return Promise.resolve(undefined);
 };
 
 export { membershipEngagementBannerInit };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -10,7 +10,7 @@ import { testCanBeRun } from 'common/modules/experiments/test-can-run-checks';
 import { isInTest, variantFor } from 'common/modules/experiments/segment-util';
 import { engagementBannerParams } from 'common/modules/commercial/membership-engagement-banner-parameters';
 import { isBlocked } from 'common/modules/commercial/membership-engagement-banner-block';
-import { get as getGeoLocation } from 'lib/geolocation';
+import { getSync as getGeoLocation } from 'lib/geolocation';
 
 import {
     submitComponentEvent,
@@ -186,26 +186,24 @@ const showBanner = (params: EngagementBannerParams): void => {
     }
 };
 
-const membershipEngagementBannerInit = (): Promise<void> =>
-    getGeoLocation().then(location => {
-        const bannerParams = deriveBannerParams(location);
-
-        if (bannerParams && getVisitCount() >= bannerParams.minArticles) {
-            return commercialFeatures.asynchronous.canDisplayMembershipEngagementBanner.then(
-                canShow => {
-                    if (canShow) {
-                        mediator.on(
-                            'modules:onwards:breaking-news:ready',
-                            breakingShown => {
-                                if (!breakingShown) {
-                                    showBanner(bannerParams);
-                                }
+const membershipEngagementBannerInit = () => {
+    const bannerParams = deriveBannerParams(getGeoLocation());
+    if (bannerParams && getVisitCount() >= bannerParams.minArticles) {
+        return commercialFeatures.asynchronous.canDisplayMembershipEngagementBanner.then(
+            canShow => {
+                if (canShow) {
+                    mediator.on(
+                        'modules:onwards:breaking-news:ready',
+                        breakingShown => {
+                            if (!breakingShown) {
+                                showBanner(bannerParams);
                             }
-                        );
-                    }
+                        }
+                    );
                 }
-            );
-        }
-    });
+            }
+        );
+    }
+}
 
 export { membershipEngagementBannerInit };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -204,6 +204,6 @@ const membershipEngagementBannerInit = () => {
             }
         );
     }
-}
+};
 
 export { membershipEngagementBannerInit };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -186,7 +186,7 @@ const showBanner = (params: EngagementBannerParams): void => {
     }
 };
 
-const membershipEngagementBannerInit = () => {
+const membershipEngagementBannerInit = (): Promise<void> => {
     const bannerParams = deriveBannerParams(getGeoLocation());
     if (bannerParams && getVisitCount() >= bannerParams.minArticles) {
         return commercialFeatures.asynchronous.canDisplayMembershipEngagementBanner.then(

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -133,15 +133,14 @@ afterEach(() => {
 
 describe('Membership engagement banner', () => {
     describe('If breaking news banner has show', () => {
-        it('should not show the membership engagement banner', () =>
-            membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', true);
-                expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
-            }));
+        it('should not show the membership engagement banner', () => {
+            membershipEngagementBannerInit();
+            fakeMediator.emit('modules:onwards:breaking-news:ready', true);
+            expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
+        });
     });
 
     describe('If breaking news banner has not shown', () => {
-        let showBanner;
         let emitSpy;
 
         beforeEach(() => {
@@ -153,42 +152,36 @@ describe('Membership engagement banner', () => {
                 linkUrl: 'fake-link-url',
             }));
             emitSpy = jest.spyOn(fakeMediator, 'emit');
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
+            membershipEngagementBannerInit();
+            fakeMediator.emit('modules:onwards:breaking-news:ready', false);
         });
         afterEach(() => {
             emitSpy.mockRestore();
         });
 
-        it('should show the membership engagement banner', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1);
-            }));
-        it('should emit a display event', () =>
-            showBanner.then(() => {
-                expect(emitSpy).toHaveBeenCalledWith(
-                    'membership-message:display'
-                );
-            }));
-        it('should record the component event in ophan with a/b test info', () =>
-            showBanner.then(() => {
-                expect(fakeOphan.record).toHaveBeenCalledWith({
-                    componentEvent: {
-                        component: {
-                            componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
-                            products: ['CONTRIBUTION'],
-                            id: 'fake-campaign-id_fake-variant-id',
-                            campaignCode: 'fake-campaign-id_fake-variant-id',
-                        },
-                        action: 'INSERT',
-                        abTest: {
-                            name: 'fake-test-id',
-                            variant: 'fake-variant-id',
-                        },
+        it('should show the membership engagement banner', () => {
+            expect(FakeMessage.prototype.show).toHaveBeenCalledTimes(1);
+        });
+        it('should emit a display event', () => {
+            expect(emitSpy).toHaveBeenCalledWith('membership-message:display');
+        });
+        it('should record the component event in ophan with a/b test info', () => {
+            expect(fakeOphan.record).toHaveBeenCalledWith({
+                componentEvent: {
+                    component: {
+                        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+                        products: ['CONTRIBUTION'],
+                        id: 'fake-campaign-code',
+                        campaignCode: 'fake-campaign-code',
                     },
-                });
-            }));
+                    action: 'INSERT',
+                    abTest: {
+                        name: 'fake-test-id',
+                        variant: 'fake-variant-id',
+                    },
+                },
+            });
+        });
     });
 
     describe('If user already member', () => {
@@ -204,16 +197,14 @@ describe('Membership engagement banner', () => {
             );
         });
 
-        it('should not show any messages even to engaged readers', () =>
-            membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-                expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
-            }));
+        it('should not show any messages even to engaged readers', () => {
+            membershipEngagementBannerInit();
+            fakeMediator.emit('modules:onwards:breaking-news:ready', false);
+            expect(FakeMessage.prototype.show).not.toHaveBeenCalled();
+        });
     });
 
     describe('creates message with', () => {
-        let showBanner;
-
         beforeEach(() => {
             engagementBannerParams.mockImplementationOnce(() => ({
                 minArticles: 1,
@@ -228,28 +219,24 @@ describe('Membership engagement banner', () => {
                     engagementBannerParams: {},
                 },
             }));
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
+            fakeMediator.emit('modules:onwards:breaking-news:ready', false);
         });
 
-        it('correct campaign code', () =>
-            showBanner.then(() => {
-                expect(
-                    FakeMessage.mock.calls[0][1].siteMessageComponentName
-                ).toBe('fake-campaign-id_fake-variant-id');
-            }));
-        it('correct CSS modifier class', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.mock.calls[0][1].cssModifierClass).toBe(
-                    'fake-colour-class'
-                );
-            }));
+        it('correct campaign code', () => {
+            membershipEngagementBannerInit();
+            expect(FakeMessage.mock.calls[0][1].siteMessageComponentName).toBe(
+                'fake-campaign-id_fake-variant-id'
+            );
+        });
+        it('correct CSS modifier class', () => {
+            membershipEngagementBannerInit();
+            expect(FakeMessage.mock.calls[0][1].cssModifierClass).toBe(
+                'fake-colour-class'
+            );
+        });
     });
 
     describe('renders message with', () => {
-        let showBanner;
-
         beforeEach(() => {
             engagementBannerParams.mockImplementationOnce(() => ({
                 minArticles: 1,
@@ -265,46 +252,39 @@ describe('Membership engagement banner', () => {
             fakeConstructQuery.mockImplementationOnce(
                 () => 'fake-query-parameters'
             );
-            showBanner = membershipEngagementBannerInit().then(() => {
-                fakeMediator.emit('modules:onwards:breaking-news:ready', false);
-            });
+            membershipEngagementBannerInit();
+            fakeMediator.emit('modules:onwards:breaking-news:ready', false);
         });
 
-        it('message text', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-message-text/
-                );
-            }));
-        it('paypal and credit card image', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-paypal-and-credit-card-image/
-                );
-            }));
-        it('colour class', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-colour-class/
-                );
-            }));
-        it('link URL', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-link-url\?fake-query-parameters/
-                );
-            }));
-        it('button caption', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-button-caption/
-                );
-            }));
-        it('button SVG', () =>
-            showBanner.then(() => {
-                expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                    /fake-button-svg/
-                );
-            }));
+        it('message text', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-message-text/
+            );
+        });
+        it('paypal and credit card image', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-paypal-and-credit-card-image/
+            );
+        });
+        it('colour class', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-colour-class/
+            );
+        });
+        it('link URL', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-link-url\?fake-query-parameters/
+            );
+        });
+        it('button caption', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-button-caption/
+            );
+        });
+        it('button SVG', () => {
+            expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
+                /fake-button-svg/
+            );
+        });
     });
 });


### PR DESCRIPTION
## What does this change?
AU has been reporting problems with the currency displayed on the banner, so we are reverting to the sync method, which we know is reliable as we use it on the epic. This method will try and get the geolocation from local storage, and failing that, it defaults to edition

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
