### PR TITLE
Experiments opt-in tool

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -334,7 +334,7 @@ const bootEnhanced = (): void => {
         }
     });
 
-    if (window.location.hash.indexOf('experiments') !== -1) {
+    if (window.location.hash.includes('experiments')) {
         require.ensure(
             [],
             require => {

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -334,16 +334,16 @@ const bootEnhanced = (): void => {
         }
     });
 
-    if (window.location.hash.indexOf('devtools') !== -1) {
+    if (window.location.hash.indexOf('experiments') !== -1) {
         require.ensure(
             [],
             require => {
                 bootstrapContext(
-                    'devtools',
-                    require('common/modules/devtools').showDevTools
+                    'experiments',
+                    require('common/modules/experiments').showExperiments
                 );
             },
-            'devtools'
+            'experiments'
         );
     }
 

--- a/static/src/javascripts/projects/common/modules/devtools/index.js
+++ b/static/src/javascripts/projects/common/modules/devtools/index.js
@@ -6,6 +6,7 @@ import bean from 'bean';
 import overlay from 'raw-loader!common/views/devtools/overlay.html';
 import styles from 'raw-loader!common/views/devtools/styles.css';
 import { TESTS } from 'common/modules/experiments/ab-tests';
+import { abTestClashData } from 'common/modules/experiments/acquisition-test-selector';
 
 const getSelectedAbTests = () =>
     JSON.parse(storage.get('gu.devtools.ab')) || [];
@@ -70,8 +71,9 @@ const applyCss = () => {
 };
 
 const appendOverlay = () => {
+    const allTests = TESTS.concat(abTestClashData);
     const data = {
-        tests: TESTS.map(test => ({
+        tests: allTests.map(test => ({
             id: test.id,
             variants: test.variants,
         })),

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -71,7 +71,11 @@ const applyCss = () => {
 };
 
 const appendOverlay = () => {
-    const extractData = ({ id, variants }) => ({ id, variants });
+    const extractData = ({ id, variants, description }) => ({
+        id,
+        variants,
+        description,
+    });
     const data = {
         tests: TESTS.map(extractData),
         acquisitionsTests: abTestClashData.map(extractData),

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -3,18 +3,18 @@ import template from 'lodash/utilities/template';
 import { local as storage } from 'lib/storage';
 import $ from 'lib/$';
 import bean from 'bean';
-import overlay from 'raw-loader!common/views/devtools/overlay.html';
-import styles from 'raw-loader!common/views/devtools/styles.css';
+import overlay from 'raw-loader!common/views/experiments/overlay.html';
+import styles from 'raw-loader!common/views/experiments/styles.css';
 import { TESTS } from 'common/modules/experiments/ab-tests';
 import { abTestClashData } from 'common/modules/experiments/acquisition-test-selector';
 
 const getSelectedAbTests = () =>
-    JSON.parse(storage.get('gu.devtools.ab')) || [];
+    JSON.parse(storage.get('gu.experiments.ab')) || [];
 
 const selectRadios = () => {
     const abTests = getSelectedAbTests();
 
-    $('.js-devtools-radio').each(radio => {
+    $('.js-experiments-radio').each(radio => {
         $(radio).attr('checked', false);
     });
 
@@ -24,7 +24,7 @@ const selectRadios = () => {
 };
 
 const bindEvents = () => {
-    $('.js-devtools-force-ab').each(label => {
+    $('.js-experiments-force-ab').each(label => {
         bean.on(label, 'click', () => {
             const testId = label.getAttribute('data-ab-test');
             const variantId = label.getAttribute('data-ab-variant');
@@ -38,28 +38,28 @@ const bindEvents = () => {
             } else {
                 abTests.push({ testId, variantId });
             }
-            storage.set('gu.devtools.ab', JSON.stringify(abTests));
+            storage.set('gu.experiments.ab', JSON.stringify(abTests));
         });
     });
 
-    bean.on($('.js-devtools-clear-ab')[0], 'click', () => {
-        storage.set('gu.devtools.ab', JSON.stringify([]));
+    bean.on($('.js-experiments-clear-ab')[0], 'click', () => {
+        storage.set('gu.experiments.ab', JSON.stringify([]));
         selectRadios();
     });
 
-    bean.on($('.js-devtools-reload')[0], 'click', () => {
+    bean.on($('.js-experiments-reload')[0], 'click', () => {
         window.location.reload();
     });
 
-    bean.on($('.js-devtools-toggle')[0], 'click', () => {
-        const toggleButton = $('.js-devtools-toggle');
+    bean.on($('.js-experiments-toggle')[0], 'click', () => {
+        const toggleButton = $('.js-experiments-toggle');
 
         if (toggleButton.text() === 'X') {
             toggleButton.text('>');
         } else {
             toggleButton.text('X');
         }
-        $('.devtools').toggleClass('devtools--hidden');
+        $('.experiments').toggleClass('experiments--hidden');
     });
 };
 
@@ -82,7 +82,7 @@ const appendOverlay = () => {
     $('body').prepend(template(overlay, data));
 };
 
-export const showDevTools = () => {
+export const showExperiments = () => {
     appendOverlay();
     bindEvents();
     selectRadios();

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -71,12 +71,10 @@ const applyCss = () => {
 };
 
 const appendOverlay = () => {
-    const allTests = TESTS.concat(abTestClashData);
+    const extractData = ({ id, variants }) => ({ id, variants });
     const data = {
-        tests: allTests.map(test => ({
-            id: test.id,
-            variants: test.variants,
-        })),
+        tests: TESTS.map(extractData),
+        acquisitionsTests: abTestClashData.map(extractData),
     };
 
     $('body').prepend(template(overlay, data));

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -3,6 +3,7 @@ import template from 'lodash/utilities/template';
 import { local as storage } from 'lib/storage';
 import $ from 'lib/$';
 import bean from 'bean';
+import config from 'lib/config';
 import overlay from 'raw-loader!common/views/experiments/overlay.html';
 import styles from 'raw-loader!common/views/experiments/styles.css';
 import { TESTS } from 'common/modules/experiments/ab-tests';
@@ -71,11 +72,16 @@ const applyCss = () => {
 };
 
 const appendOverlay = () => {
-    const extractData = ({ id, variants, description }) => ({
-        id,
-        variants,
-        description,
-    });
+    const extractData = ({ id, variants, description }) => {
+        const isSwitchedOn = config.get(`switches.ab${id}`);
+
+        return {
+            id,
+            variants,
+            description,
+            isSwitchedOn,
+        };
+    };
     const data = {
         tests: TESTS.map(extractData),
         acquisitionsTests: abTestClashData.map(extractData),

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -8,6 +8,7 @@ import overlay from 'raw-loader!common/views/experiments/overlay.html';
 import styles from 'raw-loader!common/views/experiments/styles.css';
 import { TESTS } from 'common/modules/experiments/ab-tests';
 import { abTestClashData } from 'common/modules/experiments/acquisition-test-selector';
+import { isExpired } from 'common/modules/experiments/test-can-run-checks';
 
 const getSelectedAbTests = () =>
     JSON.parse(storage.get('gu.experiments.ab')) || [];
@@ -72,16 +73,13 @@ const applyCss = () => {
 };
 
 const appendOverlay = () => {
-    const extractData = ({ id, variants, description }) => {
-        const isSwitchedOn = config.get(`switches.ab${id}`);
-
-        return {
-            id,
-            variants,
-            description,
-            isSwitchedOn,
-        };
-    };
+    const extractData = ({ id, variants, description, expiry }) => ({
+        id,
+        variants,
+        description,
+        isSwitchedOn: config.get(`switches.ab${id}`),
+        isExpired: isExpired(expiry),
+    });
     const data = {
         tests: TESTS.map(extractData),
         acquisitionsTests: abTestClashData.map(extractData),

--- a/static/src/javascripts/projects/common/modules/experiments/utils.js
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.js
@@ -95,7 +95,7 @@ export const getForcedTests = (): Array<{
         });
     }
 
-    return JSON.parse(local.get('gu.devtools.ab') || '[]') || [];
+    return JSON.parse(local.get('gu.experiments.ab') || '[]') || [];
 };
 
 export const getForcedVariant = (test: ABTest): ?Variant => {

--- a/static/src/javascripts/projects/common/views/experiments/overlay.html
+++ b/static/src/javascripts/projects/common/views/experiments/overlay.html
@@ -1,6 +1,6 @@
 <div class="experiments experiments--hidden">
     <div class="experiments__controls">
-        <h1>AB Tests</h1>
+        <h1>Experiments</h1>
         <button type="button" class="js-experiments-clear-ab">Clear all</button>
         <button type="button" class="js-experiments-reload">Reload</button>
         <button type="button" class="js-experiments-toggle experiments__controls__toggle">&gt;</button>
@@ -16,7 +16,7 @@
                 <%= test.description %>
             </div>
             <%
-            if (test.isSwitchedOn) {
+            if (test.isSwitchedOn && !test.isExpired) {
                 test.variants.forEach(function(variant) {
             %>
                 <div class="experiments__variant">
@@ -38,6 +38,19 @@
             <%
                 });
             }
+            if (!test.isSwitchedOn) {
+            %>
+                <div class="experiments__alert">
+                    You can turn this switch on using the Frontend Switchboard
+                </div>
+            <%
+            } if (test.isExpired) {
+            %>
+                <div class="experiments__alert">
+                    This test has expired
+                </div>
+            <%
+            }
             %>
         </li>
         <% }); %>
@@ -53,7 +66,7 @@
                     <%= test.description %>
                 </div>
                 <%
-                if (test.isSwitchedOn) {
+                if (test.isSwitchedOn && !test.isExpired) {
                     test.variants.forEach(function(variant) {
                 %>
                     <div class="experiments__variant">
@@ -74,6 +87,19 @@
                     </div>
                 <%
                     });
+                }
+                if (!test.isSwitchedOn) {
+                %>
+                <div class="experiments__alert">
+                    You can turn this switch on using the Frontend Switchboard
+                </div>
+                <%
+                } if (test.isExpired) {
+                %>
+                <div class="experiments__alert">
+                    This test has expired
+                </div>
+                <%
                 }
                 %>
             </li>

--- a/static/src/javascripts/projects/common/views/experiments/overlay.html
+++ b/static/src/javascripts/projects/common/views/experiments/overlay.html
@@ -5,6 +5,35 @@
         <button type="button" class="js-experiments-reload">Reload</button>
         <button type="button" class="js-experiments-toggle experiments__controls__toggle">&gt;</button>
     </div>
+    <h2>Acquisitions tests</h2>
+    <ul class="experiments__tests experiments__tests--acquisitions">
+        <% acquisitionsTests.forEach(function(test) { %>
+        <li>
+            <div class="experiments__test">
+                <%= test.id %>
+            </div>
+            <% test.variants.forEach(function(variant) { %>
+            <div class="experiments__variant">
+                <input
+                    type="radio"
+                    id="<%=test.id%>-<%=variant.id%>"
+                    name="<%= test.id %>"
+                    class="js-experiments-radio experiments__variant__button"
+                >
+                <label
+                    data-ab-test="<%= test.id %>"
+                    data-ab-variant="<%= variant.id %>"
+                    class="js-experiments-force-ab experiments__variant__label"
+                    for="<%=test.id%>-<%=variant.id%>"
+                >
+                    <%= variant.id %>
+                </label>
+            </div>
+            <% }); %>
+        </li>
+        <% }); %>
+    </ul>
+    <h2>Other tests</h2>
     <ul class="experiments__tests">
         <% tests.forEach(function(test) { %>
             <li>

--- a/static/src/javascripts/projects/common/views/experiments/overlay.html
+++ b/static/src/javascripts/projects/common/views/experiments/overlay.html
@@ -15,24 +15,30 @@
             <div class="experiments__description">
                 <%= test.description %>
             </div>
-            <% test.variants.forEach(function(variant) { %>
-            <div class="experiments__variant">
-                <input
-                    type="radio"
-                    id="<%=test.id%>-<%=variant.id%>"
-                    name="<%= test.id %>"
-                    class="js-experiments-radio experiments__variant__button"
-                >
-                <label
-                    data-ab-test="<%= test.id %>"
-                    data-ab-variant="<%= variant.id %>"
-                    class="js-experiments-force-ab experiments__variant__label"
-                    for="<%=test.id%>-<%=variant.id%>"
-                >
-                    <%= variant.id %>
-                </label>
-            </div>
-            <% }); %>
+            <%
+            if (test.isSwitchedOn) {
+                test.variants.forEach(function(variant) {
+            %>
+                <div class="experiments__variant">
+                    <input
+                        type="radio"
+                        id="<%=test.id%>-<%=variant.id%>"
+                        name="<%= test.id %>"
+                        class="js-experiments-radio experiments__variant__button"
+                    >
+                    <label
+                        data-ab-test="<%= test.id %>"
+                        data-ab-variant="<%= variant.id %>"
+                        class="js-experiments-force-ab experiments__variant__label"
+                        for="<%=test.id%>-<%=variant.id%>"
+                    >
+                        <%= variant.id %>
+                    </label>
+                </div>
+            <%
+                });
+            }
+            %>
         </li>
         <% }); %>
     </ul>
@@ -46,7 +52,10 @@
                 <div class="experiments__description">
                     <%= test.description %>
                 </div>
-                <% test.variants.forEach(function(variant) { %>
+                <%
+                if (test.isSwitchedOn) {
+                    test.variants.forEach(function(variant) {
+                %>
                     <div class="experiments__variant">
                         <input
                             type="radio"
@@ -63,7 +72,10 @@
                             <%= variant.id %>
                         </label>
                     </div>
-                <% }); %>
+                <%
+                    });
+                }
+                %>
             </li>
         <% }); %>
     </ul>

--- a/static/src/javascripts/projects/common/views/experiments/overlay.html
+++ b/static/src/javascripts/projects/common/views/experiments/overlay.html
@@ -1,28 +1,28 @@
-<div class="devtools devtools--hidden">
-    <div class="devtools__controls">
+<div class="experiments experiments--hidden">
+    <div class="experiments__controls">
         <h1>AB Tests</h1>
-        <button type="button" class="js-devtools-clear-ab">Clear all</button>
-        <button type="button" class="js-devtools-reload">Reload</button>
-        <button type="button" class="js-devtools-toggle devtools__controls__toggle">&gt;</button>
+        <button type="button" class="js-experiments-clear-ab">Clear all</button>
+        <button type="button" class="js-experiments-reload">Reload</button>
+        <button type="button" class="js-experiments-toggle experiments__controls__toggle">&gt;</button>
     </div>
-    <ul class="devtools__tests">
+    <ul class="experiments__tests">
         <% tests.forEach(function(test) { %>
             <li>
-                <div class="devtools__test">
+                <div class="experiments__test">
                     <%= test.id %>
                 </div>
                 <% test.variants.forEach(function(variant) { %>
-                    <div class="devtools__variant">
+                    <div class="experiments__variant">
                         <input
                             type="radio"
                             id="<%=test.id%>-<%=variant.id%>"
                             name="<%= test.id %>"
-                            class="js-devtools-radio devtools__variant__button"
+                            class="js-experiments-radio experiments__variant__button"
                         >
                         <label
                             data-ab-test="<%= test.id %>"
                             data-ab-variant="<%= variant.id %>"
-                            class="js-devtools-force-ab devtools__variant__label"
+                            class="js-experiments-force-ab experiments__variant__label"
                             for="<%=test.id%>-<%=variant.id%>"
                         >
                             <%= variant.id %>

--- a/static/src/javascripts/projects/common/views/experiments/overlay.html
+++ b/static/src/javascripts/projects/common/views/experiments/overlay.html
@@ -12,6 +12,9 @@
             <div class="experiments__test">
                 <%= test.id %>
             </div>
+            <div class="experiments__description">
+                <%= test.description %>
+            </div>
             <% test.variants.forEach(function(variant) { %>
             <div class="experiments__variant">
                 <input
@@ -39,6 +42,9 @@
             <li>
                 <div class="experiments__test">
                     <%= test.id %>
+                </div>
+                <div class="experiments__description">
+                    <%= test.description %>
                 </div>
                 <% test.variants.forEach(function(variant) { %>
                     <div class="experiments__variant">

--- a/static/src/javascripts/projects/common/views/experiments/styles.css
+++ b/static/src/javascripts/projects/common/views/experiments/styles.css
@@ -30,15 +30,24 @@
 }
 
 .experiments__test {
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif
-    font-weight: 700;
+    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    font-size: 20px;
     margin-top: 18px;
-    border-bottom: 1px solid #005689;
+}
+
+.experiments__description {
+    margin-top: 6px;
+    font-size: 14px;
 }
 
 .experiments__tests {
     list-style: none;
     margin: 0;
+}
+
+.experiments__variant {
+    display: inline-block;
+    margin: 6px 3px;
 }
 
 .experiments__variant__button {
@@ -48,8 +57,10 @@
 .experiments__variant__label {
     display: block;
     width: 100%;
+    border: 1px solid #cccccc;
     border-radius: 6px;
     padding: 6px;
+    font-size: 14px;
 }
 
 .experiments__variant__label:hover,

--- a/static/src/javascripts/projects/common/views/experiments/styles.css
+++ b/static/src/javascripts/projects/common/views/experiments/styles.css
@@ -73,6 +73,12 @@
     background-color: #cccccc;
 }
 
+.experiments__alert {
+    font-size: 14px;
+    margin-top: 6px;
+    color: #dd0000;
+}
+
 .experiments__controls button {
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     font-size: 14px;

--- a/static/src/javascripts/projects/common/views/experiments/styles.css
+++ b/static/src/javascripts/projects/common/views/experiments/styles.css
@@ -1,8 +1,8 @@
-.devtools, .devtools * {
+.experiments, .experiments * {
     box-sizing: border-box;
 }
 
-.devtools {
+.experiments {
     background-color: #f6f6f6;
     position: fixed;
     top: 0;
@@ -15,54 +15,54 @@
     transition: 250ms left;
 }
 
-.devtools--hidden {
+.experiments--hidden {
     left: -90vw;
 }
 
 @media (min-width: 768px) {
-    .devtools {
+    .experiments {
         width: 500px;
     }
 
-    .devtools--hidden {
+    .experiments--hidden {
         left: -440px;
     }
 }
 
-.devtools__test {
+.experiments__test {
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif
     font-weight: 700;
     margin-top: 18px;
     border-bottom: 1px solid #005689;
 }
 
-.devtools__tests {
+.experiments__tests {
     list-style: none;
     margin: 0;
 }
 
-.devtools__variant__button {
+.experiments__variant__button {
     display: none;
 }
 
-.devtools__variant__label {
+.experiments__variant__label {
     display: block;
     width: 100%;
     border-radius: 6px;
     padding: 6px;
 }
 
-.devtools__variant__label:hover,
-.devtools__variant__label:active {
+.experiments__variant__label:hover,
+.experiments__variant__label:active {
     background-color: #dfdfdf;
     cursor: pointer;
 }
 
-.devtools__variant__button:checked + .devtools__variant__label {
+.experiments__variant__button:checked + .experiments__variant__label {
     background-color: #cccccc;
 }
 
-.devtools__controls button {
+.experiments__controls button {
     font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     font-size: 14px;
     color: #ffffff;
@@ -73,16 +73,16 @@
     margin: 0 6px;
 }
 
-.devtools__controls button:first-of-type {
+.experiments__controls button:first-of-type {
     margin-left: 36px;
 }
 
-.devtools__controls button:hover,
-.devtools__controls button:active {
+.experiments__controls button:hover,
+.experiments__controls button:active {
     background-color: #005689;
 }
 
-.devtools__controls .devtools__controls__toggle {
+.experiments__controls .experiments__controls__toggle {
     float: right;
     width: 35px;
     border-radius: 35px;
@@ -90,12 +90,12 @@
     margin: 0;
 }
 
-.devtools__controls h1 {
+.experiments__controls h1 {
     display: inline;
 }
 
-.devtools__controls h1,
-.devtools__controls button {
+.experiments__controls h1,
+.experiments__controls button {
     vertical-align: middle;
 }
 


### PR DESCRIPTION
## What does this change?

The devtool was introduced in #16113, allowing developers to easily opt in to frontend AB tests. This change builds on this work:

1. Allows us to opt in to Acquisitions tests (which currently do not appear)
2. Renames `devtools` to the more explicit `experiments`
3. Slight style improvements
4. Indicates why a particular experiment might not be working (expired or not switched on)

You can display the Experiments panel on any Guardian page by appending `#experiments` to the URL

@guardian/membership-and-subscriptions 

## What is the value of this and can you measure success?

Makes the tool more useful

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

<img width="1012" alt="picture 387" src="https://user-images.githubusercontent.com/5931528/33378835-0d8c4cb6-d50e-11e7-9be4-21974b8f3445.png">


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
