### PR TITLE
Update wording on email preferences page

### DIFF
--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -56,21 +56,16 @@
     <div class="js-errorHolder manage-account__errors"></div>
 
     @* Marketing Consent *@
-    <div class="manage-account-headerWrapper">
-        <h2 class="manage-account-header">Marketing preferences</h2>
-    </div>
-    <fieldset class="fieldset">
+    <fieldset class="fieldset fieldset--manage-account-noborder">
 
         <div class="fieldset__heading">
-            <h2 class="form__heading">Marketing</h2>
+            <h2 class="form__heading">What can we tell you about?</h2>
         </div>
 
         <div class="fieldset__fields">
             <ul class="u-unstyled">
                 <li class="form-field">
-                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
-                    <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
-
+                    <label class="label">The Guardian and their partners would like to occasionally send you information about their products, services and events.</label>
                     <div class="form-fields-group">
                         @consentCheckboxes
                     </div>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -56,9 +56,9 @@
                     @if(ProfileShowContributorTab.isSwitchedOn) {
                         @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-membership-tab")
 
-                        @tab(6, "Email", "/email-prefs", None, optionalClass="qa-privacy-tab")
+                        @tab(6, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab")
                     } else {
-                        @tab(5, "Email", "/email-prefs", None, optionalClass="qa-privacy-tab")
+                        @tab(5, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab")
                     }
                 </ol>
             </div>


### PR DESCRIPTION
## What does this change?
Makes the 🌳WORDS⭐️ on the email preferences page better and more exciting for end users. To be precise this PR changes the `Email` tab to `Emails`, and updates the copy on the first row of the existing consent preferences 

## What is the value of this and can you measure success?
_Marketing_ no longer is, twice, literally the first thing you read on the page, which is a far better look

## Screenshots
Before (and bad)
![screen shot 2017-11-23 at 16 37 52](https://user-images.githubusercontent.com/11539094/33182683-ea7e5afc-d06c-11e7-924a-596b24dba37a.png)
After (good, pure, wholesome)
![screen shot 2017-11-23 at 16 37 33](https://user-images.githubusercontent.com/11539094/33182735-0a7f6e72-d06d-11e7-85cc-f38d98fba7f5.png)

