### PR TITLE
Add newsletter consent hint

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -55,7 +55,7 @@ class EditProfileController(
   def displayEmailPrefsForm(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] =
     displayForm(EmailPrefsProfilePage, consentsUpdated, consentHint)
 
-  def displayConsentJourneyForm(journey: String, consentHint: Option[String]): Action[AnyContent] = {
+  def displayConsentJourneyForm(journey: String, consentHint: Option[String], newsletterHint: Option[String]): Action[AnyContent] = {
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
       recentlyAuthenticated { implicit request =>
         NotFound(views.html.errors._404())
@@ -69,7 +69,8 @@ class EditProfileController(
             journey = journey,
             forms = ProfileForms(userWithHintedConsent(consentHint), PublicEditProfilePage),
             request.user,
-            consentHint
+            consentHint,
+            newsletterHint
           )
         }
       }
@@ -199,7 +200,8 @@ class EditProfileController(
       journey: String,
       forms: ProfileForms,
       user: User,
-      consentHint: Option[String])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
+      consentHint: Option[String],
+      newsletterHint: Option[String])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
     newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
 
@@ -214,7 +216,8 @@ class EditProfileController(
         emailFilledForm,
         newsletterService.getEmailSubscriptions(emailFilledForm),
         EmailNewsletters.all,
-        consentHint
+        consentHint,
+        newsletterHint
       )))
 
     }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -17,8 +17,23 @@
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
-    consentHint: Option[String] = None
+    consentHint: Option[String] = None,
+    newsletterHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+
+@onlySubscribedToNewsletters = @{
+    EmailNewsletters.all.subscriptions.filter { newsletter =>
+        emailSubscriptions.contains(newsletter.listId.toString)
+    }
+}
+
+@hintendNewsletters = @{
+   if (newsletterHint.isDefined) {
+       onlySubscribedToNewsletters
+   } else {
+       EmailNewsletters.all.subscriptions
+   }
+}
 
 @mainLegacy(page, projectName = Option("identity")) { } {
 
@@ -88,7 +103,7 @@
                                 <p class="manage-account-headerNote">You were receiving these newsletters, check them again to confirm you want to keep receiving them.</p>
                                 <div class="manage-account__switches">
                                     <ul>
-                                    @availableLists.subscriptions.filter(_.theme == "news").zipWithRowInfo.map { case (newsletter, row) =>
+                                    @hintendNewsletters.filter(_.theme == "news").zipWithRowInfo.map { case (newsletter, row) =>
                                         <li>
                                             @fragments.newsletterSwitch(
                                                 emailPrefsForm,

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -62,5 +62,5 @@ POST        /privacy/edit-ajax                      controllers.EditProfileContr
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
-GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: String ?= "repermission", consentHint: Option[String])
+GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: String ?= "repermission", consentHint: Option[String], newsletterHint: Option[String])
 ########################################################################################################################


### PR DESCRIPTION
## What does this change?

Newsletters consent can be hinted via query parameter `newsletterHint` which means users will see only newsletters they are subscribed to.

`/consent?journey=repermission&newsletterHint=foobar`

Note currently nothing will be shown if user is subscribed to none of the newsletters.

Related PR: https://github.com/guardian/frontend/pull/18378

## What is the value of this and can you measure success?

Help with GDPR re-permissioning conversion.
