### PR TITLE
Remove switch to control display of contributions tab in edit profile

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -505,16 +505,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  val ProfileShowContributorTab = Switch(
-    SwitchGroup.Feature,
-    "profile-show-contributor-tab",
-    "When ON, the edit profile page will include a Contributions tab",
-    owners = Seq(Owner.withGithub("justinpinner")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 11, 30),
-    exposeClientSide = true
-  )
-
     // Owner: Journalism
   val ReaderAnswersDeliveryMechanism = Switch(
     SwitchGroup.Feature,

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -1,6 +1,5 @@
 @import conf.Static
 @import views.support.RenderClasses
-@import conf.switches.Switches.ProfileShowContributorTab
 @import model.{ApplicationContext, EmailNewsletters, IdentityPage}
 @import services.EmailPrefsData
 @import form.IdFormHelpers.nonInputFields

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -1,6 +1,5 @@
 @import conf.Static
 @import views.support.RenderClasses
-@import conf.switches.Switches.ProfileShowContributorTab
 @import model.{ApplicationContext, EmailNewsletters, IdentityPage}
 @import services.EmailPrefsData
 
@@ -54,13 +53,9 @@
 
                     @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
 
-                    @if(ProfileShowContributorTab.isSwitchedOn) {
-                        @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-membership-tab")
+                    @tab(5, "Contributions", "/contribution/recurring/edit", None, optionalClass="qa-membership-tab")
 
-                        @tab(6, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab")
-                    } else {
-                        @tab(5, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab")
-                    }
+                    @tab(6, "Emails", "/email-prefs", None, optionalClass="qa-privacy-tab")
                 </ol>
             </div>
         </div>
@@ -80,13 +75,9 @@
 
                         @content(4, "/digitalpack/edit")(profile.digitalPackDetailsForm(idUrlBuilder, idRequest, user))
 
-                        @if(ProfileShowContributorTab.isSwitchedOn) {
-                            @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
+                        @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
-                            @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated))
-                        } else {
-                            @content(5, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated)))
-                        }
+                        @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated))
                     </div>
                 </div>
             </div>

--- a/static/src/javascripts/bootstraps/enhanced/membership.js
+++ b/static/src/javascripts/bootstraps/enhanced/membership.js
@@ -1,5 +1,4 @@
 // @flow
-import config from 'lib/config';
 import { membershipTab } from 'membership/membership-tab';
 import { digitalpackTab } from 'membership/digitalpack-tab';
 import { recurringContributionTab } from 'membership/contributions-recurring-tab';
@@ -7,7 +6,5 @@ import { recurringContributionTab } from 'membership/contributions-recurring-tab
 export const init = (): void => {
     membershipTab();
     digitalpackTab();
-    if (config.get('switches.profileShowContributorTab')) {
-        recurringContributionTab();
-    }
+    recurringContributionTab();
 };


### PR DESCRIPTION
## What does this change?
We're not planning to turn the contributions tab off now, so the feature switch can go.

## What is the value of this and can you measure success?
Removes a switch we no longer need.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

## Screenshots
![remove-contribution-switch-screencapture-profile-code-dev-theguardian-contribution-recurring-edit-1512042990872](https://user-images.githubusercontent.com/690395/33429698-c57ead84-d5c5-11e7-8d07-871e38d9df94.png)

## Tested in CODE?
Yes

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
