### PR TITLE
Garnett: replace kicker colour on liveblog cards

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -102,7 +102,7 @@ $lifestyle-garnett-feature: #df2770;
 $lifestyle-garnett-main-media-1: #ffabdb;
 
 $live-garnett-main-1: #dd0812;
-$live-garnett-main-2: #f6bf2b;
+$live-garnett-main-2: #ffbac8;
 $live-garnett-accent: #d65353;
 
 // Tones

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -73,6 +73,8 @@ $pillars: (
         background-color: $darkerCardBackground;
 
         .fc-item__kicker {
+            background-color: $darkerCardBackground;
+
             &:before {
                 background-color: $darkerCardBackground;
             }
@@ -88,7 +90,8 @@ $pillars: (
     }
 
     .fc-item__kicker {
-        color: map-get($palette, kicker);;
+        background-color: $cardBackground;
+        color: map-get($palette, kicker);
 
         &:before {
             background-color: $cardBackground;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -19,7 +19,7 @@
         border: 0;
 
         &::before {
-            background-color: $live-garnett-main-2;
+            background-color: $live-garnett-main-1;
         }
 
         &::after {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -27,7 +27,7 @@
     }
 
     .fc-item__standfirst {
-        color: $live-garnett-main-2;
+        color: #ffffff;
     }
 
     .fc-trail__count--commentcount {

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -14,8 +14,13 @@
     }
 
     .fc-item__kicker {
+        background-color: $live-garnett-main-1;
         color: $live-garnett-main-2;
         border: 0;
+
+        &::before {
+            background-color: $live-garnett-main-2;
+        }
 
         &::after {
             background-color: $live-garnett-main-2;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -67,6 +67,10 @@
         .fc-item__container::before {
             background-color: darken($live-garnett-main-1, 5%);
         }
+
+        .fc-item__kicker::before {
+            background-color: darken($live-garnett-main-1, 5%);
+        }
     }
 
     // list media overrides


### PR DESCRIPTION
## What does this change?

Update the kicker colour for facia liveblog cards in garnett 

## What is the value of this and can you measure success?

Uptodate palette

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No