### PR TITLE
[acquisitions] acquisition links enrichment - part 2

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -1,0 +1,43 @@
+package navigation
+
+import com.netaporter.uri.Uri
+import conf.Configuration
+import enumeratum.EnumEntry
+
+import scala.collection.immutable.IndexedSeq
+import scala.util.Try
+
+sealed trait ReaderRevenueSite extends EnumEntry {
+  val url: String
+}
+
+object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
+
+  override val values: IndexedSeq[ReaderRevenueSite] = findValues
+
+  private def getHost(url: String): Option[String] = Try(Uri.parse(url).host).toOption.flatten
+
+  private val hosts: Set[String] = values.flatMap(site => getHost(site.url)).toSet
+
+  def isReaderRevenueSiteUrl(url: String): Boolean = getHost(url).exists(hosts.contains)
+
+  case object Support extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/uk"
+  }
+
+  case object Membership extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.membershipUrl}/supporter"
+  }
+
+  case object SupportUsContribute extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/us/contribute"
+  }
+
+  case object Contribute extends ReaderRevenueSite {
+    val url: String = Configuration.id.contributeUrl
+  }
+
+  case object Subscribe extends ReaderRevenueSite {
+    val url: String = Configuration.id.subscribeUrl
+  }
+}

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,32 +1,14 @@
 package navigation
 
-import conf.Configuration
 import conf.switches.Switches.{UkSupportFrontendActive, UsSupportFrontendActive}
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import common.Edition
+import navigation.ReaderRevenueSite._
 import ophan.thrift.componentEvent.ComponentType
 import ophan.thrift.event.AcquisitionSource
 
 object UrlHelpers {
-  sealed trait ReaderRevenueSite {
-    val url: String
-  }
-  case object Support extends ReaderRevenueSite {
-    val url: String = s"${Configuration.id.supportUrl}/uk"
-  }
-  case object Membership extends ReaderRevenueSite {
-    val url: String = s"${Configuration.id.membershipUrl}/supporter"
-  }
-  case object SupportUsContribute extends ReaderRevenueSite {
-    val url: String = s"${Configuration.id.supportUrl}/us/contribute"
-  }
-  case object Contribute extends ReaderRevenueSite {
-    val url: String = Configuration.id.contributeUrl
-  }
-  case object Subscribe extends ReaderRevenueSite {
-    val url: String = Configuration.id.subscribeUrl
-  }
 
   sealed trait Position
   case object NewHeader extends Position

--- a/common/app/navigation/helpers/helpers.scala
+++ b/common/app/navigation/helpers/helpers.scala
@@ -1,13 +1,12 @@
 package navigation
 
 import common.{Edition, Navigation}
-import conf.Configuration
 import model.Page
 import SectionLinks._
 import NewNavigation._
 import SubSectionLinks._
 import NavLinks._
-import UrlHelpers.{Membership, SideMenu, Subscribe, getReaderRevenueUrl, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl}
+import UrlHelpers.{SideMenu, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl}
 import play.api.mvc.RequestHeader
 
 object NavigationHelpers {

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -3,7 +3,8 @@
 @import conf.Configuration
 @import common.LinkTo
 @import navigation.NewNavigation
-@import navigation.UrlHelpers.{getReaderRevenueUrl, AmpHeader, Membership}
+@import navigation.ReaderRevenueSite.Membership
+@import navigation.UrlHelpers.{getReaderRevenueUrl, AmpHeader}
 
 <header class="header"
         role="banner">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -3,7 +3,8 @@
 @import org.joda.time.DateTime
 @import common.Edition
 @import common.LinkTo
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Contribute, Membership, Subscribe, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContributeUrl}
+@import navigation.ReaderRevenueSite.{Contribute, Membership, Subscribe}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, getSupportOrMembershipUrl, getSupportOrSubscriptionUrl, getSupportOrContributeUrl}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
 @import conf.switches.Switches.EmailInlineInFooterSwitch

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -2,7 +2,8 @@
 @import common.{Edition, LinkTo}
 @import conf.Configuration
 @import conf.switches.Switches._
-@import navigation.UrlHelpers.{Membership, OldHeader, Subscribe, getReaderRevenueUrl, getSupportOrSubscriptionUrl, getSupportOrMembershipUrl}
+@import navigation.ReaderRevenueSite.{Membership, Subscribe}
+@import navigation.UrlHelpers.{OldHeader, getSupportOrSubscriptionUrl, getSupportOrMembershipUrl}
 @import views.support.RenderClasses
 
 @* TODO: When implementing the desktop design, aim to consolidate the html *@

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -6,7 +6,8 @@
 @import views.support.RenderClasses
 @import views.html.fragments.topNav.editionMenu
 @import navigation.UrlHelpers.oldNav._
-@import navigation.UrlHelpers.{getReaderRevenueUrl, SlimHeaderDropdown, Membership, Subscribe}
+@import navigation.ReaderRevenueSite.{Membership, Subscribe}
+@import navigation.UrlHelpers.{getReaderRevenueUrl, SlimHeaderDropdown}
 
 @ellipsis() = {
     <a class="brand-bar__item--action popup__toggle"

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -8,7 +8,8 @@ import conf.switches.Switches._
 import layout.ContentWidths
 import layout.ContentWidths._
 import model._
-import model.content.{Atom, Atoms, MediaAtom, MediaWrapper, ExplainerAtom}
+import model.content.{Atom, Atoms, ExplainerAtom, MediaAtom, MediaWrapper}
+import navigation.ReaderRevenueSite
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
@@ -230,6 +231,10 @@ case class InBodyLinkCleaner(dataLinkName: String, amp: Boolean = false)(implici
       }
       if (amp && link.hasAttr("style")) {
         link.removeAttr("style")
+      }
+
+      if (ReaderRevenueSite.isReaderRevenueSiteUrl(link.attr("href"))) {
+        link.addClass("js-acquisition-link")
       }
     }
 


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

This updates the `InBodyLinkCleaner` to add the `js-acquisition-link` class to links to reader revenue sites.

To do in part 3:
- listen to requests from iframes to enrich acquisition links.

Implementation note: the `ReaderRevenueSite` trait was moved to a separate file as (1) it is now being used outside of `UrlHelpers`; and (2) it mitigates against cyclic dependencies.

## What is the value of this and can you measure success?

This will allow the link enrichment logic in #18145 to target all reader revenue links in the body of the web page.

## Does this affect other platforms - Amp, Apps, etc?

Think so (?)

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Don't think so (?)

## Tested in CODE?

Steps taken to test this pull request:

1. `~/.gu/frontend.conf` update:

    ```
    devOverrides {
      content.api.host="https://internal.content.code.dev-guardianapis.com"
    }
    ```
2. Created an article in `composer.code.dev-gutools.co.uk`with reader revenue links in the standfirst and body

3. Checked that the `js-acquisition-link` class was added to the reader revenue links in the created article
