### PR TITLE
404 font loading fix

### DIFF
--- a/ui/src/.eslintrc.js
+++ b/ui/src/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     ],
     plugins: ['flow-header', 'flowtype'],
     rules: {
-        'no-plusplus': 'off',
         'flow-header/flow-header': 'error',
 
         // flow should take care of our return values

--- a/ui/src/.eslintrc.js
+++ b/ui/src/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     ],
     plugins: ['flow-header', 'flowtype'],
     rules: {
+        'no-plusplus': 'off',
         'flow-header/flow-header': 'error',
 
         // flow should take care of our return values

--- a/ui/src/components/head/__inline__/loadFonts.js
+++ b/ui/src/components/head/__inline__/loadFonts.js
@@ -297,7 +297,10 @@ do you have fonts in localStorage?
 
                     // - no point in searching the whole thing, so keep it as short
                     // as possible.
+
+                    //eslint-disable-next-line no-plusplus
                     for (let x = 0; x <= 16; ++x) {
+                        //eslint-disable-next-line no-plusplus
                         for (let y = 0; y <= 16; ++y) {
                             const alpha = ctx.getImageData(x, y, 1, 1).data[3];
 

--- a/ui/src/components/head/__inline__/loadFonts.js
+++ b/ui/src/components/head/__inline__/loadFonts.js
@@ -297,8 +297,8 @@ do you have fonts in localStorage?
 
                     // - no point in searching the whole thing, so keep it as short
                     // as possible.
-                    for (let x = 0; x <= 16; x + 1) {
-                        for (let y = 0; y <= 16; y + 1) {
+                    for (let x = 0; x <= 16; x = x + 1) {
+                        for (let y = 0; y <= 16; y = y + 1) {
                             const alpha = ctx.getImageData(x, y, 1, 1).data[3];
 
                             if (alpha > 0 && alpha < 255) {

--- a/ui/src/components/head/__inline__/loadFonts.js
+++ b/ui/src/components/head/__inline__/loadFonts.js
@@ -297,8 +297,8 @@ do you have fonts in localStorage?
 
                     // - no point in searching the whole thing, so keep it as short
                     // as possible.
-                    for (let x = 0; x <= 16; x = x + 1) {
-                        for (let y = 0; y <= 16; y = y + 1) {
+                    for (let x = 0; x <= 16; ++x) {
+                        for (let y = 0; y <= 16; ++y) {
                             const alpha = ctx.getImageData(x, y, 1, 1).data[3];
 
                             if (alpha > 0 && alpha < 255) {

--- a/ui/src/components/head/__inline__/loadFonts.js
+++ b/ui/src/components/head/__inline__/loadFonts.js
@@ -298,9 +298,9 @@ do you have fonts in localStorage?
                     // - no point in searching the whole thing, so keep it as short
                     // as possible.
 
-                    //eslint-disable-next-line no-plusplus
+                    // eslint-disable-next-line no-plusplus
                     for (let x = 0; x <= 16; ++x) {
-                        //eslint-disable-next-line no-plusplus
+                        // eslint-disable-next-line no-plusplus
                         for (let y = 0; y <= 16; ++y) {
                             const alpha = ctx.getImageData(x, y, 1, 1).data[3];
 


### PR DESCRIPTION
## What does this change?

Fixes issue with for loop on 404 page's font loading script, the current code would cause an infinite loop if you followed this code path :grimacing:

## What is the value of this and can you measure success?

Fixes bug...

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

No

## Tested in CODE?

No
