### PR TITLE
Header v3 navigation

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -101,7 +101,7 @@ object NavLinks {
   val classical = NavLink("classical", "/music/classicalmusicandopera", "music/classicalmusicandopera")
 
   /* LIFE */
-  val lifestyle = NavLink("life", "/lifeandstyle", "lifeandstyle", longTitle = "lifestyle home", iconName = "home")
+  val lifestyle = NavLink("lifestyle", "/lifeandstyle", "lifeandstyle", longTitle = "lifestyle home", iconName = "home")
   val fashion = NavLink("fashion", "/fashion", "fashion")
   val fashionAu = NavLink("fashion", "/au/lifeandstyle/fashion", "au/lifeandstyle/fashion")
   val food = NavLink("food", "/lifeandstyle/food-and-drink", "lifeandstyle/food-and-drink")

--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -12,7 +12,7 @@ case class NavLinkLists(mostPopular: Seq[NavLink], leastPopular: Seq[NavLink] = 
 object NewNavigation {
 
   val PrimaryLinks = List(headlines, opinion, sport, culture, lifestyle)
-  val topLevelSections = List(News, Opinion, Sport, Arts, Life)
+  val topLevelSections = List(News, Opinion, Sport, Arts, Lifestyle)
 
   trait EditionalisedNavigationSection {
     def name: String
@@ -42,7 +42,7 @@ object NewNavigation {
     case "opinion" => Opinion
     case "sport" => Sport
     case "arts" => Arts
-    case "life" => Life
+    case "lifestyle" => Lifestyle
   }
 
   case object MostPopular extends EditionalisedNavigationSection {
@@ -183,8 +183,8 @@ object NewNavigation {
     )
   }
 
-  case object Life extends EditionalisedNavigationSection {
-    val name = "life"
+  case object Lifestyle extends EditionalisedNavigationSection {
+    val name = "lifestyle"
 
     val uk = NavLinkLists(
       List(lifestyle, fashion, food, recipes, travel, loveAndSex, family),

--- a/common/app/navigation/SectionLinks.scala
+++ b/common/app/navigation/SectionLinks.scala
@@ -71,19 +71,19 @@ object SectionLinks {
     SectionsLink ("music/classicalmusicandopera", classical, Arts),
     SectionsLink ("games", games, Arts),
 
-    SectionsLink ("lifeandstyle", lifestyle, Life),
-    SectionsLink ("fashion", fashion, Life),
-    SectionsLink ("travel", travel, Life),
-    SectionsLink ("society", society, Life),
-    SectionsLink ("lifeandstyle/food-and-drink", food, Life),
-    SectionsLink ("tone/recipes", recipes, Life),
-    SectionsLink ("lifeandstyle/women", women, Life),
-    SectionsLink ("lifeandstyle/health-and-wellbeing", health, Life),
-    SectionsLink ("lifeandstyle/family", family, Life),
-    SectionsLink ("lifeandstyle/love-and-sex", loveAndSex, Life),
-    SectionsLink ("au/lifeandstyle/fashion", fashionAu, Life),
-    SectionsLink ("au/lifeandstyle/food-and-drink", foodAu, Life),
-    SectionsLink ("au/lifeandstyle/relationships", relationshipsAu, Life),
-    SectionsLink ("au/lifeandstyle/health-and-wellbeing", healthAu, Life)
+    SectionsLink ("lifeandstyle", lifestyle, Lifestyle),
+    SectionsLink ("fashion", fashion, Lifestyle),
+    SectionsLink ("travel", travel, Lifestyle),
+    SectionsLink ("society", society, Lifestyle),
+    SectionsLink ("lifeandstyle/food-and-drink", food, Lifestyle),
+    SectionsLink ("tone/recipes", recipes, Lifestyle),
+    SectionsLink ("lifeandstyle/women", women, Lifestyle),
+    SectionsLink ("lifeandstyle/health-and-wellbeing", health, Lifestyle),
+    SectionsLink ("lifeandstyle/family", family, Lifestyle),
+    SectionsLink ("lifeandstyle/love-and-sex", loveAndSex, Lifestyle),
+    SectionsLink ("au/lifeandstyle/fashion", fashionAu, Lifestyle),
+    SectionsLink ("au/lifeandstyle/food-and-drink", foodAu, Lifestyle),
+    SectionsLink ("au/lifeandstyle/relationships", relationshipsAu, Lifestyle),
+    SectionsLink ("au/lifeandstyle/health-and-wellbeing", healthAu, Lifestyle)
   )
 }

--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -14,8 +14,9 @@
             <a class="header-cta-item js-acquisition-link"
                data-link-name="amp : nav : supporter-cta"
                 href="@getReaderRevenueUrl(Membership, AmpHeader)">
-                <span class="header-cta-item__label">
-                    become a <span class="header-cta-item__new-line">supporter</span>
+                <span class="header-cta-item--circle"></span>
+                <span class="header-cta-item--text">
+                    become a <br>supporter</span>
                 </span>
             </a>
         </div>

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -7,7 +7,8 @@
 
 @subNavItem(link: NavLink, id: String, shouldHideUntilDesktop: Boolean) = {
     <li class="@RenderClasses(Map(
-            "hide-until-desktop" -> shouldHideUntilDesktop
+            "hide-until-desktop" -> shouldHideUntilDesktop,
+            "subnav__item--current-section" -> (id == link.uniqueSection)
         ), "subnav__item")">
         <a class="@RenderClasses(Map(
                 "subnav-link" -> true,
@@ -45,6 +46,7 @@
                         js-toggle-nav-section"
                         data-link-name="nav2 : subnav-toggle">
                         more
+                        <span class="subnav-link--toggle-more__icon"></span>
                     </button>
                 </li>
             }

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -25,7 +25,6 @@
 
 <div class="subnav">
     <div class="gs-container">
-
         @defining(NavigationHelpers.getActivePillar(page)) { case (id, activePillarName) =>
             <ul class="subnav__list"
                 data-pillar-title="@activePillarName">
@@ -36,10 +35,11 @@
                     @mostPopular.map { link => @subNavItem(link, id, false)}
                     @leastPopular.map { link => @subNavItem(link, id, true)}
                 }
+    	    </ul>
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!(id == "uk" ||  id == "us" ||  id == "au" ||  id == "international" || isFooter)) {
-                <li class="subnav__item js-visible hide-on-desktop">
+                <div class="subnav__item subnav__item--toggle-more js-visible hide-on-desktop">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more
@@ -48,9 +48,8 @@
                         more
                         <span class="subnav-link--toggle-more__icon"></span>
                     </button>
-                </li>
+                </div>
             }
-    	    </ul>
         }
     </div>
 </div>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -100,10 +100,12 @@
                        tabindex="0"
                        data-link-name="nav2 : veggie-burger : show">
                     <span class="veggie-burger hide-from-desktop">
-                         <span class="veggie-burger__icon"></span>
+                        <span class="veggie-burger__icon"></span>
                     </span>
+
                     <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
-                        <span class="pillar-link pillar-link--dropdown pillar-link--sections">
+                        <span class="u-h">All</span>
+
                         sections
                         <span class="pillar-link--dropdown__icon"></span>
                     </span>

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -79,6 +79,8 @@
                        data-link-name="nav2 : veggie-burger : show"
                        aria-controls="main-menu">
 
+                <div class="new-header__break"></div>
+
                 <ul class="pillars">
                     @NewNavigation.PrimaryLinks.map { link =>
                         <li class="pillars__item">
@@ -94,13 +96,17 @@
                 </ul>
 
                 <label for="main-menu-toggle"
-                       class="veggie-burger js-change-link"
+                       class="js-change-link new-header__menu-toggle"
                        tabindex="0"
                        data-link-name="nav2 : veggie-burger : show">
-                    <span class="veggie-burger__icon"></span>
-                    <span class="@RenderClasses(Map(
-                            "u-h" -> page.metadata.hasSlimHeader
-                        ), "veggie-burger__label")">All sections</span>
+                    <span class="veggie-burger hide-from-desktop">
+                         <span class="veggie-burger__icon"></span>
+                    </span>
+                    <span class="pillar-link pillar-link--dropdown pillar-link--sections hide-until-desktop">
+                        <span class="pillar-link pillar-link--dropdown pillar-link--sections">
+                        sections
+                        <span class="pillar-link--dropdown__icon"></span>
+                    </span>
                 </label>
 
                 @fragments.nav.newHeaderMenu()

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -79,8 +79,6 @@
                        data-link-name="nav2 : veggie-burger : show"
                        aria-controls="main-menu">
 
-                <div class="new-header__break"></div>
-
                 <ul class="pillars">
                     @NewNavigation.PrimaryLinks.map { link =>
                         <li class="pillars__item">

--- a/onward/test/NavigationControllerTest.scala
+++ b/onward/test/NavigationControllerTest.scala
@@ -47,6 +47,6 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     contentAsString(result) should include("\"opinion\"")
     contentAsString(result) should include("\"sport\"")
     contentAsString(result) should include("\"arts\"")
-    contentAsString(result) should include("\"life\"")
+    contentAsString(result) should include("\"lifestyle\"")
   }
 }

