### PR TITLE
garnett article placeholders

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -24,7 +24,15 @@
             "has-feature-showcase-element" -> (article.tags.isFeature && article.elements.hasShowcaseMainElement),
             "paid-content" -> isPaidContent,
             "paid-content--white" -> (isPaidContent && CommercialPaidContentTemplateVariant.isParticipating(request))
-        ),  "content", "content--article", "tonal", s"tonal--${toneClass(article)}", s"section-${article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")}")"
+        ),
+            "content",
+            "content--article",
+            "content--pillar-news", // temporarily hardcoded
+            "content--type-article", // temporarily hardcoded
+            "tonal",
+            s"tonal--${toneClass(article)}",
+            s"section-${article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")}"
+        )"
 
         itemscope itemtype="@schemaType(model)" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">

--- a/static/src/stylesheets/head.content.garnett.scss
+++ b/static/src/stylesheets/head.content.garnett.scss
@@ -14,6 +14,8 @@
    ========================================================================== */
 @import 'module/content-garnett/_article';
 @import 'module/content-garnett/_content';
+@import 'module/content-garnett/_pillars';
+@import 'module/content-garnett/_types';
 @import 'module/content-garnett/_media.head';
 @import 'module/content-garnett/live-blog/_live-blog.head';
 @import 'module/_breadcrumbs';

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,3 +1,3 @@
 .content--pillar-news {
-    background-color: blue
+   
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,0 +1,3 @@
+.content--pillar-news {
+    background-color: blue
+}

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1,0 +1,3 @@
+.content--type-article {
+
+}


### PR DESCRIPTION
## What does this change?

hard codes `news`/`article` pillar and type on articles, and adds placeholder scoping sass rules for them, to unblock article work