### PR TITLE
remove weird c character from HtmlCleaner which was breaking amp validation

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -296,7 +296,7 @@ class TweetCleaner(content: Content, amp: Boolean) extends HtmlCleaner {
             element.empty()
             element.tagName("amp-twitter")
             element.attr("data-tweetId", elem.id)
-            element.attr("data-​c​ards", "hidden")
+            element.attr("data-cards", "hidden")
             element.attr("layout", "responsive")
             element.attr("width", "486")
             element.attr("data-conversation","none")


### PR DESCRIPTION
remove weird c character from HtmlCleaner which was breaking amp validation

## What does this change?

HtmlCleaner for generating AMP pages

## What is the value of this and can you measure success?

We generate valid AMP pages with google's new validation

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

Not necessary

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
