### PR TITLE
Upgrade Yarn to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tools/amp-validation"
   ],
   "engines": {
-    "yarn": "1.2.0"
+    "yarn": "1.2.1"
   },
   "dependencies": {
     "bean": "~1.0.14",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
         "watch:nashorn:server": "webpack --config ./__config__/webpack.config.nashorn.dev.js --env.server --watch"
     },
     "dependencies": {
-        "@guardian/guui": "^1.4.0"
+        "@guardian/guui": "1.4.1"
     },
     "devDependencies": {
         "babel-core": "^6.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@guardian/guui@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/guui/-/guui-1.4.0.tgz#aa6a865bb5b03b330b549daaeb6be92c27923b8f"
+"@guardian/guui@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@guardian/guui/-/guui-1.4.1.tgz#77292a091197bf12afff94917c42e8ee5d03b184"
   dependencies:
     babel-plugin-emotion "7.3.2"
     emotion "^7.3.2"


### PR DESCRIPTION
## What does this change?

Upgrades Yarn to v1.2.1

[CHANGELOG](https://github.com/yarnpkg/yarn/releases/tag/v1.2.1)

Notable: **Fix a bug that was affecting how peer dependencies were optimized**

I also had to patch `@guardian/guui` to make it more permissive of which Yarn version a dependant client application is enforcing.

Note [v1.3.0 is on the horizon](https://github.com/yarnpkg/yarn/releases/tag/v1.3.0) but has not yet been released to `npm`. It might also insist on everyone using at least Git v2.13.0 (for info, the [current latest is v2.15.0](https://git-scm.com/download), released 3 days ago, but not yet available for Mac)

## What is the value of this and can you measure success?

Up-to-date software = happier GDPR
