### PR TITLE
retry mechanism for weather api

### DIFF
--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -1,3 +1,4 @@
+import akka.actor.ActorSystem
 import http.{CommonFilters, CorsHttpErrorHandler}
 import app.{FrontendApplicationLoader, FrontendComponents}
 import business.{StocksData, StocksDataLifecycle}
@@ -31,6 +32,7 @@ class AppLoader extends FrontendApplicationLoader {
 trait OnwardServices {
   def wsClient: WSClient
   def environment: Environment
+  def actorSystem: ActorSystem
   implicit def appContext: ApplicationContext
   implicit val executionContext: ExecutionContext
   lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -96,7 +96,6 @@ object WeatherApi extends Logging {
     def loop(attemptsRemaining: Int): Future[JsValue] = {
       request().recoverWith {
         case NonFatal(error) =>
-          log.warn(s"Error on weather request, attempts remaining $attemptsRemaining", error)
           if (attemptsRemaining <= 1) Future.failed(error) else after(retryDelay, scheduler)(loop(attemptsRemaining - 1))
       }
     }

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -2,6 +2,7 @@ package weather
 
 import java.net.{URI, URLEncoder}
 
+import akka.actor.{ActorSystem, Scheduler}
 import common.{Logging, ResourcesHelper}
 import conf.Configuration
 import play.api.libs.json.{JsValue, Json}
@@ -9,8 +10,6 @@ import play.api.libs.ws.WSClient
 import weather.geo.LatitudeLongitude
 import weather.models.CityId
 import weather.models.accuweather.{ForecastResponse, LocationResponse, WeatherResponse}
-import java.util.concurrent.TimeoutException
-
 import model.ApplicationContext
 
 import scala.concurrent.duration._
@@ -18,16 +17,16 @@ import play.api.Mode
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+import akka.pattern.after
 
-class WeatherApi(wsClient: WSClient, context: ApplicationContext)(implicit ec: ExecutionContext) extends ResourcesHelper with Logging {
+class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit ec: ExecutionContext) extends ResourcesHelper with Logging {
   lazy val weatherApiKey: String = Configuration.weather.apiKey.getOrElse(
     throw new RuntimeException("Weather API Key not set")
   )
 
-  val requestTimeout = 300.milliseconds
-  val requestRetryMax = 3
-  val requestRetryDelay = 100.milliseconds
-  val requestRetryBackoffBase = 2
+  val requestTimeout: FiniteDuration = 300.milliseconds
+  val requestRetryMax: Int = 3
+  val requestRetryDelay: FiniteDuration = 100.milliseconds
 
   private def autocompleteUrl(query: String): String =
     s"http://api.accuweather.com/locations/v1/cities/autocomplete?apikey=$weatherApiKey&q=${URLEncoder.encode(query, "utf-8")}"
@@ -51,17 +50,20 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext)(implicit ec: E
   }
 
   private def getJsonWithRetry(url: String): Future[JsValue] = {
+    WeatherApi.retryWeatherRequest(() => getJsonRequest(url), requestRetryDelay, actorSystem.scheduler, requestRetryMax).recover {
+      case NonFatal(error) =>
+        log.error(s"Error fetching $url - $error")
+        throw error
+    }
+  }
+
+  private def getJsonRequest(url: String): Future[JsValue] = {
     wsClient
       .url(url)
       .withRequestTimeout(requestTimeout)
       .get()
       .map { response =>
         if(response.status == 200) response.json else throw new RuntimeException(s"Weather API response: $response")
-      }
-      .recoverWith {
-        case NonFatal(error) =>
-          log.error(s"Error fetching $url - $error")
-          Future.failed(error)
       }
   }
 
@@ -86,4 +88,19 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext)(implicit ec: E
     getJson(forecastLookUp(cityId)).map({ r =>
       Json.fromJson[Seq[ForecastResponse]](r).get
     })
+}
+
+object WeatherApi extends Logging {
+
+  def retryWeatherRequest(request: () => Future[JsValue], retryDelay: FiniteDuration, scheduler: Scheduler, attempts: Int)(implicit ec: ExecutionContext): Future[JsValue] = {
+    def loop(attemptsRemaining: Int): Future[JsValue] = {
+      request().recoverWith {
+        case NonFatal(error) =>
+          log.warn(s"Error on weather request, attempts remaining $attemptsRemaining", error)
+          if (attemptsRemaining <= 1) Future.failed(error) else after(retryDelay, scheduler)(loop(attemptsRemaining - 1))
+      }
+    }
+    loop(attempts)
+  }
+
 }

--- a/onward/test/weather/WeatherApiTest.scala
+++ b/onward/test/weather/WeatherApiTest.scala
@@ -1,0 +1,34 @@
+package weather
+
+import akka.actor.ActorSystem
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.{JsString, JsValue}
+import org.mockito.Mockito._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import scala.language.postfixOps
+
+class WeatherApiTest extends FlatSpec with ScalaFutures with Matchers with MockitoSugar {
+  val actorSystem = ActorSystem()
+
+  "retryWeatherRequest" should "return for a successful future" in {
+    val jsValue = JsString("Test")
+
+    val funMock = mock[() => Future[JsValue]]
+    when(funMock.apply()) thenReturn Future.successful(jsValue)
+
+    whenReady(WeatherApi.retryWeatherRequest(funMock, 100 milli, actorSystem.scheduler, 5))(_ shouldBe jsValue)
+    verify(funMock, times(1)).apply()
+  }
+
+  "retryWeatherRequest" should "fail after 5 exceptions" in {
+    val funMock = mock[() => Future[JsValue]]
+    when(funMock.apply()) thenReturn Future.failed(new RuntimeException("failure"))
+
+    WeatherApi.retryWeatherRequest(funMock, 1 milli, actorSystem.scheduler, 5).failed.futureValue shouldBe a [RuntimeException]
+    verify(funMock, times(5)).apply()
+  }
+}


### PR DESCRIPTION
## What does this change?

Add retry mechanism for the onward weather api

## What is the value of this and can you measure success?

Fewer failures on weather requests for fronts

## Tested in CODE?

will do!

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
