### PR TITLE
Only create a background image if it doesn't already exist.

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -106,10 +106,6 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
 
         Object.assign(background.style, specStyles);
 
-        if (specStyles.backgroundColor) {
-            backgroundParent.style.backgroundColor = specStyles.backgroundColor;
-        }
-
         if (specs.scrollType === 'fixed') {
             return fastdom
                 .read(() => {
@@ -119,6 +115,11 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
                 })
                 .then(rect =>
                     fastdom.write(() => {
+                        if (specStyles.backgroundColor) {
+                            backgroundParent.style.backgroundColor =
+                                specStyles.backgroundColor;
+                        }
+
                         if (rect) {
                             background.style.left = `${rect.left}px`;
                             background.style.right = `${rect.right}px`;

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -19,6 +19,11 @@ type SpecStyles = {
     backgroundPosition: string,
 };
 
+type Background = {
+    backgroundParent: HTMLElement,
+    background: HTMLElement,
+};
+
 const getStylesFromSpec = (specs: AdSpec): SpecStyles =>
     Object.keys(specs).reduce((result, key) => {
         if (key !== 'scrollType') {
@@ -38,50 +43,99 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
         !('backgroundImage' in specs) ||
         !('backgroundRepeat' in specs) ||
         !('backgroundPosition' in specs) ||
-        !('scrollType' in specs)
+        !('scrollType' in specs) ||
+        !(adSlot instanceof Element)
     ) {
         return Promise.resolve();
     }
 
     const specStyles: SpecStyles = getStylesFromSpec(specs);
 
-    // Create an element to hold the background image
-    const background = document.createElement('div');
-    background.className = `creative__background creative__background--${specs.scrollType}`;
-    Object.assign(background.style, specStyles);
+    // check to see whether the parent div exists already, if so, jut alter the style
+    const backgroundParentClass = 'creative__background-parent';
+    const backgroundClass = 'creative__background';
 
-    // Wrap the background image in a DIV for positioning. Also, we give
-    // this DIV a background colour if it is provided. This is because
-    // if we set the background colour in the creative itself, the background
-    // image won't be visible (think z-indexed layers)
-    const backgroundParent = document.createElement('div');
-    backgroundParent.className = 'creative__background-parent';
-    if (specStyles.backgroundColor) {
-        backgroundParent.style.backgroundColor = specStyles.backgroundColor;
-    }
-    backgroundParent.appendChild(background);
+    const maybeBackgroundParent = adSlot.querySelector(
+        `.${backgroundParentClass}`
+    );
+    const maybeBackground = maybeBackgroundParent
+        ? maybeBackgroundParent.querySelector(`.${backgroundClass}`)
+        : null;
+    const backgroundAlreadyExists = !!(
+        maybeBackgroundParent && maybeBackground
+    );
 
-    if (specs.scrollType === 'fixed') {
+    const getBackground = (): Promise<Background> => {
+        if (
+            maybeBackground &&
+            maybeBackgroundParent &&
+            backgroundAlreadyExists
+        ) {
+            return Promise.resolve({
+                backgroundParent: maybeBackgroundParent,
+                background: maybeBackground,
+            });
+        }
+        // Wrap the background image in a DIV for positioning. Also, we give
+        // this DIV a background colour if it is provided. This is because
+        // if we set the background colour in the creative itself, the background
+        // image won't be visible (think z-indexed layers)
+        const backgroundParent = document.createElement('div');
+
+        // Create an element to hold the background image
+        const background = document.createElement('div');
+        backgroundParent.appendChild(background);
+
         return fastdom
-            .read(() => {
-                if (adSlot instanceof Element) {
-                    return adSlot.getBoundingClientRect();
+            .write(() => {
+                if (backgroundParent) {
+                    adSlot.insertBefore(backgroundParent, adSlot.firstChild);
                 }
             })
-            .then(rect =>
-                fastdom.write(() => {
-                    if (rect) {
-                        background.style.left = `${rect.left}px`;
-                        background.style.right = `${rect.right}px`;
-                        background.style.width = `${rect.width}px`;
+            .then(() => ({ backgroundParent, background }));
+    };
+
+    const updateStyles = (
+        backgroundParent: HTMLElement,
+        background: HTMLElement
+    ) => {
+        backgroundParent.className = backgroundParentClass;
+        background.className = `${backgroundClass} creative__background--${specs.scrollType}`;
+
+        Object.assign(background.style, specStyles);
+
+        if (specStyles.backgroundColor) {
+            backgroundParent.style.backgroundColor = specStyles.backgroundColor;
+        }
+
+        if (specs.scrollType === 'fixed') {
+            return fastdom
+                .read(() => {
+                    if (adSlot instanceof Element) {
+                        return adSlot.getBoundingClientRect();
                     }
-                    adSlot.insertBefore(backgroundParent, adSlot.firstChild);
                 })
-            );
-    }
+                .then(rect =>
+                    fastdom.write(() => {
+                        if (rect) {
+                            background.style.left = `${rect.left}px`;
+                            background.style.right = `${rect.right}px`;
+                            background.style.width = `${rect.width}px`;
+                        }
+                    })
+                )
+                .then(() => ({ backgroundParent, background }));
+        }
+
+        return Promise.resolve({ backgroundParent, background });
+    };
+
     let updateQueued = false;
 
-    const onScroll = () => {
+    const onScroll = (
+        backgroundParent: HTMLElement,
+        background: HTMLElement
+    ) => {
         if (!updateQueued) {
             updateQueued = true;
             fastdom.read(() => {
@@ -102,15 +156,23 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
         }
     };
 
-    return fastdom
-        .write(() => {
-            adSlot.insertBefore(backgroundParent, adSlot.firstChild);
-        })
-        .then(() => {
-            addEventListener(window, 'scroll', onScroll, {
-                passive: true,
-            });
-            onScroll();
+    return getBackground()
+        .then(({ backgroundParent, background }) =>
+            updateStyles(backgroundParent, background)
+        )
+        .then(({ backgroundParent, background }) => {
+            if (!backgroundAlreadyExists) {
+                addEventListener(
+                    window,
+                    'scroll',
+                    () => onScroll(backgroundParent, background),
+                    {
+                        passive: true,
+                    }
+                );
+
+                onScroll(backgroundParent, background);
+            }
         });
 };
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -55,11 +55,13 @@ const setBackground = (specs: AdSpec, adSlot: Node): Promise<any> => {
     const backgroundParentClass = 'creative__background-parent';
     const backgroundClass = 'creative__background';
 
-    const maybeBackgroundParent = adSlot.querySelector(
-        `.${backgroundParentClass}`
-    );
+    const maybeBackgroundParent = ((adSlot.getElementsByClassName(
+        backgroundParentClass
+    ): any): HTMLCollection<HTMLElement>)[0];
     const maybeBackground = maybeBackgroundParent
-        ? maybeBackgroundParent.querySelector(`.${backgroundClass}`)
+        ? ((maybeBackgroundParent.getElementsByClassName(
+              backgroundClass
+          ): any): HTMLCollection<HTMLElement>)[0]
         : null;
     const backgroundAlreadyExists = !!(
         maybeBackgroundParent && maybeBackground


### PR DESCRIPTION
## What does this change?
As part of our `messenger` protocol, we have a `background` message handler, which creates a background element for a given iframe. Currently, whenever this message is received, the background element is created and added above the iframe.

For iframes that need to update this background image - e.g. upon a viewport resize - this handler should allow for the fact that the background already exists, in which case it should simply apply the requested updates to the existing background.

## What is the value of this and can you measure success?
More flexible message handler for the `background` messages, which allows iframes to update themselves on viewport changes.