### PR TITLE
Build up the initial route setup for /repermission

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -165,6 +165,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val IdentityAllowAccessToGdprJourneyPageSwitch = Switch(
+    SwitchGroup.Identity,
+    "id-allow-access-to-gdpr-journey-page",
+    "If switched on, users will be able to access the /repermission endpoint",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 1),
+    exposeClientSide = false
+  )
+
   val EnhanceTweetsSwitch = Switch(
     SwitchGroup.Feature,
     "enhance-tweets",

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -49,10 +49,11 @@ class EditProfileController(
   def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)
   def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
   def displayEmailPrefsForm: Action[AnyContent] = displayForm(EmailPrefsProfilePage)
+
   def displayRepermissioningJourneyForm: Action[AnyContent] = {
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
       recentlyAuthenticated { implicit request =>
-        Redirect(routes.EditProfileController.displayEmailPrefsForm(), TEMPORARY_REDIRECT)
+        NotFound(views.html.errors._404())
       }
     }
     else {
@@ -66,7 +67,6 @@ class EditProfileController(
       }
     }
   }
-
 
   def displayPrivacyFormRedirect: Action[AnyContent] = csrfAddToken {
     recentlyAuthenticated { implicit request =>

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -16,6 +16,7 @@ import play.filters.csrf.{CSRFAddToken, CSRFCheck}
 import services.{EmailPrefsData, _}
 import utils.SafeLogging
 import scala.concurrent.Future
+import conf.switches.Switches.IdentityAllowAccessToGdprJourneyPageSwitch
 
 object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
 object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
@@ -48,6 +49,24 @@ class EditProfileController(
   def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)
   def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
   def displayEmailPrefsForm: Action[AnyContent] = displayForm(EmailPrefsProfilePage)
+  def displayRepermissioningJourneyForm: Action[AnyContent] = {
+    if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
+      recentlyAuthenticated { implicit request =>
+        Redirect(routes.EditProfileController.displayEmailPrefsForm(), TEMPORARY_REDIRECT)
+      }
+    }
+    else {
+      csrfAddToken {
+        recentlyAuthenticated.async { implicit request =>
+          repermissionJourneyView(
+            page = EmailPrefsProfilePage,
+            forms = ProfileForms(request.user, PublicEditProfilePage),
+            request.user)
+        }
+      }
+    }
+  }
+
 
   def displayPrivacyFormRedirect: Action[AnyContent] = csrfAddToken {
     recentlyAuthenticated { implicit request =>
@@ -156,6 +175,27 @@ class EditProfileController(
         ) // end fold
       } // end authActionWithUser.async
     } // end csrfCheck
+
+  private def repermissionJourneyView(
+    page: IdentityPage,
+    forms: ProfileForms,
+    user: User) (implicit request: AuthRequest[AnyContent]): Future[Result] = {
+
+    newsletterService.preferences(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
+
+      NoCache(Ok(views.html.repermissionJourney(
+        page,
+        user,
+        forms,
+        idRequestParser(request),
+        idUrlBuilder,
+        emailFilledForm,
+        newsletterService.getEmailSubscriptions(emailFilledForm),
+        EmailNewsletters.all
+      )))
+
+    }
+  }
 
   private def profileFormsView(
       page: IdentityPage,

--- a/identity/app/views/repermissionJourney.scala.html
+++ b/identity/app/views/repermissionJourney.scala.html
@@ -45,7 +45,9 @@
 
                 <div class=" u-cf identity-section">
 
-                    Greetings! Welcome to the repermissioning journey
+                    <center>
+                        <img width="100%" src="https://i.imgur.com/TqI7Ub8.png" />
+                    </center>
 
                 </div>
             </div>

--- a/identity/app/views/repermissionJourney.scala.html
+++ b/identity/app/views/repermissionJourney.scala.html
@@ -1,0 +1,54 @@
+@import conf.Static
+@import views.support.RenderClasses
+@import conf.switches.Switches.ProfileShowContributorTab
+@import model.{ApplicationContext, EmailNewsletters, IdentityPage}
+@import services.EmailPrefsData
+
+@(
+    page: model.Page,
+    user: com.gu.identity.model.User,
+    forms: controllers.ProfileForms,
+    idRequest: services.IdentityRequest,
+    idUrlBuilder: services.IdentityUrlBuilder,
+    emailPrefsForm: Form[EmailPrefsData],
+    emailSubscriptions: List[String],
+    availableLists: EmailNewsletters
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+
+@tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "") = {
+    <li class="tabs__tab @if(hidden){is-hidden} @if(page.metadata.id == url){tabs__tab--selected tone-colour tone-accent-border} @optionalClass" role="tab" id="tabs-account-profile-@i-tab" aria-selected="@(page.metadata.id == url)" aria-controls="tabs-account-profile-@i">
+        <a href="@url" data-tabs-href="#tabs-account-profile-@i" data-link-name="@url edit profile tab" data-pushstate-url="@url"
+            @dataTestId.map{idValue => data-test-id="@idValue"}>@name</a>
+    </li>
+}
+
+@content(i: Int, url: String, optionalClass: String = "")(body: => Html) = {
+    <div id="tabs-account-profile-@i"
+         class="@RenderClasses(Map(
+            "u-h" -> (page.metadata.id != url)
+         ), "tabs__pane u-cf @optionalClass")"
+         role="tabpanel"
+         aria-labelledby="tabs-account-profile-@i-tab"
+         data-link-name="Public Profile"
+         data-link-context="Identity/profile">
+        @body
+    </div>
+}
+
+@mainLegacy(page, projectName = Option("identity")){
+    <link rel="stylesheet" id="stripe-sprite" type="text/css" media="all" href="@Static("stylesheets/membership-icons.css")"/>
+}{
+
+    <div class="identity-wrapper-for-bg">
+        <div class="gs-container">
+            <div class="monocol-wrapper js-account-profile-forms">
+
+                <div class=" u-cf identity-section">
+
+                    Greetings! Welcome to the repermissioning journey
+
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -61,4 +61,6 @@ POST        /privacy/edit-ajax                      controllers.EditProfileContr
 
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
+
+GET         /repermission                           controllers.EditProfileController.displayRepermissioningJourneyForm
 ########################################################################################################################


### PR DESCRIPTION
## What does this change?
Creates /repermission under identity (hidden behind a switch) and shows an empty view that will eventually host the repermission journey

## What is the value of this and can you measure success?
We really really really need those permissions

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![screen shot 2017-11-21 at 18 16 54](https://user-images.githubusercontent.com/11539094/33089379-4e90a7a6-cee8-11e7-89bf-1c36f281e1ac.png)

## Tested in CODE?
No