### PR TITLE
Add marketing consent ajax endpoint

### DIFF
--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -10,7 +10,7 @@ class AccountDetailsMapping extends UserFormMapping[AccountFormData] with Addres
 
   private val genders = List("Male", "Female", "Transgender", "Other", "unknown", "")
 
-  protected def formMapping(implicit messagesProvider: MessagesProvider) = {
+  def formMapping(implicit messagesProvider: MessagesProvider) = {
     mapping(
       ("primaryEmailAddress", idEmail),
       ("title", comboList("" :: Titles.titles)),

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -12,7 +12,7 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
   private val dateTimeFormatISO8601: String = "yyyy-MM-dd'T'HH:mm:ssZZ"
 
-  protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] =
+  def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] =
     mapping(
       "receiveGnmMarketing" -> boolean,     // TODO: statusFields to be removed once GDPR V2 is in PROD
       "receive3rdPartyMarketing" -> boolean,

--- a/identity/app/form/ProfileMapping.scala
+++ b/identity/app/form/ProfileMapping.scala
@@ -8,7 +8,7 @@ import play.api.i18n.{MessagesApi, MessagesProvider}
 
 class ProfileMapping extends UserFormMapping[ProfileFormData] {
 
-  protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[ProfileFormData] = mapping(
+  def formMapping(implicit messagesProvider: MessagesProvider): Mapping[ProfileFormData] = mapping(
     "location" -> textField,
     "aboutMe" -> textArea,
     "interests" -> textField,

--- a/identity/app/form/UserFormMapping.scala
+++ b/identity/app/form/UserFormMapping.scala
@@ -27,7 +27,7 @@ trait UserFormMapping[T <: UserFormData] extends Mappings {
   def formFieldKeyBy(idapiErrorContext: IdapiErrorContext): String =
     idapiErrorContextToFormFieldKeyMap.getOrElse(idapiErrorContext, default = idapiErrorContext)
 
-  protected def formMapping(implicit messagesProvider: MessagesProvider): Mapping[T]
+  def formMapping(implicit messagesProvider: MessagesProvider): Mapping[T]
 
   /**
     * Converts User domain object from IDAPI to form processing DTO

--- a/identity/app/idapiclient/responses/Error.scala
+++ b/identity/app/idapiclient/responses/Error.scala
@@ -1,8 +1,14 @@
 package idapiclient.responses
 
+import play.api.libs.json.Json
+
 /**
   * FIXME:
   *   This seems to be exactly the same as com.gu.identity.model.Error from identity-request library.
   *   Is this only representing IDAPI errors?
   */
 case class Error(message: String, description: String, statusCode: Int = 500, context: Option[String] = None)
+
+object Error {
+  implicit val errorFormat = Json.format[Error]
+}

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -57,6 +57,7 @@ GET         /digitalpack/edit                       controllers.EditProfileContr
 
 GET         /privacy/edit                           controllers.EditProfileController.displayPrivacyFormRedirect
 POST        /privacy/edit                           controllers.EditProfileController.submitPrivacyForm
+POST        /privacy/edit-ajax                      controllers.EditProfileController.saveConsentPreferencesAjax
 
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferences


### PR DESCRIPTION
## What does this change?

Enables marketing consent form to be submitted by JavaScript, similarly to newsletter subscriptions form.

This PR does not affect current users yet. There will be a separate PR that actually implements the Javascript side.

## What is the value of this and can you measure success?

Step towards standardising user experience on `email-prefs` page, where the goal is for, both marketing and newsletters forms, to be submitted in the same way. Currently marketing form submission reloads the page.

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

No
