### PR TITLE
Desktop Header: align arrows for dropdown

### DIFF
--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -18,7 +18,7 @@
     display: none;
     position: absolute;
     top: $gs-baseline * 2 + $gs-baseline / 2;
-    right: -$gs-gutter / 4;
+    right: -6px;
     width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
     border-radius: $gs-baseline / 4;


### PR DESCRIPTION
## What does this change?
There are some annoying misaligned arrows in the desktop header. This hopefully makes it a bit less annoying. 

## What is the value of this and can you measure success?
Piece of mind :sun_behind_small_cloud: 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/33177917-2beb32dc-d05c-11e7-857b-f9c839cd7383.png)

After:
![image](https://user-images.githubusercontent.com/8774970/33177910-256f380e-d05c-11e7-86b6-fb921426685d.png)


## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
