### PR TITLE
Remove dispatch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,6 @@ val common = library("common").settings(
     scalajTime,
     ws,
     faciaFapiScalaClient,
-    dispatchTest,
     closureCompiler,
     jerseyCore,
     jerseyClient,
@@ -127,17 +126,9 @@ val identity = application("identity").dependsOn(commonWithTests).aggregate(comm
   )
 )
 
-val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common).settings(
-  libraryDependencies ++= Seq(
-    dispatch
-  )
-)
+val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common)
 
-val onward = application("onward").dependsOn(commonWithTests).aggregate(common).settings(
-  libraryDependencies ++= Seq(
-    dispatch
-  )
-)
+val onward = application("onward").dependsOn(commonWithTests).aggregate(common)
 
 val dev = application("dev-build")
   .dependsOn(

--- a/commercial/app/model/feeds/FeedFetcher.scala
+++ b/commercial/app/model/feeds/FeedFetcher.scala
@@ -2,7 +2,6 @@ package commercial.model.feeds
 
 import java.lang.System.currentTimeMillis
 
-import com.ning.http.client.Response
 import conf.Configuration
 import commercial.model.merchandise.events.Eventbrite.{Response => EbResponse}
 import commercial.model.merchandise.soulmates.SoulmatesAgent

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,6 @@ object Dependencies {
   val awsVersion = "1.11.181"
   val faciaVersion = "2.4.1"
   val capiVersion = "11.37"
-  val dispatchVersion = "0.11.3"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.6.3"
@@ -31,8 +30,6 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "3.7.0"
-  val dispatch = "net.databinder.dispatch" %% "dispatch-core" % dispatchVersion
-  val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % dispatchVersion % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play26" % faciaVersion
   val configMagic = "com.gu" %% "configuration-magic-core" %  "1.3.0"


### PR DESCRIPTION
Note: also removing the weather API retry mechanism. We would need to
monitor errors to make sure the situation with the accuweather api is
not getting worse with this change.

## What is the value of this and can you measure success?
One less dependency. Especially since it was used for a tiny low priority feature.
We'll have to make sure there are not an increase of errors coming from accuweather api calls

## Tested in CODE?
Yes
