### PR TITLE
Fix email checkbox submit before js load

### DIFF
--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -12,7 +12,7 @@
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
-<label class="manage-account__switch @switchJsBehaviour(behaviour)">
+<label class="manage-account__switch @switchJsBehaviour(behaviour)" data-originally-checked="@field.value">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.js
@@ -1,12 +1,29 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
 
+const checkboxShouldUpdate = (
+    checkedValue: boolean,
+    originallyCheckedValue: string
+): boolean => {
+    if (
+        (originallyCheckedValue === 'false' && checkedValue === true) ||
+        (originallyCheckedValue === 'true' && checkedValue === false)
+    ) {
+        return true;
+    }
+    return false;
+};
+
 export const getInfo = (labelEl: HTMLElement): Promise<any> =>
     fastdom
         .read((): ?HTMLElement => labelEl.querySelector('input'))
         .then((checkboxEl: HTMLInputElement) => ({
             checked: checkboxEl.checked,
             name: checkboxEl.name,
+            shouldUpdate: checkboxShouldUpdate(
+                checkboxEl.checked,
+                labelEl.dataset.originallyChecked
+            ),
         }));
 
 export const flip = (labelEl: HTMLElement): Promise<any> =>

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
@@ -1,13 +1,46 @@
 // @flow
 import $ from 'lib/$';
-import { addSpinner, removeSpinner } from './switch';
+import { addSpinner, removeSpinner, getInfo } from './switch';
 
 beforeEach(() => {
     if (document.body) {
         document.body.innerHTML = `
-            <div class="originalClassName"></div>
+            <div class="originalClassName" data-originally-checked="false"><input type="checkbox" checked name="test-name" /></div>
         `;
     }
+});
+
+test('gets info', () => {
+    const el = $('.originalClassName');
+    getInfo(el).then(info => {
+        expect(info.checked).toEqual(true);
+        expect(info.name).toEqual('test-name');
+        expect(info.shouldUpdate).toEqual(true);
+    });
+});
+
+test('doesnt force update with an empty data-originally-checked', () => {
+    if (document.body) {
+        document.body.innerHTML = `
+            <div class="originalClassName"><input type="checkbox" checked name="test-name" /></div>
+        `;
+    }
+    const el = $('.originalClassName');
+    getInfo(el).then(info => {
+        expect(info.shouldUpdate).toEqual(false);
+    });
+});
+
+test('doesnt force update with an invalid data-originally-checked', () => {
+    if (document.body) {
+        document.body.innerHTML = `
+            <div class="originalClassName" data-originally-checked="🔔"><input type="checkbox" checked name="test-name" /></div>
+        `;
+    }
+    const el = $('.originalClassName');
+    getInfo(el).then(info => {
+        expect(info.shouldUpdate).toEqual(false);
+    });
 });
 
 test('adds a spinner', () => {


### PR DESCRIPTION
## What does this change?
Fixes a somewhat cheeky bug where you could click the consent checkboxes before the javascript loaded and end up with a displayed value that was not submitted to the server and also not really have a way to submit it manually except for clicking twice

## What is the value of this and can you measure success?
This component is crucial for the repermissioning flow so it needs to be rock solid or else we risk losing valuable user consents

## Screenshots
![ezgif-5-20a43bcf3c](https://user-images.githubusercontent.com/11539094/33274243-6cc36cba-d387-11e7-9df2-1d092151c883.gif)
