### PR TITLE
Garnett - Added styling for 'Topics'

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -33,10 +33,10 @@
 
     .submeta__link {
         font-weight: 200;
+    }
 
-        &-item {
-            @include fs-textSans(3);
-        }
+    .submeta__link-item {
+        @include fs-textSans(3);
     }
 
     .submeta__label {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1,52 +1,49 @@
 .content--type-article {
+    .submeta {
+        position: relative;
+        border-top: 0;
+        margin-top: $gs-row-height;
 
-  .submeta {
-    position: relative;
-    border-top: none;
-    margin-top: $gs-row-height;
+        &:before {
+            content: '';
+            position: absolute;
+            top: -10px;
+            left: 0;
+            right: 0;
+            height: 3px;
+            border-bottom: 1px solid $neutral-5;
+            border-top: 1px solid $neutral-5;
+        }
 
-    &:before {
-      content: " ";
-      position: absolute;
-      top: -10px;
-      left: 0;
-      right: 0;
-      height: 3px;
-      border-bottom: 1px solid $neutral-5;
-      border-top: 1px solid $neutral-5;
+        &:after {
+            content: '';
+            position: absolute;
+            top: -2px;
+            left: 0;
+            right: 0;
+            height: 3px;
+            border-bottom: 1px solid $neutral-5;
+            border-top: 1px solid $neutral-5;
+        }
+
+        &__link {
+            font-weight: 200;
+
+            &-item {
+                @include fs-textSans(3);
+            }
+        }
+
+        &__label {
+            margin-bottom: 0;
+        }
+
+        &__keywords {
+            padding-bottom: $gs-baseline/2;
+        }
     }
 
-    &:after {
-      content: " ";
-      position: absolute;
-      top: -2px;
-      left: 0;
-      right: 0;
-      height: 3px;
-      border-bottom: 1px solid $neutral-5;
-      border-top: 1px solid $neutral-5;
+    .submeta__section-labels .submeta__link {
+        @include f-bodyHeading;
     }
-
-    &__link{
-        font-weight: 200;
-
-          &-item {
-            @include fs-textSans(3);
-          }
-      }
-
-    &__label {
-      margin-bottom: 0;
-    }
-
-    &__keywords {
-      padding-bottom: $gs-baseline/2;
-    }
-
-  }
-
-  .submeta__section-labels .submeta__link {
-    @include f-bodyHeading;
-  }
-
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -1,3 +1,52 @@
 .content--type-article {
 
+  .submeta {
+    position: relative;
+    border-top: none;
+    margin-top: $gs-row-height;
+
+    &:before {
+      content: " ";
+      position: absolute;
+      top: -10px;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-bottom: 1px solid $neutral-5;
+      border-top: 1px solid $neutral-5;
+    }
+
+    &:after {
+      content: " ";
+      position: absolute;
+      top: -2px;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-bottom: 1px solid $neutral-5;
+      border-top: 1px solid $neutral-5;
+    }
+
+    &__link{
+        font-weight: 200;
+
+          &-item {
+            @include fs-textSans(3);
+          }
+      }
+
+    &__label {
+      margin-bottom: 0;
+    }
+
+    &__keywords {
+      padding-bottom: $gs-baseline/2;
+    }
+
+  }
+
+  .submeta__section-labels .submeta__link {
+    @include f-bodyHeading;
+  }
+
 }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -26,21 +26,25 @@
             border-top: 1px solid $neutral-5;
         }
 
-        &__link {
-            font-weight: 200;
-
-            &-item {
-                @include fs-textSans(3);
-            }
-        }
-
-        &__label {
-            margin-bottom: 0;
-        }
-
         &__keywords {
             padding-bottom: $gs-baseline/2;
         }
+    }
+
+    .submeta__link {
+        font-weight: 200;
+
+        &-item {
+            @include fs-textSans(3);
+        }
+    }
+
+    .submeta__label {
+        margin-bottom: 0;
+    }
+
+    .submeta__keywords {
+        padding-bottom: $gs-baseline/2;
     }
 
     .submeta__section-labels .submeta__link {


### PR DESCRIPTION
## What does this change?
Garnett - Added styling for 'Topics'

## What is the value of this and can you measure success?
N/A

## Does this affect other platforms - Amp, Apps, etc?
N/A

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
N/A

## Tested in CODE?
Yes.

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
