### PR TITLE
Animate wizard pagination changes

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -147,6 +147,7 @@ export const setPosition = (
                 });
             }
         )
+        .catch(() => setPosition(wizardEl, 0));
 
 export const enhance = (wizardEl: HTMLElement): Promise<void> =>
     setPosition(wizardEl, 0).then(() =>

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -23,24 +23,14 @@ const stepTransitionClassnames = [
     stepOutReverseClassname,
 ];
 
-const updateCounter = (wizardEl: HTMLElement): Promise<void> =>
-    fastdom
-        .read(() => [...wizardEl.getElementsByClassName(pagerClassname)])
-        .then((pagerEls: Array<HTMLElement>) =>
-            fastdom.write(() => {
-                wizardEl.classList.toggle(
-                    completedClassname,
-                    parseInt(wizardEl.dataset.position, 10) >=
-                        parseInt(wizardEl.dataset.length, 10) - 1
-                );
-                pagerEls.forEach((pagerEl: HTMLElement) => {
-                    pagerEl.innerText = `${parseInt(
-                        wizardEl.dataset.position,
-                        10
-                    ) + 1} / ${wizardEl.dataset.length}`;
-                });
-            })
-        );
+const getDirection = (currentPosition: number, newPosition: number): string => {
+    if (currentPosition < 0) {
+        return 'none';
+    } else if (currentPosition > newPosition) {
+        return 'backwards';
+    }
+    return 'forwards';
+};
 
 const animateIncomingStep = (
     wizardEl: HTMLElement,
@@ -82,14 +72,24 @@ const animateOutgoingStep = (
         }, 200);
     });
 
