### PR TITLE
Support all three flows in the consent journey

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -36,16 +36,90 @@
    }
 }
 
-@consentStep() = {
-    Consent step contents
+@consentStep(journey:String) = {
+    <div class="manage-account-wizard__step" data-wizard-step-name="consent">
+
+        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+            @views.html.helper.CSRF.formField
+
+            @if(journey == "repermission") {
+                <h1 class="identity-title">
+                    We need you to consent again to receiving communications from The Guardian
+                </h1>
+                <p class="manage-account-headerNote">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
+            } else {
+                <h1 class="identity-title">
+                    Would you like to receive communications from us?
+                </h1>
+                <p class="manage-account-headerNote">Tick the boxes you are interested in</p>
+            }
+            <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
+                <div class="manage-account__switches">
+                    <ul>
+                    @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
+                        <li>
+                            @if(index == 0) {
+                                @fragments.consentSwitch(consentField, consentHint)(messages)
+                            } else {
+                                @fragments.consentSwitch(consentField)(messages)
+                            }
+                        </li>
+                    }
+                    </ul>
+                </div>
+            </div>
+        </form>
+
+    </div>
 }
 
-@emailStep() = {
-    Emails step contents
+@emailStep(isNarrow: Boolean = false) = {
+    <div class="manage-account-wizard__step" data-wizard-step-name="email">
+
+        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+            @views.html.helper.CSRF.formField
+            @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+
+            @if(isNarrow) {
+                <h2 class="identity-title">Email Preferences</h2>
+                <p class="manage-account-headerNote">
+                    You were receiving these newsletters, check them again to confirm you want to keep receiving them.
+                </p>
+            } else {
+                <h2 class="identity-title">Sorry for the interruption</h2>
+                <p class="manage-account-headerNote">
+                    Do you still want to receive the following newsletters? Please check them again if you do.
+                </p>
+            }
+            <div class="manage-account__switches">
+                <ul>
+                @hintendNewsletters.filter(_.theme == "news").zipWithRowInfo.map { case (newsletter, row) =>
+                <li>
+                    @fragments.newsletterSwitch(
+                        emailPrefsForm,
+                        emailSubscriptions,
+                        newsletter = newsletter
+                    )(nonInputFields, messages, request)
+                </li>
+                }
+                </ul>
+            </div>
+        </form>
+    </div>
 }
 
-@successStep() = {
-    Success step contents
+@endcardStep() = {
+    <div class="manage-account-wizard__step" data-wizard-step-name="endcard">
+        <div class="js-manage-account-wizard__next">
+            <div class="manage-account-consent-thanks">
+                <h2 class="manage-account-consent-thanks__title">Thank you</h2>
+                <aside class="manage-account-consent-thanks__content">
+                    <p>Your support helps us deliver the quality independent journalism the world needs</p>
+                    <a class="manage-account__button" href="@verifiedReturnUrl">Continue</a>
+                </aside>
+            </div>
+        </div>
+    </div>
 }
 
 
@@ -60,87 +134,23 @@
                     <div class="js-errorHolder manage-account__errors"></div>
 
                     <div class="manage-account-wizard manage-account-wizard--consent" >
-                        <div class="manage-account-wizard__step" data-wizard-step-name="consent">
 
-                            <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-                                @views.html.helper.CSRF.formField
+                        @journey match {
+                            case "repermission-narrow" => {
+                                @emailStep()
+                            }
+                            case "repermission" => {
+                                @consentStep(journey = "repermission")
+                                @emailStep(isNarrow = true)
+                            }
+                            case "signup" => {
+                                @consentStep(journey = "signup")
+                                @emailStep()
+                            }
+                        }
 
-                                @if(journey == "repermission") {
-                                    <h1 class="identity-title">
-                                        We need you to consent again to receiving communications from The Guardian
-                                    </h1>
-                                    <p class="manage-account-headerNote">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
-                                } else {
-                                    <h1 class="identity-title">
-                                        Would you like to receive communications from us?
-                                    </h1>
-                                    <p class="manage-account-headerNote">Tick the boxes you are interested in</p>
-                                }
-                                <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
-                                    <div class="manage-account__switches">
-                                        <ul>
-                                        @helper.repeatWithIndex(forms.privacyForm("consents"), min=1) { (consentField, index) =>
-                                            <li>
-                                                @if(index == 0) {
-                                                    @fragments.consentSwitch(consentField, consentHint)(messages)
-                                                } else {
-                                                    @fragments.consentSwitch(consentField)(messages)
-                                                }
-                                            </li>
-                                        }
-                                        </ul>
-                                    </div>
-                                </div>
+                        @endcardStep()
 
-                                <fieldset class="fieldset fieldset--manage-account-rightsubmit js-manage-account__ajaxForm-submit">
-                                    <div class="fieldset__heading"></div>
-                                    <div class="fieldset__fields">
-                                        <ul class="u-unstyled">
-                                            <li>
-                                                <button type="submit" class="manage-account__button" data-link-name="Save changes">Save changes</button>
-                                            </li>
-                                        </ul>
-                                    </div>
-
-                                </fieldset>
-
-                            </form>
-
-                        </div>
-                        <div class="manage-account-wizard__step" data-wizard-step-name="email">
-
-                            <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-                                @views.html.helper.CSRF.formField
-                                @fragments.form.hidden(emailPrefsForm("htmlPreference"))
-
-                                <h2 class="manage-account-header">Email Preferences</h2>
-                                <p class="manage-account-headerNote">You were receiving these newsletters, check them again to confirm you want to keep receiving them.</p>
-                                <div class="manage-account__switches">
-                                    <ul>
-                                    @hintendNewsletters.filter(_.theme == "news").zipWithRowInfo.map { case (newsletter, row) =>
-                                        <li>
-                                            @fragments.newsletterSwitch(
-                                                emailPrefsForm,
-                                                emailSubscriptions,
-                                                newsletter = newsletter
-                                            )(nonInputFields, messages, request)
-                                        </li>
-                                    }
-                                    </ul>
-                                </div>
-                            </form>
-                        </div>
-                        <div class="manage-account-wizard__step" data-wizard-step-name="endcard">
-                            <div class="js-manage-account-wizard__next">
-                                <div class="manage-account-consent-thanks">
-                                    <h2 class="manage-account-consent-thanks__title">Thank you</h2>
-                                    <aside class="manage-account-consent-thanks__content">
-                                        <p>Your support helps us deliver the quality independent journalism the world needs</p>
-                                        <a class="manage-account__button" href="@verifiedReturnUrl">Continue</a>
-                                    </aside>
-                                </div>
-                            </div>
-                        </div>
                         <div class="manage-account-wizard__controls">
                             <a class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev">
                                 <span class="u-h">Previous</span>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -36,6 +36,19 @@
    }
 }
 
