### PR TITLE
Bump atom lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "1.2.1"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.8.15",
+    "@guardian/atom-renderer": "0.8.16",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.8.15"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.8.16"
 
   // Fixing transient dependency issue
   // AWS SDK (1.11.181), which kinesis-logback-appender depends on, brings com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat libs in version 2.6.9

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@guardian/atom-renderer@0.8.15":
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.8.15.tgz#1c25f28d79562f2d69803c4d1de0069588c2aa35"
+"@guardian/atom-renderer@0.8.16":
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.8.16.tgz#b8c4fb57739484f7f679a9b2e49909e4e59eba74"
   dependencies:
     autoprefixer "^7.1.6"
     css-loader "^0.28.7"


### PR DESCRIPTION
[Fixes](https://github.com/guardian/atom-renderer/pull/4) an issue where Ophan events were reported with numbers instead of strings for the serialization of Thrift enums.

<img width="274" alt="screen shot 2017-11-21 at 16 40 35" src="https://user-images.githubusercontent.com/629976/33086110-9aece718-cede-11e7-9bb9-9f0c41065a94.png">
