### PR TITLE
Repermission cookie check to access consent page

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -81,13 +81,10 @@ class AuthenticatedActions(
     def refine[A](request: Request[A]) =
       authService.authenticateUserForPermissions(request) match {
         case Some(permUser) => Future.successful(Right(new AuthenticatedRequest(permUser, request)))
-        case None => if(authService.recentlyAuthenticated(request)) {
+        case _ =>
           authService.authenticatedUserFor(request) match {
-            case Some(authenticatedUser) => Future.successful(Right(new AuthenticatedRequest(authenticatedUser, request)))
-            case None => checkIdApiForUserAndRedirect(request)
-          }
-        } else {
-            Future.successful(Left(sendUserToReauthenticate(request)))
+            case Some(user) if user.hasRecentlyAuthenticated => Future.successful(Right(new AuthenticatedRequest(user, request)))
+            case _ => Future.successful(Left(sendUserToReauthenticate(request)))
           }
         }
   }

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -137,7 +137,7 @@ class AuthenticatedActions(
     override val executionContext = ec
 
     def refine[A](request: AuthRequest[A]) = Future.successful {
-      if (authService.recentlyAuthenticated(request)) Right(request) else Left(sendUserToReauthenticate(request))
+      if (request.user.hasRecentlyAuthenticated) Right(request) else Left(sendUserToReauthenticate(request))
     }
   }
   // Play will not let you set up an ActionBuilder with a Refiner hence this empty actionBuilder to set up Auth

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -64,7 +64,7 @@ class EditProfileController(
     }
     else {
       csrfAddToken {
-        recentlyAuthenticated.async { implicit request =>
+        permissionAuthentication.async { implicit request =>
           consentJourneyView(
             page = ConsentJourneyPage,
             journey = journey.getOrElse("repermission"),

--- a/identity/app/idapiclient/Auth.scala
+++ b/identity/app/idapiclient/Auth.scala
@@ -31,6 +31,10 @@ case class ScGuU(scGuUValue: String, data: GuUCookieData) extends Auth {
   override def headers: Parameters = Iterable("X-GU-ID-FOWARDED-SC-GU-U" -> scGuUValue)
 }
 
+case class ScGuRp(scGuRpValue: String) extends Auth {
+  override def headers: Parameters = Iterable("X-GU-ID-FOWARDED-SC-GU-RP" -> scGuRpValue)
+}
+
 case class TrackingData(returnUrl:Option[String], registrationType: Option[String], omnitureSVi: Option[String],
                             ipAddress: Option[String], referrer: Option[String], userAgent: Option[String]) {
   def parameters: Parameters = List(

--- a/identity/app/services/AuthenticationService.scala
+++ b/identity/app/services/AuthenticationService.scala
@@ -1,9 +1,8 @@
 package services
 
-import idapiclient.Auth
+import idapiclient.{Auth, ScGuRp, ScGuU}
 import com.gu.identity.model.User
 import conf.FrontendIdentityCookieDecoder
-import idapiclient.ScGuU
 import play.api.mvc.{RequestHeader, Results}
 
 import scala.language.implicitConversions
@@ -32,6 +31,11 @@ class AuthenticationService(cookieDecoder: FrontendIdentityCookieDecoder,
     authedUser <- authenticatedUserFor(request)
     scGuLa <- request.cookies.get("SC_GU_LA")
   } yield cookieDecoder.userHasRecentScGuLaCookie(authedUser, scGuLa.value, Minutes.minutes(20).toStandardDuration)).getOrElse(false)
+
+  def authenticateUserForPermissions(request: RequestHeader): Option[AuthenticatedUser] = for {
+    scGuRp <- request.cookies.get("SC_GU_RP")
+    fullUser <- cookieDecoder.getUserDataForGuRp(scGuRp.value)
+  } yield AuthenticatedUser(fullUser, ScGuRp(scGuRp.value))
 
   def requestPresentsAuthenticationCredentials(request: RequestHeader): Boolean = authenticatedUserFor(request).isDefined
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -50,7 +50,7 @@ import scala.concurrent.Future
     val userId: String = "123"
     val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
     val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
-    val authenticatedUser = AuthenticatedUser(user, testAuth)
+    val authenticatedUser = AuthenticatedUser(user, testAuth, true)
     val phoneNumbers = PhoneNumbers
 
     val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder], controllerComponent, newsletterService, idRequestParser)
@@ -62,7 +62,6 @@ import scala.concurrent.Future
     )
 
     when(authService.authenticatedUserFor(MockitoMatchers.any[RequestHeader])) thenReturn Some(authenticatedUser)
-    when(authService.recentlyAuthenticated(MockitoMatchers.any[RequestHeader])) thenReturn true
     when(api.me(testAuth)) thenReturn Future.successful(Right(user))
 
     when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.94"
+  val identityLibVersion = "3.95"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.43"


### PR DESCRIPTION
## What does this change?
- Allows access to the /consent page if user has a valid SU_GU_RP cookie or a recently authenticated SC_GU_LA cookie (same level needed to access /profile pages).
- Related to https://github.com/guardian/identity/pull/731 .
- Tests failing as the identity-cookie library has not been published yet.

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
