### PR TITLE
We are sometimes hiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Gitter](https://badges.gitter.im/guardian/frontend.svg)](https://gitter.im/guardian/frontend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
+## We're hiring!
+Ever thought about joining us? 
+https://workforus.theguardian.com/careers/digital-development/
+
 # Frontend
 [The Guardian](http://www.theguardian.com) website frontend.
 

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -9,12 +9,13 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent, mainContent}
+import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.ContentCSSFile
+import conf.switches.Switches.WeAreHiring
 
 object ContentHtmlPage extends HtmlPage[Page] {
 
@@ -44,6 +45,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.ApplicationContext
@@ -8,11 +9,11 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import crosswords.{AccessibleCrosswordPage, CrosswordPage, CrosswordPageWithSvg, CrosswordSearchPageNoResult, CrosswordSearchPageWithResults}
 import views.html.fragments._
-import crosswords.{accessibleCrosswordContent, crosswordContent, crosswordSearch, printableCrosswordBody, crosswordNoResult}
+import crosswords.{accessibleCrosswordContent, crosswordContent, crosswordNoResult, crosswordSearch, printableCrosswordBody}
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
 
@@ -40,6 +41,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),
@@ -70,6 +72,7 @@ object PrintableCrosswordHtmlPage extends HtmlPage[CrosswordPageWithSvg] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(CrosswordHtmlPage.allStyles),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, GalleryPage, Page}
@@ -8,7 +9,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
@@ -35,6 +36,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.ApplicationContext
@@ -13,7 +14,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
 
