### PR TITLE
Add correct access limitations to paradise test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-paradise.js
@@ -2,10 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import { paradiseDifferentHighlight } from 'common/modules/commercial/acquisitions-copy';
 import config from 'lib/config';
-import {
-    isRecentContributor,
-    isPayingMember,
-} from 'commercial/modules/user-features';
+import { shouldSeeReaderRevenue } from 'commercial/modules/user-features';
 
 const tagsMatch = () => {
     const pageKeywords = config.page.nonKeywordTagIds;
@@ -15,8 +12,6 @@ const tagsMatch = () => {
     }
     return false;
 };
-
-const isTargetReader = () => !isPayingMember() || !isRecentContributor();
 
 const worksWellWithPageTemplate = () =>
     config.page.contentType === 'Article' &&
@@ -42,7 +37,7 @@ export const acquisitionsEpicParadise = makeABTest({
     audience: 1,
     audienceOffset: 0,
     overrideCanRun: true,
-    canRun: () => tagsMatch() && isTargetReader() && isTargetPage(),
+    canRun: () => tagsMatch() && shouldSeeReaderRevenue() && isTargetPage(),
 
     variants: [
         {


### PR DESCRIPTION
## What does this change?
The `shouldSeeReaderRevenue` function covers recurring contributors as well as one off's and members, so we should use that rather than the combo of `!isPayingMember()` and `!isRecentContributor()` to decide whether someone should see the epic 

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
