### PR TITLE
Correct the banner CTA for US

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -65,7 +65,9 @@ const monthlySupporterCost = (location: string): string => {
 };
 
 const supporterEngagementCtaCopy = (location: string): string =>
-    `Support us for ${monthlySupporterCost(location)} a month.`;
+    location === 'US'
+        ? `Support us with a one-time contribution`
+        : `Support us for ${monthlySupporterCost(location)} a month.`;
 
 const supporterParams = (location: string): EngagementBannerParams =>
     Object.assign({}, baseParams, {


### PR DESCRIPTION
## What does this change?
The CTA for the US on the banner should not read "for $6.99 a month" as it doesn't push people towards membership. This PR fixes that

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
