### PR TITLE
Update the consent journey to the new wizard API

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -134,7 +134,7 @@
                             </a>
                             <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
                             </div>
-                            <a class="manage-account__button--icon manage-account__button js-manage-account-wizard__next">
+                            <a class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next">
                                 <span>Next</span>
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </a>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -46,7 +46,7 @@
                     <div class="js-errorHolder manage-account__errors"></div>
 
                     <div class="manage-account-wizard manage-account-wizard--consent" >
-                        <div class="manage-account-wizard__step">
+                        <div class="manage-account-wizard__step" data-wizard-step-name="consent">
 
                             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
                                 @views.html.helper.CSRF.formField
@@ -93,7 +93,7 @@
                             </form>
 
                         </div>
-                        <div class="manage-account-wizard__step">
+                        <div class="manage-account-wizard__step" data-wizard-step-name="email">
 
                             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
                                 @views.html.helper.CSRF.formField
@@ -116,7 +116,7 @@
                                 </div>
                             </form>
                         </div>
-                        <div class="manage-account-wizard__step">
+                        <div class="manage-account-wizard__step" data-wizard-step-name="endcard">
                             <div class="js-manage-account-wizard__next">
                                 <div class="manage-account-consent-thanks">
                                     <h2 class="manage-account-consent-thanks__title">Thank you</h2>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -58,7 +58,7 @@
                                     <p class="manage-account-headerNote">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
                                 } else {
                                     <h1 class="identity-title">
-                                        Would you like to receive communicatons from us?
+                                        Would you like to receive communications from us?
                                     </h1>
                                     <p class="manage-account-headerNote">Tick the boxes you are interested in</p>
                                 }

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -16,15 +16,6 @@ const positions = {
     endcard: 'endcard',
 };
 
-const getRejectedCheckboxes = (
-    checkboxesEl: Array<HTMLLabelElement>
-): Array<HTMLLabelElement> =>
-    checkboxesEl.filter(
-        (checkboxEl: HTMLLabelElement) =>
-            checkboxEl.control instanceof HTMLInputElement &&
-            !checkboxEl.control.checked
-    );
-
 const getAcceptedCheckboxes = (
     checkboxesEl: Array<HTMLLabelElement>
 ): Array<HTMLLabelElement> =>
@@ -89,34 +80,11 @@ const bindNextButton = (buttonEl: HTMLElement): void => {
     const wizardEl = [
         ...document.getElementsByClassName('manage-account-wizard--consent'),
     ][0];
-    const checkboxesEl = getEmailCheckboxes();
     buttonEl.addEventListener('click', (ev: Event) => {
         ev.preventDefault();
-        getWizardInfoObject(wizardEl).then(wizardInfo => {
-            if (wizardInfo.positionName === positions.email) {
-                const rejectedEmailNames = getRejectedCheckboxes(
-                    checkboxesEl
-                ).map(
-                    checkboxEl =>
-                        checkboxEl.getElementsByClassName(
-                            'manage-account__switch-title'
-                        )[0].innerText
-                );
-                if (rejectedEmailNames.length > 2) {
-                    if (
-                        window.confirm(
-                            `You will stop receiving the following newsletters. Are you sure? : ${rejectedEmailNames.join()}`
-                        )
-                    ) {
-                        return setPosition(wizardEl, wizardInfo.position + 1);
-                    }
-
-                    return;
-                }
-            }
-
-            return setPosition(wizardEl, wizardInfo.position + 1);
-        });
+        getWizardInfoObject(wizardEl).then(wizardInfo =>
+            setPosition(wizardEl, wizardInfo.position + 1)
+        );
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -10,6 +10,8 @@ import {
     getInfoObject as getWizardInfoObject,
 } from './wizard';
 
+const ERR_IDENTITY_CONSENT_WIZARD_MISSING = 'Missing wizard element';
+
 const positions = {
     consent: 'consent',
     email: 'email',
@@ -77,15 +79,19 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
 };
 
 const bindNextButton = (buttonEl: HTMLElement): void => {
-    const wizardEl = [
-        ...document.getElementsByClassName('manage-account-wizard--consent'),
-    ][0];
-    buttonEl.addEventListener('click', (ev: Event) => {
-        ev.preventDefault();
-        getWizardInfoObject(wizardEl).then(wizardInfo =>
-            setPosition(wizardEl, wizardInfo.position + 1)
-        );
-    });
+    const wizardEl: ?Element = buttonEl.closest(
+        '.manage-account-wizard--consent'
+    );
+    if (wizardEl && wizardEl instanceof HTMLElement) {
+        buttonEl.addEventListener('click', (ev: Event) => {
+            ev.preventDefault();
+            getWizardInfoObject(wizardEl).then(wizardInfo =>
+                setPosition(wizardEl, wizardInfo.position + 1)
+            );
+        });
+    } else {
+        throw new Error(ERR_IDENTITY_CONSENT_WIZARD_MISSING);
+    }
 };
 
 const createEmailConsentCounter = (counterEl: HTMLElement): void => {


### PR DESCRIPTION
## What does this change?
Updates the js & html consent journey to use named steps instead of best guessing step numbers. also preemptively abstracts the `next` button so some steps can override it to show a roadblock or disable it.

## What is the value of this and can you measure success?
At the moment some detectors in `wizardPageChangedEv` are no longer working because i introduced some breaking changes on `wizard` as no production code is using it. This fixes that.