### PR TITLE
Extend Outstream switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -21,7 +21,7 @@ trait CommercialSwitches {
     "Deactivates the sizecallback for videos (620x1) that hides the slot.",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
-    sellByDate = new LocalDate(2017, 11, 29),
+    sellByDate = new LocalDate(2017, 12, 13),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Now that our Outstream proposition has moved, it needs to be confirmed with the business as to whether this is still required or not.