### PR TITLE
More button should expand the subnav, not open the menu

### DIFF
--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -24,7 +24,7 @@
 <div class="subnav">
     <div class="gs-container">
         @defining(NavigationHelpers.getActivePillar(page)) { case (id, activePillarName) =>
-            <ul class="subnav__list"
+            <ul class="subnav__list js-expand-subnav-list"
                 data-pillar-title="@activePillarName">
 
                 @defining(
@@ -40,7 +40,7 @@
                     <button class="
                         subnav-link
                         subnav-link--toggle-more
-                        js-toggle-nav-section"
+                        js-toggle-more-sections"
                         data-link-name="nav2 : subnav-toggle">
                         more
                     </button>

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -36,7 +36,7 @@
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!isFooter) {
-                <div class="subnav__item subnav__item--toggle-more js-show-more-button is-hidden">
+                <div class="subnav__item subnav__item--toggle-more js-show-more-button js-visible">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -24,7 +24,7 @@
 <div class="subnav js-expand-subnav">
     <div class="gs-container">
         @defining(NavigationHelpers.getActivePillar(page)) { case (id, activePillarName) =>
-            <ul class="subnav__list"
+            <ul class="subnav__list js-get-last-child-subnav"
                 data-pillar-title="@activePillarName">
 
                 @defining(
@@ -36,7 +36,7 @@
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!isFooter) {
-                <div class="subnav__item subnav__item--toggle-more js-visible hide-from-tablet">
+                <div class="subnav__item subnav__item--toggle-more js-show-more-button is-hidden">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -36,7 +36,7 @@
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!isFooter) {
-                <div class="subnav__item subnav__item--toggle-more js-show-more-button js-visible">
+                <div class="subnav__item subnav__item--toggle-more hide-from-desktop js-show-more-button js-visible">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more

--- a/common/app/views/fragments/nav/subNav.scala.html
+++ b/common/app/views/fragments/nav/subNav.scala.html
@@ -21,10 +21,10 @@
 }
 
 
-<div class="subnav">
+<div class="subnav js-expand-subnav">
     <div class="gs-container">
         @defining(NavigationHelpers.getActivePillar(page)) { case (id, activePillarName) =>
-            <ul class="subnav__list js-expand-subnav-list"
+            <ul class="subnav__list"
                 data-pillar-title="@activePillarName">
 
                 @defining(
@@ -36,7 +36,7 @@
 
             @* Hiding the 'more' link on the homepage and footer *@
             @if(!isFooter) {
-                <div class="subnav__item subnav__item--toggle-more js-visible hide-on-desktop">
+                <div class="subnav__item subnav__item--toggle-more js-visible hide-from-tablet">
                     <button class="
                         subnav-link
                         subnav-link--toggle-more

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -329,20 +329,6 @@ const enhanceMenuToggles = (): void => {
     });
 };
 
-const toggleMenuWithOpenSection = () => {
-    const menu = getMenu();
-    const subnav = document.querySelector('.subnav__list');
-    const pillarTitle = (subnav && subnav.dataset.pillarTitle) || '';
-    const targetSelector = `.js-navigation-item[data-section-name="${pillarTitle}"]`;
-    const section = menu && menu.querySelector(targetSelector);
-
-    if (section) {
-        openMenuSection(section, { scrollIntoView: true });
-    }
-
-    toggleMenu();
-};
-
 const getRecentSearch = (): ?string => local.get(SEARCH_STORAGE_KEY);
 
 const clearRecentSearch = (): void => local.remove(SEARCH_STORAGE_KEY);
@@ -362,11 +348,26 @@ const trackRecentSearch = (): void => {
 
 const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
 
+const expandSubnavSections = (moreButton): void => {
+    fastdom
+        .read(() => document.querySelector('.js-expand-subnav-list'))
+        .then(subnavList => {
+            if (subnavList) {
+                fastdom.write(() => {
+                    subnavList.classList.add('subnav__list--expanded');
+
+                    // Todo: should be able to toggle this, but right now just expands
+                    moreButton.innerText = 'less';
+                });
+            }
+        });
+};
+
 const addEventHandler = (): void => {
     const menu = getMenu();
     const search = menu && menu.querySelector('.js-menu-search');
     const toggleWithMoreButton = document.querySelector(
-        '.js-toggle-nav-section'
+        '.js-toggle-more-sections'
     );
 
     if (menu) {
@@ -400,7 +401,7 @@ const addEventHandler = (): void => {
 
     if (toggleWithMoreButton) {
         toggleWithMoreButton.addEventListener('click', () => {
-            toggleMenuWithOpenSection();
+            expandSubnavSections(toggleWithMoreButton);
         });
     }
 };

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -348,16 +348,19 @@ const trackRecentSearch = (): void => {
 
 const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
 
-const expandSubnavSections = (moreButton): void => {
+const toggleSubnavSections = (moreButton: HTMLElement): void => {
     fastdom
         .read(() => document.querySelector('.js-expand-subnav'))
         .then(subnav => {
             if (subnav) {
                 fastdom.write(() => {
-                    subnav.classList.add('subnav--expanded');
+                    const isOpen = subnav.classList.contains(
+                        'subnav--expanded'
+                    );
 
-                    // Todo: should be able to toggle this, but right now just expands
-                    moreButton.innerText = 'less';
+                    subnav.classList.toggle('subnav--expanded');
+
+                    moreButton.innerText = isOpen ? 'more' : 'less';
                 });
             }
         });
@@ -401,7 +404,7 @@ const addEventHandler = (): void => {
 
     if (toggleWithMoreButton) {
         toggleWithMoreButton.addEventListener('click', () => {
-            expandSubnavSections(toggleWithMoreButton);
+            toggleSubnavSections(toggleWithMoreButton);
         });
     }
 };

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -368,12 +368,14 @@ const showMoreButton = (): void => {
             }
         })
         .then(els => {
-            const { moreButton, lastChildRect, subnavRect } = els;
+            if (els) {
+                const { moreButton, lastChildRect, subnavRect } = els;
 
-            if (subnavRect.top === lastChildRect.top) {
-                fastdom.write(() => {
-                    moreButton.classList.add('is-hidden');
-                });
+                if (subnavRect.top === lastChildRect.top) {
+                    fastdom.write(() => {
+                        moreButton.classList.add('is-hidden');
+                    });
+                }
             }
         });
 };

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -370,9 +370,9 @@ const showMoreButton = (): void => {
         .then(els => {
             const { moreButton, lastChildRect, subnavRect } = els;
 
-            if (subnavRect.top !== lastChildRect.top) {
+            if (subnavRect.top === lastChildRect.top) {
                 fastdom.write(() => {
-                    moreButton.classList.remove('is-hidden');
+                    moreButton.classList.add('is-hidden');
                 });
             }
         });

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -348,6 +348,36 @@ const trackRecentSearch = (): void => {
 
 const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
 
+const showMoreButton = (): void => {
+    fastdom
+        .read(() => {
+            const moreButton = document.querySelector('.js-show-more-button');
+            const subnav = document.querySelector('.js-expand-subnav');
+            const subnavList = document.querySelector(
+                '.js-get-last-child-subnav'
+            );
+
+            if (subnav && subnavList) {
+                const subnavItems = subnavList.querySelectorAll('li');
+                const lastChild = subnavItems[subnavItems.length - 1];
+
+                const lastChildRect = lastChild.getBoundingClientRect();
+                const subnavRect = subnav.getBoundingClientRect();
+
+                return { moreButton, lastChildRect, subnavRect };
+            }
+        })
+        .then(els => {
+            const { moreButton, lastChildRect, subnavRect } = els;
+
+            if (subnavRect.top !== lastChildRect.top) {
+                fastdom.write(() => {
+                    moreButton.classList.remove('is-hidden');
+                });
+            }
+        });
+};
+
 const toggleSubnavSections = (moreButton: HTMLElement): void => {
     fastdom
         .read(() => document.querySelector('.js-expand-subnav'))
@@ -411,6 +441,7 @@ const addEventHandler = (): void => {
 
 export const newHeaderInit = (): void => {
     enhanceMenuToggles();
+    showMoreButton();
     addEventHandler();
     showMyAccountIfNecessary();
     initiateUserAccountDropdown();

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -350,11 +350,11 @@ const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
 
 const expandSubnavSections = (moreButton): void => {
     fastdom
-        .read(() => document.querySelector('.js-expand-subnav-list'))
-        .then(subnavList => {
-            if (subnavList) {
+        .read(() => document.querySelector('.js-expand-subnav'))
+        .then(subnav => {
+            if (subnav) {
                 fastdom.write(() => {
-                    subnavList.classList.add('subnav__list--expanded');
+                    subnav.classList.add('subnav--expanded');
 
                     // Todo: should be able to toggle this, but right now just expands
                     moreButton.innerText = 'less';

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -5,24 +5,24 @@
     font-size: 15px;
     height: $veggie-burger-medium - $gs-baseline;
     line-height: $veggie-burger-medium - $gs-baseline;
-    padding: 0 7px;
+    padding: 0 ($gs-gutter / 4);
     position: relative;
+    transition: color 150ms ease-out;
 
-    @include mq($from: mobileMedium, $until: tablet) {
+    @include mq(mobileMedium) {
         font-size: 17px;
     }
 
     @include mq(tablet) {
         height: 42px;
         line-height: 42px;
-        padding: 0 ($gs-gutter / 2 + $gs-gutter / 4) 0 ($gs-gutter / 4);
     }
 
     &:after {
         border-bottom: 1px solid $neutral-5;
         bottom: -1px;
         content: '';
-        left: 7px;
+        left: $gs-gutter / 4;
         position: absolute;
         right: -9999px;
     }
@@ -38,7 +38,6 @@
     background: transparent;
     border: 0;
     color: $neutral-2;
-    padding-right: $gs-gutter / 3;
 
     &:hover,
     &:focus {
@@ -48,6 +47,10 @@
 }
 
 .subnav-link--current-section {
-    font-weight: 700;
-    color: $guardian-brand;
+    &,
+    &:hover,
+    &:focus {
+        font-weight: 700;
+        color: $guardian-brand;
+    }
 }

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -5,31 +5,8 @@
     font-size: 15px;
     height: $veggie-burger-medium - $gs-baseline;
     line-height: $veggie-burger-medium - $gs-baseline;
-    padding: 0 ($gs-gutter / 4);
+    padding: 0 7px;
     position: relative;
-
-    &:before,
-    &:after {
-        bottom: 0;
-        content: '';
-        display: block;
-        left: 0;
-        position: absolute;
-    }
-
-    &:before {
-        // Dividing lines
-        border-left: 1px solid $neutral-4;
-        top: 14px;
-        z-index: 1;
-    }
-
-    &:after {
-        // Underlines
-        border-bottom: 0 solid $neutral-3;
-        right: 0;
-        transition: border 150ms ease-out;
-    }
 
     @include mq($from: mobileMedium, $until: tablet) {
         font-size: 17px;
@@ -39,28 +16,21 @@
         height: 42px;
         line-height: 42px;
         padding: 0 ($gs-gutter / 2 + $gs-gutter / 4) 0 ($gs-gutter / 4);
+    }
 
-        &:before {
-            top: 18px;
-        }
+    &:after {
+        border-bottom: 1px solid $neutral-5;
+        bottom: -1px;
+        content: '';
+        left: 7px;
+        position: absolute;
+        right: -9999px;
     }
 
     &:hover,
     &:focus {
-        color: $neutral-1;
+        color: $guardian-brand;
         text-decoration: none;
-
-        &:not(.subnav-link--toggle-more):after {
-            border-bottom-width: 4px;
-        }
-    }
-
-    .subnav__item:first-child > & {
-        padding-left: 0;
-
-        &:before {
-            content: none;
-        }
     }
 }
 
@@ -70,15 +40,14 @@
     color: $neutral-2;
     padding-right: $gs-gutter / 3;
 
+    &:hover,
     &:focus {
+        color: $neutral-2;
         outline: 0;
     }
 }
 
 .subnav-link--current-section {
     font-weight: 700;
-
-    &:after {
-        border-bottom-width: 4px;
-    }
+    color: $guardian-brand;
 }

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -14,6 +14,14 @@
     }
 }
 
+.subnav--expanded {
+    height: auto;
+
+    .subnav-link--toggle-more {
+        float: left;
+    }
+}
+
 // TODO: reset list-style mixin
 .subnav__list {
     box-sizing: border-box;
@@ -22,11 +30,17 @@
     margin: 0;
     // Width of the container minus the rough width of the more toggle
     max-width: calc(100% - 60px);
-    padding: 0 $gs-gutter / 2;
+    padding: 0 3px;
 
     @include mq(mobileLandscape) {
         max-width: calc(100% - 70px);
-        padding: 0 $gs-gutter;
+        padding: 0 ($gs-gutter / 2 + $gs-gutter / 4);
+    }
+
+    .subnav--expanded & {
+        padding-bottom: $gs-baseline;
+        max-width: 100%;
+        width: 100%;
     }
 }
 

--- a/static/src/stylesheets/layout/new-header/_subnav.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav.scss
@@ -30,7 +30,7 @@
     margin: 0;
     // Width of the container minus the rough width of the more toggle
     max-width: calc(100% - 60px);
-    padding: 0 3px;
+    padding: 0 ($gs-gutter / 4);
 
     @include mq(mobileLandscape) {
         max-width: calc(100% - 70px);


### PR DESCRIPTION
## What does this change?
There are lots of things wrong with how the navigation is currently structured, but one is definitely the notion of secondary and tertiary navigation. There are a few things we will be improving in terms of display next week, but for now the more button should show more of the same list and not just open the menu.

## What is the value of this and can you measure success?
More button shows more of the items in the list, not just open the menu. This is important for tertiary navigation. See football and UK news for examples.

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![giph subnav](https://user-images.githubusercontent.com/8774970/32948216-717f5ca8-cb96-11e7-9ce6-7ab8ca1ae8b2.gif)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
