### PR TITLE
Add list compact classes to garnett

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -11,6 +11,8 @@
 @import 'item-layouts/fc-item--three-quarters-right';
 @import 'item-layouts/fc-item--three-quarters-tall';
 @import 'item-layouts/fc-item--list';
+@import 'item-layouts/fc-item--list-compact';
+@import 'item-layouts/fc-item--list-compact--media';
 @import 'item-layouts/fc-item--list-media';
 @import 'item-layouts/fc-item--full-media-50';
 @import 'item-layouts/fc-item--full-media-75';
@@ -238,37 +240,37 @@
         &:not(.fc-item--has-cutout) {
             .fc-item__header {
                 @include fs-headline(3, true);
-        
+
                 @include mq(desktop) {
                     @include fs-headline(5, true);
                     @include headline-boost(6);
                 }
             }
-        
+
             .fc-item__standfirst {
                 display: block;
             }
-        
+
             &.fc-item--has-sublinks-3 {
                 .fc-item__standfirst {
                     display: none;
                 }
             }
-    
+
             &.fc-item--has-sublinks-4 {
                 @include fc-sublinks--below;
             }
-        
+
             .fc-sublink:nth-child(n+5) {
                 display: none;
             }
         }
-    
+
         &.fc-item--has-cutout {
             .fc-item__header {
                 @include fs-headline(4, true);
                 @include headline-boost(5);
-    
+
                 @include mq(desktop) {
                     @include fs-headline(6, true);
                     @include headline-boost(7);
@@ -324,4 +326,13 @@
             padding-right: 30%;
         }
     }
+}
+
+// Commercial items
+.fc-item--list-compact {
+    @include fc-item--list-compact;
+}
+
+.fc-item--list-compact--media {
+    @include fc-item--list-compact--media;
 }

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-compact--media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-compact--media.scss
@@ -1,0 +1,37 @@
+/*
+
+Compact list item. Looks a bit like this:
+
+x x x x x x x x x x x x x x x x x x x x x x x
+
+ */
+
+@mixin fc-item--list-compact--media {
+    @include fc-item--list-compact;
+
+    // calculate image width
+    $media-ratio: 5 / 3;
+    $item-min-height: get-line-height(bodyHeading, 2) * 3;
+    $image-width: $item-min-height * $media-ratio;
+
+    min-height: $item-min-height;
+    padding-left: $image-width;
+
+    // Override u-responsive-ratio
+    // Circumvents Chrome bug with positioning, overflow: hidden and columns
+    // https://code.google.com/p/chromium/issues/detail?id=527709
+    .fc-item__image-container {
+        overflow: visible;
+    }
+
+    .fc-item__image-container {
+        display: block;
+    }
+
+    .fc-item__media-wrapper {
+        width: $image-width;
+        padding-right: $gs-gutter * .5;
+        margin-left: 0 - $image-width;
+        float: left;
+    }
+}

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-compact.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-compact.scss
@@ -1,0 +1,22 @@
+/*
+
+Compact list item. Looks a bit like this:
+
+x x x x x x x x x x x x x x x x x x x x x x x
+
+ */
+
+@mixin fc-item--list-compact {
+    @include fs-bodyHeading(2);
+    color: $neutral-1;
+    padding-top: $gs-baseline/3;
+    padding-bottom: $gs-baseline;
+    border-top: 1px solid $neutral-6;
+    display: block !important;
+    background-color: transparent;
+
+    .fc-item__container {
+        @include fs-headline(2, true);
+        display: block !important;
+    }
+}


### PR DESCRIPTION
## What does this change?

It turns out we need the `list-compact` and `list-compact--media` classes to support navigation on pages like the [About page](https://www.theguardian.com/about).
