### PR TITLE
Update fapi-client and commercial-shared libs

### DIFF
--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -1,7 +1,8 @@
 package model.facia
 
-import com.gu.commercial.branding.{BrandingFinder, ContainerBranding}
+import com.gu.commercial.branding.ContainerBranding
 import com.gu.facia.api.{models => fapi}
+import com.gu.facia.api.utils.ContainerBrandingFinder
 import com.gu.facia.client.models.Branded
 import common.Edition
 import implicits.CollectionsOps._
@@ -38,7 +39,7 @@ case class PressedCollection(
   }
 
   def branding(edition: Edition): Option[ContainerBranding] = {
-    BrandingFinder.findContainerBranding(
+    ContainerBrandingFinder.findBranding(
       isConfiguredForBranding = config.metadata.exists(_.contains(Branded)),
       optBrandings = curatedPlusBackfillDeduplicated.map(_.branding(edition)).toSet
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.80"
   val awsVersion = "1.11.181"
-  val faciaVersion = "2.4.1"
+  val faciaVersion = "2.5.0"
   val capiVersion = "11.37"
   val dispatchVersion = "0.11.3"
   val romeVersion = "1.0"
@@ -69,7 +69,7 @@ object Dependencies {
   val targetingClient = "com.gu" %% "targeting-client" % "0.14.0"
   val scanamo = "com.gu" %% "scanamo" % "0.9.5"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.5.11"
-  val commercialShared = "com.gu" %% "commercial-shared" % "6.0.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "6.1.2"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"


### PR DESCRIPTION
Update fapi-client and commercial-shared libs

Note: Container branding finder logic has been moved from
commercial-shared to fapi client

## What is the value of this and can you measure success?
Updating libraries in preparation of scala 2.12 upgrade

## Tested in CODE?
Yes