### PR TITLE
Filter out inconsistent V2 consents on forms

### DIFF
--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -115,8 +115,8 @@ object PrivacyFormData extends SafeLogging {
   /**
     * Checks if a consents is on the library and logs if not
     *
-    * @param consent Consent object
-    * @return true or false
+    * @param consent Consent
+    * @return Boolean (false if consent does not exist)
     */
   def checkIfConsentExistsInModel(consent:Consent): Boolean = {
     Try(Consent.wording(consent.id, consent.version)) match {
@@ -131,8 +131,8 @@ object PrivacyFormData extends SafeLogging {
   /**
     * Logs a missing consent
     *
-    * @param consent Consent object
-    * @return true or false
+    * @param consent Consent
+    * @return Unit
     */
   def LogMissingConsent(consent:Consent): Unit = {
     logger.error(s"Failed to find consent in model: $consent.id")

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -113,7 +113,7 @@ case class PrivacyFormData(
 object PrivacyFormData extends SafeLogging {
 
   /**
-    * Checks if a consents is on the library and logs if not
+    * Checks if a consent exists on the identity library and logs if not
     *
     * @param consent Consent
     * @return Boolean (false if consent does not exist)


### PR DESCRIPTION
## What does this change?
At the moment, when a user has consents for things that are not on the consent model the identity application will crash. This PR filters out any consents that are missing from the model before they can crash, and logs them so any errors related to them are retrievable.

## What is the value of this and can you measure success?
A crash on this area of the application is very hard to recover from the user side because any list that could allow them to set their consents back to a consistent state will fail to load because thy are having wonky ones in the first place