### PR TITLE
Sentry: ignore more errors

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -31,6 +31,8 @@ const sentryOptions = {
         /InvalidStateError/gi,
         /Fetch error:/gi,
         'Network request failed',
+        'This video is no longer available.',
+        'UnknownError',
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?

Ignore two more Sentry errors:

- "This video is no longer available." https://sentry.io/the-guardian/client-side-prod/issues/388271191/ because is logging that shouldn't happen at this point.
- "UnknownError" https://sentry.io/the-guardian/client-side-prod/issues/220577772/ because it's happening in ophan, is already wrappend in `try {} catch` will never be fixed and is not really an issue (I believe)

## What is the value of this and can you measure success?

Less logged errors in Sentry, makes it more useful.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.