### PR TITLE
[acquisitions] bump the priority of the US gun campaign

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
+++ b/static/src/javascripts/projects/common/modules/experiments/acquisition-test-selector.js
@@ -21,9 +21,9 @@ import { acquisitionsEpicEndOfYearCountdown } from 'common/modules/experiments/t
  */
 const tests: $ReadOnlyArray<AcquisitionsABTest> = [
     alwaysAsk,
+    acquisitionsEpicUSGunCampaign,
     acquisitionsEpicEndOfYearCountdown,
     acquisitionsEpicTestimonialsGroup,
-    acquisitionsEpicUSGunCampaign,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
     acquisitionsEpicLiveblog,


### PR DESCRIPTION
## What does this change?

Prevents other Epic being displayed on Break the Cycle articles.

## What is the value of this and can you measure success?

Keeps the messaging and design across the campaign consistent.
