### PR TITLE
[Story questions] - Fix wrong question sent to ophan

### DIFF
--- a/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
+++ b/static/src/javascripts-legacy/projects/common/modules/atoms/story-questions.js
@@ -191,18 +191,18 @@ define([
             var isEmailSubmissionReady = isEmailSubmissionReadyElement && isEmailSubmissionReadyElement.dataset.isEmailSubmissionReady === 'true';
             var isDeliveryTestReady = isDeliveryTestReadyElement && isDeliveryTestReadyElement.dataset.isAnswerDeliveryTestReady === 'true';
 
-            var readerQuestionsContainer = document.getElementById('user__question-atom-' + atomId);
-            var askQuestionLinks = Array.from(document.querySelectorAll('.js-ask-question-link'));
+            var askQuestionLinks = $('.js-ask-question-link');
 
             var answersDeliveryPreferences = document.querySelectorAll('.btn-answer-delivery-' + atomId);
             var answerDeliveryPrefContainer = document.getElementById('js-delivery-selection-body-' + atomId);
 
-            if (readerQuestionsContainer) {
-                bean.one(readerQuestionsContainer, 'click', askQuestionLinks, function (event) {
+
+            askQuestionLinks.each(function (el) {
+                bean.on(el, 'click', function(event) {
                     askQuestion(event, isEmailSubmissionReady, isDeliveryTestReady);
                     this.classList.add('is-clicked');
                 });
-            }
+            });
 
             if (answerDeliveryPrefContainer) {
                 var deliveryPrefList = Array.from(answersDeliveryPreferences);


### PR DESCRIPTION
## What does this change?
Before change in [404 test](https://github.com/guardian/frontend/pull/18078), the event listener was installed on each
question, and the code handling the response was expecting this, as it's using the [event current target](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget) instead of the event target.

## What is the value of this and can you measure success?
The wrong question is sent to ophan which is preventing any useful usage of the feature.  

## Does this affect other platforms - Amp, Apps, etc?
no

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
no
