### PR TITLE
Update banner copy logic

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -468,7 +468,7 @@ trait FeatureSwitches {
   val UkSupportFrontendActive = Switch(
     SwitchGroup.Feature,
     "uk-supporter-traffic-to-new-support-frontend",
-    "When ON, all UK membership/contribute/support links send traffic to support.theguardian.com",
+    "When ON, all UK membership/contribute/support links send traffic to support.theguardian.com (aside from the banner)",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = On,
     sellByDate = new LocalDate(2018, 10, 17),
@@ -478,13 +478,13 @@ trait FeatureSwitches {
   val UsSupportFrontendActive = Switch(
     SwitchGroup.Feature,
     "us-supporter-traffic-to-new-support-frontend",
-    "When ON, all US membership/contribute/support links send traffic to support.theguardian.com",
+    "When ON, all US membership/contribute/support links send traffic to support.theguardian.com (aside from the banner)",
     owners = Seq(Owner.withGithub("justinpinner")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 10, 17),
     exposeClientSide = true
   )
-  
+
   val ProfileShowContributorTab = Switch(
     SwitchGroup.Feature,
     "profile-show-contributor-tab",
@@ -504,7 +504,7 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 2, 1),
     exposeClientSide = false
   )
-  
+
     // Owner: Journalism
   val ReaderAnswersDeliveryMechanism = Switch(
     SwitchGroup.Feature,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -62,12 +62,19 @@ const monthlySupporterCost = (location: string): string => {
 };
 
 const supporterEngagementCtaCopy = (location: string): string =>
-    `Support us for ${monthlySupporterCost(location)} per month.`;
-
-const contributionEngagementBannerCopy = (): string =>
-    `Support us with a one-time contribution`;
+    `Support us for ${monthlySupporterCost(location)} a month.`;
 
 const supporterParams = (location: string): EngagementBannerParams =>
+    Object.assign({}, baseParams, {
+        buttonCaption: 'Support the Guardian',
+        linkUrl: 'https://support.theguardian.com',
+        products: ['CONTRIBUTION', 'RECURRING_CONTRIBUTION'],
+        messageText: engagementBannerCopy(),
+        ctaText: supporterEngagementCtaCopy(location),
+        pageviewId: config.get('ophan.pageViewId', 'not_found'),
+    });
+
+const membershipSupporterParams = (location: string): EngagementBannerParams =>
     Object.assign({}, baseParams, {
         buttonCaption: 'Become a Supporter',
         linkUrl: 'https://membership.theguardian.com/supporter',
@@ -77,17 +84,11 @@ const supporterParams = (location: string): EngagementBannerParams =>
         pageviewId: config.get('ophan.pageViewId', 'not_found'),
     });
 
-const contributionParams = (): EngagementBannerParams =>
-    Object.assign({}, baseParams, {
-        buttonCaption: 'Make a Contribution',
-        linkUrl: 'https://contribute.theguardian.com',
-        products: ['CONTRIBUTION'],
-        messageText: engagementBannerCopy(),
-        ctaText: contributionEngagementBannerCopy(),
-        pageviewId: config.get('ophan.pageViewId', 'not_found'),
-    });
-
 export const engagementBannerParams = (
     location: string
-): EngagementBannerParams =>
-    location === 'US' ? contributionParams() : supporterParams(location);
+): EngagementBannerParams => {
+    if (location === 'US' || location === 'GB') {
+        return supporterParams(location);
+    }
+    return membershipSupporterParams(location);
+};

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -16,10 +16,6 @@ import {
     submitComponentEvent,
     addTrackingCodesToUrl,
 } from 'common/modules/commercial/acquisitions-ophan';
-import {
-    selectBaseUrl,
-    selectEngagementBannerButtonCaption,
-} from 'common/modules/commercial/support-utilities';
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 
 // change messageCode to force redisplay of the message to users who already closed it.
@@ -126,7 +122,7 @@ const showBanner = (params: EngagementBannerParams): void => {
     const ctaText = params.ctaText;
 
     const linkUrl = addTrackingCodesToUrl({
-        base: selectBaseUrl(params.linkUrl),
+        base: params.linkUrl,
         componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
         componentId: params.campaignCode,
         campaignCode: params.campaignCode,
@@ -135,9 +131,7 @@ const showBanner = (params: EngagementBannerParams): void => {
                 ? { name: test.id, variant: variant.id }
                 : undefined,
     });
-    const buttonCaption = selectEngagementBannerButtonCaption(
-        params.buttonCaption
-    );
+    const buttonCaption = params.buttonCaption;
     const buttonSvg = inlineSvg('arrowWhiteRight');
     const templateParams = {
         messageText,


### PR DESCRIPTION
## What does this change?

A few things. 

Globally, we are moving from {local price} `per` month to {local price} `a` month on the banner CTA. 

This PR also removes the responsibility of setting the link in the banner to the appropriate link from the feature switches, and bakes it into the banner creation logic. 

Here are some screenshots of what the control banner now looks like:
UK: 
![uk](https://user-images.githubusercontent.com/2844554/32383019-b9eb0fd4-c0ae-11e7-83e1-4310b6b29e98.png)

US:
![us](https://user-images.githubusercontent.com/2844554/32383020-b9ffea30-c0ae-11e7-9ffa-d6373daefd25.png)

AU:
![au](https://user-images.githubusercontent.com/2844554/32377581-11dcee60-c0a0-11e7-8761-b253e0a90521.png)

ROW:
![de](https://user-images.githubusercontent.com/2844554/32377584-121d34e8-c0a0-11e7-898e-dfcd8d77dda0.png)

 Both UK and US link to the new support site, which will redirect them to the appropriate page. AU and ROW will have a link to the old supporter site



## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
