### PR TITLE
Account for semantic discrepancy between ajax and non-ajax consent submission

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -21,7 +21,6 @@ import scala.concurrent.Future
 object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
 object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
 object EmailPrefsProfilePage extends IdentityPage("/email-prefs", "Privacy")
-object PrivacyEditProfilePage extends IdentityPage("/privacy-edit", "Privacy")
 object MembershipEditProfilePage extends IdentityPage("/membership/edit", "Membership")
 object recurringContributionPage extends IdentityPage("/contribution/recurring/edit", "Contributions")
 object DigiPackEditProfilePage extends IdentityPage("/digitalpack/edit", "Digital Pack")
@@ -59,7 +58,6 @@ class EditProfileController(
 
   def submitPublicProfileForm(): Action[AnyContent] = submitForm(PublicEditProfilePage)
   def submitAccountForm(): Action[AnyContent] = submitForm(AccountEditProfilePage)
-//  def submitPrivacyForm(): Action[AnyContent] = submitForm(PrivacyEditProfilePage)
 
   def saveEmailPreferences: Action[AnyContent] =
     csrfCheck {
@@ -130,8 +128,6 @@ class EditProfileController(
                   profileFormsView(page, boundProfileForms.withErrors(idapiErrors), userDO)
 
                 case Right(updatedUser) =>
-                  println("ssdsfsdfdsfdfswowowoho")
-                  println("ssdsfsdfdsfdfswowowoho")
                   profileFormsView(page, boundProfileForms.bindForms(updatedUser), updatedUser)
               }
           } // end of success
@@ -226,7 +222,6 @@ case class ProfileForms(
     case PublicEditProfilePage => publicForm
     case AccountEditProfilePage => accountForm
     case EmailPrefsProfilePage => privacyForm
-    case PrivacyEditProfilePage => privacyForm
   }
 
   private lazy val activeMapping = activePage match {
@@ -282,7 +277,6 @@ case class ProfileForms(
       case PublicEditProfilePage => copy(publicForm = changeFunc(publicForm).asInstanceOf[Form[ProfileFormData]])
       case AccountEditProfilePage => copy(accountForm = changeFunc(accountForm).asInstanceOf[Form[AccountFormData]])
       case EmailPrefsProfilePage => copy(privacyForm = changeFunc(privacyForm).asInstanceOf[Form[PrivacyFormData]])
-      case PrivacyEditProfilePage => copy(privacyForm = changeFunc(privacyForm).asInstanceOf[Form[PrivacyFormData]])
     }
   }
 }

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -59,7 +59,7 @@ class EditProfileController(
   def submitPublicProfileForm(): Action[AnyContent] = submitForm(PublicEditProfilePage)
   def submitAccountForm(): Action[AnyContent] = submitForm(AccountEditProfilePage)
 
-  def saveEmailPreferences: Action[AnyContent] =
+  def saveEmailPreferencesAjax: Action[AnyContent] =
     csrfCheck {
       authActionWithUser.async { implicit request =>
         newsletterService.savePreferences().map { form  =>

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -98,7 +98,7 @@ class EditProfileController(
           },
 
           privacyFormData => {
-            identityApiClient.saveUser(userDO.id, privacyFormData.toUserUpdateDTO(userDO), userDO.auth) map {
+            identityApiClient.saveUser(userDO.id, privacyFormData.toUserUpdateDTOAjax(userDO), userDO.auth) map {
               case Left(idapiErrors) =>
                 logger.error(s"Failed to process marketing consent form submission for user ${userDO.getId}: $idapiErrors")
                 InternalServerError(Json.toJson(idapiErrors))

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -49,8 +49,11 @@ case class PrivacyFormData(
     consents: List[Consent]) extends UserFormData{
 
   /**
+    * FIXME: Fix the semantic discrepancy between toUserUpdateDTO and toUserUpdateDTOAjax.
+    * In the non-ajax case no value means set it to false while in the ajax case no value means use the old value.
+    *
     * If a checkbox is unchecked then nothing is sent to dotocom identity frontend,
-    * however IDAPI is expecting Some(false), so we gave to getOrElse.
+    * however IDAPI is expecting Some(false)
     *
     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox:
     *
@@ -58,6 +61,7 @@ case class PrivacyFormData(
     * the server to represent its unchecked state (e.g. value=unchecked); the value is not submitted
     * to the server at all."
     */
+
   def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO =
     UserUpdateDTO(
       statusFields = Some(oldUserDO.statusFields.copy(
@@ -66,6 +70,32 @@ case class PrivacyFormData(
         allowThirdPartyProfiling = Some(allowThirdPartyProfiling.getOrElse(false))
       )),
       consents = Some(consents))
+
+  def toUserUpdateDTOAjax(oldUserDO: User): UserUpdateDTO = {
+
+    val newReceiveGnmMarketing = receiveGnmMarketing match {
+      case None => oldUserDO.statusFields.receiveGnmMarketing
+      case Some(_) => receiveGnmMarketing
+    }
+
+    val newReceive3rdPartyMarketing = receive3rdPartyMarketing match {
+      case None => oldUserDO.statusFields.receive3rdPartyMarketing
+      case Some(_) => receive3rdPartyMarketing
+    }
+
+    val newAllowThirdPartyProfiling = allowThirdPartyProfiling match {
+      case None => oldUserDO.statusFields.allowThirdPartyProfiling
+      case Some(_) => allowThirdPartyProfiling
+    }
+
+    UserUpdateDTO(
+      statusFields = Some(oldUserDO.statusFields.copy(
+        receive3rdPartyMarketing = newReceive3rdPartyMarketing,
+        receiveGnmMarketing = newReceiveGnmMarketing,
+        allowThirdPartyProfiling = newAllowThirdPartyProfiling
+      )),
+      consents = Some(consents))
+  }
 }
 
 object PrivacyFormData {

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -14,9 +14,9 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
   def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] =
     mapping(
-      "receiveGnmMarketing" -> boolean,     // TODO: statusFields to be removed once GDPR V2 is in PROD
-      "receive3rdPartyMarketing" -> boolean,
-      "allowThirdPartyProfiling" -> boolean,
+      "receiveGnmMarketing" -> optional(boolean),     // TODO: statusFields to be removed once GDPR V2 is in PROD
+      "receive3rdPartyMarketing" -> optional(boolean),
+      "allowThirdPartyProfiling" -> optional(boolean),
       "consents" -> list(
         mapping(
           "actor" -> text,
@@ -43,17 +43,27 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
   * Form specific DTO representing marketing consent subset of User model
   */
 case class PrivacyFormData(
-    receiveGnmMarketing: Boolean,
-    receive3rdPartyMarketing: Boolean,
-    allowThirdPartyProfiling: Boolean,
+    receiveGnmMarketing: Option[Boolean],
+    receive3rdPartyMarketing: Option[Boolean],
+    allowThirdPartyProfiling: Option[Boolean],
     consents: List[Consent]) extends UserFormData{
 
+  /**
+    * If a checkbox is unchecked then nothing is sent to dotocom identity frontend,
+    * however IDAPI is expecting Some(false), so we gave to getOrElse.
+    *
+    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox:
+    *
+    * "Note: If a checkbox is unchecked when its form is submitted, there is no value submitted to
+    * the server to represent its unchecked state (e.g. value=unchecked); the value is not submitted
+    * to the server at all."
+    */
   def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO =
     UserUpdateDTO(
       statusFields = Some(oldUserDO.statusFields.copy(
-      receive3rdPartyMarketing = Some(receive3rdPartyMarketing),
-      receiveGnmMarketing = Some(receiveGnmMarketing),
-      allowThirdPartyProfiling = Some(allowThirdPartyProfiling)
+        receive3rdPartyMarketing = Some(receive3rdPartyMarketing.getOrElse(false)),
+        receiveGnmMarketing = Some(receiveGnmMarketing.getOrElse(false)),
+        allowThirdPartyProfiling = Some(allowThirdPartyProfiling.getOrElse(false))
       )),
       consents = Some(consents))
 }
@@ -67,9 +77,9 @@ object PrivacyFormData {
     */
   def apply(userDO: User): PrivacyFormData =
     PrivacyFormData(
-      receiveGnmMarketing = userDO.statusFields.receiveGnmMarketing.getOrElse(false),
-      receive3rdPartyMarketing = userDO.statusFields.receive3rdPartyMarketing.getOrElse(false),
-      allowThirdPartyProfiling = userDO.statusFields.allowThirdPartyProfiling.getOrElse(true),
+      receiveGnmMarketing = userDO.statusFields.receiveGnmMarketing,
+      receive3rdPartyMarketing = userDO.statusFields.receive3rdPartyMarketing,
+      allowThirdPartyProfiling = userDO.statusFields.allowThirdPartyProfiling,
       consents = if (userDO.consents.isEmpty) defaultConsents else userDO.consents)
 
   private val defaultConsents =

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -56,7 +56,7 @@ GET         /contribution/recurring/edit            controllers.EditProfileContr
 GET         /digitalpack/edit                       controllers.EditProfileController.displayDigitalPackForm
 
 GET         /privacy/edit                           controllers.EditProfileController.displayPrivacyFormRedirect
-POST        /privacy/edit                           controllers.EditProfileController.submitPrivacyForm
+POST        /privacy/edit                           controllers.EditProfileController.saveConsentPreferences
 POST        /privacy/edit-ajax                      controllers.EditProfileController.saveConsentPreferencesAjax
 
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -60,5 +60,5 @@ POST        /privacy/edit                           controllers.EditProfileContr
 POST        /privacy/edit-ajax                      controllers.EditProfileController.saveConsentPreferencesAjax
 
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm
-POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferences
+POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 ########################################################################################################################

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -144,7 +144,7 @@ import scala.concurrent.Future
         when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
           .thenReturn(Future.successful(Right(user.copy(consents = List(consent)))))
 
-        val result = controller.submitPrivacyForm().apply(fakeRequest)
+        val result = controller.saveConsentPreferences().apply(fakeRequest)
 
         status(result) should be(200)
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -446,7 +446,7 @@ import scala.concurrent.Future
         val fakeRequestEmailPrefs = FakeCSRFRequest(csrfAddToken).withFormUrlEncodedBody("htmlPreference" -> "Text")
         when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Right(()))
 
-        val result = controller.saveEmailPreferences().apply(fakeRequestEmailPrefs)
+        val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should be(200)
         contentAsString(result) should include ("updated")
 
@@ -458,7 +458,7 @@ import scala.concurrent.Future
         val errors = List(Error("Test message", "Test description", 500))
         when(api.updateUserEmails(MockitoMatchers.anyString(), MockitoMatchers.any[Subscriber], MockitoMatchers.any[Auth], MockitoMatchers.any[TrackingData])) thenReturn Future.successful(Left(errors))
 
-        val result = controller.saveEmailPreferences().apply(fakeRequestEmailPrefs)
+        val result = controller.saveEmailPreferencesAjax().apply(fakeRequestEmailPrefs)
         status(result) should not be(200)
         contentAsString(result) should include ("There was an error saving your preferences")
 


### PR DESCRIPTION
## What does this change?

Account for semantic discrepancy between ajax version of submission of marketing consents and non-ajax version. In the non-ajax case no checkbox value means set the corresponding consent to false, while in the ajax case no value means use the old value.

Ideally we should standardise this behaviour in separate PR.

## What is the value of this and can you measure success?

Step towards GDPR compliance. Enables ajax submission of consents to go live: https://github.com/guardian/frontend/pull/18231

## Does this affect other platforms - Amp, Apps, etc?

No

## Tested in CODE?

Noe

