### PR TITLE
[acquisitions] acquisition links enrichment - part 1

### DIFF
--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -138,7 +138,7 @@ object UrlHelpers {
     countryUrlLogic(editionId, position, Membership)
   }
 
-  def getSupportOrContribute(position: Position)(implicit request: RequestHeader): String = {
+  def getSupportOrContributeUrl(position: Position)(implicit request: RequestHeader): String = {
     val editionId = Edition(request).id.toLowerCase()
     countryUrlLogic(editionId, position, Contribute)
   }

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -10,7 +10,7 @@
     <nav class="header__inner">
 
         <div class="header__cta-container">
-            <a class="header-cta-item"
+            <a class="header-cta-item js-acquisition-link"
                data-link-name="amp : nav : supporter-cta"
                 href="@getReaderRevenueUrl(Membership, AmpHeader)">
                 <span class="header-cta-item__label">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -3,7 +3,7 @@
 @import org.joda.time.DateTime
 @import common.Edition
 @import common.LinkTo
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContribute}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContributeUrl}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
 @import conf.switches.Switches.EmailInlineInFooterSwitch
@@ -91,10 +91,10 @@
                             <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
                                 dating</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" class="js-acquisition-link" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" class="js-acquisition-link" href="@getSupportOrContributeUrl(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
@@ -157,7 +157,7 @@
                             <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                                 Twitter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="@getSupportOrSubscriptionUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : subscribe" class="js-acquisition-link" href="@getSupportOrSubscriptionUrl(Footer)">
                                 subscribe</a>
                             </li>
                         </ul>
@@ -168,10 +168,10 @@
                             <li class="colophon__item"><a data-link-name="us : footer : jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                                 jobs</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getSupportOrMembershipUrl(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" class="js-acquisition-link" href="@getSupportOrMembershipUrl(Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getSupportOrContribute(Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" class="js-acquisition-link" href="@getSupportOrContributeUrl(Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs-us}">
@@ -230,7 +230,7 @@
                             <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
                                 Twitter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="@getReaderRevenueUrl(Subscribe, Footer)">
+                            <li class="colophon__item"><a data-link-name="us : footer : subscribe" class="js-acquisition-link" href="@getReaderRevenueUrl(Subscribe, Footer)">
                                 subscribe</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
