### PR TITLE
Football: Fix more buttons on fixture tables

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -373,10 +373,9 @@ const init = (): void => {
         (e: Event): void => {
             e.preventDefault();
 
-            const el =
-                e.currentTarget instanceof HTMLLinkElement && e.currentTarget;
+            const el = ((e.currentTarget: any): HTMLLinkElement);
 
-            if (el) {
+            if (el && el.tagName === 'A') {
                 const href = el.getAttribute('href');
                 const putsMore = el.getAttribute('data-puts-more-into');
                 const newData = el.getAttribute('data-new-url');


### PR DESCRIPTION
## What does this change?

Fixes the more button underneath the fixture tables.

Why not checking if `el instanceof HTMLLinkElement`? Well, for some unknown reason, this check returns false, even if the element is the `<a />`. I don't know why.

## What is the value of this and can you measure success?

Less errors.

## Does this affect other platforms - Amp, Apps, etc?

No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No.

## Screenshots

No.

## Tested in CODE?

No.