### PR TITLE
Add US gun campaign interactive Epic

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -146,4 +146,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 1, 4),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-us-gun-campaign-interactive-2017",
+    "Show a custom Epic for interactives with the US gun campaign tag",
+    owners = Seq(Owner.withGithub("desbo")),
+    safeState = On,
+    sellByDate = new LocalDate(2018, 1, 4),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -14,6 +14,7 @@ import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/te
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicParadise } from 'common/modules/experiments/tests/acquisitions-epic-paradise';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
+import { acquisitionsEpicUSGunCampaignInteractive } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign-interactive';
 
 /**
  * acquisition tests in priority order (highest to lowest)
@@ -22,6 +23,7 @@ const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
     acquisitionsEpicParadise,
     acquisitionsEpicUSGunCampaign,
+    acquisitionsEpicUSGunCampaignInteractive,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign-interactive.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-us-gun-campaign-interactive.js
@@ -1,0 +1,51 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import config from 'lib/config';
+
+const campaignTag = 'us-news/series/break-the-cycle';
+
+const tagsMatch = () =>
+    config
+        .get('page.nonKeywordTagIds', '')
+        .split(',')
+        .includes(campaignTag);
+
+export const acquisitionsEpicUSGunCampaignInteractive = makeABTest({
+    id: 'AcquisitionsUsGunCampaignInteractive2017',
+    campaignId: 'epic_us_gun_campaign_interactive_2017',
+
+    start: '2017-11-14',
+    expiry: '2018-01-04',
+
+    author: 'Sam Desborough',
+    description:
+        'Show a custom Epic for interactives with the US gun campaign tag',
+    successMeasure: 'AV2.0',
+    idealOutcome:
+        'The US gun campaign resonates with our readers, and we continue to provide quality reporting on this important issue',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    canRun: tagsMatch,
+    pageCheck: page => page.contentType === 'Interactive',
+
+    variants: [
+        {
+            id: 'control',
+            products: ['CONTRIBUTION'],
+            options: {
+                isUnlimited: true,
+                usesIframe: true,
+                template: variant =>
+                    `<iframe src="https://interactive.guim.co.uk/embed/2017/11/break-the-cycle/epic.html"
+                        data-component="${variant.options.componentName}"
+                        class="acquisitions-epic-iframe contributions__epic-interactive-wrapper contributions__epic-interactive-wrapper--gun-campaign"
+                        id="${variant.options.iframeId}">
+                    </iframe>`,
+                insertAtSelector: '.content__main-column--interactive',
+                insertAfter: true,
+            },
+        },
+    ],
+});

--- a/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
+++ b/static/src/stylesheets/module/experiments/_acquisitions-epic-interactive.scss
@@ -15,3 +15,7 @@
         margin-left: 240px;
     }
 }
+
+.contributions__epic-interactive-wrapper--gun-campaign {
+    padding: 0;
+}


### PR DESCRIPTION
## What does this change?
Displays the Epic introduced in https://github.com/guardian/frontend/pull/18229 on interactive articles in the same campaign.

## Screenshots
See linked PR – it's the same iframe, just displayed on a different type of article. 

## Tested in CODE?
Just locally 