### PR TITLE
Ensure that all commercial logo links are no-follow.

### DIFF
--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -21,7 +21,7 @@
 <div class="badge__label">
   @branding.logo.label
 </div>
-<a class="badge__link" href="@branding.logo.link" data-sponsor="@branding.sponsorName.toLowerCase">
+<a class="badge__link" href="@branding.logo.link" data-sponsor="@branding.sponsorName.toLowerCase" rel="nofollow">
     @if(request.isAmp) {
         @if(onDarkBackground && branding.logoForDarkBackground.nonEmpty) {
             @for(highContrastLogo <- branding.logoForDarkBackground) {


### PR DESCRIPTION
All links to commercial content should include the `rel=nofollow` attribute to signify to ~Google~ some search engines that the hyperlink should not influence the ranking of the lin's target in the search engine's index.

Our logos are currently missing this, but no longer....