### PR TITLE
compile dev build to catch when it breaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,8 @@ val main = root().aggregate(
   onward,
   archive,
   preview,
-  rss
+  rss,
+  dev
 ).settings(
   riffRaffBuildIdentifier := System.getenv().getOrDefault("BUILD_NUMBER", "0").replaceAll("\"",""),
   riffRaffUploadArtifactBucket := Some(System.getenv().getOrDefault("RIFF_RAFF_ARTIFACT_BUCKET", "aws-frontend-teamcity")),


### PR DESCRIPTION
## What does this change?
Compile dev-build in teamcity to catch errors affecting developer local environments
This adds an extra minute to the build time :(

## Tested in CODE?
not necessary

