### PR TITLE
Shorter banner tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2018, 2, 28),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-banner-shorter-copy",
+    "Test highlighting a different sentance in the epic",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2017, 12, 13),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -94,6 +94,11 @@ const membershipSupporterParams = (location: string): EngagementBannerParams =>
         pageviewId: config.get('ophan.pageViewId', 'not_found'),
     });
 
+export const engagementBannerCopyShorter = (): string =>
+    `<strong>Unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we
+    can.</strong> The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to
+    produce. To help secure our future, we increasingly need our readers to fund us.`;
+
 export const engagementBannerParams = (
     location: string
 ): EngagementBannerParams => {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-shorter-copy.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-banner-shorter-copy.js
@@ -1,0 +1,33 @@
+// @flow
+import { makeBannerABTestVariants } from 'common/modules/commercial/contributions-utilities';
+import { engagementBannerCopyShorter } from 'common/modules/commercial/membership-engagement-banner-parameters';
+
+export const AcquisitionsBannerShorterCopy: AcquisitionsABTest = {
+    id: 'AcquisitionsBannerShorterCopy',
+    campaignId: 'banner_shorter_copy',
+    start: '2017-11-24',
+    expiry: '2018-12-13',
+    author: 'Jonathan Rankin',
+    description: 'Test a shorter banner copy variant',
+    successMeasure: 'Conversion rate',
+    idealOutcome: 'Acquires many Supporters',
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+    canRun: () => true,
+
+    variants: makeBannerABTestVariants([
+        {
+            id: 'control',
+        },
+        {
+            id: 'shorter',
+            options: {
+                engagementBannerParams: {
+                    messageText: engagementBannerCopyShorter(),
+                },
+            },
+        },
+    ]),
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-engagement-banner-tests.js
@@ -1,4 +1,6 @@
 // @flow
+import { AcquisitionsBannerShorterCopy } from 'common/modules/experiments/tests/acquisitions-banner-shorter-copy';
+
 export const membershipEngagementBannerTests: $ReadOnlyArray<
     AcquisitionsABTest
-> = [];
+> = [AcquisitionsBannerShorterCopy];


### PR DESCRIPTION
## What does this change?

Adds a new banner test which tests out a version with shorter copy

Control:
![control](https://user-images.githubusercontent.com/2844554/33214082-5575607a-d122-11e7-81c7-a7d125bc82c5.png)

Variant:
![var](https://user-images.githubusercontent.com/2844554/33214083-5587df52-d122-11e7-974a-e65a4dde52e6.png)
