### PR TITLE
Acquisitions engagement banner "Just One Pound" test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 11, 23),
     exposeClientSide = true
   )
+
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-just-one-pound",
+    "Test highlighting a different sentance in the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 11, 23),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-one-pound.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-one-pound.js
@@ -1,0 +1,69 @@
+// @flow
+import {
+    makeABTest,
+    defaultButtonTemplate,
+} from 'common/modules/commercial/contributions-utilities';
+import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
+import { control } from 'common/modules/commercial/acquisitions-copy';
+
+export const acquisitionsEpicElectionInteractiveEnd = makeABTest({
+    id: 'AcquisitionsInteractiveEnd',
+    campaignId: 'epic_interactive_end',
+
+    start: '2017-05-22',
+    expiry: '2018-07-03',
+
+    author: 'Sam Desborough',
+    description: 'This places the epic underneath certain interactives',
+    successMeasure: 'Member acquisition and contributions',
+    idealOutcome:
+        'Our wonderful readers will support The Guardian in this time of need!',
+
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    pageCheck(page) {
+        const isElection =
+            page.keywordIds &&
+            page.keywordIds.includes('general-election-2017') &&
+            page.contentType === 'Interactive';
+
+        const isFootball =
+            page.pageId.indexOf(
+                'transfer-window-2017-every-deal-in-europes-top-five-leagues'
+            ) > -1;
+
+        return isElection || isFootball;
+    },
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+
+            options: {
+                isUnlimited: true,
+
+                insertAtSelector: '.content-footer',
+                successOnView: true,
+
+                template: function makeControlTemplate(variant) {
+                    return acquisitionsEpicControlTemplate({
+                        copy: control,
+                        componentName: variant.options.componentName,
+                        buttonTemplate: defaultButtonTemplate({
+                            membershipUrl: variant.options.membershipURL,
+                            contributeUrl: variant.options.contributeURL,
+                            supportUrl: variant.options.supportURL,
+                        }),
+                        testimonialBlock: variant.options.testimonialBlock,
+                        epicClass:
+                            'contributions__epic--interactive gs-container',
+                        wrapperClass: 'contributions__epic-interactive-wrapper',
+                    });
+                },
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-one-pound.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-just-one-pound.js
@@ -1,69 +1,38 @@
 // @flow
-import {
-    makeABTest,
-    defaultButtonTemplate,
-} from 'common/modules/commercial/contributions-utilities';
-import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
-import { control } from 'common/modules/commercial/acquisitions-copy';
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+import { getSync as getGeoLocation } from 'lib/geolocation';
 
-export const acquisitionsEpicElectionInteractiveEnd = makeABTest({
-    id: 'AcquisitionsInteractiveEnd',
-    campaignId: 'epic_interactive_end',
+const ctaText =
+    getGeoLocation() === 'US'
+        ? 'Support the Guardian from as little as $1.'
+        : 'Support the Guardian from as little as £1.';
 
-    start: '2017-05-22',
-    expiry: '2018-07-03',
-
-    author: 'Sam Desborough',
-    description: 'This places the epic underneath certain interactives',
-    successMeasure: 'Member acquisition and contributions',
-    idealOutcome:
-        'Our wonderful readers will support The Guardian in this time of need!',
-
+export const AcquisitionsBannerJustOnePound: AcquisitionsABTest = {
+    id: 'AcquisitionsBannerJustOnePound',
+    campaignId: 'banner_just_one',
+    start: '2017-10-26',
+    expiry: '2018-11-27',
+    author: 'Jonathan Rankin',
+    description: 'Tests 2 new banner variants',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     audienceCriteria: 'All',
     audience: 1,
     audienceOffset: 0,
+    canRun: () => getGeoLocation() === 'US' || getGeoLocation() === 'GB',
 
-    pageCheck(page) {
-        const isElection =
-            page.keywordIds &&
-            page.keywordIds.includes('general-election-2017') &&
-            page.contentType === 'Interactive';
-
-        const isFootball =
-            page.pageId.indexOf(
-                'transfer-window-2017-every-deal-in-europes-top-five-leagues'
-            ) > -1;
-
-        return isElection || isFootball;
-    },
-
-    variants: [
+    variants: makeBannerABTestVariants([
         {
             id: 'control',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-
+        },
+        {
+            id: 'just_one',
             options: {
-                isUnlimited: true,
-
-                insertAtSelector: '.content-footer',
-                successOnView: true,
-
-                template: function makeControlTemplate(variant) {
-                    return acquisitionsEpicControlTemplate({
-                        copy: control,
-                        componentName: variant.options.componentName,
-                        buttonTemplate: defaultButtonTemplate({
-                            membershipUrl: variant.options.membershipURL,
-                            contributeUrl: variant.options.contributeURL,
-                            supportUrl: variant.options.supportURL,
-                        }),
-                        testimonialBlock: variant.options.testimonialBlock,
-                        epicClass:
-                            'contributions__epic--interactive gs-container',
-                        wrapperClass: 'contributions__epic-interactive-wrapper',
-                    });
+                engagementBannerParams: {
+                    ctaText,
                 },
             },
         },
-    ],
-});
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,4 +1,6 @@
 // @flow
+import { AcquisitionsBannerJustOnePound } from 'common/modules/experiments/tests/acquisitions-banner-just-one-pound';
+
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsBannerJustOnePound];


### PR DESCRIPTION
## What does this change?

A new test, which tests the CTA copy of "Support the Guardian from as little as £1/$1"

This test is only for the UK and US.

## Screenshots
UK control:
![ukcon](https://user-images.githubusercontent.com/2844554/32616891-6d6f8d94-c56b-11e7-9648-bee3cb9cc7af.png)

UK just one:
![ukvar](https://user-images.githubusercontent.com/2844554/32616893-6d8480be-c56b-11e7-9848-201650aa0b89.png)

US control:
![uscon](https://user-images.githubusercontent.com/2844554/32616905-78fc732a-c56b-11e7-9d42-134d2f50bb3c.png)

US just one:
![usvar](https://user-images.githubusercontent.com/2844554/32616906-7910c032-c56b-11e7-9e10-c1c1e84cd05d.png)


@guardian/contributions 

## Tested in CODE?

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
