### PR TITLE
Don't float all pull quotes

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -557,8 +557,10 @@
         }
     }
 
-    .element--supporting {
-        float: left;
+    .element--showcase,
+    .element--inline,
+    .element--halfWidth {
+        float: none;
     }
 
     .ad-slot--inline {

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -557,8 +557,8 @@
         }
     }
 
-    .element--showcase {
-        float: none;
+    .element--supporting {
+        float: left;
     }
 
     .ad-slot--inline {

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -337,7 +337,6 @@ figure.element--thumbnail + h2 {
 
     @include mq(tablet) {
         width: gs-span(3);
-        float: left;
         // Prevent previous embeds from interfering
         clear: left;
         padding-right: $gs-gutter;

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -337,6 +337,7 @@ figure.element--thumbnail + h2 {
 
     @include mq(tablet) {
         width: gs-span(3);
+        float: left;
         // Prevent previous embeds from interfering
         clear: left;
         padding-right: $gs-gutter;


### PR DESCRIPTION
## What does this change?

Pull quotes can get a bit messy when they are inlined.

![picture 393](https://user-images.githubusercontent.com/5931528/33554661-8e002698-d8f5-11e7-9c6f-da67a5e73117.png)


This is because pull quotes are always set to `float: left`. Ideally, only supporting pull quotes should float left, and all others should sit in the normal document flow. 

## What is the value of this and can you measure success?

Inline pull quotes look awesome again

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

**Before (inline)**

![picture 392](https://user-images.githubusercontent.com/5931528/33554553-13f9622e-d8f5-11e7-9843-6c29672ffefd.png)

**After (inline)**

![picture 391](https://user-images.githubusercontent.com/5931528/33554565-1d9d4cbe-d8f5-11e7-89ec-83786b15bade.png)

## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
