### PR TITLE
Allow a control banner variant to be declared without declaring options

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -56,6 +56,10 @@ const getUserVariantParams = (
         }
 
         return userVariantParams;
+    } else if (campaignId && userVariant) {
+        return {
+            campaignCode: buildCampaignCode(campaignId, userVariant.id),
+        };
     }
     return {};
 };

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -57,9 +57,7 @@ const getUserVariantParams = (
 
         return userVariantParams;
     } else if (campaignId && userVariant) {
-        return {
-            campaignCode: buildCampaignCode(campaignId, userVariant.id),
-        };
+        return {};
     }
     return {};
 };


### PR DESCRIPTION
## What does this change?
Previously, if you wanted to declare a control banner variant where the only modification from the control was a campaign code change, you had to do the following:

```
id: 'control',
options: {
   engagementBannerParams: {},
}
```

with a redundent options -> engagementBannerParams, just to get to the logic where the campaignCode is created. This PR allows you to just declare a control like this"

```
id: 'control'
```

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