+@consentStep() = {
+    Consent step contents
+}
+
+@emailStep() = {
+    Emails step contents
+}
+
+@successStep() = {
+    Success step contents
+}
+
+
 @mainLegacy(page, projectName = Option("identity")) { } {
 
     <div class="identity-wrapper-for-bg">

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -144,7 +144,7 @@
 
                     <div class="js-errorHolder manage-account__errors"></div>
 
-                    <div class="manage-account-wizard manage-account-wizard--consent" >
+                    <div class="manage-account-wizard manage-account-wizard--consent" data-journey="@journey">
 
                         @journey match {
                             case "repermission-narrow" => {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -93,16 +93,35 @@
             }
             <div class="manage-account__switches">
                 <ul>
-                @hintendNewsletters.filter(_.theme == "news").zipWithRowInfo.map { case (newsletter, row) =>
-                <li>
-                    @fragments.newsletterSwitch(
-                        emailPrefsForm,
-                        emailSubscriptions,
-                        newsletter = newsletter
-                    )(nonInputFields, messages, request)
-                </li>
-                }
+                    @onlySubscribedToNewsletters.zipWithRowInfo.map { case (newsletter, row) =>
+                        <li>
+                            @fragments.newsletterSwitch(
+                                emailPrefsForm,
+                                emailSubscriptions,
+                                newsletter = newsletter
+                            )(nonInputFields, messages, request)
+                        </li>
+                    }
                 </ul>
+            </div>
+        </form>
+    </div>
+}
+
+@emailSignupStep() = {
+    <div class="manage-account-wizard__step" data-wizard-step-name="email-signup">
+
+        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+            @views.html.helper.CSRF.formField
+            @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+
+            <h2 class="identity-title">Love email? Gosh, so do we!</h2>
+            <p class="manage-account-headerNote">
+                Sign up to whatever newsletters tickle your fancy and we'll make sure you get them on time.
+            </p>
+
+            <div class="manage-account__switches">
+                @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions,true)(request, messages)
             </div>
         </form>
     </div>
@@ -145,7 +164,7 @@
                             }
                             case "signup" => {
                                 @consentStep(journey = "signup")
-                                @emailStep()
+                                @emailSignupStep()
                             }
                         }
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -28,14 +28,6 @@
     }
 }
 
