### PR TITLE
Refactor newsletter switch scala template

### DIFF
--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -45,7 +45,7 @@
                     </div>
                 }
                 @if(newsletterPreview.isDefined){
-                    <a class="" href="#">
+                    <a href="@newsletterPreview">
                         See the latest email
                     </a>
                 }

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -7,8 +7,7 @@
     behaviour: Option[String],
     field: Field,
     extraFields: Option[List[play.twirl.api.HtmlFormat.Appendable]] = None,
-    newsletterFrequency: Option[String] = None,
-    newsletterPreview: Option[String] = None
+    footer: Option[Html] = None
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 <label class="
@@ -36,19 +35,9 @@
         @if(extraFields.isDefined){
             @extraFields
         }
-        @if(newsletterFrequency.isDefined || newsletterPreview.isDefined) {
+        @if(footer.isDefined) {
             <div class="manage-account__switch-footer">
-                @if(newsletterFrequency.isDefined){
-                    <div class="manage-account__switch-footer-tidbit">
-                        @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
-                        @newsletterFrequency
-                    </div>
-                }
-                @if(newsletterPreview.isDefined){
-                    <a href="@newsletterPreview">
-                        See the latest email
-                    </a>
-                }
+                @footer
             </div>
         }
     </div>

--- a/identity/app/views/fragments/form/switchNewsletter.scala.html
+++ b/identity/app/views/fragments/form/switchNewsletter.scala.html
@@ -1,0 +1,37 @@
+@import model.{EmailNewsletter, EmailNewsletters}
+@import common.LinkTo
+@import _root_.form.IdFormHelpers.nonInputFields
+
+
+@(
+    newsletter: EmailNewsletter
+)(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages, request: RequestHeader, form: Form[_], emailSubscriptions: List[String])
+
+@buildFooter(newsletter: EmailNewsletter) = {
+    <div class="manage-account__switch-footer-tidbit">
+        @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
+        @newsletter.frequency
+    </div>
+    @if(newsletter.exampleUrl.isDefined){
+        <a target="preview-email-@newsletter.listId" href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })">
+            See the latest email
+        </a>
+    }
+}
+
+    @fragments.form.switch(
+        title = newsletter.name,
+        subheading = newsletter.subheading,
+        description = Some(newsletter.description),
+        behaviour = Some("newsletter"),
+        field = new Field(
+            form = form,
+            name = newsletter.listId.toString(),
+            constraints = Seq(),
+            format = None,
+            errors = Seq(),
+            value = Some(newsletter.subscribedTo(emailSubscriptions).toString())
+        ),
+        extraFields = None,
+        footer = Some(buildFooter(newsletter))
+    )(nonInputFields, messages)

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -1,10 +1,7 @@
 @import form.IdFormHelpers.nonInputFields
 @import model.{EmailNewsletter, EmailNewsletters}
 @import views.html.fragments.form.radioField
-@import views.support.RenderClasses
 @import views.support.`package`.Seq2zipWithRowInfo
-@import common.LinkTo
-@import conf.Configuration
 
 @import services.EmailPrefsData
 
@@ -23,23 +20,9 @@
             @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
 
                 <li>
-
-                    @fragments.form.switch(
-                        title = newsletter.name,
-                        subheading = newsletter.subheading,
-                        description = Some(newsletter.description),
-                        behaviour = Some("newsletter"),
-                        field = new Field(
-                            form = emailPrefsForm,
-                            name = newsletter.listId.toString(),
-                            constraints = Seq(),
-                            format = None,
-                            errors = Seq(),
-                            value = Some(newsletter.subscribedTo(emailSubscriptions).toString())
-                        ),
-                        newsletterPreview = newsletter.exampleUrl,
-                        newsletterFrequency = Some(newsletter.frequency)
-                    )(nonInputFields, messages)
+                    @fragments.form.switchNewsletter(
+                        newsletter = newsletter
+                    )(nonInputFields, messages, request, emailPrefsForm, emailSubscriptions)
                 </li>
             }
         </ul></div>


### PR DESCRIPTION
## What does this change?
Splits newsletter-related `switch.scala.html` functionality into a separate `switchnewsletter.scala.html` view that only takes a newsletter as a parameter, keeping the signature on the main switch cleaner and free of newsletter-related code

## What is the value of this and can you measure success?
Claner code. Plus, more importantly, fixes a bug where the "See latest email" link not working

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No 

## Screenshots
N/A

## Tested in CODE?
No
