### PR TITLE
Config: fix get() for the case where an early index might not exist

### DIFF
--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -11,7 +11,7 @@ const get = (path: string = '', defaultValue: any): any => {
     const value = path
         .replace(/\[(.+?)\]/g, '.$1')
         .split('.')
-        .reduce((o, key) => o[key], config);
+        .reduce((o, key) => o && o[key], config);
 
     if (typeof value !== 'undefined') {
         return value;

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -56,6 +56,11 @@ describe('Config', () => {
         expect(config.get('page.x.y.z')).toEqual('z');
     });
 
+    it('`get` should return undefined for non existing indexes', () => {
+        expect(config.get('page.x.z.y')).toEqual(undefined);
+        expect(config.get('page.x.z.y', false)).toEqual(false);
+    });
+
     it('`get` should return a value using bracket notation', () => {
         expect(config.get('page[x].y[z]')).toEqual('z');
     });


### PR DESCRIPTION
## What does this change?

Makes `config.get()` safer through an additional null check, so it doesn't throw an error, if one index returns a falsy.

Related Sentry issues:

- https://sentry.io/the-guardian/client-side-prod/issues/407511184/
- https://sentry.io/the-guardian/client-side-prod/issues/407511226/
- https://sentry.io/the-guardian/client-side-prod/issues/407511166/
- https://sentry.io/the-guardian/client-side-prod/issues/407511284/
- https://sentry.io/the-guardian/client-side-prod/issues/407511334/
- https://sentry.io/the-guardian/client-side-prod/issues/407511075/

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.