### PR TITLE
[acquisitions] acquisition link enrichment - part 3

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -51,6 +51,27 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     });
 };
 
+const addReferrerDataToAcquisitionLinksInIframes = (): void => {
+    window.addEventListener('message', event => {
+        let data;
+        try {
+            data = JSON.parse(event.data);
+        } catch (e) {
+            return;
+        }
+
+        // Expects enrich requests to be made via iframe-messenger:
+        // https://github.com/guardian/iframe-messenger
+        if (data.type === 'enrich-acquisition-links' && data.id) {
+            data.referrerData = addReferrerData({});
+            [...document.getElementsByTagName('iframe')].forEach(iframe => {
+                iframe.contentWindow.postMessage(data);
+            });
+        }
+    });
+};
+
 export const init = (): void => {
+    addReferrerDataToAcquisitionLinksInIframes();
     addReferrerDataToAcquisitionLinksOnPage();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -51,7 +51,7 @@ const addReferrerDataToAcquisitionLinksOnPage = (): void => {
     });
 };
 
-const addReferrerDataToAcquisitionLinksInIframes = (): void => {
+const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
     window.addEventListener('message', event => {
         let data;
         try {
@@ -65,13 +65,16 @@ const addReferrerDataToAcquisitionLinksInIframes = (): void => {
         if (data.type === 'enrich-acquisition-links' && data.id) {
             data.referrerData = addReferrerData({});
             [...document.getElementsByTagName('iframe')].forEach(iframe => {
-                iframe.contentWindow.postMessage(data);
+                iframe.contentWindow.postMessage(
+                    data,
+                    'https://interactive.guim.co.uk'
+                );
             });
         }
     });
 };
 
 export const init = (): void => {
-    addReferrerDataToAcquisitionLinksInIframes();
+    addReferrerDataToAcquisitionLinksInInteractiveIframes();
     addReferrerDataToAcquisitionLinksOnPage();
 };


### PR DESCRIPTION
cc @guardian/contributions 

## What does this change?

Following on from #18166, adds a listener to reply to acquisition link enrichment requests from iframes by sending them referrer page data (page view id and page url).

See [#14](https://github.com/guardian/iframe-messenger/pull/14) for the corresponding pull request in iframe messenger.

## What is the value of this and can you measure success?

Comprehensive tracking of acquisition links in iframes.

## Does this affect other platforms - Amp, Apps, etc?

Don't think so (?)

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Don't think so (?)

## Tested in CODE?

No.
