### PR TITLE
Increase the number of parallel fronts served by facia

### DIFF
--- a/facia/app/services/PressedPageService.scala
+++ b/facia/app/services/PressedPageService.scala
@@ -9,7 +9,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class PressedPageService(wsClient: WSClient) extends Logging {
-  val parallelJsonPresses = 8
+  val parallelJsonPresses = 24
   val secureS3Request = new SecureS3Request(wsClient)
   val futureSemaphore = new FutureSemaphore(parallelJsonPresses)
 


### PR DESCRIPTION
## What does this change?

Increasing the pool of futures used to serve fronts on Facia after seeing sporadic failures in PROD. Merging straight to master after speaking to @TBonnin 

## Tested in CODE?

No, requires production traffic to test. Failures are rare enough that they do not affect the user experience.