### PR TITLE
Going yellow

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -114,7 +114,7 @@ $story-package:          $news-support-7;
 
 $paidfor-background:     $news-support-3;
 //temporary change from #fce800 whilst secret special report is running
-$special-report-accent:  $news-main-2;
+$special-report-accent:  #ffd900;
 
 // This is only for use of the subnav in the header
 $subnav-grey: #5c6268;

--- a/static/src/stylesheets/amp/_onward-tones.scss
+++ b/static/src/stylesheets/amp/_onward-tones.scss
@@ -36,7 +36,7 @@
 
     &.tone-special-report {
         background-color: $news-support-6;
-        border-top-color: $news-support-1;
+        border-top-color: $special-report-accent;
 
         .fc-item__meta {
             color: $neutral-4;
@@ -58,10 +58,6 @@
                 fill: $features-support-3;
             }
         }
-    }
-
-    &.tone-special-report {
-        border-top-color: $news-support-1;
     }
 
     &.tone-comment {


### PR DESCRIPTION
## What does this change?
Special report tone is going yellow (again)

## What is the value of this and can you measure success?
🐝 🌻 🌞 💛 

## Does this affect other platforms - Amp, Apps, etc?
Changed this on AMP too

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
I don't think so

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
