### PR TITLE
Testimonials Cycle test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,16 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2017, 12, 13),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-acquisitions-epic-testimonials-group",
+    "Test changing the epic testimonial each view",
+    owners = Seq(Owner.withGithub("jranks123")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 11),
+    exposeClientSide = true
+  )
+
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -9,12 +9,15 @@ export type AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: string,
 };
 
+export type AcquisitionsEpicTestimonialTemplateParametersGroup = [AcquisitionsEpicTestimonialTemplateParameters]
+
 // control
 const controlQuoteSvg = quoteSvg.markup;
 
 const controlMessage =
     'I appreciate there not being a paywall: it is more democratic for the media to be available for all and not a commodity to be purchased by a few. I’m happy to make a contribution so others with less means still have access to information.';
 const controlName = 'Thomasine F-R.';
+
 
 const usLocalisedMessage =
     'I made a contribution to the Guardian today because I believe our country, the US, is in peril and we need quality independent journalism more than ever. Reading news from websites like this helps me keep some sense of sanity and provides a bit of hope in these dangerous, alarming times. Keep up the good work! I appreciate you.';
@@ -31,3 +34,56 @@ export const usLocalised: AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialMessage: usLocalisedMessage,
     testimonialName: usLocalisedName,
 };
+
+const cycle1: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'It is a paper I trust. It provides reasoned argument. It keeps alive the imperative of a social conscience. It \'makes my day\'',
+    testimonialName: 'Robert C, Kosovo',
+};
+
+
+const cycle2: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'I’ve been enjoying the Guardian’s top-quality journalism for several years now. Today, when so much seems to be going wrong in the world, the Guardian is working hard to confront and challenge those in power. I want to support that',
+    testimonialName: 'Robb H, Canada',
+};
+
+
+const cycle3: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'The Guardian kept me informed on the 2017 UK general election night (as on so many occasions). We are at such a significant, uncertain time, worldwide. I want the Guardian to continue to reflect that, respond to and question it',
+    testimonialName: 'Susan A, UK',
+};
+
+const cycle4: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'High-quality journalism is essential intellectual nourishment. The generosity of providing such a service without a paywall deserves recognition and support',
+    testimonialName: 'Giacomo P, Italy',
+};
+
+const cycle5: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'In these times, it is imperative to have an independent newspaper that allows us to understand what is going on around us. The Guardian is an absolute necessity',
+    testimonialName: 'Delphine M, Mexico',
+};
+
+const cycle6: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely',
+    testimonialName: 'Alice S-L, Netherlands',
+};
+
+const cycle7: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support',
+    testimonialName: 'Roland P, France',
+};
+
+
+const cycle8: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage: 'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible independent check on the government, this donation was pretty good value for money',
+    testimonialName: 'Jack H, UK',
+};
+
+export const testimonialCycleGroup: AcquisitionsEpicTestimonialTemplateParametersGroup = [cycle1, cycle2, cycle3, cycle4, cycle5, cycle6, cycle7, cycle8];

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -9,10 +9,6 @@ export type AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: string,
 };
 
-export type AcquisitionsEpicTestimonialTemplateParametersGroup = Array<
-    AcquisitionsEpicTestimonialTemplateParameters
->;
-
 // control
 const controlQuoteSvg = quoteSvg.markup;
 
@@ -27,56 +23,56 @@ const usLocalisedName = 'Charru B.';
 const cycle1: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        "It is a paper I trust. It provides reasoned argument. It keeps alive the imperative of a social conscience. It 'makes my day'",
+        'It is a paper I trust. It provides reasoned argument. It keeps alive the imperative of a social conscience. It ‘makes my day’.',
     testimonialName: 'Robert C, Kosovo',
 };
 
 const cycle2: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'I’ve been enjoying the Guardian’s top-quality journalism for several years now. Today, when so much seems to be going wrong in the world, the Guardian is working hard to confront and challenge those in power. I want to support that',
