### PR TITLE
Increase Facia cache time

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -19,7 +19,8 @@ object CacheTime {
   object Default extends CacheTime(60)
   object LiveBlogActive extends CacheTime(5)
   object RecentlyUpdated extends CacheTime(60)
-  object Facia extends CacheTime(300)
+  // There is lambda which invalidates the cache on press events, so the facia cache time can be high.
+  object Facia extends CacheTime(3600)
   object ArchiveRedirect extends CacheTime(300)
   object ShareCount extends CacheTime(600)
   object NotFound extends CacheTime(10) // This will be overwritten by fastly

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -3,8 +3,11 @@ package model
 import conf.switches.Switches.LongCacheSwitch
 import org.joda.time.DateTime
 import com.github.nscala_time.time.Implicits._
+import common.GuardianConfiguration
+import conf.Configuration
 import play.api.http.Writeable
 import play.api.mvc._
+
 import scala.math.{max, min}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
@@ -20,7 +23,7 @@ object CacheTime {
   object LiveBlogActive extends CacheTime(5)
   object RecentlyUpdated extends CacheTime(60)
   // There is lambda which invalidates the cache on press events, so the facia cache time can be high.
-  object Facia extends CacheTime(3600)
+  object Facia extends CacheTime(Configuration.faciatool.adminPressJobLowPushRateInMinutes * 60)
   object ArchiveRedirect extends CacheTime(300)
   object ShareCount extends CacheTime(600)
   object NotFound extends CacheTime(10) // This will be overwritten by fastly

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -3,11 +3,9 @@ package model
 import conf.switches.Switches.LongCacheSwitch
 import org.joda.time.DateTime
 import com.github.nscala_time.time.Implicits._
-import common.GuardianConfiguration
 import conf.Configuration
 import play.api.http.Writeable
 import play.api.mvc._
-
 import scala.math.{max, min}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration


### PR DESCRIPTION
There is lambda which invalidates the cache on press events, so the facia cache time can be high.
Low priority fronts are only pressed every 60 minutes. Making the cache time shorter than 1h is then useless

## What does this change?

Cache time for Facia

## What is the value of this and can you measure success?

Facia does less json processing.

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
