### PR TITLE
Prevent profile.js from breaking on a rogue module

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -36,18 +36,39 @@ const initFormstack = (): void => {
     });
 };
 
-const initProfile = (): void => {
-    initFormstack();
-    forgottenEmail();
-    passwordToggle();
-    initValidationEmail();
-    initUserAvatars();
-    initTabs();
+const initAccountProfile = (): void => {
     // eslint-disable-next-line no-new
     new AccountProfile();
-    enhanceManageAccount();
-    setupLoadingAnimation();
-    initPublicProfile();
+};
+
+const initProfile = (): void => {
+    const modules = [
+        initFormstack,
+        forgottenEmail,
+        passwordToggle,
+        initValidationEmail,
+        initUserAvatars,
+        initTabs,
+        initAccountProfile,
+        enhanceManageAccount,
+        setupLoadingAnimation,
+        initPublicProfile,
+    ];
+
+    const exceptions = [];
+
+    modules.map(module => {
+        try {
+            return module();
+        } catch (err) {
+            exceptions.push(err);
+            return err;
+        }
+    });
+
+    exceptions.map(err => {
+        throw err;
+    });
 };
 
 export { initProfile };

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { catchErrorsWithContext } from 'lib/robust';
 import { forgottenEmail, passwordToggle } from 'common/modules/identity/forms';
 import { Formstack } from 'common/modules/identity/formstack';
 import { FormstackIframe } from 'common/modules/identity/formstack-iframe';
@@ -42,33 +43,19 @@ const initAccountProfile = (): void => {
 };
 
 const initProfile = (): void => {
-    const modules:Array<Function> = [
-        initFormstack,
-        forgottenEmail,
-        passwordToggle,
-        initValidationEmail,
-        initUserAvatars,
-        initTabs,
-        initAccountProfile,
-        enhanceManageAccount,
-        setupLoadingAnimation,
-        initPublicProfile,
+    const modules: Array<Array<string | Function>> = [
+        ['init-form-stack', initFormstack],
+        ['forgotten-email', forgottenEmail],
+        ['password-toggle', passwordToggle],
+        ['init-validation-email', initValidationEmail],
+        ['init-user-avatars', initUserAvatars],
+        ['init-tabs', initTabs],
+        ['init-account-profile', initAccountProfile],
+        ['enhance-manage-account', enhanceManageAccount],
+        ['setup-loading-animation', setupLoadingAnimation],
+        ['init-public-profile', initPublicProfile],
     ];
-
-    const exceptions:Array<Error> = [];
-
-    modules.map((module:Function):(void|Error) => {
-        try {
-            return module();
-        } catch (err) {
-            exceptions.push(err);
-            return err;
-        }
-    });
-
-    exceptions.map((err:Error) => {
-        throw err;
-    });
+    catchErrorsWithContext(modules);
 };
 
 export { initProfile };

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -42,7 +42,7 @@ const initAccountProfile = (): void => {
 };
 
 const initProfile = (): void => {
-    const modules = [
+    const modules:Array<Function> = [
         initFormstack,
         forgottenEmail,
         passwordToggle,
@@ -55,9 +55,9 @@ const initProfile = (): void => {
         initPublicProfile,
     ];
 
-    const exceptions = [];
+    const exceptions:Array<Error> = [];
 
-    modules.map(module => {
+    modules.map((module:Function):(void|Error) => {
         try {
             return module();
         } catch (err) {
@@ -66,7 +66,7 @@ const initProfile = (): void => {
         }
     });
 
-    exceptions.map(err => {
+    exceptions.map((err:Error) => {
         throw err;
     });
 };


### PR DESCRIPTION
## What does this change?
the way `profile.js` is set up at the moment, any uncaught exception inside any of the javascript modules it loads will stop the rest of modules from loading.

## What is the value of this and can you measure success?
Ideally we wouldn't have exceptions at all but should they happen, (we had one this weekend oopsies) this change will prevent them from bringing the rest of modules which are isolated and have no dependencies with each other) from going down with it.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
N/A

## Tested in CODE?