### PR TITLE
Get Special report from campaign for card style in pressed fronts

### DIFF
--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -1,22 +1,33 @@
 package model
 
-import com.gu.facia.api.utils.{CardStyle, SpecialReport}
+import com.gu.facia.api.utils.{CardStyle, FaciaContentUtils, SpecialReport}
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 import com.gu.targeting.client.{Campaign, ReportFields}
-import com.gu.contentapi.client.model.{v1 => contentapi}
+import com.gu.contentapi.client.model.v1.{Content => CapiContent}
+import com.gu.facia.api.models.FaciaContent
 import commercial.targeting.CampaignAgent
 
 object CardStylePicker {
 
-  def apply(content: contentapi.Content, trailMetaData: MetaDataCommonFields): CardStyle = {
-    extractCampaigns(content) match {
+  def apply(content: CapiContent, trailMetaData: MetaDataCommonFields): CardStyle = {
+    val tags = content.tags.map(_.id)
+    extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
       case _ => SpecialReport
     }
   }
 
-  private def extractCampaigns(content: contentapi.Content): List[Campaign] = {
-    CampaignAgent.getCampaignsForTags(content.tags.map(_.id))
+  def apply(content: FaciaContent): CardStyle = {
+    val tags = FaciaContentUtils.tags(content).map(_.id)
+    extractCampaigns(tags) match {
+      case Nil => FaciaContentUtils.cardStyle(content)
+      case _ => SpecialReport
+    }
+  }
+
+  private def extractCampaigns(tags: Seq[String]): List[Campaign] = {
+    CampaignAgent
+      .getCampaignsForTags(tags)
       .filter(_.fields.isInstanceOf[ReportFields])
   }
 }

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata}
 import common.{Edition, HTML}
 import common.commercial.EditionBranding
 import model.content.{Atoms, MediaAtom}
-import model.{Commercial, Elements, Fields, DotcomContentType, ImageMedia, MetaData, Pillar, Pillars, SectionId, SupportedUrl, Tags, Trail, VideoElement}
+import model.{CardStylePicker, Commercial, DotcomContentType, Elements, Fields, ImageMedia, MetaData, Pillar, Pillars, SectionId, SupportedUrl, Tags, Trail, VideoElement}
 import org.joda.time.DateTime
 
 object DisplayHints {
@@ -317,7 +317,7 @@ final case class PressedDiscussionSettings(
 object PressedCard {
   def make(content: fapi.FaciaContent): PressedCard = PressedCard(
     id = FaciaContentUtils.id(content),
-    cardStyle = CardStyle.make(FaciaContentUtils.cardStyle(content)),
+    cardStyle = CardStyle.make(CardStylePicker(content)),
     isLive = FaciaContentUtils.isLive(content),
     webPublicationDateOption = FaciaContentUtils.webPublicationDateOption(content),
     mediaType = fapiutils.MediaType.fromFaciaContent(content).map(MediaType.make),

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -1,5 +1,4 @@
 import app.{FrontendApplicationLoader, FrontendComponents}
-import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
@@ -16,6 +15,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import services.ConfigAgentLifecycle
 import router.Routes
+import _root_.commercial.targeting.TargetingLifecycle
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
@@ -39,7 +39,8 @@ trait AppComponents extends FrontendComponents {
     wire[ConfigAgentLifecycle],
     wire[SwitchboardLifecycle],
     wire[CloudWatchMetricsLifecycle],
-    wire[FaciaPressLifecycle]
+    wire[FaciaPressLifecycle],
+    wire[TargetingLifecycle]
   )
 
   lazy val router: Router = wire[Routes]


### PR DESCRIPTION
## What does this change?
Apply `Special Report` on pressed card based on campaign

## What is the value of this and can you measure success?
Special report card on fronts don't currently have the right style because the wrong card style is set.
This PR make sure to check campaigns and apply the `Special Report` style if an exisiting special report campaign runs for this tag

## Does this affect other platforms - Amp, Apps, etc?
No

## Screenshots
![screen shot 2017-11-06 at 12 06 25](https://user-images.githubusercontent.com/233326/32440404-f2861378-c2ea-11e7-93f2-846bd32d1650.png)

## Tested in CODE?
No

