### PR TITLE
Visual update of the email preferences page

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -79,63 +79,20 @@
 
                 <fieldset class="fieldset">
                     <div class="fieldset__heading">
-                        <h2 class="form__heading"></h2>
+                        <h2 class="form__heading">Newsletter options</h2>
                     </div>
 
-                    <div class="fieldset__fields">
+                    <div class="fieldset__fields email-subscription__options">
                         <ul class="u-unstyled">
-
-                            <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
-                                <label class="label">In which format would you like to receive email?</label>
-                                <div class="form-field__note">
-                                    HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
-                                    <br />
-                                    We recommend HTML emails.
-                                </div>
-
-                                @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
-
-                            </li>
-
                             <li>
-                                <button type="button" class="email-subscription__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
-                            </li>
-                        </ul>
-                    </div>
-
-                </fieldset>
-
-                <fieldset class="fieldset">
-                    <div class="fieldset__heading">
-                        <h2 class="form__heading"></h2>
-                    </div>
-                    <div class="fieldset__fields">
-                        <ul class="u-unstyled">
-
-                            <li class="form-field">
-                                <label class="label">Want to receive emails elsewhere?</label>
+                                <a type="button" href=@buildIdentityUrl("account/edit") class="email-subscription__button email-subscription__button--mini " data-link-name="Change email address">Update your email address</a>
                             </li>
                             <li>
-                                <a type="button" href=@buildIdentityUrl("account/edit") class="email-subscription__button" data-link-name="Change email address">Change email address</a>
+                                <div type="link" role="link" class="js-email-subscription__formatFieldsetToggle email-subscription__button email-subscription__button--mini " data-link-name="Change format">Change format</div>
                             </li>
-                        </ul>
-                    </div>
-
-                </fieldset>
-
-                <fieldset class="fieldset">
-                    <div class="fieldset__heading">
-                        <h2 class="form__heading"></h2>
-                    </div>
-                    <div class="fieldset__fields">
-                        <ul class="u-unstyled">
-
-                            <li class="form-field">
+                            <li>
                                 <label class="label">No longer want to receive any of these emails?</label>
-                            </li>
-
-                            <li>
-                                <button type="button" class="email-subscription__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
+                                <button type="button" class="email-subscription__button--mini email-subscription__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
                             </li>
                         </ul>
                     </div>
@@ -150,5 +107,41 @@
             </ul>
 
         </form>
