### PR TITLE
Fix config mock, lint up mocks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@
 node_modules
 __flow__
 flow-type*
-__mocks__
 __snapshots__
 dist
 coverage

--- a/static/src/javascripts/lib/__mocks__/config.js
+++ b/static/src/javascripts/lib/__mocks__/config.js
@@ -2,18 +2,20 @@
 
 export default {
     get(path: string, defaultValue: any): any {
-        const value = path.split('.').reduce((acc: Object, prop: string): any => {
-            if (acc[prop]) {
-                return acc[prop]
-            }
+        const value = path
+            .split('.')
+            .reduce((acc: Object, prop: string): any => {
+                if (acc[prop]) {
+                    return acc[prop];
+                }
 
-            return defaultValue;
-        }, this);
+                return defaultValue;
+            }, this);
 
         if (typeof value !== 'undefined') {
             return value;
         }
 
         return defaultValue;
-    }
+    },
 };

--- a/static/src/javascripts/lib/__mocks__/config.js
+++ b/static/src/javascripts/lib/__mocks__/config.js
@@ -2,12 +2,18 @@
 
 export default {
     get(path: string, defaultValue: any): any {
-        return path.split('.').reduce((acc: Object, prop: string): any => {
+        const value = path.split('.').reduce((acc: Object, prop: string): any => {
             if (acc[prop]) {
                 return acc[prop]
             }
 
             return defaultValue;
         }, this);
+
+        if (typeof value !== 'undefined') {
+            return value;
+        }
+
+        return defaultValue;
     }
 };

--- a/static/src/javascripts/projects/common/modules/__mocks__/user-prefs.js
+++ b/static/src/javascripts/projects/common/modules/__mocks__/user-prefs.js
@@ -1,9 +1,11 @@
+// @flow
+
 const storage = {};
-const get = (key) => storage[key];
+const get = key => storage[key];
 const set = (key, value) => {
     storage[key] = value;
 };
-const remove = (key) => {
+const remove = key => {
     delete storage[key];
 };
 

--- a/static/src/javascripts/projects/common/modules/__mocks__/user-prefs.js
+++ b/static/src/javascripts/projects/common/modules/__mocks__/user-prefs.js
@@ -1,11 +1,11 @@
 // @flow
 
 const storage = {};
-const get = key => storage[key];
-const set = (key, value) => {
+const get = (key: string): mixed => storage[key];
+const set = (key: string, value: mixed): void => {
     storage[key] = value;
 };
-const remove = key => {
+const remove = (key: string) => {
     delete storage[key];
 };
 


### PR DESCRIPTION
## What does this change?

The `lib/config` mock was not updated to reflect changes to the real `lib/config` in #18106 

I've also reinstated linting for `__mocks__`, as I can't see the harm in that?

## What is the value of this and can you measure success?

More consistent code
