### PR TITLE
Atoms CSS from the library

### DIFF
--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -27,6 +27,13 @@ object StoryHtmlPage {
     override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
   }
 
+  def atomStyles(implicit page: Page) = Page.getContent(page) 
+    .flatMap(_.atoms)
+    .map(_.atomTypes.map { atomType =>
+      stylesheetLink(s"stylesheets/atom-$atomType-article-index.css")
+    })
+    .getOrElse(Nil)
+
   def html(
     header: Html,
     content: Html,
@@ -43,7 +50,7 @@ object StoryHtmlPage {
         titleTag(),
         metaData(),
         head,
-        styles(allStyles),
+        styles(allStyles, atomStyles),
         fixIEReferenceErrors(),
         inlineJSBlocking()
       ),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -272,15 +272,8 @@ final case class Content(
       ("atoms", JsArray(atomIdentifiers))
     }
 
-    val atomTypesMeta = atoms.map { atoms =>
-      val atomTypes = Map(
-        "guide" -> JsBoolean(!atoms.guides.isEmpty),
-        "profile" -> JsBoolean(!atoms.profiles.isEmpty),
-        "qanda" -> JsBoolean(!atoms.qandas.isEmpty),
-        "timeline" -> JsBoolean(!atoms.timelines.isEmpty)
-      )
-      
-      ("atomTypes", JsObject(atomTypes))
+    val atomTypesMeta = atoms.map(_.atomTypes).map { atomTypes =>
+      ("atomTypes", JsObject(atomTypes.map(_ -> JsBoolean(true)).toMap))
     }
 
     // There are many checks that might disable sticky top banner, listed below.

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -28,6 +28,13 @@ final case class Atoms(
   timelines: Seq[TimelineAtom]
 ) {
   val all: Seq[Atom] = quizzes ++ media ++ interactives ++ recipes ++ reviews ++ storyquestions ++ explainers ++ qandas ++ guides ++ profiles ++ timelines
+
+  def atomTypes: Seq[String] = Seq(
+    if (guides.isEmpty) None else Some("guide"),
+    if (qandas.isEmpty) None else Some("qanda"),
+    if (profiles.isEmpty) None else Some("profile"),
+    if (timelines.isEmpty) None else Some("timeline")
+  ).flatten
 }
 
 sealed trait Atom {

--- a/common/app/views/fragments/page/head/stylesheets/styles.scala.html
+++ b/common/app/views/fragments/page/head/stylesheets/styles.scala.html
@@ -1,4 +1,4 @@
-@(styles: html.Styles)(implicit applicationContext: model.ApplicationContext)
+@(styles: html.Styles, atomStyles: Seq[Html] = Nil)(implicit applicationContext: model.ApplicationContext)
 
 @import conf.Static
 
@@ -53,6 +53,8 @@
 @styles.criticalCss
 @styles.linkCss
 <!--<![endif]-->
+
+@atomStyles.map { atomStyle => @atomStyle }
 
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "1.2.1"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.0.13",
+    "@guardian/atom-renderer": "0.7.11",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",

--- a/tools/__tasks__/compile/css/atoms.js
+++ b/tools/__tasks__/compile/css/atoms.js
@@ -5,12 +5,12 @@ const { target } = require('../../config').paths;
 const atomCssPrefix = 'atom';
 
 const fontMap = {
-    'f-serif-text': "'Guardian Text Egyptian Web', Georgia, serif",
-    'f-serif-headline': "'Guardian Egyptian Web', Georgia, serif",
+    'f-serif-text': '\\"Guardian Text Egyptian Web\\", Georgia, serif',
+    'f-serif-headline': '\\"Guardian Egyptian Web\\", Georgia, serif',
     'f-sans-serif-text':
-        "'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif",
+        '\\"Guardian Text Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif',
     'f-sans-serif-headline':
-        "'Guardian Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif",
+        '\\"Guardian Sans Web\\", \\"Helvetica Neue\\", Helvetica, Arial, \\"Lucida Grande\\", sans-serif',
 };
 
 module.exports = {
@@ -46,12 +46,9 @@ module.exports = {
                                 Object.entries(
                                     fontMap
                                 ).map(([varName, varValue]) =>
-                                    execa('sed', [
-                                        '-i',
-                                        "''",
-                                        `'s/var(--${varName})/${varValue}/'`,
-                                        dest,
-                                    ])
+                                    execa.shell(
+                                        `sed -i '' 's/var(--${varName})/${varValue}/' '${dest}'`
+                                    )
                                 )
                             )
                         );

--- a/tools/__tasks__/compile/css/atoms.js
+++ b/tools/__tasks__/compile/css/atoms.js
@@ -47,7 +47,7 @@ module.exports = {
                                     fontMap
                                 ).map(([varName, varValue]) =>
                                     execa.shell(
-                                        `sed -i '' 's/var(--${varName})/${varValue}/' '${dest}'`
+                                        `sed -i -e 's/var(--${varName})/${varValue}/' '${dest}'`
                                     )
                                 )
                             )

--- a/tools/__tasks__/compile/css/atoms.js
+++ b/tools/__tasks__/compile/css/atoms.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const execa = require('execa');
+const { target } = require('../../config').paths;
+
+const atomCssPrefix = 'atom';
+
+module.exports = {
+    description: 'Copy atom CSS to target',
+    task: () =>
+        execa
+            .shell(
+                `ls -d ${path.join(
+                    'node_modules',
+                    '@guardian',
+                    'atom-renderer',
+                    'dist'
+                )}/*/`
+            )
+            .then(dirs => {
+                const dirsArray = dirs.stdout
+                    .split('\n')
+                    .map(dir => dir.replace(/\/$/, ''));
+
+                return Promise.all(
+                    dirsArray.map(dir => {
+                        const dirName = dir.split('/')[
+                            dir.split('/').length - 1
+                        ];
+
+                        return execa('cp', [
+                            `${dir}/article/index.css`,
+                            path.join(
+                                target,
+                                'stylesheets',
+                                `${atomCssPrefix}-${dirName}-article-index.css`
+                            ),
+                        ]);
+                    })
+                );
+            }),
+};

--- a/tools/__tasks__/compile/css/atoms.js
+++ b/tools/__tasks__/compile/css/atoms.js
@@ -4,6 +4,15 @@ const { target } = require('../../config').paths;
 
 const atomCssPrefix = 'atom';
 
+const fontMap = {
+    'f-serif-text': "'Guardian Text Egyptian Web', Georgia, serif",
+    'f-serif-headline': "'Guardian Egyptian Web', Georgia, serif",
+    'f-sans-serif-text':
+        "'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif",
+    'f-sans-serif-headline':
+        "'Guardian Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif",
+};
+
 module.exports = {
     description: 'Copy atom CSS to target',
     task: () =>
@@ -24,15 +33,28 @@ module.exports = {
                 return Promise.all(
                     dirsArray.map(dir => {
                         const dirName = dir.substr(dir.lastIndexOf('/') + 1);
-
+                        const dest = path.join(
+                            target,
+                            'stylesheets',
+                            `${atomCssPrefix}-${dirName}-article-index.css`
+                        );
                         return execa('cp', [
                             `${dir}/article/index.css`,
-                            path.join(
-                                target,
-                                'stylesheets',
-                                `${atomCssPrefix}-${dirName}-article-index.css`
-                            ),
-                        ]);
+                            dest,
+                        ]).then(() =>
+                            Promise.all(
+                                Object.entries(
+                                    fontMap
+                                ).map(([varName, varValue]) =>
+                                    execa('sed', [
+                                        '-i',
+                                        "''",
+                                        `'s/var(--${varName})/${varValue}/'`,
+                                        dest,
+                                    ])
+                                )
+                            )
+                        );
                     })
                 );
             }),

