### PR TITLE
Update newsletter preferences to use ajax checkboxes

### DIFF
--- a/identity/app/views/fragments/form/switchboardLabel.scala.html
+++ b/identity/app/views/fragments/form/switchboardLabel.scala.html
@@ -2,6 +2,7 @@
 
 @(
     title: String,
+    subheading: Option[String],
     description: Option[String],
     behaviour: Option[String],
     field: Field,
@@ -21,9 +22,12 @@
     <div class="account__switchboardLabelContent">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switchboardCheckbox"></div>
-        <p class="manage-account__switchboardTitle">
+        <h3 class="manage-account__switchboardTitle">
             @title
-        </p>
+            @if(subheading.isDefined){
+                <strong>@subheading</strong>
+            }
+        </h3>
         @if(description) {
             <p class="manage-account__switchboardCopy">
                 @description

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -18,42 +18,31 @@
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
     @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
-        @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
-            <div class="@RenderClasses(Map(
-                "u-cf" -> true,
-                "email-subscription" -> true,
-                "email-subscription--subscribed" -> newsletter.subscribedTo(emailSubscriptions),
-                "email-subscription--first" -> row.isFirst))">
-                @if(newsletter.subscribedTo(emailSubscriptions)){<input type="hidden" name="emailSubscription[]" value="@newsletter.listId" />}
-                <div class="email-subscription__name">
-                    <h2 class="email-subscription__heading">@newsletter.name</h2>
 
-                    @if(newsletter.subheading.isDefined){
-                        <h3 class="email-subscription__subheading">@newsletter.subheading</h3>
-                    }
-                </div>
+        <div class="manage-account__switchboard"><ul>
+            @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
 
-                <div class="email-subscription__description">
-                  @newsletter.description
-                  @if(newsletter.exampleUrl.isDefined){<br>
-                  <a href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })" target="preview-email-@newsletter.listId">See the latest email</a>}
-                </div>
+                <li>
 
-                <div class="email-subscription__meta u-cf">
-                    <button class="manage-account__button js-subscription-button"
-                            data-link-name="@if(newsletter.subscribedTo(emailSubscriptions)){Unsubscribe}else{Subscribe} to @newsletter.name"
-                            name="addEmailSubscription"
-                            type="button"
-                            value="@if(newsletter.subscribedTo(emailSubscriptions)){unsubscribe-@{newsletter.allIds.mkString(",")}}else{@newsletter.listId}">
-                        @if(newsletter.subscribedTo(emailSubscriptions)){Unsubscribe}else{Subscribe}
-                    </button>
-                    <div class="email-subscription__frequency">
-                        @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
-                        @newsletter.frequency
-                    </div>
-                </div>
-            </div>
-        }
+                    @fragments.form.switchboardLabel(
+                        title = newsletter.name,
+                        subheading = newsletter.subheading,
+                        description = Some(newsletter.description),
+                        behaviour = Some("newsletter"),
+                        field = new Field(
+                            form = emailPrefsForm,
+                            name = newsletter.listId.toString(),
+                            constraints = Seq(),
+                            format = None,
+                            errors = Seq(),
+                            value = Some(newsletter.subscribedTo(emailSubscriptions).toString())
+                        ),
+                        newsletterPreview = newsletter.exampleUrl,
+                        newsletterFrequency = Some(newsletter.frequency)
+                    )(nonInputFields, messages)
+                </li>
+            }
+        </ul></div>
     }
 }
 

