### PR TITLE
Introduce a flag on dropdowns to animate them

### DIFF
--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -1,7 +1,7 @@
-@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false)(content: Html)
+@(name: String, modifier: Option[String] = None, isActive: Boolean = false, isClientSideTemplate: Boolean = false, isAnimated: Boolean = false)(content: Html)
 
 @defining("dropdown-"+content.hashCode){ hash =>
-<div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active}">
+<div class="dropdown dropdown-styled u-cf @modifier.map("dropdown--" + _) @if(isActive){dropdown--active} @if(isAnimated){dropdown--animated}">
     <button class="dropdown__button u-button-reset js-dropdown-button"
             type="button"
             data-link-name="Show dropdown: @if(isClientSideTemplate) {<%=name%>} else {@name}"

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -25,9 +25,7 @@ const init = (): void => {
         const container = (e.currentTarget: any).closest(containerSelector);
 
         if (container) {
-
             fastdom.read(() => {
-                
                 const content = container.querySelector(`.${contentCN}`);
                 const isActive: boolean = container.classList.contains(
                     'dropdown--active'
@@ -49,7 +47,6 @@ const init = (): void => {
                 */
 
                 if (isAnimated && 'ontransitionend' in window) {
-
                     fastdom.write(() => {
                         container.style.pointerEvents = 'none';
                         if (!isActive) {

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -29,6 +29,9 @@ const init = (): void => {
             const isActive: boolean = container.classList.contains(
                 'dropdown--active'
             );
+            const isAnimated: boolean = container.classList.contains(
+                'dropdown--animated'
+            );
             const contentEstimatedHeight =
                 content.offsetHeight !== undefined &&
                 content.offsetHeight < window.innerHeight
@@ -42,8 +45,9 @@ const init = (): void => {
             because its starting to close from the bottom, which is off-screen
             */
 
-            if ('ontransitionend' in window) {
+            if (isAnimated && 'ontransitionend' in window) {
                 fastdom.write(() => {
+                    container.style.pointerEvents = 'none';
                     if (!isActive) {
                         container.classList.toggle('dropdown--active');
                     }
@@ -60,6 +64,7 @@ const init = (): void => {
                             fastdom.write(() => {
                                 updateAria(container);
                                 content.style.height = 'auto';
+                                container.style.pointerEvents = 'all';
                                 if (isActive) {
                                     container.classList.toggle(
                                         'dropdown--active'

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -25,69 +25,89 @@ const init = (): void => {
         const container = (e.currentTarget: any).closest(containerSelector);
 
         if (container) {
+            fastdom
+                .read(() => {
+                    const content = container.querySelector(`.${contentCN}`);
+                    const isActive: boolean = container.classList.contains(
+                        'dropdown--active'
+                    );
+                    const isAnimated: boolean = container.classList.contains(
+                        'dropdown--animated'
+                    );
+                    const contentEstimatedHeight =
+                        content.offsetHeight !== undefined &&
+                        content.offsetHeight < window.innerHeight
+                            ? content.offsetHeight
+                            : window.innerHeight;
 
-            fastdom.read(() => {
-                const content = container.querySelector(`.${contentCN}`);
-                const isActive: boolean = container.classList.contains(
-                    'dropdown--active'
-                );
-                const isAnimated: boolean = container.classList.contains(
-                    'dropdown--animated'
-                );
-                const contentEstimatedHeight =
-                    content.offsetHeight !== undefined &&
-                    content.offsetHeight < window.innerHeight
-                        ? content.offsetHeight
-                        : window.innerHeight;
+                    /*
+                    by clamping the transition to windowHeight we avoid
+                    a very awkward effect where a long list doesn't really
+                    get any visual closing feedback in the first milliseconds
+                    because its starting to close from the bottom, which is off-screen
+                    */
 
-                /*
-                by clamping the transition to windowHeight we avoid
-                a very awkward effect where a long list doesn't really
-                get any visual closing feedback in the first milliseconds
-                because its starting to close from the bottom, which is off-screen
-                */
-
-                return {content, isActive, isAnimated, contentEstimatedHeight};
-
-            }).then(({content, isActive, isAnimated, contentEstimatedHeight}) => {
-
-                if (isAnimated && 'ontransitionend' in window) {
-
-                    fastdom.write(() => {
-                        container.style.pointerEvents = 'none';
-                        if (!isActive) {
-                            container.classList.toggle('dropdown--active');
-                        }
-                        content.style.height = isActive
-                            ? `${contentEstimatedHeight}px`
-                            : 0;
-                    }).then(()=>{
-                        requestAnimationFrame(() => {
-                            content.style.height = isActive
-                                ? 0
-                                : `${contentEstimatedHeight}px`;
-
-                            bean.one(content, 'transitionend', () => {
-                                fastdom.write(() => {
-                                    updateAria(container);
-                                    content.style.height = 'auto';
-                                    container.style.pointerEvents = 'all';
-                                    if (isActive) {
+                    return {
+                        content,
+                        isActive,
+                        isAnimated,
+                        contentEstimatedHeight,
+                    };
+                })
+                .then(
+                    ({
+                        content,
+                        isActive,
+                        isAnimated,
+                        contentEstimatedHeight,
+                    }) => {
+                        if (isAnimated && 'ontransitionend' in window) {
+                            fastdom
+                                .write(() => {
+                                    container.style.pointerEvents = 'none';
+                                    if (!isActive) {
                                         container.classList.toggle(
                                             'dropdown--active'
                                         );
                                     }
+                                    content.style.height = isActive
+                                        ? `${contentEstimatedHeight}px`
+                                        : 0;
+                                })
+                                .then(() => {
+                                    requestAnimationFrame(() => {
+                                        content.style.height = isActive
+                                            ? 0
+                                            : `${contentEstimatedHeight}px`;
+
+                                        bean.one(
+                                            content,
+                                            'transitionend',
+                                            () => {
+                                                fastdom.write(() => {
+                                                    updateAria(container);
+                                                    content.style.height =
+                                                        'auto';
+                                                    container.style.pointerEvents =
+                                                        'all';
+                                                    if (isActive) {
+                                                        container.classList.toggle(
+                                                            'dropdown--active'
+                                                        );
+                                                    }
+                                                });
+                                            }
+                                        );
+                                    });
                                 });
+                        } else {
+                            fastdom.write(() => {
+                                container.classList.toggle('dropdown--active');
+                                updateAria(container);
                             });
-                        });
-                    });
-                } else {
-                    fastdom.write(() => {
-                        container.classList.toggle('dropdown--active');
-                        updateAria(container);
-                    });
-                }
-            })
+                        }
+                    }
+                );
         }
     });
 };

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -1,6 +1,6 @@
 // @flow
 import bean from 'bean';
-import fastdom from 'fastdom';
+import fastdom from 'lib/fastdom-promise';
 
 const containerSelector = '.dropdown';
 const buttonCN = 'dropdown__button';
@@ -25,6 +25,7 @@ const init = (): void => {
         const container = (e.currentTarget: any).closest(containerSelector);
 
         if (container) {
+
             fastdom.read(() => {
                 const content = container.querySelector(`.${contentCN}`);
                 const isActive: boolean = container.classList.contains(
@@ -46,7 +47,12 @@ const init = (): void => {
                 because its starting to close from the bottom, which is off-screen
                 */
 
+                return {content, isActive, isAnimated, contentEstimatedHeight};
+
+            }).then(({content, isActive, isAnimated, contentEstimatedHeight}) => {
+
                 if (isAnimated && 'ontransitionend' in window) {
+
                     fastdom.write(() => {
                         container.style.pointerEvents = 'none';
                         if (!isActive) {
@@ -55,7 +61,7 @@ const init = (): void => {
                         content.style.height = isActive
                             ? `${contentEstimatedHeight}px`
                             : 0;
-
+                    }).then(()=>{
                         requestAnimationFrame(() => {
                             content.style.height = isActive
                                 ? 0
@@ -81,7 +87,7 @@ const init = (): void => {
                         updateAria(container);
                     });
                 }
-            });
+            })
         }
     });
 };

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -25,61 +25,66 @@ const init = (): void => {
         const container = (e.currentTarget: any).closest(containerSelector);
 
         if (container) {
-            const content = container.querySelector(`.${contentCN}`);
-            const isActive: boolean = container.classList.contains(
-                'dropdown--active'
-            );
-            const isAnimated: boolean = container.classList.contains(
-                'dropdown--animated'
-            );
-            const contentEstimatedHeight =
-                content.offsetHeight !== undefined &&
-                content.offsetHeight < window.innerHeight
-                    ? content.offsetHeight
-                    : window.innerHeight;
 
-            /*
-            by clamping the transition to windowHeight we avoid
-            a very awkward effect where a long list doesn't really
-            get any visual closing feedback in the first milliseconds
-            because its starting to close from the bottom, which is off-screen
-            */
+            fastdom.read(() => {
+                
+                const content = container.querySelector(`.${contentCN}`);
+                const isActive: boolean = container.classList.contains(
+                    'dropdown--active'
+                );
+                const isAnimated: boolean = container.classList.contains(
+                    'dropdown--animated'
+                );
+                const contentEstimatedHeight =
+                    content.offsetHeight !== undefined &&
+                    content.offsetHeight < window.innerHeight
+                        ? content.offsetHeight
+                        : window.innerHeight;
 
-            if (isAnimated && 'ontransitionend' in window) {
-                fastdom.write(() => {
-                    container.style.pointerEvents = 'none';
-                    if (!isActive) {
-                        container.classList.toggle('dropdown--active');
-                    }
-                    content.style.height = isActive
-                        ? `${contentEstimatedHeight}px`
-                        : 0;
+                /*
+                by clamping the transition to windowHeight we avoid
+                a very awkward effect where a long list doesn't really
+                get any visual closing feedback in the first milliseconds
+                because its starting to close from the bottom, which is off-screen
+                */
 
-                    requestAnimationFrame(() => {
+                if (isAnimated && 'ontransitionend' in window) {
+
+                    fastdom.write(() => {
+                        container.style.pointerEvents = 'none';
+                        if (!isActive) {
+                            container.classList.toggle('dropdown--active');
+                        }
                         content.style.height = isActive
-                            ? 0
-                            : `${contentEstimatedHeight}px`;
+                            ? `${contentEstimatedHeight}px`
+                            : 0;
 
-                        bean.one(content, 'transitionend', () => {
-                            fastdom.write(() => {
-                                updateAria(container);
-                                content.style.height = 'auto';
-                                container.style.pointerEvents = 'all';
-                                if (isActive) {
-                                    container.classList.toggle(
-                                        'dropdown--active'
-                                    );
-                                }
+                        requestAnimationFrame(() => {
+                            content.style.height = isActive
+                                ? 0
+                                : `${contentEstimatedHeight}px`;
+
+                            bean.one(content, 'transitionend', () => {
+                                fastdom.write(() => {
+                                    updateAria(container);
+                                    content.style.height = 'auto';
+                                    container.style.pointerEvents = 'all';
+                                    if (isActive) {
+                                        container.classList.toggle(
+                                            'dropdown--active'
+                                        );
+                                    }
+                                });
                             });
                         });
                     });
-                });
-            } else {
-                fastdom.write(() => {
-                    container.classList.toggle('dropdown--active');
-                    updateAria(container);
-                });
-            }
+                } else {
+                    fastdom.write(() => {
+                        container.classList.toggle('dropdown--active');
+                        updateAria(container);
+                    });
+                }
+            });
         }
     });
 };

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -54,11 +54,22 @@
     }
 }
 
+.dropdown__content {
+    transition: height .2s linear;
+}
+
 .dropdown__toggle:checked + .dropdown__content,
 .dropdown--active .dropdown__content {
-    display: block;
+    position: static;
+    visibility: visible;
+    pointer-events: all;
 }
 
 .dropdown__content {
-    display: none;
+    overflow: hidden;
+    position: fixed;
+    top: -9999em;
+    left: -9999em;
+    visibility: hidden;
+    pointer-events: none;
 }

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -54,10 +54,6 @@
     }
 }
 
-.dropdown__content {
-    transition: height .2s linear;
-}
-
 .dropdown__toggle:checked + .dropdown__content,
 .dropdown--active .dropdown__content,
 .dropdown--animated.dropdown--active .dropdown__content {
@@ -79,4 +75,10 @@
     left: -9999em;
     visibility: hidden;
     pointer-events: none;
+    transition: height .2s linear;
+    /*
+    moving the dropdown off-layout instead of hiding it
+    lets dropdown.js retrieve a close enough height
+    for the animation
+    */
 }

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -63,9 +63,15 @@
     position: static;
     visibility: visible;
     pointer-events: all;
+    display: block;
 }
 
 .dropdown__content {
+    display: none;
+}
+
+.js-on .dropdown--animated .dropdown__content {
+    display: block;
     overflow: hidden;
     position: fixed;
     top: -9999em;

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -59,7 +59,8 @@
 }
 
 .dropdown__toggle:checked + .dropdown__content,
-.dropdown--active .dropdown__content {
+.dropdown--active .dropdown__content,
+.dropdown--animated.dropdown--active .dropdown__content {
     position: static;
     visibility: visible;
     pointer-events: all;
@@ -70,7 +71,7 @@
     display: none;
 }
 
-.js-on .dropdown--animated .dropdown__content {
+.dropdown--animated .dropdown__content {
     display: block;
     overflow: hidden;
     position: fixed;


### PR DESCRIPTION
## What does this change?
The dropdown template can now use isAnimated: true to have a open/close animation, this pr just provides the flag but it's not actually applied anywhere so nothing should change

## What is the value of this and can you measure success?
The dropdowns in the email preferences page were confusing from a ux standpoint as they are extremely long, and opening or closing them made you lose context in the page. This could potentially benefit other dropdowns as well.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![ezgif-5-594c6d90fc](https://user-images.githubusercontent.com/11539094/32487911-e229c4da-c3a2-11e7-9aed-fe058eaeaf02.gif)

## Tested in CODE?
No