### PR TITLE
Remove switch for games link. The link is now just `/games`

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -2,7 +2,6 @@ package common
 
 import model._
 import play.api.mvc.RequestHeader
-import conf.switches.Switches.GamesLinkSwitch
 
 case class SectionLink(zone: String, title: String, breadcrumbTitle: String, href: String) {
   def currentFor(page: Page): Boolean = page.metadata.url == href ||
@@ -129,8 +128,7 @@ trait Navigation {
 
   //Technology
   val technologyblog = SectionLink("technology", "technology blog", "Technology blog", "/technology/blog")
-  private val gamesLink = if(GamesLinkSwitch.isSwitchedOn) "/games" else "/technology/games"
-  val games = SectionLink("culture", "games", "Games", gamesLink)
+  val games = SectionLink("culture", "games", "Games", "/games")
   val gamesblog = SectionLink("technology", "games blog", "Games blog", "/technology/gamesblog")
   val appsblog = SectionLink("technology", "apps blog", "Apps blog", "/technology/appsblog")
   val askjack = SectionLink("technology", "ask jack", "Ask Jack blog", "/technology/askjack")

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -525,15 +525,4 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 10, 24),
     exposeClientSide = false
   )
-
-  // This switch is just for the tag migration happening on 9/11/2017. Please delete this afterwards
-  val GamesLinkSwitch = Switch(
-    SwitchGroup.Feature,
-    "games-link-switch",
-    "When on, the link to games will be `/games`. When off, it will be `technology/games`",
-    owners = Seq(Owner.withGithub("natalialkb")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 11, 13),
-    exposeClientSide = false
-  )
 }

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -1,7 +1,5 @@
 package navigation
 
-import conf.switches.Switches.GamesLinkSwitch
-
 object NavLinks {
   /* NEWS */
 
@@ -96,8 +94,7 @@ object NavLinks {
   val film = NavLink("film", "/film", "film")
   val tvAndRadio = NavLink("tv & radio", "/tv-and-radio", "tv-and-radio")
   val music = NavLink("music", "/music", "music")
-  private val gamesId = if(GamesLinkSwitch.isSwitchedOn) "games" else "technology/games"
-  val games = NavLink("games", s"/$gamesId", gamesId)
+  val games = NavLink("games", "/games", "games")
   val books = NavLink("books", "/books", "books")
   val artAndDesign = NavLink("art & design", "/artanddesign", "artanddesign")
   val stage = NavLink("stage", "/stage", "stage")
@@ -141,7 +138,6 @@ object NavLinks {
   var holidays = NavLink("holidays", "https://holidays.theguardian.com")
 
   val tagPages = List(
-    "technology/games",
     "us-news/us-politics",
     "australia-news/australian-politics",
     "australia-news/australian-immigration-and-asylum",

--- a/common/app/navigation/SectionLinks.scala
+++ b/common/app/navigation/SectionLinks.scala
@@ -27,7 +27,6 @@ object SectionLinks {
     SectionsLink ("global-development", globalDevelopment, News),
     SectionsLink ("sustainable-business", sustainableBusiness, News),
     SectionsLink ("law", law, News),
-    SectionsLink ("technology/games", games, News),
     SectionsLink ("us-news/us-politics", usPolitics, News),
     SectionsLink ("australia-news/australian-politics", auPolitics, News),
     SectionsLink ("australia-news/australian-immigration-and-asylum", auImmigration, News),
@@ -70,6 +69,7 @@ object SectionLinks {
     SectionsLink ("artanddesign", artAndDesign, Arts),
     SectionsLink ("stage", stage, Arts),
     SectionsLink ("music/classicalmusicandopera", classical, Arts),
+    SectionsLink ("games", games, Arts),
 
     SectionsLink ("lifeandstyle", lifestyle, Life),
     SectionsLink ("fashion", fashion, Life),


### PR DESCRIPTION
## What does this change?
Cleanup after the tag migration for games

We don't need the switch, and games is under Arts in the Nav
