### PR TITLE
Factor out V1 marketing consent form

### DIFF
--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -1,0 +1,121 @@
+@* FIXME: To be deleted after GDPR goes live *@
+
+@import views.html.fragments.form.switchboardLabel
+@import _root_.form.IdFormHelpers.nonInputFields
+@import com.gu.identity.model.ConsentText
+@import com.gu.identity.model.ConsentText._
+
+@(idUrlBuilder: services.IdentityUrlBuilder,
+  idRequest: services.IdentityRequest,
+  privacyForm: Form[_root_.form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+
+
+@getConsentText(consentField: Field) = {
+    @ConsentText.getText(
+        consentField("consentIdentifier").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
+        consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
+}
+
+@consentCheckboxes = {
+    <div class="manage-account__switchboard">
+        <ul>
+            <li>
+                @switchboardLabel(
+                    title = currentConsents(FirstParty.name),
+                    description = None,
+                    behaviour = Some("consent"),
+                    field = privacyForm("receiveGnmMarketing")
+                )(nonInputFields, messages)
+            </li>
+            <li>
+                @switchboardLabel(
+                    title = currentConsents(ThirdParty.name),
+                    description = None,
+                    behaviour = Some("consent"),
+                    field = privacyForm("receive3rdPartyMarketing")
+                )(nonInputFields, messages)
+            </li>
+        </ul>
+    </div>
+}
+
+@* MARKETING CONSENT *@
+<form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+    @views.html.helper.CSRF.formField
+
+    @* This displays both global and key-bound errors *@
+    @if(privacyForm.hasErrors) {
+        <div class="form__error">
+            Error processing the form. Your changes have not been saved:
+            <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
+        </div>
+    }
+
+    <div class="js-errorHolder manage-account__errors"></div>
+
+    @* Marketing Consent *@
+    <div class="manage-account-headerWrapper">
+        <h2 class="manage-account-header">Marketing preferences</h2>
+    </div>
+    <fieldset class="fieldset">
+
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Marketing</h2>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li class="form-field">
+                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
+                    <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
+
+                    <div class="form-fields-group">
+                        @consentCheckboxes
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+
+    @* Profiling *@
+    <fieldset class="fieldset">
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Profiling</h2>
+        </div>
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li class="form-field">
+                    <label class="label">In addition to the data that you provide to us, we may also match profiling data from third parties with your registration details.</label>
+
+                    <div class="manage-account__switchboard manage-account__switchboard--narrow">
+                        <ul>
+                            <li>
+                            @fragments.form.switchboardLabel(
+                                title = "Allow matching with third party data",
+                                description = None,
+                                behaviour = Some("consent"),
+                                field = privacyForm("allowThirdPartyProfiling")
+                            )(nonInputFields, messages)
+                            </li>
+                        </ul>
+                    </div>
+
+                </li>
+            </ul>
+        </div>
+    </fieldset>
+
+    @* Submit button *@
+    <fieldset class="fieldset js-manage-account__consentCheckboxesSubmit">
+        <div class="fieldset__heading"></div>
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li>
+                    <button type="submit" class="manage-account__button" data-link-name="Save privacy preferences">Save changes</button>
+                </li>
+            </ul>
+        </div>
+
+    </fieldset>
+</form>
+

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -1,11 +1,9 @@
-@import views.html.fragments.form.checkboxField
-@import views.html.fragments.form.switchboardLabel
 @import views.html.fragments.registrationFooter
-@import _root_.form.IdFormHelpers.{Checkbox, nonInputFields}
+@import _root_.form.IdFormHelpers.nonInputFields
 @import com.gu.identity.model.ConsentText
 @import com.gu.identity.model.ConsentText._
 @import conf.switches.Switches.IdentityGdprMarketingConsentSwitch
-@import model.{ApplicationContext, EmailNewsletters, IdentityPage}
+@import model.{EmailNewsletters, IdentityPage}
 @import services.EmailPrefsData
 
 @(idUrlBuilder: services.IdentityUrlBuilder,
@@ -16,9 +14,7 @@
   emailSubscriptions: List[String],
   availableLists: EmailNewsletters)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
-
-@v2ConsentCheckbox(consentField: Field) = {
-
+@consentCheckbox(consentField: Field) = {
     @fragments.form.switchboardLabel(
         title = getConsentText(consentField).toString(),
         description = None,
@@ -30,12 +26,6 @@
             )
     )
     )(nonInputFields, messages)
-
-
-}
-
-@v2consentCheckboxes = {
-  @helper.repeat(privacyForm("consents"), min=1) { consentField => @v2ConsentCheckbox(consentField) }
 }
 
 @getConsentText(consentField: Field) = {
@@ -44,54 +34,30 @@
         consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
 }
 
-@v1consentCheckboxes = {
-    <div class="manage-account__switchboard">
-        <ul>
-            <li>
-                @fragments.form.switchboardLabel(
-                    title = currentConsents(FirstParty.name),
-                    description = None,
-                    behaviour = Some("consent"),
-                    field = privacyForm("receiveGnmMarketing")
-                )(nonInputFields, messages)
-            </li>
-            <li>
-                @fragments.form.switchboardLabel(
-                    title = currentConsents(ThirdParty.name),
-                    description = None,
-                    behaviour = Some("consent"),
-                    field = privacyForm("receive3rdPartyMarketing")
-                )(nonInputFields, messages)
-            </li>
-        </ul>
-    </div>
-}
-
-@* MARKETING CONSENT *@
+@marketingConsentForm = {
     <form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-    @views.html.helper.CSRF.formField
+        @views.html.helper.CSRF.formField
 
-    @* This displays both global and key-bound errors *@
-    @if(privacyForm.hasErrors) {
-        <div class="form__error">
-            Error processing the form. Your changes have not been saved:
-            <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
-        </div>
-    }
+        @* This displays both global and key-bound errors *@
+        @if(privacyForm.hasErrors) {
+            <div class="form__error">
+                Error processing the form. Your changes have not been saved:
+                <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
+            </div>
+        }
 
         <div class="js-errorHolder manage-account__errors"></div>
 
-    @if(IdentityGdprMarketingConsentSwitch.isSwitchedOn) {
         <h2 class="manage-account-header">Would you like to receive information from the Guardian and their partners?</h2>
         <p class="manage-account-headerNote">The Guardian and their partners would like to occasionally send you information about their products, services and events</p>
         <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
             <div class="manage-account__switchboard">
                 <ul>
-                    @helper.repeat(privacyForm("consents"), min=1) { consentField =>
-                        <li>
-                            @v2ConsentCheckbox(consentField)
-                        </li>
-                    }
+                @helper.repeat(privacyForm("consents"), min=1) { consentField =>
+                    <li>
+                        @consentCheckbox(consentField)
+                    </li>
+                }
                 </ul>
             </div>
         </div>
@@ -107,80 +73,19 @@
             </div>
 
         </fieldset>
-    }
-
-    @if(!IdentityGdprMarketingConsentSwitch.isSwitchedOn) {
-        @* Marketing Consent *@
-        <div class="manage-account-headerWrapper">
-            <h2 class="manage-account-header">Marketing preferences</h2>
-        </div>
-        <fieldset class="fieldset">
-
-        <div class="fieldset__heading">
-            <h2 class="form__heading">Marketing</h2>
-        </div>
-
-        <div class="fieldset__fields">
-            <ul class="u-unstyled">
-                <li class="form-field">
-                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
-                    <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
-
-                    <div class="form-fields-group">
-                        @v1consentCheckboxes
-                    </div>
-                </li>
-            </ul>
-        </div>
-    </fieldset>
-        @* Profiling *@
-        <fieldset class="fieldset">
-            <div class="fieldset__heading">
-                <h2 class="form__heading">Profiling</h2>
-            </div>
-            <div class="fieldset__fields">
-                <ul class="u-unstyled">
-                    <li class="form-field">
-                        <label class="label">In addition to the data that you provide to us, we may also match profiling data from third parties with your registration details.</label>
-
-                        <div class="manage-account__switchboard manage-account__switchboard--narrow">
-                            <ul>
-                                <li>
-                                @fragments.form.switchboardLabel(
-                                    title = "Allow matching with third party data",
-                                    description = None,
-                                    behaviour = Some("consent"),
-                                    field = privacyForm("allowThirdPartyProfiling")
-                                )(nonInputFields, messages)
-                                </li>
-                            </ul>
-                        </div>
-
-                    </li>
-                </ul>
-            </div>
-        </fieldset>
-        @* Submit button *@
-        <fieldset class="fieldset js-manage-account__consentCheckboxesSubmit">
-            <div class="fieldset__heading"></div>
-            <div class="fieldset__fields">
-                <ul class="u-unstyled">
-                    <li>
-                        <button type="submit" class="manage-account__button" data-link-name="Save privacy preferences">Save changes</button>
-                    </li>
-                </ul>
-            </div>
-
-        </fieldset>
-    }
     </form>
+}
+
+@* MARKETING CONSENT *@
+@if(IdentityGdprMarketingConsentSwitch.isSwitchedOn) {
+    @marketingConsentForm
+} else {
+    @profile.marketingConsentFormV1(idUrlBuilder, idRequest, privacyForm)
+}
 
 @* NEWSLETTERS *@
-
-    <hr class="manage-account-divider" />
-    <h2 class="manage-account-header">Select which newsletters you would like to receive</h2>
-
+<hr class="manage-account-divider" />
+<h2 class="manage-account-header">Select which newsletters you would like to receive</h2>
 @profile.emailPrefs(IdentityPage("/email-prefs", "Email preferences"), emailPrefsForm, emailSubscriptions, availableLists, idRequest, idUrlBuilder)
-
 
 @registrationFooter(idRequest, idUrlBuilder)


### PR DESCRIPTION
## What does this change?

Factor out `marketingConsentFormV1.scala.html` out of `privacyForm.scala.html`.

## What is the value of this and can you measure success?

Easier to remove V1 after we go live with GDPR. Also cleaner switch.
