### PR TITLE
[acquisitions] convert iframe message to JSON before posting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -66,7 +66,7 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
             data.referrerData = addReferrerData({});
             [...document.getElementsByTagName('iframe')].forEach(iframe => {
                 iframe.contentWindow.postMessage(
-                    data,
+                    JSON.stringify(data),
                     'https://interactive.guim.co.uk'
                 );
             });


### PR DESCRIPTION
## What does this change?

Ensures that iframe messenger can successfully parse the referrer data message it receives.

## What is the value of this and can you measure success?

Allows us to run content analysis on campaigns where embedded acquisition components are used e.g. Break The Cycle.
