### PR TITLE
[acquisitions] referrer data listener update

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -60,6 +60,8 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
             return;
         }
 
+        // TODO: remove this when only https://github.com/guardian/acquisition-iframe-tracking
+        // TODO: is being used for acquisition iframe tracking
         // Expects enrich requests to be made via iframe-messenger:
         // https://github.com/guardian/iframe-messenger
         if (data.type === 'enrich-acquisition-links' && data.id) {
@@ -69,6 +71,27 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
                     JSON.stringify(data),
                     'https://interactive.guim.co.uk'
                 );
+            });
+        }
+
+        if (data.type === 'referrer-acquisition-data-request') {
+            const eventSrc = event.source.location.href;
+
+            [...document.getElementsByTagName('iframe')].forEach(el => {
+                const iframeSrc = el.getAttribute('src');
+                if (
+                    iframeSrc &&
+                    iframeSrc.startsWith('https://interactive.guim.co.uk') &&
+                    iframeSrc === eventSrc
+                ) {
+                    el.contentWindow.postMessage(
+                        JSON.stringify({
+                            type: 'referrer-acquisition-data-response',
+                            referrerData: addReferrerData({}),
+                        }),
+                        '*'
+                    );
+                }
             });
         }
     });

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -75,14 +75,12 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
         }
 
         if (data.type === 'referrer-acquisition-data-request') {
-            const eventSrc = event.source.location.href;
-
             [...document.getElementsByTagName('iframe')].forEach(el => {
                 const iframeSrc = el.getAttribute('src');
                 if (
                     iframeSrc &&
                     iframeSrc.startsWith('https://interactive.guim.co.uk') &&
-                    iframeSrc === eventSrc
+                    iframeSrc === event.source.location.href
                 ) {
                     el.contentWindow.postMessage(
                         JSON.stringify({

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -74,7 +74,7 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
             });
         }
 
-        if (data.type === 'referrer-acquisition-data-request') {
+        if (data.type === 'acquisition-data-request') {
             [...document.getElementsByTagName('iframe')].forEach(el => {
                 const iframeSrc = el.getAttribute('src');
                 if (
@@ -84,8 +84,11 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
                 ) {
                     el.contentWindow.postMessage(
                         JSON.stringify({
-                            type: 'referrer-acquisition-data-response',
-                            referrerData: addReferrerData({}),
+                            type: 'acquisition-data-response',
+                            acquisitionData: {
+                                ...addReferrerData({}),
+                                source: 'GUARDIAN_WEB',
+                            },
                         }),
                         '*'
                     );


### PR DESCRIPTION
## What does this change?

Accounts for the case where a request for referrer data is initiated by [acquisition iFrame tracking](https://github.com/guardian/acquisition-iframe-tracking).

## What is the value of this and can you measure success?

Provides more robust acquisition tracking from iFrames.
