### PR TITLE
Add Project Syndicate series link to business navbar

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -155,7 +155,7 @@ trait Navigation {
   val eurozone = SectionLink("business", "eurozone", "Eurozone", "/business/eurozone")
   val businessToBusiness = SectionLink("business", "business to business", "Business to Business", "/business-to-business")
   val diversityequality = SectionLink("business", "diversity & equality in business", "Diversity & equality in business", "/business/diversity-and-equality")
-
+  val projectSyndicate = SectionLink("business", "project syndicate", "Project Syndicate", "/business/series/project-syndicate-economists")
 
   //Money
   val money = SectionLink("money", "money", "Money", "/money")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -30,7 +30,7 @@ object Au extends Edition(
     classicalMusic
   )
 
-  val economyLocalNav: Seq[SectionLink] = Seq(markets, money)
+  val economyLocalNav: Seq[SectionLink] = Seq(markets, money, projectSyndicate)
 
   override val navigation: Seq[NavItem] = {
     Seq(

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -67,7 +67,7 @@ object International extends Edition(
     banking,
     retail,
     markets,
-    eurozone
+    projectSyndicate
   )
 
   val environmentLocalNav = Seq(

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -68,7 +68,7 @@ object Uk extends Edition(
     banking,
     retail,
     markets,
-    eurozone,
+    projectSyndicate,
     businessToBusiness
   )
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -32,8 +32,7 @@ object Us extends Edition(
     economics,
     ussustainablebusiness,
     diversityequality,
-    ussmallbusiness,
-    projectSyndicate
+    ussmallbusiness
   )
 
   val worldLocalNav = Seq(

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -32,7 +32,8 @@ object Us extends Edition(
     economics,
     ussustainablebusiness,
     diversityequality,
-    ussmallbusiness
+    ussmallbusiness,
+    projectSyndicate
   )
 
   val worldLocalNav = Seq(

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -44,6 +44,7 @@ object NavLinks {
   val sustainableBusiness = NavLink("sustainable business", "/us/sustainable-business", "us/sustainable-business")
   val diversityEquality = NavLink("diversity & equality in business", "/business/diversity-and-equality", "business/diversity-and-equality")
   val smallBusiness = NavLink("small business", "/business/us-small-business", "business/us-small-business")
+  val projectSyndicate = NavLink("project syndicate", "/business/series/project-syndicate-economists", "business/series/project-syndicate-economists")
   val climateChange = NavLink("climate change", "/environment/climate-change", "environment/climate-change")
   val wildlife = NavLink("wildlife", "/environment/wildlife", "environment/wildlife")
   val energy = NavLink("energy", "/environment/energy", "environment/energy")

--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -347,9 +347,9 @@ object NewNavigation {
     case object businessSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(business, economics, banking, money, markets, eurozone, businessToBusiness))
+      val uk = NavLinkLists(List(business, economics, banking, money, markets, projectSyndicate, businessToBusiness))
       val us = NavLinkLists(List(business, economics, sustainableBusiness, diversityEquality, smallBusiness))
-      val au = NavLinkLists(List(business, markets, money))
+      val au = NavLinkLists(List(business, markets, money, projectSyndicate))
       val int = uk
     }
 


### PR DESCRIPTION
## What does this change?

Adds the Project Syndicate series link to the business section of the UK, AU and International meganav and new navigation

## What is the value of this and can you measure success?

Navigation reflects editorial preferences

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
