### PR TITLE
Improved expanded header for non-js

### DIFF
--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -7,6 +7,7 @@
             }
 
             @include mq(desktop) {
+                background-color: $guardian-brand;
                 display: block;
             }
         }
@@ -42,21 +43,48 @@
             }
         }
 
-        & ~ .new-header__menu-toggle .pillar-link--sections {
-            color: #ffffff;
-            background-color: $guardian-brand-dark;
-
-            &:before {
-                content: none;
+        & ~ .new-header__menu-toggle {
+            @include mq(desktop) {
+                position: absolute;
+                left: 0;
+                padding-left: $gs-gutter - $gs-gutter / 4;
+                right: auto;
+                width: gs-span(6);
+                padding-top: $gs-baseline;
+                top: 0;
+                background-color: $guardian-brand;
+                z-index: $zindex-main-menu + 2;
             }
 
-            .pillar-link--dropdown__icon {
-                transform: translateY(0) rotate(45deg);
+            .menu-close {
+                background-color: $guardian-brand-dark;
+                display: block;
+            }
+
+            .pillar-link--sections {
+                display: none;
             }
         }
 
         & ~ .pillars {
-            color: $news-support-1;
+            .pillars__item {
+                @include mq(desktop) {
+                    width: 160px;
+
+                    &:first-child {
+                        width: 153px;
+                    }
+
+                    .pillar-link {
+                        font-weight: 400;
+
+                        &:before,
+                        &:after {
+                            content: none;
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The new header expanded with no js was looking like

# this
<img width="1386" alt="screen shot 2017-12-08 at 10 34 55" src="https://user-images.githubusercontent.com/14570016/33762170-77d67050-dc03-11e7-929f-e87da643e183.png">

Now it's looking like
# this 
<img width="1352" alt="screen shot 2017-12-08 at 10 31 15" src="https://user-images.githubusercontent.com/14570016/33762186-8371356c-dc03-11e7-8029-84415990dbba.png">

I've had to expand the width of the sections div to hide the editions container to make the close button visible.

