### PR TITLE
Hardcode tag matching on epic highlight test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -1,21 +1,31 @@
 // @flow
-import { makeABTest, defaultCanEpicBeDisplayed } from 'common/modules/commercial/contributions-utilities';
-import {
-    paradiseHighlight,
-    paradiseDifferentHighlight,
-} from 'common/modules/commercial/acquisitions-copy';
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { paradiseDifferentHighlight } from 'common/modules/commercial/acquisitions-copy';
 import config from 'lib/config';
+import {
+    isRecentContributor,
+    isPayingMember,
+} from 'commercial/modules/user-features';
 
 const tagsMatch = () => {
-    var pageKeywords = config.page.nonKeywordTagIds;
-    if (typeof(pageKeywords) !== 'undefined') {
-        var keywordList = pageKeywords.split(',');
+    const pageKeywords = config.page.nonKeywordTagIds;
+    if (typeof pageKeywords !== 'undefined') {
+        const keywordList = pageKeywords.split(',');
         console.log(keywordList);
-        return keywordList.some(x => (x === 'news/series/paradise-papers'));
-    } else {
-        return false;
+        return keywordList.some(x => x === 'news/series/paradise-papers');
     }
+    return false;
 };
+
+const isTargetReader = () => isPayingMember() || isRecentContributor();
+
+const worksWellWithPageTemplate = () =>
+config.page.contentType === 'Article' &&
+!config.page.isMinuteArticle &&
+!(config.page.isImmersive === true);
+
+const isTargetPage = () =>
+worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
 
 export const acquisitionsEpicParadise = makeABTest({
     id: 'AcquisitionsEpicParadise',
@@ -33,8 +43,8 @@ export const acquisitionsEpicParadise = makeABTest({
     audience: 1,
     audienceOffset: 0,
     overrideCanRun: true,
-    canRun : () => {
-        return tagsMatch();
+    canRun: () => {
+        return isTargetReader() && isTargetPage() && tagsMatch();
     },
 
     variants: [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -1,9 +1,21 @@
 // @flow
-import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { makeABTest, defaultCanEpicBeDisplayed } from 'common/modules/commercial/contributions-utilities';
 import {
     paradiseHighlight,
     paradiseDifferentHighlight,
 } from 'common/modules/commercial/acquisitions-copy';
+import config from 'lib/config';
+
+const tagsMatch = () => {
+    var pageKeywords = config.page.nonKeywordTagIds;
+    if (typeof(pageKeywords) !== 'undefined') {
+        var keywordList = pageKeywords.split(',');
+        console.log(keywordList);
+        return keywordList.some(x => (x === 'news/series/paradise-papers'));
+    } else {
+        return false;
+    }
+};
 
 export const acquisitionsEpicParadise = makeABTest({
     id: 'AcquisitionsEpicParadise',
@@ -20,7 +32,10 @@ export const acquisitionsEpicParadise = makeABTest({
     audienceCriteria: 'All',
     audience: 1,
     audienceOffset: 0,
-    useTargetingTool: true,
+    overrideCanRun: true,
+    canRun : () => {
+        return tagsMatch();
+    },
 
     variants: [
         {
@@ -35,14 +50,6 @@ export const acquisitionsEpicParadise = makeABTest({
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             options: {
                 copy: paradiseDifferentHighlight,
-                isUnlimited: true,
-            },
-        },
-        {
-            id: 'paradise_highlight',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            options: {
-                copy: paradiseHighlight,
                 isUnlimited: true,
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -11,21 +11,20 @@ const tagsMatch = () => {
     const pageKeywords = config.page.nonKeywordTagIds;
     if (typeof pageKeywords !== 'undefined') {
         const keywordList = pageKeywords.split(',');
-        console.log(keywordList);
         return keywordList.some(x => x === 'news/series/paradise-papers');
     }
     return false;
 };
 
-const isTargetReader = () => isPayingMember() || isRecentContributor();
+const isTargetReader = () => !isPayingMember() || !isRecentContributor();
 
 const worksWellWithPageTemplate = () =>
-config.page.contentType === 'Article' &&
-!config.page.isMinuteArticle &&
-!(config.page.isImmersive === true);
+    config.page.contentType === 'Article' &&
+    !config.page.isMinuteArticle &&
+    !(config.page.isImmersive === true);
 
 const isTargetPage = () =>
-worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
+    worksWellWithPageTemplate() && !config.page.shouldHideReaderRevenue;
 
 export const acquisitionsEpicParadise = makeABTest({
     id: 'AcquisitionsEpicParadise',
@@ -43,9 +42,7 @@ export const acquisitionsEpicParadise = makeABTest({
     audience: 1,
     audienceOffset: 0,
     overrideCanRun: true,
-    canRun: () => {
-        return isTargetReader() && isTargetPage() && tagsMatch();
-    },
+    canRun: () => tagsMatch() && isTargetReader() && isTargetPage(),
 
     variants: [
         {


### PR DESCRIPTION
## What does this change?
The articles that this tag will appear on are going to be sensitive, so we can't use the targeting tool. Therefore we need to hardcode in the tag. This PR also removes an unneeded variant

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
