### PR TITLE
Update tabs.scss for mobile

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -44,6 +44,7 @@ rules:
     - extra-properties:
         - overflow-scrolling
         - osx-font-smoothing
+        - grid-column-gap
   no-trailing-zero: 1
   no-url-protocols: 0
 

--- a/identity/app/views/publicProfilePage.scala.html
+++ b/identity/app/views/publicProfilePage.scala.html
@@ -34,7 +34,7 @@
         <div class="modern-visible">
             @defining("/user/id/"+user.id){ link =>
                 <div class="tabs tabs--identity">
-                    <ol class="tabs__container">
+                    <ol class="tabs__container tabs__container--multiple">
                         <li class="tabs__tab @if(activityType == "discussions"){tabs__tab--selected}">
                             <a href="@link" class="js-activity-stream-change" data-stream-type="discussions" data-link-name="Profile discussions tab">Comments</a>
                         </li>

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -64,11 +64,17 @@ category: Common
     margin: 0;
     border-bottom: 1px solid $neutral-5;
     border-top: 3px solid $neutral-6;
-    float: none;
-    width: 100%;
+    float: left;
+    width: 50%;
+
+    @supports ( display: grid ) {
+        width: 100%;
+    }
 
     @include mq(tablet) {
         display: table-cell;
+        float: none;
+        width: 100%;
     }
 
     &.tabs__tab--selected {

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -47,6 +47,7 @@ category: Common
     overflow: hidden;
     z-index: 2;
     background: $neutral-6;
+    border-top: 3px solid $neutral-6;
 
     @include mq(tablet) {
         margin-bottom: -1px;
@@ -57,11 +58,12 @@ category: Common
     width: 50%;
     float: left;
     margin: 0;
-    border-top: 3px solid $neutral-6;
+    border-bottom: 1px solid $neutral-5;
+    border-left: 2px solid rgba(255, 255, 255, .75);
+    margin-left: -2px;
 
     @include mq(tablet) {
         max-width: gs-span(3);
-        border-bottom: 1px solid $neutral-5;
     }
 
     a,
@@ -96,21 +98,12 @@ category: Common
         color: inherit;
     }
 
-    & + & a {
-        border-left: 2px solid rgba(255, 255, 255, .75);
-        padding-left: 6px;
-    }
 }
 
 .tabs__tab--selected {
     a,
     .tab__link {
         background: #ffffff;
-    }
-
-    + .tabs__tab a {
-        border-left: 0;
-        padding-left: 8px;
     }
 
     @include mq(tablet) {
@@ -145,40 +138,24 @@ category: Common
  */
 
 .tabs__container--multiple {
-
     width: 100%;
     margin: 0;
     margin-bottom: 10px;
+    table-layout: fixed;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    display: table;
+    display: grid;
 
     .tabs__tab {
-        width: 50%;
-        float: left;
-        @include mq($until: desktop) {
-            max-width: 100%;
-            border: 0;
-            border-bottom: 1px solid $neutral-5;
-            margin-bottom: -1px;
-
-            &:nth-child(odd) {
-                box-shadow: 1px 0 0 0 $neutral-5;
-            }
-
-            & > a {
-                border-left: 0;
-                padding-left: 6px;
-            }
+        float: none;
+        width: auto;
+        max-width: 100%;
+        @include mq(tablet) {
+            display: table-cell;
         }
     }
 
     @include mq(desktop) {
-        display: table;
-        table-layout: fixed;
-
-        .tabs__tab {
-            display: table-cell;
-            width: auto;
-            float: none;
-        }
         .tab--stats {
             display: none;
         }

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -46,6 +46,8 @@ category: Common
     list-style-type: none;
     overflow: hidden;
     z-index: 2;
+    width: 100%;
+    max-width: gs-span(6);
     background: lighten($neutral-6, 5%);
     table-layout: fixed;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
@@ -59,14 +61,14 @@ category: Common
 }
 
 .tabs__tab {
-    width: 50%;
-    float: left;
     margin: 0;
     border-bottom: 1px solid $neutral-5;
     border-top: 3px solid $neutral-6;
+    float: none;
+    width: 100%;
 
     @include mq(tablet) {
-        max-width: gs-span(3);
+        display: table-cell;
     }
 
     &.tabs__tab--selected {
@@ -137,19 +139,7 @@ category: Common
  */
 
 .tabs__container--multiple {
-    width: 100%;
-    margin: 0;
     margin-bottom: 10px;
-
-    .tabs__tab {
-        float: none;
-        width: auto;
-        max-width: 100%;
-
-        @include mq(tablet) {
-            display: table-cell;
-        }
-    }
 
     @include mq(desktop) {
         .tab--stats {

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -146,43 +146,43 @@ category: Common
 
 .tabs__container--multiple {
 
-  width: 100%;
-  margin: 0;
-  margin-bottom: 10px;
-
-  .tabs__tab {
-    width: 50%;
-    float: left;
-    @include mq($until: desktop) {
-      max-width: 100%;
-      border: 0;
-      border-bottom: 1px solid $neutral-5;
-      margin-bottom: -1px;
-
-      &:nth-child(odd) {
-        box-shadow: 1px 0 0 0 $neutral-5;
-      }
-
-      & > a {
-        border-left: 0;
-        padding-left: 6px;
-      }
-    }
-  }
-
-  @include mq(desktop) {
-    display: table;
-    table-layout: fixed;
+    width: 100%;
+    margin: 0;
+    margin-bottom: 10px;
 
     .tabs__tab {
-        display: table-cell;
-        width: auto;
-        float: none;
+        width: 50%;
+        float: left;
+        @include mq($until: desktop) {
+            max-width: 100%;
+            border: 0;
+            border-bottom: 1px solid $neutral-5;
+            margin-bottom: -1px;
+
+            &:nth-child(odd) {
+                box-shadow: 1px 0 0 0 $neutral-5;
+            }
+
+            & > a {
+                border-left: 0;
+                padding-left: 6px;
+            }
+        }
     }
-    .tab--stats {
-        display: none;
+
+    @include mq(desktop) {
+        display: table;
+        table-layout: fixed;
+
+        .tabs__tab {
+            display: table-cell;
+            width: auto;
+            float: none;
+        }
+        .tab--stats {
+            display: none;
+        }
     }
-  }
 }
 
 // Most Popular FRONTS customisation: change layout to accommodate MPU (with or without tabs)

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -146,6 +146,7 @@ category: Common
 
 .tabs__container--multiple {
     margin-bottom: 10px;
+    max-width: 100%;
 
     @include mq(desktop) {
         .tab--stats {

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -150,6 +150,7 @@ category: Common
         float: none;
         width: auto;
         max-width: 100%;
+        
         @include mq(tablet) {
             display: table-cell;
         }

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -46,6 +46,7 @@ category: Common
     list-style-type: none;
     overflow: hidden;
     z-index: 2;
+    background: $neutral-6;
 
     @include mq(tablet) {
         margin-bottom: -1px;
@@ -70,9 +71,11 @@ category: Common
         box-sizing: border-box;
         min-height: $gs-row-height;
         padding: $gs-baseline/3 8px 0;
-        background-color: $neutral-6;
         text-align: left;
         text-decoration: none;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
 
         &:active,
         &:focus {
@@ -142,11 +145,34 @@ category: Common
  */
 
 .tabs__container--multiple {
+
+  width: 100%;
+  margin: 0;
+  margin-bottom: 10px;
+
+  .tabs__tab {
+    width: 50%;
+    float: left;
+    @include mq($until: desktop) {
+      max-width: 100%;
+      border: 0;
+      border-bottom: 1px solid $neutral-5;
+      margin-bottom: -1px;
+
+      &:nth-child(odd) {
+        box-shadow: 1px 0 0 0 $neutral-5;
+      }
+
+      & > a {
+        border-left: 0;
+        padding-left: 6px;
+      }
+    }
+  }
+
+  @include mq(desktop) {
     display: table;
     table-layout: fixed;
-    width: 100%;
-    margin: 0;
-    margin-bottom: 10px;
 
     .tabs__tab {
         display: table-cell;
@@ -156,6 +182,7 @@ category: Common
     .tab--stats {
         display: none;
     }
+  }
 }
 
 // Most Popular FRONTS customisation: change layout to accommodate MPU (with or without tabs)

--- a/static/src/stylesheets/module/_tabs.scss
+++ b/static/src/stylesheets/module/_tabs.scss
@@ -46,8 +46,12 @@ category: Common
     list-style-type: none;
     overflow: hidden;
     z-index: 2;
-    background: $neutral-6;
-    border-top: 3px solid $neutral-6;
+    background: lighten($neutral-6, 5%);
+    table-layout: fixed;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    grid-column-gap: 2px;
+    display: table;
+    display: grid;
 
     @include mq(tablet) {
         margin-bottom: -1px;
@@ -59,11 +63,16 @@ category: Common
     float: left;
     margin: 0;
     border-bottom: 1px solid $neutral-5;
-    border-left: 2px solid rgba(255, 255, 255, .75);
-    margin-left: -2px;
+    border-top: 3px solid $neutral-6;
 
     @include mq(tablet) {
         max-width: gs-span(3);
+    }
+
+    &.tabs__tab--selected {
+        @include mq(desktop) {
+            border-bottom-color: #ffffff !important;
+        }
     }
 
     a,
@@ -72,25 +81,16 @@ category: Common
         display: block;
         box-sizing: border-box;
         min-height: $gs-row-height;
-        padding: $gs-baseline/3 8px 0;
+        padding: $gs-baseline/3 $gs-gutter/3.5 0;
         text-align: left;
         text-decoration: none;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
-
-        &:active,
-        &:focus {
-            background-color: #ffffff;
-            text-decoration: none;
-        }
+        background: $neutral-6;
 
         @include mq($until: tablet) {
             font-size: 14px;
-        }
-
-        @include mq(tablet) {
-            padding: $gs-baseline/3 $gs-gutter/2 0;
         }
     }
 
@@ -98,17 +98,16 @@ category: Common
         color: inherit;
     }
 
-}
-
-.tabs__tab--selected {
-    a,
-    .tab__link {
-        background: #ffffff;
+    & a:active,
+    & a:focus,
+    & .tab__link:active,
+    & .tab__link:focus,
+    &.tabs__tab--selected a,
+    &.tabs__tab--selected .tab__link {
+        background-color: #ffffff;
+        text-decoration: none;
     }
 
-    @include mq(tablet) {
-        border-bottom-color: #ffffff !important;
-    }
 }
 
 .tabs__content {
@@ -141,16 +140,12 @@ category: Common
     width: 100%;
     margin: 0;
     margin-bottom: 10px;
-    table-layout: fixed;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    display: table;
-    display: grid;
 
     .tabs__tab {
         float: none;
         width: auto;
         max-width: 100%;
-        
+
         @include mq(tablet) {
             display: table-cell;
         }
@@ -166,6 +161,7 @@ category: Common
 // Most Popular FRONTS customisation: change layout to accommodate MPU (with or without tabs)
 .tabs--mostpop .tabs__content,
 .fc-slice--popular {
+
     @include mq(desktop) {
         display: table;
         display: flex;

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -281,24 +281,23 @@
 }
 
 .tabs--identity {
+
+    .tabs__container {
+        max-width: gs-span(12);
+        @include mq($until: desktop) {
+            margin-top: 5px;
+        }
+    }
+
     .tabs__tab--selected {
         border-top-color: $news-accent;
-    }
-    .tabs__tab {
-        max-width: gs-span(3);
-        width: 25%;
+        color: $news-accent;
     }
 
     @include mq($until: tablet) {
         a {
             padding-top: $gs-baseline/4;
             line-height: 13px !important;
-        }
-    }
-    @include mq($until: 500px) {
-        .tabs__tab {
-            width: 50%;
-            margin-top: 5px;
         }
     }
 }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -24,14 +24,6 @@
     max-width: gs-span(16);
 }
 
-.identity-wrapper--with-membership {
-    @include mq($until: desktop) {
-        .tabs__tab {
-            width: auto;
-        }
-    }
-}
-
 .identity-header {
     @include mq(tablet) {
         margin-left: $gs-gutter;


### PR DESCRIPTION
## What does this change?
Updates _tabs.scss to make long lists of tabs look better on mobile. This fixes a current bug on the profile edit page where there's just too many tabs for narrow screens to handle gracefully but it also cascades to all the lists of 2+ tabs (unsure if that's desirable or a bad idea). 

I'm a bit concerned about having moved the background color from the tabs' link to the tabbar itself, because it makes more sense on the current design but it might break some css mods (i have checked and it doesn't seem to but would like confirmation)

## What is the value of this and can you measure success?
Currently tabs will all smush together on mobile devices and break into multiple lines breaking the layout

## Does this affect other platforms - Amp, Apps, etc?
A bit, the profile edit screen shows up in a webview inside the app

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
Maybe? 

## Screenshots
![picture 6](https://user-images.githubusercontent.com/11539094/32324724-3ee6ddd0-bfc4-11e7-9d38-2ae70fd0b038.png)

## Tested in CODE?
no

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