--- a/tools/__tasks__/compile/css/atoms.js
+++ b/tools/__tasks__/compile/css/atoms.js
@@ -23,9 +23,7 @@ module.exports = {
 
                 return Promise.all(
                     dirsArray.map(dir => {
-                        const dirName = dir.split('/')[
-                            dir.split('/').length - 1
-                        ];
+                        const dirName = dir.substr(dir.lastIndexOf('/') + 1);
 
                         return execa('cp', [
                             `${dir}/article/index.css`,

--- a/tools/__tasks__/compile/css/index.dev.js
+++ b/tools/__tasks__/compile/css/index.dev.js
@@ -5,5 +5,6 @@ module.exports = {
         require('./mkdir'),
         require('../images'),
         require('./sass'),
+        require('./atoms'),
     ],
 };

--- a/tools/__tasks__/compile/css/index.js
+++ b/tools/__tasks__/compile/css/index.js
@@ -6,5 +6,6 @@ module.exports = {
         require('../images'),
         require('./update-caniuse'),
         require('./sass'),
+        require('./atoms'),
     ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@guardian/atom-renderer@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.0.13.tgz#27becd9b189826892cf216b8e388bc6a5d35413e"
+"@guardian/atom-renderer@0.7.11":
+  version "0.7.11"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.7.11.tgz#0940945d8e01efe50f19ca1b9a4161b91e63e5fa"
   dependencies:
     sass-mq "^3.3.2"
     webpack "^3.5.6"


### PR DESCRIPTION
Includes the whole pipeline to get the CSS from the atom library, swap in the correct values for CSS variables (i.e. local webfonts) and loads the stylesheets in articles when necessary.