### PR TITLE
Fix a typo in MMA contributions tab url that caused a 404 on reload

### DIFF
--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -52,7 +52,7 @@
             @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
 
             @if(ProfileShowContributorTab.isSwitchedOn) {
-                @tab(5, "Contributions", "/contributions/recurring/edit", None, optionalClass="qa-membership-tab")
+                @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-membership-tab")
 
                 @tab(6, "Privacy", "/privacy/edit", None, optionalClass="qa-privacy-tab")
             } else {
@@ -70,7 +70,7 @@
             @content(4, "/digitalpack/edit")(fragments.profile.digitalPackDetailsForm(idUrlBuilder, idRequest, user))
 
             @if(ProfileShowContributorTab.isSwitchedOn) {
-                @content(5, "/contributions/recurring/edit")(fragments.profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
+                @content(5, "/contribution/recurring/edit")(fragments.profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
                 @content(6, "/privacy/edit")(fragments.profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm))
             } else {


### PR DESCRIPTION
## What does this change?
I introduced a typo in the user's profile page. The tab for contributions specified `/contributions/recurring/edit`, but the routes file defined it as `/contribution/recurring/edit` (no 's' on contribution) so we got a 404 on reload.

## What is the value of this and can you measure success?
Fixes a self-inflicted 404 error.

## Does this affect other platforms - Amp, Apps, etc?
No, web only.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

## Screenshots
N/A

## Tested in CODE?
YES

cc @paulbrown1982 @davidfurey 