### PR TITLE
Deps: Upgrade flow-bin to 0.59.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-react": "^7.4.0",
     "execa": "^0.8.0",
     "figures": "^2.0.0",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.59.0",
     "flow-typed": "^2.1.5",
     "git-user-name": "^1.2.0",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,6 +4036,10 @@ flow-bin@^0.57.3:
   version "0.57.3"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
+flow-bin@^0.59.0:
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+
 flow-typed@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/flow-typed/-/flow-typed-2.1.5.tgz#c96912807a286357340042783c9369360f384bbd"


### PR DESCRIPTION
## What does this change?

Upgrades `flow-bin` to 0.59.0. [Changelog](https://github.com/facebook/flow/releases/tag/v0.59.0)
