### PR TITLE
Prefer a bottom margin to padding on the right-hand slot.

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -12,8 +12,8 @@
  * Margins on children don't affect the position of elements we make sticky.
  */
 .ad-slot-container > :last-child {
-    margin-bottom: 0;
-    padding-bottom: $gs-baseline * 2;
+    padding-bottom: 0;
+    margin-bottom: $gs-baseline * 2;
 }
 .ad-slot--dark {
     background-color: lighten($media-background, 2.5%);


### PR DESCRIPTION
Related to #18336; but in this case we actually do want a bit of space between the right-hand slot's bottom and the next item in the right-hand slot.

Fortunately, we can just use a margin instead :+1: