### PR TITLE
Remove <gu-atom> when there is no corresponding atom

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -676,21 +676,24 @@ case class AtomsCleaner(atoms: Option[Atoms], shouldFence: Boolean = true, amp: 
         bodyElement <- atomContainer.getElementsByTag("gu-atom").asScala
         atomId <- Some(bodyElement.attr("data-atom-id"))
         atomType <- Some(bodyElement.attr("data-atom-type"))
-        atomData <- findAtom(atomId)
       } {
-        if(mediaWrapper.contains(MediaWrapper.MainMedia)){
-          atomContainer.addClass("element-atom--main-media")
-        }
-        if(atomData.isInstanceOf[MediaAtom]){
-          atomContainer.addClass("element-atom--media")
-        }
+        findAtom(atomId).fold { 
+          atomContainer.remove() 
+        } { atomData => 
+          if(mediaWrapper.contains(MediaWrapper.MainMedia)){
+            atomContainer.addClass("element-atom--main-media")
+          }
+          if(atomData.isInstanceOf[MediaAtom]){
+            atomContainer.addClass("element-atom--media")
+          }
 
-        atomContainer.attr("data-atom-id", atomId)
-        atomContainer.attr("data-atom-type", atomType)
+          atomContainer.attr("data-atom-id", atomId)
+          atomContainer.attr("data-atom-type", atomType)
 
-        val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper).toString()
-        bodyElement.remove()
-        atomContainer.append(html)
+          val html = views.html.fragments.atoms.atom(atomData, shouldFence, amp, mediaWrapper).toString()
+          bodyElement.remove()
+          atomContainer.append(html)
+        }
       }
     }
     document


### PR DESCRIPTION
As a matter of precaution, we remove the `figure` elements inside documents for atoms that don't end up in the `Atoms` collection. This should never happen, but it's the price to pay for having soft delete logic in the model, e.g. in readers questions.

A [related fix](https://github.com/guardian/atom-workshop/pull/186) is going out at the same time, to clear the `defaultHtml` where a readers questions atom is closed.