### PR TITLE
Remove useless error logging and refactor Container.storiesCount

### DIFF
--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -24,16 +24,13 @@ object Container extends Logging {
   /** So that we don't blow up at runtime, which would SUCK */
   val default = Fixed(FixedContainers.fixedSmallSlowIV)
 
-  def resolve(id: String): Container = all.getOrElse(id, {
-    log.error(s"Could not resolve container id $id, using default container")
-    default
-  })
+  def resolve(id: String): Container = all.getOrElse(id, default)
 
   def fromConfig(collectionConfig: CollectionConfig): Container =
     resolve(collectionConfig.collectionType)
 
-  def storiesCount(collectionConfig: CollectionConfig, items: Seq[PressedContent]): Option[Int] = {
-    resolve(collectionConfig.collectionType) match {
+  def storiesCount(collectionType: String, items: Seq[PressedContent]): Option[Int] = {
+    resolve(collectionType) match {
       case Dynamic(dynamicPackage) => dynamicPackage
         .slicesFor(items.map(Story.fromFaciaContent))
         .map(Front.itemsVisible)

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -175,7 +175,7 @@ trait FapiFrontPress extends Logging {
         .contains(collection.collectionConfig.collectionType)
         .toOption(storyCountTotal)
         .getOrElse(Math.min(Configuration.facia.collectionCap, storyCountTotal))
-      val storyCountVisible = Container.storiesCount(CollectionConfig.make(collection.collectionConfig), curated ++ backfill).getOrElse(storyCountMax)
+      val storyCountVisible = Container.storiesCount(collection.collectionConfig.collectionType, curated ++ backfill).getOrElse(storyCountMax)
       val hasMore = storyCountVisible < storyCountMax
 
       PressedCollectionVersions(


### PR DESCRIPTION
Logged error was not really a error since it defaulted to a default value. It was also not very informative and only logged the collectionType

## What is the value of this and can you measure success?
Less useless error in the logs

## Tested in CODE?
No