### PR TITLE
Move byline image in front of name

### DIFF
--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -19,6 +19,13 @@
 }
 
 @metaBody() = {
+
+    @if(item.content.showCircularBylinePicAtSide && !item.content.isImmersive) {
+        <div class="media__img meta__image">
+        @fragments.meta.bylineImage(item.tags)
+        </div>
+    }
+
     @if(!(item.content.isGallery || item.content.isImmersive)) {
         @if(!item.content.hasTonalHeaderByline) {
             @byline()
@@ -37,6 +44,7 @@
     @if(!(item.trail.shouldHidePublicationDate || item.content.isGallery)) {
         @fragments.meta.dateline(item.trail.webPublicationDate, item.fields.lastModified, item.content.hasBeenModified, item.fields.firstPublicationDate, item.tags.isLiveBlog, item.fields.isLive)
     }
+
     @if(showExtras) {
         <div class="meta__extras @if(!ageNotice.isEmpty){ meta__extras--notice }">
             <div class="meta__social" data-component="share">
@@ -55,12 +63,6 @@
                     </div>
                 </div>
             }
-        </div>
-    }
-
-    @if(item.content.showCircularBylinePicAtSide && !item.content.isImmersive) {
-        <div class="media__img meta__image">
-            @fragments.meta.bylineImage(item.tags)
         </div>
     }
 }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -513,12 +513,6 @@
             bottom: -14px;
         }
     }
-
-    .meta__image {
-        @include mq(leftCol) {
-            border-top: 1px dotted $neutral-5;
-        }
-    }
 }
 
 .content__meta-container--float {
@@ -568,7 +562,9 @@
     top: 0;
 
     @include mq(leftCol) {
-        border-top: 1px dotted $neutral-5;
+        border-top: 1px dotted;
+        border-bottom: 1px dotted;
+        border-color: $neutral-5;
         height: 36px;
         padding-bottom: $gs-baseline / 4;
         padding-top: $gs-baseline / 4;


### PR DESCRIPTION
## What does this change?

A rejig of the meta container (#18412) accidentally moved byline images below the social share icons. This change restores the byline image to its rightful place.

## What is the value of this and can you measure success?

No floating heads

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

No

## Screenshots

**Before**

![picture 407](https://user-images.githubusercontent.com/5931528/33728253-c4f22eb6-db71-11e7-9a4a-5acfa825b68e.png)

**After**

![picture 408](https://user-images.githubusercontent.com/5931528/33728285-dba1f70e-db71-11e7-8ded-85409742ea70.png)


## Tested in CODE?

No

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
