### PR TITLE
Fix compilation error

### DIFF
--- a/common/app/common/akka.scala
+++ b/common/app/common/akka.scala
@@ -1,12 +1,12 @@
 package common
 
 import scala.concurrent.duration._
-import play.api.{Environment, Mode}
+import play.api.{Environment => PlayEnv, Mode}
 
 import scala.concurrent.ExecutionContext
 import akka.actor.ActorSystem
 
-class AkkaAsync(env: Environment, actorSystem: ActorSystem) {
+class AkkaAsync(env: PlayEnv, actorSystem: ActorSystem) {
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   // "apply" isn't expressive and doesn't explain what it does.


### PR DESCRIPTION
Caused by warning about Environment being permanently hidden.

Note, this didn't get picked up locally or in the build because it required a clean to become visible :( . I only noticed it because it broke the build on the central TC that I've been testing.

Introduced here: https://github.com/guardian/frontend/pull/18298. 

```[error] /Users/nlong/projects/frontend/common/app/common/akka.scala:4: imported `Environment' is permanently hidden by definition of object Environment in package common
[error] import play.api.{Environment, Mode}
[error]```