### PR TITLE
Convert all instances of HTMLLinkElement to HTMLAnchorElement

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -373,9 +373,9 @@ const init = (): void => {
         (e: Event): void => {
             e.preventDefault();
 
-            const el = ((e.currentTarget: any): HTMLLinkElement);
+            const el = e.currentTarget;
 
-            if (el && el.tagName === 'A') {
+            if (el && el instanceof HTMLAnchorElement) {
                 const href = el.getAttribute('href');
                 const putsMore = el.getAttribute('data-puts-more-into');
                 const newData = el.getAttribute('data-new-url');

--- a/static/src/javascripts/projects/admin/modules/abtests/participation-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/participation-item.js
@@ -31,7 +31,7 @@ class ParticipationItem extends Component {
             : document.location.origin;
         const href = `${this.config.examplePath}=${this.config.variant}`;
 
-        if (this.elem instanceof HTMLLinkElement) {
+        if (this.elem instanceof HTMLAnchorElement) {
             this.elem.textContent = this.config.variant;
             this.elem.href = origin + href;
         }

--- a/static/src/javascripts/projects/admin/modules/abtests/participation.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/participation.js
@@ -29,7 +29,7 @@ class Participation extends Component {
             ? 'http://www.theguardian.com'
             : document.location.origin;
         const examplePath = `${test.examplePath || '/uk'}#ab-${test.id}`;
-        const optOutEl = ((this.getElem('opt-out'): any): HTMLLinkElement);
+        const optOutEl = ((this.getElem('opt-out'): any): HTMLAnchorElement);
 
         optOutEl.href = `${origin}${examplePath}=notintest`;
 

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -18,7 +18,7 @@ class Component {
     componentClass: ?string;
     endpoint: ?string | ?() => string;
     classes: ?Object;
-    elem: ?(HTMLElement | HTMLLinkElement | HTMLInputElement);
+    elem: ?(HTMLElement | HTMLAnchorElement | HTMLInputElement);
     template: ?string;
     rendered: boolean;
     destroyed: boolean;
@@ -143,7 +143,7 @@ class Component {
         });
     }
 
-    _ready(elem?: ?(HTMLElement | HTMLLinkElement | HTMLInputElement)): void {
+    _ready(elem?: ?(HTMLElement | HTMLAnchorElement | HTMLInputElement)): void {
         if (!this.destroyed) {
             this.rendered = true;
             this._autoupdate();
@@ -199,7 +199,7 @@ class Component {
      * This function is made to be overridden
      */
     // eslint-disable-next-line class-methods-use-this, no-unused-vars
-    ready(elem: ?(HTMLElement | HTMLLinkElement | HTMLInputElement)): void {}
+    ready(elem: ?(HTMLElement | HTMLAnchorElement | HTMLInputElement)): void {}
 
     /**
      * Once the render / decorate methods have been called


### PR DESCRIPTION
## What does this change?

Converts all occurences of `HTMLLinkElement` to `HTMLAnchorElement`, thanks to @SiAdcock great finding in https://github.com/guardian/frontend/pull/18376.

## What is the value of this and can you measure success?

😱 ⬇️ 

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

No

## Tested in CODE?

No