### PR TITLE
Add Epic highlight test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,6 +128,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-acquisitions-epic-paradise",
+    "Test highlighting a different sentance in the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 11, 23),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-banner-big-long-two",
     "Test a big variant and a long variant against the banner control",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -9,6 +9,10 @@ import { getLocalCurrencySymbol } from 'lib/geolocation';
 const controlHeading = 'Since you’re here &hellip;';
 const controlP1 =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
+
+const paradiseHighlightP1 =
+    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. <span class="contributions__highlight">The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce</span>. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
+
 const controlP2FirstSentence =
     ' If everyone who reads our reporting, who likes it, helps fund it, our future would be much more secure.';
 const controlP2 = (currencySymbol: string) =>
@@ -76,6 +80,12 @@ export const justOnePound: AcquisitionsEpicTemplateCopy = {
     heading: controlHeading,
     p1: controlP1,
     p2: justOnePoundP2(getLocalCurrencySymbol()),
+};
+
+export const paradiseHighlight: AcquisitionsEpicTemplateCopy = {
+    heading: controlHeading,
+    p1: paradiseHighlightP1,
+    p2: controlP2(getLocalCurrencySymbol()),
 };
 
 export const liveblog = (

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,12 +13,14 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicEaseOfPayment } from 'common/modules/experiments/tests/acquisitions-epic-ease-of-payment';
+import { acquisitionsEpicParadise } from 'common/modules/experiments/tests/acquisitions-epic-paradise';
 
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
+    acquisitionsEpicParadise,
     acquisitionsEpicEaseOfPayment,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -1,0 +1,39 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { paradiseHighlight } from 'common/modules/commercial/acquisitions-copy';
+
+export const acquisitionsEpicParadise = makeABTest({
+    id: 'AcquisitionsEpicParadise',
+    campaignId: 'epic_paradise',
+
+    start: '2017-11-02',
+    expiry: '2017-11-23',
+
+    author: 'Jonathan Rankin',
+    description:
+        'Test highlighting a different part of the epic when running against a particular story',
+    successMeasure: 'AV2.0',
+    idealOutcome: 'We find a winning variant',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    useTargetingTool: true,
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            options: {
+                isUnlimited: true,
+            },
+        },
+        {
+            id: 'paradise_highlight',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            options: {
+                copy: paradiseHighlight,
+                isUnlimited: true,
+            },
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?
A test for the epic where a different sentence is highlighted, on certain stories

Control:
![control](https://user-images.githubusercontent.com/2844554/32367755-20b93d50-c07b-11e7-8f10-6cce68b1f8fd.png)

Highlight:
![hilight](https://user-images.githubusercontent.com/2844554/32367756-20dc1262-c07b-11e7-9a91-3b44bbc7ed14.png)