--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -17,7 +17,7 @@
 }
 
 @consentCheckboxes = {
-    <div class="manage-account__switchboard">
+    <div class="manage-account__switchboard manage-account__switchboard--narrow">
         <ul>
             <li>
                 @switchboardLabel(

--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -22,6 +22,7 @@
             <li>
                 @switchboardLabel(
                     title = currentConsents(FirstParty.name),
+                    subheading = None,
                     description = None,
                     behaviour = Some("consent"),
                     field = privacyForm("receiveGnmMarketing")
@@ -30,6 +31,7 @@
             <li>
                 @switchboardLabel(
                     title = currentConsents(ThirdParty.name),
+                    subheading = None,
                     description = None,
                     behaviour = Some("consent"),
                     field = privacyForm("receive3rdPartyMarketing")
@@ -92,6 +94,7 @@
                             <li>
                             @fragments.form.switchboardLabel(
                                 title = "Allow matching with third party data",
+                                subheading = None,
                                 description = None,
                                 behaviour = Some("consent"),
                                 field = privacyForm("allowThirdPartyProfiling")

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -17,6 +17,7 @@
 @consentCheckbox(consentField: Field) = {
     @fragments.form.switchboardLabel(
         title = getConsentText(consentField).toString(),
+        subheading = None,
         description = None,
         behaviour = Some("consent"),
         field = consentField("hasConsented"),

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -150,6 +150,11 @@ const bindUnsubscribeFromAll = buttonEl => {
                 .then(([newsletterIds, csrfToken]) =>
                     submitNewsletterAction(csrfToken, 'remove', newsletterIds)
                 )
+                .catch((err: Error) => {
+                    pushError(err, 'reload').then(() => {
+                        window.scrollTo(0, 0);
+                    });
+                })
                 .then(() => {
                     removeUpdatingState(buttonEl);
                 });
@@ -189,7 +194,9 @@ const bindNewsletterLabelFromSwitchboard = (labelEl: HTMLElement): void => {
                     )
                 )
                 .catch((err: Error) => {
-                    pushError(err, 'reload');
+                    pushError(err, 'reload').then(() => {
+                        window.scrollTo(0, 0);
+                    });
                     return flipCheckbox(labelEl);
                 })
                 .then(() => removeSpinner(labelEl));
@@ -218,7 +225,9 @@ const bindConsentLabelFromSwitchboard = (labelEl: HTMLElement): void => {
                     submitPartialFormStatus('consent', formData)
                 )
                 .catch((err: Error) => {
-                    pushError(err, 'reload');
+                    pushError(err, 'reload').then(() => {
+                        window.scrollTo(0, 0);
+                    });
                     return flipCheckbox(labelEl);
                 })
                 .then(() => removeSpinner(labelEl));

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -10,14 +10,14 @@ import $ from 'lib/$';
 import { push as pushError } from './modules/show-errors';
 import { addSpinner, removeSpinner, flip as flipCheckbox, getInfo as getCheckboxInfo } from './modules/switchboardLabel';
 
-const addUpdatingState = (buttonEl:HTMLElement) =>
+const addUpdatingState = (buttonEl:HTMLButtonElement) =>
     fastdom.write(() => {
         buttonEl.disabled = true;
         $(buttonEl).addClass('is-updating is-updating-subscriptions');
     });
 
 
-const removeUpdatingState = (buttonEl:HTMLElement) =>
+const removeUpdatingState = (buttonEl:HTMLButtonElement) =>
     fastdom.write(() => {
         buttonEl.disabled = false;
         $(buttonEl).removeClass('is-updating is-updating-subscriptions');
@@ -129,7 +129,7 @@ const submitPartialFormStatus = (type: ?string = null, formData: FormData): Prom
     });
 }
 
-const submitNewsletterAction = (csrfToken: string, action: ?string = null, newsletters: array = []) => {
+const submitNewsletterAction = (csrfToken: string, action: string = 'none', newsletters: Array<string> = []) => {
 
     const formData = new FormData();
     formData.append('csrfToken', csrfToken);

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -215,7 +215,7 @@ const bindConsentLabelFromSwitchboard = (labelEl: HTMLElement): void => {
                     buildFormDataForFields(token, fields)
                 )
                 .then((formData: FormData) =>
-                    submitPartialFormStatus('newsletter', formData)
+                    submitPartialFormStatus('consent', formData)
                 )
                 .catch((err: Error) => {
                     pushError(err, 'reload');

--- a/static/src/javascripts/projects/common/modules/identity/modules/button.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/button.js
@@ -1,0 +1,15 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import $ from 'lib/$';
+
+export const addUpdatingState = (buttonEl: HTMLButtonElement) =>
+    fastdom.write(() => {
+        buttonEl.disabled = true;
+        $(buttonEl).addClass('is-updating is-updating-subscriptions');
+    });
+
+export const removeUpdatingState = (buttonEl: HTMLButtonElement) =>
+    fastdom.write(() => {
+        buttonEl.disabled = false;
+        $(buttonEl).removeClass('is-updating is-updating-subscriptions');
+    });

--- a/static/src/javascripts/projects/common/modules/identity/modules/switchboardLabel.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switchboardLabel.js
@@ -1,6 +1,31 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
 
+export const getInfo = (labelEl: HTMLElement):Promise<any> =>
+    fastdom
+        .read((): ?HTMLElement =>
+            labelEl.querySelector('input')
+        )
+        .then((checkboxEl: HTMLInputElement)=>{
+            return {
+                checked: checkboxEl.checked,
+                name: checkboxEl.name
+            };
+        });
+
+
+export const flip = (labelEl: HTMLElement): Promise<any> =>
+    fastdom
+        .read((): ?HTMLElement =>
+            labelEl.querySelector('input')
+        )
+        .then((checkboxEl: HTMLInputElement) => {
+            fastdom.write(() => {
+                checkboxEl.checked = !checkboxEl.checked;
+            });
+        });
+
+
 export const addSpinner = (labelEl: HTMLElement): Promise<any> =>
     fastdom.write(() => {
         if (document.body) {

--- a/static/src/javascripts/projects/common/modules/identity/modules/switchboardLabel.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switchboardLabel.js
@@ -1,30 +1,22 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
 
-export const getInfo = (labelEl: HTMLElement):Promise<any> =>
+export const getInfo = (labelEl: HTMLElement): Promise<any> =>
     fastdom
-        .read((): ?HTMLElement =>
-            labelEl.querySelector('input')
-        )
-        .then((checkboxEl: HTMLInputElement)=>{
-            return {
-                checked: checkboxEl.checked,
-                name: checkboxEl.name
-            };
-        });
-
+        .read((): ?HTMLElement => labelEl.querySelector('input'))
+        .then((checkboxEl: HTMLInputElement) => ({
+            checked: checkboxEl.checked,
+            name: checkboxEl.name,
+        }));
 
 export const flip = (labelEl: HTMLElement): Promise<any> =>
     fastdom
-        .read((): ?HTMLElement =>
-            labelEl.querySelector('input')
-        )
+        .read((): ?HTMLElement => labelEl.querySelector('input'))
         .then((checkboxEl: HTMLInputElement) => {
             fastdom.write(() => {
                 checkboxEl.checked = !checkboxEl.checked;
             });
         });
-
 
 export const addSpinner = (labelEl: HTMLElement): Promise<any> =>
     fastdom.write(() => {

--- a/static/src/stylesheets/module/identity/_switchboard.scss
+++ b/static/src/stylesheets/module/identity/_switchboard.scss
@@ -15,7 +15,7 @@ $checkbox-size: $gs-gutter / 1.25;
 .manage-account__switchboard {
 
     ul {
-        grid-template-columns: repeat(auto-fit, minmax(gs-span(3), 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(gs-span(4), 1fr));
         grid-auto-rows: 1fr;
         display: grid;
         padding-top: $local-gutter;
@@ -24,8 +24,9 @@ $checkbox-size: $gs-gutter / 1.25;
     }
 
     &--narrow ul {
+        grid-template-columns: repeat(1,1fr);
         @include mq(tablet) {
-            grid-template-columns: repeat(auto-fit, minmax(gs-span(3), .5fr));
+            grid-template-columns: repeat(2,1fr);
         }
     }
 
@@ -42,11 +43,12 @@ $checkbox-size: $gs-gutter / 1.25;
 .manage-account__switchboardLabel {
 
     @include fs-textSans(1);
-    display: block;
     background-color: $neutral-8;
     border-top: 1px solid $neutral-4;
     overflow: hidden;
     position: relative;
+    display: flex;
+    width: 100%;
 
     .account__switchboardLabelHeader {
         @include f-header;
@@ -73,6 +75,8 @@ $checkbox-size: $gs-gutter / 1.25;
         padding-left: $local-gutter * 2 + $checkbox-size;
         padding-top: $local-gutter * .9;
         position: relative;
+        display: flex;
+        flex-direction: column;
     }
 
     &:hover {
@@ -114,6 +118,7 @@ $checkbox-size: $gs-gutter / 1.25;
     .manage-account__switchboardCopy {
         cursor: pointer;
         opacity: .9;
+        flex: 1 1 auto;
     }
 
     .manage-account__switchboardTidbit {
@@ -130,6 +135,10 @@ $checkbox-size: $gs-gutter / 1.25;
         display: flex;
         justify-content: space-between;
         width: 100%;
+
+        > :last-child {
+            text-align: right;
+        }
     }
 
     &:before {

--- a/static/src/stylesheets/module/identity/_switchboard.scss
+++ b/static/src/stylesheets/module/identity/_switchboard.scss
@@ -24,9 +24,9 @@ $checkbox-size: $gs-gutter / 1.25;
     }
 
     &--narrow ul {
-        grid-template-columns: repeat(1,1fr);
+        grid-template-columns: repeat(1, 1fr);
         @include mq(tablet) {
-            grid-template-columns: repeat(2,1fr);
+            grid-template-columns: repeat(2, 1fr);
         }
     }
 


### PR DESCRIPTION
## What does this change?
Updates the newsletter preferences page to use the ajax checkbox module introduced in #18241 

## What is the value of this and can you measure success?
Code reuse! Visually the page is way shorter and more parseable as the newsletters are now on a 2 column grid

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![screen shot 2017-11-16 at 14 56 55](https://user-images.githubusercontent.com/11539094/32897912-adf1eee8-cade-11e7-8b9f-78ec40dc5fb7.png)
]

## Tested in CODE?
No