+        'I’ve been enjoying the Guardian’s top-quality journalism for several years now. Today, when so much seems to be going wrong in the world, the Guardian is working hard to confront and challenge those in power. I want to support that.',
     testimonialName: 'Robb H, Canada',
 };
 
 const cycle3: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'The Guardian kept me informed on the 2017 UK general election night (as on so many occasions). We are at such a significant, uncertain time, worldwide. I want the Guardian to continue to reflect that, respond to and question it',
+        'The Guardian kept me informed on the 2017 UK general election night (as on so many occasions). We are at such a significant, uncertain time, worldwide. I want the Guardian to continue to reflect that, respond to and question it.',
     testimonialName: 'Susan A, UK',
 };
 
 const cycle4: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'High-quality journalism is essential intellectual nourishment. The generosity of providing such a service without a paywall deserves recognition and support',
+        'High-quality journalism is essential intellectual nourishment. The generosity of providing such a service without a paywall deserves recognition and support.',
     testimonialName: 'Giacomo P, Italy',
 };
 
 const cycle5: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'In these times, it is imperative to have an independent newspaper that allows us to understand what is going on around us. The Guardian is an absolute necessity',
+        'In these times, it is imperative to have an independent newspaper that allows us to understand what is going on around us. The Guardian is an absolute necessity.',
     testimonialName: 'Delphine M, Mexico',
 };
 
 const cycle6: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely',
+        'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely.',
     testimonialName: 'Alice S-L, Netherlands',
 };
 
 const cycle7: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support',
+        'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support.',
     testimonialName: 'Roland P, France',
 };
 
 const cycle8: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible independent check on the government, this donation was pretty good value for money',
+        'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible independent check on the government, this donation was pretty good value for money.',
     testimonialName: 'Jack H, UK',
 };
 
@@ -92,7 +88,7 @@ export const usLocalised: AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: usLocalisedName,
 };
 
-export const testimonialCycleGroup: AcquisitionsEpicTestimonialTemplateParametersGroup = [
+export const testimonialCycleGroup: AcquisitionsEpicTestimonialTemplateParameters[] = [
     cycle1,
     cycle2,
     cycle3,

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -9,7 +9,9 @@ export type AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: string,
 };
 
-export type AcquisitionsEpicTestimonialTemplateParametersGroup = [AcquisitionsEpicTestimonialTemplateParameters]
+export type AcquisitionsEpicTestimonialTemplateParametersGroup = [
+    AcquisitionsEpicTestimonialTemplateParameters,
+];
 
 // control
 const controlQuoteSvg = quoteSvg.markup;
@@ -18,10 +20,65 @@ const controlMessage =
     'I appreciate there not being a paywall: it is more democratic for the media to be available for all and not a commodity to be purchased by a few. I’m happy to make a contribution so others with less means still have access to information.';
 const controlName = 'Thomasine F-R.';
 
-
 const usLocalisedMessage =
     'I made a contribution to the Guardian today because I believe our country, the US, is in peril and we need quality independent journalism more than ever. Reading news from websites like this helps me keep some sense of sanity and provides a bit of hope in these dangerous, alarming times. Keep up the good work! I appreciate you.';
 const usLocalisedName = 'Charru B.';
+
+const cycle1: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        "It is a paper I trust. It provides reasoned argument. It keeps alive the imperative of a social conscience. It 'makes my day'",
+    testimonialName: 'Robert C, Kosovo',
+};
+
+const cycle2: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'I’ve been enjoying the Guardian’s top-quality journalism for several years now. Today, when so much seems to be going wrong in the world, the Guardian is working hard to confront and challenge those in power. I want to support that',
+    testimonialName: 'Robb H, Canada',
+};
+
+const cycle3: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'The Guardian kept me informed on the 2017 UK general election night (as on so many occasions). We are at such a significant, uncertain time, worldwide. I want the Guardian to continue to reflect that, respond to and question it',
+    testimonialName: 'Susan A, UK',
+};
+
+const cycle4: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'High-quality journalism is essential intellectual nourishment. The generosity of providing such a service without a paywall deserves recognition and support',
+    testimonialName: 'Giacomo P, Italy',
+};
+
+const cycle5: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'In these times, it is imperative to have an independent newspaper that allows us to understand what is going on around us. The Guardian is an absolute necessity',
+    testimonialName: 'Delphine M, Mexico',
+};
+
+const cycle6: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely',
+    testimonialName: 'Alice S-L, Netherlands',
+};
+
+const cycle7: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support',
+    testimonialName: 'Roland P, France',
+};
+
+const cycle8: AcquisitionsEpicTestimonialTemplateParameters = {
+    quoteSvg: controlQuoteSvg,
+    testimonialMessage:
+        'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible independent check on the government, this donation was pretty good value for money',
+    testimonialName: 'Jack H, UK',
+};
 
 export const control: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
