### PR TITLE
Added a message for when the user clicks a magic consent link

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -48,7 +48,7 @@ class EditProfileController(
   def displayMembershipForm: Action[AnyContent] = displayForm(MembershipEditProfilePage)
   def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)
   def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
-  def displayEmailPrefsForm: Action[AnyContent] = displayForm(EmailPrefsProfilePage)
+  def displayEmailPrefsForm(consentsUpdated: Boolean): Action[AnyContent] = displayForm(EmailPrefsProfilePage, consentsUpdated)
 
   def displayRepermissioningJourneyForm: Action[AnyContent] = {
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
@@ -131,12 +131,14 @@ class EditProfileController(
 
   def saveConsentPreferences: Action[AnyContent] = submitForm(EmailPrefsProfilePage)
 
-  private def displayForm(page: IdentityPage) = csrfAddToken {
+  private def displayForm(page: IdentityPage, consentsUpdated: Boolean = false) = csrfAddToken {
     recentlyAuthenticated.async { implicit request =>
         profileFormsView(
           page = page,
           forms = ProfileForms(request.user, PublicEditProfilePage),
-          request.user)
+          request.user,
+          consentsUpdated
+        )
     }
   }
 
@@ -200,7 +202,8 @@ class EditProfileController(
   private def profileFormsView(
       page: IdentityPage,
       forms: ProfileForms,
-      user: User)
+      user: User,
+      consentsUpdated: Boolean = false)
       (implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
     newsletterService.preferences(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
@@ -213,8 +216,8 @@ class EditProfileController(
         idUrlBuilder,
         emailFilledForm,
         newsletterService.getEmailSubscriptions(emailFilledForm),
-        EmailNewsletters.all
-
+        EmailNewsletters.all,
+        consentsUpdated
       )))
 
     }

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -27,12 +27,6 @@
                 <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
             </div>
         }
-        @if(consentsUpdated) {
-            <div>
-                <h2 class="manage-account-header">Thank you</h2>
-                <p class="manage-account-headerNote">Your Email preferences have been updated.</p>
-            </div>
-        }
 
         <div class="js-errorHolder manage-account__errors"></div>
 
@@ -62,6 +56,13 @@
 
         </fieldset>
     </form>
+}
+
+@if(consentsUpdated) {
+    <div class="form__success">
+        <h2>Thank you</h2>
+        <p>Your Email preferences have been updated.</p>
+    </div>
 }
 
 @* MARKETING CONSENT *@

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -12,7 +12,9 @@
   privacyForm: Form[_root_.form.PrivacyFormData],
   emailPrefsForm: Form[EmailPrefsData],
   emailSubscriptions: List[String],
-  availableLists: EmailNewsletters)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+  availableLists: EmailNewsletters,
+  consentsUpdated: Boolean = false
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @marketingConsentForm = {
     <form class="js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
@@ -23,6 +25,12 @@
             <div class="form__error">
                 Error processing the form. Your changes have not been saved:
                 <p>@privacyForm.errors.map(formError => (formError.key, formError.message)).mkString(", ")</p>
+            </div>
+        }
+        @if(consentsUpdated) {
+            <div>
+                <h2 class="manage-account-header">Thank you</h2>
+                <p class="manage-account-headerNote">Your Email preferences have been updated.</p>
             </div>
         }
 

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -12,7 +12,8 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters
+    availableLists: EmailNewsletters,
+    consentsUpdated: Boolean
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "") = {
@@ -82,9 +83,9 @@
                         @if(ProfileShowContributorTab.isSwitchedOn) {
                             @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
-                            @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists))
+                            @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated))
                         } else {
-                            @content(5, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists)))
+                            @content(5, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated)))
                         }
                     </div>
                 </div>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -59,7 +59,7 @@ GET         /privacy/edit                           controllers.EditProfileContr
 POST        /privacy/edit                           controllers.EditProfileController.saveConsentPreferences
 POST        /privacy/edit-ajax                      controllers.EditProfileController.saveConsentPreferencesAjax
 
-GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm
+GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false)
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
 GET         /repermission                           controllers.EditProfileController.displayRepermissioningJourneyForm

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -472,7 +472,7 @@ import scala.concurrent.Future
         when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
-        val result = controller.displayEmailPrefsForm().apply(FakeCSRFRequest(csrfAddToken))
+        val result = controller.displayEmailPrefsForm(false).apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
         contentAsString(result) should include (EmailNewsletters.guardianTodayUk.name)
         contentAsString(result) should include ("Unsubscribe")


### PR DESCRIPTION
## What does this change?

`/email-prefs`

## What is the value of this and can you measure success?

The user will be be presented with a message saying their preferences have been updated, if the `consentsUpdated` query parameter is set to true. 

## Does this affect other platforms - Amp, Apps, etc?

No 

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots
![screen shot 2017-11-27 at 13 32 50](https://user-images.githubusercontent.com/3636251/33269348-43da2de8-d378-11e7-9556-f2dc2dfeeabe.png)

## Tested in CODE?

No. 

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
