### PR TITLE
[minor identity bugfix] prevent recursive urlencoding

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -29,7 +29,7 @@ class AuthenticatedActions(
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
 
   def redirectWithReturn(request: RequestHeader, path: String): Result = {
-    val returnUrl = URLEncoder.encode(identityUrlBuilder.buildUrl(request.uri), "UTF-8")
+    val returnUrl = identityUrlBuilder.buildUrl(request.uri)
 
     val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, List(
       "INTCMP" -> "email",


### PR DESCRIPTION
## What does this change?
`redirectWithReturn()` was redundantly urlencoding the returnUrl one time too many (since `appendQueryParams` already encodes the parameters), potentially breaking it