### PR TITLE
Media atoms for hosted

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -1,9 +1,67 @@
 @import common.commercial.hosted.HostedArticlePage
 @(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
+@import views.BodyCleaner
 @import model.hosted.HostedArticleQuotes.prepareQuotes
 
 @mainLegacy(page, Some("commercial")) { } {
+
+    @inlineStyles()
+
+    <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
+        @hostedLogo(page)
+    </div></div></div>
+    @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.fontColour.isDark) " hosted-page--bright" else ""), page)
+    <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.fontColour.isDark) {hosted-page--bright}">
+
+        <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--paid-content" role="main">
+            @showcaseMedia(page)
+            <div class="content__main">
+                <div class="gs-container">
+                    <div class="hosted-article__main-column content__main-column content__main-column--article js-content-main-column">
+                        <div class="content__meta-container js-content-meta js-football-meta u-cf content__meta-container--showcase">
+                            <div class="meta__extras" data-component="share">
+                            @guardianHostedShareButtons(page)
+                            </div>
+                        </div>
+
+                        @BodyCleaner(page, body(page).toString())(request, context)
+
+                        <div class="hosted__onward-journey">
+                            <div class="js-onward-placeholder"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        @guardianHostedCta(page, page.cta, isAMP = false)
+    </div>
+}
+
+@showcaseMedia(page: HostedArticlePage) = {
+    <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">
+        <div class="gs-container">
+            <h2 class="title content__main-column">@{page.title}</h2>
+        </div>
+        <span class="caption hosted-tone">@{page.mainPictureCaption}</span>
+    </div>
+}
+
+@body(page: HostedArticlePage) = {
+    <div class="content__article-body from-content-api js-article__body">
+        <p class="intro">@Html(page.standfirst)</p>
+
+        @Html(prepareQuotes(page.body))
+
+        <div class="hosted__standfirst">
+            @hostedExplainer()
+        </div>
+    </div>
+}
+
+@inlineStyles() = {
+
     <!--[if (gt IE 9)|(IEMobile)]><!-->
     <style>
     .hosted-tone {
@@ -67,45 +125,4 @@
 
     </style>
     <!--<![endif]-->
-    <div class="hosted__header"><div class="hosted__headerwrap"><div class="hostedbadge">
-        @hostedLogo(page)
-    </div></div></div>
-    @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.fontColour.isDark) " hosted-page--bright" else ""), page)
-    <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.fontColour.isDark) {hosted-page--bright}">
-
-        <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--paid-content" role="main">
-            <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">
-                <div class="gs-container">
-                    <h2 class="title content__main-column">@{page.title}</h2>
-                </div>
-                <span class="caption hosted-tone">@{page.mainPictureCaption}</span>
-            </div>
-            <div class="content__main">
-                <div class="gs-container">
-                    <div class="hosted-article__main-column content__main-column content__main-column--article js-content-main-column">
-                        <div class="content__meta-container js-content-meta js-football-meta u-cf content__meta-container--showcase">
-                            <div class="meta__extras" data-component="share">
-                            @guardianHostedShareButtons(page)
-                            </div>
-                        </div>
-
-                        <div class="content__article-body from-content-api js-article__body">
-                            <p class="intro">@Html(page.standfirst)</p>
-
-                            @Html(prepareQuotes(page.body))
-
-                            <div class="hosted__standfirst">
-                                @hostedExplainer()
-                            </div>
-                        </div>
-                        <div class="hosted__onward-journey">
-                            <div class="js-onward-placeholder"></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        @guardianHostedCta(page, page.cta, isAMP = false)
-    </div>
 }

--- a/commercial/app/views/package.scala
+++ b/commercial/app/views/package.scala
@@ -1,0 +1,18 @@
+package views
+
+import common.commercial.hosted.HostedArticlePage
+import model.ApplicationContext
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+import views.support.{AtomsCleaner, BulletCleaner, withJsoup}
+
+object BodyCleaner {
+  def apply(article: HostedArticlePage, html: String)(implicit request: RequestHeader, context: ApplicationContext): Html = {
+
+    val cleaners = List(
+      AtomsCleaner(atoms = article.content.atoms)
+    )
+
+    withJsoup(BulletCleaner(html))(cleaners :_*)
+  }
+}

