### PR TITLE
Avoid package collision

### DIFF
--- a/commercial/app/views/CommercialBodyCleaner.scala
+++ b/commercial/app/views/CommercialBodyCleaner.scala
@@ -6,7 +6,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.support.{AtomsCleaner, withJsoup}
 
-object BodyCleaner {
+object CommercialBodyCleaner {
   def apply(article: HostedArticlePage, html: String)(implicit request: RequestHeader, context: ApplicationContext): Html = {
 
     val cleaners = List(

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -1,7 +1,7 @@
 @import common.commercial.hosted.HostedArticlePage
 @(page: HostedArticlePage)(implicit request: RequestHeader, context: model.ApplicationContext)
 @import views.html.hosted._
-@import views.BodyCleaner
+@import views.CommercialBodyCleaner
 @import model.hosted.HostedArticleQuotes.prepareQuotes
 
 @mainLegacy(page, Some("commercial")) { } {
@@ -25,7 +25,7 @@
                             </div>
                         </div>
 
-                        @BodyCleaner(page, body(page).toString())(request, context)
+                        @CommercialBodyCleaner(page, body(page).toString())(request, context)
 
                         <div class="hosted__onward-journey">
                             <div class="js-onward-placeholder"></div>


### PR DESCRIPTION
The commercial and article apps both have a views.BodyCleaner, which causes conflicts in the preview app.
