### PR TITLE
Bump version of big long banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,7 +128,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-acquisitions-banner-big-long",
+    "ab-acquisitions-banner-big-long-two",
     "Test a big variant and a long variant against the banner control",
     owners = Seq(Owner.withGithub("jranks123")),
     safeState = On,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-big-long-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-big-long-two.js
@@ -3,9 +3,9 @@ import { acquisitionsBannerBigTemplate } from 'common/modules/commercial/templat
 import { acquisitionsBannerLongTemplate } from 'common/modules/commercial/templates/acquisitions-banner-long';
 import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
 
-export const AcquisitionsBannerBigLong: AcquisitionsABTest = {
-    id: 'AcquisitionsBannerBigLong',
-    campaignId: 'banner_big_long',
+export const AcquisitionsBannerBigLongTwo: AcquisitionsABTest = {
+    id: 'AcquisitionsBannerBigLongTwo',
+    campaignId: 'banner_big_long_two',
     start: '2017-10-26',
     expiry: '2018-11-27',
     author: 'Jonathan Rankin',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { AcquisitionsBannerBigLong } from 'common/modules/experiments/tests/acquisitions-banner-big-long';
+import { AcquisitionsBannerBigLongTwo } from 'common/modules/experiments/tests/acquisitions-banner-big-long-two';
 
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [AcquisitionsBannerBigLong];
+> = [AcquisitionsBannerBigLongTwo];


### PR DESCRIPTION
## What does this change?
Due to a tracking issue, we need to redeploy this test with a fresh name and campaign id

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
