### PR TITLE
Sync marketing consent wording with Registration page

### DIFF
--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -7,6 +7,7 @@
 @import views.html.fragments.registrationFooter
 @import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
 @import com.gu.identity.model.ConsentText
+@import com.gu.identity.model.ConsentText._
 @import conf.switches.Switches.IdentityGdprMarketingConsentSwitch
 
 @v2ConsentCheckbox(consentField: Field) = {
@@ -37,8 +38,8 @@
 }
 
 @v1consentCheckboxes = {
-    @checkboxField(Checkbox(privacyForm("receiveGnmMarketing"), '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
-    @checkboxField(Checkbox(privacyForm("receive3rdPartyMarketing"), '_label -> "Receive email from other organisations"))(nonInputFields, messages)
+    @checkboxField(Checkbox(privacyForm("receiveGnmMarketing"), '_label -> currentConsents(FirstParty.name)))(nonInputFields, messages)
+    @checkboxField(Checkbox(privacyForm("receive3rdPartyMarketing"), '_label -> currentConsents(ThirdParty.name)))(nonInputFields, messages)
 }
 
 <form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.AuthenticatedActions
 import idapiclient.Auth
 import com.gu.identity.cookie.GuUCookieData
+import com.gu.identity.model.ConsentText.FirstParty
 import com.gu.identity.model._
 import form._
 import idapiclient.{TrackingData, _}
@@ -122,7 +123,7 @@ import scala.concurrent.Future
 
     "submitPrivacyForm method is called with valid CSRF request" should {
       "post UserUpdateDTO with consent to IDAPI" in new EditProfileFixture {
-        val consent = Consent("user", "firstParty", false)
+        val consent = Consent("user", FirstParty.name, false)
 
         val fakeRequest = FakeCSRFRequest(csrfAddToken)
           .withFormUrlEncodedBody(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.81"
+  val identityLibVersion = "3.83"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.37"


### PR DESCRIPTION
## What does this change?

Makes marketing consent wording on [Edit Profile](https://profile.theguardian.com/privacy/edit) page the same as the wording on  [Registration](https://profile.theguardian.com/register) page.

## What is the value of this and can you measure success?

Legal requirement.

## Screenshots

**Before:**

![image](https://user-images.githubusercontent.com/13835317/32508161-55620262-c3e1-11e7-87d6-208961b093ce.png)

**After:**

![image](https://user-images.githubusercontent.com/13835317/32508282-b8edc9e2-c3e1-11e7-8bc6-56bcf66ed9e5.png)


Related PR: https://github.com/guardian/identity/pull/707