### PR TITLE
Removing columnists from the opinion list in the Nav

### DIFF
--- a/common/app/navigation/NewNavigation.scala
+++ b/common/app/navigation/NewNavigation.scala
@@ -102,11 +102,7 @@ object NewNavigation {
       columnists,
       cartoons,
       inMyOpinion,
-      letters,
-      NavLink("Polly Toynbee", "/profile/pollytoynbee"),
-      NavLink("Owen Jones", "/profile/owen-jones"),
-      NavLink("Jonathan Freedland", "/profile/jonathanfreedland"),
-      NavLink("Marina Hyde", "/profile/marinahyde")
+      letters
     )
 
     val au = List(
@@ -115,9 +111,7 @@ object NewNavigation {
       cartoons,
       indigenousAustraliaOpinion,
       theGuardianView.copy(title="editorials"),
-      letters,
-      NavLink("first dog on the moon", "/profile/first-dog-on-the-moon"),
-      NavLink("Katharine Murphy", "/profile/katharine-murphy")
+      letters
     )
 
     val us = List(
@@ -125,10 +119,6 @@ object NewNavigation {
       theGuardianView,
       columnists,
       letters,
-      NavLink("Jill Abramson", "/profile/jill-abramson"),
-      NavLink("Jessica Valenti", "/commentisfree/series/jessica-valenti-column"),
-      NavLink("Steven W Thrasher", "/profile/steven-w-thrasher"),
-      NavLink("Richard Wolffe", "/profile/richard-wolffe"),
       inMyOpinion,
       cartoons
     )


### PR DESCRIPTION
## What does this change?
We shouldn't really be promoting some columnists over others in Opinion so lets remove them from the navigation 😄 

## What is the value of this and can you measure success?
Less links!

## Does this affect other platforms - Amp, Apps, etc?
This will affect the nav in AMP as well

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/8774970/33387834-41ed82b4-d526-11e7-85f2-70c5db50417f.png)

After:
![image](https://user-images.githubusercontent.com/8774970/33387886-593f3ee4-d526-11e7-95d8-675a79ab9511.png)

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
