### PR TITLE
Support new consents from identity library

### DIFF
--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -19,9 +19,9 @@
 }
 
 @fragments.form.switch(
-    title = getConsentText(consentField).getOrElse(""),
+    title = getConsentText(consentField).wording,
     subheading = None,
-    description = None,
+    description = getConsentText(consentField).description,
     behaviour = ConsentSwitch,
     field = consentField("consented"),
     extraFields = consentHiddenFormFields,

--- a/identity/app/views/profile/marketingConsentFormV1.scala.html
+++ b/identity/app/views/profile/marketingConsentFormV1.scala.html
@@ -15,7 +15,7 @@
         <ul>
             <li>
                 @switch(
-                    title = FirstParty.latestWording,
+                    title = FirstParty.latestWording.wording,
                     subheading = None,
                     description = None,
                     behaviour = ConsentSwitch,
@@ -24,7 +24,7 @@
             </li>
             <li>
                 @switch(
-                    title = ThirdParty.latestWording,
+                    title = ThirdParty.latestWording.wording,
                     subheading = None,
                     description = None,
                     behaviour = ConsentSwitch,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.91"
+  val identityLibVersion = "3.94"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.42"


### PR DESCRIPTION
## What does this change?
Replaces [Consent].latestWording with [Consent].latestWording.wording.

On hold while the updated library is published