### PR TITLE
Selection sharing: Add early return to avoid errors

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -82,6 +82,11 @@ const updateSelection = (): void => {
     if (body && selection && selection.rangeCount > 0 && selection.toString()) {
         const range = selection.getRangeAt(0);
         const rect = Rangefix.getBoundingClientRect(range);
+
+        if (!rect) {
+            return;
+        }
+
         const top = $(body).scrollTop() + rect.top;
         let twitterMessage = range.toString();
 


### PR DESCRIPTION
## What does this change?

Adds an early return, fix to the following sentry error:

- https://sentry.io/the-guardian/client-side-prod/issues/388266405/

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.