### PR TITLE
Trialling the new header test for the weeekend

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -50,7 +50,7 @@ object ABNewDesktopHeader extends Experiment(
   description = "Users in this experiment will see the new desktop design.",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
   sellByDate = new LocalDate(2018, 1, 10),
-  participationGroup = Perc0A
+  participationGroup = Perc1B
 )
 
 object Garnett extends Experiment(


### PR DESCRIPTION
## What does this change?
We are just about ready to start the desktop header test, but the actual test will be on 20% of the audience 😱 . 

To make sure everything is fine, we are going to do a trial test over the weekend on 1% of the audience. 

@zeftilldeath please note that the header you need to send for local development will change.

@TBonnin will people have to opt in again? The link is the same, but the participation group is different.

cc @guardian/guardian-frontend-team 

## What is the value of this and can you measure success?
Nope

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots
![image](https://user-images.githubusercontent.com/8774970/33763101-0732c6d8-dc07-11e7-8afd-1cc1e131d095.png)

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