+    </div>
+
+    <div class="email-subscriptions__modal email-subscriptions__modal--newsletterFormat">
+        <div class="email-subscriptions__modalContent">
+            <button class="email-subscriptions__modalCloser js-email-subscriptions__modalCloser">
+                @fragments.inlineSvg("cross", "icon")
+            </button>
+            <fieldset class="fieldset">
+                <div class="fieldset__heading">
+                    <h2 class="form__heading">Formatting</h2>
+                </div>
+
+                <div class="fieldset__fields">
+                    <ul class="u-unstyled">
+
+                        <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
+                            <label class="label">In which format would you like to receive email?</label>
+                            <div class="form-field__note">
+                                HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
+                                <br />
+                                We recommend HTML emails.
+                            </div>
+
+                            @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
+
+                        </li>
+
+                        <li>
+                            <button type="button" class="email-subscription__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
+                        </li>
+                    </ul>
+                </div>
+
+            </fieldset>
+        </div>
+        <div class="email-subscriptions__modalBg js-email-subscriptions__modalCloser"></div>
     </div>
 }

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -15,7 +15,7 @@
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
-    @fragments.dropdown(theme, isActive = isActive) {
+    @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive) {
         @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
             <div class="@RenderClasses(Map(
                 "u-cf" -> true,

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -15,7 +15,7 @@
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
-    @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive) {
+    @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
         @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
             <div class="@RenderClasses(Map(
                 "u-cf" -> true,

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -63,7 +63,7 @@
 }{
     <div class="identity-wrapper monocolumn-wrapper">
         <h1 class="identity-title">Email preferences</h1>
-        <h4 class="email-subscription__meta">To change your email address please click <a href=@buildIdentityUrl("account/edit")>here.</a></h4>
+        <h4 class="email-subscription__meta">Select which newsletters you would like to receive.</h4>
         <form class="form" novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post">
             @views.html.helper.CSRF.formField
             @if(emailPrefsForm.globalError.isDefined) {
@@ -75,52 +75,74 @@
                 }
             </div>
 
-            <fieldset class="fieldset">
-                <div class="fieldset__heading">
-                    <h2 class="form__heading">Edit email format</h2>
-                </div>
+            <div class="email-subscription__fieldset">
 
-                <div class="fieldset__fields">
-                    <ul class="u-unstyled">
+                <fieldset class="fieldset">
+                    <div class="fieldset__heading">
+                        <h2 class="form__heading"></h2>
+                    </div>
 
-                        <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
-                            <label class="label">In which format would you like to receive email?</label>
-                            <div class="form-field__note">
-                                HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
-                                <br />
-                                We recommend HTML emails.
-                            </div>
+                    <div class="fieldset__fields">
+                        <ul class="u-unstyled">
 
-                            @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
+                            <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
+                                <label class="label">In which format would you like to receive email?</label>
+                                <div class="form-field__note">
+                                    HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
+                                    <br />
+                                    We recommend HTML emails.
+                                </div>
 
-                        </li>
+                                @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
 
-                        <li>
-                            <button type="button" class="email-subscription__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
-                        </li>
-                    </ul>
-                </div>
+                            </li>
 
-            </fieldset>
+                            <li>
+                                <button type="button" class="email-subscription__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
+                            </li>
+                        </ul>
+                    </div>
 
-            <fieldset class="fieldset">
-                <div class="fieldset__heading">
-                    <h2 class="form__heading"></h2>
-                </div>
-                <div class="fieldset__fields">
-                    <ul class="u-unstyled">
+                </fieldset>
 
-                        <li class="form-field">
-                            <label class="label">No longer want to receive any of these emails?</label>
-                        </li>
+                <fieldset class="fieldset">
+                    <div class="fieldset__heading">
+                        <h2 class="form__heading"></h2>
+                    </div>
+                    <div class="fieldset__fields">
+                        <ul class="u-unstyled">
 
-                        <li>
-                            <button type="button" class="email-subscription__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
-                        </li>
-                    </ul>
-                </div>
+                            <li class="form-field">
+                                <label class="label">Want to receive emails elsewhere?</label>
+                            </li>
+                            <li>
+                                <a type="button" href=@buildIdentityUrl("account/edit") class="email-subscription__button" data-link-name="Change email address">Change email address</a>
+                            </li>
+                        </ul>
+                    </div>
 
-            </fieldset>
+                </fieldset>
+
+                <fieldset class="fieldset">
+                    <div class="fieldset__heading">
+                        <h2 class="form__heading"></h2>
+                    </div>
+                    <div class="fieldset__fields">
+                        <ul class="u-unstyled">
+
+                            <li class="form-field">
+                                <label class="label">No longer want to receive any of these emails?</label>
+                            </li>
+
+                            <li>
+                                <button type="button" class="email-subscription__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
+                            </li>
+                        </ul>
+                    </div>
+
+                </fieldset>
+
+            </div>
 
             <ul class="nav nav--registration identity-section" data-link-name="Email prefs footer">
                 <li class="nav__item"><a class="nav__link" href="@controllers.routes.EditProfileController.displayPrivacyForm" data-link-name="Privacy and marketing settings">Privacy &amp; marketing settings</a></li>

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -171,25 +171,31 @@ const unsubscribeFromAll = buttonEl => {
 const toggleFormatFieldset = buttonEl => {
     bean.on(buttonEl, 'click', () => {
         fastdom.write(() => {
-            $('.email-subscriptions__modal--newsletterFormat')[0].classList.add('email-subscriptions__modal--active');
+            $('.email-subscriptions__modal--newsletterFormat')[0].classList.add(
+                'email-subscriptions__modal--active'
+            );
         });
     });
-}
+};
 
 const bindModalCloser = buttonEl => {
     bean.on(buttonEl, 'click', () => {
-        buttonEl.closest('.email-subscriptions__modal').classList.remove('email-subscriptions__modal--active');
+        buttonEl
+            .closest('.email-subscriptions__modal')
+            .classList.remove('email-subscriptions__modal--active');
     });
-}
+};
 
 const enhanceEmailPreferences = () => {
     $.forEachElement('.js-subscription-button', reqwestEmailSubscriptionUpdate);
     $.forEachElement('.js-save-button', reqwestEmailSubscriptionUpdate);
     $.forEachElement('.js-unsubscribe', unsubscribeFromAll);
-    $.forEachElement('.js-email-subscription__formatFieldsetToggle', toggleFormatFieldset);
+    $.forEachElement(
+        '.js-email-subscription__formatFieldsetToggle',
+        toggleFormatFieldset
+    );
     $.forEachElement('.js-email-subscriptions__modalCloser', bindModalCloser);
     $.forEachElement('.js-email-subscriptions__modalCloser', bindModalCloser);
-
 };
 
 export { enhanceEmailPreferences };

