### PR TITLE
Remove prefix from IAS switch (no longer AB switch).

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -27,7 +27,7 @@ trait CommercialSwitches {
 
   Switch(
     SwitchGroup.Commercial,
-    "ab-ias-ad-targeting",
+    "ias-ad-targeting",
     "Enables the IAS slot-targeting optimisation.",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -107,7 +107,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
 
         To see debugging output from IAS add the URL param `&iasdebug=true` to the page URL
      */
-    if (config.get('switches.abIasAdTargeting', false)) {
+    if (config.get('switches.iasAdTargeting', false)) {
         /* eslint-disable no-underscore-dangle */
         // this should all have been instantiated by commercial/modules/third-party-tags/ias.js
         window.__iasPET = window.__iasPET || {};


### PR DESCRIPTION
Forgot to remove the "ab-" prefix from the switch when I moved it from the AB switches. Doh.