### PR TITLE
Header z-index and close button alignment

### DIFF
--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -55,6 +55,7 @@
 @import 'module/nav/_has-localnav-overrides';
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
+@import 'module/_icons.head';
 @import 'module/onward/_rich-links-default.head';
 @import 'module/_main-media-captions';
 

--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -7,7 +7,6 @@
    ========================================================================== */
 @import 'icons/_global-icons-svg';
 @import 'icons/video-icons-svg';
-@import 'module/_icons.head';
 
 /* ==========================================================================
    Global modules

--- a/static/src/stylesheets/head.facia.scss
+++ b/static/src/stylesheets/head.facia.scss
@@ -19,4 +19,3 @@
 @import 'module/facia/_treats';
 @import 'module/facia/_cp-scott';
 @import 'module/_badging';
-@import 'module/_icons.head';

--- a/static/src/stylesheets/head.facia.scss
+++ b/static/src/stylesheets/head.facia.scss
@@ -19,3 +19,4 @@
 @import 'module/facia/_treats';
 @import 'module/facia/_cp-scott';
 @import 'module/_badging';
+@import 'module/_icons.head';

--- a/static/src/stylesheets/layout/new-header/_close-button.scss
+++ b/static/src/stylesheets/layout/new-header/_close-button.scss
@@ -7,7 +7,7 @@
     width: $veggie-burger-medium;
     border-radius: 50%;
     position: relative;
-    z-index: $zindex-sticky-top-banner;
+    z-index: $zindex-main-menu + 1;
 
     &:hover {
         background-color: $news-support-2;

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -24,7 +24,7 @@
 
     .new-header--slim.new-header--open & {
         @include mq(desktop) {
-            z-index: $zindex-sticky-top-banner;
+            z-index: $zindex-main-menu + 1;
             position: absolute;
             top: $gs-baseline * 4;
         }


### PR DESCRIPTION
## Look at this...
<img width="105" alt="screen shot 2017-11-30 at 16 54 58" src="https://user-images.githubusercontent.com/14570016/33443386-59e73832-d5ef-11e7-84f6-ca46268c8141.png">

It's happening because the centered-icon class is only pulled into article templates.

Now it's shown everywhere, as the header is shown everywhere:
<img width="220" alt="screen shot 2017-11-30 at 17 05 50" src="https://user-images.githubusercontent.com/14570016/33443933-c37b13da-d5f0-11e7-82ad-2d7b2f63cb9d.png">

Also the close button and pillars were showing above the ads due to a z-index fail. 
