### PR TITLE
Add marketing consent hints

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -16,7 +16,8 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters
+    availableLists: EmailNewsletters,
+    consentHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @mainLegacy(page, projectName = Option("identity")) { } {
@@ -49,9 +50,13 @@
                                 <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
                                     <div class="manage-account__switches">
                                         <ul>
-                                        @helper.repeat(forms.privacyForm("consents"), min=1) { consentField =>
+                                        @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
                                             <li>
-                                                @fragments.consentSwitch(consentField)(messages)
+                                                @if(index == 0) {
+                                                    @fragments.consentSwitch(consentField, consentHint)(messages)
+                                                } else {
+                                                    @fragments.consentSwitch(consentField)(messages)
+                                                }
                                             </li>
                                         }
                                         </ul>

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -4,7 +4,7 @@
 
 @* Product consent switch/checkbox *@
 
-@(consentField: Field)(messages: play.api.i18n.Messages)
+@(consentField: Field, highlighted: Boolean = false)(messages: play.api.i18n.Messages)
 
 @getConsentText(consentField: Field) = @{
     Consent.wording(
@@ -24,5 +24,6 @@
     description = None,
     behaviour = ConsentSwitch,
     field = consentField("consented"),
-    extraFields = consentHiddenFormFields
+    extraFields = consentHiddenFormFields,
+    highlighted = highlighted
 )(nonInputFields, messages)

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -20,7 +20,7 @@
         ""
 }
 
-<label class="manage-account__switch @switchJsBehaviour(behaviour) @highlight">
+<label class="manage-account__switch @switchJsBehaviour(behaviour) data-originally-checked="@field.value" @highlight">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -15,12 +15,12 @@
 
 @highlight = @{
     if(highlighted)
-        """border:violet;border-style:solid;background-color:lawngreen"""
+        "" // TODO: for Laura
     else
         ""
 }
 
-<label class="manage-account__switch @switchJsBehaviour(behaviour)" style="@highlight">
+<label class="manage-account__switch @switchJsBehaviour(behaviour) @highlight">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -8,11 +8,19 @@
     behaviour: SwitchBehaviour,
     field: Field,
     extraFields: List[Html] = Nil,
-    footer: Option[Html] = None
+    footer: Option[Html] = None,
+    highlighted: Boolean = false
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
-<label class="manage-account__switch @switchJsBehaviour(behaviour)" data-originally-checked="@field.value">
+@highlight = @{
+    if(highlighted)
+        """border:violet;border-style:solid;background-color:lawngreen"""
+    else
+        ""
+}
+
+<label class="manage-account__switch @switchJsBehaviour(behaviour)" style="@highlight">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -13,7 +13,8 @@
   emailPrefsForm: Form[EmailPrefsData],
   emailSubscriptions: List[String],
   availableLists: EmailNewsletters,
-  consentsUpdated: Boolean = false
+  consentsUpdated: Boolean = false,
+  consentHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @marketingConsentForm = {
@@ -35,9 +36,13 @@
         <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
             <div class="manage-account__switches">
                 <ul>
-                @helper.repeat(privacyForm("consents"), min=1) { consentField =>
+                @helper.repeatWithIndex(privacyForm("consents"), min=1) { (consentField, index) =>
                     <li>
-                        @fragments.consentSwitch(consentField)(messages)
+                        @if(index == 0) {
+                            @fragments.consentSwitch(consentField, consentHint)(messages)
+                        } else {
+                            @fragments.consentSwitch(consentField)(messages)
+                        }
                     </li>
                 }
                 </ul>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -12,7 +12,8 @@
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
-    consentsUpdated: Boolean
+    consentsUpdated: Boolean,
+    consentHint: Option[String]
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @tab(i: Int, name: String, url: String, dataTestId: Option[String], hidden: Boolean = false, optionalClass: String = "") = {
@@ -77,7 +78,7 @@
 
                         @content(5, "/contribution/recurring/edit")(profile.recurringContributionDetailsForm(idUrlBuilder, idRequest, user))
 
-                        @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated))
+                        @content(6, "/email-prefs")(profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm, emailPrefsForm, emailSubscriptions, availableLists, consentsUpdated, consentHint))
                     </div>
                 </div>
             </div>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -55,11 +55,11 @@ GET         /membership/edit                        controllers.EditProfileContr
 GET         /contribution/recurring/edit            controllers.EditProfileController.displayRecurringContributionForm
 GET         /digitalpack/edit                       controllers.EditProfileController.displayDigitalPackForm
 
-GET         /privacy/edit                           controllers.EditProfileController.displayPrivacyFormRedirect
+GET         /privacy/edit                           controllers.EditProfileController.displayPrivacyFormRedirect(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /privacy/edit                           controllers.EditProfileController.saveConsentPreferences
 POST        /privacy/edit-ajax                      controllers.EditProfileController.saveConsentPreferencesAjax
 
-GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false)
+GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
 GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: String)

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -62,5 +62,5 @@ POST        /privacy/edit-ajax                      controllers.EditProfileContr
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
-GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: String)
+GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: String ?= "repermission", consentHint: Option[String])
 ########################################################################################################################

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -474,7 +474,7 @@ import scala.concurrent.Future
         when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData]))
           .thenReturn(Future.successful(Right(Subscriber("Text", userEmailSubscriptions))))
 
-        val result = controller.displayEmailPrefsForm(false).apply(FakeCSRFRequest(csrfAddToken))
+        val result = controller.displayEmailPrefsForm(false, None).apply(FakeCSRFRequest(csrfAddToken))
         status(result) should be(200)
         contentAsString(result) should include (EmailNewsletters.guardianTodayUk.name)
         contentAsString(result) should include ("Unsubscribe")


### PR DESCRIPTION
## What does this change?

Marketing consent can be hinted via query parameter `consentHint` which means users will see this consent first and highlighted.

`/email-prefs?consentHint=DUMMYthirdPartyProfiling`
`/consent?consentHint=DUMMYthirdPartyProfiling`

In `views/fragments/form/switch.scala.html` there is a stub for @walaura to fill with styling.

Newsletter hints will be a separate PR.

## What is the value of this and can you measure success?

Help with GDPR re-permissioning conversion.