### PR TITLE
Fix the save button on switchboard to the window's bottom end

### DIFF
--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -50,7 +50,9 @@
                     }
                 </div>
             }
-            <input class="btn btn-large btn-success" type="submit" value="Save">
+            <footer class="actions">
+                <input class="btn btn-large btn-success" type="submit" value="Save">
+            </footer>
         </form>
     </div>
     }

--- a/admin/public/css/switchboard.css
+++ b/admin/public/css/switchboard.css
@@ -56,3 +56,13 @@ input[type=text] {
 #switchboard .checkbox:nth-child(odd) {
     background-color: #E9E9E9;
 }
+
+.actions {
+    position: sticky;
+    bottom: 0;
+    left:0;
+    right:0;
+    padding: 20px 0;
+    background: #fff;
+    border-top: 1px solid #eee;
+}


### PR DESCRIPTION
## What does this change?
Makes the switchboard footer sticky so you always get easy 1 click access to the save button intead of (gasp!) having to scroll all the way down to save

## What is the value of this and can you measure success?
Literal **minutes** of productivity saved per year, especially for people who use mice and can't just flick the page all the way down on a trackpad

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![screen shot 2017-11-22 at 11 55 15](https://user-images.githubusercontent.com/11539094/33126354-17e9be24-cf7c-11e7-8797-191afb93111b.png)

## Tested in CODE?
No