### PR TITLE
Improved supporter cta - no longer shows above header

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -41,6 +41,7 @@
                               data-link-name="nav2 : supporter-cta"
                               data-edition="@{editionId}"
                               href="@getContributionOrSupporterUrl(editionId)">
+                              <span class="top-bar__item--cta--circle"></span>
                               <span class="top-bar__item--cta--text">
                                   @if(editionId == "us") {
                                      make a <br>contribution

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -72,28 +72,41 @@
         display: none;
     }
 
+    &:hover,
+    &:focus {
+        color: $guardian-brand-dark;
+
+        & .top-bar__item--cta--circle {
+            transform: scale(1.05);
+
+            &:before {
+                background: $highlight-blue;
+            }
+        }
+    }
+}
+
+.top-bar__item--cta--circle {
+    bottom: -$gs-baseline;
+    left: 0;
+    overflow: hidden;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: transform 250ms ease-out;
+    transform-origin: top center;
+
     &:before {
         background: $news-main-2;
         border-radius: 50%;
-        bottom: -$gs-baseline;
+        bottom: 0;
         content: '';
         display: block;
         left: 0;
         padding-top: 100%;
         position: absolute;
-        transform: scale(1);
-        transition: transform 250ms ease-out, background-color 250ms ease-out;
-        width: 100%;
-    }
-
-    &:hover,
-    &:focus {
-        color: $guardian-brand-dark;
-
-        &:before {
-            background: $highlight-blue;
-            transform: scale(1.05);
-        }
+        right: 0;
+        transition: background-color 250ms ease-out;
     }
 }
 


### PR DESCRIPTION
The supporter call to action was peaking outside of the navigation.

# Before
![0-1](https://user-images.githubusercontent.com/14570016/32322044-032e568c-bfbb-11e7-89ea-bad019651090.png)

# After
<img width="526" alt="screen shot 2017-11-02 at 10 46 55" src="https://user-images.githubusercontent.com/14570016/32322175-884ef60a-bfbb-11e7-9366-8a355a88d98a.png">

I've had to scoop up the circle as a separate span so I can mask just the top edge using overflow hidden. Now as you hover nothing is clipped as the circle expands.  