@@ -35,55 +92,13 @@ export const usLocalised: AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: usLocalisedName,
 };
 
-const cycle1: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'It is a paper I trust. It provides reasoned argument. It keeps alive the imperative of a social conscience. It \'makes my day\'',
-    testimonialName: 'Robert C, Kosovo',
-};
-
-
-const cycle2: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'I’ve been enjoying the Guardian’s top-quality journalism for several years now. Today, when so much seems to be going wrong in the world, the Guardian is working hard to confront and challenge those in power. I want to support that',
-    testimonialName: 'Robb H, Canada',
-};
-
-
-const cycle3: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'The Guardian kept me informed on the 2017 UK general election night (as on so many occasions). We are at such a significant, uncertain time, worldwide. I want the Guardian to continue to reflect that, respond to and question it',
-    testimonialName: 'Susan A, UK',
-};
-
-const cycle4: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'High-quality journalism is essential intellectual nourishment. The generosity of providing such a service without a paywall deserves recognition and support',
-    testimonialName: 'Giacomo P, Italy',
-};
-
-const cycle5: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'In these times, it is imperative to have an independent newspaper that allows us to understand what is going on around us. The Guardian is an absolute necessity',
-    testimonialName: 'Delphine M, Mexico',
-};
-
-const cycle6: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely',
-    testimonialName: 'Alice S-L, Netherlands',
-};
-
-const cycle7: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support',
-    testimonialName: 'Roland P, France',
-};
-
-
-const cycle8: AcquisitionsEpicTestimonialTemplateParameters = {
-    quoteSvg: controlQuoteSvg,
-    testimonialMessage: 'I’m a 19 year old student disillusioned by an unequal society with a government that has stopped even pretending to work in my generation’s interests. So for the strength of our democracy, for the voice of the young, for a credible independent check on the government, this donation was pretty good value for money',
-    testimonialName: 'Jack H, UK',
-};
-
-export const testimonialCycleGroup: AcquisitionsEpicTestimonialTemplateParametersGroup = [cycle1, cycle2, cycle3, cycle4, cycle5, cycle6, cycle7, cycle8];
+export const testimonialCycleGroup: AcquisitionsEpicTestimonialTemplateParametersGroup = [
+    cycle1,
+    cycle2,
+    cycle3,
+    cycle4,
+    cycle5,
+    cycle6,
+    cycle7,
+    cycle8,
+];

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -9,9 +9,9 @@ export type AcquisitionsEpicTestimonialTemplateParameters = {
     testimonialName: string,
 };
 
-export type AcquisitionsEpicTestimonialTemplateParametersGroup = [
-    AcquisitionsEpicTestimonialTemplateParameters,
-];
+export type AcquisitionsEpicTestimonialTemplateParametersGroup = Array<
+    AcquisitionsEpicTestimonialTemplateParameters
+>;
 
 // control
 const controlQuoteSvg = quoteSvg.markup;

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-epic-testimonial-parameters.js
@@ -58,14 +58,14 @@ const cycle5: AcquisitionsEpicTestimonialTemplateParameters = {
 const cycle6: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworth journalism to remain available to everyone freely.',
+        'I benefit from the Guardian’s high-quality website every day and would like its investigative and trustworthy journalism to remain available to everyone freely.',
     testimonialName: 'Alice S-L, Netherlands',
 };
 
 const cycle7: AcquisitionsEpicTestimonialTemplateParameters = {
     quoteSvg: controlQuoteSvg,
     testimonialMessage:
-        'Unrivaled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support.',
+        'Unrivalled, in-depth journalism that has become essential to me. Incredible coverage of my homeland news with an eye I hardly find in the local media. Time has come for me to support.',
     testimonialName: 'Roland P, France',
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
@@ -30,4 +30,8 @@ const viewsInPreviousDays = (days: number, testId: ?string): number => {
     ).length;
 };
 