@@ -242,10 +242,10 @@
 
                     case Au => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" class="js-acquisition-link" href="@getReaderRevenueUrl(Membership, Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" class="js-acquisition-link" href="@getReaderRevenueUrl(Contribute, Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
@@ -312,7 +312,7 @@
                             <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
                                 Twitter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="@getReaderRevenueUrl(Subscribe, Footer)">
+                            <li class="colophon__item"><a data-link-name="au : footer : subscribe" class="js-acquisition-link" href="@getReaderRevenueUrl(Subscribe, Footer)">
                                 subscribe</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="digital newspaper archive" href="https://theguardian.newspapers.com">
@@ -323,10 +323,10 @@
 
                     case International => {
                         <ul class="colophon__list">
-                            <li class="colophon__item"><a data-link-name="uk : footer : membership" href="@getReaderRevenueUrl(Membership, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : membership" class="js-acquisition-link" href="@getReaderRevenueUrl(Membership, Footer)">
                                 become a supporter</a>
                             </li>
-                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" href="@getReaderRevenueUrl(Contribute, Footer)">
+                            <li class="colophon__item"><a data-link-name="uk : footer : contribute" class="js-acquisition-link" href="@getReaderRevenueUrl(Contribute, Footer)">
                                 make a contribution</a>
                             </li>
                             <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -83,14 +83,14 @@
                             @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
                             <a href="@getSupportOrMembershipUrl(OldHeader)"
                             data-link-name="Register link"
-                            class="brand-bar__item--action brand-bar__item--split--first js-become-member">
+                            class="brand-bar__item--action brand-bar__item--split--first js-become-member js-acquisition-link">
                                 <span class="control__info js-control-info control__info--supporting">
                                     become a supporter
                                 </span>
                             </a>
 
                             <a href="@getSupportOrSubscriptionUrl(OldHeader)"
-                               class="brand-bar__item--action brand-bar__item--split--last js-subscribe js-change-subscribe-link"
+                               class="brand-bar__item--action brand-bar__item--split--last js-subscribe js-change-subscribe-link js-acquisition-link"
                                data-link-name="@Edition(request).id.toLowerCase : topNav : subscribe">
                                 <span class="control__info js-control-info">subscribe</span>
                             </a>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -37,7 +37,7 @@
                         Edition(request).id.toLowerCase()
                     ) { editionId =>
                       @if(!page.metadata.hasSlimHeader) {
-                            <a class="top-bar__item top-bar__item--cta js-change-become-member-link"
+                            <a class="top-bar__item top-bar__item--cta js-change-become-member-link js-acquisition-link"
                               data-link-name="nav2 : supporter-cta"
                               data-edition="@{editionId}"
                               href="@getContributionOrSupporterUrl(editionId)">
@@ -50,7 +50,7 @@
                               </span>
                             </a>
 
-                            <a class="top-bar__item hide-until-tablet js-change-subscribe-link"
+                            <a class="top-bar__item hide-until-tablet js-change-subscribe-link js-acquisition-link"
                                 data-link-name="nav2 : subscribe-cta"
                                 data-edition="@{editionId}"
                                 href="@getSupportOrSubscriptionUrl(NewHeader)">

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -59,11 +59,11 @@
                     <h3 class="popup__group-header">support us:</h3>
                     <ul class="popup__group">
                         <li class="popup__item">
-                            <a class="brand-bar__item--action" data-link-name="uk : topNav : membership"
+                            <a class="brand-bar__item--action js-acquisition-link" data-link-name="uk : topNav : membership"
                             href="@getReaderRevenueUrl(Membership, SlimHeaderDropdown)">membership</a>
                         </li>
                         <li class="popup__item">
-                            <a class="brand-bar__item--action" data-link-name="uk : topNav : subscribe"
+                            <a class="brand-bar__item--action js-acquisition-link" data-link-name="uk : topNav : subscribe"
                             href="@getReaderRevenueUrl(Subscribe, SlimHeaderDropdown)">subscribe</a>
                         </li>
                     </ul>

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -82,10 +82,7 @@ const bootEnhanced = (): void => {
             },
         ],
 
-        [
-            'enrich-acquisition-links',
-            initAcquisitionsLinkEnrichment
-        ],
+        ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
     ]);
 
     bootstrapContext('common', initCommon);

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -18,6 +18,7 @@ import { initSport } from 'bootstraps/enhanced/sport';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { init as geolocationInit } from 'lib/geolocation';
 import { initCheckDispatcher } from 'common/modules/check-dispatcher';
+import { init as initAcquisitionsLinkEnrichment } from 'common/modules/commercial/acquisitions-link-enrichment';
 
 const bootEnhanced = (): void => {
     const bootstrapContext = (featureName, bootstrap) => {
@@ -79,6 +80,11 @@ const bootEnhanced = (): void => {
 
                 trackABTests();
             },
+        ],
+
+        [
+            'enrich-acquisition-links',
+            initAcquisitionsLinkEnrichment
         ],
     ]);
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,0 +1,45 @@
+import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
+
+const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
+
+    const acquisitionDataField = 'acquisitionData';
+
+    let url;
+    try {
+        url = new URL(rawUrl);
+    } catch (e) {
+        return rawUrl;
+    }
+
+    let acquisitionData;
+    try {
+        acquisitionData = JSON.parse(url.searchParams.get(acquisitionDataField))
+    } catch (e) {
+        return rawUrl;
+    }
+
+    if (acquisitionData) {
+        acquisitionData = addReferrerData(acquisitionData);
+        url.searchParams.set(acquisitionDataField, JSON.stringify(acquisitionData));
+    }
+
+    return url.toString()
+};
+
+const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
+
+const addReferrerDataToAcquisitionLinksOnPage = (): void => {
+
+    const links = Array.from(document.getElementsByClassName(ACQUISITION_LINK_CLASS));
+
+    links.forEach(el => {
+        const link = el.getAttribute('href');
+        if (link) {
+            el.setAttribute('href', addReferrerDataToAcquisitionLink(link))
+        }
+    })
+};
+
+export const init = (): void => {
+  addReferrerDataToAcquisitionLinksOnPage();
+};

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,5 +1,6 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
+import fastdom from 'lib/fastdom-promise';
 
 const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
     const acquisitionDataField = 'acquisitionData';
