### PR TITLE
Update paid-content class for hosted articles

### DIFF
--- a/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianAmpHostedArticle.scala.html
@@ -39,7 +39,7 @@
             @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.fontColour.isDark) " hosted-page--bright" else ""), page, isAMP = true)
             <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.fontColour.isDark) {hosted-page--bright}">
 
-                <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--paid-content" role="main">
+                <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage paid-content" role="main">
                     <div class="media-primary media-content media-primary--showcase">
                         <h2 class="title content__hosted-body">@{page.title}</h2>
                     </div>

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -14,7 +14,7 @@
     @guardianHostedHeader("hosted-article-page hosted__header--sticky" + (if(page.fontColour.isDark) " hosted-page--bright" else ""), page)
     <div class="hosted-page l-side-margins hosted__side hosted-article-page @if(page.fontColour.isDark) {hosted-page--bright}">
 
-        <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--paid-content" role="main">
+        <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage paid-content" role="main">
             @showcaseMedia(page)
             <div class="content__main">
                 <div class="gs-container">


### PR DESCRIPTION
## What does this change?
The hosted `article` tag was still using the old unused `content--paid-content` class. This updates it to use `paid-content`.