@@ -37,6 +38,7 @@ object IndexHtml {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         headContent,

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import controllers.InteractivePage
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -9,7 +10,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
@@ -44,6 +45,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.{ApplicationContext, SimplePage}
@@ -10,7 +11,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.ContentCSSFile
@@ -32,6 +33,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
 import model.{ApplicationContext, ContributorsListing, PreferencesMetaData, StandalonePage, SubjectsListing, TagIndexPage}
@@ -10,7 +11,7 @@ import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
 import html.HtmlPageHelpers.ContentCSSFile
@@ -41,6 +42,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -1,7 +1,7 @@
 package pages
 
 import common.Edition
-import conf.switches.Switches.SurveySwitch
+import conf.switches.Switches.{SurveySwitch, WeAreHiring}
 import html.HtmlPageHelpers._
 import html.Styles
 import model.{ApplicationContext, Page}
@@ -12,7 +12,7 @@ import views.html.fragments.commercial.{pageSkin, survey}
 import views.html.fragments.page._
 import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import html.HtmlPageHelpers.ContentCSSFile
 
 object StoryHtmlPage {
@@ -40,6 +40,7 @@ object StoryHtmlPage {
 
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         head,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -525,4 +525,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 10, 24),
     exposeClientSide = false
   )
+
+  val WeAreHiring = Switch(
+    SwitchGroup.Feature,
+    "we-are-hiring",
+    "When ON, hiring messages will appear in browser console and HTML source",
+    owners = Seq(Owner.withGithub("siadcock")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -530,7 +530,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "we-are-hiring",
     "When ON, hiring messages will appear in browser console and HTML source",
-    owners = Seq(Owner.withGithub("siadcock")),
+    owners = Seq(Owner.withName("dotcom.platform")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -1,19 +1,22 @@
 @(projectName: Option[String] = None, head: Html)(implicit page: model.Page, request: RequestHeader, context: model.ApplicationContext)
 
 @import model.Page.getContent
+@import conf.switches.Switches.WeAreHiring
 @import implicits.Strings.String2Uri
 @import views.support.JavaScriptPage.getMap
 
-<!--
- __        __                      _     _      _
- \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
-  \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
-   \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
-    \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
-                                                        |___/
-Ever thought about joining us?
-https://workforus.theguardian.com/careers/digital-development/
- --->
+@if(WeAreHiring.isSwitchedOn) {
+    <!--
+     __        __                      _     _      _
+     \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
+      \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
+       \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
+        \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
+                                                            |___/
+    Ever thought about joining us?
+    https://workforus.theguardian.com/careers/digital-development/
+     --->
+}
 <title>@views.support.Title(page)</title>
 
 @fragments.metaData()

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -4,6 +4,16 @@
 @import implicits.Strings.String2Uri
 @import views.support.JavaScriptPage.getMap
 
+<!--
+ __        __                      _     _      _
+ \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
+  \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
+   \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
+    \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
+                                                        |___/
+Ever thought about joining us?
+https://workforus.theguardian.com/careers/digital-development/
+ --->
 <title>@views.support.Title(page)</title>
 
 @fragments.metaData()

--- a/common/app/views/fragments/page/head/weAreHiring.scala.html
+++ b/common/app/views/fragments/page/head/weAreHiring.scala.html
@@ -1,0 +1,12 @@
+@()(implicit page: model.Page, request: RequestHeader)
+
+<!--
+     __        __                      _     _      _
+     \ \      / /__    __ _ _ __ ___  | |__ (_)_ __(_)_ __   __ _
+      \ \ /\ / / _ \  / _` | '__/ _ \ | '_ \| | '__| | '_ \ / _` |
+       \ V  V /  __/ | (_| | | |  __/ | | | | | |  | | | | | (_| |
+        \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
+                                                            |___/
+    Ever thought about joining us?
+    https://workforus.theguardian.com/careers/digital-development/
+     --->

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -1,6 +1,7 @@
 package pages
 
 import common.Edition
+import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
 import model.{ApplicationContext, PressedPage}
@@ -9,7 +10,7 @@ import play.twirl.api.Html
 import views.html.fragments.commercial.pageSkin
 import views.html.fragments._
 import views.html.fragments.page.body.{bodyTag, breakingNewsDiv, mainContent, skipToMainContent}
-import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
 
@@ -42,6 +43,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     implicit val p: PressedPage = page
     htmlTag(
       headTag(
+        weAreHiring() when WeAreHiring.isSwitchedOn,
         titleTag(),
         metaData(),
         frontMeta(),

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -49,7 +49,7 @@ const setAdTestCookie = (): void => {
 
 const showHiringMessage = (): void => {
     try {
-        if (!config.page.isDev) {
+        if (!config.get('page.isDev') && config.get('switches.weAreHiring')) {
             window.console.log(
                 '\n' +
                     '%cHello.\n' +
@@ -69,7 +69,7 @@ const showHiringMessage = (): void => {
 };
 
 const handleMembershipAccess = (): void => {
-    const { membershipUrl, membershipAccess, contentId } = config.page;
+    const { membershipUrl, membershipAccess, contentId } = config.get('page');
 
     const redirect = (): void => {
         window.location.href = `${membershipUrl}/membership-content?referringContent=${contentId}&membershipAccess=${membershipAccess}`;
@@ -204,7 +204,7 @@ const bootStandard = (): void => {
     removeCookie('GU_AFU');
 
     // If we turn off the ad-free trial, immediately remove the cookie
-    if (!config.switches.adFreeSubscriptionTrial) {
+    if (!config.get('switches.adFreeSubscriptionTrial')) {
         removeCookie('GU_AF1');
     }
 
@@ -215,7 +215,7 @@ const bootStandard = (): void => {
         storage.set(key, alreadyVisited + 1);
     }
 
-    if (config.switches.blockIas && navigator.serviceWorker) {
+    if (config.get('switches.blockIas') && navigator.serviceWorker) {
         navigator.serviceWorker.ready.then(swreg => {
             const sw = swreg.active;
             const ias = window.location.hash.includes('noias');
@@ -235,7 +235,7 @@ const bootStandard = (): void => {
         Authenticating requires CORS and withCredentials. If we don't cut the
         mustard then pass through.
     */
-    if (config.page.requiresMembershipAccess) {
+    if (config.get('page.requiresMembershipAccess')) {
         handleMembershipAccess();
     }
 

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -49,13 +49,13 @@ const setAdTestCookie = (): void => {
 
 const showHiringMessage = (): void => {
     try {
-        if (!config.get('page.isDev') && config.get('switches.weAreHiring')) {
+        if (config.get('switches.weAreHiring')) {
             window.console.log(
                 '\n' +
                     '%cHello.\n' +
                     '\n' +
                     '%cWe are hiring – ever thought about joining us? \n' +
-                    '%chttp://developers.theguardian.com/join-the-team.html%c \n' +
+                    '%chttps://workforus.theguardian.com/careers/digital-development%c \n' +
                     '\n',
                 'font-family: Georgia, serif; font-size: 32px; color: #005689',
                 'font-family: Georgia, serif; font-size: 16px; color: #767676',

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -49,7 +49,7 @@ const setAdTestCookie = (): void => {
 
 const showHiringMessage = (): void => {
     try {
-        if (config.get('switches.weAreHiring')) {
+        if (!config.get('page.isDev') && config.get('switches.weAreHiring')) {
             window.console.log(
                 '\n' +
                     '%cHello.\n' +

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -47,6 +47,27 @@ const setAdTestCookie = (): void => {
     }
 };
 
+const showHiringMessage = (): void => {
+    try {
+        if (!config.page.isDev) {
+            window.console.log(
+                '\n' +
+                    '%cHello.\n' +
+                    '\n' +
+                    '%cWe are hiring – ever thought about joining us? \n' +
+                    '%chttp://developers.theguardian.com/join-the-team.html%c \n' +
+                    '\n',
+                'font-family: Georgia, serif; font-size: 32px; color: #005689',
+                'font-family: Georgia, serif; font-size: 16px; color: #767676',
+                'font-family: Helvetica Neue, sans-serif; font-size: 11px; text-decoration: underline; line-height: 1.2rem; color: #767676',
+                ''
+            );
+        }
+    } catch (e) {
+        /* do nothing */
+    }
+};
+
 const handleMembershipAccess = (): void => {
     const { membershipUrl, membershipAccess, contentId } = config.page;
 
@@ -221,6 +242,8 @@ const bootStandard = (): void => {
     identityInit();
 
     newHeaderInit();
+
+    showHiringMessage();
 
     markTime('standard end');
 


### PR DESCRIPTION
## What does this change?

Reinstate "we are hiring" messages in:

- frontend repo readme
- browser console panel
- HTML source

(originally removed in #16641 and #16484)

Messages in console panel and HTML source are now behind a feature switch for easy on/off-ability 

## What is the value of this and can you measure success?

Free recruitment advertising

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

**Browser console**

![picture 334](https://user-images.githubusercontent.com/5931528/32671048-c1d77f5e-c63d-11e7-9ed1-30f5e7d38578.png)

**HTML source**

![picture 335](https://user-images.githubusercontent.com/5931528/32671057-cb866e70-c63d-11e7-9301-5e3796032fdc.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
