### PR TITLE
Messenger: Add null check and update flow definitions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -20,7 +20,7 @@ const normalise = (length: string): string => {
 const resize = (
     specs: Specs,
     iframe: HTMLElement,
-    iframeContainer: HTMLElement,
+    iframeContainer: ?HTMLElement,
     adSlot: HTMLElement
 ): ?Promise<any> => {
     if (
@@ -45,7 +45,10 @@ const resize = (
     return fastdom.write(() => {
         Object.assign(adSlot.style, styles);
         Object.assign(iframe.style, styles);
-        Object.assign(iframeContainer.style, styles);
+
+        if (iframeContainer) {
+            Object.assign(iframeContainer.style, styles);
+        }
     });
 };
 


### PR DESCRIPTION
## What does this change?

Adds a null check, to fix the following Sentry errors:

- https://sentry.io/the-guardian/client-side-prod/issues/392887294/
- https://sentry.io/the-guardian/client-side-prod/issues/392891106/

The flow type definitions appears to be wrong, but flow didn't pick it up.

```js
const iframeContainer = iframe && iframe.closest('.ad-slot__content');
```

should be nullable.

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.