### PR TITLE
(Behind switch) Redirect users with V1 consents to /consent

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -175,6 +175,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val IdentityRedirectUsersWithLingeringV1ConsentsSwitch = Switch(
+    SwitchGroup.Identity,
+    "id-redirect-users-with-lingering-v1-consents",
+    "If switched on, users trying to reach /email-prefs will go to /consent to repermission",
+    owners = Seq(Owner.withGithub("walaura")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 15),
+    exposeClientSide = false
+  )
+
   val EnhanceTweetsSwitch = Switch(
     SwitchGroup.Feature,
     "enhance-tweets",

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -103,7 +103,7 @@ class AuthenticatedActions(
         request.user.statusFields.hasRepermissioned match {
           case Some(true) =>
             newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
-              val subs = newsletterService.getEmailSubscriptions(emailFilledForm)
+              val subs = newsletterService.getV1EmailSubscriptions(emailFilledForm)
               if(subs.length <= 0) {
                 Right(request)
               }

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -97,16 +97,16 @@ class AuthenticatedActions(
 
   def apiUserShouldRepermissionRefiner: ActionRefiner[AuthRequest, AuthRequest] = new ActionRefiner[AuthRequest, AuthRequest] {
     override val executionContext = ec
-    //TODO: verify if the user reperm'd instead of validate. also verify v1 email subs
+    //TODO: verify v1 email subs
     def refine[A](request: AuthRequest[A]) = Future.successful {
       if(IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn) {
-        request.user.statusFields.userEmailValidated match {
-          case Some(true) => Right(request);
-          case _ => Left(sendUserToConsentJourney(request));
+        request.user.statusFields.hasRepermissioned match {
+          case Some(true) => Right(request)
+          case _ => Left(sendUserToConsentJourney(request))
         }
       }
       else {
-        Right(request);
+        Right(request)
       }
     }
   }

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -34,7 +34,7 @@ class AuthenticatedActions(
     val redirectUrlWithParams =identityUrlBuilder.appendQueryParams(path,List(
       "INTCMP" -> "email",
       "returnUrl" -> returnUrl
-    ));
+    ))
 
     SeeOther(identityUrlBuilder.buildUrl(redirectUrlWithParams))
   }

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -29,14 +29,12 @@ class AuthenticatedActions(
   def redirectWithReturn(request: RequestHeader, path: String): Result = {
     val returnUrl = URLEncoder.encode(identityUrlBuilder.buildUrl(request.uri), "UTF-8")
 
-    val paramsToPass =
-      List("INTCMP", "email")
-        .flatMap(name => request.getQueryString(name).map(value => s"&$name=$value"))
-        .mkString
+    val redirectUrlWithParams =identityUrlBuilder.appendQueryParams(path,List(
+      "INTCMP" -> "email",
+      "returnUrl" -> returnUrl
+    ));
 
-    val signinUrl = s"$path?returnUrl=$returnUrl$paramsToPass"
-
-    SeeOther(identityUrlBuilder.buildUrl(signinUrl))
+    SeeOther(identityUrlBuilder.buildUrl(redirectUrlWithParams))
   }
 
   def sendUserToConsentJourney(request: RequestHeader): Result =

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -40,7 +40,10 @@ class AuthenticatedActions(
   }
 
   def sendUserToConsentJourney(request: RequestHeader): Result =
-    redirectWithReturn(request, "/consent")
+    redirectWithReturn(request, "/consent?journey=repermission")
+
+  def sendUserToNarrowConsentJourney(request: RequestHeader): Result =
+    redirectWithReturn(request, "/consent?journey=repermission-narrow")
 
   def sendUserToSignin(request: RequestHeader): Result =
     redirectWithReturn(request, "/signin")

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -101,8 +101,8 @@ class AuthenticatedActions(
     def refine[A](request: AuthRequest[A]) = Future.successful {
       if(IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn) {
         request.user.statusFields.userEmailValidated match {
-          case Some(true) => Left(sendUserToConsentJourney(request));
-          case _ => Right(request);
+          case Some(true) => Right(request);
+          case _ => Left(sendUserToConsentJourney(request));
         }
       }
       else {

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -8,7 +8,7 @@ import idapiclient.IdApiClient
 import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
 import play.api.mvc._
 import services.{AuthenticatedUser, AuthenticationService, IdentityUrlBuilder}
-import conf.switches.Switches.IdentityRedirectUsersWithLingeringV1ConsentsSwitch
+import conf.switches.Switches.{IdentityRedirectUsersWithLingeringV1ConsentsSwitch, IdentityAllowAccessToGdprJourneyPageSwitch}
 
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -99,7 +99,7 @@ class AuthenticatedActions(
     override val executionContext = ec
     //TODO: verify if the user reperm'd instead of validate. also verify v1 email subs
     def refine[A](request: AuthRequest[A]) = Future.successful {
-      if(IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn) {
+      if(IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn) {
         request.user.statusFields.userEmailValidated match {
           case Some(true) => Left(sendUserToConsentJourney(request));
           case _ => Right(request);

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -147,7 +147,7 @@ class EditProfileController(
       consentHint: Option[String] = None) = {
 
     csrfAddToken {
-      recentlyAuthenticated.async { implicit request =>
+      authWithConsentRedirectAction.async { implicit request =>
         profileFormsView(
           page = page,
           forms = ProfileForms(userWithHintedConsent(consentHint), PublicEditProfilePage),

--- a/identity/app/services/NewsletterService.scala
+++ b/identity/app/services/NewsletterService.scala
@@ -71,11 +71,18 @@ class NewsletterService(
   }
 
   def getEmailSubscriptions(
+     form: Form[EmailPrefsData],
+     add: List[String] = List(),
+     remove: List[String] = List()): List[String] = {
+    (form.data.filter(_._1.startsWith("currentEmailSubscriptions")).map(_._2).filterNot(remove.toSet) ++ add).toList
+  }
+
+  def getV1EmailSubscriptions(
       form: Form[EmailPrefsData],
       add: List[String] = List(),
       remove: List[String] = List()): List[String] = {
-
-    (form.data.filter(_._1.startsWith("currentEmailSubscriptions")).map(_._2).filterNot(remove.toSet) ++ add).toList
+    //TODO: only return V1 subscriptions when V2 subscriptions are in place
+    getEmailSubscriptions(form,add,remove)
   }
 }
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -53,7 +53,7 @@ import scala.concurrent.Future
     val authenticatedUser = AuthenticatedUser(user, testAuth)
     val phoneNumbers = PhoneNumbers
 
-    val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent)
+    val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser)
 
     val profileFormsMapping = ProfileFormsMapping(
       new AccountDetailsMapping,

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -37,10 +37,12 @@ class FormstackControllerTest extends path.FreeSpec
   val idRequest = mock[IdentityRequest]
   val trackingData = mock[TrackingData]
   val authService = mock[AuthenticationService]
+  val api = mock[IdApiClient]
+  val newsletterService = spy(new NewsletterService(api, requestParser, idUrlBuilder))
 
   val userId = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
-  val authenticatedActions = new AuthenticatedActions(authService, mock[IdApiClient], mock[IdentityUrlBuilder], controllerComponents)
+  val authenticatedActions = new AuthenticatedActions(authService, mock[IdApiClient], mock[IdentityUrlBuilder], controllerComponents, newsletterService, requestParser)
 
   when(authService.authenticatedUserFor(MockitoMatchers.any[RequestHeader])) thenReturn Some(AuthenticatedUser(user, ScGuU("abc", GuUCookieData(user, 0, None))))
 


### PR DESCRIPTION
## What does this change?
When this switch is enabled, redirects users going to `/email-prefs` (or any profile page at the moment) to `/consent?journey=repermission`so they can get their consents inline with the V2 ones. it also defines a second redirection to `/consent?journey=repermission-narrow` which will be used when a user has already repermissioned but created a new V1 email consent after that

## What is the value of this and can you measure success?
TODO: there's still no check for V1 email consents

Related PR: https://github.com/guardian/identity/pull/728