### PR TITLE
Adding TargetingLifecycle to onward

### DIFF
--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -22,6 +22,7 @@ import router.Routes
 import services.OphanApi
 import services.breakingnews.{BreakingNewsApi, S3BreakingNews}
 import weather.WeatherApi
+import _root_.commercial.targeting.TargetingLifecycle
 
 import scala.concurrent.ExecutionContext
 
@@ -65,7 +66,8 @@ trait AppComponents extends FrontendComponents with OnwardControllers with Onwar
     wire[StocksDataLifecycle],
     wire[MostPopularFacebookAutoRefreshLifecycle],
     wire[SwitchboardLifecycle],
-    wire[CachedHealthCheckLifeCycle]
+    wire[CachedHealthCheckLifeCycle],
+    wire[TargetingLifecycle]
   )
 
   lazy val router: Router = wire[Routes]

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -21,13 +21,13 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
   private def contentType(path: String)(implicit request: RequestHeader): Future[Option[ContentType]] = {
     val fields = "headline,standfirst,shortUrl,webUrl,byline,starRating,trailText,liveBloggingNow"
     val response = lookup(path, fields)(request)
-    response map { _.content.map(Content(_)) }
+    response.map(_.content.map(Content(_)))
   }
 
   private def richLinkHtml(content: ContentType)(implicit request: RequestHeader, context: ApplicationContext): Html =
     views.html.richLink(content)(request, context)
 
-  private def richLinkBodyHtml(content: ContentType)(implicit request: RequestHeader, context: ApplicationContext) =
+  private def richLinkBodyHtml(content: ContentType)(implicit request: RequestHeader, context: ApplicationContext): Html =
     views.html.fragments.richLinkBody(content)(request)
 
 }


### PR DESCRIPTION
onward serves rich links which styling depend on the targeting campaigns
data to assign SpecialRepost card style

## What is the value of this and can you measure success?
Special report rich links are styled properly

## Tested in CODE?
No