### PR TITLE
Adding switch for games link in preparation for tag migration

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -2,6 +2,7 @@ package common
 
 import model._
 import play.api.mvc.RequestHeader
+import conf.switches.Switches.GamesLinkSwitch
 
 case class SectionLink(zone: String, title: String, breadcrumbTitle: String, href: String) {
   def currentFor(page: Page): Boolean = page.metadata.url == href ||
@@ -128,7 +129,8 @@ trait Navigation {
 
   //Technology
   val technologyblog = SectionLink("technology", "technology blog", "Technology blog", "/technology/blog")
-  val games = SectionLink("culture", "games", "Games", "/technology/games")
+  val gamesLink = if(GamesLinkSwitch.isSwitchedOn) "/games" else "/technology/games"
+  val games = SectionLink("culture", "games", "Games", gamesLink)
   val gamesblog = SectionLink("technology", "games blog", "Games blog", "/technology/gamesblog")
   val appsblog = SectionLink("technology", "apps blog", "Apps blog", "/technology/appsblog")
   val askjack = SectionLink("technology", "ask jack", "Ask Jack blog", "/technology/askjack")

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -129,7 +129,7 @@ trait Navigation {
 
   //Technology
   val technologyblog = SectionLink("technology", "technology blog", "Technology blog", "/technology/blog")
-  val gamesLink = if(GamesLinkSwitch.isSwitchedOn) "/games" else "/technology/games"
+  private val gamesLink = if(GamesLinkSwitch.isSwitchedOn) "/games" else "/technology/games"
   val games = SectionLink("culture", "games", "Games", gamesLink)
   val gamesblog = SectionLink("technology", "games blog", "Games blog", "/technology/gamesblog")
   val appsblog = SectionLink("technology", "apps blog", "Apps blog", "/technology/appsblog")

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -525,4 +525,15 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 10, 24),
     exposeClientSide = false
   )
+
+  // This switch is just for the tag migration happening on 9/11/2017. Please delete this afterwards
+  val GamesLinkSwitch = Switch(
+    SwitchGroup.Feature,
+    "games-link-switch",
+    "When on, the link to games will be `/games`. When off, it will be `technology/games`",
+    owners = Seq(Owner.withGithub("natalialkb")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 11, 13),
+    exposeClientSide = false
+  )
 }

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -96,7 +96,7 @@ object NavLinks {
   val film = NavLink("film", "/film", "film")
   val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", "tv-and-radio")
   val music = NavLink("music", "/music", "music")
-  val gamesId = if(GamesLinkSwitch.isSwitchedOn) "games" else "technology/games"
+  private val gamesId = if(GamesLinkSwitch.isSwitchedOn) "games" else "technology/games"
   val games = NavLink("games", s"/$gamesId", gamesId)
   val books = NavLink("books", "/books", "books")
   val artAndDesign = NavLink("art & design", "/artanddesign", "artanddesign")

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -1,5 +1,7 @@
 package navigation
 
+import conf.switches.Switches.GamesLinkSwitch
+
 object NavLinks {
   /* NEWS */
 
@@ -94,7 +96,8 @@ object NavLinks {
   val film = NavLink("film", "/film", "film")
   val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", "tv-and-radio")
   val music = NavLink("music", "/music", "music")
-  val games = NavLink("games", "/technology/games", "technology/games")
+  val gamesId = if(GamesLinkSwitch.isSwitchedOn) "games" else "technology/games"
+  val games = NavLink("games", s"/$gamesId", gamesId)
   val books = NavLink("books", "/books", "books")
   val artAndDesign = NavLink("art & design", "/artanddesign", "artanddesign")
   val stage = NavLink("stage", "/stage", "stage")


### PR DESCRIPTION
## What does this change?
Adding a switch in preparation for a tag migration happening tomorrow. `technology/games` will become `games/games`. This will likely take more than 20 minutes (but no one knows exactly how long).

During the migration both tags will exist and content will be moving from one to the other. To make sure users are always seeing the most recent content, this switch will help decide which tag to show during the migration (we are unsure of what content is being migrated first).

After the migration `technology/games` will be deleted. There will be a redirect in place to make sure if anyone is going to `technology/games` they will be redirected to `games/games`

cc @guardian/dotcom-platform 

## What is the value of this and can you measure success?
Hopefully nothing appears broken or weird to users and they can access the most recent content in games during the migration.

## Does this affect other platforms - Amp, Apps, etc?
Yes (both)

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
