### PR TITLE
Add repermissioned POST endpoint

### DIFF
--- a/identity/app/implicits/Forms.scala
+++ b/identity/app/implicits/Forms.scala
@@ -44,5 +44,12 @@ trait Forms extends I18nSupport {
     def toFlashWithDataDiscarded: Flash = {
       Flash(Map())
     }
- }
+  }
+
+  implicit val formErrorWrites = new Writes[FormError] {
+    def writes(formError: FormError) = Json.obj(
+      "key" -> formError.key,
+      "message" -> formError.message
+    )
+  }
 }

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -63,5 +63,5 @@ GET         /email-prefs                            controllers.EditProfileContr
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
 GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: Option[String], consentHint: Option[String], newsletterHint: Option[String])
-POST        /repermissioned                         controllers.EditProfileController.submitRepermissionedFlag
+POST        /complete-consent                         controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -63,5 +63,5 @@ GET         /email-prefs                            controllers.EditProfileContr
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
 GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: Option[String], consentHint: Option[String], newsletterHint: Option[String])
-POST        /repermissioned                         controllers.EditProfileController.submitRepermissionedFlag(returnUrl: String)
+POST        /repermissioned                         controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -63,4 +63,5 @@ GET         /email-prefs                            controllers.EditProfileContr
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
 GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: Option[String], consentHint: Option[String], newsletterHint: Option[String])
+POST        /repermissioned                         controllers.EditProfileController.submitRepermissionedFlag(returnUrl: String)
 ########################################################################################################################

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -18,6 +18,7 @@ import org.scalatest.{DoNotDiscover, Matchers, OptionValues, WordSpec}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.ConfiguredServer
 import play.api.data.Form
+import play.api.http.HttpConfiguration
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -46,6 +47,7 @@ import scala.concurrent.Future
     val trackingData = mock[TrackingData]
     val returnUrlVerifier = mock[ReturnUrlVerifier]
     val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+    val httpConfiguration = HttpConfiguration.createWithDefaults()
 
     val userId: String = "123"
     val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
@@ -82,7 +84,8 @@ import scala.concurrent.Future
       returnUrlVerifier,
       profileFormsMapping,
       controllerComponent,
-      newsletterService
+      newsletterService,
+      httpConfiguration
     )
   }
 


### PR DESCRIPTION
## What does this change?

Adds `/complete-consent` endpoint. Post `returnUrl=example.com` in the body. 

Allows `statusFields.hasRepermissioned` flag to be set at the end of consent journey.

## What is the value of this and can you measure success?

GDPR work.