### PR TITLE
Fix acquisition tracking for motherload campaign

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -79,8 +79,9 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
                 const iframeSrc = el.getAttribute('src');
                 if (
                     iframeSrc &&
-                    iframeSrc.startsWith('https://interactive.guim.co.uk') &&
-                    iframeSrc === event.source.location.href
+                    iframeSrc.startsWith(
+                        'https://interactive.guim.co.uk/embed/2017/12/the-mother-load/'
+                    )
                 ) {
                     el.contentWindow.postMessage(
                         JSON.stringify({

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -79,6 +79,8 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
                 const iframeSrc = el.getAttribute('src');
                 if (
                     iframeSrc &&
+                    // Currently the only acquisition components on the site are from the Mother Load campaign.
+                    // Work needs to be done so we don't have to hard code what campaigns are running.
                     iframeSrc.startsWith(
                         'https://interactive.guim.co.uk/embed/2017/12/the-mother-load/'
                     )


### PR DESCRIPTION
## What does this change?

Changes the condition on which acquisition data is sent to an iFrame. The issue with the previous check was that Chrome prevents access to iFrames from a different domain. Note, this fix isn't general, but sufficient for now.

## What is the value of this and can you measure success?

Allows us to analyse the conversion rates of different articles.

