### PR TITLE
Ensure that the engagement banner close button is always accessible

### DIFF
--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -21,7 +21,6 @@
 }
 
 .site-message__inner {
-    display: table;
     padding: 0 $gs-gutter/2;
     width: 100%;
 
@@ -51,7 +50,6 @@
     padding-top: $gs-baseline/2;
     padding-bottom: $gs-baseline/2;
     position: relative;
-    display: table-cell;
     vertical-align: middle;
 
     @include mq(tablet) {
@@ -545,27 +543,34 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message--membership-prominent {
     .site-message__message {
+        padding-right: 45px;
         @include mq($until: tablet) {
             padding-left: 5px;
         }
         @include mq($from: tablet) {
             padding-left: 10px;
         }
+        @include mq($from: desktop) {
+            padding-left: 55qqpx;
+        }
     }
     .site-message__media {
         vertical-align: top;
+        position: absolute;
         @include mq($from: mobile) {
             padding-top: 4px;
         }
         @include mq($from: tablet) {
-            display: table-cell;
             padding-top: 1px;
         }
     }
     .site-message__close {
         vertical-align: top;
         width: 36px;
-        height: 36px;
+        position: absolute;
+        right: 0;
+        top: 0;
+        height: 100%;
         @include mq($from: mobile) {
             padding-right: 10px;
         }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -543,6 +543,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message--membership-prominent {
     .site-message__message {
+        max-height: 80%;
         padding-right: 45px;
         @include mq($until: tablet) {
             padding-left: 5px;
@@ -551,7 +552,8 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
             padding-left: 10px;
         }
         @include mq($from: desktop) {
-            padding-left: 55qqpx;
+            padding-left: 55px;
+            padding-right: 40px;
         }
     }
     .site-message__media {


### PR DESCRIPTION
## What does this change?
We have had some complaints from mobile users coming from facebook that the engagement banner close button was out of the viewport  and thus inaccessible. This PR ensures that the close button is always in the view port, as demonstrated by the screenshots below:

![screenshot at dec 01 17-23-47](https://user-images.githubusercontent.com/2844554/33495028-e785f34a-d6bc-11e7-8b66-77e2b1f50692.png)

These screenshots show it on an iPhone 5 and an iPhone 6:
![iphone6](https://user-images.githubusercontent.com/2844554/33495026-e742f69e-d6bc-11e7-95ea-33d31f46b28c.png)
![newiphone5](https://user-images.githubusercontent.com/2844554/33495027-e769e0ce-d6bc-11e7-9bd5-60c3553868db.png)

