### PR TITLE
Fhj garnett base article meta 1

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -26,4 +26,81 @@
             fill: #DD0812;
         }
     }
+
+    .social-icon,
+    .social-icon.social-icon--more {
+        background-color: transparent;
+        border: 1px solid $neutral-5;
+
+        svg {
+            fill: #DD0812;
+        }
+        &:hover {
+            background-color: #DD0812;
+            border: 1px solid #DD0812;
+
+            svg {
+                fill: #FFFFFF;
+            }
+        }
+    }
+
+    .meta__social,
+    .meta__numbers,
+    .byline,
+    .content__dateline {
+        border-top: 1px solid $neutral-5;
+    }
+
+    .byline {
+        font-weight: 200;
+        color: #333333;
+        font-style: italic;
+
+        a {
+            color: #DD0812;
+        }
+
+        span[itemprop="author"]  {
+            display: block;
+            font-style: normal;
+            font-weight: 900;
+        }
+    }
+
+    .meta__twitter {
+
+        a {
+            background-color: transparent;
+            border: 1px solid $neutral-5;
+        }
+
+        .inline-tone-fill {
+            fill: #DD0812;
+        }
+
+        .button--secondary {
+            color: #DD0812;
+        }
+
+        &:hover {
+            a {
+                background-color: #DD0812;
+                border: 1px solid #DD0812;
+            }
+            .inline-tone-fill {
+                fill: #FFFFFF;
+            }
+            .button--secondary {
+                color: #FFFFFF;
+            }
+        }
+    }
+
+    .tone-colour {
+        color: #DD0812;
+    }
+    .inline-tone-fill {
+        fill: #dd0812;
+    }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -4,14 +4,16 @@
     .content__section-label__link,
     .drop-cap,
     .element-pullquote p,
