### PR TITLE
[Hackday] Fast headline tests

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -91,6 +91,31 @@
             </script>
         }
 
+        @**********************
+          H A C K D A Y - healine fast testing (mch)
+
+          We update the headline with another one.  
+        ************************@
+        @if(request.path == "/uk") {
+            <script type="text/javascript">
+                var anchorElement = document.querySelectorAll('a.fc-item__link[href^="https://www.theguardian.com/politics/2017/nov/29/brexit-bill-of-50bn-no-more-than-what-uk-owes-eu-says-grayling"]')[0];
+                if (anchorElement) {
+                    var headlineElement = container.querySelector('span.js-headline-text');
+                    if (headlineElement) {
+                        var newHeadline = 'Leading Brexiter tell Britain should pay the Brexit bill';
+                        var oldHeadline = headlineElement.textContent;
+                        
+                        if (Date.now() % 2) {
+                            headlineElement.textContent = newHeadline;
+                            anchorElement.setAttribute('data-link-headline', newHeadline);
+                        } else {
+                            anchorElement.setAttribute('data-link-headline', oldHeadline);
+                        }
+                    }
+                }
+            </script>
+        }
+
         @fragments.footer()
 
         @fragments.inlineJSNonBlocking()

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -107,9 +107,9 @@
                         
                         if (Date.now() % 2) {
                             headlineElement.textContent = newHeadline;
-                            anchorElement.setAttribute('data-link-headline', newHeadline);
+                            anchorElement.setAttribute('data-headline', newHeadline);
                         } else {
-                            anchorElement.setAttribute('data-link-headline', oldHeadline);
+                            anchorElement.setAttribute('data-headline', oldHeadline);
                         }
                     }
                 }


### PR DESCRIPTION
The headline is added as a new attribute of the anchor so it can be used by analytics.
The article to update the headline and modification is hardcoded for the hackday but one can imagine retrieving it from the fronts or another specific source.

@oilnam 

* [ ] [Update tracker-js](https://github.com/guardian/ophan/pull/2569/files) & publish a new version to collect the headline value
* [ ] Update [big loader and the slab](https://github.com/guardian/ophan/pull/2570/files) to store this value in ophan cluster
* [ ] Add a new view in Ophan to compare how headlines perform 