### PR TITLE
Account for V2 consent ajax submission semantic discrepancy

### DIFF
--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -88,13 +88,23 @@ case class PrivacyFormData(
       case Some(_) => allowThirdPartyProfiling
     }
 
+    val newConsents = for {
+      oldConsent <- oldUserDO.consents
+      newConsent <- consents
+    } yield {
+      if (oldConsent.consentIdentifier == newConsent.consentIdentifier)
+        newConsent
+      else
+        oldConsent
+    }
+
     UserUpdateDTO(
       statusFields = Some(oldUserDO.statusFields.copy(
         receive3rdPartyMarketing = newReceive3rdPartyMarketing,
         receiveGnmMarketing = newReceiveGnmMarketing,
         allowThirdPartyProfiling = newAllowThirdPartyProfiling
       )),
-      consents = Some(consents))
+      consents = Some(newConsents))
   }
 }
 


### PR DESCRIPTION
## What does this change?

Same as https://github.com/guardian/frontend/pull/18240 but for V2 GDPR consents.


