### PR TITLE
 Football: fix conversion bug in isLiveClockwatch()

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -319,10 +319,9 @@ const init = (): void => {
     });
 
     isLiveClockwatch(() => {
-        const isItACompetition = isCompetition();
         const ml = new MatchListLive(
             'match-day',
-            isItACompetition === false ? false : 'premierleague',
+            isCompetition() || 'premierleague',
             config.dateFromSlug()
         );
         const $img = $('.media-primary');

--- a/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
@@ -5,11 +5,7 @@ import bonzo from 'bonzo';
 import { Component } from 'common/modules/component';
 
 class MatchListLive extends Component {
-    constructor(
-        type: string,
-        competition: string | boolean,
-        date: ?string
-    ): void {
+    constructor(type: string, competition: string | true, date: ?string): void {
         super();
 
         const slug = ['football', type, competition, date]

--- a/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
@@ -7,7 +7,7 @@ import { Component } from 'common/modules/component';
 class MatchListLive extends Component {
     constructor(
         type: string,
-        competition: string | false,
+        competition: string | boolean,
         date: ?string
     ): void {
         super();


### PR DESCRIPTION
## What does this change?

Fixes a difference. which was introduced during the ES6 conversion of `football.js`.

Before the line read:

https://github.com/guardian/frontend/blob/c8f42bccb4f093c26e16845d8b9f6c4ecc939e6b/static/src/javascripts-legacy/bootstraps/enhanced/football.js#L233

It was accidentally converted that way, because the flow definition was wrong.

## What is the value of this and can you measure success?

Proper football live tables.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No

## Tested in CODE?

No.