### PR TITLE
Named steps on wizard.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -26,6 +26,10 @@ const wizardPageChangedEv = 'wizardPageChanged';
 
 const ERR_WIZARD_INVALID_POSITION = 'Invalid position';
 
+declare class PopStateEvent extends Event {
+    state: Object;
+}
+
 const getPositionFromName = (
     wizardEl: HTMLElement,
     position: string
@@ -278,9 +282,8 @@ const enhance = (wizardEl: HTMLElement): Promise<void> =>
         getIdentifier(wizardEl),
         setPosition(wizardEl, 0, false),
     ]).then(([wizardElIdentifier]) => {
-        window.addEventListener('popstate', ev => {
+        window.addEventListener('popstate', (ev: PopStateEvent) => {
             if (
-                ev.state &&
                 ev.state.dispatcher &&
                 ev.state.dispatcher === wizardElIdentifier
             ) {
@@ -289,6 +292,11 @@ const enhance = (wizardEl: HTMLElement): Promise<void> =>
             }
         });
 
+        /*
+        The following code checks for the
+        existence of .closest() to catch any HTMLElement
+        derived types such as canvases or svgs
+        */
         wizardEl.addEventListener('click', (ev: Event) => {
             if (
                 ev.target.closest &&

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -40,9 +40,18 @@ const getPositionFromName = (
     throw new Error(ERR_WIZARD_INVALID_POSITION);
 };
 
-const getPositionName = (wizardEl: HTMLElement, step: number): string =>
-    [...wizardEl.getElementsByClassName(stepClassname)][step].dataset
-        .wizardStepName || `step-${step}`;
+const getPositionName = (wizardEl: HTMLElement, step: number): string => {
+    if (
+        [...wizardEl.getElementsByClassName(stepClassname)][step] &&
+        [...wizardEl.getElementsByClassName(stepClassname)][step].dataset
+            .wizardStepName
+    ) {
+        return [...wizardEl.getElementsByClassName(stepClassname)][step].dataset
+            .wizardStepName;
+    }
+
+    return `step-${step}`;
+};
 
 const getIdentifier = (wizardEl: HTMLElement): Promise<string> =>
     fastdom.read(() => wizardEl.id || containerClassname);

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -41,13 +41,10 @@ const getPositionFromName = (
 };
 
 const getPositionName = (wizardEl: HTMLElement, step: number): string => {
-    if (
-        [...wizardEl.getElementsByClassName(stepClassname)][step] &&
-        [...wizardEl.getElementsByClassName(stepClassname)][step].dataset
-            .wizardStepName
-    ) {
-        return [...wizardEl.getElementsByClassName(stepClassname)][step].dataset
-            .wizardStepName;
+    const stepEl = [...wizardEl.getElementsByClassName(stepClassname)][step];
+
+    if (stepEl && stepEl.dataset && stepEl.dataset.wizardStepName) {
+        return stepEl.dataset.wizardStepName;
     }
 
     return `step-${step}`;

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -63,7 +63,7 @@ const getPosition = (wizardEl: HTMLElement): Promise<number> =>
 const getInfoObject = (
     wizardEl: HTMLElement,
     optionalPosition: ?number
-): Promise<{ dispatcher: string, position: number, positionName: string }> =>
+): Promise<{| dispatcher: string, position: number, positionName: string |}> =>
     Promise.all([
         getIdentifier(wizardEl),
         optionalPosition || getPosition(wizardEl),

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -56,11 +56,17 @@ const getPositionName = (wizardEl: HTMLElement, step: number): string => {
 const getIdentifier = (wizardEl: HTMLElement): Promise<string> =>
     fastdom.read(() => wizardEl.id || containerClassname);
 
+const getPosition = (wizardEl: HTMLElement): Promise<number> =>
+    Promise.resolve(parseInt(wizardEl.dataset.position, 10));
+
 const getInfoObject = (
     wizardEl: HTMLElement,
-    position: number
+    optionalPosition: ?number
 ): Promise<{ dispatcher: string, position: number, positionName: string }> =>
-    getIdentifier(wizardEl).then(wizardElIdentifier => ({
+    Promise.all([
+        getIdentifier(wizardEl),
+        optionalPosition || getPosition(wizardEl),
+    ]).then(([wizardElIdentifier, position]) => ({
         dispatcher: wizardElIdentifier,
         position,
         positionName: getPositionName(wizardEl, position),
@@ -310,4 +316,10 @@ const enhance = (wizardEl: HTMLElement): Promise<void> =>
         });
     });
 
-export { containerClassname, wizardPageChangedEv, enhance, setPosition };
+export {
+    containerClassname,
+    wizardPageChangedEv,
+    enhance,
+    setPosition,
+    getInfoObject,
+};

--- a/static/src/javascripts/projects/common/modules/identity/wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/wizard.js
@@ -273,8 +273,9 @@ const enhance = (wizardEl: HTMLElement): Promise<void> =>
 
         wizardEl.addEventListener('click', (ev: Event) => {
             if (
-                ev.target instanceof HTMLElement &&
-                ev.target.closest(`.${nextButtonElClassname}`)
+                ev.target.closest &&
+                ev.target.closest instanceof Function &&
+                ev.target.closest(`.${nextButtonElClassname}`) !== null
             ) {
                 setPosition(
                     wizardEl,
@@ -282,8 +283,9 @@ const enhance = (wizardEl: HTMLElement): Promise<void> =>
                 );
             }
             if (
-                ev.target instanceof HTMLElement &&
-                ev.target.closest(`.${prevButtonElClassname}`)
+                ev.target.closest &&
+                ev.target.closest instanceof Function &&
+                ev.target.closest(`.${prevButtonElClassname}`) !== null
             ) {
                 setPosition(
                     wizardEl,


### PR DESCRIPTION
## What does this change?
Adds named steps to the wizard.js api so other code can make it go to a named step instead of just guessing which page to go to as if this was BASIC or something

## What is the value of this and can you measure success?
WIll prevent potential bugs on the repermission flow