### PR TITLE
Subnav improvements

### DIFF
--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -37,15 +37,6 @@ object NewNavigation {
     case "lifestyle" => Lifestyle
   }
 
-  case object MostPopular extends EditionalisedNavigationSection {
-    val name = "news"
-
-    val uk = List(headlines, ukNews, world, business, environment, tech, football)
-    val au = List(headlines, australiaNews, world, auPolitics, environment, football)
-    val us = List(headlines, usNews, world, usPolitics, business, environment, soccer)
-    val int = List(headlines, world, ukNews, business, science, globalDevelopment, football)
-  }
-
   case object News extends EditionalisedNavigationSection {
     val name = "news"
 

--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -40,10 +40,57 @@ object NewNavigation {
   case object News extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = List(headlines, ukNews, world, business, environment, tech, politics, science, globalDevelopment, cities, obituaries)
-    val au = List(headlines, australiaNews, world, auPolitics, environment, indigenousAustralia, auImmigration, media)
-    val us = List(headlines, usNews, world, environment, usPolitics, business, science, money, tech, obituaries)
-    val int = List(headlines, world, ukNews, science, cities, globalDevelopment, tech, business, environment, obituaries)
+    val uk = List(
+      headlines,
+      ukNews,
+      world,
+      environment,
+      football,
+      business,
+      tech,
+      politics,
+      science,
+      globalDevelopment,
+      cities,
+      obituaries
+    )
+    val au = List(
+      headlines,
+      australiaNews,
+      world,
+      auPolitics,
+      environment,
+      football,
+      indigenousAustralia,
+      auImmigration,
+      media
+    )
+    val us = List(
+      headlines,
+      usNews,
+      world,
+      environment,
+      soccer,
+      usPolitics,
+      business,
+      science,
+      money,
+      tech,
+      obituaries
+    )
+    val int = List(
+      headlines,
+      world,
+      ukNews,
+      science,
+      cities,
+      globalDevelopment,
+      football,
+      tech,
+      business,
+      environment,
+      obituaries
+    )
   }
 
   case object Opinion extends EditionalisedNavigationSection {

--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -6,8 +6,7 @@ import common.editions
 
 case class NavLink(title: String, url: String, uniqueSection: String = "", longTitle: String = "", iconName: String = "")
 case class SectionsLink(pageId: String, navLink: NavLink, parentSection: NewNavigation.EditionalisedNavigationSection)
-case class SubSectionLink(pageId: String, parentSection: NavLinkLists)
-case class NavLinkLists(mostPopular: Seq[NavLink], leastPopular: Seq[NavLink] = List())
+case class SubSectionLink(pageId: String, parentSection: List[NavLink])
 
 object NewNavigation {
 
@@ -17,19 +16,12 @@ object NewNavigation {
   trait EditionalisedNavigationSection {
     def name: String
 
-    def uk: NavLinkLists
-    def us: NavLinkLists
-    def au: NavLinkLists
-    def int: NavLinkLists
+    def uk: List[NavLink]
+    def us: List[NavLink]
+    def au: List[NavLink]
+    def int: List[NavLink]
 
-    def getAllEditionalisedNavLinks(edition: Edition): Seq[NavLink] = edition match {
-      case editions.Uk => uk.mostPopular ++ uk.leastPopular
-      case editions.Au => au.mostPopular ++ au.leastPopular
-      case editions.Us => us.mostPopular ++ us.leastPopular
-      case editions.International => int.mostPopular ++ int.leastPopular
-    }
-
-    def getEditionalisedSubSectionLinks(edition: Edition): NavLinkLists = edition match {
+    def getEditionalisedNavLinks(edition: Edition): List[NavLink] = edition match {
       case editions.Uk => uk
       case editions.Au => au
       case editions.Us => us
@@ -48,192 +40,128 @@ object NewNavigation {
   case object MostPopular extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(List(headlines, ukNews, world, business, environment, tech, football))
-    val au = NavLinkLists(List(headlines, australiaNews, world, auPolitics, environment, football))
-    val us = NavLinkLists(List(headlines, usNews, world, usPolitics, business, environment, soccer))
-    val int = NavLinkLists(List(headlines, world, ukNews, business, science, globalDevelopment, football))
+    val uk = List(headlines, ukNews, world, business, environment, tech, football)
+    val au = List(headlines, australiaNews, world, auPolitics, environment, football)
+    val us = List(headlines, usNews, world, usPolitics, business, environment, soccer)
+    val int = List(headlines, world, ukNews, business, science, globalDevelopment, football)
   }
 
   case object News extends EditionalisedNavigationSection {
     val name = "news"
 
-    val uk = NavLinkLists(
-      List(headlines, ukNews, world, business, environment, tech, politics),
-      List(science, globalDevelopment, cities, obituaries)
-    )
-    val au = NavLinkLists(
-      List(headlines, australiaNews, world, auPolitics, environment),
-      List(indigenousAustralia, auImmigration, media)
-    )
-    val us = NavLinkLists(
-      List(headlines, usNews, world, environment, usPolitics, business),
-      List(science, money, tech, obituaries)
-    )
-    val int = NavLinkLists(
-      List(headlines, world, ukNews, science, cities, globalDevelopment),
-      List(tech, business, environment, obituaries)
-    )
+    val uk = List(headlines, ukNews, world, business, environment, tech, politics, science, globalDevelopment, cities, obituaries)
+    val au = List(headlines, australiaNews, world, auPolitics, environment, indigenousAustralia, auImmigration, media)
+    val us = List(headlines, usNews, world, environment, usPolitics, business, science, money, tech, obituaries)
+    val int = List(headlines, world, ukNews, science, cities, globalDevelopment, tech, business, environment, obituaries)
   }
 
   case object Opinion extends EditionalisedNavigationSection {
     val name = "opinion"
 
-    val uk = NavLinkLists(
-      List(
-        opinion,
-        theGuardianView,
-        columnists,
-        cartoons,
-        inMyOpinion
-      ),
-      List(
-        letters,
-        NavLink("Polly Toynbee", "/profile/pollytoynbee"),
-        NavLink("Owen Jones", "/profile/owen-jones"),
-        NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
-        NavLink("Marina Hyde", "/profile/marinahyde")
-      )
+    val uk = List(
+      opinion,
+      theGuardianView,
+      columnists,
+      cartoons,
+      inMyOpinion,
+      letters,
+      NavLink("Polly Toynbee", "/profile/pollytoynbee"),
+      NavLink("Owen Jones", "/profile/owen-jones"),
+      NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
+      NavLink("Marina Hyde", "/profile/marinahyde")
     )
 
-    val au = NavLinkLists(
-      List(
-        opinion,
-        auColumnists,
-        cartoons,
-        indigenousAustraliaOpinion,
-        theGuardianView.copy(title="editorials")
-      ),
-      List(
-        letters,
-        NavLink("first dog on the moon", "/profile/first-dog-on-the-moon"),
-        NavLink("Katharine Murphy", "/profile/katharine-murphy")
-      )
+    val au = List(
+      opinion,
+      auColumnists,
+      cartoons,
+      indigenousAustraliaOpinion,
+      theGuardianView.copy(title="editorials"),
+      letters,
+      NavLink("first dog on the moon", "/profile/first-dog-on-the-moon"),
+      NavLink("Katharine Murphy", "/profile/katharine-murphy")
     )
 
-    val us = NavLinkLists(
-      List(
-        opinion,
-        theGuardianView,
-        columnists,
-        letters
-      ),
-      List(
-        NavLink("Jill Abramson", "/profile/jill-abramson"),
-        NavLink("Jessica Valenti", "/commentisfree/series/jessica-valenti-column"),
-        NavLink("Steven W Thrasher", "/profile/steven-w-thrasher"),
-        NavLink("Richard Wolffe", "/profile/richard-wolffe"),
-        inMyOpinion,
-        cartoons
-      )
+    val us = List(
+      opinion,
+      theGuardianView,
+      columnists,
+      letters,
+      NavLink("Jill Abramson", "/profile/jill-abramson"),
+      NavLink("Jessica Valenti", "/commentisfree/series/jessica-valenti-column"),
+      NavLink("Steven W Thrasher", "/profile/steven-w-thrasher"),
+      NavLink("Richard Wolffe", "/profile/richard-wolffe"),
+      inMyOpinion,
+      cartoons
     )
 
-    val int = NavLinkLists(
-      List(
-          opinion,
-          theGuardianView,
-          columnists,
-          cartoons,
-          inMyOpinion
-        ),
-      List(
-        letters
-      )
+    val int = List(
+      opinion,
+      theGuardianView,
+      columnists,
+      cartoons,
+      inMyOpinion,
+      letters
     )
   }
 
   case object Sport extends EditionalisedNavigationSection {
     val name = "sport"
 
-    val uk = NavLinkLists(
-      List(sport, football, rugbyUnion, cricket, tennis, cycling, formulaOne),
-      List(rugbyLeague, racing, usSports, golf)
-    )
-    val au = NavLinkLists(
-      List(sport, football, AFL, NRL, aLeague, cricket, rugbyUnion),
-      List(tennis)
-    )
-    val us = NavLinkLists(
-      List(sport, soccer, NFL, tennis, MLB, MLS),
-      List(NBA, NHL)
-    )
-    val int = NavLinkLists(
-      List(sport, football, rugbyUnion, cricket, tennis, cycling, formulaOne),
-      List(golf, usSports)
-    )
+    val uk = List(sport, football, rugbyUnion, cricket, tennis, cycling, formulaOne, rugbyLeague, racing, usSports, golf)
+    val au = List(sport, football, AFL, NRL, aLeague, cricket, rugbyUnion, tennis)
+    val us = List(sport, soccer, NFL, tennis, MLB, MLS, NBA, NHL)
+    val int = List(sport, football, rugbyUnion, cricket, tennis, cycling, formulaOne, golf, usSports)
   }
 
   case object Arts extends EditionalisedNavigationSection {
     val name = "arts"
 
-    val uk = NavLinkLists(
-      List(culture, tvAndRadio, music, film, stage, books, games, artAndDesign),
-      List(classical)
-    )
-    val au = NavLinkLists(
-      List(culture, film, music, books, tvAndRadio, artAndDesign, stage),
-      List(games, classical)
-    )
-    val us = NavLinkLists(
-      List(culture, film, books, music, artAndDesign, tvAndRadio, stage),
-      List(classical, games)
-    )
-    val int = NavLinkLists(
-      List(culture, books, music, tvAndRadio, artAndDesign, film),
-      List(games, classical, stage)
-    )
+    val uk = List(culture, tvAndRadio, music, film, stage, books, games, artAndDesign, classical)
+    val au = List(culture, film, music, books, tvAndRadio, artAndDesign, stage, games, classical)
+    val us = List(culture, film, books, music, artAndDesign, tvAndRadio, stage, classical, games)
+    val int = List(culture, books, music, tvAndRadio, artAndDesign, film, games, classical, stage)
   }
 
   case object Lifestyle extends EditionalisedNavigationSection {
     val name = "lifestyle"
 
-    val uk = NavLinkLists(
-      List(lifestyle, fashion, food, recipes, travel, loveAndSex, family),
-      List(home, health, women, money)
-    )
-    val au = NavLinkLists(
-      List(lifestyle, travel, foodAu, relationshipsAu, fashionAu, healthAu),
-      List(loveAndSex, family, home)
-    )
-    val us = NavLinkLists(
-      List(lifestyle, fashion, food, recipes, loveAndSex, home),
-      List(health, family, travel, money)
-    )
-    val int = NavLinkLists(
-      List(lifestyle, fashion, food, recipes, loveAndSex, health),
-      List(home, women, family, travel, money)
-    )
+    val uk = List(lifestyle, fashion, food, recipes, travel, loveAndSex, family, home, health, women, money)
+    val au = List(lifestyle, travel, foodAu, relationshipsAu, fashionAu, healthAu, loveAndSex, family, home)
+    val us = List(lifestyle, fashion, food, recipes, loveAndSex, home, health, family, travel, money)
+    val int = List(lifestyle, fashion, food, recipes, loveAndSex, health, home, women, family, travel, money)
   }
 
   case object BrandExtensions extends EditionalisedNavigationSection {
     val name = ""
 
-    val uk = NavLinkLists(List(
+    val uk = List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader"),
       holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
       ukMasterClasses
-    ))
+    )
 
-    val au = NavLinkLists(List(
+    val au = List(
       jobs.copy(url = jobs.url + "/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"),
       auEvents
-    ))
+    )
 
-    val us = NavLinkLists(List(
+    val us = List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader")
-    ))
+    )
 
-    val int = NavLinkLists(List(
+    val int = List(
       jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader"),
       dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader"),
       holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader")
-    ))
+    )
   }
 
   case object OtherLinks extends EditionalisedNavigationSection {
     val name = ""
 
-    val uk = NavLinkLists(List(
+    val uk = List(
       apps.copy(url = apps.url + "?INTCMP=apps_uk_web_newheader"),
       video,
       podcasts,
@@ -244,9 +172,9 @@ object NewNavigation {
       digitalNewspaperArchive,
       NavLink("professional networks", "/guardian-professional"),
       crosswords
-    ))
+    )
 
-    val au = NavLinkLists(List(
+    val au = List(
       apps.copy(url = apps.url + "?INTCMP=apps_au_web_newheader"),
       video,
       podcasts,
@@ -254,9 +182,9 @@ object NewNavigation {
       newsletters,
       digitalNewspaperArchive,
       crosswords
-    ))
+    )
 
-    val us = NavLinkLists(List(
+    val us = List(
       apps.copy(url = apps.url + "?INTCMP=apps_us_web_newheader"),
       video,
       podcasts,
@@ -264,9 +192,9 @@ object NewNavigation {
       newsletters,
       digitalNewspaperArchive,
       crosswords
-    ))
+    )
 
-    val int = NavLinkLists(List(
+    val int = List(
       apps.copy(url = apps.url + "?INTCMP=apps_int_web_newheader"),
       video,
       podcasts,
@@ -276,98 +204,80 @@ object NewNavigation {
       observer,
       digitalNewspaperArchive,
       crosswords
-    ))
+    )
   }
 
   object SubSectionLinks {
 
-    val ukNewsSubNav = NavLinkLists(
-      List(ukNews, politics, education, media, society, law, scotland),
-      List(wales, northernIreland)
+    val ukNewsSubNav = List(ukNews, politics, education, media, society, law, scotland, wales, northernIreland)
+    val worldSubNav = List(world, europe, usNews, americas, asia, australiaNews, middleEast, africa, inequality, cities, globalDevelopment)
+    val moneySubNav = List(money, property, pensions, savings, borrowing, careers)
+
+    val footballSubNav = List(
+      football,
+      NavLink("live scores", "/football/live", "football/live"),
+      NavLink("tables", "/football/tables", "football/tables"),
+      NavLink("competitions", "/football/competitions", "football/competitions"),
+      NavLink("results", "/football/results", "football/results"),
+      NavLink("fixtures", "/football/fixtures", "football/fixtures"),
+      NavLink("clubs", "/football/teams", "football/teams")
     )
 
-    val worldSubNav = NavLinkLists(
-      List(world, europe, usNews, americas, asia, australiaNews, middleEast, africa),
-      List(inequality, cities, globalDevelopment)
+    val todaysPaperSubNav = List(
+      todaysPaper,
+      NavLink("obituaries", "/tone/obituaries"),
+      NavLink("g2", "/theguardian/g2"),
+      NavLink("weekend", "/theguardian/weekend"),
+      NavLink("the guide", "/theguardian/theguide"),
+      NavLink("saturday review", "/theguardian/guardianreview")
     )
 
-    val moneySubNav = NavLinkLists(List(money, property, pensions, savings, borrowing, careers))
-
-    val footballSubNav = NavLinkLists(
-      List(
-        football,
-        NavLink("live scores", "/football/live", "football/live"),
-        NavLink("tables", "/football/tables", "football/tables"),
-        NavLink("competitions", "/football/competitions", "football/competitions"),
-        NavLink("results", "/football/results", "football/results"),
-        NavLink("fixtures", "/football/fixtures", "football/fixtures"),
-        NavLink("clubs", "/football/teams", "football/teams")
-      )
+    val theObserverSubNav = List(
+      observer,
+      NavLink("comment", "/theobserver/news/comment"),
+      NavLink("the new review", "/theobserver/new-review"),
+      NavLink("observer magazine", "/theobserver/magazine")
     )
 
-    val todaysPaperSubNav = NavLinkLists(
-      List(
-        todaysPaper,
-        NavLink("obituaries", "/tone/obituaries"),
-        NavLink("g2", "/theguardian/g2"),
-        NavLink("weekend", "/theguardian/weekend"),
-        NavLink("the guide", "/theguardian/theguide"),
-        NavLink("saturday review", "/theguardian/guardianreview")
-      )
-    )
-
-    val theObserverSubNav = NavLinkLists(
-      List(
-        observer,
-        NavLink("comment", "/theobserver/news/comment"),
-        NavLink("the new review", "/theobserver/new-review"),
-        NavLink("observer magazine", "/theobserver/magazine")
-      )
-    )
-
-    val crosswordsSubNav = NavLinkLists(
-      List(
-        crosswords,
-        NavLink("blog", "/crosswords/crossword-blog"),
-        NavLink("editor", "/crosswords/series/crossword-editor-update"),
-        NavLink("quick", "/crosswords/series/quick"),
-        NavLink("cryptic", "/crosswords/series/cryptic"),
-        NavLink("prize", "/crosswords/series/prize"),
-        NavLink("weekend", "/crosswords/series/weekend-crossword")
-      ),
-      List(
-        NavLink("quiptic", "/crosswords/series/quiptic"),
-        NavLink("genius", "/crosswords/series/genius"),
-        NavLink("speedy", "/crosswords/series/speedy"),
-        NavLink("everyman", "/crosswords/series/everyman"),
-        NavLink("azed", "/crosswords/series/azed")
-      )
+    val crosswordsSubNav = List(
+      crosswords,
+      NavLink("blog", "/crosswords/crossword-blog"),
+      NavLink("editor", "/crosswords/series/crossword-editor-update"),
+      NavLink("quick", "/crosswords/series/quick"),
+      NavLink("cryptic", "/crosswords/series/cryptic"),
+      NavLink("prize", "/crosswords/series/prize"),
+      NavLink("weekend", "/crosswords/series/weekend-crossword"),
+      NavLink("quiptic", "/crosswords/series/quiptic"),
+      NavLink("genius", "/crosswords/series/genius"),
+      NavLink("speedy", "/crosswords/series/speedy"),
+      NavLink("everyman", "/crosswords/series/everyman"),
+      NavLink("azed", "/crosswords/series/azed")
     )
 
     case object businessSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(business, economics, banking, money, markets, projectSyndicate, businessToBusiness))
-      val us = NavLinkLists(List(business, economics, sustainableBusiness, diversityEquality, smallBusiness))
-      val au = NavLinkLists(List(business, markets, money, projectSyndicate))
+      val uk = List(business, economics, banking, money, markets, projectSyndicate, businessToBusiness)
+      val us = List(business, economics, sustainableBusiness, diversityEquality, smallBusiness)
+      val au = List(business, markets, money, projectSyndicate)
       val int = uk
     }
 
     case object environmentSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(environment, climateChange, wildlife, energy, pollution))
+      val uk = List(environment, climateChange, wildlife, energy, pollution)
       val us = uk
-      val au = NavLinkLists(List(environment, cities, globalDevelopment, sustainableBusiness))
+      val au = List(environment, cities, globalDevelopment, sustainableBusiness)
       val int = uk
     }
 
     case object travelSubNav extends EditionalisedNavigationSection {
       val name = ""
 
-      val uk = NavLinkLists(List(travel, travelUk, travelEurope, travelUs))
-      val us = NavLinkLists(List(travel, travelUs, travelEurope, travelUk))
-      val au = NavLinkLists(List(travel, travelAustralasia, travelAsia, travelUk, travelEurope, travelUs))
+      val uk = List(travel, travelUk, travelEurope, travelUs)
+      val us = List(travel, travelUs, travelEurope, travelUk)
+      val au = List(travel, travelAustralasia, travelAsia, travelUk, travelEurope, travelUs)
       val int = uk
     }
 

--- a/common/app/navigation/SectionLinks.scala
+++ b/common/app/navigation/SectionLinks.scala
@@ -6,10 +6,10 @@ import NewNavigation._
 object SectionLinks {
 
   val sectionLinks = List (
-    SectionsLink ("uk", headlines, MostPopular),
-    SectionsLink ("us", headlines, MostPopular),
-    SectionsLink ("au", headlines, MostPopular),
-    SectionsLink ("international", headlines, MostPopular),
+    SectionsLink ("uk", headlines, News),
+    SectionsLink ("us", headlines, News),
+    SectionsLink ("au", headlines, News),
+    SectionsLink ("international", headlines, News),
     SectionsLink ("uk-news", ukNews, News),
     SectionsLink ("world", world, News),
     SectionsLink ("world/europe-news", europe, News),

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -21,7 +21,7 @@
             data-edition="@{edition.id.toLowerCase}"
             aria-label="Submenu @{topLevelSection.name}"
             role="menu">
-            @topLevelSection.getAllEditionalisedNavLinks(edition).map { sectionItem =>
+            @topLevelSection.getEditionalisedNavLinks(edition).map { sectionItem =>
                 <li class="@RenderClasses(Map(
                             "menu-item--home" -> (sectionItem.iconName == "home")
                         ), "menu-item")"
@@ -103,7 +103,7 @@
 
             <ul class="menu-group menu-group--membership"
                 role="menubar">
-                @NavigationHelpers.getMembershipLinks(edition).mostPopular.map { item =>
+                @NavigationHelpers.getMembershipLinks(edition).map { item =>
                     <li class="menu-item hide-on-desktop"
                         data-edition="@{edition.id.toLowerCase}"
                         role="menuitem">
@@ -127,7 +127,7 @@
                 data-edition="@{edition.id.toLowerCase}"
                 role="menubar">
 
-                @NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map { item =>
+                @NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map { item =>
                     <li class="menu-item hide-on-desktop"
                         role="menuitem">
                         <a class="menu-item__title"
@@ -138,7 +138,7 @@
                     </li>
                 }
 
-                @NewNavigation.OtherLinks.getAllEditionalisedNavLinks(edition).map { item =>
+                @NewNavigation.OtherLinks.getEditionalisedNavLinks(edition).map { item =>
                     <li class="@RenderClasses(Map(
                             "hide-on-desktop" -> (item.title == "the guardian app"),
                             "menu-item--no-border" -> (item.title == "video")
@@ -179,7 +179,7 @@
             <div class="menu-brand-extensions__inner gs-container">
                 @fragments.inlineSvg("guardian-logo-160", "logo", List("menu-brand-extensions__logo"))
                 <ul class="menu-brand-extensions__list">
-                    @NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map { item =>
+                    @NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map { item =>
                         @brandExtensions(item)
                     }
                 </ul>

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -35,7 +35,7 @@
     	    </ul>
 
             @* Hiding the 'more' link on the homepage and footer *@
-            @if(!(id == "uk" ||  id == "us" ||  id == "au" ||  id == "international" || isFooter)) {
+            @if(!isFooter) {
                 <div class="subnav__item subnav__item--toggle-more js-visible hide-on-desktop">
                     <button class="
                         subnav-link

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -5,15 +5,13 @@
 @import views.support.RenderClasses
 
 
-@subNavItem(link: NavLink, id: String, shouldHideUntilDesktop: Boolean) = {
+@subNavItem(link: NavLink, id: String) = {
     <li class="@RenderClasses(Map(
-            "hide-until-desktop" -> shouldHideUntilDesktop,
             "subnav__item--current-section" -> (id == link.uniqueSection)
         ), "subnav__item")">
         <a class="@RenderClasses(Map(
-                "subnav-link" -> true,
                 "subnav-link--current-section" -> (id == link.uniqueSection)
-            ))"
+            ), "subnav-link")"
             href="@LinkTo(link.url)"
             data-link-name="nav2 : subnav : @{if(link.longTitle.isEmpty) link.title else link.longTitle}">
 
@@ -31,9 +29,8 @@
 
                 @defining(
                     NavigationHelpers.getSubSectionNavLinks(id, Edition(request), page.metadata.isFront)
-                ) { case (mostPopular, leastPopular) =>
-                    @mostPopular.map { link => @subNavItem(link, id, false)}
-                    @leastPopular.map { link => @subNavItem(link, id, true)}
+                ) { case subNav =>
+                    @subNav.map { link => @subNavItem(link, id)}
                 }
     	    </ul>
 

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -42,8 +42,8 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
   def renderAmpNav: Action[AnyContent] = Action { implicit request =>
     val edition = Edition(request)
     val navSecondarySections = List.concat(
-      NewNavigation.BrandExtensions.getAllEditionalisedNavLinks(edition).map(section => navSectionLink(section)),
-      NewNavigation.OtherLinks.getAllEditionalisedNavLinks(edition).map(section => navSectionLink(section))
+      NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map(section => navSectionLink(section)),
+      NewNavigation.OtherLinks.getEditionalisedNavLinks(edition).map(section => navSectionLink(section))
     )
 
     Cached(900) {
@@ -58,7 +58,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
       implicit val topLevelSectionWrites = new Writes[topLevelNavItems] {
         def writes(item: topLevelNavItems) = Json.obj(
           "title" -> item.editionalisedSection.name,
-          "subSections" -> item.editionalisedSection.getAllEditionalisedNavLinks(edition).map(subsection => navSectionLink(subsection))
+          "subSections" -> item.editionalisedSection.getEditionalisedNavLinks(edition).map(subsection => navSectionLink(subsection))
         )
       }
 
@@ -66,7 +66,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
         "items" -> Json.arr(
           Json.obj(
             "topLevelSections" -> NewNavigation.topLevelSections.map( section => topLevelNavItems(section) ),
-            "membershipLinks" -> NavigationHelpers.getMembershipLinks(edition).mostPopular.map( section => navSectionLink(section)),
+            "membershipLinks" -> NavigationHelpers.getMembershipLinks(edition).map( section => navSectionLink(section)),
             "secondarySections" -> navSecondarySections
           )
         )


### PR DESCRIPTION
## What does this change?
This change is pretty separated by commit, and if you want to you can review commit by commit. 

1. [We used to have two lists organised by most popular and now we don't need that anymore](https://github.com/guardian/frontend/pull/18248/commits/726e0fcf42a9721ab6c1886af6aa70482ef88ffe)
2. [The network front doesn't need its own special list anymore](https://github.com/guardian/frontend/pull/18248/commits/4045577ef3537c5896793ebd8696d8e603fbf07d)
3. [Football is going into the news lists](https://github.com/guardian/frontend/pull/18248/commits/e98b1ee63499178322902360259c460738a84c51)

## What is the value of this and can you measure success?
1. Cleaning up unused code
2. Better clearer user experience
3. Make the sports desk happy

## Does this affect other platforms - Amp, Apps, etc?
This will also change the nav in AMP (in the open menu state)

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/32890146-7d04a8c0-cac5-11e7-935b-a9ce35d299f2.png)

Other than the network front and news list in the nav, everything looks the same :)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
