### PR TITLE
Redeploy engagement banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner-parameters.js
@@ -95,9 +95,9 @@ const membershipSupporterParams = (location: string): EngagementBannerParams =>
     });
 
 export const engagementBannerCopyShorter = (): string =>
-    `<strong>Unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism as open as we
-    can.</strong> The Guardian’s independent, investigative journalism takes a lot of time, money and hard work to
-    produce. To help secure our future, we increasingly need our readers to fund us.`;
+    `<strong>Unlike many news organisations, we haven’t put up a paywall &ndash; we want to keep our journalism
+    as open as we can.</strong> The Guardian’s independent, investigative journalism takes a lot of time, money
+    and hard work to produce. But advertising revenue is falling, so we need our readers to help make our future more secure.`;
 
 export const engagementBannerParams = (
     location: string

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -19,7 +19,7 @@ import {
 import { acquisitionsBannerControlTemplate } from 'common/modules/commercial/templates/acquisitions-banner-control';
 
 // change messageCode to force redisplay of the message to users who already closed it.
-const messageCode = 'engagement-banner-2017-11-02';
+const messageCode = 'engagement-banner-2017-11-24';
 
 const getUserTest = (): ?AcquisitionsABTest =>
     membershipEngagementBannerTests.find(


### PR DESCRIPTION
## What does this change?
Re-deploys the engagement banner, and updates the copy in the new banner test (https://github.com/guardian/frontend/pull/18328) to the approved verison.

Here is the banner with the new copy:

![nat](https://user-images.githubusercontent.com/2844554/33216186-b01f7a9e-d12a-11e7-840c-b5f2aae94d1b.png)
