### PR TITLE
Prevent 3rd party tags from loading on Secure Contact page

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -1,5 +1,5 @@
 // @flow
-import config from 'lib/config';
+import defaultConfig from 'lib/config';
 import { getBreakpoint, adblockInUse } from 'lib/detect';
 import { isAdFreeUser } from 'commercial/modules/user-features';
 import { isUserLoggedIn } from 'common/modules/identity/api';
@@ -23,7 +23,7 @@ class CommercialFeatures {
     adFeedback: any;
     adFree: any;
 
-    constructor() {
+    constructor(config: any = defaultConfig) {
         // this is used for SpeedCurve tests
         const noadsUrl = window.location.hash.match(/[#&]noads(&.*)?$/);
         const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
@@ -45,9 +45,9 @@ class CommercialFeatures {
             document.documentElement.classList.contains('has-sticky');
         const newRecipeDesign =
             config.page.showNewRecipeDesign && config.tests.abNewRecipeDesign;
-        const isSecureContact = config.page.pageId.contains(
-            'contact-the-guardian-securely'
-        );
+        const isSecureContact = config
+            .get('page.pageId', '')
+            .includes('contact-the-guardian-securely');
 
         // Feature switches
         this.adFree =

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -45,6 +45,9 @@ class CommercialFeatures {
             document.documentElement.classList.contains('has-sticky');
         const newRecipeDesign =
             config.page.showNewRecipeDesign && config.tests.abNewRecipeDesign;
+        const isSecureContact = config.page.pageId.contains(
+            'contact-the-guardian-securely'
+        );
 
         // Feature switches
         this.adFree =
@@ -79,7 +82,8 @@ class CommercialFeatures {
             !config.page.isFront &&
             !newRecipeDesign;
 
-        this.thirdPartyTags = externalAdvertising && !isIdentityPage;
+        this.thirdPartyTags =
+            externalAdvertising && !isIdentityPage && !isSecureContact;
 
         this.outbrain =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.spec.js
@@ -33,6 +33,7 @@ jest.mock('lib/config', () => ({
     switches: {},
     page: {},
     hasTone: jest.fn(),
+    get: jest.fn(() => ''),
 }));
 
 jest.mock('commercial/modules/user-features', () => ({
@@ -73,6 +74,7 @@ describe('Commercial features', () => {
             contentType: 'Article',
             isMinuteArticle: false,
             section: 'politics',
+            pageId: 'politics-article',
             shouldHideAdverts: false,
             shouldHideReaderRevenue: false,
             isFront: false,
@@ -85,6 +87,8 @@ describe('Commercial features', () => {
             enableDiscussionSwitch: true,
             adFreeSubscriptionTrial: false,
         };
+
+        config.get.mockReturnValue('');
 
         window.location.hash = '';
 
@@ -241,6 +245,19 @@ describe('Commercial features', () => {
             // This is needed for identity pages in the profile subdomain
             config.page.section = 'identity';
             const features = new CommercialFeatures();
+            expect(features.thirdPartyTags).toBe(false);
+        });
+
+        it('Does not run on secure contact pages', () => {
+            config.page.pageId =
+                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely';
+
+            const mockConfig = {
+                get: () => config.page.pageId,
+                page: config.page,
+                switches: config.switches,
+            };
+            const features = new CommercialFeatures(mockConfig);
             expect(features.thirdPartyTags).toBe(false);
         });
     });


### PR DESCRIPTION
## What does this change?

Stops trackers from loading on page where there should not be trackers...

## What is the value of this and can you measure success?

More anonymous and confidential pages, by not loading trackers

TODO: conditionally remove the core analytics from target pages 😅

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Tested in CODE?

Nope