### PR TITLE
Declare Flow classes

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -12,12 +12,12 @@ import { isIOS, isAndroid, isBreakpoint } from 'lib/detect';
 import debounce from 'lodash/functions/debounce';
 import { isOn as accessibilityIsOn } from 'common/modules/accessibility/main';
 
-class YoutubePlayerTarget extends EventTarget {
+declare class YoutubePlayerTarget extends EventTarget {
     playVideo: () => void;
 }
 
 // This is imcomplete; see https://developers.google.com/youtube/iframe_api_reference#Events
-class YoutubePlayerEvent {
+declare class YoutubePlayerEvent {
     data: -1 | 0 | 1 | 2 | 3 | 4 | 5;
     target: YoutubePlayerTarget;
 }


### PR DESCRIPTION
## What does this change?

We're defining a couple of classes in this module that are used exclusively for type annotations. We ought therefore use the `declare` keyword to ensure the types are stripped for production.

This is currently causing issues in IE11 (and below, presumably), for which `EventTarget` resolves to `undefined`

## What is the value of this and can you measure success?

This will hopefully fix a [downstream bug](https://sentry.io/the-guardian/client-side-prod/issues/395953665/) which prevents video styling in IE11.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

Expected (Chrome):

![picture 329](https://user-images.githubusercontent.com/5931528/32446845-216c4f10-c302-11e7-900e-56983a18077c.png)

Actual (IE11): 

![picture 328](https://user-images.githubusercontent.com/5931528/32446804-fe03bdce-c301-11e7-9b01-4238979392d7.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
