### PR TITLE
Article: enhance the way twitter is loaded, to fix a sentry issue

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -21,13 +21,15 @@ const renderTweets = (): void => {
     if (nativeTweetElements.length) {
         if (!widgetScript) {
             const scriptElement = document.createElement('script');
+            const target = document.scripts[0];
+
             scriptElement.id = 'twitter-widget';
             scriptElement.async = true;
             scriptElement.src = '//platform.twitter.com/widgets.js';
-            document.scripts[0].insertAdjacentElement(
-                'beforebegin',
-                scriptElement
-            );
+
+            if (target && target.parentNode) {
+                target.parentNode.insertBefore(scriptElement, target);
+            }
         }
 
         if (
@@ -42,8 +44,8 @@ const renderTweets = (): void => {
 
 const enhanceTweets = (): void => {
     if (
-        (getBreakpoint() === 'mobile' && !config.page.isMinuteArticle) ||
-        !config.switches.enhanceTweets
+        (getBreakpoint() === 'mobile' && !config.get('page.isMinuteArticle')) ||
+        !config.get('switches.enhanceTweets')
     ) {
         return;
     }


### PR DESCRIPTION
## What does this change?

Replaces `insertAdjacentElement` with `insertBefore` because the latter has a much better browser support.

Sentry issue: https://sentry.io/the-guardian/client-side-prod/issues/388289473/

## What is the value of this and can you measure success?

Less errors for users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.