### PR TITLE
New header feedback prompt

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -535,4 +535,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2017, 12, 15),
     exposeClientSide = true
   )
+
+  val HeaderFeedback = Switch(
+    SwitchGroup.Feature,
+    "header-feedback",
+    "When ON a feedback prompt will be visible within the header test",
+    owners = Seq(Owner.withGithub("zeftilldeath")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 12, 4),
+    exposeClientSide = false
+  )
 }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -2,7 +2,7 @@
 
 @import common.{ LinkTo, Edition }
 @import navigation.{ NewNavigation, NavigationHelpers, NavLink }
-@import conf.switches.Switches.SearchSwitch
+@import conf.switches.Switches.{SearchSwitch, HeaderFeedback}
 @import views.support.RenderClasses
 
 @sectionList(topLevelSection: NewNavigation.EditionalisedNavigationSection, edition: Edition) = {
@@ -179,14 +179,16 @@
                     @brandExtensions(item)
                 }
 
-                <li class="hide-until-desktop feedback-form">
-                    @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
-                    This navigation is new. We'd appreciate your feedback.
-                    <a class="feedback-form__link"
-                    data-link-name="nav2 : feedback-form"
-                    href="">
-                    Share your thoughts here.</a>
-                </li>
+                @if(HeaderFeedback.isSwitchedOn) {
+                    <li class="hide-until-desktop feedback-form">
+                        @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
+                        This navigation is new. We'd appreciate your feedback.
+                        <a class="feedback-form__link"
+                        data-link-name="nav2 : feedback-form"
+                        href="">
+                        Share your thoughts here.</a>
+                    </li>
+                }
             </ul>
         </div>
     </div>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -182,10 +182,10 @@
                 @if(HeaderFeedback.isSwitchedOn) {
                     <li class="hide-until-desktop feedback-form">
                         @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
-                        This navigation is new. We&rsquo;d appreciate your feedback.
+                        We&rsquo;d appreciate your feedback on our new navigation.
                         <a class="feedback-form__link"
                         data-link-name="nav2 : feedback-form"
-                        href="">
+                        href="https://goo.gl/forms/j5pMsPSWINu7X2R62">
                         Share your thoughts here.</a>
                     </li>
                 }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -178,6 +178,15 @@
                 @NewNavigation.BrandExtensions.getEditionalisedNavLinks(edition).map { item =>
                     @brandExtensions(item)
                 }
+
+                <li class="hide-until-desktop feedback-form">
+                    @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
+                    This navigation is new. We'd appreciate your feedback.
+                    <a class="feedback-form__link"
+                    data-link-name="nav2 : feedback-form"
+                    href="">
+                    Share your thoughts here.</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -182,7 +182,7 @@
                 @if(HeaderFeedback.isSwitchedOn) {
                     <li class="hide-until-desktop feedback-form">
                         @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
-                        This navigation is new. We'd appreciate your feedback.
+                        This navigation is new. We&rsquo;d appreciate your feedback.
                         <a class="feedback-form__link"
                         data-link-name="nav2 : feedback-form"
                         href="">

--- a/static/src/stylesheets/layout/new-header/_menu-group.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-group.scss
@@ -111,11 +111,15 @@
             left: gs-span(12) + $gs-gutter * 2;
             top: 0;
             bottom: 0;
-            width: gs-span(3);
+            width: gs-span(2);
 
             &:before {
                 content: '';
             }
+        }
+
+        @include mq(wide) {
+            width: gs-span(3);
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -195,3 +195,28 @@ from scrolling */
 x:-o-prefocus, .new-header__cta-container  {
     display: none;
 }
+
+.feedback-form {
+    background-color: $multimedia-main-2;
+    box-sizing: border-box;
+    bottom: 0;
+    color: $neutral-1;
+    font-size: 14px;
+    line-height: 18px;
+    padding: ($gs-baseline / 2) ($gs-gutter / 4) ($gs-baseline + $gs-baseline / 2);
+    float: right;
+    margin-top: 6px;
+    max-width: gs-span(4);
+
+    body:not(.has-page-skin) & {
+        @include mq(leftCol) {
+            float: none;
+            position: absolute;
+        }
+    }
+}
+
+.feedback-form__icon__svg {
+    margin-bottom: -2px;
+    fill: $neutral-1;
+}


### PR DESCRIPTION
Just like last time, we need a very prominent prompt for feedback in the expanded menu of the new header.

# It looks like this:
<img width="1664" alt="screen shot 2017-12-04 at 16 32 32" src="https://user-images.githubusercontent.com/14570016/33563844-e3d9342c-d910-11e7-8853-45aaa94f2b16.png">
<img width="1013" alt="screen shot 2017-12-04 at 16 32 48" src="https://user-images.githubusercontent.com/14570016/33563845-e3ec6e20-d910-11e7-8255-5b81ee4cc110.png">

It's wrapped up in a switch so it can be turned off the moment we have enough responses. 

**Not going to merge** until we get a link from UX to add to the prompt.
