### PR TITLE
Better email html preference retrieval, also default to HTML

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -69,7 +69,6 @@
         </fieldset>
 
     </div>
-</form>
 
 <div class="manage-account__modal manage-account__modal--newsletterFormat">
     <div class="manage-account__modalContent">
@@ -106,3 +105,5 @@
     </div>
     <div class="manage-account__modalBg js-manage-account__modalCloser"></div>
 </div>
+
+</form>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -70,40 +70,40 @@
 
     </div>
 
-<div class="manage-account__modal manage-account__modal--newsletterFormat">
-    <div class="manage-account__modalContent">
-        <button class="manage-account__modalCloser js-manage-account__modalCloser">
-        @fragments.inlineSvg("cross", "icon")
-        </button>
-        <fieldset class="fieldset">
-            <div class="fieldset__heading">
-                <h2 class="form__heading">Formatting</h2>
-            </div>
+    <div class="manage-account__modal manage-account__modal--newsletterFormat">
+        <div class="manage-account__modalContent">
+            <button class="manage-account__modalCloser js-manage-account__modalCloser">
+            @fragments.inlineSvg("cross", "icon")
+            </button>
+            <fieldset class="fieldset">
+                <div class="fieldset__heading">
+                    <h2 class="form__heading">Formatting</h2>
+                </div>
 
-            <div class="fieldset__fields">
-                <ul class="u-unstyled">
+                <div class="fieldset__fields">
+                    <ul class="u-unstyled">
 
-                    <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
-                        <label class="label">In which format would you like to receive email?</label>
-                        <div class="form-field__note">
-                            HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
-                            <br />
-                            We recommend HTML emails.
-                        </div>
+                        <li class="form-field @if(emailPrefsForm("htmlPreference").errors.nonEmpty) {form-field--error}">
+                            <label class="label">In which format would you like to receive email?</label>
+                            <div class="form-field__note">
+                                HTML emails have formatted text, images and look better. Text emails are quicker to download, but don't contain images or any formatting.
+                                <br />
+                                We recommend HTML emails.
+                            </div>
 
-                        @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
+                            @radioField(emailPrefsForm("htmlPreference"), List("HTML" -> "HTML (images and text)", "Text" -> "Text"))(nonInputFields, messages)
 
-                    </li>
+                        </li>
 
-                    <li>
-                        <button type="button" class="manage-account__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
-                    </li>
-                </ul>
-            </div>
+                        <li>
+                            <button type="button" class="manage-account__button save__button js-save-button" data-link-name="Save email preferences">Save</button>
+                        </li>
+                    </ul>
+                </div>
 
-        </fieldset>
+            </fieldset>
+        </div>
+        <div class="manage-account__modalBg js-manage-account__modalCloser"></div>
     </div>
-    <div class="manage-account__modalBg js-manage-account__modalCloser"></div>
-</div>
 
 </form>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -33,7 +33,7 @@
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
 }
 
