### PR TITLE
Remove padding from the bottom of MPUs in facia containers.

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -259,7 +259,6 @@ Hence why a greater depth of selector specificity is needed.
 .fc-container--dynamic-slow-mpu {
     .ad-slot--container-inline {
         width: gs-span(4);
-        padding-bottom: $gs-baseline / 2;
         @include mq(tablet) {
             width: gs-span(5);
         }

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -267,7 +267,6 @@ Hence why a greater depth of selector specificity is needed.
 .fc-container--dynamic-slow-mpu {
     .ad-slot--container-inline {
         width: gs-span(4);
-        padding-bottom: $gs-baseline / 2;
         @include mq(tablet) {
             width: gs-span(5);
         }


### PR DESCRIPTION
It isn't clear why there is padding on the bottom of these MPU slots in these containers. It is also causing a bug with how our Parallax MPUs function.

To fix the bug, I can either change the padding to be a margin, or I can remove it. Since I suspect this padding is no longer necessary I'm opting to remove it. If it turns out that we do need it, then I can revert and add it back in as a margin.

**Before**
![image](https://user-images.githubusercontent.com/1821099/33261273-36703238-d35a-11e7-8fab-a9555fd1c9aa.png)
**After**
![image](https://user-images.githubusercontent.com/1821099/33261309-505bd81e-d35a-11e7-8770-2ffdc6e8f35a.png)
