### PR TITLE
Add highlight line back into epic liveblog

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -36,21 +36,21 @@ const ctaLinkSentence = (
     currencySymbol: string
 ): string => {
     if (supportFrontendLiveInUs) {
-        return `For as little as ${
+        return `<span class="contributions__highlight"> For as little as ${
             currencySymbol
-        }1, you can support the Guardian – and it only takes a minute. <a href="${
+        }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
             membershipUrl
         }" target="_blank" class="u-underline">Make a contribution</a>`;
     } else if (supportFrontendLiveInUk) {
-        return `For as little as ${
+        return `<span class="contributions__highlight">For as little as ${
             currencySymbol
-        }1, you can support the Guardian – and it only takes a minute. <a href="${
+        }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
             membershipUrl
         }" target="_blank" class="u-underline">Make a contribution or get a subscription</a>`;
     }
-    return `For as little as ${
+    return `<span class="contributions__highlight"> For as little as ${
         currencySymbol
-    }1, you can support the Guardian – and it only takes a minute. <a href="${
+    }1, you can support the Guardian – and it only takes a minute.</span> <a href="${
         membershipUrl
     }" target="_blank" class="u-underline">Become a monthly supporter</a> or <a href="${
         contributionUrl


### PR DESCRIPTION
## What does this change?

Adds the highlighted line to the epic in the liveblog

Before:
![screenshot at nov 27 14-36-04](https://user-images.githubusercontent.com/2844554/33271882-65ace4d0-d380-11e7-8de6-1334c5e0c403.png)

After
![screenshot at nov 27 14-35-33](https://user-images.githubusercontent.com/2844554/33271881-65970bec-d380-11e7-8dca-ced35647807c.png)

@guardian/contributions 
