### PR TITLE
Fix football bug

### DIFF
--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -141,7 +141,7 @@ define([
         var extras = [],
             dropdownTemplate;
 
-        var isLiveClockwatch = new Promise(function (resolve, reject) {
+        var isLiveClockwatch = new Promise(function (resolve) {
             page.isLiveClockwatch(function () {
                 var ml = new MatchListLive.MatchListLive('match-day', page.isCompetition() || 'premierleague', config.dateFromSlug()),
                     $img = $('.media-primary'),

--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -141,6 +141,39 @@ define([
         var extras = [],
             dropdownTemplate;
 
+        var isLiveClockwatch = new Promise(function (resolve, reject) {
+            page.isLiveClockwatch(function () {
+                var ml = new MatchListLive.MatchListLive('match-day', page.isCompetition() || 'premierleague', config.dateFromSlug()),
+                    $img = $('.media-primary'),
+                    $matchListContainer = $.create('<div class="football-matches__container" data-link-name="football-matches-clockwatch"></div>')
+                                              .css({ minHeight: $img[0] ? $img[0].offsetHeight : 0 });
+                             
+                $img.addClass('u-h');
+    
+                loading($matchListContainer[0], 'Fetching today’s matches…', { text: 'Impatient?', href: '/football/live' });
+    
+                $('.js-football-meta').append($matchListContainer);
+
+                var handleResponse = function(success) {
+                    if (!success || $('.football-match', $matchListContainer[0]).length === 0) {
+                        ml.destroy();
+                        $matchListContainer.remove();
+                        $img.removeClass('u-h');
+                    }
+                    
+                    $matchListContainer.css({ minHeight: 0 });
+                    loaded($matchListContainer[0]);
+                    resolve();
+                };
+                
+                ml.fetch($matchListContainer[0]).then(function() {
+                    handleResponse(true);
+                }).catch(function() {
+                    handleResponse(false);
+                });
+            });
+        });
+
         page.isMatch(function (match) {
             extras[0] = { ready: false };
             if (match.pageType === 'stats') {
@@ -223,33 +256,6 @@ define([
             }
         });
 
-        page.isLiveClockwatch(function () {
-            var ml = new MatchListLive.MatchListLive('match-day', page.isCompetition() || 'premierleague', config.dateFromSlug()),
-                $img = $('.media-primary'),
-                $matchListContainer = $.create('<div class="football-matches__container" data-link-name="football-matches-clockwatch"></div>')
-                                          .css({ minHeight: $img[0] ? $img[0].offsetHeight : 0 });
-
-            $img.addClass('u-h');
-
-            loading($matchListContainer[0], 'Fetching today’s matches…', { text: 'Impatient?', href: '/football/live' });
-
-            $('.js-football-meta').append($matchListContainer);
-            
-            ml.fetch($matchListContainer[0]).fail(function () {
-                ml.destroy();
-                $matchListContainer.remove();
-                $img.removeClass('u-h');
-            }).always(function () {
-                if ($('.football-match', $matchListContainer[0]).length === 0) {
-                    ml.destroy();
-                    $matchListContainer.remove();
-                    $img.removeClass('u-h');
-                }
-                $matchListContainer.css({ minHeight: 0 });
-                loaded($matchListContainer[0]);
-            });
-        });
-
         page.isFootballStatsPage(function () {
             $('.js-chart').each(function (el) {
                 new Doughnut().render(el);
@@ -291,6 +297,8 @@ define([
         });
 
         tagPageStats.tagPageStats();
+
+        return Promise.all([isLiveClockwatch]);
     }
 
     return {

--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -230,9 +230,11 @@ define([
                                           .css({ minHeight: $img[0] ? $img[0].offsetHeight : 0 });
 
             $img.addClass('u-h');
+
             loading($matchListContainer[0], 'Fetching today’s matches…', { text: 'Impatient?', href: '/football/live' });
 
             $('.js-football-meta').append($matchListContainer);
+            
             ml.fetch($matchListContainer[0]).fail(function () {
                 ml.destroy();
                 $matchListContainer.remove();

--- a/static/src/javascripts-legacy/bootstraps/enhanced/football.js
+++ b/static/src/javascripts-legacy/bootstraps/enhanced/football.js
@@ -141,39 +141,6 @@ define([
         var extras = [],
             dropdownTemplate;
 
-        var isLiveClockwatch = new Promise(function (resolve) {
-            page.isLiveClockwatch(function () {
-                var ml = new MatchListLive.MatchListLive('match-day', page.isCompetition() || 'premierleague', config.dateFromSlug()),
-                    $img = $('.media-primary'),
-                    $matchListContainer = $.create('<div class="football-matches__container" data-link-name="football-matches-clockwatch"></div>')
-                                              .css({ minHeight: $img[0] ? $img[0].offsetHeight : 0 });
-                             
-                $img.addClass('u-h');
-    
-                loading($matchListContainer[0], 'Fetching today’s matches…', { text: 'Impatient?', href: '/football/live' });
-    
-                $('.js-football-meta').append($matchListContainer);
-
-                var handleResponse = function(success) {
-                    if (!success || $('.football-match', $matchListContainer[0]).length === 0) {
-                        ml.destroy();
-                        $matchListContainer.remove();
-                        $img.removeClass('u-h');
-                    }
-                    
-                    $matchListContainer.css({ minHeight: 0 });
-                    loaded($matchListContainer[0]);
-                    resolve();
-                };
-                
-                ml.fetch($matchListContainer[0]).then(function() {
-                    handleResponse(true);
-                }).catch(function() {
-                    handleResponse(false);
-                });
-            });
-        });
-
         page.isMatch(function (match) {
             extras[0] = { ready: false };
             if (match.pageType === 'stats') {
@@ -262,6 +229,36 @@ define([
             });
         });
 
+        page.isLiveClockwatch(function () {
+            var ml = new MatchListLive.MatchListLive('match-day', page.isCompetition() || 'premierleague', config.dateFromSlug()),
+                $img = $('.media-primary'),
+                $matchListContainer = $.create('<div class="football-matches__container" data-link-name="football-matches-clockwatch"></div>')
+                                          .css({ minHeight: $img[0] ? $img[0].offsetHeight : 0 });
+                         
+            $img.addClass('u-h');
+
+            loading($matchListContainer[0], 'Fetching today’s matches…', { text: 'Impatient?', href: '/football/live' });
+
+            $('.js-football-meta').append($matchListContainer);
+
+            var handleResponse = function(success) {
+                if (!success || $('.football-match', $matchListContainer[0]).length === 0) {
+                    ml.destroy();
+                    $matchListContainer.remove();
+                    $img.removeClass('u-h');
+                }
+                
+                $matchListContainer.css({ minHeight: 0 });
+                loaded($matchListContainer[0]);
+            };
+            
+            ml.fetch($matchListContainer[0]).then(function() {
+                handleResponse(true);
+            }).catch(function() {
+                handleResponse(false);
+            });
+        });
+
         // Binding
         bean.on(document.body, 'click', '.js-show-more-football-matches', function (e) {
             e.preventDefault();
@@ -297,8 +294,6 @@ define([
         });
 
         tagPageStats.tagPageStats();
-
-        return Promise.all([isLiveClockwatch]);
     }
 
     return {

--- a/static/test/javascripts-legacy/spec/common/football.spec.js
+++ b/static/test/javascripts-legacy/spec/common/football.spec.js
@@ -5,43 +5,39 @@ define([
     describe('Football', function () {
         var injector = new Injector();
         var sut;
-        var sandbox;
-        var destroySpy;
-
+        var sandbox = sinon.sandbox.create();
+        var destroySpy = sandbox.spy();
+        
         function mockMatchListLive() {}
+
+        mockMatchListLive.prototype.destroy = destroySpy;
         
         beforeEach(function (done) {
             document.body.innerHTML = '<img class="media-primary"></img><div class="js-football-meta"></div>';
 
-            sandbox = sinon.sandbox.create();
-
-            destroySpy = sandbox.spy();
-
-            mockMatchListLive.prototype.destroy = destroySpy;
-
             injector.mock('lib/config', {
-                dateFromSlug: sinon.spy()
+                dateFromSlug: sandbox.spy()
             });
 
             injector.mock('bean', {
-                on: sinon.spy()
+                on: sandbox.spy()
             });
 
-            injector.mock('common/modules/sport/football/tag-page-stats', {
-                tagPageStats: sinon.spy()
-            });
-
-            injector.mock('common/modules/sport/football/match-list-live', {
-                MatchListLive: mockMatchListLive
-            });
-
-            injector.mock('lib/page', {
-                isMatch: sandbox.spy(),
-                isCompetition: sandbox.spy(),
-                isLiveClockwatch: function (cb) {
-                    cb();
+            injector.mock({
+                'common/modules/sport/football/tag-page-stats': {
+                    tagPageStats: sandbox.spy()
                 },
-                isFootballStatsPage: sandbox.spy()
+                'common/modules/sport/football/match-list-live': {
+                    MatchListLive: mockMatchListLive
+                },
+                'lib/page': {
+                    isMatch: sandbox.spy(),
+                    isCompetition: sandbox.spy(),
+                    isLiveClockwatch: function (cb) {
+                        cb();
+                    },
+                    isFootballStatsPage: sandbox.spy()
+                }
             });
 
             injector.require([

--- a/static/test/javascripts-legacy/spec/common/football.spec.js
+++ b/static/test/javascripts-legacy/spec/common/football.spec.js
@@ -78,34 +78,40 @@ define([
                 expect(document.querySelector('.media-primary').classList.contains('u-h')).toBeFalsy();
             });
             
-            it('handles successful fetch request', function (done) {
+            it('handles successful fetch request', function () {
                 fetchSpy = sandbox.spy(function(elem) {
-                    return new Promise(function (resolve) {
-                        addFootballElem(elem);
-                        resolve();
-                    });
+                    addFootballElem(elem);
+                    return {
+                        then: function(cb) {
+                            cb();
+                            return this;
+                        },
+                        catch: function() {
+                        }
+                    };
                 });
 
                 mockMatchListLive.prototype.fetch = fetchSpy;
 
-                sut.init().then(function() {
-                   done();
-                });
+                sut.init();
             });
 
-            it('handles failed fetch request', function (done) {
+            it('handles failed fetch request', function () {
                 fetchSpy = sandbox.spy(function(elem) {
-                    return new Promise(function (resolve, reject) {
-                        addFootballElem(elem);
-                        reject();
-                    });
+                    addFootballElem(elem);
+                    return {
+                        then: function() {
+                            return this;
+                        },
+                        catch: function(cb) {
+                            cb();
+                        }
+                    };
                 });
 
                 mockMatchListLive.prototype.fetch = fetchSpy;
 
-                sut.init().then(function() {
-                    done();
-                });
+                sut.init();
             });
         });
     });

--- a/static/test/javascripts-legacy/spec/common/football.spec.js
+++ b/static/test/javascripts-legacy/spec/common/football.spec.js
@@ -1,0 +1,40 @@
+define([
+    'helpers/injector'
+], function (Injector) {
+
+    describe('Football', function () {
+        var injector = new Injector();
+        var sut;
+        var sandbox;
+    
+        beforeEach(function (done) {
+            sandbox = sinon.sandbox.create();
+
+            injector.mock('lib/page', {
+                isMatch: sandbox.spy(),
+                isCompetition: sandbox.spy(),
+                isLiveClockwatch: function (cb) {
+                    console.log('***', cb);
+                    // cb();
+                },
+                isFootballStatsPage: sandbox.spy()
+            });
+
+            injector.require([
+                'bootstraps/enhanced/football'
+            ], function (football) {
+                sut = football;
+                done();
+            },
+            done.fail);
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('isLiveClockwatch', function () {
+            sut.init();
+        });
+    });
+});

--- a/static/test/javascripts-legacy/spec/common/football.spec.js
+++ b/static/test/javascripts-legacy/spec/common/football.spec.js
@@ -8,7 +8,7 @@ define([
         var sandbox;
         var destroySpy;
 
-        function mockMatchListLive() {};
+        function mockMatchListLive() {}
         
         beforeEach(function (done) {
             document.body.innerHTML = '<img class="media-primary"></img><div class="js-football-meta"></div>';
@@ -80,7 +80,7 @@ define([
             
             it('handles successful fetch request', function (done) {
                 fetchSpy = sandbox.spy(function(elem) {
-                    return new Promise(function (resolve, reject) {
+                    return new Promise(function (resolve) {
                         addFootballElem(elem);
                         resolve();
                     });

--- a/static/test/javascripts-legacy/spec/common/football.spec.js
+++ b/static/test/javascripts-legacy/spec/common/football.spec.js
@@ -6,16 +6,40 @@ define([
         var injector = new Injector();
         var sut;
         var sandbox;
-    
+        var destroySpy;
+
+        function mockMatchListLive() {};
+        
         beforeEach(function (done) {
+            document.body.innerHTML = '<img class="media-primary"></img><div class="js-football-meta"></div>';
+
             sandbox = sinon.sandbox.create();
+
+            destroySpy = sandbox.spy();
+
+            mockMatchListLive.prototype.destroy = destroySpy;
+
+            injector.mock('lib/config', {
+                dateFromSlug: sinon.spy()
+            });
+
+            injector.mock('bean', {
+                on: sinon.spy()
+            });
+
+            injector.mock('common/modules/sport/football/tag-page-stats', {
+                tagPageStats: sinon.spy()
+            });
+
+            injector.mock('common/modules/sport/football/match-list-live', {
+                MatchListLive: mockMatchListLive
+            });
 
             injector.mock('lib/page', {
                 isMatch: sandbox.spy(),
                 isCompetition: sandbox.spy(),
                 isLiveClockwatch: function (cb) {
-                    console.log('***', cb);
-                    // cb();
+                    cb();
                 },
                 isFootballStatsPage: sandbox.spy()
             });
@@ -30,11 +54,59 @@ define([
         });
 
         afterEach(function () {
+            document.body.innerHTML = '';
             sandbox.restore();
         });
 
-        it('isLiveClockwatch', function () {
-            sut.init();
+        describe('isLiveClockwatch', function () {
+            var fetchSpy;
+
+            var addFootballElem = function (elem) {
+                var footballMatchElem = document.createElement('div');
+                
+                footballMatchElem.classList.add('football-match');
+                
+                footballMatchElem.appendChild(elem);
+
+                document.body.appendChild(footballMatchElem);
+            };
+
+            afterEach(function () {
+                expect(fetchSpy).toHaveBeenCalled();
+                expect(destroySpy).toHaveBeenCalled();
+                expect(document.querySelectorAll('.football-matches__container').length).toBe(0);
+                expect(document.querySelector('.media-primary').classList.contains('u-h')).toBeFalsy();
+            });
+            
+            it('handles successful fetch request', function (done) {
+                fetchSpy = sandbox.spy(function(elem) {
+                    return new Promise(function (resolve, reject) {
+                        addFootballElem(elem);
+                        resolve();
+                    });
+                });
+
+                mockMatchListLive.prototype.fetch = fetchSpy;
+
+                sut.init().then(function() {
+                   done();
+                });
+            });
+
+            it('handles failed fetch request', function (done) {
+                fetchSpy = sandbox.spy(function(elem) {
+                    return new Promise(function (resolve, reject) {
+                        addFootballElem(elem);
+                        reject();
+                    });
+                });
+
+                mockMatchListLive.prototype.fetch = fetchSpy;
+
+                sut.init().then(function() {
+                    done();
+                });
+            });
         });
     });
 });

--- a/tools/__tasks__/test/javascript/index.js
+++ b/tools/__tasks__/test/javascript/index.js
@@ -33,10 +33,10 @@ module.exports = {
         {
             description: 'Run tests',
             task: [
-                // {
-                //     description: 'JS tests',
-                //     task: () => exec('jest'),
-                // },
+                {
+                    description: 'JS tests',
+                    task: () => exec('jest'),
+                },
                 ...legacyTests,
             ],
             concurrent: true,

--- a/tools/__tasks__/test/javascript/index.js
+++ b/tools/__tasks__/test/javascript/index.js
@@ -33,10 +33,10 @@ module.exports = {
         {
             description: 'Run tests',
             task: [
-                {
-                    description: 'JS tests',
-                    task: () => exec('jest'),
-                },
+                // {
+                //     description: 'JS tests',
+                //     task: () => exec('jest'),
+                // },
                 ...legacyTests,
             ],
             concurrent: true,


### PR DESCRIPTION
## What does this change?

Fixes a bug where the loading message failed to disappear once live football fixtures had been fetched, as described [here](https://trello.com/c/fMJRNLto/556-football-match-data-loads-but-fetching-message-fails-to-disappear).

The cause of the bug was that `ml.fetch()` was being chained with `fail` and `always`. This would've been fine if `ml.fetch()` returned a `reqwest` call, however it's actually returning a `Promise`. Therefore `fail` and `always` are `undefined`.

This error could be seen in Sentry...

![picture 74](https://user-images.githubusercontent.com/1590704/32376976-395aab46-c09e-11e7-9ad8-056a44be2fa9.png)

## What is the value of this and can you measure success?

Fixes bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No