--- a/static/src/stylesheets/amp/header/_header-cta-item.scss
+++ b/static/src/stylesheets/amp/header/_header-cta-item.scss
@@ -1,35 +1,14 @@
 .header-cta-item {
     color: $guardian-brand-dark;
-
-    &:before {
-        border-top: $gs-baseline * 4 solid $news-main-2;
-        border-left: $gs-gutter / 4 solid transparent;
-        border-right: $gs-gutter solid transparent;
-        content: '';
-        left: 0;
-        position: absolute;
-        right: -$gs-gutter / 2;
-        top: -$gs-baseline / 2;
-        transform: rotate(-3deg);
-        transition: border-color 250ms, transform 250ms;
-
-        @include mq(mobileMedium) {
-            border-top-width: ($gs-baseline * 4) + ($gs-baseline / 2);
-        }
-    }
 }
 
-.header-cta-item__label {
-    display: inline-block;
+.header-cta-item--text {
+    box-sizing: border-box;
+    display: block;
+    padding: ($gs-baseline / 2 + $gs-baseline / 4) ($gs-gutter) ($gs-baseline / 4);
+    position: relative;
     font-size: 13px;
     line-height: 1;
-    padding: $gs-baseline $gs-gutter / 2;
-    position: relative;
-
-    @include mq(mobileMedium) {
-        font-size: 14px;
-        padding-top: 14px;
-    }
 
     .guardian-egyptian-loaded & {
         font-family: 'Guardian Egyptian Web', Georgia, serif;
@@ -37,6 +16,25 @@
     }
 }
 
-.header-cta-item__new-line {
-    display: block;
+.header-cta-item--circle {
+    bottom: -$gs-baseline;
+    left: 0;
+    overflow: hidden;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: transform 250ms ease-out;
+    transform-origin: top center;
+
+    &:before {
+        background: $news-main-2;
+        border-radius: 50%;
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        padding-top: 100%;
+        position: absolute;
+        right: 0;
+    }
 }

--- a/static/src/stylesheets/amp/header/_header.scss
+++ b/static/src/stylesheets/amp/header/_header.scss
@@ -6,12 +6,12 @@
 }
 
 .header__cta-container {
-    left: $gs-gutter / 4;
+    left: -$gs-gutter / 2;
     position: absolute;
     top: 0;
 
     @include mq(mobileLandscape) {
-        left: $gs-gutter / 2;
+        left: 0;
     }
 }
 
@@ -32,5 +32,9 @@
     @include mq(mobileMedium) {
         height: calc(3 / 16 * 225px);
         width: 225px;
+    }
+
+    @include mq(mobileLandscape) {
+        margin-right: $gs-gutter
     }
 }

