### PR TITLE
Add styling for Unruly on tablet

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -492,3 +492,13 @@
     // out-of-page and shouldn't be seen
     height: 0;
 }
+
+.ad-slot--unruly {
+    width: 100%;
+
+    @include mq(tablet) {
+        float: none;
+        margin-left: 0;
+    }
+
+}

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -34,7 +34,8 @@
         .content__article-body {
             padding-right: gs-span(1) + $gs-gutter;
 
-            .ad-slot:not(.ad-slot--im) {
+            // Unruly video expands to 100%; this negative right margin affects Unruly on Tablet
+            .ad-slot:not(.ad-slot--im):not(.ad-slot--unruly) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
             }
 


### PR DESCRIPTION
## What does this change?

This adds `ad-slot--unruly` which removes the `float`, `margin-right` and `margin-left` for it on tablet. The Unruly adslot needs to expand to 100%, but with these CSS rules affecting it, it is completely out of place and misaligned.

The Unruly advert will appear in `inline1`.

## Screenshots

### Broken
![screen shot 2017-11-20 at 14 49 55](https://user-images.githubusercontent.com/445472/33024312-a883dcb0-ce02-11e7-9341-42afb9353c98.png)

### Fixed

![screen shot 2017-11-20 at 14 52 38](https://user-images.githubusercontent.com/445472/33024319-ad72f6c0-ce02-11e7-9312-38d8b12a0b71.png)


