### PR TITLE
[acquisitions] make campaign code an explicit field

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -30,6 +30,7 @@ declare type ABTest = {
 declare type AcquisitionsABTest = ABTest & {
     campaignId: string,
     componentType: OphanComponentType,
+    campaignCode?: string,
 };
 
 declare type EpicABTest = AcquisitionsABTest & {
@@ -70,6 +71,7 @@ declare type InitEpicABTest = {
     locations?: string[],
     locationCheck?: () => boolean,
     dataLinkNames?: string,
+    campaignCode?: string,
     campaignPrefix?: string,
     campaignSuffix?: string,
     useLocalViewLog?: boolean,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -63,8 +63,6 @@ export const addTrackingCodesToUrl = ({
     });
 
     const params = {
-        REFPVID: config.get('ophan.pageViewId') || 'not_found',
-        INTCMP: campaignCode,
         acquisitionData: JSON.stringify(acquisitionData),
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -144,7 +144,7 @@ const getCopy = (useTailor: boolean): Promise<AcquisitionsEpicTemplateCopy> => {
     return Promise.resolve(acquisitionsCopyControl);
 };
 
-const getCampaignCode = (
+const getComponentId = (
     campaignCodePrefix,
     campaignID,
     id,
@@ -181,7 +181,7 @@ const makeABTestVariant = (
     parentTest: EpicABTest
 ): Variant => {
     const trackingCampaignId = `epic_${parentTest.campaignId}`;
-    const campaignCode = getCampaignCode(
+    const componentId = getComponentId(
         parentTest.campaignPrefix,
         parentTest.campaignId,
         id,
@@ -196,8 +196,8 @@ const makeABTestVariant = (
         contributeURL = addTrackingCodesToUrl({
             base: contributionsBaseURL,
             componentType: parentTest.componentType,
-            componentId: campaignCode,
-            campaignCode,
+            componentId,
+            campaignCode: parentTest.campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -206,8 +206,8 @@ const makeABTestVariant = (
         membershipURL = addTrackingCodesToUrl({
             base: membershipBaseURL,
             componentType: parentTest.componentType,
-            componentId: campaignCode,
-            campaignCode,
+            componentId,
+            campaignCode: parentTest.campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -217,8 +217,8 @@ const makeABTestVariant = (
         supportURL = addTrackingCodesToUrl({
             base: supportCustomURL || selectBaseUrl(),
             componentType: parentTest.componentType,
-            componentId: campaignCode,
-            campaignCode,
+            componentId,
+            campaignCode: parentTest.campaignCode,
             abTest: {
                 name: parentTest.id,
                 variant: id,
@@ -246,8 +246,8 @@ const makeABTestVariant = (
                     component: {
                         componentType: parentTest.componentType,
                         products,
-                        campaignCode,
-                        id: campaignCode,
+                        campaignCode: parentTest.campaignCode,
+                        id: componentId,
                     },
                     abTest: {
                         name: parentTest.id,
@@ -263,8 +263,8 @@ const makeABTestVariant = (
                     component: {
                         componentType: parentTest.componentType,
                         products,
-                        campaignCode,
-                        id: campaignCode,
+                        campaignCode: parentTest.campaignCode,
+                        id: componentId,
                     },
                     abTest: {
                         name: parentTest.id,
@@ -284,12 +284,12 @@ const makeABTestVariant = (
 
         options: {
             componentName: `mem_acquisition_${trackingCampaignId}_${id}`,
-            campaignCodes: [campaignCode],
+            campaignCodes: [parentTest.campaignCode],
 
             maxViews,
             isUnlimited,
             products,
-            campaignCode,
+            campaignCode: parentTest.campaignCode,
             contributeURL,
             membershipURL,
             supportURL,
@@ -346,7 +346,7 @@ const makeABTestVariant = (
                                 mediator.emit(parentTest.insertEvent, {
                                     componentType: parentTest.componentType,
                                     products,
-                                    campaignCode,
+                                    campaignCode: parentTest.campaignCode,
                                 });
                                 onInsert(component);
 
@@ -366,7 +366,8 @@ const makeABTestVariant = (
                                             componentType:
                                                 parentTest.componentType,
                                             products,
-                                            campaignCode,
+                                            campaignCode:
+                                                parentTest.campaignCode,
                                         });
                                         mediator.emit(
                                             'register:end',
@@ -395,8 +396,8 @@ const makeABTestVariant = (
             return addTrackingCodesToUrl({
                 base: contributionsBaseURL,
                 componentType: parentTest.componentType,
-                componentId: codeModifier(campaignCode),
-                campaignCode: codeModifier(campaignCode),
+                componentId: codeModifier(componentId),
+                campaignCode: codeModifier(parentTest.campaignCode),
                 abTest: {
                     name: parentTest.id,
                     variant: id,
@@ -408,8 +409,8 @@ const makeABTestVariant = (
             return addTrackingCodesToUrl({
                 base: membershipBaseURL,
                 componentType: parentTest.componentType,
-                componentId: codeModifier(campaignCode),
-                campaignCode: codeModifier(campaignCode),
+                componentId: codeModifier(componentId),
+                campaignCode: codeModifier(parentTest.campaignCode),
                 abTest: {
                     name: parentTest.id,
                     variant: id,
@@ -438,6 +439,7 @@ const makeABTest = ({
     locations = [],
     locationCheck = () => true,
     dataLinkNames = '',
+    campaignCode,
     campaignPrefix = 'gdnwb_copts_memco',
     campaignSuffix = '',
     useLocalViewLog = false,
@@ -479,6 +481,7 @@ const makeABTest = ({
         idealOutcome,
         dataLinkNames,
         campaignId,
+        campaignCode,
         campaignPrefix,
         campaignSuffix,
         useLocalViewLog,


### PR DESCRIPTION
## What does this change?

For acquisition components deployed via the AB test framework, don't automatically generate a unique campaign code per variant. Instead, if the 'test' is part of a campaign, set the respective campaign code at the test level. If the test isn't part of a campaign, don't define the field.

## What is the value of this and can you measure success?

Previously, if there were 2 tests, each with 2 variants, all part of the same campaign, there would be 4 different campaign codes. This would complicate reporting on the campaign. Whereas now both tests can be created to have the same campaign code field at the test level, which will simplify reporting.

## Does this affect other platforms - Amp, Apps, etc?

Nay

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Nay

## Tested in CODE? 

Tested locally

