### PR TITLE
Add test so some audience get images served from the test image service

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -30,10 +30,12 @@ class OptInController(val controllerComponents: ControllerComponents) extends Ba
   def handle(feature: String, choice: String): Action[AnyContent] = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
       case "desktopheader" => newDesktopHeader.opt(choice)
+      case "imgxfallbacktest" => imgxFallbackTest.opt(choice)
       case _ => NotFound
     }))
   }
 
   //cookies should correspond with those checked by fastly-edge-cache
   val newDesktopHeader = OptInFeature("new_desktop_header", controllerComponents)
+  val imgxFallbackTest = OptInFeature("imgix-fallback-test", controllerComponents)
 }

--- a/commercial/app/views/hosted/guardianHostedGalleryImage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryImage.scala.html
@@ -4,7 +4,7 @@
 @import model.ImageAsset
 @import com.gu.contentapi.client.model.v1.Asset
 @import com.gu.contentapi.client.model.v1.AssetType
-@(image: HostedGalleryImage, content: String = "")
+@(image: HostedGalleryImage, content: String = "")(implicit request: RequestHeader)
     <div class="js-hosted-gallery-image hosted-gallery__image hosted-tone--dark">
         <div class="hosted-gallery__image-sizer js-hosted-gallery-image-sizer">
             @fragments.image(

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -76,6 +76,18 @@ object ABJavascriptRenderingControl extends TestDefinition(
   def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("control")
 }
 
+object ABImageTestService extends TestDefinition(
+  name = "ab-image-test-service",
+  description = "Audience in this test will access the test image service (with imgx fallback)",
+  owners = Seq(Owner.withName("tbonnin")),
+  sellByDate = new LocalDate(2017, 12, 7)
+) {
+
+  def participationGroup(implicit request: RequestHeader): Option[String] = request.headers.get("X-GU-ab-imgix-fallback-test")
+
+  def canRun(implicit request: RequestHeader): Boolean = participationGroup.contains("variant")
+}
+
 trait ServerSideABTests {
   val tests: Seq[TestDefinition]
 
@@ -103,7 +115,8 @@ object ActiveTests extends ServerSideABTests {
     ABNewDesktopHeaderVariant,
     ABNewDesktopHeaderControl,
     ABJavascriptRenderingVariant,
-    ABJavascriptRenderingControl
+    ABJavascriptRenderingControl,
+    ABImageTestService
   )
 }
 

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -1,5 +1,5 @@
 @import layout.ContentWidths.MainMedia
-@import views.support.{ImgSrc, RenderClasses}
+@import views.support.{ImgSrc, RenderClasses, ImageService}
 
 @(
     picture: model.ImageMedia,
@@ -8,7 +8,7 @@
     imageAltText: String,
     isFeatureAndShowcase: Boolean = false,
     isImmersiveMainMedia: Boolean = false
-)
+)(implicit request: RequestHeader)
 
 @immersivePortraitSource(largestImage: model.ImageAsset, hidpi: Boolean = false) = {
     <source media="@if(hidpi) {
@@ -48,10 +48,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)(ImageService.test)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
         sizes="@breakpointWidth.width"
-        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))" />
+        srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))(ImageService.test)" />
     }
 
     <!--[if IE 9]></video><![endif]-->

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,8 +1,14 @@
 @import layout.WidthsByBreakpoint
 @import model.ImageMedia
-@import views.support.{ImgSrc, RenderClasses}
+@import views.support.{ImgSrc, RenderClasses, ImageService}
 
-@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageMedia: Option[ImageMedia] = None, maybePath: Option[String] = None, maybeSrc: Option[String] = None)
+@(
+    classes: Seq[String],
+    widths: WidthsByBreakpoint,
+    maybeImageMedia: Option[ImageMedia] = None,
+    maybePath: Option[String] = None,
+    maybeSrc: Option[String] = None
+)(implicit request: RequestHeader)
 
 <picture>
     @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
@@ -10,10 +16,10 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)(ImageService.test)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)(ImageService.test)" />
     }
     <!--[if IE 9]></video><![endif]-->
     <img class="@RenderClasses(classes: _*)"


### PR DESCRIPTION
Using implicit with default value so the minimum amount of code outside of the profile.scala needs to be changed.
I would not follow this approach if this code was supposed to stay in
the codebase but this is a temporary solution to test image service with imgx fallback

## What is the value of this and can you measure success?
Being able to test the change made on image service with a small slice of our audience

## Tested in CODE?
Yes