### PR TITLE
Use pillar-card class names on sublinks if switched on 

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -39,8 +39,8 @@ case class EditionalisedLink(
 object Sublink {
   def fromFaciaContent(faciaContent: PressedContent): Sublink = {
     val storyContent: Option[PressedStory] = faciaContent.properties.maybeContent
-    val pillar: Pillar = Pillar.pillarFromPressedContent(storyContent)
-    val contentType: DotcomContentType = DotcomContentType.dotcomContentTypeFromPressedContent(storyContent)
+    val pillar: Pillar = Pillar(storyContent)
+    val contentType: DotcomContentType = DotcomContentType(storyContent)
 
     Sublink(
       faciaContent.header.kicker,
@@ -346,8 +346,8 @@ case class ContentCard(
     case _ => false
   }
 
-  val pillar: Pillar = Pillar.pillarFromPressedContent(storyContent)
-  val contentType: DotcomContentType = DotcomContentType.dotcomContentTypeFromPressedContent(storyContent)
+  val pillar: Pillar = Pillar(storyContent)
+  val contentType: DotcomContentType = DotcomContentType(storyContent)
 }
 object ContentCard {
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -39,8 +39,8 @@ case class EditionalisedLink(
 object Sublink {
   def fromFaciaContent(faciaContent: PressedContent): Sublink = {
     val storyContent: Option[PressedStory] = faciaContent.properties.maybeContent
-    val pillar: Pillar = storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
-    val contentType: DotcomContentType = storyContent.flatMap(_.metadata.`type`).getOrElse(DotcomContentType.Article)
+    val pillar: Pillar = Pillar.pillarFromPressedContent(storyContent)
+    val contentType: DotcomContentType = DotcomContentType.dotcomContentTypeFromPressedContent(storyContent)
 
     Sublink(
       faciaContent.header.kicker,
@@ -346,9 +346,8 @@ case class ContentCard(
     case _ => false
   }
 
-  val pillar: Pillar = storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
-
-  val contentType: DotcomContentType = storyContent.flatMap(_.metadata.`type`).getOrElse(DotcomContentType.Article)
+  val pillar: Pillar = Pillar.pillarFromPressedContent(storyContent)
+  val contentType: DotcomContentType = DotcomContentType.dotcomContentTypeFromPressedContent(storyContent)
 }
 object ContentCard {
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -37,14 +37,21 @@ case class EditionalisedLink(
 }
 
 object Sublink {
-  def fromFaciaContent(faciaContent: PressedContent): Sublink =
+  def fromFaciaContent(faciaContent: PressedContent): Sublink = {
+    val storyContent: Option[PressedStory] = faciaContent.properties.maybeContent
+    val pillar: Pillar = storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
+    val contentType: DotcomContentType = storyContent.flatMap(_.metadata.`type`).getOrElse(DotcomContentType.Article)
+
     Sublink(
       faciaContent.header.kicker,
       faciaContent.header.headline,
       EditionalisedLink.fromFaciaContent(faciaContent),
       faciaContent.card.cardStyle,
-      faciaContent.card.mediaType
+      faciaContent.card.mediaType,
+      pillar.name.toLowerCase(),
+      contentType.name.toLowerCase()
     )
+  }
 }
 
 case class Sublink(
@@ -52,7 +59,9 @@ case class Sublink(
   headline: String,
   url: EditionalisedLink,
   cardStyle: CardStyle,
-  mediaType: Option[MediaType]
+  mediaType: Option[MediaType],
+  pillar: String,
+  contentType: String
 )
 
 object DiscussionSettings {

--- a/common/app/model/DotcomContentType.scala
+++ b/common/app/model/DotcomContentType.scala
@@ -12,6 +12,7 @@ Audio => ApiAudio
 }
 import play.api.libs.json._
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
+import model.pressed.PressedStory
 
 // If you are reading this, you're probably trying to create a new Content Type.
 // Please note that we send the content types to DFP for ad tracking.
@@ -79,5 +80,9 @@ object DotcomContentType {
       case ApiAudio => Some(DotcomContentType.Audio)
       case _ => None
     }
+  }
+
+  def dotcomContentTypeFromPressedContent(storyContent: Option[PressedStory]): DotcomContentType = {
+    storyContent.flatMap(_.metadata.`type`).getOrElse(DotcomContentType.Article)
   }
 }

--- a/common/app/model/DotcomContentType.scala
+++ b/common/app/model/DotcomContentType.scala
@@ -82,7 +82,7 @@ object DotcomContentType {
     }
   }
 
-  def dotcomContentTypeFromPressedContent(storyContent: Option[PressedStory]): DotcomContentType = {
+  def apply(storyContent: Option[PressedStory]): DotcomContentType = {
     storyContent.flatMap(_.metadata.`type`).getOrElse(DotcomContentType.Article)
   }
 }

--- a/common/app/model/Pillars.scala
+++ b/common/app/model/Pillars.scala
@@ -28,9 +28,9 @@ object Pillar {
     override def writes(o: Pillar): JsValue = JsString(o.name)
   }
 
-   def pillarFromPressedContent(storyContent: Option[PressedStory]): Pillar = {
-     storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
-   }
+  def apply(storyContent: Option[PressedStory]): Pillar = {
+    storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
+  }
 }
 
 object Pillars {

--- a/common/app/model/Pillars.scala
+++ b/common/app/model/Pillars.scala
@@ -1,6 +1,8 @@
 package model
 
 import play.api.libs.json._
+import model.pressed.PressedStory
+
 
 sealed trait Pillar {
   val name: String
@@ -25,6 +27,10 @@ object Pillar {
 
     override def writes(o: Pillar): JsValue = JsString(o.name)
   }
+
+   def pillarFromPressedContent(storyContent: Option[PressedStory]): Pillar = {
+     storyContent.flatMap(_.metadata.pillar).getOrElse(Pillar.News)
+   }
 }
 
 object Pillars {

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -41,7 +41,7 @@ object GetClasses {
 
   def forSubLink(sublink: Sublink): String = RenderClasses(Map(
     ("fc-sublink", true),
-    (TrailCssClasses.toneClassFromStyle(sublink.cardStyle) + "--sublink", true),
+    (TrailCssClasses.toneClassFromStyle(sublink.cardStyle) + "--sublink", PillarCards.isSwitchedOff),
     (sublinkMediaTypeClass(sublink).getOrElse(""), true),
     ("fc-sublink--pillar-" + sublink.pillar, PillarCards.isSwitchedOn),
     ("fc-sublink--type-" + sublink.contentType, PillarCards.isSwitchedOn)

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -39,11 +39,13 @@ object GetClasses {
     )
   }
 
-  def forSubLink(sublink: Sublink): String = RenderClasses(Seq(
-    Some("fc-sublink"),
-    Some(TrailCssClasses.toneClassFromStyle(sublink.cardStyle) + "--sublink"),
-    sublinkMediaTypeClass(sublink)
-  ).flatten: _*)
+  def forSubLink(sublink: Sublink): String = RenderClasses(Map(
+    ("fc-sublink", true),
+    (TrailCssClasses.toneClassFromStyle(sublink.cardStyle) + "--sublink", true),
+    (sublinkMediaTypeClass(sublink).getOrElse(""), true),
+    ("fc-sublink--pillar-" + sublink.pillar, PillarCards.isSwitchedOn),
+    ("fc-sublink--type-" + sublink.contentType, PillarCards.isSwitchedOn)
+  ))
 
   def mediaTypeClass(faciaCard: ContentCard): Option[String] = faciaCard.mediaType map {
     case Gallery => "fc-item--gallery"


### PR DESCRIPTION
## What does this change?

Add pillar card class names to sublinks on fronts if pillar cards switched on

## What is the value of this and can you measure success?

Makes classnames available if pillar cards switched on

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

No

## Tested in CODE?

No