### PR TITLE
Fix optional content type when deducing ad unit string.

### DIFF
--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -41,7 +41,7 @@ case class AmpAd(article: Article, uri: String, edition: String) {
 case class AmpAdDataSlot(article: Article) {
   override def toString(): String = {
     val section = article.metadata.sectionId
-    val contentType = article.metadata.contentType.map(_.name.toLowerCase)
+    val contentType = article.metadata.contentType.map(_.name.toLowerCase).getOrElse("unknown")
 
     s"/59666047/theguardian.com/$section/$contentType/amp"
   }

--- a/common/test/views/support/AmpAdTest.scala
+++ b/common/test/views/support/AmpAdTest.scala
@@ -10,14 +10,14 @@ class AmpAdTest extends FlatSpec with Matchers {
      val sectionId = "sectionId"
      val result = AmpAdDataSlot(article(sectionId)).toString()
 
-     result should include(sectionId)
+     result should include(s"/$sectionId/")
    }
 
   "AmpAdDataSlot" should "return a string containing article's contentType" in {
     val contentType = "article"
     val result = AmpAdDataSlot(article("")).toString()
 
-    result should include(contentType)
+    result should include(s"/$contentType/")
   }
 
   "AmpAd" should "return a JSON object containing passed URI" in {

--- a/common/test/views/support/AmpAdTest.scala
+++ b/common/test/views/support/AmpAdTest.scala
@@ -10,14 +10,14 @@ class AmpAdTest extends FlatSpec with Matchers {
      val sectionId = "sectionId"
      val result = AmpAdDataSlot(article(sectionId)).toString()
 
-     result should include(s"/$sectionId/")
+     result should be(s"/59666047/theguardian.com/$sectionId/article/amp")
    }
 
   "AmpAdDataSlot" should "return a string containing article's contentType" in {
-    val contentType = "article"
-    val result = AmpAdDataSlot(article("")).toString()
+    val sectionId = "sectionId"
+    val result = AmpAdDataSlot(article(sectionId)).toString()
 
-    result should include(s"/$contentType/")
+    result should be(s"/59666047/theguardian.com/$sectionId/article/amp")
   }
 
   "AmpAd" should "return a JSON object containing passed URI" in {


### PR DESCRIPTION
When generating the ad unit ID on AMP, the value `contentType` is an `Option[String]` and so must be extracted before concatenating to the other elements of the String.

It is my understanding that all articles on AMP will have a `contentType` and, as such, this needn't really be an `Option[String]`, however I think it is beyond the scope of this issue to go through the codebase changing this, so I've opted for a `getOrElse` with a grep-able string should we find that there _are_ articles with no `contentType`.