### PR TITLE
[bugfix] isNarrow on consent journey was set the other way around

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -148,11 +148,11 @@
 
                         @journey match {
                             case "repermission-narrow" => {
-                                @emailStep()
+                                @emailStep(isNarrow = true)
                             }
                             case "repermission" => {
                                 @consentStep(journey = "repermission")
-                                @emailStep(isNarrow = true)
+                                @emailStep()
                             }
                             case "signup" => {
                                 @consentStep(journey = "signup")

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -73,14 +73,14 @@
             @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
             @if(isNarrow) {
-                <h2 class="identity-title">Email Preferences</h2>
-                <p class="manage-account-headerNote">
-                    You were receiving these newsletters, check them again to confirm you want to keep receiving them.
-                </p>
-            } else {
                 <h2 class="identity-title">Sorry for the interruption</h2>
                 <p class="manage-account-headerNote">
                     Do you still want to receive the following newsletters? Please check them again if you do.
+                </p>
+            } else {
+                <h2 class="identity-title">Email Preferences</h2>
+                <p class="manage-account-headerNote">
+                    You were receiving these newsletters, check them again to confirm you want to keep receiving them.
                 </p>
             }
             <div class="manage-account__switches">


### PR DESCRIPTION
## What does this change?
Extremely quick bugfix to make `isNarrow` on the consent journey page represent a narrow journey instead of it being set the other way around