--- a/commercial/app/views/package.scala
+++ b/commercial/app/views/package.scala
@@ -4,7 +4,7 @@ import common.commercial.hosted.HostedArticlePage
 import model.ApplicationContext
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
-import views.support.{AtomsCleaner, BulletCleaner, withJsoup}
+import views.support.{AtomsCleaner, withJsoup}
 
 object BodyCleaner {
   def apply(article: HostedArticlePage, html: String)(implicit request: RequestHeader, context: ApplicationContext): Html = {
@@ -13,6 +13,6 @@ object BodyCleaner {
       AtomsCleaner(atoms = article.content.atoms)
     )
 
-    withJsoup(BulletCleaner(html))(cleaners :_*)
+    withJsoup(html)(cleaners :_*)
   }
 }

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -1,10 +1,10 @@
 package common.commercial.hosted
 
-import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common.Logging
 import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
-import model.MetaData
+import model.{Content, MetaData}
 
 case class HostedArticlePage(
   override val id: String,
@@ -18,14 +18,15 @@ case class HostedArticlePage(
   override val thumbnailUrl: String,
   override val socialShareText: Option[String],
   override val shortSocialShareText: Option[String],
-  override val metadata: MetaData
+  override val metadata: MetaData,
+  content: Content
 ) extends HostedPage {
   override val mainImageUrl = mainPicture
 }
 
 object HostedArticlePage extends Logging {
 
-  def fromContent(content: Content): Option[HostedArticlePage] = {
+  def fromContent(content: ApiContent): Option[HostedArticlePage] = {
     log.info(s"Building hosted article ${content.id} ...")
 
     val page = for {
@@ -49,7 +50,8 @@ object HostedArticlePage extends Logging {
         thumbnailUrl = thumbnailUrl(content),
         socialShareText = content.fields.flatMap(_.socialShareText),
         shortSocialShareText = content.fields.flatMap(_.shortSocialShareText),
-        metadata = HostedMetadata.fromContent(content).copy(openGraphImages = mainImageAsset.flatMap(_.file).toList)
+        metadata = HostedMetadata.fromContent(content).copy(openGraphImages = mainImageAsset.flatMap(_.file).toList),
+        content = Content.make(content)
       )
     }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -114,7 +114,7 @@
         h1 {
             line-height: 28px;
         }
-        figcaption {
+        & :not(.element-atom--media) figcaption {
             font-size: 12px;
             line-height: 16px;
             color: $neutral-2;

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -20,6 +20,27 @@
         .gs-container {
             height: 100%;
         }
+
+        .caption {
+            position: absolute;
+            left: 10px;
+            top: 390px;
+            right: unset;
+
+            @include mq(tablet) {
+                left: $gs-gutter * 1.5;
+            }
+
+            @include mq(desktop) {
+                left: unset;
+                right: $gs-column-width + 10;
+                width: $gs-column-width * 3 + 40;
+            }
+
+            @include mq(leftCol) {
+                right: 10px;
+            }
+        }
     }
     article.content--article {
         background: #ffffff;
@@ -35,26 +56,6 @@
         font-weight: bold;
         @include mq(tablet, desktop) {
             padding-right: gs-span(1) + $gs-gutter;
-        }
-    }
-    .caption {
-        position: absolute;
-        left: 10px;
-        top: 390px;
-        right: unset;
-
-        @include mq(tablet) {
-            left: $gs-gutter * 1.5;
-        }
-
-        @include mq(desktop) {
-            left: unset;
-            right: $gs-column-width + 10;
-            width: $gs-column-width * 3 + 40;
-        }
-
-        @include mq(leftCol) {
-            right: 10px;
         }
     }
     .content__meta-container {


### PR DESCRIPTION
Tweaks styling for captions on hosted pages, and wraps atoms so that they are sized consistently with the rest of the site. 

![screen shot 2017-11-09 at 10 02 03](https://user-images.githubusercontent.com/4549425/32599697-34881a36-c535-11e7-8909-27b89053720c.png)
