### PR TITLE
US gun campaign epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -136,4 +136,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 11, 23),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-us-gun-campaign-2017",
+    "Show a custom Epic for articles with the US gun campaign tag",
+    owners = Seq(Owner.withGithub("Mullefa")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 1, 4),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,6 +13,7 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicParadise } from 'common/modules/experiments/tests/acquisitions-epic-paradise';
+import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -20,6 +21,7 @@ import { acquisitionsEpicParadise } from 'common/modules/experiments/tests/acqui
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     acquisitionsEpicParadise,
+    acquisitionsEpicUSGunCampaign,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -8,7 +8,7 @@ const tagsMatch = () =>
     config
         .get('page.nonKeywordTagIds', '')
         .split(',')
-        .some(tag => tag === campaignTag);
+        .includes(campaignTag);
 
 export const acquisitionsEpicUSGunCampaign = makeABTest({
     id: 'AcquisitionsUsGunCampaign2017',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -2,7 +2,7 @@
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
 import config from 'lib/config';
 
-const campaignTag = '/us-news/series/break-the-cycle';
+const campaignTag = 'us-news/series/break-the-cycle';
 
 const tagsMatch = () =>
     config

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -1,0 +1,50 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import config from 'lib/config';
+
+const campaignTag = '/us-news/series/break-the-cycle';
+
+const tagsMatch = () => {
+    const pageKeywords = config.page.nonKeywordTagIds;
+    if (typeof pageKeywords !== 'undefined') {
+        const keywordList = pageKeywords.split(',');
+        return keywordList.some(x => x === campaignTag);
+    }
+    return false;
+};
+
+export const acquisitionsEpicUSGunCampaign = makeABTest({
+    id: 'AcquisitionsUsGunCampaign2017',
+    campaignId: 'epic_us_gun_campaign_2017',
+
+    start: '2017-11-14',
+    expiry: '2018-01-04',
+
+    author: 'Guy Dawson',
+    description:
+        'Show a custom Epic for articles with the US gun campaign tag',
+    successMeasure: 'AV2.0',
+    idealOutcome:
+        'The US gun campaign resonates with our readers, and we continue to provide quality reporting on this important issue',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    // canRun: tagsMatch,
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION'],
+            options: {
+                isUnlimited: true,
+                usesIframe: true,
+                template: variant =>
+                    `<iframe src="https://interactive.guim.co.uk/embed/2017/11/break-the-cycle/epic.html"
+                        data-component="${variant.options.componentName}"
+                        class="acquisitions-epic-iframe"
+                        id="${variant.options.iframeId}">
+                    </iframe>`
+            },
+        },
+    ],
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -21,8 +21,7 @@ export const acquisitionsEpicUSGunCampaign = makeABTest({
     expiry: '2018-01-04',
 
     author: 'Guy Dawson',
-    description:
-        'Show a custom Epic for articles with the US gun campaign tag',
+    description: 'Show a custom Epic for articles with the US gun campaign tag',
     successMeasure: 'AV2.0',
     idealOutcome:
         'The US gun campaign resonates with our readers, and we continue to provide quality reporting on this important issue',
@@ -43,7 +42,7 @@ export const acquisitionsEpicUSGunCampaign = makeABTest({
                         data-component="${variant.options.componentName}"
                         class="acquisitions-epic-iframe"
                         id="${variant.options.iframeId}">
-                    </iframe>`
+                    </iframe>`,
             },
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -29,7 +29,7 @@ export const acquisitionsEpicUSGunCampaign = makeABTest({
     audienceCriteria: 'All',
     audience: 1,
     audienceOffset: 0,
-    // canRun: tagsMatch,
+    canRun: tagsMatch,
 
     variants: [
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign.js
@@ -4,14 +4,11 @@ import config from 'lib/config';
 
 const campaignTag = '/us-news/series/break-the-cycle';
 
-const tagsMatch = () => {
-    const pageKeywords = config.page.nonKeywordTagIds;
-    if (typeof pageKeywords !== 'undefined') {
-        const keywordList = pageKeywords.split(',');
-        return keywordList.some(x => x === campaignTag);
-    }
-    return false;
-};
+const tagsMatch = () =>
+    config
+        .get('page.nonKeywordTagIds', '')
+        .split(',')
+        .some(tag => tag === campaignTag);
 
 export const acquisitionsEpicUSGunCampaign = makeABTest({
     id: 'AcquisitionsUsGunCampaign2017',


### PR DESCRIPTION
## What does this change?

Add the US Break the Cycle gun campaign.

## Screenshots

__Desktop:__

![custom_epic](https://user-images.githubusercontent.com/4085817/32774957-e21c2964-c925-11e7-9624-2cdd3fca0e08.jpg)

__Mobile:__

![custom_epic_mobile](https://user-images.githubusercontent.com/4085817/32774960-e9e394f2-c925-11e7-86f7-6dae51112fc4.jpg)

## Tested in CODE?

__Tested locally__