-const getDirection = (currentPosition: number, newPosition: number): string => {
-    if (currentPosition < 0) {
-        return 'none';
-    } else if (currentPosition > newPosition) {
-        return 'backwards';
-    }
-    return 'forwards';
-};
+const updateCounter = (wizardEl: HTMLElement): Promise<void> =>
+    fastdom
+        .read(() => [...wizardEl.getElementsByClassName(pagerClassname)])
+        .then((pagerEls: Array<HTMLElement>) =>
+            fastdom.write(() => {
+                wizardEl.classList.toggle(
+                    completedClassname,
+                    parseInt(wizardEl.dataset.position, 10) >=
+                        parseInt(wizardEl.dataset.length, 10) - 1
+                );
+                pagerEls.forEach((pagerEl: HTMLElement) => {
+                    pagerEl.innerText = `${parseInt(
+                        wizardEl.dataset.position,
+                        10
+                    ) + 1} / ${wizardEl.dataset.length}`;
+                });
+            })
+        );
 
 const updateSteps = (
     wizardEl: HTMLElement,

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -31,6 +31,7 @@ const getDirection = (currentPosition: number, newPosition: number): string => {
     return 'forwards';
 };
 
+// #? polyfill.io might struggle with multiple classnames on classList
 const animateIncomingStep = (
     wizardEl: HTMLElement,
     stepEl: HTMLElement,

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -6,15 +6,22 @@ import { scrollTo } from 'lib/scroller';
 
 const completedClassname = 'manage-account-wizard--completed';
 const pagerClassname = 'manage-account-wizard__controls-pager';
+const nextButtonElClassname = 'js-manage-account-wizard__next';
+const prevButtonElClassname = 'js-manage-account-wizard__prev';
+const containerClassname = 'manage-account-wizard';
+
 const stepClassname = 'manage-account-wizard__step';
 const stepHiddenClassname = 'manage-account-wizard__step--hidden';
 const stepOutClassname = 'manage-account-wizard__step--out';
 const stepInClassname = 'manage-account-wizard__step--in';
 const stepOutReverseClassname = 'manage-account-wizard__step--out-reverse';
 const stepInReverseClassname = 'manage-account-wizard__step--in-reverse';
-const nextButtonElClassname = 'js-manage-account-wizard__next';
-const prevButtonElClassname = 'js-manage-account-wizard__prev';
-const containerClassname = 'manage-account-wizard';
+const stepTransitionClassnames = [
+    stepInClassname,
+    stepInReverseClassname,
+    stepOutClassname,
+    stepOutReverseClassname,
+];
 
 const updateCounter = (wizardEl: HTMLElement): Promise<void> =>
     fastdom
@@ -63,18 +70,12 @@ export const setPosition = (
                     if (currentPosition > -1 && window.scrollY > offsetTop) {
                         scrollTo(offsetTop, 250, 'linear');
                     }
-                    const transitionClassnames = [
-                        stepInClassname,
-                        stepInReverseClassname,
-                        stepOutClassname,
-                        stepOutReverseClassname,
-                    ];
                     steps.forEach((stepEl: HTMLElement, i: number) => {
                         switch (i) {
                             case newPosition:
                                 stepEl.classList.remove(
                                     stepHiddenClassname,
-                                    ...transitionClassnames
+                                    ...stepTransitionClassnames
                                 );
                                 wizardEl.style.minHeight = `${stepEl.getBoundingClientRect()
                                     .height}px`;
@@ -88,7 +89,7 @@ export const setPosition = (
                                 break;
                             case currentPosition:
                                 stepEl.classList.remove(
-                                    ...transitionClassnames
+                                    ...stepTransitionClassnames
                                 );
                                 stepEl.classList.add(
                                     ...[
@@ -100,14 +101,14 @@ export const setPosition = (
                                 );
                                 setTimeout(() => {
                                     stepEl.classList.remove(
-                                        ...transitionClassnames
+                                        ...stepTransitionClassnames
                                     );
                                 }, 200);
                                 break;
                             default:
                                 stepEl.classList.add(stepHiddenClassname);
                                 stepEl.classList.remove(
-                                    ...transitionClassnames
+                                    ...stepTransitionClassnames
                                 );
                         }
                     });

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable no-underscore-dangle, react/sort-comp */
 
 import fastdom from 'lib/fastdom-promise';
 import { scrollTo } from 'lib/scroller';

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -46,7 +46,7 @@ const animateIncomingStep = (
     wizardEl: HTMLElement,
     stepEl: HTMLElement,
     direction: string
-) =>
+): Promise<void> =>
     fastdom.write(() => {
         stepEl.classList.remove(
             stepHiddenClassname,
@@ -66,20 +66,21 @@ const animateOutgoingStep = (
     wizardEl: HTMLElement,
     stepEl: HTMLElement,
     direction: string
-) => {
-    stepEl.classList.remove(...stepTransitionClassnames);
-    stepEl.classList.add(
-        ...[
-            stepHiddenClassname,
-            direction === 'forwards'
-                ? stepOutClassname
-                : stepOutReverseClassname,
-        ]
-    );
-    setTimeout(() => {
+): Promise<void> =>
+    fastdom.write(() => {
         stepEl.classList.remove(...stepTransitionClassnames);
-    }, 200);
-};
+        stepEl.classList.add(
+            ...[
+                stepHiddenClassname,
+                direction === 'forwards'
+                    ? stepOutClassname
+                    : stepOutReverseClassname,
+            ]
+        );
+        setTimeout(() => {
+            stepEl.classList.remove(...stepTransitionClassnames);
+        }, 200);
+    });
 
 const getDirection = (currentPosition: number, newPosition: number): string => {
     if (currentPosition < 0) {
@@ -123,7 +124,7 @@ const updateSteps = (
 export const setPosition = (
     wizardEl: HTMLElement,
     newPosition: number
-): Promise<void> =>
+): Promise<Array<*>> =>
     fastdom
         .read(() => [
             wizardEl.getBoundingClientRect().top - 20,

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -37,20 +37,26 @@ const animateIncomingStep = (
     stepEl: HTMLElement,
     direction: string
 ): Promise<void> =>
-    fastdom.write(() => {
-        stepEl.classList.remove(
-            stepHiddenClassname,
-            ...stepTransitionClassnames
-        );
-        wizardEl.style.minHeight = `${stepEl.getBoundingClientRect().height}px`;
-        if (direction !== 'none') {
-            stepEl.classList.add(
-                direction === 'forwards'
-                    ? stepInClassname
-                    : stepInReverseClassname
+    fastdom
+        .write(() => {
+            stepEl.classList.remove(
+                stepHiddenClassname,
+                ...stepTransitionClassnames
             );
-        }
-    });
+            if (direction !== 'none') {
+                stepEl.classList.add(
+                    direction === 'forwards'
+                        ? stepInClassname
+                        : stepInReverseClassname
+                );
+            }
+        })
+        .then(() => fastdom.read(() => stepEl.getBoundingClientRect().height))
+        .then(stepHeight =>
+            fastdom.write(() => {
+                wizardEl.style.minHeight = `${stepHeight}px`;
+            })
+        );
 
 const animateOutgoingStep = (
     wizardEl: HTMLElement,

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -2,10 +2,16 @@
 /* eslint-disable no-underscore-dangle, react/sort-comp */
 
 import fastdom from 'lib/fastdom-promise';
+import { scrollTo } from 'lib/scroller';
 
 const completedClassname = 'manage-account-wizard--completed';
 const pagerClassname = 'manage-account-wizard__controls-pager';
 const stepClassname = 'manage-account-wizard__step';
+const stepHiddenClassname = 'manage-account-wizard__step--hidden';
+const stepOutClassname = 'manage-account-wizard__step--out';
+const stepInClassname = 'manage-account-wizard__step--in';
+const stepOutReverseClassname = 'manage-account-wizard__step--out-reverse';
+const stepInReverseClassname = 'manage-account-wizard__step--in-reverse';
 const nextButtonElClassname = 'js-manage-account-wizard__next';
 const prevButtonElClassname = 'js-manage-account-wizard__prev';
 const containerClassname = 'manage-account-wizard';
@@ -31,25 +37,85 @@ const updateCounter = (wizardEl: HTMLElement): Promise<void> =>
 
 export const setPosition = (
     wizardEl: HTMLElement,
-    positionAt: number
+    newPosition: number
 ): Promise<void> =>
     fastdom
-        .read(() => [...wizardEl.getElementsByClassName(stepClassname)])
-        .then((steps: Array<HTMLElement>) =>
-            fastdom.write(() => {
-                wizardEl.dataset.length = steps.length.toString();
-                if (positionAt < 0 || !steps[positionAt]) {
-                    throw new Error('Invalid position');
-                }
-                steps.forEach(stepEl => {
-                    stepEl.style.display = 'none';
-                });
-                wizardEl.dataset.position = positionAt.toString();
-                steps[positionAt].style.display = 'block';
-                updateCounter(wizardEl);
-            })
-        )
-        .catch(() => setPosition(wizardEl, 0));
+        .read(() => [
+            wizardEl.getBoundingClientRect().top - 20,
+            parseInt(
+                wizardEl.dataset.position ? wizardEl.dataset.position : -1,
+                10
+            ),
+            [...wizardEl.getElementsByClassName(stepClassname)],
+        ])
+        .then(
+            (
+                [
+                    offsetTop: number,
+                    currentPosition: number,
+                    steps: Array<HTMLElement>,
+                ]
+            ) =>
+                fastdom.write(() => {
+                    if (newPosition < 0 || !steps[newPosition]) {
+                        throw new Error('Invalid position');
+                    }
+                    if (currentPosition > -1 && window.scrollY > offsetTop) {
+                        scrollTo(offsetTop, 250, 'linear');
+                    }
+                    const transitionClassnames = [
+                        stepInClassname,
+                        stepInReverseClassname,
+                        stepOutClassname,
+                        stepOutReverseClassname,
+                    ];
+                    steps.forEach((stepEl: HTMLElement, i: number) => {
+                        switch (i) {
+                            case newPosition:
+                                stepEl.classList.remove(
+                                    stepHiddenClassname,
+                                    ...transitionClassnames
+                                );
+                                wizardEl.style.minHeight = `${stepEl.getBoundingClientRect()
+                                    .height}px`;
+                                if (currentPosition > -1) {
+                                    stepEl.classList.add(
+                                        currentPosition < newPosition
+                                            ? stepInClassname
+                                            : stepInReverseClassname
+                                    );
+                                }
+                                break;
+                            case currentPosition:
+                                stepEl.classList.remove(
+                                    ...transitionClassnames
+                                );
+                                stepEl.classList.add(
+                                    ...[
+                                        stepHiddenClassname,
+                                        currentPosition < newPosition
+                                            ? stepOutClassname
+                                            : stepOutReverseClassname,
+                                    ]
+                                );
+                                setTimeout(() => {
+                                    stepEl.classList.remove(
+                                        ...transitionClassnames
+                                    );
+                                }, 200);
+                                break;
+                            default:
+                                stepEl.classList.add(stepHiddenClassname);
+                                stepEl.classList.remove(
+                                    ...transitionClassnames
+                                );
+                        }
+                    });
+                    wizardEl.dataset.length = steps.length.toString();
+                    wizardEl.dataset.position = newPosition.toString();
+                    updateCounter(wizardEl);
+                })
+        );
 
 export const enhance = (wizardEl: HTMLElement): Promise<void> =>
     setPosition(wizardEl, 0).then(() =>

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -2,6 +2,7 @@
     @include clearfix();
     position: relative;
     transition: min-height .2s;
+    will-change: min-height;
     &--completed {
         .manage-account-wizard__controls {
             display: none;
@@ -13,6 +14,7 @@
     top: 0;
     left: 0;
     right: 0;
+    will-change: transform;
     &--hidden {
         display: none;
     }

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -1,9 +1,36 @@
 .manage-account-wizard {
     @include clearfix();
+    position: relative;
+    transition: min-height .2s;
     &--completed {
         .manage-account-wizard__controls {
             display: none;
         }
+    }
+}
+
+.manage-account-wizard__step {
+    top: 0;
+    left: 0;
+    right: 0;
+    &--hidden {
+        display: none;
+    }
+    &--out {
+        display: block;
+        position: absolute;
+        animation: manage-account-wizard__fadeLeft .2s both;
+    }
+    &--in {
+        animation: manage-account-wizard__fadeRight .2s reverse both;
+    }
+    &--out-reverse {
+        display: block;
+        position: absolute;
+        animation: manage-account-wizard__fadeRight .2s both;
+    }
+    &--in-reverse {
+        animation: manage-account-wizard__fadeLeft .2s reverse both;
     }
 }
 
@@ -20,5 +47,27 @@
     @include fs-textSans(1);
     @include mq($until: tablet) {
         display: none;
+    }
+}
+
+@keyframes manage-account-wizard__fadeLeft {
+    from {
+        transform: translateX(0);
+        opacity:1;
+    }
+    to {
+        transform: translateX(-5em);
+        opacity:0;
+    }
+}
+
+@keyframes manage-account-wizard__fadeRight {
+    from {
+        transform: translateX(0);
+        opacity:1;
+    }
+    to {
+        transform: translateX(5em);
+        opacity:0;
     }
 }

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -58,7 +58,7 @@
         opacity: 1;
     }
     to {
-        transform: translateX(-5em);
+        transform: translateX(-80px);
         opacity: 0;
     }
 }
@@ -69,7 +69,7 @@
         opacity: 1;
     }
     to {
-        transform: translateX(5em);
+        transform: translateX(80px);
         opacity: 0;
     }
 }

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -53,21 +53,21 @@
 @keyframes manage-account-wizard__fadeLeft {
     from {
         transform: translateX(0);
-        opacity:1;
+        opacity: 1;
     }
     to {
         transform: translateX(-5em);
-        opacity:0;
+        opacity: 0;
     }
 }
 
 @keyframes manage-account-wizard__fadeRight {
     from {
         transform: translateX(0);
-        opacity:1;
+        opacity: 1;
     }
     to {
         transform: translateX(5em);
-        opacity:0;
+        opacity: 0;
     }
 }

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -3,10 +3,10 @@
     position: relative;
     transition: min-height .2s;
     will-change: min-height;
-    .manage-account-wizard--completed {
-        .manage-account-wizard__controls {
-            display: none;
-        }
+}
+.manage-account-wizard--completed {
+    .manage-account-wizard__controls {
+        display: none;
     }
 }
 
@@ -15,25 +15,25 @@
     left: 0;
     right: 0;
     will-change: transform;
-    .manage-account-wizard__step--hidden {
-        display: none;
-    }
-    .manage-account-wizard__step--out {
-        display: block;
-        position: absolute;
-        animation: manage-account-wizard__fadeLeft .2s both;
-    }
-    .manage-account-wizard__step--in {
-        animation: manage-account-wizard__fadeRight .2s reverse both;
-    }
-    .manage-account-wizard__step--out-reverse {
-        display: block;
-        position: absolute;
-        animation: manage-account-wizard__fadeRight .2s both;
-    }
-    .manage-account-wizard__step--in-reverse {
-        animation: manage-account-wizard__fadeLeft .2s reverse both;
-    }
+}
+.manage-account-wizard__step--hidden {
+    display: none;
+}
+.manage-account-wizard__step--out {
+    display: block;
+    position: absolute;
+    animation: manage-account-wizard__fadeLeft .2s both;
+}
+.manage-account-wizard__step--in {
+    animation: manage-account-wizard__fadeRight .2s reverse both;
+}
+.manage-account-wizard__step--out-reverse {
+    display: block;
+    position: absolute;
+    animation: manage-account-wizard__fadeRight .2s both;
+}
+.manage-account-wizard__step--in-reverse {
+    animation: manage-account-wizard__fadeLeft .2s reverse both;
 }
 
 .manage-account-wizard__controls {

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -3,7 +3,7 @@
     position: relative;
     transition: min-height .2s;
     will-change: min-height;
-    &--completed {
+    .manage-account-wizard--completed {
         .manage-account-wizard__controls {
             display: none;
         }
@@ -15,23 +15,23 @@
     left: 0;
     right: 0;
     will-change: transform;
-    &--hidden {
+    .manage-account-wizard__step--hidden {
         display: none;
     }
-    &--out {
+    .manage-account-wizard__step--out {
         display: block;
         position: absolute;
         animation: manage-account-wizard__fadeLeft .2s both;
     }
-    &--in {
+    .manage-account-wizard__step--in {
         animation: manage-account-wizard__fadeRight .2s reverse both;
     }
-    &--out-reverse {
+    .manage-account-wizard__step--out-reverse {
         display: block;
         position: absolute;
         animation: manage-account-wizard__fadeRight .2s both;
     }
-    &--in-reverse {
+    .manage-account-wizard__step--in-reverse {
         animation: manage-account-wizard__fadeLeft .2s reverse both;
     }
 }
@@ -51,6 +51,10 @@
         display: none;
     }
 }
+
+/*
+80px looks somewhat good for a .2s transition
+*/
 
 @keyframes manage-account-wizard__fadeLeft {
     from {

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -53,7 +53,8 @@
 }
 
 /*
-80px looks somewhat good for a .2s transition
+4 times $gs-gutter looks non-dizzying 
+for a .2s transition
 */
 
 @keyframes manage-account-wizard__fadeLeft {
@@ -62,7 +63,7 @@
         opacity: 1;
     }
     to {
-        transform: translateX(-80px);
+        transform: translateX($gs-gutter*-4);
         opacity: 0;
     }
 }
@@ -73,7 +74,7 @@
         opacity: 1;
     }
     to {
-        transform: translateX(80px);
+        transform: translateX($gs-gutter*4);
         opacity: 0;
     }
 }


### PR DESCRIPTION
## What does this change?
Updates `manage-account-wizard` so pagination changes are more fluid while still keeping a somewhat lean & small filesize (so for instance animating height changes is a bit of a mess but it covers most cases) (its faster than the gif

## What is the value of this and can you measure success?
This helps users have some spatial context of what is going on with during page changes.

## Does this affect other platforms - Amp, Apps, etc?
No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No

## Screenshots
![ezgif-5-5b8817b3b1](https://user-images.githubusercontent.com/11539094/33136628-998b0b56-cf9d-11e7-863a-2a033f188bc5.gif)
(the kinda ugly prev/next ui is not part of this pr, it's up to each particular implementation to make it pretty)

## Tested in CODE?
No