### PR TITLE
Promote AtomsCleaner to decorate links with .u-underline

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -45,6 +45,7 @@ object BodyCleaner {
 
     val cleaners = List(
       InBodyElementCleaner,
+      AtomsCleaner(atoms = article.content.atoms, shouldFence = true, amp = amp),
       InBodyLinkCleaner("in body link", amp),
       BlockNumberCleaner,
       new TweetCleaner(article.content, amp),
@@ -53,7 +54,6 @@ object BodyCleaner {
       TableEmbedComplimentaryToP,
       R2VideoCleaner,
       PictureCleaner(article, amp),
-      AtomsCleaner(atoms = article.content.atoms, shouldFence = true, amp = amp),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,


### PR DESCRIPTION
Embedded atoms should embrace local styling as much as possible. Links in frontend have a characteristic rendering, provided by a class `u-underline` which is added at runtime.

Before
![screen shot 2017-11-20 at 17 36 05](https://user-images.githubusercontent.com/629976/33032627-bd0c7cca-ce19-11e7-9b28-a7cbc6333225.png)

After
![screen shot 2017-11-20 at 17 35 51](https://user-images.githubusercontent.com/629976/33032629-bf9e77fe-ce19-11e7-9778-e2865b2b7345.png)

Will run this through immersives, liveblogs, etc. to make sure it doesn't have any adverse effect.