### PR TITLE
Use full fronts in facia until fix

### DIFF
--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -23,7 +23,10 @@ trait FrontJsonFapi extends Logging {
   }
 
   def getLite(path: String)(implicit executionContext: ExecutionContext): Future[Option[PressedPage]] = errorLoggingF(s"FrontJsonFapi.getLite $path") {
-    pressedPageFromS3(getAddressForPath(path, LiteType.suffix))
+//    pressedPageFromS3(getAddressForPath(path, LiteType.suffix))
+    // TODO temporary fix until solution is implemented for container layout issues.
+    // Containers are missing stories after filtering is applied. This is because the lite versions of fronts do not have extra stories to replace the filtered ones.
+    get(path)
   }
 
   private def pressedPageFromS3(path: String)(implicit executionContext: ExecutionContext): Future[Option[PressedPage]] = errorLoggingF(s"FrontJsonFapi.pressedPageFromS3 $path") {


### PR DESCRIPTION
## What does this change?

Use full fronts (not lite versions) while a fix is implemented for container layout issues. 

Containers are missing stories after filtering is applied. This is because the lite versions of fronts do not have extra stories to replace the filtered ones.

## What is the value of this and can you measure success?

No bug in production while we implement a fix

## Tested in CODE?

locally