### PR TITLE
Use GDPR consents by product model

### DIFF
--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -1,7 +1,7 @@
 package form
 
-import com.gu.identity.model.{Consent, ConsentText, User}
-import com.gu.identity.model.ConsentText._
+import com.gu.identity.model.{Consent,User}
+import com.gu.identity.model.Consent._
 import idapiclient.UserUpdateDTO
 import play.api.data.Forms._
 import play.api.data.JodaForms.jodaDate
@@ -20,11 +20,11 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
       "consents" -> list(
         mapping(
           "actor" -> text,
-          "consentIdentifier" -> text,
-          "consentIdentifierVersion" -> number,
-          "hasConsented" -> boolean,
+          "id" -> text,
+          "version" -> number,
+          "consented" -> boolean,
           "timestamp" -> jodaDate(dateTimeFormatISO8601),
-          "privacyPolicy" -> number
+          "privacyPolicyVersion" -> number
         )(Consent.apply)(Consent.unapply) // NOTE: Consent here is DO from identity-model
       )
     )(PrivacyFormData.apply)(PrivacyFormData.unapply)
@@ -92,7 +92,7 @@ case class PrivacyFormData(
       oldConsent <- oldUserDO.consents
       newConsent <- consents
     } yield {
-      if (oldConsent.consentIdentifier == newConsent.consentIdentifier)
+      if (oldConsent.id == newConsent.id)
         newConsent
       else
         oldConsent
@@ -121,10 +121,4 @@ object PrivacyFormData {
       receive3rdPartyMarketing = userDO.statusFields.receive3rdPartyMarketing,
       allowThirdPartyProfiling = userDO.statusFields.allowThirdPartyProfiling,
       consents = if (userDO.consents.isEmpty) defaultConsents else userDO.consents)
-
-  private val defaultConsents =
-    List(
-      Consent("user", FirstParty.name, false),
-      Consent("user", ThirdParty.name, false),
-      Consent("user", ThirdPartyProfiling.name, false))
 }

--- a/identity/app/views/fragments/consentCheckbox.scala.html
+++ b/identity/app/views/fragments/consentCheckbox.scala.html
@@ -1,12 +1,12 @@
-@import com.gu.identity.model.ConsentText
+@import com.gu.identity.model.Consent
 @import _root_.form.IdFormHelpers.nonInputFields
 
 @(consentField: Field)(messages: play.api.i18n.Messages)
 
 @getConsentText(consentField: Field) = {
-    @ConsentText.getText(
-        consentField("consentIdentifier").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
-        consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
+    @Consent.wording(
+        consentField("id").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
+        consentField("version").value.getOrElse("0").toInt)
 }
 
 @fragments.form.switch(
@@ -14,9 +14,9 @@
     subheading = None,
     description = None,
     behaviour = Some("consent"),
-    field = consentField("hasConsented"),
+    field = consentField("consented"),
     extraFields = Some(
-        List("actor","consentIdentifier","consentIdentifierVersion","timestamp","privacyPolicy").map(field =>
+        List("actor","id","version","timestamp","privacyPolicyVersion").map(field =>
             fragments.form.hidden(consentField(field))
         )
     )

--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -2,8 +2,8 @@
 
 @import views.html.fragments.form.switch
 @import _root_.form.IdFormHelpers.nonInputFields
-@import com.gu.identity.model.ConsentText
-@import com.gu.identity.model.ConsentText._
+@import com.gu.identity.model.Consent
+@import com.gu.identity.model.Consent._
 
 @(idUrlBuilder: services.IdentityUrlBuilder,
   idRequest: services.IdentityRequest,
@@ -11,9 +11,9 @@
 
 
 @getConsentText(consentField: Field) = {
-    @ConsentText.getText(
-        consentField("consentIdentifier").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
-        consentField("consentIdentifierVersion").value.getOrElse("0").toInt)
+    @Consent.wording(
+        consentField("id").value.getOrElse("unknownConsent"), // OrElse will never execute as there is always a default
+        consentField("version").value.getOrElse("0").toInt)
 }
 
 @consentCheckboxes = {
@@ -21,7 +21,7 @@
         <ul>
             <li>
                 @switch(
-                    title = currentConsents(FirstParty.name),
+                    title = FirstParty.latestWording,
                     subheading = None,
                     description = None,
                     behaviour = Some("consent"),
@@ -30,7 +30,7 @@
             </li>
             <li>
                 @switch(
-                    title = currentConsents(ThirdParty.name),
+                    title = ThirdParty.latestWording,
                     subheading = None,
                     description = None,
                     behaviour = Some("consent"),

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -1,7 +1,7 @@
 @import views.html.fragments.registrationFooter
 @import _root_.form.IdFormHelpers.nonInputFields
-@import com.gu.identity.model.ConsentText
-@import com.gu.identity.model.ConsentText._
+@import com.gu.identity.model.Consent
+@import com.gu.identity.model.Consent._
 @import conf.switches.Switches.IdentityGdprMarketingConsentSwitch
 @import model.{EmailNewsletters, IdentityPage}
 @import services.EmailPrefsData

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.AuthenticatedActions
 import actions.AuthenticatedActions.AuthRequest
 import com.gu.identity.cookie.GuUCookieData
-import com.gu.identity.model.ConsentText.FirstParty
+import com.gu.identity.model.Consent.FirstParty
 import com.gu.identity.model._
 import form._
 import idapiclient.{TrackingData, _}
@@ -129,16 +129,16 @@ import scala.concurrent.Future
 
     "submitPrivacyForm method is called with valid CSRF request" should {
       "post UserUpdateDTO with consent to IDAPI" in new EditProfileFixture {
-        val consent = Consent("user", FirstParty.name, false)
+        val consent = Consent(FirstParty.id, "user", false)
 
         val fakeRequest = FakeCSRFRequest(csrfAddToken)
           .withFormUrlEncodedBody(
             "consents[0].actor" -> consent.actor,
-            "consents[0].consentIdentifier" -> consent.consentIdentifier,
-            "consents[0].hasConsented" -> consent.hasConsented.toString,
-            "consents[0].privacyPolicy" -> consent.privacyPolicy.toString,
+            "consents[0].id" -> consent.id,
+            "consents[0].consented" -> consent.consented.toString,
+            "consents[0].privacyPolicyVersion" -> consent.privacyPolicyVersion.toString,
             "consents[0].timestamp" -> consent.timestamp.toString(ISODateTimeFormat.dateTimeNoMillis.withZoneUTC()),
-            "consents[0].consentIdentifierVersion" -> consent.consentIdentifierVersion.toString
+            "consents[0].version" -> consent.version.toString
           )
 
         when(api.saveUser(MockitoMatchers.any[String], MockitoMatchers.any[UserUpdateDTO], MockitoMatchers.any[Auth]))
@@ -153,8 +153,8 @@ import scala.concurrent.Future
         val userUpdateDTO = userUpdateDTOCapture.getValue
 
         userUpdateDTO.consents.value.head.actor should equal(consent.actor)
-        userUpdateDTO.consents.value.head.consentIdentifier should equal(consent.consentIdentifier)
-        userUpdateDTO.consents.value.head.hasConsented should equal(consent.hasConsented)
+        userUpdateDTO.consents.value.head.id should equal(consent.id)
+        userUpdateDTO.consents.value.head.consented should equal(consent.consented)
       }
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.84"
+  val identityLibVersion = "3.87"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.42"


### PR DESCRIPTION
## What does this change?

Uses GDPR consents by product model. 

Related PR: https://github.com/guardian/identity/pull/720

## What is the value of this and can you measure success?

Step towards GDPR compliance.
