### PR TITLE
Future[Try[String]] -> Future[String]

### DIFF
--- a/common/app/rendering/core/Renderer.scala
+++ b/common/app/rendering/core/Renderer.scala
@@ -9,10 +9,9 @@ import akka.util.Timeout
 import common.Logging
 import play.api.Mode
 import play.twirl.api.Html
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 case class RenderingException(error: String) extends RuntimeException(error)
 
@@ -27,15 +26,12 @@ class Renderer(implicit actorSystem: ActorSystem, executionContext: ExecutionCon
   def render[R <: Renderable](renderable: R): Future[Html] = {
     (actor ? Rendering(renderable))
       .mapTo[Try[String]]
-      .recover { case t => Try(throw t)}
-      .map {
-        _ match {
-          case Success(s) => Html(s)
-          case Failure(f) =>
-            val errorMessage = f.getLocalizedMessage.replaceAll("\u001B\\[[0-9]*m", "") // stripping terminal colors
-            log.error(errorMessage)
-            throw new RenderingException(errorMessage)
-        }
+      .flatMap(Future.fromTry(_))
+      .map(Html(_))
+      .recover { case t: Throwable =>
+        val errorMessage = t.getLocalizedMessage.replaceAll("\u001B\\[[0-9]*m", "") // stripping terminal colors
+        log.error(errorMessage)
+        throw new RenderingException(errorMessage)
       }
 
   }


### PR DESCRIPTION
## What is the value of this and can you measure success?
I find it easier to read. Rather than recovering the Future first it "flattens" the `Try` in the `Future` and deal with failure with the recover at the very end of the flow 

## Tested in CODE?
Not yet