### PR TITLE
Tweaked search styling new header

### DIFF
--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -71,7 +71,7 @@
                             }
 
                             @if(SearchSwitch.isSwitchedOn) {
-                                <a class="top-bar__item hide-until-desktop js-search-toggle"
+                                <a class="top-bar__item hide-until-desktop top-bar__item--dropdown js-search-toggle"
                                     href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
                                     data-is-ajax
                                     data-link-name="nav2 : search"

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -182,6 +182,15 @@ from scrolling */
     height: $slim-nav-height;
 }
 
+
+.new-header .popup--search {
+    background-color: #ffffff;
+    border-radius: $gs-baseline / 4;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .1);
+    padding: $gs-baseline 0;
+    top: $gs-baseline * 2 + $gs-baseline / 2;
+}
+
 // Don't show trapezoid on opera mini: https://wp-mix.com/css-target-opera/
 x:-o-prefocus, .new-header__cta-container  {
     display: none;

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -30,15 +30,6 @@
 
 .dropdown-menu--open {
     display: block;
-
-    & ~ .top-bar__item--dropdown {
-        color: #ffffff;
-        background-color: rgba(0, 0, 0, .3);
-
-        &:after {
-            transform: translateY(0) rotate(45deg);
-        }
-    }
 }
 
 .dropdown-menu__title {

--- a/static/src/stylesheets/layout/new-header/_top-bar.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar.scss
@@ -24,8 +24,7 @@
     }
 
     &:hover,
-    &:focus,
-    &.is-active {
+    &:focus {
         color: #ffffff;
         text-decoration: none;
     }
@@ -50,6 +49,16 @@
         margin-left: 2px;
         vertical-align: middle;
         transition: transform 250ms ease-out;
+    }
+
+    .dropdown-menu--open ~ &,
+    &.is-active {
+        color: #ffffff;
+        background-color: rgba(0, 0, 0, .3);
+
+        &:after {
+            transform: translateY(0) rotate(45deg);
+        }
     }
 
     &:hover:after {


### PR DESCRIPTION
For the time being search on the new header is the same as search on the OLD header. To help make this slightly less jarring I've tweaked the padding/bg/shadow a tiny bit to make it more in line without other drop down styles.

# Before
![screen shot 2017-12-01 at 15 09 23](https://user-images.githubusercontent.com/14570016/33488948-4ee27a80-d6aa-11e7-89a0-3a1d65f7aea5.png)

# After
![screen shot 2017-12-01 at 15 09 50](https://user-images.githubusercontent.com/14570016/33488949-4f09290a-d6aa-11e7-9107-cba5efcc085a.png)
