### PR TITLE
Babel: Unify plugins between dev and test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -43,6 +43,12 @@
                     "useBuiltIns": true
                 }]
             ],
+            "plugins": [
+                ["babel-plugin-transform-runtime", {
+                    "polyfill": false
+                }],
+                "babel-plugin-transform-class-properties",
+            ],
         },
         "internal": {
             "presets": [


### PR DESCRIPTION
## What does this change?

I recently ran into the issue, that code could not be transpiled, because of static class properties. @SiAdcock found out, that we use different presets for dev and test. This PR unifies the plugins, which are loaded in both stages to avoid that problem.

## What is the value of this and can you measure success?

...

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.