### PR TITLE
Fix Garnett facia layout in old IE

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -110,6 +110,7 @@ $fc-item-gutter: $gs-gutter / 4;
     display: flex;
     flex-direction: column;
     position: relative;
+    width: 100%;
 
     &:before {
         content: '';


### PR DESCRIPTION
## What does this change?

Garnett Facia layout is completely broken in IE11 as cards don't know how wide they need to be. This change fixes this 

## What is the value of this and can you measure success?

Layout looks correct in IE (and everywhere else!)
