### PR TITLE
Raven: Ignore "Network request failed" from whatwg-fetch/fetch

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -30,6 +30,7 @@ const sentryOptions = {
         'Comments failed to load:',
         /InvalidStateError/gi,
         /Fetch error:/gi,
+        'Network request failed',
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?

Ignore another error in Sentry which reports on failed requests, which should be loggend in Kibana and not through the error logger.

- https://sentry.io/the-guardian/client-side-prod/issues/395976083/

## What is the value of this and can you measure success?

Less errors in Sentry.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.