--- a/static/src/javascripts/projects/common/modules/identity/email-preferences.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-preferences.js
@@ -168,10 +168,28 @@ const unsubscribeFromAll = buttonEl => {
     });
 };
 
+const toggleFormatFieldset = buttonEl => {
+    bean.on(buttonEl, 'click', () => {
+        fastdom.write(() => {
+            $('.email-subscriptions__modal--newsletterFormat')[0].classList.add('email-subscriptions__modal--active');
+        });
+    });
+}
+
+const bindModalCloser = buttonEl => {
+    bean.on(buttonEl, 'click', () => {
+        buttonEl.closest('.email-subscriptions__modal').classList.remove('email-subscriptions__modal--active');
+    });
+}
+
 const enhanceEmailPreferences = () => {
     $.forEachElement('.js-subscription-button', reqwestEmailSubscriptionUpdate);
     $.forEachElement('.js-save-button', reqwestEmailSubscriptionUpdate);
     $.forEachElement('.js-unsubscribe', unsubscribeFromAll);
+    $.forEachElement('.js-email-subscription__formatFieldsetToggle', toggleFormatFieldset);
+    $.forEachElement('.js-email-subscriptions__modalCloser', bindModalCloser);
+    $.forEachElement('.js-email-subscriptions__modalCloser', bindModalCloser);
+
 };
 
 export { enhanceEmailPreferences };

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -72,7 +72,7 @@
 }
 
 .dropdown__content {
-    display:none;
+    display: none;
     height: 0;
     overflow: hidden;
 }

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -43,15 +43,22 @@
     }
 
     .dropdown__content {
-        margin-bottom: $gs-baseline;
-        margin-top: $gs-baseline;
+        transition: margin .1s linear, height .2s linear;
     }
 
     &.dropdown--active {
         .dropdown__button .inline-icon {
             transform: rotate(180deg);
         }
+        .dropdown__content {
+            margin-bottom: $gs-baseline;
+            margin-top: $gs-baseline;
+        }
     }
+}
+
+.dropdown__content {
+    transition: height .2s linear;
 }
 
 .dropdown__toggle:checked + .dropdown__content,
@@ -61,10 +68,13 @@
     visibility: visible;
     pointer-events: all;
     display: block;
+    height: auto;
 }
 
 .dropdown__content {
-    display: none;
+    display:none;
+    height: 0;
+    overflow: hidden;
 }
 
 .dropdown--animated .dropdown__content {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -315,6 +315,10 @@
     opacity: .8;
 }
 
