### PR TITLE
Polyfill JS for all unknown browsers

### DIFF
--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled
+https://assets.guim.co.uk/polyfill.io/v2/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry&flags=gated&callback=guardianPolyfilled&unknown=polyfill


### PR DESCRIPTION
## What does this change?

As suggested in https://github.com/Financial-Times/polyfill-service/issues/1401#issuecomment-347169013 this adds the `&unknown=polyfill` parameter to the polyfill.io url. After the change all unknown browser will receive the polyfills aswell.

This hopefully fixes an issue, where the Safari WebView is interpreted as `Safari 2` and therefore does not receive the polyfills, which results in a large number of sentry issues.

## What is the value of this and can you measure success?

Less errors for users.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.