### PR TITLE
Rerun the IAS test, ensuring that the PET.js script is loaded.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -18,7 +18,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-ias-ad-targeting",
+    "ab-ias-ad-targeting-v2",
     "Test to assess the impact of integrating with IAS to provide richer targeting of our ad slots",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -22,7 +22,7 @@ trait ABTestSwitches {
     "Test to assess the impact of integrating with IAS to provide richer targeting of our ad slots",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 11, 16),
+    sellByDate = new LocalDate(2017, 11, 20),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -109,7 +109,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
      */
     if (
         config.get('switches.abIasAdTargeting', false) &&
-        getTestVariantId('IasAdTargeting') === 'variant'
+        getTestVariantId('IasAdTargetingV2') === 'variant'
     ) {
         /* eslint-disable no-underscore-dangle */
         // this should all have been instantiated by commercial/modules/third-party-tags/ias.js

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -108,7 +108,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
         To see debugging output from IAS add the URL param `&iasdebug=true` to the page URL
      */
     if (
-        config.get('switches.abIasAdTargeting', false) &&
+        config.get('switches.abIasAdTargetingV2', false) &&
         getTestVariantId('IasAdTargetingV2') === 'variant'
     ) {
         /* eslint-disable no-underscore-dangle */

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
@@ -2,6 +2,6 @@
 import config from 'lib/config';
 
 export const ias: ThirdPartyTag = {
-    shouldRun: config.switches.iasOptimisation,
+    shouldRun: config.switches.abIasAdTargeting,
     url: '//cdn.adsafeprotected.com/iasPET.1.js',
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
@@ -1,7 +1,10 @@
 // @flow
 import config from 'lib/config';
+import { getTestVariantId } from 'common/modules/experiments/utils';
 
 export const ias: ThirdPartyTag = {
-    shouldRun: config.switches.abIasAdTargeting,
+    shouldRun:
+        config.get('switches.abIasAdTargeting', false) &&
+        getTestVariantId('IasAdTargetingV2') === 'variant',
     url: '//cdn.adsafeprotected.com/iasPET.1.js',
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
@@ -4,7 +4,7 @@ import { getTestVariantId } from 'common/modules/experiments/utils';
 
 export const ias: ThirdPartyTag = {
     shouldRun:
-        config.get('switches.abIasAdTargeting', false) &&
+        config.get('switches.abIasAdTargetingV2', false) &&
         getTestVariantId('IasAdTargetingV2') === 'variant',
     url: '//cdn.adsafeprotected.com/iasPET.1.js',
 };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -5,14 +5,14 @@ import { getTest as getAcquisitionTest } from 'common/modules/experiments/acquis
 import { paidContentVsOutbrain2 } from 'common/modules/experiments/tests/paid-content-vs-outbrain';
 import { outstreamFrequencyCapHoldback } from 'common/modules/experiments/tests/outstream-cap-holdback';
 import { acquisitionsEpicElectionInteractiveEnd } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
-import { iasAdTargeting } from 'common/modules/experiments/tests/ias-ad-targeting';
+import { iasAdTargetingV2 } from 'common/modules/experiments/tests/ias-ad-targeting';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     paidContentVsOutbrain2,
     getAcquisitionTest(),
     acquisitionsEpicElectionInteractiveEnd,
     outstreamFrequencyCapHoldback,
-    iasAdTargeting,
+    iasAdTargetingV2,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/ias-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/ias-ad-targeting.js
@@ -1,9 +1,9 @@
 // @flow
 
-export const iasAdTargeting: ABTest = {
-    id: 'IasAdTargeting',
-    start: '2017-10-31',
-    expiry: '2017-11-15',
+export const iasAdTargetingV2: ABTest = {
+    id: 'IasAdTargetingV2',
+    start: '2017-11-09',
+    expiry: '2017-11-17',
     author: 'Jon Norman',
     description:
         'Adds additional targeting to ad slots, sourced from an IAS optimisation integration.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/ias-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/ias-ad-targeting.js
@@ -3,7 +3,7 @@
 export const iasAdTargetingV2: ABTest = {
     id: 'IasAdTargetingV2',
     start: '2017-11-09',
-    expiry: '2017-11-17',
+    expiry: '2017-11-20',
     author: 'Jon Norman',
     description:
         'Adds additional targeting to ad slots, sourced from an IAS optimisation integration.',


### PR DESCRIPTION
## What does this change?
This reruns the test implementing the IAS viewability tracker. The last test may not have produced accurate results as the main third-party-script that was supposed to execute on pageload was not being called due to a renamed switch (when this was put behind an AB test).