### PR TITLE
Atoms v0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "1.2.1"
   },
   "dependencies": {
-    "@guardian/atom-renderer": "0.9.0",
+    "@guardian/atom-renderer": "0.9.1",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "circular-dependency-plugin": "3.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "0.9.0"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "0.9.1"
 
   // Fixing transient dependency issue
   // AWS SDK (1.11.181), which kinesis-logback-appender depends on, brings com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat libs in version 2.6.9

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@guardian/atom-renderer@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.9.0.tgz#5874e77700fade87a29844e7bb2a7f7633577dea"
+"@guardian/atom-renderer@0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-0.9.1.tgz#28b615a5c22e1bdaaa892043995455e5a9cb1ad1"
   dependencies:
     autoprefixer "^7.1.6"
     css-loader "^0.28.7"


### PR DESCRIPTION
Makes a few visual improvements, see [here](https://github.com/guardian/atom-renderer/pull/7)