### PR TITLE
Hide VideoJS enhancement for embeds behind switch

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -1,6 +1,7 @@
 @import conf.{Configuration, Static}
 @import model.{EmbedPage, VideoPlayer}
 @import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
+@import conf.switches.Switches.EnhancedVideoPlayerSwitch
 
 @(page: EmbedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -99,14 +100,16 @@
         document.documentElement.className = docClass;
         </script>
 
-        <script>
-        (function (document) {
-            var script = document.createElement('script');
-            var ref = document.getElementsByTagName('script')[0];
-            script.src = '@Static("javascripts/graun.video-embed.js")';
-            ref.parentNode.insertBefore(script, ref);
-        })(document);
-        </script>
+        @if(EnhancedVideoPlayerSwitch.isSwitchedOn) {
+            <script>
+            (function (document) {
+                var script = document.createElement('script');
+                var ref = document.getElementsByTagName('script')[0];
+                script.src = '@Static("javascripts/graun.video-embed.js")';
+                ref.parentNode.insertBefore(script, ref);
+            })(document);
+            </script>
+        }
 
         @fragments.analytics.base()(page, request, context)
 


### PR DESCRIPTION
## What does this change?

Hides VideoJS enhancement behind a feature switch. 

This change ensures the `video-embed`, which applies the VideoJS enhancements bundle is only loaded when the `EnhancedVideoSwitch` is on.

Depends on #18104

## What is the value of this and can you measure success?

Provides the ability to turn off VideoJS enhancements, allowing us to gauge impact in advance of removing VideoJS entirely.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

**Before**

![picture 323](https://user-images.githubusercontent.com/5931528/32288499-084b3d68-bf2c-11e7-91ce-c925ceebdc8e.png)

**After**

![picture 322](https://user-images.githubusercontent.com/5931528/32288474-f5c9fd78-bf2b-11e7-9456-ea6a4861ffb0.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
