### PR TITLE
Add variant to Epic Highlight test

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -11,6 +11,9 @@ const controlP1 =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And <span class="contributions__highlight">unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can</span>. So you can see why we need to ask for your help. The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 
 const paradiseHighlightP1 =
+    '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. <span class="contributions__highlight">The Guardian’s independent, investigative journalism on stories like the Paradise Papers required multiple journalists to work full time for more than a year to produce it</span>. But we do it because we want to keep investing in quality investigative journalism that helps our readers make sense of the world.';
+
+const paradiseDifferentHighlightP1 =
     '&hellip; we have a small favour to ask. More people are reading the Guardian than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we can. So you can see why we need to ask for your help. <span class="contributions__highlight">The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to produce</span>. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too.';
 
 const controlP2FirstSentence =
@@ -86,6 +89,12 @@ export const justOnePound: AcquisitionsEpicTemplateCopy = {
 export const paradiseHighlight: AcquisitionsEpicTemplateCopy = {
     heading: controlHeading,
     p1: paradiseHighlightP1,
+    p2: controlP2(getLocalCurrencySymbol()),
+};
+
+export const paradiseDifferentHighlight: AcquisitionsEpicTemplateCopy = {
+    heading: controlHeading,
+    p1: paradiseDifferentHighlightP1,
     p2: controlP2(getLocalCurrencySymbol()),
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -1,6 +1,9 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
-import { paradiseHighlight } from 'common/modules/commercial/acquisitions-copy';
+import {
+    paradiseHighlight,
+    paradiseDifferentHighlight,
+} from 'common/modules/commercial/acquisitions-copy';
 
 export const acquisitionsEpicParadise = makeABTest({
     id: 'AcquisitionsEpicParadise',
@@ -24,6 +27,14 @@ export const acquisitionsEpicParadise = makeABTest({
             id: 'control',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             options: {
+                isUnlimited: true,
+            },
+        },
+        {
+            id: 'different_highlight',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            options: {
+                copy: paradiseDifferentHighlight,
                 isUnlimited: true,
             },
         },


### PR DESCRIPTION
## What does this change?
Adds another variant to the highlight test 


Screenshots:
Control:
![control](https://user-images.githubusercontent.com/2844554/32387695-343c4f7e-c0bd-11e7-9f7d-6c04ec1c39b8.png)

Different highlight:
![diff](https://user-images.githubusercontent.com/2844554/32387696-3451e780-c0bd-11e7-86cd-69d5ad4bae75.png)

New text highlight:
![screenshot at nov 03 17-45-57](https://user-images.githubusercontent.com/2844554/32388211-e0bbd1b0-c0be-11e7-8178-970e2d70258e.png)