@@ -39,10 +40,14 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     );
 
     links.forEach(el => {
-        const link = el.getAttribute('href');
-        if (link) {
-            el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
-        }
+        fastdom.read(() => el.getAttribute('href'))
+            .then(link => {
+                if (link) {
+                    fastdom.write(() => {
+                        el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
+                    })
+                }
+            });
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -35,9 +35,7 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const addReferrerDataToAcquisitionLinksOnPage = (): void => {
-    const links = Array.from(
-        document.getElementsByClassName(ACQUISITION_LINK_CLASS)
-    );
+    const links = [...document.getElementsByClassName(ACQUISITION_LINK_CLASS)];
 
     links.forEach(el => {
         fastdom.read(() => el.getAttribute('href')).then(link => {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -40,14 +40,16 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     );
 
     links.forEach(el => {
-        fastdom.read(() => el.getAttribute('href'))
-            .then(link => {
-                if (link) {
-                    fastdom.write(() => {
-                        el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
-                    })
-                }
-            });
+        fastdom.read(() => el.getAttribute('href')).then(link => {
+            if (link) {
+                fastdom.write(() => {
+                    el.setAttribute(
+                        'href',
+                        addReferrerDataToAcquisitionLink(link)
+                    );
+                });
+            }
+        });
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,7 +1,7 @@
+// @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 
 const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
-
     const acquisitionDataField = 'acquisitionData';
 
     let url;
@@ -13,33 +13,39 @@ const addReferrerDataToAcquisitionLink = (rawUrl: string): string => {
 
     let acquisitionData;
     try {
-        acquisitionData = JSON.parse(url.searchParams.get(acquisitionDataField))
+        acquisitionData = JSON.parse(
+            url.searchParams.get(acquisitionDataField)
+        );
     } catch (e) {
         return rawUrl;
     }
 
     if (acquisitionData) {
         acquisitionData = addReferrerData(acquisitionData);
-        url.searchParams.set(acquisitionDataField, JSON.stringify(acquisitionData));
+        url.searchParams.set(
+            acquisitionDataField,
+            JSON.stringify(acquisitionData)
+        );
     }
 
-    return url.toString()
+    return url.toString();
 };
 
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const addReferrerDataToAcquisitionLinksOnPage = (): void => {
-
-    const links = Array.from(document.getElementsByClassName(ACQUISITION_LINK_CLASS));
+    const links = Array.from(
+        document.getElementsByClassName(ACQUISITION_LINK_CLASS)
+    );
 
     links.forEach(el => {
         const link = el.getAttribute('href');
         if (link) {
-            el.setAttribute('href', addReferrerDataToAcquisitionLink(link))
+            el.setAttribute('href', addReferrerDataToAcquisitionLink(link));
         }
-    })
+    });
 };
 
 export const init = (): void => {
-  addReferrerDataToAcquisitionLinksOnPage();
+    addReferrerDataToAcquisitionLinksOnPage();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -39,6 +39,14 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
         action: 'VIEW',
     });
 
+export const addReferrerData = (acquisitionData: {}) => {
+    // Note: the current page is the referrer data in the context of the acquisition.
+    return Object.assign({}, acquisitionData, {
+        referrerPageviewId: config.get('ophan.pageViewId') || undefined,
+        referrerUrl: window.location.href.split('?')[0],
+    })
+};
+
 export const addTrackingCodesToUrl = ({
     base,
     componentType,
@@ -46,15 +54,13 @@ export const addTrackingCodesToUrl = ({
     campaignCode,
     abTest,
 }: AcquisitionLinkParams) => {
-    const acquisitionData = {
+    const acquisitionData = addReferrerData({
         source: 'GUARDIAN_WEB',
         componentId,
         componentType,
-        referrerPageviewId: config.get('ophan.pageViewId') || undefined,
-        referrerUrl: window.location.href.split('?')[0],
         campaignCode,
         abTest,
-    };
+    });
 
     const params = {
         REFPVID: config.get('ophan.pageViewId') || 'not_found',

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -39,13 +39,12 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
         action: 'VIEW',
     });
 
-export const addReferrerData = (acquisitionData: {}) => {
+export const addReferrerData = (acquisitionData: {}) =>
     // Note: the current page is the referrer data in the context of the acquisition.
-    return Object.assign({}, acquisitionData, {
+    Object.assign({}, acquisitionData, {
         referrerPageviewId: config.get('ophan.pageViewId') || undefined,
         referrerUrl: window.location.href.split('?')[0],
-    })
-};
+    });
 
 export const addTrackingCodesToUrl = ({
     base,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -39,7 +39,7 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
         action: 'VIEW',
     });
 
-export const addReferrerData = (acquisitionData: {}) =>
+export const addReferrerData = (acquisitionData: {}): {} =>
     // Note: the current page is the referrer data in the context of the acquisition.
     Object.assign({}, acquisitionData, {
         referrerPageviewId: config.get('ophan.pageViewId'),

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -42,7 +42,7 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
 export const addReferrerData = (acquisitionData: {}) =>
     // Note: the current page is the referrer data in the context of the acquisition.
     Object.assign({}, acquisitionData, {
-        referrerPageviewId: config.get('ophan.pageViewId') || undefined,
+        referrerPageviewId: config.get('ophan.pageViewId'),
         referrerUrl: window.location.href.split('?')[0],
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -41,7 +41,8 @@ export const submitViewEvent = (componentEvent: ComponentEventWithoutAction) =>
 
 export const addReferrerData = (acquisitionData: {}): {} =>
     // Note: the current page is the referrer data in the context of the acquisition.
-    Object.assign({}, acquisitionData, {
+    ({
+        ...acquisitionData,
         referrerPageviewId: config.get('ophan.pageViewId'),
         referrerUrl: window.location.href.split('?')[0],
     });


### PR DESCRIPTION
## What does this change?

Follows on from #17861. Adds data that is only available client side to the acquisition links in the footer and header.

Todo in future pull requests...

- add an HTML cleaner which adds the `js-acquisition-links` class to reader revenue links
- listen to requests from iframes to enrich acquisition links

## What is the value of this and can you measure success?

The added data ends up in the acquisitions table and can be used to analyse acquisition components.

## Does this affect other platforms - Amp, Apps, etc?

I think so (?)

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Don't think so (?)

## Tested in CODE?

Tested locally.