-<form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post">
+<form novalidate action="@buildIdentityUrl("email-prefs")" role="main" method="post" class="js-manage-account__ajaxForm">
     @views.html.helper.CSRF.formField
     @if(emailPrefsForm.globalError.isDefined) {
         <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -47,9 +47,9 @@ const getNewsletterHtmlPreferenceFromElement = (
 
         if (!closestFormEl) throw new Error(ERR_IDENTITY_HTML_PREF_NOT_FOUND);
 
-        const inputEls: Array<any> = [
+        const inputEls: Array<HTMLInputElement> = ([
             ...closestFormEl.querySelectorAll('[name="htmlPreference"]'),
-        ];
+        ]: Array<any>).filter(el => el instanceof HTMLInputElement);
 
         /*
         loop over radio/checkbox-like fields first

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -186,7 +186,7 @@ const bindHtmlPreferenceChange = (buttonEl: HTMLButtonElement): void => {
     );
 };
 
-const bindUnsubscribeFromAll = (buttonEl: Element)=> {
+const bindUnsubscribeFromAll = (buttonEl: Element) => {
     bean.on(buttonEl, 'click', () => {
         if ($(buttonEl).hasClass('js-confirm-unsubscribe')) {
             addUpdatingState(buttonEl);
@@ -200,7 +200,7 @@ const bindUnsubscribeFromAll = (buttonEl: Element)=> {
 
                     throw error;
                 })
-                .then((htmlPreference:string)=>
+                .then((htmlPreference: string) =>
                     Promise.all([
                         htmlPreference,
                         fastdom.read(() => {
@@ -219,7 +219,12 @@ const bindUnsubscribeFromAll = (buttonEl: Element)=> {
                     ])
                 )
                 .then(([htmlPreference, newsletterIds, csrfToken]) =>
-                    submitNewsletterAction(csrfToken, htmlPreference, 'remove', newsletterIds)
+                    submitNewsletterAction(
+                        csrfToken,
+                        htmlPreference,
+                        'remove',
+                        newsletterIds
+                    )
                 )
                 .catch((err: Error) => {
                     pushError(err, 'reload').then(() => {
@@ -329,11 +334,11 @@ const toggleFormatModal = (buttonEl: HTMLElement): void => {
     });
 };
 
-const bindAjaxFormEventOverride = (formEl:HTMLFormElement):void => {
-    formEl.addEventListener('submit',(ev:Event)=>{
+const bindAjaxFormEventOverride = (formEl: HTMLFormElement): void => {
+    formEl.addEventListener('submit', (ev: Event) => {
         ev.preventDefault();
     });
-}
+};
 
 const enhanceManageAccount = (): void => {
     $.forEachElement('.js-save-button', bindHtmlPreferenceChange);

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -16,7 +16,7 @@ import {
 } from './modules/switch';
 import { addUpdatingState, removeUpdatingState } from './modules/button';
 
-const ERR_HTML_PREF_NOT_FOUND = `Can't find HTML preference`;
+const ERR_IDENTITY_HTML_PREF_NOT_FOUND = `Can't find HTML preference`;
 
 const submitPartialFormStatus = (
     type: ?string = null,
@@ -45,7 +45,7 @@ const getNewsletterHtmlPreferenceFromElement = (
     fastdom.read(() => {
         const closestFormEl: ?Element = originalEl.closest('form');
 
-        if (!closestFormEl) throw Error(ERR_HTML_PREF_NOT_FOUND);
+        if (!closestFormEl) throw new Error(ERR_IDENTITY_HTML_PREF_NOT_FOUND);
 
         const checkboxEl: ?HTMLElement = closestFormEl.querySelector(
             '[name="htmlPreference"]:checked'
@@ -59,7 +59,7 @@ const getNewsletterHtmlPreferenceFromElement = (
         } else if (inputEl && inputEl.value) {
             return inputEl.value;
         }
-        throw Error(ERR_HTML_PREF_NOT_FOUND);
+        throw new Error(ERR_IDENTITY_HTML_PREF_NOT_FOUND);
     });
 
 const submitNewsletterHtmlPreference = (
@@ -194,7 +194,7 @@ const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
 
             getNewsletterHtmlPreferenceFromElement(buttonEl)
                 .catch((error: Error) => {
-                    if (error.message === ERR_HTML_PREF_NOT_FOUND) {
+                    if (error.message === ERR_IDENTITY_HTML_PREF_NOT_FOUND) {
                         return 'HTML';
                     }
 
@@ -259,7 +259,7 @@ const bindNewsletterSwitch = (labelEl: HTMLElement): void => {
             }
             getNewsletterHtmlPreferenceFromElement(labelEl)
                 .catch((error: Error) => {
-                    if (error.message === ERR_HTML_PREF_NOT_FOUND) {
+                    if (error.message === ERR_IDENTITY_HTML_PREF_NOT_FOUND) {
                         return 'HTML';
                     }
 

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -186,7 +186,7 @@ const bindHtmlPreferenceChange = (buttonEl: HTMLButtonElement): void => {
     );
 };
 
-const bindUnsubscribeFromAll = (buttonEl: Element) => {
+const bindUnsubscribeFromAll = (buttonEl: HTMLButtonElement) => {
     bean.on(buttonEl, 'click', () => {
         if ($(buttonEl).hasClass('js-confirm-unsubscribe')) {
             addUpdatingState(buttonEl);

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -47,18 +47,25 @@ const getNewsletterHtmlPreferenceFromElement = (
 
         if (!closestFormEl) throw new Error(ERR_IDENTITY_HTML_PREF_NOT_FOUND);
 
-        const checkboxEl: ?HTMLElement = closestFormEl.querySelector(
-            '[name="htmlPreference"]:checked'
-        );
-        const inputEl: ?HTMLElement = closestFormEl.querySelector(
-            '[name="htmlPreference"]'
+        const inputEls: Array<any> = [
+            ...closestFormEl.querySelectorAll('[name="htmlPreference"]'),
+        ];
+
+        /*
+        loop over radio/checkbox-like fields first
+        to avoid submitting the wrong one
+        */
+
+        const checkedInputEl: ?HTMLInputElement = inputEls.find(
+            (inputEl: HTMLInputElement) => inputEl && inputEl.checked
         );
 
-        if (checkboxEl && checkboxEl.value) {
-            return checkboxEl.value;
-        } else if (inputEl && inputEl.value) {
-            return inputEl.value;
+        if (checkedInputEl && checkedInputEl.value) {
+            return checkedInputEl.value;
+        } else if (inputEls[0] && inputEls[0].value) {
+            return inputEls[0].value;
         }
+
         throw new Error(ERR_IDENTITY_HTML_PREF_NOT_FOUND);
     });
 

--- a/static/src/javascripts/projects/common/modules/identity/manage-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/manage-account.js
@@ -318,9 +318,16 @@ const toggleFormatModal = (buttonEl: HTMLElement): void => {
     });
 };
 
+const bindAjaxFormEventOverride = (formEl:HTMLFormElement):void => {
+    formEl.addEventListener('submit',(ev:Event)=>{
+        ev.preventDefault();
+    });
+}
+
 const enhanceManageAccount = (): void => {
     $.forEachElement('.js-save-button', bindHtmlPreferenceChange);
     $.forEachElement('.js-unsubscribe', bindUnsubscribeFromAll);
+    $.forEachElement('.js-manage-account__ajaxForm', bindAjaxFormEventOverride);
     $.forEachElement('.js-manage-account__modalCloser', bindModalCloser);
     $.forEachElement('.js-manage-account__consentCheckbox', bindConsentSwitch);
     $.forEachElement(


### PR DESCRIPTION
## What does this change?
Small fix to make the retrieval for the newsletter html/text type look for it on fields of types other than radio buttons _and_ should it fail to find it, default to html. Currently it will return `null` and fail when attempting to subscribe to a newsletter, which seems harsher

@mario-galic to be fair we don't really need to be sending this to the server at all for a newsletter sub, would it be possible to just not require this field on the scala side of things so js can default to not sending it?