+.dropdown--email-subscription .dropdown__label {
+  @include fs-bodyHeading(3);
+}
+
 .email-subscription__name,
 .email-subscription__heading {
     @include fs-headline(3);

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -319,6 +319,9 @@
     margin-top: 3em;
     background: lighten($neutral-8,2%);
     border-top: 1px solid $news-main-2;
+    @include mq($until: desktop) {
+        padding: 0 $gs-gutter;
+    }
 }
 
 .dropdown--email-subscription .dropdown__label {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -317,24 +317,26 @@
 
 .email-subscription__fieldset {
     margin-top: 3em;
-    background: lighten($neutral-8,2%);
-    border-top: 1px solid $news-main-2;
-    @include mq($until: desktop) {
-        padding: 0 $gs-gutter;
-    }
 }
 
-.dropdown--email-subscription .dropdown__label {
-  @include fs-bodyHeading(3);
+.dropdown--email-subscription {
+    .dropdown__label {
+        @include fs-bodyHeading(3);
+        color: $guardian-brand;
+    }
+    &:hover .dropdown__label {
+        color: $guardian-brand-dark;
+    }
+    .dropdown__content {
+        padding-bottom: 2em;
+    }
 }
 
 .email-subscription__name,
 .email-subscription__heading {
-    @include fs-headline(3);
-    margin-bottom: $gs-baseline;
+    @include fs-bodyHeading(2);
 
     @include mq(desktop) {
-        @include fs-headline(3, true);
         box-sizing: border-box;
         float: left;
         padding-right: $gs-gutter;
@@ -410,10 +412,6 @@
         }
     }
 
-    .email-subscription--subscribed & {
-        background-color: $neutral-2-contrasted;
-    }
-
     &.is-updating-subscriptions {
         display: inherit;
         margin-top: 0;
@@ -424,17 +422,58 @@
         background-size: 40px;
     }
 
-    &.email-unsubscribe {
-        float: none;
+    .email-subscription--subscribed &,
+    &--mini {
         color: $guardian-brand;
         background-color: transparent;
-        border: 2px solid $guardian-brand;
+        border: 1px solid $news-main-2;
+        &:hover {
+            color: $guardian-brand-dark;
+            background-color: transparent;
+            border-color: currentColor;
+        }
     }
 
-    &.email-unsubscribe--confirm {
+    &--mini {
+        @include fs-textSans(1);
+        width: auto;
+        min-width: 0;
+        display: inline-flex;
+        height: $gs-gutter * 1.5;
+        line-height: .8;
+    }
+
+    &.email-unsubscribe {
+        float: none;
+    }
+
+    &.email-unsubscribe--confirm,
+    &.email-unsubscribe--confirm:hover{
         color: $error;
         font-weight: bold;
         border: 2px solid $error;
+    }
+
+    .fieldset & {
+        float: none;;
+    }
+
+}
+
+.email-subscription__options {
+
+    > ul > li:not(:last-child) {
+        margin-bottom: $gs-gutter / 2;
+    }
+
+    .email-subscription__button {
+        float: none;
+        clear: both;
+    }
+
+    label {
+        @include fs-bodyCopy(1,true);
+        margin-top: $gs-gutter;
     }
 }
 
@@ -448,6 +487,84 @@
 
 .save__button {
     float: none;
+}
+
+.fieldset.email-subscription__formatFieldset {
+    display:none;
+}
+
+/* Email subcriptions modals
+   ========================================================================== */
+.email-subscriptions__modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    display: none;
+
+    &--active {
+        display: block;
+        display: flex;
+    }
+
+    .email-subscriptions__modalBg {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: $neutral-1;
+        opacity:.95;
+        z-index: 9;
+    }
+
+    .email-subscriptions__modalContent {
+        max-width: gs-span(10);
+        background: #fff;
+        width: 100%;
+        position: relative;
+        z-index: 10;
+        border-top: 1px solid $news-main-2;
+        padding: ($gs-gutter * 3.75) ($gs-gutter * 1) ($gs-gutter * 1);
+        margin: auto;
+        float: none;
+    }
+
+    .email-subscriptions__modalCloser {
+        width: $gs-gutter * 1.75;
+        height: $gs-gutter * 1.75;
+        border: 1px solid $guardian-brand;
+        border-radius: 100%;
+        display: block;
+        position: absolute;
+        top: $gs-gutter;
+        right: $gs-gutter;
+
+        svg {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            margin: auto;
+        }
+
+        svg * {
+            fill: $guardian-brand;
+        }
+
+        &:hover {
+            border-color: #000;
+            svg * {
+                fill: #000;
+            }
+        }
+    }
 }
 
 /* Delete Account page

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -401,7 +401,7 @@
         background-color: $guardian-brand-dark;
     }
 
-    &:hover,&:active,&:focus {
+    &:hover, &:active, &:focus {
         color: #ffffff;
         text-decoration: none;
     }
@@ -448,7 +448,7 @@
     }
 
     &.email-unsubscribe--confirm,
-    &.email-unsubscribe--confirm:hover{
+    &.email-unsubscribe--confirm:hover {
         color: $error;
         font-weight: bold;
         border: 2px solid $error;
@@ -472,7 +472,7 @@
     }
 
     label {
-        @include fs-bodyCopy(1,true);
+        @include fs-bodyCopy(1, true);
         margin-top: $gs-gutter;
     }
 }
@@ -490,7 +490,7 @@
 }
 
 .fieldset.email-subscription__formatFieldset {
-    display:none;
+    display: none;
 }
 
 /* Email subcriptions modals
@@ -502,7 +502,6 @@
     right: 0;
     bottom: 0;
     z-index: 9999;
-    display: flex;
     align-items: center;
     justify-content: center;
     display: none;
@@ -519,13 +518,13 @@
         right: 0;
         bottom: 0;
         background: $neutral-1;
-        opacity:.95;
+        opacity: .95;
         z-index: 9;
     }
 
     .email-subscriptions__modalContent {
         max-width: gs-span(10);
-        background: #fff;
+        background: #ffffff;
         width: 100%;
         position: relative;
         z-index: 10;
@@ -559,9 +558,9 @@
         }
 
         &:hover {
-            border-color: #000;
+            border-color: #000000;
             svg * {
-                fill: #000;
+                fill: #000000;
             }
         }
     }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -315,6 +315,12 @@
     opacity: .8;
 }
 
+.email-subscription__fieldset {
+    margin-top: 3em;
+    background: lighten($neutral-8,2%);
+    border-top: 1px solid $news-main-2;
+}
+
 .dropdown--email-subscription .dropdown__label {
   @include fs-bodyHeading(3);
 }
@@ -341,6 +347,7 @@
 }
 .email-subscription__meta {
     margin-top: $gs-baseline;
+    font-weight: 400;
 }
 
 .email-subscription__frequency {
@@ -371,9 +378,33 @@
     cursor: pointer;
     float: left;
     padding: $gs-baseline/1.2 $gs-gutter $gs-baseline/1.5;
+    min-width: $gs-baseline * 14;
+    white-space: nowrap;
+    text-overflow: clip;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    box-sizing: border-box;
+    text-align: center;
+    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+        background-color: $guardian-brand-dark;
+    }
+
+    &:hover,&:active,&:focus {
+        color: #ffffff;
+        text-decoration: none;
+    }
 
     @include mq(desktop) {
-        float: right;
+        .dropdown--email-subscription & {
+            float: right;
+        }
     }
 
     .email-subscription--subscribed & {
@@ -393,9 +424,8 @@
     &.email-unsubscribe {
         float: none;
         color: $guardian-brand;
-        background-color: #ffffff;
+        background-color: transparent;
         border: 2px solid $guardian-brand;
-        min-width: $gs-baseline * 14;
     }
 
     &.email-unsubscribe--confirm {
@@ -415,7 +445,6 @@
 
 .save__button {
     float: none;
-    min-width: $gs-baseline * 14;
 }
 
 /* Delete Account page


### PR DESCRIPTION
## What does this change?
Updates the email preferences page to make it a bit leaner and shorter before merging it with the user privacy page as part of the re-permissioning privacy work

## What is the value of this and can you measure success?
Overall the visual structure has better hierarchy and is more aligned with the main guardian, although a lot of this will probably change again once we throw in the new permission checkboxes

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![screen shot 2017-11-08 at 11 36 16](https://user-images.githubusercontent.com/11539094/32547118-0f67ad5a-c479-11e7-890f-d05183b25b95.png)


## Tested in CODE?
No