### PR TITLE
New header JS wasn't completely running for skinny hav

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -260,6 +260,10 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
             '.js-edition-picker-trigger'
         );
 
+        const buttonClickHandlers = {};
+
+        buttonClickHandlers['main-menu-toggle'] = toggleMenu;
+
         if (
             menuEl &&
             menuEl instanceof HTMLElement &&
@@ -271,42 +275,39 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
                 trigger: triggerEl,
             };
 
-            const buttonClickHandlers = {
-                'main-menu-toggle': toggleMenu,
-                'edition-picker-toggle': toggleDropdown.bind(
-                    null,
-                    editionPickerDropdownEls
-                ),
-            };
-
-            const enhance = () => {
-                const eventHandler = buttonClickHandlers[checkboxId];
-
-                if (checkboxClassAttr) {
-                    button.setAttribute('class', checkboxClassAttr);
-                }
-
-                button.addEventListener('click', () => eventHandler());
-                button.setAttribute('id', checkboxId);
-                button.setAttribute('aria-expanded', 'false');
-
-                if (dataLinkName) {
-                    button.setAttribute('data-link-name', dataLinkName);
-                }
-
-                if (checkboxControls) {
-                    button.setAttribute('aria-controls', checkboxControls);
-                }
-
-                if (checkbox.parentNode) {
-                    checkbox.parentNode.replaceChild(button, checkbox);
-                }
-
-                enhanced[button.id] = true;
-            };
-
-            fastdom.write(enhance);
+            buttonClickHandlers['edition-picker-toggle'] = toggleDropdown.bind(
+                null,
+                editionPickerDropdownEls
+            );
         }
+
+        const enhance = () => {
+            const eventHandler = buttonClickHandlers[checkboxId];
+
+            if (checkboxClassAttr) {
+                button.setAttribute('class', checkboxClassAttr);
+            }
+
+            button.addEventListener('click', () => eventHandler());
+            button.setAttribute('id', checkboxId);
+            button.setAttribute('aria-expanded', 'false');
+
+            if (dataLinkName) {
+                button.setAttribute('data-link-name', dataLinkName);
+            }
+
+            if (checkboxControls) {
+                button.setAttribute('aria-controls', checkboxControls);
+            }
+
+            if (checkbox.parentNode) {
+                checkbox.parentNode.replaceChild(button, checkbox);
+            }
+
+            enhanced[button.id] = true;
+        };
+
+        fastdom.write(enhance);
     });
 };
 


### PR DESCRIPTION
## What does this change?
Because there was no edition picker on the skinny nav, the JS didn't run. I introduced this bug in https://github.com/guardian/frontend/pull/18039

## What is the value of this and can you measure success?
Now the JS runs properly which enhances the JS and makes it accessible. It also looks better when the menu opens!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
