### PR TITLE
Restored tones and widths to new header

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -91,12 +91,12 @@
         left: -$gs-gutter / 2;
         top: -$gs-baseline * 2;
         bottom: 0;
-        border-left: 1px solid $news-support-1;
+        border-left: 1px solid $news-support-2;
     }
 }
 
 .menu-group--brand-extensions {
-    border-top: 1px solid $news-support-1;
+    border-top: 1px solid $news-support-2;
     display: block;
     position: relative;
 

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -38,7 +38,7 @@
 
     &:before {
         // Dividing lines
-        border-left: 1px solid $news-support-1;
+        border-left: 1px solid $news-support-2;
         top: $gs-baseline + 1;
         z-index: 1;
 

--- a/static/src/stylesheets/layout/new-header/_pillars.scss
+++ b/static/src/stylesheets/layout/new-header/_pillars.scss
@@ -36,8 +36,6 @@
     float: left;
 
     @include mq(desktop) {
-        width: 117px;
-
         .new-header--open & {
             width: 160px;
 


### PR DESCRIPTION
I've restored the variable spacing and tones that were agreed upon in our meeting, to go out for the test.

![screen shot 2017-12-01 at 10 28 36](https://user-images.githubusercontent.com/14570016/33478807-848692de-d682-11e7-960e-043299a9a9e9.png)