--- a/static/src/stylesheets/amp/header/_pillar-link.scss
+++ b/static/src/stylesheets/amp/header/_pillar-link.scss
@@ -1,17 +1,25 @@
 .pillar-link {
     font-size: 16px;
-    font-size: 5.1vw; // scss-lint:disable-line no-duplicate-properties
-    line-height: $gs-baseline * 2.5;
+    display: block;
+    height: $veggie-burger-medium - $gs-baseline;
+    line-height: $veggie-burger-medium - $gs-baseline;
+    padding: 0 ($gs-gutter / 4);
+    position: relative;
     color: currentColor;
     cursor: pointer;
 
     @include mq(mobileMedium) {
-        line-height: $gs-baseline * 3;
+        font-size: 18px;
     }
 
-    @include mq(mobileLandscape) {
-        font-size: 24px;
-        line-height: $gs-baseline * 3.5;
+    &:before {
+        content: '';
+        display: block;
+        left: 0;
+        bottom: 0;
+        position: absolute;
+        border-left: 1px solid $news-support-2;
+        top: $gs-baseline + 1;
     }
 
     .guardian-text-sans-loaded & {

--- a/static/src/stylesheets/amp/header/_pillars.scss
+++ b/static/src/stylesheets/amp/header/_pillars.scss
@@ -1,29 +1,24 @@
 .pillars {
-    color: $news-support-1;
+    color: #ffffff;
     font-size: 0;
+    height: $veggie-burger-medium - $gs-baseline;
     margin: 0;
     padding: 0 $gs-gutter / 2;
-    width: 100%;
 
     @include mq(mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
+        padding: 0 0 0 $gs-gutter;
     }
 }
 
 .pillars__item {
-    display: inline-block;
+    display: block;
+    float: left;
 
-    > *:after {
-        content: '/';
-        color: $news-main-2;
-        margin-left: -1px;
-        margin-right: 2px;
-        opacity: .6;
-        pointer-events: none;
-    }
+    &:first-child .pillar-link {
+        padding-left: 0;
 
-    &:last-child > *:after {
-        display: none;
+        &:before {
+            content: none;
+        }
     }
 }

--- a/static/src/stylesheets/amp/header/_pillars.scss
+++ b/static/src/stylesheets/amp/header/_pillars.scss
@@ -1,12 +1,11 @@
 .pillars {
     color: #ffffff;
-    font-size: 0;
     height: $veggie-burger-medium - $gs-baseline;
     margin: 0;
     padding: 0 $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
-        padding: 0 0 0 $gs-gutter;
+        padding-left: $gs-gutter;
     }
 }
 

--- a/static/src/stylesheets/amp/header/_veggie-burger.scss
+++ b/static/src/stylesheets/amp/header/_veggie-burger.scss
@@ -2,7 +2,7 @@
     background-color: $news-main-2;
     bottom: -$gs-baseline / 2;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
-    color: #ffffff;
+    color: $guardian-brand-dark;
     cursor: pointer;
     height: $veggie-burger-medium;
     min-width: $veggie-burger-medium;
@@ -12,13 +12,13 @@
     outline: none;
     right: $gutter-small;
 
-    @include mq(mobileMedium) {
+    @include mq(mobileLandscape) {
         right: $gutter-medium;
     }
 }
 
 .veggie-burger__icon {
-    margin-top: -($gs-baseline / 6) / 2;
+    margin-top: -1px;
     right: 0;
     margin-left: auto;
     margin-right: auto;
@@ -35,10 +35,10 @@
     }
 
     &:before {
-        top: -$gs-gutter / 4;
+        top: -$gs-baseline / 2;
     }
 
     &:after {
-        bottom: -$gs-gutter / 4;
+        bottom: -$gs-baseline / 2;
     }
 }

--- a/static/src/stylesheets/amp/header/_veggie-burger.scss
+++ b/static/src/stylesheets/amp/header/_veggie-burger.scss
@@ -4,8 +4,8 @@
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
     color: #ffffff;
     cursor: pointer;
-    height: $veggie-burger-small;
-    min-width: $veggie-burger-small;
+    height: $veggie-burger-medium;
+    min-width: $veggie-burger-medium;
     position: absolute;
     border: 0;
     border-radius: 50%;
@@ -13,9 +13,6 @@
     right: $gutter-small;
 
     @include mq(mobileMedium) {
-        height: $veggie-burger-medium;
-        width: $veggie-burger-medium;
-        //Align with the 'i' in 'theguardian'
         right: $gutter-medium;
     }
 }

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -58,6 +58,12 @@
     }
 }
 
+.hide-from-desktop {
+    @include mq(desktop) {
+        display: none !important;
+    }
+}
+
 .hide-from-leftcol {
     @include mq(leftCol) {
         display: none !important;

--- a/static/src/stylesheets/layout/footer/_back-to-top.scss
+++ b/static/src/stylesheets/layout/footer/_back-to-top.scss
@@ -5,45 +5,27 @@
 
 .footer__back-to-top {
     @include fs-textSans(4);
+    font-size: 16px;
     position: relative;
     text-align: right;
-
-    @include mq($from: mobile, $until: mobileLandscape) {
-        font-size: 14px;
-        font-size: 4.6vw;
-    }
-
-    @include mq(mobileLandscape) {
-        font-size: 20px;
-    }
 }
 
 .back-to-top__text {
     display: inline-block;
     color: $news-support-1;
-    line-height: 32px;
+    line-height: 42px;
     padding-right: $gs-gutter / 2;
-
-    @include mq(mobileMedium) {
-        line-height: 43px;
-    }
 }
 
 .back-to-top__icon-container {
     position: relative;
     float: right;
     margin-top: -($gs-baseline / 2);
-    margin-bottom: -($gs-baseline / 2);
     border-radius: 100%;
     background-color: $news-main-2;
     cursor: pointer;
-    height: $veggie-burger-small;
-    min-width: $veggie-burger-small;
-
-    @include mq(mobileMedium) {
-        height: $veggie-burger-medium;
-        width: $veggie-burger-medium;
-    }
+    height: $veggie-burger-medium;
+    min-width: $veggie-burger-medium;
 }
 
 .back-to-top__icon {
@@ -54,17 +36,12 @@
         left: 0;
         right: 0;
         margin: auto;
-        border: 2px solid #ffffff;
+        border: 2px solid $guardian-brand-dark;
         border-bottom: 0;
         border-right: 0;
         content: '';
-        height: 11px;
-        width: 11px;
+        height: 9px;
+        width: 9px;
         transform: rotate(45deg);
-
-        @include mq(mobileMedium) {
-            height: 14px;
-            width: 14px;
-        }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -26,7 +26,7 @@
     }
 
     @include mq(mobileMedium) {
-        margin-right: $gutter-medium + ($veggie-burger-medium / 2);
+        margin-right: $gutter-small + ($veggie-burger-medium / 2);
     }
 
     // based on https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6

--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -6,7 +6,7 @@
     font-size: 20px;
     left: 0;
     line-height: 1;
-    margin-right: $gutter-small + ($veggie-burger-small / 2);
+    margin-right: $gutter-small + ($veggie-burger-medium / 2);
     padding-bottom: $gs-baseline * 2;
     top: 0;
     z-index: $zindex-main-menu;
@@ -27,14 +27,6 @@
 
     @include mq(mobileMedium) {
         margin-right: $gutter-medium + ($veggie-burger-medium / 2);
-    }
-
-    @include mq(mobileLandscape) {
-        margin-right: $gutter-large + ($veggie-burger-medium / 2);
-    }
-
-    @include mq(tablet) {
-        margin-right: $gutter-xlarge + ($veggie-burger-medium / 2);
     }
 
     // based on https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6

--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -29,6 +29,10 @@
         margin-right: $gutter-small + ($veggie-burger-medium / 2);
     }
 
+    @include mq(mobileLandscape) {
+        margin-right: $gutter-medium + ($veggie-burger-medium / 2);
+    }
+
     // based on https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6
     @include mq(desktop) {
         display: none;

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -45,7 +45,6 @@ from scrolling */
         align-items: flex-start;
         display: flex;
         flex-wrap: wrap;
-        justify-content: space-between;
         padding-bottom: 0;
     }
 }
