### PR TITLE
Desktop header: dropdown improvements

### DIFF
--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -11,20 +11,6 @@
         sign in
     </a>
 
-    <button class="u-h js-user-account-trigger"
-        id="my-account-toggle"
-        title="user account toggle"
-        data-link-name="nav2 : topbar: my account"
-        aria-expanded="false"
-        aria-controls="my-account-dropdown"></button>
-
-    <label class="top-bar__item top-bar__item--dropdown u-h js-navigation-account-actions"
-        for="my-account-toggle"
-        data-link-name="nav2 : topbar: my account">
-
-        my account
-    </label>
-
     <ul class="dropdown-menu js-user-account-dropdown-menu"
         id="my-account-dropdown"
         aria-hidden="true">
@@ -69,4 +55,18 @@
             </a>
         </li>
     </ul>
+
+    <button class="u-h js-user-account-trigger"
+        id="my-account-toggle"
+        title="user account toggle"
+        data-link-name="nav2 : topbar: my account"
+        aria-expanded="false"
+        aria-controls="my-account-dropdown"></button>
+
+    <label class="top-bar__item top-bar__item--dropdown u-h js-navigation-account-actions"
+        for="my-account-toggle"
+        data-link-name="nav2 : topbar: my account">
+
+        my account
+    </label>
 </div>

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -18,7 +18,7 @@
     display: none;
     position: absolute;
     top: $gs-baseline * 2 + $gs-baseline / 2;
-    right: -$gs-gutter / 4;
+    right: 0;
     width: $gs-column-width * 3 + $gs-gutter;
     background-color: #ffffff;
     border-radius: $gs-baseline / 4;
@@ -26,28 +26,6 @@
     margin: 0;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .1);
     z-index: $zindex-main-menu;
-
-    // triangle
-    &:before,
-    &:after {
-        content: '';
-        position: absolute;
-        right: $gs-gutter / 2;
-        border-left: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
-        border-right: $gs-baseline / 2 + $gs-baseline / 4 solid transparent;
-        border-bottom: $gs-baseline / 2 + $gs-baseline / 4 solid;
-        transform: translateY(-100%);
-    }
-
-    &:before {
-        top: -1px;
-        border-bottom-color: rgba(0, 0, 0, .1);
-    }
-
-    &:after {
-        top: 0;
-        border-bottom-color: #ffffff;
-    }
 }
 
 .dropdown-menu--open {

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -33,7 +33,7 @@
 
     & ~ .top-bar__item--dropdown {
         color: #ffffff;
-        background-color: rgba(0, 0, 0, 0.3);
+        background-color: rgba(0, 0, 0, .3);
 
         &:after {
             transform: translateY(0) rotate(45deg);

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -33,7 +33,7 @@
 
     & ~ .top-bar__item--dropdown {
         color: #ffffff;
-        background-color: $guardian-brand-dark;
+        background-color: rgba(0, 0, 0, 0.3);
 
         &:after {
             transform: translateY(0) rotate(45deg);


### PR DESCRIPTION
## What does this change?
First, I just wanted to align the silly arrows: https://github.com/guardian/frontend/pull/18308.

But with @zeftilldeath 's helpful input, we don't need the arrow at all! This PR:
* removes one of the arrows
* darkens the active state
* makes sure that the account links dropdown has an active state.

After:
![image](https://user-images.githubusercontent.com/8774970/33272487-2f321306-d382-11e7-8dd4-c30878553ee2.png)

![image](https://user-images.githubusercontent.com/8774970/33272418-fce09030-d381-11e7-9c82-863a0bcd43e6.png)

Before:
![image](https://user-images.githubusercontent.com/8774970/33272387-ee453e04-d381-11e7-9781-63639070900a.png)
![image](https://user-images.githubusercontent.com/8774970/33272410-f5d6f4fa-d381-11e7-9bfa-5627458af677.png)


## What is the value of this and can you measure success?
Looks nicer :)

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
