### PR TITLE
Redirect user to signin/register from identity profile pages links

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -4,14 +4,12 @@ import java.net.URLEncoder
 
 import actions.AuthenticatedActions.AuthRequest
 import utils.Logging
-
 import idapiclient.IdApiClient
 import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
 import play.api.mvc._
 import services.{AuthenticatedUser, AuthenticationService, IdentityUrlBuilder}
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object AuthenticatedActions {
   type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedUser]
@@ -42,8 +40,27 @@ class AuthenticatedActions(
   def sendUserToReauthenticate(request: RequestHeader): Result =
     redirectWithReturn(request, "/reauthenticate")
 
-  def authAction: AuthenticatedBuilder[AuthenticatedUser] =
-    new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, sendUserToSignin)
+  def sendUserToRegister(request: RequestHeader) : Result =
+    redirectWithReturn(request, "/register")
+
+  def authRefiner: ActionRefiner[Request, AuthRequest] = new ActionRefiner[Request, AuthRequest] {
+    override val executionContext = ec
+
+    def refine[A](request: Request[A]) =
+      authService.authenticatedUserFor(request) match {
+        case Some(authenticatedUser) => Future.successful(Right(new AuthenticatedRequest(authenticatedUser, request)))
+        case None =>
+          // If an email query param exists we want to check the DB for the user and redirect them to signin/register
+          val email =request.getQueryString("email")
+
+          email.map(e => identityApiClient.userFromQueryParam(e, "emailAddress").map {
+              case Right(userExists)=> Left(sendUserToSignin(request))
+              case Left(err) => Left(sendUserToRegister(request))
+          }.recover { case e: Exception =>
+            Left(sendUserToRegister(request))
+          }).getOrElse(Future.successful(Left(sendUserToSignin(request))))
+      }
+  }
 
   def agreeAction(unAuthorizedCallback: (RequestHeader) => Result): AuthenticatedBuilder[AuthenticatedUser] =
     new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, unAuthorizedCallback)
@@ -73,9 +90,14 @@ class AuthenticatedActions(
     }
   }
 
+
+  def authAction: AuthenticatedBuilder[AuthenticatedUser] =
+    new AuthenticatedBuilder(authService.authenticatedUserFor, anyContentParser, sendUserToSignin)
+
   def authActionWithUser: ActionBuilder[AuthRequest, AnyContent] =
-    authAction andThen apiVerifiedUserRefiner
+    DefaultActionBuilder(anyContentParser) andThen authRefiner andThen apiVerifiedUserRefiner
 
   def recentlyAuthenticated: ActionBuilder[AuthRequest, AnyContent] =
-    authAction andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
+    DefaultActionBuilder(anyContentParser) andThen authRefiner andThen recentlyAuthenticatedRefiner andThen apiVerifiedUserRefiner
+
 }

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -57,6 +57,15 @@ class IdApiClient(
     response map extractUser
   }
 
+  def userFromQueryParam(param: String, field: String,auth: Auth = Anonymous): Future[Response[User]] = {
+    val apiPath = s"/user?${field}=${param}"
+    println(apiPath)
+    val params = buildParams(Some(auth))
+    val headers = buildHeaders(Some(auth))
+    val response = httpClient.GET(apiUrl(apiPath), None, params, headers)
+    response map extractUser
+  }
+
   def saveUser(userId: String, user: UserUpdateDTO, auth: Auth): Future[Response[User]] =
     post(urlJoin("user", userId), Some(auth), body = Some(write(user))) map extractUser
 

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -59,7 +59,6 @@ class IdApiClient(
 
   def userFromQueryParam(param: String, field: String,auth: Auth = Anonymous): Future[Response[User]] = {
     val apiPath = s"/user?${field}=${param}"
-    println(apiPath)
     val params = buildParams(Some(auth))
     val headers = buildHeaders(Some(auth))
     val response = httpClient.GET(apiUrl(apiPath), None, params, headers)


### PR DESCRIPTION
## What does this change?
- When a user follows a link to an identity page with an ?email=[***] query param (e.g https://profile.theguardian.com/public/edit?email=foo@bar.com) and they do not have a current valid cookie they will be redirected to either /signin or /register depending on wether that email exists in the identity DB

## What is the value of this and can you measure success?
- Better flow for re-permissioning 
- There will also be a corresponding PR in identity-frontend to auto fill the email fields

## Does this affect other platforms - Amp, Apps, etc?
- Shouldn't do
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

## Screenshots

## Tested in CODE?
Not yet

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