-    a {
+    a,
+    .tone-colour {
         color: $pillarColor;
     }
 
     .inline-close,
     .inline-tone-fill,
     .social-icon svg,
-    .social-icon.social-icon--more svg {
+    .social-icon.social-icon--more svg,
+    .inline-close svg, {
         fill: $pillarColor;
     }
 
@@ -28,11 +30,21 @@
     }
 
     .social-icon,
-    .social-icon.social-icon--more {
+    .social-icon.social-icon--more,
+    .meta__twitter,
+    .inline-close {
         &:focus,
         &:hover {
             background-color: $pillarColor;
             border: 1px solid $pillarColor;
+        }
+    }
+
+    .social-tray__button {
+        &:hover {
+            .inline-close {
+                background-color: $pillarColor;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,5 +1,4 @@
 .content--pillar-news {
-<<<<<<< HEAD
     .content__section-label__link,
     .drop-cap,
     .element-pullquote p,
@@ -18,12 +17,7 @@
     .u-underline:hover {
         border-bottom: solid 1px $news-garnett-main-1;
     }
-=======
-
-    .social-icon,
-    .social-icon.social-icon--more {
-        background-color: transparent;
-        border: 1px solid $neutral-5;
+<<<<<<< HEAD
 
         svg {
             fill: #DD0812;

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,3 +1,51 @@
+@mixin colorPalatte($pillarColor, $kickerColor) {
+   .content__section-label__link,
+   .drop-cap,
+   .element-pullquote p,
+   a,
+   .byline,
+   .button--secondary {
+       color: $pillarColor;
+
+       }
+
+    .inline-tone-fill,
+    .social-icon svg,
+    .social-icon.social-icon--more svg,
+    .inline-close {
+        fill: $pillarColor;
+    }
+
+   .inline-quote svg {
+       fill: $kickerColor;
+   }
+
+   .pullquote-cite {
+       color: $kickerColor;
+   }
+
+   .u-underline:hover {
+       border-bottom: solid 1px $pillarColor;
+   }
+
+   .social-icon,
+   .social-icon.social-icon--more {
+       &:hover, &:focus {
+           background-color: $pillarColor;
+           border: 1px solid $pillarColor;
+       }
+   }
+
+}
+
+.content--pillar-news {
+   @include colorPalatte($news-garnett-main-1, $neutral-3);
+}
+
+.content--pillar-opinion {
+   @include colorPalatte($opinion-garnett-main-1, $neutral-3);
+}
+
 .content--pillar-news {
     .content__section-label__link,
     .drop-cap,
@@ -23,84 +71,7 @@
         border: 1px solid #neutral-1;
 
         svg {
-            fill: #DD0812;
+            fill: $news-garnett-main-1;
         }
-    }
-
-    .social-icon,
-    .social-icon.social-icon--more {
-        background-color: transparent;
-        border: 1px solid $neutral-5;
-
-        svg {
-            fill: #DD0812;
-        }
-        &:hover {
-            background-color: #DD0812;
-            border: 1px solid #DD0812;
-
-            svg {
-                fill: #FFFFFF;
-            }
-        }
-    }
-
-    .meta__social,
-    .meta__numbers,
-    .byline,
-    .content__dateline {
-        border-top: 1px solid $neutral-5;
-    }
-
-    .byline {
-        font-weight: 200;
-        color: #333333;
-        font-style: italic;
-
-        a {
-            color: #DD0812;
-        }
-
-        span[itemprop="author"]  {
-            display: block;
-            font-style: normal;
-            font-weight: 900;
-        }
-    }
-
-    .meta__twitter {
-
-        a {
-            background-color: transparent;
-            border: 1px solid $neutral-5;
-        }
-
-        .inline-tone-fill {
-            fill: #DD0812;
-        }
-
-        .button--secondary {
-            color: #DD0812;
-        }
-
-        &:hover {
-            a {
-                background-color: #DD0812;
-                border: 1px solid #DD0812;
-            }
-            .inline-tone-fill {
-                fill: #FFFFFF;
-            }
-            .button--secondary {
-                color: #FFFFFF;
-            }
-        }
-    }
-
-    .tone-colour {
-        color: #DD0812;
-    }
-    .inline-tone-fill {
-        fill: #dd0812;
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -31,8 +31,7 @@
 
     .social-icon,
     .social-icon.social-icon--more,
-    .meta__twitter,
-    .inline-close {
+    .meta__twitter a {
         &:focus,
         &:hover {
             background-color: $pillarColor;

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,3 +1,24 @@
 .content--pillar-news {
-   
+
+
+
+.social-icon {
+    background-color: inherit;
+    border: 1px solid #neutral-1;
+
+    svg {
+        fill: #DD0812;
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -17,4 +17,13 @@
     .u-underline:hover {
         border-bottom: solid 1px $news-garnett-main-1;
     }
+
+    .social-icon {
+        background-color: inherit;
+        border: 1px solid #neutral-1;
+
+        svg {
+            fill: #DD0812;
+        }
+    }
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -20,26 +20,82 @@
     }
 =======
 
+    .social-icon,
+    .social-icon.social-icon--more {
+        background-color: transparent;
+        border: 1px solid $neutral-5;
 
+        svg {
+            fill: #DD0812;
+        }
+        &:hover {
+            background-color: #DD0812;
+            border: 1px solid #DD0812;
 
-.social-icon {
-    background-color: inherit;
-    border: 1px solid #neutral-1;
-
-    svg {
-        fill: #DD0812;
+            svg {
+                fill: #FFFFFF;
+            }
+        }
     }
-}
 
+    .meta__social,
+    .meta__numbers,
+    .byline,
+    .content__dateline {
+        border-top: 1px solid $neutral-5;
+    }
 
+    .byline {
+        font-weight: 200;
+        color: #333333;
+        font-style: italic;
 
+        a {
+            color: #DD0812;
+        }
 
+        span[itemprop="author"]  {
+            display: block;
+            font-style: normal;
+            font-weight: 900;
+        }
+    }
 
+    .meta__twitter {
 
+        a {
+            background-color: transparent;
+            border: 1px solid $neutral-5;
+        }
 
+        .inline-tone-fill {
+            fill: #DD0812;
+        }
 
+        .button--secondary {
+            color: #DD0812;
+        }
 
+        &:hover {
+            a {
+                background-color: #DD0812;
+                border: 1px solid #DD0812;
+            }
+            .inline-tone-fill {
+                fill: #FFFFFF;
+            }
+            .button--secondary {
+                color: #FFFFFF;
+            }
+        }
+    }
 
+    .tone-colour {
+        color: #DD0812;
+    }
+    .inline-tone-fill {
+        fill: #dd0812;
+    }
 
 >>>>>>> testing red
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,3 +1,51 @@
+@mixin colorPalatte($pillarColor, $kickerColor) {
+   .content__section-label__link,
+   .drop-cap,
+   .element-pullquote p,
+   a,
+   .byline,
+   .button--secondary {
+       color: $pillarColor;
+
+       }
+
+    .inline-tone-fill,
+    .social-icon svg,
+    .social-icon.social-icon--more svg,
+    .inline-close {
+        fill: $pillarColor;
+    }
+
+   .inline-quote svg {
+       fill: $kickerColor;
+   }
+
+   .pullquote-cite {
+       color: $kickerColor;
+   }
+
+   .u-underline:hover {
+       border-bottom: solid 1px $pillarColor;
+   }
+
+   .social-icon,
+   .social-icon.social-icon--more {
+       &:hover, &:focus {
+           background-color: $pillarColor;
+           border: 1px solid $pillarColor;
+       }
+   }
+
+}
+
+.content--pillar-news {
+   @include colorPalatte($news-garnett-main-1, $neutral-3);
+}
+
+.content--pillar-opinion {
+   @include colorPalatte($opinion-garnett-main-1, $neutral-3);
+}
+
 .content--pillar-news {
     .content__section-label__link,
     .drop-cap,
@@ -21,73 +69,6 @@
         svg {
             fill: #DD0812;
         }
-        &:hover {
-            background-color: #DD0812;
-            border: 1px solid #DD0812;
-
-            svg {
-                fill: #FFFFFF;
-            }
-        }
-    }
-
-    .meta__social,
-    .meta__numbers,
-    .byline,
-    .content__dateline {
-        border-top: 1px solid $neutral-5;
-    }
-
-    .byline {
-        font-weight: 200;
-        color: #333333;
-        font-style: italic;
-
-        a {
-            color: #DD0812;
-        }
-
-        span[itemprop="author"]  {
-            display: block;
-            font-style: normal;
-            font-weight: 900;
-        }
-    }
-
-    .meta__twitter {
-
-        a {
-            background-color: transparent;
-            border: 1px solid $neutral-5;
-        }
-
-        .inline-tone-fill {
-            fill: #DD0812;
-        }
-
-        .button--secondary {
-            color: #DD0812;
-        }
-
-        &:hover {
-            a {
-                background-color: #DD0812;
-                border: 1px solid #DD0812;
-            }
-            .inline-tone-fill {
-                fill: #FFFFFF;
-            }
-            .button--secondary {
-                color: #FFFFFF;
-            }
-        }
-    }
-
-    .tone-colour {
-        color: #DD0812;
-    }
-    .inline-tone-fill {
-        fill: #dd0812;
     }
 
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -17,7 +17,6 @@
     .u-underline:hover {
         border-bottom: solid 1px $news-garnett-main-1;
     }
-<<<<<<< HEAD
 
         svg {
             fill: #DD0812;
@@ -91,5 +90,4 @@
         fill: #dd0812;
     }
 
->>>>>>> testing red
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,24 +1,80 @@
 .content--pillar-news {
 
+    .social-icon,
+    .social-icon.social-icon--more {
+        background-color: transparent;
+        border: 1px solid $neutral-5;
 
+        svg {
+            fill: #DD0812;
+        }
+        &:hover {
+            background-color: #DD0812;
+            border: 1px solid #DD0812;
 
-.social-icon {
-    background-color: inherit;
-    border: 1px solid #neutral-1;
-
-    svg {
-        fill: #DD0812;
+            svg {
+                fill: #FFFFFF;
+            }
+        }
     }
-}
 
+    .meta__social,
+    .meta__numbers,
+    .byline,
+    .content__dateline {
+        border-top: 1px solid $neutral-5;
+    }
 
+    .byline {
+        font-weight: 200;
+        color: #333333;
+        font-style: italic;
 
+        a {
+            color: #DD0812;
+        }
 
+        span[itemprop="author"]  {
+            display: block;
+            font-style: normal;
+            font-weight: 900;
+        }
+    }
 
+    .meta__twitter {
 
+        a {
+            background-color: transparent;
+            border: 1px solid $neutral-5;
+        }
 
+        .inline-tone-fill {
+            fill: #DD0812;
+        }
 
+        .button--secondary {
+            color: #DD0812;
+        }
 
+        &:hover {
+            a {
+                background-color: #DD0812;
+                border: 1px solid #DD0812;
+            }
+            .inline-tone-fill {
+                fill: #FFFFFF;
+            }
+            .button--secondary {
+                color: #FFFFFF;
+            }
+        }
+    }
 
+    .tone-colour {
+        color: #DD0812;
+    }
+    .inline-tone-fill {
+        fill: #dd0812;
+    }
 
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -1,4 +1,5 @@
 .content--pillar-news {
+<<<<<<< HEAD
     .content__section-label__link,
     .drop-cap,
     .element-pullquote p,
@@ -17,4 +18,28 @@
     .u-underline:hover {
         border-bottom: solid 1px $news-garnett-main-1;
     }
+=======
+
+
+
+.social-icon {
+    background-color: inherit;
+    border: 1px solid #neutral-1;
+
+    svg {
+        fill: #DD0812;
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+>>>>>>> testing red
 }

--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -13,7 +13,7 @@
     .inline-tone-fill,
     .social-icon svg,
     .social-icon.social-icon--more svg,
-    .inline-close svg, {
+    .inline-close svg {
         fill: $pillarColor;
     }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -78,6 +78,9 @@ $quote-tail: 25px; // ********** Article Type **********
         }
     }
 
+
+
+
     .meta__social,
     .meta__numbers,
     .byline,
@@ -106,10 +109,6 @@ $quote-tail: 25px; // ********** Article Type **********
         }
 
         &:hover, &:focus  {
-            a {
-                background-color: $news-garnett-main-1;
-                border: 1px solid $news-garnett-main-1;
-            }
             .inline-tone-fill {
                 fill: #FFFFFF;
             }
@@ -117,10 +116,6 @@ $quote-tail: 25px; // ********** Article Type **********
                 color: #FFFFFF;
             }
         }
-    }
-
-    .tone-colour {
-        color: $news-garnett-main-1;
     }
 
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -73,7 +73,7 @@ $quote-tail: 25px; // ********** Article Type **********
         &:focus,
         &:hover {
             svg {
-                fill: #FFFFFF;
+                fill: $neutral-garnett-1;
             }
         }
     }
@@ -106,11 +106,11 @@ $quote-tail: 25px; // ********** Article Type **********
             &:focus,
             &:hover {
                 .inline-tone-fill {
-                    fill: #FFFFFF;
+                    fill: $neutral-garnett-1;
                 }
 
                 .contact {
-                    color: #FFFFFF;
+                    color: $neutral-garnett-1;
                 }
             }
         }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -90,7 +90,7 @@ $quote-tail: 25px; // ********** Article Type **********
         color: #333333;
         font-style: italic;
 
-        span[itemprop="author"] {
+        span[itemprop='author'] {
             @include f-header;
             display: block;
             font-style: normal;
@@ -244,10 +244,10 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                 @include fs-headlineGarnett(2);
+                @include fs-headlineGarnett(2);
             }
             @include mq(desktop) {
-                 @include fs-headlineGarnett(3);
+                @include fs-headlineGarnett(3);
             }
         }
     }
@@ -271,13 +271,13 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                 @include fs-headlineGarnett(3);
+                @include fs-headlineGarnett(3);
             }
             @include mq(phablet) {
-                 @include fs-headlineGarnett(4);
+                @include fs-headlineGarnett(4);
             }
             @include mq(desktop) {
-                 @include fs-headlineGarnett(5);
+                @include fs-headlineGarnett(5);
             }
         }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -63,28 +63,25 @@ $quote-tail: 25px; // ********** Article Type **********
             margin-left: -$gs-gutter/2;
         }
     }
-
     // meta__styling
+    .inline-close,
     .social-icon,
-    .social-icon.social-icon--more,
-    .inline-close {
+    .social-icon.social-icon--more {
         background-color: transparent;
         border: 1px solid $neutral-4;
 
-        &:hover, &:focus {
+        &:focus,
+        &:hover {
             svg {
                 fill: #FFFFFF;
             }
         }
     }
 
-
-
-
-    .meta__social,
-    .meta__numbers,
     .byline,
-    .content__dateline {
+    .content__dateline,
+    .meta__numbers,
+    .meta__social {
         border-top: 1px solid $neutral-3;
     }
 
@@ -93,7 +90,7 @@ $quote-tail: 25px; // ********** Article Type **********
         color: #333333;
         font-style: italic;
 
-        span[itemprop="author"]  {
+        span[itemprop="author"] {
             @include f-header;
             display: block;
             font-style: normal;
@@ -102,23 +99,22 @@ $quote-tail: 25px; // ********** Article Type **********
     }
 
     .meta__twitter {
-
         a {
             background-color: transparent;
             border: 1px solid $neutral-4;
 
-            &:hover, &:focus  {
+            &:focus,
+            &:hover {
                 .inline-tone-fill {
                     fill: #FFFFFF;
                 }
+
                 .contact {
                     color: #FFFFFF;
                 }
+            }
         }
-
     }
-}
-
 
     .badge,
     .content__meta-container {
@@ -226,10 +222,10 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                @include fs-headlineGarnett(2);
+                 @include fs-headlineGarnett(2);
             }
             @include mq(desktop) {
-                @include fs-headlineGarnett(3);
+                 @include fs-headlineGarnett(3);
             }
         }
     }
@@ -248,10 +244,10 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                @include fs-headlineGarnett(2);
+                 @include fs-headlineGarnett(2);
             }
             @include mq(desktop) {
-                @include fs-headlineGarnett(3);
+                 @include fs-headlineGarnett(3);
             }
         }
     }
@@ -275,13 +271,13 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                @include fs-headlineGarnett(3);
+                 @include fs-headlineGarnett(3);
             }
             @include mq(phablet) {
-                @include fs-headlineGarnett(4);
+                 @include fs-headlineGarnett(4);
             }
             @include mq(desktop) {
-                @include fs-headlineGarnett(5);
+                 @include fs-headlineGarnett(5);
             }
         }
 

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -222,10 +222,10 @@ $quote-tail: 25px; // ********** Article Type **********
         .pullquote-cite,
         .pullquote-paragraph {
             @include mq(mobile) {
-                 @include fs-headlineGarnett(2);
+                @include fs-headlineGarnett(2);
             }
             @include mq(desktop) {
-                 @include fs-headlineGarnett(3);
+                @include fs-headlineGarnett(3);
             }
         }
     }

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -64,6 +64,66 @@ $quote-tail: 25px; // ********** Article Type **********
         }
     }
 
+    // meta__styling
+    .social-icon,
+    .social-icon.social-icon--more,
+    .inline-close {
+        background-color: transparent;
+        border: 1px solid $neutral-4;
+
+        &:hover, &:focus {
+            svg {
+                fill: #FFFFFF;
+            }
+        }
+    }
+
+    .meta__social,
+    .meta__numbers,
+    .byline,
+    .content__dateline {
+        border-top: 1px solid $neutral-3;
+    }
+
+    .byline {
+        font-weight: 200;
+        color: #333333;
+        font-style: italic;
+
+        span[itemprop="author"]  {
+            @include f-header;
+            display: block;
+            font-style: normal;
+            font-weight: 900;
+        }
+    }
+
+    .meta__twitter {
+
+        a {
+            background-color: transparent;
+            border: 1px solid $neutral-4;
+        }
+
+        &:hover, &:focus  {
+            a {
+                background-color: $news-garnett-main-1;
+                border: 1px solid $news-garnett-main-1;
+            }
+            .inline-tone-fill {
+                fill: #FFFFFF;
+            }
+            .button--secondary {
+                color: #FFFFFF;
+            }
+        }
+    }
+
+    .tone-colour {
+        color: $news-garnett-main-1;
+    }
+
+
     .badge,
     .content__meta-container {
         @include mq(leftCol) {

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -106,17 +106,18 @@ $quote-tail: 25px; // ********** Article Type **********
         a {
             background-color: transparent;
             border: 1px solid $neutral-4;
+
+            &:hover, &:focus  {
+                .inline-tone-fill {
+                    fill: #FFFFFF;
+                }
+                .contact {
+                    color: #FFFFFF;
+                }
         }
 
-        &:hover, &:focus  {
-            .inline-tone-fill {
-                fill: #FFFFFF;
-            }
-            .button--secondary {
-                color: #FFFFFF;
-            }
-        }
     }
+}
 
 
     .badge,


### PR DESCRIPTION
## What does this change?
Simplifying of meta styling, open and close and share buttons and some colour additions. Twitter looks a little broken at mobile - will tweak this, but still would like to get this stuff up so myself/Josh/Akemi are working off the same thing.

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

## Tested in CODE?
Yes

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
