### PR TITLE
Desktop header: Search take 2

### DIFF
--- a/common/app/views/fragments/amp/headerMenu.scala.html
+++ b/common/app/views/fragments/amp/headerMenu.scala.html
@@ -43,7 +43,7 @@
                 <ul class="menu-group menu-group--membership"
                     role="menubar">
                     {{ #membershipLinks }}
-                        <li class="menu-item hide-on-desktop"
+                        <li class="menu-item hide-from-desktop"
                             role="menuitem">
 
                             <a class="menu-item__title"

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -102,7 +102,7 @@
                                 <a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
                                    data-is-ajax data-link-name="Search icon"
                                    class="brand-bar__item--action popup__toggle js-search-toggle"
-                                   data-toggle="popup--search"
+                                   data-toggle="js-search-old"
                                    aria-haspopup="true">
                                     @fragments.inlineSvg("search-36", "icon", List("rounded-icon", "control__icon-wrapper"))
                                     <span class="control__info">search</span>
@@ -113,7 +113,7 @@
                     </div>
                 </div>
 
-                <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
+                <div class="popup popup--default popup--search js-search-old js-search-popup is-off"><div class="js-search-placeholder"></div></div>
 
                 <div class="l-header-main">
                     @if((page.metadata.sectionId == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -3,7 +3,7 @@
 @import common.{Edition, LinkTo}
 @import views.support.RenderClasses
 
-<li class="menu-item js-navigation-item hide-on-desktop">
+<li class="menu-item js-navigation-item">
     <button class="menu-item__title js-navigation-toggle"
             data-link-name="nav2 : edition picker"
             aria-haspopup="true"

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -9,7 +9,7 @@
     <li class="menu-item js-navigation-item"
         data-section-name="@topLevelSection.name"
         role="menuitem">
-        <button class="menu-item__title hide-on-desktop js-navigation-toggle"
+        <button class="menu-item__title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : secondary : @topLevelSection.name"
                 aria-haspopup="true"
                 aria-expanded="true">
@@ -68,7 +68,8 @@
             </ul>
 
             @if(SearchSwitch.isSwitchedOn) {
-                <div class="menu-group menu-group--search">
+                @* TODO: clean up search menu desktop styling *@
+                <div class="menu-group menu-group--search hide-from-desktop">
                     <form class="menu-search js-menu-search"
                           action="https://www.google.co.uk/search">
                         <input type="text"
@@ -104,7 +105,7 @@
             <ul class="menu-group menu-group--membership"
                 role="menubar">
                 @NavigationHelpers.getMembershipLinks(edition).map { item =>
-                    <li class="menu-item hide-on-desktop"
+                    <li class="menu-item hide-from-desktop"
                         data-edition="@{edition.id.toLowerCase}"
                         role="menuitem">
 
@@ -119,7 +120,7 @@
                 @fragments.nav.userAccountLinks()
             </ul>
 
-            <ul class="menu-group menu-group--editions">
+            <ul class="menu-group menu-group--editions hide-from-desktop">
                 @fragments.nav.editionPicker()
             </ul>
 
@@ -128,7 +129,7 @@
                 role="menubar">
 
                 @NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map { item =>
-                    <li class="menu-item hide-on-desktop"
+                    <li class="menu-item hide-from-desktop"
                         role="menuitem">
                         <a class="menu-item__title"
                            href="@LinkTo { @item.url }"
@@ -140,7 +141,7 @@
 
                 @NewNavigation.OtherLinks.getEditionalisedNavLinks(edition).map { item =>
                     <li class="@RenderClasses(Map(
-                            "hide-on-desktop" -> (item.title == "the guardian app"),
+                            "hide-from-desktop" -> (item.title == "the guardian app"),
                             "menu-item--no-border" -> (item.title == "video")
                         ), "menu-item")"
                         role="menuitem">
@@ -153,7 +154,7 @@
                     </li>
                 }
 
-                <li class="menu-item hide-on-desktop"
+                <li class="menu-item hide-from-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://www.facebook.com/theguardian"
@@ -163,7 +164,7 @@
                     </a>
                 </li>
 
-                <li class="menu-item hide-on-desktop"
+                <li class="menu-item hide-from-desktop"
                     role="menuitem">
                     <a class="menu-item__title"
                        href="https://twitter.com/guardian"

--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -4,7 +4,7 @@
 @import conf.switches.Switches.IdentityProfileNavigationSwitch
 
 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
-    <li class="menu-item js-navigation-sign-in hide-on-desktop">
+    <li class="menu-item js-navigation-sign-in hide-from-desktop">
         <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN"
            data-link-name="nav2 : sign in"
            class="menu-item__title">
@@ -12,8 +12,8 @@
         </a>
     </li>
 
-    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-on-desktop">
-        <button class="menu-item__title hide-on-desktop js-navigation-toggle"
+    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-from-desktop">
+        <button class="menu-item__title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : my account"
                 aria-haspopup="true"
                 aria-expanded="true">

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -4,7 +4,7 @@
 @import views.support.RenderClasses
 @import navigation.{NewNavigation, NavigationHelpers}
 @import navigation.UrlHelpers.{getJobUrl, getContributionOrSupporterUrl, NewHeader, getSupportOrSubscriptionUrl}
-@import conf.switches.Switches.IdentityProfileNavigationSwitch
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
 
 <header class="@RenderClasses(Map(
             "new-header--mvt-desktop" -> mvt.ABNewDesktopHeaderVariant.isParticipating,
@@ -69,9 +69,21 @@
                             @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
                                 @fragments.nav.userAccountDropdown()
                             }
+
+                            @if(SearchSwitch.isSwitchedOn) {
+                                <a class="top-bar__item hide-until-desktop js-search-toggle"
+                                    href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+                                    data-is-ajax data-link-name="nav2 : search"
+                                    data-toggle="popup--search"
+                                    aria-haspopup="true">
+                                                    search
+                                </a>
+                            }
                         }
                     }
                 </div>
+
+                <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
 
                 <input type="checkbox"
                        id="main-menu-toggle"

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -73,8 +73,9 @@
                             @if(SearchSwitch.isSwitchedOn) {
                                 <a class="top-bar__item hide-until-desktop js-search-toggle"
                                     href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
-                                    data-is-ajax data-link-name="nav2 : search"
-                                    data-toggle="popup--search"
+                                    data-is-ajax
+                                    data-link-name="nav2 : search"
+                                    data-toggle="js-search-new"
                                     aria-haspopup="true">
                                                     search
                                 </a>
@@ -83,7 +84,7 @@
                     }
                 </div>
 
-                <div class="popup popup--default popup--search js-search-popup is-off"><div class="js-search-placeholder"></div></div>
+                <div class="popup popup--default popup--search js-search-popup js-search-new is-off"><div class="js-search-placeholder"></div></div>
 
                 <input type="checkbox"
                        id="main-menu-toggle"

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -39,7 +39,7 @@
             <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
-                    <li class="popup__item brand-bar__popup--soulmates hide-on-desktop show-on-slim-header">
+                    <li class="popup__item brand-bar__popup--soulmates hide-from-desktop show-on-slim-header">
                         <a class="brand-bar__item--action" data-link-name="uk : topNav : soulmates"
                            href="@soulmatesUrl("uk")">dating</a>
                     </li>
@@ -56,7 +56,7 @@
                         href="@holidaysUrl">holidays</a>
                     </li>
                 </ul>
-                <div class="brand-bar__popup--membership hide-on-desktop show-on-slim-header">
+                <div class="brand-bar__popup--membership hide-from-desktop show-on-slim-header">
                     <h3 class="popup__group-header">support us:</h3>
                     <ul class="popup__group">
                         <li class="popup__item">
@@ -99,7 +99,7 @@
             <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
-                    <li class="popup__item brand-bar__popup--soulmates hide-on-desktop show-on-slim-header">
+                    <li class="popup__item brand-bar__popup--soulmates hide-from-desktop show-on-slim-header">
                         <a class="brand-bar__item--action" data-link-name="int : topNav : soulmates"
                            href="@soulmatesUrl("int")">dating</a>
                     </li>

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -1,10 +1,9 @@
 // @flow
 
 import bean from 'bean';
-import fastdom from 'fastdom';
+import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 import config from 'lib/config';
-import throttle from 'lodash/functions/throttle';
 
 const focusSearchField = (): void => {
     const $input = $('input.gsc-input');
@@ -19,147 +18,207 @@ class Search {
     resultSetSize: number;
 
     constructor(): void {
-        const toggle = document.getElementsByClassName('js-search-toggle')[0];
-        let searchLoader;
-        const googleSearchSwitch = config.get('switches.googleSearch');
-        const googleSearchUrl = config.get('page.googleSearchUrl');
-        const googleSearchId = config.get('page.googleSearchId');
+        fastdom
+            .read(() => [
+                ...document.getElementsByClassName('js-search-toggle'),
+            ])
+            .then(toggles => {
+                const googleSearchSwitch = config.get('switches.googleSearch');
+                const googleSearchUrl = config.get('page.googleSearchUrl');
+                const googleSearchId = config.get('page.googleSearchId');
 
-        if (googleSearchSwitch && googleSearchUrl && googleSearchId && toggle) {
-            this.gcsUrl = `${googleSearchUrl}?cx=${googleSearchId}`;
-            this.resultSetSize =
-                config.get('page.section') === 'identity' ? 3 : 10;
+                if (
+                    googleSearchSwitch &&
+                    googleSearchUrl &&
+                    googleSearchId &&
+                    toggles.length > 0
+                ) {
+                    this.gcsUrl = `${googleSearchUrl}?cx=${googleSearchId}`;
+                    this.resultSetSize =
+                        config.get('page.section') === 'identity' ? 3 : 10;
 
-            searchLoader = throttle(() => {
-                this.load();
-            });
+                    toggles.forEach(toggle => {
+                        const popupClass = toggle.getAttribute('data-toggle');
 
-            bean.on(toggle, 'click', e => {
-                const popup = document.getElementsByClassName(
-                    'js-search-popup'
-                )[0];
-                const maybeDismissSearchPopup = event => {
-                    let el = event.target;
-                    let clickedPop = false;
-
-                    if (popup) {
-                        while (el && !clickedPop) {
-                            /* either the search pop-up or the autocomplete resultSetSize
-                               NOTE: it would be better to check for `.gssb_c`,
-                                     which is the outer autocomplete element, but
-                                     google stops the event bubbling earlier
-                            */
-                            if (
-                                el &&
-                                el.classList &&
-                                (el.classList.contains('js-search-popup') ||
-                                    el.classList.contains('gsq_a'))
-                            ) {
-                                clickedPop = true;
-                            }
-
-                            el = el.parentNode;
+                        if (!popupClass) {
+                            return;
                         }
 
-                        if (!clickedPop) {
-                            event.preventDefault();
-                            toggle.classList.remove('is-active');
-                            popup.classList.add('is-off');
-                            bean.off(
-                                document,
-                                'click',
-                                maybeDismissSearchPopup
-                            );
-                        }
-                    }
-                };
+                        fastdom
+                            .read(
+                                () =>
+                                    document.getElementsByClassName(
+                                        popupClass
+                                    )[0]
+                            )
+                            .then(popup => {
+                                if (!popup) {
+                                    return;
+                                }
 
-                setTimeout(() => {
-                    if (toggle.classList.contains('is-active')) {
-                        bean.on(document, 'click', maybeDismissSearchPopup);
-                    }
-                });
+                                bean.on(toggle, 'click', e => {
+                                    const maybeDismissSearchPopup = event => {
+                                        let el = event.target;
+                                        let clickedPop = false;
 
-                searchLoader();
-                // Make sure search is always in the correct state
-                focusSearchField();
-                e.preventDefault();
+                                        while (el && !clickedPop) {
+                                            /* either the search pop-up or the autocomplete resultSetSize
+                                           NOTE: it would be better to check for `.gssb_c`,
+                                                 which is the outer autocomplete element, but
+                                                 google stops the event bubbling earlier
+                                        */
+                                            if (
+                                                el &&
+                                                el.classList &&
+                                                (el.classList.contains(
+                                                    popupClass
+                                                ) ||
+                                                    el.classList.contains(
+                                                        'gsq_a'
+                                                    ))
+                                            ) {
+                                                clickedPop = true;
+                                            }
+
+                                            el = el.parentNode;
+                                        }
+
+                                        if (!clickedPop) {
+                                            event.preventDefault();
+                                            toggle.classList.remove(
+                                                'is-active'
+                                            );
+                                            popup.classList.add('is-off');
+
+                                            bean.off(
+                                                document,
+                                                'click',
+                                                maybeDismissSearchPopup
+                                            );
+                                        }
+                                    };
+
+                                    setTimeout(() => {
+                                        if (
+                                            toggle.classList.contains(
+                                                'is-active'
+                                            )
+                                        ) {
+                                            bean.on(
+                                                document,
+                                                'click',
+                                                maybeDismissSearchPopup
+                                            );
+                                        }
+                                    });
+
+                                    this.load(popup);
+
+                                    // Make sure search is always in the correct state
+                                    focusSearchField();
+                                    e.preventDefault();
+                                });
+                            });
+                    });
+                }
             });
-        }
     }
 
-    load(): void {
+    load(popup: HTMLElement): void {
         let s;
         let x;
 
-        const containers = [
-            ...document.querySelectorAll('.js-search-placeholder'),
-        ];
-        const container = containers[0];
+        fastdom
+            .read(() => ({
+                allSearchPlaceholders: [
+                    ...document.getElementsByClassName('js-search-placeholder'),
+                ],
+                searchPlaceholder: popup.getElementsByClassName(
+                    'js-search-placeholder'
+                )[0],
+            }))
+            .then(els => {
+                const { allSearchPlaceholders, searchPlaceholder } = els;
 
-        // Set so Google know what to do
-        // eslint-disable-next-line no-underscore-dangle
-        window.__gcse = {
-            callback: focusSearchField,
-        };
+                // Set so Google know what to do
+                // eslint-disable-next-line no-underscore-dangle
+                window.__gcse = {
+                    callback: focusSearchField,
+                };
 
-        // Unload any search placeholders elsewhere in the DOM
-        containers.forEach(c => {
-            if (c !== container) {
-                fastdom.write(() => {
-                    c.innerHTML = '';
-                });
-            }
-        });
-
-        // Load the Google search monolith, if not already present in this context.
-        // We have to re-run their script each time we do this.
-        if (container && !container.innerHTML) {
-            fastdom.write(() => {
-                if (container) {
-                    container.innerHTML = `<div class="search-box" role="search">
-                        <gcse:searchbox></gcse:searchbox>
-                        </div>
-                        <div class="search-results" data-link-name="search">
-                        <gcse:searchresults webSearchResultSetSize="'}${
-                            this.resultSetSize
-                        }" linkTarget="_self"></gcse:searchresults>
-                        </div>`;
+                if (!searchPlaceholder) {
+                    return;
                 }
-            });
 
-            bean.on(container, 'keydown', '.gsc-input', () => {
-                fastdom.read(() => {
-                    const $autoCompleteObject = $('.gssb_c');
-                    const searchFromTop = $autoCompleteObject.css('top');
-                    const windowOffset = $(window).scrollTop();
+                // Unload any search placeholders elsewhere in the DOM
+                allSearchPlaceholders.forEach(c => {
+                    if (c !== searchPlaceholder) {
+                        fastdom.write(() => {
+                            c.innerHTML = '';
+                        });
+                    }
+                });
 
+                // Load the Google search monolith, if not already present in this context.
+                // We have to re-run their script each time we do this.
+                if (!searchPlaceholder.innerHTML) {
                     fastdom.write(() => {
-                        $autoCompleteObject.css({
-                            top: parseInt(searchFromTop, 10) + windowOffset,
-                            'z-index': '1030',
+                        if (searchPlaceholder) {
+                            searchPlaceholder.innerHTML = `<div class="search-box" role="search">
+                            <gcse:searchbox></gcse:searchbox>
+                            </div>
+                            <div class="search-results" data-link-name="search">
+                            <gcse:searchresults webSearchResultSetSize="'}${
+                                this.resultSetSize
+                            }" linkTarget="_self"></gcse:searchresults>
+                            </div>`;
+                        }
+                    });
+
+                    bean.on(searchPlaceholder, 'keydown', '.gsc-input', () => {
+                        fastdom.read(() => {
+                            const $autoCompleteObject = $('.gssb_c');
+                            const searchFromTop = $autoCompleteObject.css(
+                                'top'
+                            );
+                            const windowOffset = $(window).scrollTop();
+
+                            fastdom.write(() => {
+                                $autoCompleteObject.css({
+                                    top:
+                                        parseInt(searchFromTop, 10) +
+                                        windowOffset,
+                                    'z-index': '1030',
+                                });
+                            });
                         });
                     });
-                });
-            });
 
-            bean.on(container, 'click', '.search-results', e => {
-                const targetEl = e.target;
-                if (targetEl.nodeName.toLowerCase() === 'a') {
-                    targetEl.target = '_self';
+                    bean.on(
+                        searchPlaceholder,
+                        'click',
+                        '.search-results',
+                        e => {
+                            const targetEl = e.target;
+
+                            if (targetEl.nodeName.toLowerCase() === 'a') {
+                                targetEl.target = '_self';
+                            }
+                        }
+                    );
+
+                    s = document.createElement('script');
+                    s.async = true;
+                    s.src = this.gcsUrl;
+                    x = document.getElementsByTagName('script')[0];
+
+                    fastdom.write(() => {
+                        if (x.parentNode) {
+                            x.parentNode.insertBefore(s, x);
+                        }
+                    });
                 }
             });
-
-            s = document.createElement('script');
-            s.async = true;
-            s.src = this.gcsUrl;
-            x = document.getElementsByTagName('script')[0];
-            fastdom.write(() => {
-                if (x.parentNode) {
-                    x.parentNode.insertBefore(s, x);
-                }
-            });
-        }
     }
 }
 

--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -37,7 +37,7 @@ class Toggles {
     }
 
     reset(omitEl: ?HTMLElement): void {
-        const doNotReset = ['popup--search'];
+        const doNotReset = ['js-search-old', 'js-search-new'];
 
         this.controls
             .filter(

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -111,12 +111,6 @@
     }
 }
 
-.hide-on-desktop {
-    @include mq(desktop) {
-        display: none !important;
-    }
-}
-
 .u-cf {
     @include clearfix;
 }

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -24,7 +24,8 @@
     }
 
     &:hover,
-    &:focus {
+    &:focus,
+    &.is-active {
         color: #ffffff;
         text-decoration: none;
     }


### PR DESCRIPTION
## What does this change?
The old desktop search  on the new desktop header. 

If we have time, @zeftilldeath will be updating the styling. 

## What is the value of this and can you measure success?
Easier search on desktop

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/33175686-6a0040f6-d054-11e7-8c12-f02cfe5199b6.png)
![image](https://user-images.githubusercontent.com/8774970/33175694-70e7c98e-d054-11e7-822a-71cde0454935.png)

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