@@ -98,13 +97,25 @@ from scrolling */
     }
 }
 
+.new-header__menu-toggle {
+    &:focus {
+        outline: 0;
+    }
+}
+
+.new-header--slim .new-header__menu-toggle {
+    @include mq(desktop) {
+        order: -1;
+    }
+}
+
 .new-header__logo__svg {
     display: block;
-    height: calc(3 / 16 * 170px);
+    height: calc(3 / 16 * 180px);
     margin-bottom: $gs-baseline / 2;
     margin-right: $gs-gutter / 2;
     margin-top: $gs-baseline / 2;
-    width: 170px;
+    width: 180px;
 
     @include mq(mobileMedium) {
         height: calc(3 / 16 * 225px);
@@ -112,41 +123,45 @@ from scrolling */
     }
 
     @include mq(mobileLandscape) {
-        height: calc(3 / 16 * 260px);
         margin-bottom: 0;
         margin-right: $gs-gutter;
-        width: 260px;
     }
 
     @include mq(tablet) {
         height: calc(3 / 16 * 345px);
-        margin-bottom: -5px;
         margin-top: $gs-baseline + $gs-baseline / 4;
         width: 345px;
     }
 
-    @include mq(leftCol) {
+    @include mq(desktop) {
         height: calc(3 / 16 * 385px);
-        margin-bottom: -1px;
+        margin-top: $gs-baseline + $gs-baseline / 4;
+        margin-bottom: -$gs-gutter;
         width: 385px;
     }
 
     .new-header--slim & {
-        height: calc(3 / 16 * 155px);
-        margin-right: $gs-gutter;
-        margin-top: 7px;
-        width: 155px;
+        height: calc(3 / 16 * 180px);
+        margin: 5px ($veggie-burger-large + $gs-gutter) 0 0;
+        width: 180px;
 
         @include mq(mobileLandscape) {
-            margin-right: $gs-gutter * 1.5;
+            margin-right: $veggie-burger-large + $gs-gutter + ($gs-gutter / 2);
         }
 
-        @include mq(tablet) {
-            height: calc(3 / 16 * 170px);
-            margin-top: 5px;
-            width: 170px;
+        @include mq(desktop) {
+            margin-right: $gs-gutter;
         }
     }
+}
+
+.new-header--slim {
+    height: $veggie-burger-large - $gs-baseline;
+}
+
+// This is to force the primary links (news, opinion, sport, arts, lifestyle) onto a new line
+.new-header__break {
+    width: 100%;
 }
 
 // Don't show trapezoid on opera mini: https://wp-mix.com/css-target-opera/

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -79,6 +79,20 @@ from scrolling */
 }
 
 .new-header__menu-toggle {
+    @include mq($until: desktop) {
+        bottom: -$gs-baseline / 2;
+        position: absolute;
+        right: $gutter-small;
+    }
+
+    @include mq(mobileLandscape) {
+        right: $gutter-medium;;
+    }
+
+    @include mq($from: tablet, $until: desktop) {
+        right: $gutter-large;
+    }
+
     &:focus {
         outline: 0;
     }

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -40,13 +40,6 @@ from scrolling */
 
 .new-header__inner {
     @include clearfix();
-
-    @supports(display: flex) {
-        align-items: flex-start;
-        display: flex;
-        flex-wrap: wrap;
-        padding-bottom: 0;
-    }
 }
 
 .new-header__edition-container {
@@ -78,18 +71,6 @@ from scrolling */
     display: block;
     float: right;
 
-    @supports(display: flex) {
-        display: flex;
-        float: none;
-        margin-left: auto;
-    }
-
-    @include mq(desktop) {
-        &:focus {
-            outline: none;
-        }
-    }
-
     .new-header--slim.new-header--open & {
         @include mq($from: desktop, $until: leftCol) {
             display: none;
@@ -100,12 +81,6 @@ from scrolling */
 .new-header__menu-toggle {
     &:focus {
         outline: 0;
-    }
-}
-
-.new-header--slim .new-header__menu-toggle {
-    @include mq(desktop) {
-        order: -1;
     }
 }
 
@@ -157,11 +132,6 @@ from scrolling */
 
 .new-header--slim {
     height: $veggie-burger-large - $gs-baseline;
-}
-
-// This is to force the primary links (news, opinion, sport, arts, lifestyle) onto a new line
-.new-header__break {
-    width: 100%;
 }
 
 // Don't show trapezoid on opera mini: https://wp-mix.com/css-target-opera/

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -42,7 +42,7 @@
         z-index: 1;
 
         @include mq(tablet) {
-            top: $gs-baseline / 2;
+            top: $gs-baseline / 2 + 3;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -67,6 +67,7 @@
         font-size: 20px;
         height: $veggie-burger-large - $gs-baseline;
         line-height: $veggie-burger-large - $gs-baseline;
+        padding-top: 0;
 
         &:before {
             top: 17px;

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -1,77 +1,123 @@
 .pillar-link {
     @include fs-textSans(5);
-    box-sizing: border-box;
     color: currentColor;
     cursor: pointer;
     display: block;
     font-size: 16px;
-    font-size: 4.9vw;
-    line-height: $gs-baseline * 2.5;
+    height: $veggie-burger-medium - $gs-baseline;
+    line-height: $veggie-burger-medium - $gs-baseline;
+    padding: 0 ($gs-gutter / 4);
     position: relative;
-    transition: color 350ms;
+    transition: color 150ms ease-out;
 
     @include mq(mobileMedium) {
-        line-height: $gs-baseline * 3;
-    }
-
-    @include mq(mobileLandscape) {
-        font-size: 24px;
-        line-height: $gs-baseline * 3.5;
+        font-size: 18px;
     }
 
     @include mq(tablet) {
-        font-size: 28px;
+        font-size: 24px;
+        height: $gs-baseline * 3 + $gs-baseline / 2;
         letter-spacing: -.04rem;
+        line-height: 1;
+        padding: ($gs-baseline / 4) ($gs-gutter) 0 ($gs-gutter / 4);
     }
 
-    @include mq(desktop) {
-        font-size: 32px;
+    @include mq(leftCol) {
+        padding: ($gs-baseline / 4) ($gs-gutter * 2) 0 ($gs-gutter / 3);
     }
 
-    &:focus,
-    &:hover {
+    &:before,
+    &:after {
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        position: absolute;
+    }
+
+    &:before {
+        // Dividing lines
+        border-left: 1px solid $news-support-2;
+        top: $gs-baseline + 1;
+        z-index: 1;
+
+        @include mq(tablet) {
+            top: $gs-baseline / 2;
+        }
+    }
+
+    &:after {
+        // Underlines
+        border-bottom: 0 solid $news-main-2;
+        right: 0;
+        transition: border 150ms ease-out;
+    }
+
+    &:hover,
+    &:focus {
         color: #ffffff;
-        outline: none;
         text-decoration: none;
+
+        &:not(.pillar-link--dropdown):after {
+            border-bottom-width: 4px;
+        }
     }
 
     .new-header--slim & {
-        @include mq(tablet) {
-            font-size: 24px;
+        font-size: 20px;
+        height: $veggie-burger-large - $gs-baseline;
+        line-height: $veggie-burger-large - $gs-baseline;
+
+        &:before {
+            top: 17px;
         }
     }
 }
 
 .pillar-link--current-section {
-    color: #ffffff;
+    font-weight: 700;
 
-    @include mq(desktop) {
-        .new-header--open & {
-            color: $news-support-1;
-
-            &:focus,
-            &:hover {
-                color: #ffffff;
-                text-decoration: none;
-            }
-        }
+    &:after {
+        border-bottom-width: 4px;
     }
 
-    // triangle
-    &:before {
-        content: '';
-        position: absolute;
-        left: 50%;
-        bottom: 0;
-        transform: translateX(-100%);
-        border-bottom: $gs-baseline / 2 solid $subnav-grey;
-        border-left: $gs-baseline / 2 solid transparent;
-        border-right: $gs-baseline / 2 solid transparent;
+    .new-header--open & {
+        font-weight: normal;
 
-        @include mq(desktop) {
-            .new-header--open & {
-                display: none;
-            }
+        &:after {
+            border-bottom-width: 0;
+        }
+    }
+}
+
+.pillar-link--dropdown__icon {
+    border: 2px solid currentColor;
+    border-left: transparent;
+    border-top: transparent;
+    display: inline-block;
+    height: 6px;
+    margin-left: 2px;
+    transform: translateY(-2px) rotate(45deg);
+    transition: transform 250ms ease-out;
+    vertical-align: middle;
+    width: 6px;
+
+    .pillar-link--dropdown:hover &,
+    .new-header--open & {
+        transform: translateY(0) rotate(45deg);
+    }
+}
+
+.pillar-link--sections {
+    color: $news-support-1;
+    float: left;
+
+    .new-header--open & {
+        color: #ffffff;
+        background-color: $guardian-brand-dark;
+
+        &:before {
+            content: none;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -104,7 +104,8 @@
     width: 6px;
 
     .pillar-link--dropdown:hover &,
-    .new-header--open & {
+    .new-header--open &,
+    .new-header__menu-toggle:focus & {
         transform: translateY(0) rotate(45deg);
     }
 }
@@ -120,5 +121,9 @@
         &:before {
             content: none;
         }
+    }
+
+    .new-header__menu-toggle:focus & {
+        color: #ffffff;
     }
 }

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -5,11 +5,9 @@
     list-style: none;
     margin: 0;
     padding: 0 $gs-gutter / 2;
-    width: 100%;
 
     @include mq(mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
+        padding: 0 0 0 $gs-gutter;
     }
 
     @include mq(desktop) {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -1,6 +1,6 @@
 .pillars {
     clear: right;
-    color: $news-support-1;
+    color: #ffffff;
     font-size: 0;
     list-style: none;
     margin: 0;
@@ -17,7 +17,6 @@
     }
 
     .new-header--slim & {
-        width: auto;
         order: -1;
 
         @include mq($until: tablet) {
@@ -27,50 +26,18 @@
 }
 
 .pillars__item {
-    box-sizing: border-box;
-    display: inline-block;
+    display: block;
+    float: left;
 
-    @include mq(desktop) {
-        min-width: 0;
-        padding-right: $gs-gutter;
-        transition: min-width 200ms ease;
-        will-change: min-width;
-
-        .new-header--open & {
-            min-width: gs-span(2) + $gs-gutter / 2;
-        }
-
-        .new-header--open &:not(:first-child) {
-            margin-left: $gs-gutter / 2;
-        }
+    &:hover .pillar-link {
+        color: #ffffff;
     }
 
-    > *:after {
-        content: '/';
-        color: $news-main-2;
-        display: inline-block;
-        margin-left: -1px;
-        margin-right: 2px;
-        pointer-events: none;
+    &:first-child .pillar-link {
+        padding-left: 0;
 
-        // Slashes switch to left hand side for open animation
-        @include mq(desktop) {
-            left: -$gs-gutter / 1.5;
-            margin: 0;
-            position: absolute;
-            top: 0;
-        }
-    }
-
-    @include mq($until: desktop) {
-        &:last-child > *:after {
-            display: none;
-        }
-    }
-
-    @include mq(desktop) {
-        &:first-child > *:after {
-            display: none;
+        &:before {
+            content: none;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -21,6 +21,10 @@
             display: none;
         }
     }
+
+    .new-header--open & {
+        color: $news-support-1;
+    }
 }
 
 .pillars__item {

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -1,13 +1,11 @@
 .pillars {
     clear: right;
     color: #ffffff;
-    font-size: 0;
-    list-style: none;
     margin: 0;
     padding: 0 $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
-        padding: 0 0 0 $gs-gutter;
+        padding-left: $gs-gutter;
     }
 
     @include mq(desktop) {
@@ -17,7 +15,7 @@
     }
 
     .new-header--slim & {
-        order: -1;
+        clear: none;
 
         @include mq($until: tablet) {
             display: none;

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -2,7 +2,7 @@
     @include fs-textSans(5);
     color: $neutral-1;
     display: block;
-    font-size: 16px;
+    font-size: 15px;
     height: $veggie-burger-medium - $gs-baseline;
     line-height: $veggie-burger-medium - $gs-baseline;
     padding: 0 ($gs-gutter / 4);
@@ -29,6 +29,10 @@
         border-bottom: 0 solid $neutral-3;
         right: 0;
         transition: border 150ms ease-out;
+    }
+
+    @include mq($from: mobileMedium, $until: tablet) {
+        font-size: 17px;
     }
 
     @include mq(tablet) {
@@ -74,7 +78,7 @@
 .subnav-link--toggle-more__icon {
     top: 50%;
     float: right;
-    margin-top: -($gs-baseline / 6) / 2;
+    transform: translateY(-50%);
 
     &,
     &:before,
@@ -96,7 +100,6 @@
         bottom: -4px;
     }
 }
-
 
 .subnav-link--current-section {
     font-weight: 700;

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -1,34 +1,103 @@
 .subnav-link {
     @include fs-textSans(5);
-    color: currentColor;
-    display: inline-block;
+    color: $neutral-1;
+    display: block;
     font-size: 16px;
-    font-size: 4.9vw;
-    line-height: 1.3em;
+    height: $veggie-burger-medium - $gs-baseline;
+    line-height: $veggie-burger-medium - $gs-baseline;
+    padding: 0 ($gs-gutter / 4);
+    position: relative;
 
-    @include mq(mobileLandscape) {
-        font-size: 19px;
-        max-height: $gs-baseline * 4.8;
+    &:before,
+    &:after {
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        position: absolute;
     }
 
-    @include mq(desktop) {
-        // to make sure that the words are not visible on subnav desktop if they fall to the second line
-        margin-bottom: $gs-baseline;
+    &:before {
+        // Dividing lines
+        border-left: 1px solid $neutral-4;
+        top: 14px;
+        z-index: 1;
+    }
+
+    &:after {
+        // Underlines
+        border-bottom: 0 solid $neutral-3;
+        right: 0;
+        transition: border 150ms ease-out;
+    }
+
+    @include mq(tablet) {
+        height: 42px;
+        line-height: 42px;
+        padding: 0 ($gs-gutter / 2 + $gs-gutter / 4) 0 ($gs-gutter / 4);
+
+        &:before {
+            top: 18px;
+        }
     }
 
     &:hover,
     &:focus {
+        color: $neutral-1;
         text-decoration: none;
+
+        &:not(.subnav-link--toggle-more):after {
+            border-bottom-width: 4px;
+        }
+    }
+
+    .subnav__item:first-child > & {
+        padding-left: 0;
+
+        &:before {
+            content: none;
+        }
     }
 }
 
 .subnav-link--toggle-more {
     background: transparent;
     border: 0;
-    color: $neutral-3;
-    padding: 0;
+    color: $neutral-2;
+    padding-right: $gs-gutter / 3;
 }
 
+.subnav-link--toggle-more__icon {
+    top: 50%;
+    float: right;
+    margin-top: -($gs-baseline / 6) / 2;
+
+    &,
+    &:before,
+    &:after {
+        background-color: currentColor;
+        border-radius: 50%;
+        content: '';
+        height: 3px;
+        right: 0;
+        position: absolute;
+        width: 3px;
+    }
+
+    &:before {
+        top: -4px;
+    }
+
+    &:after {
+        bottom: -4px;
+    }
+}
+
+
 .subnav-link--current-section {
-    color: #ffffff;
+    font-weight: 700;
+
+    &:after {
+        border-bottom-width: 4px;
+    }
 }

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -65,6 +65,10 @@
     border: 0;
     color: $neutral-2;
     padding-right: $gs-gutter / 3;
+
+    &:focus {
+        outline: 0;
+    }
 }
 
 .subnav-link--toggle-more__icon {

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -86,18 +86,18 @@
         background-color: currentColor;
         border-radius: 50%;
         content: '';
-        height: 3px;
+        height: 2px;
         right: 0;
         position: absolute;
-        width: 3px;
+        width: 2px;
     }
 
     &:before {
-        top: -4px;
+        top: -$gs-baseline / 4;
     }
 
     &:after {
-        bottom: -4px;
+        bottom: -$gs-baseline / 4;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -1,37 +1,21 @@
 .subnav {
-    background-color: $subnav-grey;
-    color: $neutral-4;
-    max-height: $gs-baseline * 3.4;
+    background-color: #ffffff;
+    border-bottom: 1px solid $neutral-5;
+    color: $neutral-1;
+    height: $veggie-burger-medium - $gs-baseline;
     overflow: hidden;
-    padding: $gs-baseline / 3 $gs-gutter / 2;
-
-    @include mq(mobile) {
-        max-height: $gs-baseline * 3.5;
-        max-height: 13vw;
-    }
+    padding: 0 $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
-        padding: $gs-baseline / 2 0;
+        padding: 0;
     }
 
-    @include mq(desktop) {
-        max-height: $gs-baseline * 2;
+    @include mq(tablet) {
+        height: 42px;
     }
 
-    // Spacer to prevent text from sitting directly beneath the veggie burger
-    &:before {
-        content: '';
-        float: right;
-        width: $gutter-small + $veggie-burger-small - ($gs-gutter / 2);
-        height: 1px;
-
-        @include mq(mobileMedium) {
-            width: $gutter-medium + $veggie-burger-medium - ($gs-gutter / 2);
-        }
-
-        @include mq(mobileLandscape) {
-            width: $gutter-large + $veggie-burger-medium - ($gs-gutter / 2);
-        }
+    .l-footer & {
+        border-top: 1px solid $neutral-5;
     }
 }
 
@@ -53,42 +37,12 @@
 }
 
 .subnav__item {
-    display: inline-block;
-
-    &:focus,
-    &:hover {
-        color: #ffffff;
-    }
+    display: block;
+    float: left;
 
     @include mq($until: tablet) {
-        > *:after {
-            content: '/';
-            color: rgba(255, 255, 255, .3);
-            display: inline-block;
-            font-size: 1em;
-            pointer-events: none;
-            margin-left: -2px;
-            margin-right: -2px;
-        }
-
-        &:last-child > *:after {
-            content: '';
-        }
-    }
-
-    @include mq(tablet) {
-        > *:before {
-            content: '/';
-            color: rgba(255, 255, 255, .3);
-            display: inline-block;
-            font-size: 1em;
-            pointer-events: none;
-            margin-left: -2px;
-            margin-right: -2px;
-        }
-
-        &:first-child > *:before {
-            content: '';
+        &:nth-child(1n+4):not(:last-child):not(.subnav__item--current-section) {
+            display: none;
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -41,8 +41,11 @@
     float: left;
 
     @include mq($until: tablet) {
-        &:nth-child(1n+4):not(:last-child):not(.subnav__item--current-section) {
+        // Hides all but the first 2 subnav items and doesn't hide the more button
+        &:nth-child(1n+3):not(:last-child) {
             display: none;
         }
+
+        // TODO: Update logic with a class on <ul> that will allow active subnav items to be shown
     }
 }

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -4,11 +4,6 @@
     color: $neutral-1;
     height: $veggie-burger-medium - $gs-baseline;
     overflow: hidden;
-    padding: 0 $gs-gutter / 2;
-
-    @include mq(mobileLandscape) {
-        padding: 0;
-    }
 
     @include mq(tablet) {
         height: 42px;
@@ -21,31 +16,21 @@
 
 // TODO: reset list-style mixin
 .subnav__list {
+    box-sizing: border-box;
     line-height: 1;
     list-style: none;
     margin: 0;
-    padding: 0;
+    // Width of the container minus the rough width of the more toggle
+    max-width: calc(100% - 60px);
+    padding: 0 $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
-        padding-left: $gs-gutter;
-        padding-right: $gs-gutter;
-    }
-
-    @include mq(desktop) {
-        padding-right: $gs-column-width * 3;
+        max-width: calc(100% - 70px);
+        padding: 0 $gs-gutter;
     }
 }
 
-.subnav__item {
+.subnav__item:not(.subnav__item--toggle-more) {
     display: block;
     float: left;
-
-    @include mq($until: tablet) {
-        // Hides all but the first 2 subnav items and doesn't hide the more button
-        &:nth-child(1n+3):not(:last-child) {
-            display: none;
-        }
-
-        // TODO: Update logic with a class on <ul> that will allow active subnav items to be shown
-    }
 }

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -29,7 +29,7 @@
         text-decoration: none;
     }
 
-    @include mq(desktop) {
+    @include mq(tablet) {
         font-size: 15px;
     }
 }

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -1,6 +1,6 @@
 // Specific values for veggie-burger and menu
 $gutter-small: 5px;
-$gutter-medium: 50px;
+$gutter-medium: 49px;
 $gutter-large: 73px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;

--- a/static/src/stylesheets/layout/new-header/_variables.scss
+++ b/static/src/stylesheets/layout/new-header/_variables.scss
@@ -1,9 +1,7 @@
 // Specific values for veggie-burger and menu
-$gutter-small: 29px;
-$gutter-medium: 37px;
-$gutter-large: 55px;
-$gutter-xlarge: 75px;
-$gutter-xxlarge: 80px;
+$gutter-small: 5px;
+$gutter-medium: 50px;
+$gutter-large: 73px;
 
 $menu-spacing-left-small: $gs-gutter * 2 + $gs-gutter / 2;
 $menu-spacing-left-medium: $gs-gutter * 2 + $gs-gutter;
@@ -12,6 +10,5 @@ $search-and-edition-height-desktop: 42px;
 
 $highlight-blue: #74e7ff;
 
-$veggie-burger-small: 42px;
-$veggie-burger-medium: 54px;
-$veggie-burger-large: 60px;
+$veggie-burger-medium: 48px;
+$veggie-burger-large: 56px;

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -17,26 +17,6 @@
             }
         }
 
-        & ~ .pillars {
-            .pillars__item {
-                @include mq(desktop) {
-                    min-width: gs-span(2) + $gs-gutter / 2;
-                }
-            }
-
-            .pillars__item:not(:first-child) {
-                @include mq(desktop) {
-                    margin-left: $gs-gutter / 2;
-                }
-            }
-
-            .pillar-link--current-section:before {
-                @include mq(desktop) {
-                    display: none;
-                }
-            }
-        }
-
         & ~ .veggie-burger {
             z-index: $zindex-main-menu + 1;
 

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -1,5 +1,6 @@
 .veggie-burger-fallback {
     &:checked {
+
         & ~ .menu {
             @include mq($until: desktop) {
                 @include menu-animation(0%);

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -40,9 +40,22 @@
                 }
             }
         }
-    }
 
-    &:focus ~ .veggie-burger {
-        background-color: darken($news-main-2, 10%);
+        & ~ .new-header__menu-toggle .pillar-link--sections {
+            color: #ffffff;
+            background-color: $guardian-brand-dark;
+
+            &:before {
+                content: none;
+            }
+
+            .pillar-link--dropdown__icon {
+                transform: translateY(0) rotate(45deg);
+            }
+        }
+
+        & ~ .pillars {
+            color: $news-support-1;
+        }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -2,10 +2,10 @@
     background-color: $news-main-2;
     bottom: -$gs-baseline / 2;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
-    color: #ffffff;
+    color: $guardian-brand-dark;
     cursor: pointer;
-    height: $veggie-burger-small;
-    min-width: $veggie-burger-small;
+    height: $veggie-burger-medium;
+    width: $veggie-burger-medium;
     position: absolute;
     border: 0;
     border-radius: 50%;
@@ -14,52 +14,20 @@
     user-select: none;
     z-index: 1;
 
-    @include mq(mobileMedium) {
-        height: $veggie-burger-medium;
-        width: $veggie-burger-medium;
-        //Align with the 'i' in 'theguardian'
-        right: $gutter-medium;
-    }
-
     @include mq(mobileLandscape) {
-        right: $gutter-large;
+        right: $gutter-medium;;
     }
 
     @include mq(tablet) {
-        right: $gutter-xlarge;
-    }
-
-    @include mq(leftCol) {
         height: $veggie-burger-large;
-        right: $gutter-xxlarge;
         width: $veggie-burger-large;
+        right: $gutter-large;
     }
-
 
     // menu is open
     .new-header--open & {
+        background-color: $highlight-blue;
         z-index: $zindex-main-menu + 1;
-
-        &:before {
-            @include mq($until: desktop) {
-                border-radius: ($veggie-burger-small * 2) 0 0 ($veggie-burger-small * 2);
-                // Extended hit area for veggie burger close state, for fat fingers
-                content: '';
-                height: $veggie-burger-small * 2;
-                position: absolute;
-                right: $veggie-burger-small / 2;
-                top: -$veggie-burger-small / 2;
-                width: $veggie-burger-small;
-
-                @include mq(mobileMedium) {
-                    height: $veggie-burger-medium * 2;
-                    width: $veggie-burger-medium;
-                    top: -$veggie-burger-medium / 2;
-                    right: $veggie-burger-medium / 2;
-                    border-radius: ($veggie-burger-medium * 2) 0 0 ($veggie-burger-medium * 2);
-                }
-            }
-        }
     }
 
     // Don't show menu on opera mini: https://wp-mix.com/css-target-opera/
@@ -68,37 +36,15 @@
     }
 
     .new-header--slim & {
-        height: $veggie-burger-medium;
+        height: $veggie-burger-large;
         margin-bottom: -$gs-baseline;
-        position: relative;
         right: $gs-gutter / 2;
         top: -$gs-baseline / 2;
-        width: $veggie-burger-medium;
+        width: $veggie-burger-large;
 
         @include mq(mobileLandscape) {
             right: $gs-gutter;
         }
-    }
-}
-
-.veggie-burger__label {
-    @include fs-textSans(5);
-    bottom: -22px;
-    color: #ffffff;
-    font-size: 18px;
-    left: 50%;
-    position: absolute;
-    text-align: center;
-    text-transform: lowercase;
-    transform: translateX(-50%);
-    width: gs-span(2);
-
-    @include mq($until: 'desktop') {
-        @include u-h();
-    }
-
-    .new-header--open & {
-        display: none;
     }
 }
 
@@ -119,42 +65,15 @@
         height: $gs-baseline / 6;
         left: 0;
         position: absolute;
-        width: $gs-gutter;
-
-        @include mq(mobileMedium) {
-            height: $gs-baseline / 4;
-            width: 26px;
-        }
-
-        @include mq(leftCol) {
-            height: 4px;
-            width: 30px;
-        }
+        width: 20px;
     }
 
     &:before {
-        top: -$gs-gutter / 4;
-
-        // TODO: If larger sizes are kept, consider svg solution to minimize magic numbers/mqs
-        @include mq(mobileMedium) {
-            top: -7px;
-        }
-
-        @include mq(leftCol) {
-            top: -8px;
-        }
+        top: -$gs-baseline / 2;
     }
 
     &:after {
-        bottom: -$gs-gutter / 4;
-
-        @include mq(mobileMedium) {
-            bottom: -7px;
-        }
-
-        @include mq(leftCol) {
-            bottom: -8px;
-        }
+        bottom: -$gs-baseline / 2;
     }
 
     // transform burger into cross

--- a/static/src/stylesheets/layout/new-header/_veggie-burger.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger.scss
@@ -1,27 +1,21 @@
 .veggie-burger {
     background-color: $news-main-2;
-    bottom: -$gs-baseline / 2;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .08);
     color: $guardian-brand-dark;
     cursor: pointer;
+    display: block;
     height: $veggie-burger-medium;
     width: $veggie-burger-medium;
-    position: absolute;
+    position: relative;
     border: 0;
     border-radius: 50%;
     outline: none;
-    right: $gutter-small;
     user-select: none;
     z-index: 1;
-
-    @include mq(mobileLandscape) {
-        right: $gutter-medium;;
-    }
 
     @include mq(tablet) {
         height: $veggie-burger-large;
         width: $veggie-burger-large;
-        right: $gutter-large;
     }
 
     // menu is open


### PR DESCRIPTION
## What does this change?
The next stage of header v3 updates: **navigation**

Some highlights:
- 'life' has become 'lifestyle'
- Vertical dividing lines instead of slashes (which were confused as breadcrumb)
- Consistent styling between primary and secondary navigation
- White subnav (single-line on mobile)
- Clear active states
- Sections toggle at desktop breakpoints and veggie burger on devices

Important points:
- **The mobile and tablet variants will be live to 100% of our audience when this PR is merged**
- **Desktop is a test and will only be seen internally to those opted-in**
- The ellipses icon that follows "more" in the secondary nav is a suggestion from UX. Before this PR goes live we will discuss further, and I understand the ellipses sharing icon we use would need to change if we adopted a pattern for vertical ellipses. (I also recognise it's a bit small/mis aligned and won't be by the time this PR goes out.)
- Next steps will be some bug fixing with alignment, the search icon and search experience, and the contents of the "sections" menu

## Does this affect other platforms - Amp, Apps, etc?
Because the veggie burger uses shared variables between AMP and prod, I have had to update the styling of AMP in this PR also. 

## Screenshots

## Before: Desktop
<img width="1665" alt="screen shot 2017-11-10 at 16 06 04" src="https://user-images.githubusercontent.com/14570016/32667457-9f440ba2-c632-11e7-8c39-2dd191c59062.png">

## After: Desktop
<img width="1665" alt="screen shot 2017-11-10 at 16 05 49" src="https://user-images.githubusercontent.com/14570016/32667466-a392c446-c632-11e7-8d15-0cf849e883a1.png">

## Before: Mobile
<img width="359" alt="screen shot 2017-11-10 at 16 06 50" src="https://user-images.githubusercontent.com/14570016/32667525-d2fa477c-c632-11e7-962d-4d1eb36d871f.png">

## After: Mobile
<img width="360" alt="screen shot 2017-11-10 at 16 07 10" src="https://user-images.githubusercontent.com/14570016/32667533-d4a5fe2c-c632-11e7-9fd4-86dd85b593eb.png">

## Before: Desktop slim nav
<img width="1664" alt="screen shot 2017-11-10 at 16 09 18" src="https://user-images.githubusercontent.com/14570016/32667538-d8b0d190-c632-11e7-9102-4f953f71c30e.png">

## After: Desktop slim nav
<img width="1680" alt="screen shot 2017-11-10 at 16 09 27" src="https://user-images.githubusercontent.com/14570016/32667545-daf667d0-c632-11e7-8e9d-18f17b5991e2.png">

## Before: AMP
<img width="359" alt="screen shot 2017-11-10 at 16 11 41" src="https://user-images.githubusercontent.com/14570016/32667656-2ea43d44-c633-11e7-8353-2a8ba822d38d.png">

## After: AMP
<img width="360" alt="screen shot 2017-11-10 at 16 11 49" src="https://user-images.githubusercontent.com/14570016/32667666-372b894a-c633-11e7-8655-026045c21971.png">

## Before: Tablet
<img width="576" alt="screen shot 2017-11-10 at 16 43 36" src="https://user-images.githubusercontent.com/14570016/32668835-9790097a-c636-11e7-8946-55868adcdfbc.png">

## After: Tablet
<img width="575" alt="screen shot 2017-11-10 at 16 43 44" src="https://user-images.githubusercontent.com/14570016/32668861-a5728734-c636-11e7-9046-55db2544cfac.png">

## Active state of secondary nav
<img width="930" alt="screen shot 2017-11-10 at 16 11 09" src="https://user-images.githubusercontent.com/14570016/32667744-77523168-c633-11e7-8025-d8af63ec8a02.png">