-export { logView, viewsInPreviousDays };
+const overallNumberOfViews = () => {
+    return viewLog.length;
+};
+
+export { logView, viewsInPreviousDays, overallNumberOfViews };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
@@ -30,8 +30,6 @@ const viewsInPreviousDays = (days: number, testId: ?string): number => {
     ).length;
 };
 
-const overallNumberOfViews = () => {
-    return viewLog.length;
-};
+const overallNumberOfViews = () => viewLog.length;
 
 export { logView, viewsInPreviousDays, overallNumberOfViews };

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -15,7 +15,6 @@ import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acqui
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
 import { acquisitionsEpicTestimonialsGroup } from 'common/modules/experiments/tests/acquisitions-epic-testimonials-group';
 
-
 /**
  * acquisition tests in priority order (highest to lowest)
  */

--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -13,12 +13,15 @@ import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/te
 import { acquisitionsEpicAlwaysAskElection } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-election';
 import { acquisitionsEpicThankYou } from 'common/modules/experiments/tests/acquisitions-epic-thank-you';
 import { acquisitionsEpicUSGunCampaign } from 'common/modules/experiments/tests/acquisitions-epic-us-gun-campaign';
+import { acquisitionsEpicTestimonialsGroup } from 'common/modules/experiments/tests/acquisitions-epic-testimonials-group';
+
 
 /**
  * acquisition tests in priority order (highest to lowest)
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
+    acquisitionsEpicTestimonialsGroup,
     acquisitionsEpicUSGunCampaign,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
@@ -31,11 +31,11 @@ export const acquisitionsEpicTestimonialsGroup = makeABTest({
     variants: [
         {
             id: 'control',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: [],
         },
         {
             id: 'cycle',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
+            products: [],
             options: {
                 testimonialBlock: acquisitionsTestimonialBlockTemplate(
                     getTestimonialText()

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
@@ -31,9 +31,11 @@ export const acquisitionsEpicTestimonialsGroup = makeABTest({
     variants: [
         {
             id: 'control',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
         },
         {
             id: 'cycle',
+            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             options: {
                 testimonialBlock: acquisitionsTestimonialBlockTemplate(
                     getTestimonialText()

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
@@ -1,22 +1,14 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
-import { testimonialCycleGroup } from 'common/modules/commercial/acquisitions-epic-testimonial-parameters'
+import { testimonialCycleGroup } from 'common/modules/commercial/acquisitions-epic-testimonial-parameters';
 import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { overallNumberOfViews } from 'common/modules/commercial/acquisitions-view-log';
 import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/templates/acquisitions-epic-testimonial-block';
 
-const getNumberOfViews = () => {
-
-
-}
-
-const  getTestimonialText = () => {
+const getTestimonialText = () => {
     const mvtId = getMvtValue();
     const numberOfViews = overallNumberOfViews();
-    console.log('mvt id = ' + mvtId);
-    console.log('numberOfViews = ' + numberOfViews);
-    return testimonialCycleGroup[mvtId % 8 + numberOfViews % 8]
-
+    return testimonialCycleGroup[mvtId % 8 + numberOfViews % 8];
 };
 
 export const acquisitionsEpicTestimonialsGroup = makeABTest({
@@ -43,14 +35,10 @@ export const acquisitionsEpicTestimonialsGroup = makeABTest({
         {
             id: 'cycle',
             options: {
-                testimonialBlock: acquisitionsTestimonialBlockTemplate(getTestimonialText()),
+                testimonialBlock: acquisitionsTestimonialBlockTemplate(
+                    getTestimonialText()
+                ),
             },
-            maxViews: {
-                days: 100000, // Arbitrarily high number - reader should only see the thank-you for one 'cycle'.
-                count: 1000000,
-                minDaysBetweenViews: 0,
-            },
-            
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-testimonials-group.js
@@ -1,0 +1,56 @@
+// @flow
+import { makeABTest } from 'common/modules/commercial/contributions-utilities';
+import { testimonialCycleGroup } from 'common/modules/commercial/acquisitions-epic-testimonial-parameters'
+import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
+import { overallNumberOfViews } from 'common/modules/commercial/acquisitions-view-log';
+import { acquisitionsTestimonialBlockTemplate } from 'common/modules/commercial/templates/acquisitions-epic-testimonial-block';
+
+const getNumberOfViews = () => {
+
+
+}
+
+const  getTestimonialText = () => {
+    const mvtId = getMvtValue();
+    const numberOfViews = overallNumberOfViews();
+    console.log('mvt id = ' + mvtId);
+    console.log('numberOfViews = ' + numberOfViews);
+    return testimonialCycleGroup[mvtId % 8 + numberOfViews % 8]
+
+};
+
+export const acquisitionsEpicTestimonialsGroup = makeABTest({
+    id: 'AcquisitionsEpicTestimonialsGroup',
+    campaignId: 'epic_testimonials_group',
+
+    start: '2017-11-30',
+    expiry: '2018-01-11',
+
+    author: 'Jonathan Rankin',
+    description:
+        'A test to try out cycling through various testimonials vs just one testimonial',
+    successMeasure: 'Conversion rate',
+    idealOutcome:
+        'We prove that looping through testimonials has a stronger impact than showing just one testimonial',
+    audienceCriteria: 'All',
+    audience: 1,
+    audienceOffset: 0,
+
+    variants: [
+        {
+            id: 'control',
+        },
+        {
+            id: 'cycle',
+            options: {
+                testimonialBlock: acquisitionsTestimonialBlockTemplate(getTestimonialText()),
+            },
+            maxViews: {
+                days: 100000, // Arbitrarily high number - reader should only see the thank-you for one 'cycle'.
+                count: 1000000,
+                minDaysBetweenViews: 0,
+            },
+            
+        },
+    ],
+});


### PR DESCRIPTION
## What does this change?

Until now, we have always had a single testimonial in the epic. This test tries a new approach, where we cycle through a list of 8 testimonials, a new one on each view. 

The testimonial you see is calculated with a combination of your browser id and the last one you saw, so the first one you see is randomised from user to user

Control:
![control](https://user-images.githubusercontent.com/2844554/33445455-c967c884-d5f4-11e7-87b2-5e408243d7d4.png)

Variant (for the sake of brevity, i've only screenshotted the testimonial block):
![1](https://user-images.githubusercontent.com/2844554/33481305-ce03b604-d68b-11e7-85fe-25ba7955a873.png)
![2](https://user-images.githubusercontent.com/2844554/33481306-ce173e4a-d68b-11e7-8cfb-18f35842ea33.png)
![3](https://user-images.githubusercontent.com/2844554/33481307-ce295260-d68b-11e7-80e7-04ed3a083bf1.png)
![4](https://user-images.githubusercontent.com/2844554/33481309-ce40edbc-d68b-11e7-9218-ca013187784c.png)
![5](https://user-images.githubusercontent.com/2844554/33481310-ce55cff2-d68b-11e7-90af-dc75b5884fc1.png)
![6](https://user-images.githubusercontent.com/2844554/33481311-ce698f56-d68b-11e7-9f27-c39490cf52bd.png)
![8](https://user-images.githubusercontent.com/2844554/33481313-ce995fd8-d68b-11e7-9695-2e7b54e42c7c.png)
![9](https://user-images.githubusercontent.com/2844554/33481314-ceaf3330-d68b-11e7-8869-6d05d7597727.png)

