### PR TITLE
Add email to redirect query param

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -26,10 +26,13 @@ class AuthenticatedActions(
 
   def redirectWithReturn(request: RequestHeader, path: String): Result = {
     val returnUrl = URLEncoder.encode(identityUrlBuilder.buildUrl(request.uri), "UTF-8")
-    val signinUrl = request.getQueryString("INTCMP") match {
-      case Some(campaignCode) => s"$path?INTCMP=$campaignCode&returnUrl=$returnUrl"
-      case _ => s"$path?returnUrl=$returnUrl"
-    }
+
+    val paramsToPass =
+      List("INTCMP", "email")
+        .flatMap(name => request.getQueryString(name).map(value => s"&$name=$value"))
+        .mkString
+
+    val signinUrl = s"$path?returnUrl=$returnUrl$paramsToPass"
 
     SeeOther(identityUrlBuilder.buildUrl(signinUrl))
   }


### PR DESCRIPTION
## What does this change?
- Adds email query param as a separate parameter in the redirect url from identity pages to login/register

## What is the value of this and can you measure success?
- Makes directing the url in identity-frontend much simpler.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
