### PR TITLE
Add check to disable analytics on certain pages

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -241,7 +241,7 @@ final case class MetaData (
     DfpAgent.omitMPUsFromContainers(id, edition)
   } else false
 
-  val shouldBlockAnalytics: Boolean = id.contains("contact-the-guardian-securely")
+  val shouldBlockAnalytics: Boolean = id.contains("help/ng-interactive/2017/mar/17/contact-the-guardian-securely")
 
   val requiresMembershipAccess: Boolean = membershipAccess.nonEmpty
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -241,6 +241,8 @@ final case class MetaData (
     DfpAgent.omitMPUsFromContainers(id, edition)
   } else false
 
+  val shouldBlockAnalytics: Boolean = id.contains("contact-the-guardian-securely")
+
   val requiresMembershipAccess: Boolean = membershipAccess.nonEmpty
 
   val hasSlimHeader: Boolean =

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -6,26 +6,26 @@
 
 @if(!page.metadata.shouldBlockAnalytics) {
 
-@******************************************************************************
-                            Core Analytics
-******************************************************************************@
+    @******************************************************************************
+                                Core Analytics
+    ******************************************************************************@
 
-@fragments.analytics.google(page)
+    @fragments.analytics.google(page)
 
-@fragments.analytics.comscore(page)
+    @fragments.analytics.comscore(page)
 
-@******************************************************************************
-                            'Other' Analytics
-******************************************************************************@
+    @******************************************************************************
+                                'Other' Analytics
+    ******************************************************************************@
 
-@* google remarketing fallback *@
-<noscript>
-    <div style="display:inline;">
-        <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0"/>
-    </div>
-</noscript>
+    @* google remarketing fallback *@
+    <noscript>
+        <div style="display:inline;">
+            <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0"/>
+        </div>
+    </noscript>
 
-<img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
-<img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
+    <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+    <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
 
 }

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -4,6 +4,8 @@
 @import views.support.FBPixel
 
 
+@if(!page.metadata.shouldBlockAnalytics) {
+
 @******************************************************************************
                             Core Analytics
 ******************************************************************************@
@@ -25,3 +27,5 @@
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
 <img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
+
+}

--- a/static/src/javascripts/projects/commercial/modules/commercial-features.js
+++ b/static/src/javascripts/projects/commercial/modules/commercial-features.js
@@ -47,7 +47,9 @@ class CommercialFeatures {
             config.page.showNewRecipeDesign && config.tests.abNewRecipeDesign;
         const isSecureContact = config
             .get('page.pageId', '')
-            .includes('contact-the-guardian-securely');
+            .includes(
+                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
+            );
 
         // Feature switches
         this.adFree =


### PR DESCRIPTION

Follow up to https://github.com/guardian/frontend/pull/18187

## What does this change?

Privacy! 🎉 Security! 🎉 

Only Ophan is now permitted to run on pages where we want no tracking. Facebook, comscore and the other third party tags will no longer fire, which means if you go to a page where shouldBlockAnalytics is true, UBlock Origin and Privacy Badger should be chill.

I decided to place the check inside `base.scala.html` because the fragment is loaded in a few places.

## What is the value of this and can you measure success?

- Stops trackers from loading on page where there should not be trackers...

- More anonymous and confidential page, by not loading external trackers

## Does this affect other platforms - Amp, Apps, etc?

Nope

## Tested in CODE?

Nope, but current check is fairly specific and will only return true on a [certain article](https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely). Have checked that the happy paths of the interactive still work on that page, and that the expected tags and analytics are still loaded everywhere else.