-@hintendNewsletters = @{
-   if (newsletterHint.isDefined) {
-       onlySubscribedToNewsletters
-   } else {
-       EmailNewsletters.all.subscriptions
-   }
-}
-
 @consentStep(journey:String) = {
     <div class="manage-account-wizard__step" data-wizard-step-name="consent">
 

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -1,0 +1,34 @@
+@import _root_.form.IdFormHelpers.nonInputFields
+@import _root_.com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
+@import services.EmailPrefsData
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(
+    emailPrefsForm: Form[EmailPrefsData],
+    availableLists: EmailNewsletters,
+    emailSubscriptions: List[String]
+)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+
+@emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
+    @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
+        <div class="manage-account__switches">
+            <ul>
+                @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
+                    <li>
+                        @fragments.newsletterSwitch(
+                            emailPrefsForm,
+                            emailSubscriptions,
+                            newsletter = newsletter
+                        )(nonInputFields, messages, request)
+                    </li>
+                }
+            </ul>
+        </div>
+    }
+}
+
+<div class="email-subscriptions">
+    @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
+        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), false)
+    }
+</div>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -6,7 +6,8 @@
 @(
     emailPrefsForm: Form[EmailPrefsData],
     availableLists: EmailNewsletters,
-    emailSubscriptions: List[String]
+    emailSubscriptions: List[String],
+    startsOpen: Boolean = false
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
@@ -29,6 +30,6 @@
 
 <div class="email-subscriptions">
     @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
-        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), false)
+        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), (startsOpen == true && index == 0))
     }
 </div>

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -17,7 +17,7 @@
         @newsletter.frequency
     </div>
     @if(newsletter.exampleUrl.isDefined){
-        <a target="preview-email-@newsletter.listId" href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })">
+        <a class="manage-account__switch-footer-email-preview" target="preview-email-@newsletter.listId" href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })">
             See the latest email
         </a>
     }

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -13,24 +13,6 @@
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
-@emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
-    @fragments.dropdown(theme, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
-
-        <div class="manage-account__switches"><ul>
-            @newsletters.zipWithRowInfo.map { case (newsletter, row) =>
-
-                <li>
-                    @fragments.newsletterSwitch(
-                        emailPrefsForm,
-                        emailSubscriptions,
-                        newsletter = newsletter
-                    )(nonInputFields, messages, request)
-                </li>
-            }
-        </ul></div>
-    }
-}
-
 @buildIdentityUrl(endpoint: String) = {
     @idUrlBuilder.buildUrl(s"/$endpoint", idRequest)
 }
@@ -40,11 +22,8 @@
     @if(emailPrefsForm.globalError.isDefined) {
         <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
     }
