### PR TITLE
New Desktop header with the old search

### DIFF
--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -43,7 +43,7 @@
                 <ul class="menu-group menu-group--membership"
                     role="menubar">
                     {{ #membershipLinks }}
-                        <li class="menu-item hide-on-desktop"
+                        <li class="menu-item hide-from-desktop"
                             role="menuitem">
 
                             <a class="menu-item__title"

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -3,7 +3,7 @@
 @import common.{Edition, LinkTo}
 @import views.support.RenderClasses
 
-<li class="menu-item js-navigation-item hide-on-desktop">
+<li class="menu-item js-navigation-item">
     <button class="menu-item__title js-navigation-toggle"
             data-link-name="nav2 : edition picker"
             aria-haspopup="true"

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -9,7 +9,7 @@
     <li class="menu-item js-navigation-item"
         data-section-name="@topLevelSection.name"
         role="menuitem">
-        <button class="menu-item__title hide-on-desktop js-navigation-toggle"
+        <button class="menu-item__title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : secondary : @topLevelSection.name"
                 aria-haspopup="true"
                 aria-expanded="true">
@@ -68,7 +68,8 @@
             </ul>
 
             @if(SearchSwitch.isSwitchedOn) {
-                <div class="menu-group menu-group--search">
+                @* TODO: clean up search menu desktop styling *@
+                <div class="menu-group menu-group--search hide-from-desktop">
                     <form class="menu-search js-menu-search"
                           action="https://www.google.co.uk/search">
                         <input type="text"
@@ -104,7 +105,7 @@
             <ul class="menu-group menu-group--membership"
                 role="menubar">
                 @NavigationHelpers.getMembershipLinks(edition).map { item =>
-                    <li class="menu-item hide-on-desktop"
+                    <li class="menu-item hide-from-desktop"
                         data-edition="@{edition.id.toLowerCase}"
                         role="menuitem">
 
@@ -119,7 +120,7 @@
                 @fragments.nav.userAccountLinks()
             </ul>
 
-            <ul class="menu-group menu-group--editions">
+            <ul class="menu-group menu-group--editions hide-from-desktop">
                 @fragments.nav.editionPicker()
             </ul>
 
@@ -128,7 +129,7 @@
                 role="menubar">
 
                 @NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map { item =>
-                    <li class="menu-item hide-on-desktop"
+                    <li class="menu-item hide-from-desktop"
                         role="menuitem">
                         <a class="menu-item__title"
                            href="@LinkTo { @item.url }"
@@ -140,7 +141,7 @@
 
                 @NewNavigation.OtherLinks.getEditionalisedNavLinks(edition).map { item =>
                     <li class="@RenderClasses(Map(
-                            "hide-on-desktop" -> (item.title == "the guardian app"),
+                            "hide-from-desktop" -> (item.title == "the guardian app"),
                             "menu-item--no-border" -> (item.title == "video")
                         ), "menu-item")"
                         role="menuitem">
@@ -153,7 +154,7 @@
                     </li>
                 }
 
-                <li class="menu-item hide-on-desktop"
+                <li class="menu-item hide-from-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://www.facebook.com/theguardian"
@@ -163,7 +164,7 @@
                     </a>
                 </li>
 
-                <li class="menu-item hide-on-desktop"
+                <li class="menu-item hide-from-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://twitter.com/guardian"

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -4,7 +4,7 @@
 @import conf.switches.Switches.IdentityProfileNavigationSwitch
 
 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-    <li class="menu-item js-navigation-sign-in hide-on-desktop">
+    <li class="menu-item js-navigation-sign-in hide-from-desktop">
         <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN"
            data-link-name="nav2 : sign in"
            class="menu-item__title">
@@ -12,8 +12,8 @@
         </a>
     </li>
 
-    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-on-desktop">
-        <button class="menu-item__title hide-on-desktop js-navigation-toggle"
+    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-from-desktop">
+        <button class="menu-item__title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : my account"
                 aria-haspopup="true"
                 aria-expanded="true">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,7 +4,7 @@
 @import views.support.RenderClasses
 @import navigation.{NewNavigation, NavigationHelpers}
 @import navigation.UrlHelpers.{getJobUrl, getContributionOrSupporterUrl, NewHeader, getSupportOrSubscriptionUrl}
-@import conf.switches.Switches.IdentityProfileNavigationSwitch
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
 
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> mvt.ABNewDesktopHeaderVariant.isParticipating,
@@ -69,9 +69,21 @@
                             @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                                 @fragments.nav.userAccountDropdown()
                             }
+
+                            @if(SearchSwitch.isSwitchedOn) {
+                                <a class="top-bar__item hide-until-desktop js-search-toggle"
+                                    href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+                                    data-is-ajax data-link-name="nav2 : search"
+                                    data-toggle="popup--search"
+                                    aria-haspopup="true">
+                                                    search
+                                </a>
+                            }
                         }
                     }
                 </div>
+
+                <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
 
                 <input type="checkbox"
                        id="main-menu-toggle"

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -39,7 +39,7 @@
             <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
-                    <li class="popup__item brand-bar__popup--soulmates hide-on-desktop show-on-slim-header">
+                    <li class="popup__item brand-bar__popup--soulmates hide-from-desktop show-on-slim-header">
                         <a class="brand-bar__item--action" data-link-name="uk : topNav : soulmates"
                            href="@soulmatesUrl("uk")">dating</a>
                     </li>
@@ -56,7 +56,7 @@
                         href="@holidaysUrl">holidays</a>
                     </li>
                 </ul>
-                <div class="brand-bar__popup--membership hide-on-desktop show-on-slim-header">
+                <div class="brand-bar__popup--membership hide-from-desktop show-on-slim-header">
                     <h3 class="popup__group-header">support us:</h3>
                     <ul class="popup__group">
                         <li class="popup__item">
@@ -99,7 +99,7 @@
             <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
-                    <li class="popup__item brand-bar__popup--soulmates hide-on-desktop show-on-slim-header">
+                    <li class="popup__item brand-bar__popup--soulmates hide-from-desktop show-on-slim-header">
                         <a class="brand-bar__item--action" data-link-name="int : topNav : soulmates"
                            href="@soulmatesUrl("int")">dating</a>
                     </li>

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -111,12 +111,6 @@
     }
 }
 
-.hide-on-desktop {
-    @include mq(desktop) {
-        display: none !important;
-    }
-}
-
 .u-cf {
     @include clearfix;
 }

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -24,7 +24,8 @@
     }
 
     &:hover,
-    &:focus {
+    &:focus,
+    &.is-active {
         color: #ffffff;
         text-decoration: none;
     }


### PR DESCRIPTION
## What does this change?
The old desktop search  on the new desktop header. 

If we have time, @zeftilldeath will be updating the styling. 

## What is the value of this and can you measure success?
Easier search on desktop

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/33175686-6a0040f6-d054-11e7-8c12-f02cfe5199b6.png)
![image](https://user-images.githubusercontent.com/8774970/33175694-70e7c98e-d054-11e7-822a-71cde0454935.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
