### PR TITLE
Standardised buttons on identity settings pages

### DIFF
--- a/identity/app/views/emailVerified.scala.html
+++ b/identity/app/views/emailVerified.scala.html
@@ -9,7 +9,7 @@
         @if(state.isValidated){
             <h1 class="identity-title">Thank you!</h1>
             <p>Your email address has been validated.</p>
-            <a class="submit-input" href="@returnUrl" data-link-name="Continue">Continue</a>
+            <a class="manage-account__button" href="@returnUrl" data-link-name="Continue">Continue</a>
         }else {
             @if(state.isExpired){
                 <h1 class="identity-title">Your email confirmation link has expired.</h1>
@@ -18,9 +18,9 @@
                 <h1 class="identity-title">Sorry, this email confirmation link is not recognised.</h1>
             }
             @if(userIsLoggedIn) {
-                <button type="button" class="submit-input js-id-send-validation-email" data-link-name="Resend verification email">Resend my verification email</button>
+                <button type="button" class="manage-account__button js-id-send-validation-email" data-link-name="Resend verification email">Resend my verification email</button>
             } else {
-                <a class="submit-input" href="@idUrlBuilder.buildUrl("/verify-email", idRequest)" data-link-name="Sign in and resend verification email">Sign in to resend your verification email</a>
+                <a class="manage-account__button" href="@idUrlBuilder.buildUrl("/verify-email", idRequest)" data-link-name="Sign in and resend verification email">Sign in to resend your verification email</a>
             }
         }
         @registrationFooter(idRequest, idUrlBuilder)

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -205,7 +205,7 @@ a {
     min-height: 160px;
 }
 
