### PR TITLE
Unruly performance test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -146,4 +146,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 1, 4),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-unruly-performance-test",
+    "Removes 5% of users from Unruly to measure performance impact",
+    owners = Seq(Owner.withGithub("janua")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 2, 28),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,6 +6,7 @@ import { paidContentVsOutbrain2 } from 'common/modules/experiments/tests/paid-co
 import { outstreamFrequencyCapHoldback } from 'common/modules/experiments/tests/outstream-cap-holdback';
 import { acquisitionsEpicElectionInteractiveEnd } from 'common/modules/experiments/tests/acquisitions-epic-election-interactive-end';
 import { iasAdTargetingV2 } from 'common/modules/experiments/tests/ias-ad-targeting';
+import { unrulyPerformanceTest } from 'common/modules/experiments/tests/unruly-performance';
 
 export const TESTS: $ReadOnlyArray<ABTest> = [
     paidContentVsOutbrain2,
@@ -13,6 +14,7 @@ export const TESTS: $ReadOnlyArray<ABTest> = [
     acquisitionsEpicElectionInteractiveEnd,
     outstreamFrequencyCapHoldback,
     iasAdTargetingV2,
+    unrulyPerformanceTest,
 ].filter(Boolean);
 
 export const getActiveTests = (): $ReadOnlyArray<ABTest> =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/unruly-performance.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/unruly-performance.js
@@ -1,3 +1,5 @@
+// @flow
+
 export const unrulyPerformanceTest: ABTest = {
     id: 'UnrulyPerformanceTest',
     start: '2017-11-10',
@@ -5,24 +7,21 @@ export const unrulyPerformanceTest: ABTest = {
     author: 'Francis Carr',
     description:
         'This test removes 5% of users from Unruly to measure performance impact',
-    audience: 0.10,
+    audience: 0.1,
     audienceOffset: 0,
-    successMeasure:
-        'No negative impact on attention time',
+    successMeasure: 'No negative impact on attention time',
     audienceCriteria: 'All web traffic.',
     dataLinkNames: '',
-    idealOutcome:
-        'We are informed on the impact of Unruly videos to users',
+    idealOutcome: 'We are informed on the impact of Unruly videos to users',
     canRun: () => true,
     variants: [
         {
             id: 'serve-unruly',
-            test: () => {
-            }
+            test: () => {},
         },
         {
             id: 'control',
-            test: () => {}
+            test: () => {},
         },
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/unruly-performance.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/unruly-performance.js
@@ -1,0 +1,28 @@
+export const unrulyPerformanceTest: ABTest = {
+    id: 'UnrulyPerformanceTest',
+    start: '2017-11-10',
+    expiry: '2018-02-28',
+    author: 'Francis Carr',
+    description:
+        'This test removes 5% of users from Unruly to measure performance impact',
+    audience: 0.10,
+    audienceOffset: 0,
+    successMeasure:
+        'No negative impact on attention time',
+    audienceCriteria: 'All web traffic.',
+    dataLinkNames: '',
+    idealOutcome:
+        'We are informed on the impact of Unruly videos to users',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'serve-unruly',
+            test: () => {
+            }
+        },
+        {
+            id: 'control',
+            test: () => {}
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

This adds a new AB test that introduces two variants that allow us to compare the impact of the new Unruly player to the site. The AB test doesn't really have any logic and is only used to classify people as either being in or out of the test; the AB tests a user is in then subsequently gets passed to DFP and it is there that we decide whether to show Unruly or not.

## What is the value of this and can you measure success?

We can initially look at the attention time and page performance of the different groups, and subsequently begin to look at other metrics.

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Tested in CODE?

Not yet!

@rich-nguyen @JonNorman 
