### PR TITLE
Fire events from wizard.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -80,6 +80,9 @@ const animateIncomingStep = (
                         : stepInReverseClassname
                 );
             }
+            setTimeout(() => {
+                stepEl.classList.remove(...stepTransitionClassnames);
+            }, 300);
         })
         .then(() => fastdom.read(() => stepEl.getBoundingClientRect().height))
         .then(stepHeight =>
@@ -105,7 +108,7 @@ const animateOutgoingStep = (
         );
         setTimeout(() => {
             stepEl.classList.remove(...stepTransitionClassnames);
-        }, 200);
+        }, 300);
     });
 
 const updateCounter = (wizardEl: HTMLElement): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -22,6 +22,8 @@ const stepTransitionClassnames = [
     stepOutReverseClassname,
 ];
 
+const wizardPageChangedEv = 'wizardPageChanged';
+
 const ERR_WIZARD_INVALID_POSITION = 'Invalid position';
 
 const getIdentifier = (wizardEl: HTMLElement): Promise<string> =>
@@ -203,6 +205,15 @@ export const setPosition = (
                         currentPosition,
                         newPosition,
                         stepEls
+                    ),
+                    wizardEl.dispatchEvent(
+                        new CustomEvent(wizardPageChangedEv, {
+                            bubbles: true,
+                            detail: {
+                                currentPosition,
+                                newPosition,
+                            },
+                        })
                     ),
                 ]);
             }

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -263,4 +263,4 @@ export const enhance = (wizardEl: HTMLElement): Promise<void> =>
         });
     });
 
-export { containerClassname };
+export { containerClassname, wizardPageChangedEv };


### PR DESCRIPTION
## What does this change?
Lets `wizard.js` fire custom `wizardPageChanged ` events that can be cleanly picked up from the rest of the site scripting. (Also solves a pesky very dizzying bug where backwards animations weren't working)