-.submit-input {
+.manage-account__button {
     background: #005689;
     border: 0 none;
     color: #ffffff;
@@ -220,15 +220,15 @@ a {
     text-align: center;
 }
 
-.submit-input:active {
+.manage-account__button:active {
     background: #000000;
 }
 
-.submit-input:hover, .submit-input:focus {
+.manage-account__button:hover, .manage-account__button:focus {
     background: #004670;
 }
 
-.submit-input[disabled] {
+.manage-account__button[disabled] {
     background: #dfdfdf;
 }
 
@@ -328,7 +328,7 @@ a {
                     checkboxLabel: 'check-label',
                     textInput: 'text-input',
                     textArea: 'textarea textarea--no-resize',
-                    submit: 'submit-input',
+                    submit: 'manage-account__button',
                     fieldError: 'form-field--error',
                     formError: 'form__error',
                     fieldset: 'formstack-fieldset',

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -40,7 +40,7 @@ passwordExists: Boolean
                     ('tabindex, 3), ('maxlength, 72), (Symbol("data-test-id"), "new-password-repeat")))
 
                     <li class="form-field form-field__submit">
-                        <button type="submit" class="submit-input" data-link-name="Change password" tabindex="4" data-test-id="change-pwd">Change password</button>
+                        <button type="submit" class="manage-account__button" data-link-name="Change password" tabindex="4" data-test-id="change-pwd">Change password</button>
                     </li>
 
                 </ul>

--- a/identity/app/views/password/requestPasswordReset.scala.html
+++ b/identity/app/views/password/requestPasswordReset.scala.html
@@ -24,7 +24,7 @@
                     'autofocus -> true, (Symbol("data-test-id"), "password-reset-email")))
 
                     <li class="form-field">
-                        <button type="submit" class="submit-input" data-link-name="Reset password" data-test-id="reset-password-btn">Reset password</button>
+                        <button type="submit" class="manage-account__button" data-link-name="Reset password" data-test-id="reset-password-btn">Reset password</button>
                     </li>
                 </ul>
             </div>

--- a/identity/app/views/password/resetPassword.scala.html
+++ b/identity/app/views/password/resetPassword.scala.html
@@ -28,7 +28,7 @@
                         @inputField(Password(resetPasswordForm("password-confirm"), '_label -> "Repeat password", (Symbol("data-test-id"), "reset-password-repeat")))
 
                         <li class="form-field">
-                            <button type="submit" class="submit-input" data-link-name="Save password" data-test-id="reset-pwd">Save password</button>
+                            <button type="submit" class="manage-account__button" data-link-name="Save password" data-test-id="reset-pwd">Save password</button>
                         </li>
                     </ul>
                 </div>

--- a/identity/app/views/password/resetPasswordRequestNewToken.scala.html
+++ b/identity/app/views/password/resetPasswordRequestNewToken.scala.html
@@ -18,7 +18,7 @@
                     @inputField(Email(requestNewTokenForm("email-address"), '_label -> "Email address", 'autofocus -> true))
 
                     <li class="form-field">
-                        <button type="submit" class="submit-input" data-link-name="Reset password resend">Send me another</button>
+                        <button type="submit" class="manage-account__button" data-link-name="Reset password resend">Send me another</button>
                     </li>
                 </ul>
             </div>

--- a/identity/app/views/profile/accountDetailsForm.scala.html
+++ b/identity/app/views/profile/accountDetailsForm.scala.html
@@ -84,7 +84,7 @@
                     </ul>
                 </li>
                 @if(!accountDetailsForm("telephoneNumber").hasErrors && accountDetailsForm("telephoneNumber.localNumber").value.nonEmpty) {
-                    <button type="submit" class="submit-input" data-link-name="Delete Phone Number" name="deleteTelephoneNumber" value="true">
+                    <button type="submit" class="manage-account__button" data-link-name="Delete Phone Number" name="deleteTelephoneNumber" value="true">
                         Delete Phone Number</button>
                 }
             </ul>
@@ -199,7 +199,7 @@
     <fieldset class="fieldset">
         <div class="fieldset__heading"></div>
         <div class="fieldset__fields">
-            <button type="submit" class="submit-input" data-link-name="Create account" data-test-id="save-changes">Save changes</button>
+            <button type="submit" class="manage-account__button" data-link-name="Create account" data-test-id="save-changes">Save changes</button>
         </div>
     </fieldset>
 

--- a/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
+++ b/identity/app/views/profile/contributionForm/contributionUpsell.scala.html
@@ -4,5 +4,5 @@
     </div>
     <p class="manage-account-up-sell__content">Help us deliver the independent journalism the world needs. Support the Guardian's quality, investigative journalism by making a contribution.</p>
 
-    <a href="@(conf.Configuration.id.supportUrl)/?INTCMP=DOTCOM_MANAGE_JOIN" class="submit-input" data-link-name="Join today">Make a contribution</a>
+    <a href="@(conf.Configuration.id.supportUrl)/?INTCMP=DOTCOM_MANAGE_JOIN" class="manage-account__button" data-link-name="Join today">Make a contribution</a>
 </div>

--- a/identity/app/views/profile/deletion/accountDeletion.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletion.scala.html
@@ -125,7 +125,7 @@
                                 (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
 
                             <li>
-                                <button id="deleteButton" type="submit" class="submit-input delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
+                                <button id="deleteButton" type="submit" class="manage-account__button delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>
                                 <div id="deleteLoader" class="loading-animation is-updating inline-loading is-hidden"></div>
                             </li>
                         </ul>

--- a/identity/app/views/profile/digitalPackForm/upsell.scala.html
+++ b/identity/app/views/profile/digitalPackForm/upsell.scala.html
@@ -3,5 +3,5 @@
         <h2 class="manage-account-header">Try the Guardian Digital Pack</h2>
     </div>
     <p class="manage-account-up-sell__content">Enjoy the Guardian and Observer's digital pack on the tube, in the park, on a beach, or wherever it’s convenient for you. The digital pack brings you the biggest stories every day and special sections for big events on iPad, Android and Kindle Fire tablets.</p>
-    <a href="@(conf.Configuration.id.subscribeUrl)" class="submit-input" data-link-name="Join today">Get your 2 week free trial</a>
+    <a href="@(conf.Configuration.id.subscribeUrl)" class="manage-account__button" data-link-name="Join today">Get your 2 week free trial</a>
 </div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -40,7 +40,7 @@
                 </div>
 
                 <div class="email-subscription__meta u-cf">
-                    <button class="email-subscription__button js-subscription-button"
+                    <button class="manage-account__button js-subscription-button"
                             data-link-name="@if(newsletter.subscribedTo(emailSubscriptions)){Unsubscribe}else{Subscribe} to @newsletter.name"
                             name="addEmailSubscription"
                             type="button"
@@ -84,14 +84,14 @@
             <div class="fieldset__fields email-subscription__options">
                 <ul class="u-unstyled">
                     <li>
-                        <a type="button" href=@buildIdentityUrl("account/edit") class="email-subscription__button email-subscription__button--mini " data-link-name="Change email address">Update your email address</a>
+                        <a type="button" href=@buildIdentityUrl("account/edit") class="manage-account__button manage-account__button--mini " data-link-name="Change email address">Update your email address</a>
                     </li>
                     <li>
-                        <div type="link" role="link" class="js-email-subscription__formatFieldsetToggle email-subscription__button email-subscription__button--mini " data-link-name="Change format">Change format</div>
+                        <div type="link" role="link" class="js-email-subscription__formatFieldsetToggle manage-account__button manage-account__button--mini " data-link-name="Change format">Change format</div>
                     </li>
                     <li>
                         <label class="label">No longer want to receive any of these emails?</label>
-                        <button type="button" class="email-subscription__button--mini email-subscription__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
+                        <button type="button" class="manage-account__button--mini manage-account__button email-unsubscribe js-unsubscribe" data-link-name="Unsubscribe from all emails"><span class="email-unsubscribe-all__label js-unsubscribe--basic">Unsubscribe from all</span><span class="email-unsubscribe-all__label js-unsubscribe--confirm hide">Are you sure?</span></button>
                     </li>
                 </ul>
             </div>
@@ -127,7 +127,7 @@
                     </li>
 
                     <li>
-                        <button type="button" class="email-subscription__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
+                        <button type="button" class="manage-account__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
                     </li>
                 </ul>
             </div>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -70,7 +70,7 @@
     }
     <div class="email-subscriptions">
     @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
-        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), index == 0)
+        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), false)
     }
     </div>
 

--- a/identity/app/views/profile/membershipForm/details.scala.html
+++ b/identity/app/views/profile/membershipForm/details.scala.html
@@ -21,7 +21,7 @@
             <div class="fieldset__fields u-cf">
                 <div class="form-field">
                     <span class="js-mem-tier" id="qa-membership-tier"></span>
-                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" id="qa-change-tier" class="submit-input manage-account-cta" data-link-name="Change tier">Change tier</a>
+                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" id="qa-change-tier" class="manage-account__button manage-account-cta" data-link-name="Change tier">Change tier</a>
                 </div>
             </div>
         </li>

--- a/identity/app/views/profile/membershipForm/upsell.scala.html
+++ b/identity/app/views/profile/membershipForm/upsell.scala.html
@@ -3,6 +3,6 @@
         <h2 class="manage-account-header">Join Guardian Membership</h2>
     </div>
     <p class="manage-account-up-sell__content">We're bringing the Guardian to life through live events and meet-ups. Join and be part of the conversations that matter</p>
-    <a href="@(conf.Configuration.id.membershipUrl)/join?INTCMP=DOTCOM_MANAGE_JOIN" class="submit-input" data-link-name="Join today">Join today</a>
-    <a href="@(conf.Configuration.id.membershipUrl)/about?INTCMP=DOTCOM_MANAGE_ABOUT" class="submit-input" data-link-name="More about membership">More about membership</a>
+    <a href="@(conf.Configuration.id.membershipUrl)/join?INTCMP=DOTCOM_MANAGE_JOIN" class="manage-account__button" data-link-name="Join today">Join today</a>
+    <a href="@(conf.Configuration.id.membershipUrl)/about?INTCMP=DOTCOM_MANAGE_ABOUT" class="manage-account__button" data-link-name="More about membership">More about membership</a>
 </div>

--- a/identity/app/views/profile/payPal.scala.html
+++ b/identity/app/views/profile/payPal.scala.html
@@ -12,8 +12,8 @@
                 You are paying with PayPal.
                 Please login to PayPal to change your payment details.
                 </span>
-                <span id="qa-show-paypal" class="submit-input manage-account-cta js-show-paypal-button" data-link-name="Show PayPal">Show account name</span>
-                <span id="qa-show-paypal" class="submit-input manage-account-cta js-hide-paypal-button is-hidden" data-link-name="Show PayPal">Hide account name</span>
+                <span id="qa-show-paypal" class="manage-account__button manage-account-cta js-show-paypal-button" data-link-name="Show PayPal">Show account name</span>
+                <span id="qa-show-paypal" class="manage-account__button manage-account-cta js-hide-paypal-button is-hidden" data-link-name="Show PayPal">Hide account name</span>
                 <span class="is-hidden js-paypal-email-message">
                     Your PayPal account is
                     <span class="paypal-email js-paypal-email"></span>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -113,7 +113,7 @@
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li>
-                    <button type="submit" class="submit-input" data-link-name="Save privacy preferences">Save changes</button>
+                    <button type="submit" class="submit-input submit-input-v2" data-link-name="Save privacy preferences">Save changes</button>
                 </li>
             </ul>
         </div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -113,7 +113,7 @@
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li>
-                    <button type="submit" class="submit-input submit-input-v2" data-link-name="Save privacy preferences">Save changes</button>
+                    <button type="submit" class="manage-account__button" data-link-name="Save privacy preferences">Save changes</button>
                 </li>
             </ul>
         </div>

--- a/identity/app/views/profile/publicProfileForm.scala.html
+++ b/identity/app/views/profile/publicProfileForm.scala.html
@@ -69,7 +69,7 @@
                 @textareaField(Input(publicProfileForm("interests"), ('_label, "Interests"), ('class, "textarea--mid"), ('maxlength, "255")))
 
                 <li>
-                    <button type="submit" class="submit-input" data-link-name="Create account">Save changes</button>
+                    <button type="submit" class="manage-account__button" data-link-name="Create account">Save changes</button>
                 </li>
             </ul>
         </div>
@@ -93,7 +93,7 @@
                         <input type="file" name="file" accept="image/gif, image/jpeg, image/png" />
                     </li>
                     <li>
-                        <button type="submit" class="submit-input js-avatar-upload-button" data-link-name="Upload Avatar">Upload image</button>
+                        <button type="submit" class="manage-account__button js-avatar-upload-button" data-link-name="Upload Avatar">Upload image</button>
                     </li>
                 </ul>
             </div>

--- a/identity/app/views/profile/stripe.scala.html
+++ b/identity/app/views/profile/stripe.scala.html
@@ -13,7 +13,7 @@
                 <span id="qa-card-details" class="card-details js-manage-account-card">
                     •••• •••• •••• <span class="js-manage-account-card-last4"></span>
                 </span>
-                <button id="qa-change-card" class="submit-input manage-account-cta js-manage-account-change-card is-hidden" data-link-name="Change card" data-email="@user.primaryEmailAddress">
+                <button id="qa-change-card" class="manage-account__button manage-account-cta js-manage-account-change-card is-hidden" data-link-name="Change card" data-email="@user.primaryEmailAddress">
                     Change card</button>
                 <div class="is-updating js-updating show-updating"></div>
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -56,9 +56,9 @@
             @if(ProfileShowContributorTab.isSwitchedOn) {
                 @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-membership-tab")
 
-                @tab(6, "Privacy", "/email-prefs", None, optionalClass="qa-privacy-tab")
+                @tab(6, "Email", "/email-prefs", None, optionalClass="qa-privacy-tab")
             } else {
-                @tab(5, "Privacy", "/email-prefs", None, optionalClass="qa-privacy-tab")
+                @tab(5, "Email", "/email-prefs", None, optionalClass="qa-privacy-tab")
             }
         </ol>
 

--- a/identity/app/views/reauthenticate.scala.html
+++ b/identity/app/views/reauthenticate.scala.html
@@ -43,7 +43,7 @@
                         <div class="form-field__note">
                             <a class="js-forgotten-password" href='@idUrlBuilder.buildUrl("/reset", idRequest)' data-link-name="Forgotten password">Forgotten your password?</a>
                         </div>
-                        <button type="submit" class="submit-input" data-link-name="Sign in" data-test-id="sign-in-button" tabindex="3">Confirm</button>
+                        <button type="submit" class="manage-account__button" data-link-name="Sign in" data-test-id="sign-in-button" tabindex="3">Confirm</button>
                     </li>
                 </ul>
             </div>

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -391,7 +391,7 @@
     }
 
     .email-subscription--subscribed & {
-        @extend .manage-account__button--light;
+        @extend %manage-account__button--light;
     }
 
     &.email-unsubscribe {

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -372,10 +372,9 @@
         padding-left: gs-span(4);
     }
 }
-.email-subscription__button {
+.manage-account__button {
     @include fs-textSans(2);
     background-color: $guardian-brand;
-    width: $gs-baseline * 9;
     height: $gs-gutter * 2;
     border-radius: 100px;
     border: 0;
@@ -412,6 +411,10 @@
         }
     }
 
+    &.is-updating {
+        border: 0;
+    }
+
     &.is-updating-subscriptions {
         display: inherit;
         margin-top: 0;
@@ -427,7 +430,7 @@
         color: $guardian-brand;
         background-color: transparent;
         border: 1px solid $news-main-2;
-        &:hover {
+        &:not(.is-updating):hover {
             color: $guardian-brand-dark;
             background-color: transparent;
             border-color: currentColor;
@@ -436,8 +439,7 @@
 
     &--mini {
         @include fs-textSans(1);
-        width: auto;
-        min-width: 0;
+        min-width: $gs-baseline * 10;
         display: inline-flex;
         height: $gs-gutter * 1.5;
         line-height: .8;
@@ -466,7 +468,7 @@
         margin-bottom: $gs-gutter / 2;
     }
 
-    .email-subscription__button {
+    .manage-account__button {
         float: none;
         clear: both;
     }
@@ -573,11 +575,4 @@
     display: inline-block;
     margin-top: 0;
     vertical-align: middle;
-}
-
-/* Override old pasteup buttons
-   ========================================================================== */
-.submit-input-v2 {
-    border-radius: 999em;
-    @include fs-textSans(2);
 }

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -574,3 +574,10 @@
     margin-top: 0;
     vertical-align: middle;
 }
+
+/* Override old pasteup buttons
+   ========================================================================== */
+.submit-input-v2 {
+    border-radius: 999em;
+    @include fs-textSans(2);
+}

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -373,46 +373,11 @@
     }
 }
 .manage-account__button {
-    @include fs-textSans(2);
-    background-color: $guardian-brand;
-    height: $gs-gutter * 2;
-    border-radius: 100px;
-    border: 0;
-    color: #ffffff;
-    cursor: pointer;
-    float: left;
-    padding: $gs-baseline/1.2 $gs-gutter $gs-baseline/1.5;
-    min-width: $gs-baseline * 14;
-    white-space: nowrap;
-    text-overflow: clip;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    -ms-appearance: none;
-    box-sizing: border-box;
-    text-align: center;
-    display: inline-block;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-
-    &:hover {
-        background-color: $guardian-brand-dark;
-    }
-
-    &:hover, &:active, &:focus {
-        color: #ffffff;
-        text-decoration: none;
-    }
 
     @include mq(desktop) {
         .dropdown--email-subscription & {
             float: right;
         }
-    }
-
-    &.is-updating {
-        border: 0;
     }
 
     &.is-updating-subscriptions {
@@ -425,24 +390,8 @@
         background-size: 40px;
     }
 
-    .email-subscription--subscribed &,
-    &--mini {
-        color: $guardian-brand;
-        background-color: transparent;
-        border: 1px solid $news-main-2;
-        &:not(.is-updating):hover {
-            color: $guardian-brand-dark;
-            background-color: transparent;
-            border-color: currentColor;
-        }
-    }
-
-    &--mini {
-        @include fs-textSans(1);
-        min-width: $gs-baseline * 10;
-        display: inline-flex;
-        height: $gs-gutter * 1.5;
-        line-height: .8;
+    .email-subscription--subscribed & {
+        @extend .manage-account__button--light;
     }
 
     &.email-unsubscribe {
@@ -456,7 +405,7 @@
         border: 2px solid $error;
     }
 
-    .fieldset & {
+    .email-subscription__fieldset & {
         float: none;;
     }
 

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -17,6 +17,9 @@
     ========================================================================== */
     .manage-account-up-sell {
         padding: $gs-gutter*2;
+        .manage-account__button {
+            margin-right: 1em;
+        }
     }
 
     .manage-account-up-sell__heading {

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -287,6 +287,16 @@
 
 /* Button styles
 ========================================================================== */
+%manage-account__button--light {
+    color: $guardian-brand;
+    background-color: transparent;
+    border: 1px solid $news-main-2;
+    &:not(.is-updating):hover {
+        color: $guardian-brand-dark;
+        background-color: transparent;
+        border-color: currentColor;
+    }
+}
 .manage-account__button {
     @include fs-textSans(2);
     background-color: $guardian-brand;
@@ -325,19 +335,12 @@
     }
 
     &--light {
-        color: $guardian-brand;
-        background-color: transparent;
-        border: 1px solid $news-main-2;
-        &:not(.is-updating):hover {
-            color: $guardian-brand-dark;
-            background-color: transparent;
-            border-color: currentColor;
-        }
+        @extend %manage-account__button--light;
     }
 
     &--mini {
+        @extend %manage-account__button--light;
         @include fs-textSans(1);
-        @extend .manage-account__button--light;
         min-width: $gs-baseline * 10;
         display: inline-flex;
         height: $gs-gutter * 1.5;

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -287,16 +287,6 @@
 
 /* Button styles
 ========================================================================== */
-%manage-account__button--light {
-    color: $guardian-brand;
-    background-color: transparent;
-    border: 1px solid $news-main-2;
-    &:not(.is-updating):hover {
-        color: $guardian-brand-dark;
-        background-color: transparent;
-        border-color: currentColor;
-    }
-}
 .manage-account__button {
     @include fs-textSans(2);
     background-color: $guardian-brand;
@@ -321,7 +311,7 @@
     align-items: center;
     justify-content: center;
 
-    &:hover {
+    &:not(.is-updating):hover {
         background-color: $guardian-brand-dark;
     }
 
@@ -347,4 +337,14 @@
         line-height: .8;
     }
 
+}
+%manage-account__button--light {
+    color: $guardian-brand;
+    background-color: transparent;
+    border: 1px solid $news-main-2;
+    &:not(.is-updating):hover {
+        color: $guardian-brand-dark;
+        background-color: transparent;
+        border-color: currentColor;
+    }
 }

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -284,3 +284,64 @@
         }
     }
 }
+
+/* Button styles
+========================================================================== */
+.manage-account__button {
+    @include fs-textSans(2);
+    background-color: $guardian-brand;
+    height: $gs-gutter * 2;
+    border-radius: 100px;
+    border: 0;
+    color: #ffffff;
+    cursor: pointer;
+    float: left;
+    padding: $gs-baseline/1.2 $gs-gutter $gs-baseline/1.5;
+    min-width: $gs-baseline * 14;
+    white-space: nowrap;
+    text-overflow: clip;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    box-sizing: border-box;
+    text-align: center;
+    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+        background-color: $guardian-brand-dark;
+    }
+
+    &:hover, &:active, &:focus {
+        color: #ffffff;
+        text-decoration: none;
+    }
+
+    &.is-updating {
+        border: 0;
+    }
+
+    &--light {
+        color: $guardian-brand;
+        background-color: transparent;
+        border: 1px solid $news-main-2;
+        &:not(.is-updating):hover {
+            color: $guardian-brand-dark;
+            background-color: transparent;
+            border-color: currentColor;
+        }
+    }
+
+    &--mini {
+        @include fs-textSans(1);
+        @extend .manage-account__button--light;
+        min-width: $gs-baseline * 10;
+        display: inline-flex;
+        height: $gs-gutter * 1.5;
+        line-height: .8;
+    }
+
+}


### PR DESCRIPTION
## What does this change?
Following #18205, fix a couple lingering layout issues. namely renaming the privacy tab to email as well as replacing all buttons from pasteup with the style used by the email preferences page, which is more in line with the rest of guardian buttons (pill shape, sans font)

## What is the value of this and can you measure success?
In addition to unifying the button styles, the email+privacy page now looks slightly less messy. This is a half step in preparation on larger changes for GDPR compliance so not much success to measure (YET!)

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![screen shot 2017-11-10 at 10 37 08](https://user-images.githubusercontent.com/11539094/32654503-41c2ff26-c603-11e7-96eb-5d2177df9d8d.png)

## Tested in CODE?
Not yet