### PR TITLE
Garnett - add slice specific overrides

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -23,10 +23,71 @@ Hence why a greater depth of selector specificity is needed.
         }
 
         .fc-item--half-tablet {
+            @include vertical-item-separator;
+
             .fc-item__standfirst {
                 @include mq(desktop) {
                     display: none;
                 }
+            }
+        }
+    }
+}
+
+.fc-slice--h-ql4-ql4 {
+    .fc-item--half-tablet {
+        .fc-item__standfirst {
+            @include mq(tablet, desktop) {
+                display: block;
+            }
+        }
+    }
+}
+
+.fc-slice--h-q-q {
+    .fc-item--half-tablet {
+        .fc-item__standfirst {
+            @include mq(tablet) {
+                display: none;
+            }
+        }
+    }
+
+    .fc-item--standard-tablet {
+        .fc-item__standfirst {
+            @include mq(desktop) {
+                display: block;
+            }
+        }
+    }
+}
+
+.fc-slice--h-q_ql2-ql4 {
+    .fc-item--half-tablet {
+        .fc-item__standfirst {
+            @include mq(tablet) {
+                display: block !important;
+            }
+        }
+    }
+}
+
+.fc-slice--q-qqq {
+    .fc-item--list-mobile {
+        @include mq($until: tablet) {
+            .fc-item__header {
+                @include fs-headline(3, true);
+            }
+        }
+    }
+}
+
+.facia-slice--q-q-ql-ql,
+.facia-slice--q-q-q-ql {
+    .fc-item--standard-tablet {
+        @include mq(tablet, desktop) {
+            .fc-item__standfirst {
+                display: block;
             }
         }
     }
@@ -42,5 +103,216 @@ Hence why a greater depth of selector specificity is needed.
                 }
             }
         }
+    }
+}
+
+.fc-slice--h14-q-q {
+    .has-flex & {
+        flex-direction: row-reverse;
+
+        .fc-slice__item:before {
+            display: none;
+        }
+
+        .fc-item--standard-tablet {
+            @include mq(tablet) {
+                @include vertical-item-separator;
+            }
+        }
+    }
+
+    .fc-item--standard-tablet {
+        .fc-item__standfirst {
+            @include mq(tablet) {
+                display: block;
+            }
+        }
+    }
+}
+
+/**
+ * Bespoke MPU slice stylings
+ */
+
+.fc-slice--tl-tl-mpu {
+    @include mq(tablet, $until: desktop) {
+        > .fc-slice__item {
+            .fc-slice__item:before {
+                border: 0;
+            }
+
+            &:first-child {
+                flex: 1 1 auto;
+                width: 50%;
+
+                .fc-slice__item {
+                    flex-basis: 100%;
+                }
+                .fc-slice__item:nth-child(5) {
+                    padding-bottom: $gs-baseline;
+                }
+            }
+            &:last-child {
+                width: 50%;
+            }
+        }
+    }
+}
+
+.fc-slice--t-t-mpu {
+    @include mq(tablet, desktop) {
+        .fc-slice__item {
+            width: 25%;
+
+            .fc-item__title {
+                @include fs-headline(2, true);
+            }
+        }
+
+        .fc-slice__item--mpu-candidate {
+            width: 50%;
+        }
+    }
+}
+
+.fc-slice--t-tl-mpu {
+    @include mq(tablet, $until: desktop) {
+        > .fc-slice__item {
+            width: 25% !important;
+
+            &:last-child {
+                flex: 2 1 auto;
+                width: 50% !important;
+            }
+        }
+    }
+}
+
+// specific to the most viewed component that appears at the bottom of articles
+.popular-trails.fc-container__body {
+    padding-top: $gs-baseline;
+
+    @include mq(desktop) {
+        min-height: gs-height(8);
+        display: inline-flex;
+    }
+}
+
+.popular-trails__content {
+    @include mq(desktop) {
+        min-width: gs-span(8);
+        max-width: (100% / 3) * 2;
+    }
+}
+
+.fc-slice--popular {
+    .fc-slice__item:before {
+        display: none;
+    }
+
+    .live-pulse-icon:before {
+        content: none;
+    }
+
+    @include mq(desktop) {
+        .tabs__pane {
+            min-width: gs-span(8);
+            min-height: 300px;
+        }
+
+        .tabs__pane--without-mpu {
+            width: (100% / 3) * 3;
+            min-height: 300px;
+        }
+    }
+}
+
+.fc-slice__popular-mpu {
+    width: $mpu-original-width + $gs-gutter;
+    min-width: $mpu-original-width;
+    margin: $gs-baseline auto 0;
+
+    .ad-slot {
+        min-height: $mpu-original-height + $mpu-ad-label-height;
+        margin: 0;
+    }
+
+    @include mq(desktop) {
+        width: auto;
+        margin-left: auto;
+        border-top: 1px solid $neutral-5;
+        padding: $gs-baseline 0 0 $gs-gutter;
+        margin-top: 39px; // magic number: unavoidable to match the tab headings
+
+        .tabs__content & {
+            border-top: 0;
+            margin-top: 0;
+            padding-top: 0;
+        }
+
+        .has-no-flex & {
+            position: absolute;
+            top: $gs-baseline;
+            right: -($gs-gutter / 2);
+        }
+    }
+
+    .fc-slice__item--no-mpu {
+        @include mq($until: desktop) {
+            min-height: 0;
+        }
+    }
+}
+
+.fc-container--dynamic-slow-mpu {
+    .ad-slot--container-inline {
+        width: gs-span(4);
+        padding-bottom: $gs-baseline / 2;
+        @include mq(tablet) {
+            width: gs-span(5);
+        }
+        @include mq(desktop) {
+            width: gs-span(4);
+        }
+    }
+    .ad-slot__label {
+        text-align: left;
+    }
+}
+
+/**
+ * Commercial Nav lists
+ */
+
+.fc-slice--nav-list {
+    $alley: $gs-gutter * .5;
+
+    @include mq($until: tablet) {
+        @include columns($rule: true);
+    }
+
+    @include mq(tablet, desktop) {
+        @include columns($cols: 3, $gap: $alley, $rule: true);
+    }
+
+    @include mq(desktop) {
+        @include columns($cols: 4, $gap: $alley, $rule: true);
+    }
+}
+
+.fc-slice__item--nav-list {
+    display: inline-block;
+    width: 100%;
+}
+
+.fc-slice--nav-list--media {
+    $alley: $gs-gutter * .5;
+
+    @include mq($until: tablet) {
+        @include columns($rule: true);
+    }
+
+    @include mq(tablet) {
+        @include columns($cols: 3, $gap: $alley, $rule: true);
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -23,8 +23,6 @@ Hence why a greater depth of selector specificity is needed.
         }
 
         .fc-item--half-tablet {
-            @include vertical-item-separator;
-
             .fc-item__standfirst {
                 @include mq(desktop) {
                     display: none;
@@ -112,12 +110,6 @@ Hence why a greater depth of selector specificity is needed.
 
         .fc-slice__item:before {
             display: none;
-        }
-
-        .fc-item--standard-tablet {
-            @include mq(tablet) {
-                @include vertical-item-separator;
-            }
         }
     }
 


### PR DESCRIPTION
## What does this change?

The `_slices.scss` module is used only for overrides of item defaults at a slice level. This a wholesale copy of the `_slices.scss` from the `facia` directory. I've been through the file and think all these overrides are valid for `Garnett`, for now at least.

The only thing I've removed is any inclusion of `@include vertical-item-separator` as we don't use these with Garnett.

## What is the value of this and can you measure success?

Retain existing Slice overrides

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No