### PR TITLE
SCSS watch: Recompile root files

### DIFF
--- a/dev/watch.js
+++ b/dev/watch.js
@@ -77,6 +77,7 @@ const ignoredSassRegEx = /^(_|ie9|old-ie)/;
 chokidar.watch(`${sassDir}/**/*.scss`).on('change', changedFile => {
     // see what top-level files need to be recompiled
     const filesToCompile = [];
+    const changedFileBasename = path.basename(changedFile);
 
     sassGraph.visitAncestors(changedFile, ancestorPath => {
         const ancestorFileName = path.basename(ancestorPath);
@@ -84,6 +85,10 @@ chokidar.watch(`${sassDir}/**/*.scss`).on('change', changedFile => {
             filesToCompile.push(ancestorFileName);
         }
     });
+
+    if (!/^_/.test(changedFileBasename)) {
+        filesToCompile.push(changedFileBasename);
+    }
 
     // now recompile all files that matter
     Promise.all(filesToCompile.map(compileSass))


### PR DESCRIPTION
## What does this change?

Currently, root SCSS files are not recompiled by the watch task if they are changed. This means if a developer changes a root file, they need to restart the watch task to pick up those changes.

This change ensures root files are added to the list of files to recompile if they are changed.

## What is the value of this and can you measure success?

No need to restart watch task to pick up changes to an SCSS root file.