-    <div class="email-subscriptions">
-    @List("news", "features", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
-        @emailListCategoryList(theme, availableLists.subscriptions.filter(_.theme == theme), false)
-    }
-    </div>
+
+    @fragments.emailListCategories(emailPrefsForm,availableLists,emailSubscriptions)(request, messages)
 
     <div class="email-subscription__fieldset">
 

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -77,7 +77,7 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                             if (stepCount <= 2) {
                                 buttonBackEl.remove();
                             } else {
-                                buttonBackEl.classList.toggle(
+                                buttonBackEl && buttonBackEl.classList.toggle(
                                     'manage-account-consent-wizard__revealable--visible',
                                     ev.detail.position > 0
                                 );

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -76,8 +76,8 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                         fastdom.write(() => {
                             if (stepCount <= 2) {
                                 buttonBackEl.remove();
-                            } else {
-                                buttonBackEl && buttonBackEl.classList.toggle(
+                            } else if (buttonBackEl) {
+                                buttonBackEl.classList.toggle(
                                     'manage-account-consent-wizard__revealable--visible',
                                     ev.detail.position > 0
                                 );

--- a/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-wizard.js
@@ -51,6 +51,9 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
         if (ev.target === wizardEl) {
             fastdom
                 .read(() => [
+                    wizardEl.getElementsByClassName(
+                        'manage-account-wizard__step'
+                    ).length,
                     [
                         ...document.getElementsByClassName(
                             'manage-account-consent-wizard-counter'
@@ -62,18 +65,29 @@ const bindEmailConsentCounterToWizard = (wizardEl: HTMLElement): void => {
                         ),
                     ][0],
                 ])
-                .then(([counterEl: HTMLElement, buttonBackEl: HTMLElement]) => {
-                    fastdom.write(() => {
-                        counterEl.classList.toggle(
-                            'manage-account-consent-wizard__revealable--visible',
-                            ev.detail.positionName === positions.email
-                        );
-                        buttonBackEl.classList.toggle(
-                            'manage-account-consent-wizard__revealable--visible',
-                            ev.detail.position > 0
-                        );
-                    });
-                });
+                .then(
+                    (
+                        [
+                            stepCount: number,
+                            counterEl: HTMLElement,
+                            buttonBackEl: HTMLElement,
+                        ]
+                    ) =>
+                        fastdom.write(() => {
+                            if (stepCount <= 2) {
+                                buttonBackEl.remove();
+                            } else {
+                                buttonBackEl.classList.toggle(
+                                    'manage-account-consent-wizard__revealable--visible',
+                                    ev.detail.position > 0
+                                );
+                            }
+                            counterEl.classList.toggle(
+                                'manage-account-consent-wizard__revealable--visible',
+                                ev.detail.positionName === positions.email
+                            );
+                        })
+                );
         }
     });
 };

--- a/static/src/stylesheets/module/identity/_consent-wizard.scss
+++ b/static/src/stylesheets/module/identity/_consent-wizard.scss
@@ -20,6 +20,11 @@
         flex: 1 1 auto;
         margin: 0 $gs-gutter / 3;
     }
+    &[data-journey=repermission], &[data-journey=repermission-narrow] {
+        .manage-account__switch-footer-email-preview {
+            display: none;
+        }
+    }
 }
 
 .manage-account-consent-wizard__revealable {


### PR DESCRIPTION
## What does this change?
Cleans up the code on the consent journey to support all three defined launch journeys, them being:

- 🐝 **repermission**
  where all v1 consent users will be redirected to to upgrade their consents to v2 consents

- 🌳 **repermission-narrow**
  where users who have repermissioned but have a v1 newsletter consent because they used an old signup widget will be 1 time redirected to sort out their situation and upgrade their lingering v1 consents

- 🍗 **signup**
  where all new signups will land to grant us (or not!) fresh v2 consents

## What is the value of this and can you measure success?

Step towards GDPR compliance.

## Does this affect other platforms - Amp, Apps, etc?
Not at the moment, all of this is behind a flag

## Screenshots
Check the url for the journey type

![screen shot 2017-12-05 at 12 38 34](https://user-images.githubusercontent.com/11539094/33607691-cfae2e5e-d9b9-11e7-8b70-56be995b5609.png)
![screen shot 2017-12-05 at 12 38 25](https://user-images.githubusercontent.com/11539094/33607692-cfc1764e-d9b9-11e7-8377-8f93f080f052.png)
![screen shot 2017-12-05 at 12 37 49](https://user-images.githubusercontent.com/11539094/33607693-cfd66e82-d9b9-11e7-8479-8fb113a02bad.png)
