### PR TITLE
Desktop Header: Tab order

### DIFF
--- a/common/app/views/fragments/nav/editionPickerDropdown.scala.html
+++ b/common/app/views/fragments/nav/editionPickerDropdown.scala.html
@@ -33,7 +33,8 @@
 
     <label for="edition-picker-toggle"
             class="top-bar__item top-bar__item--dropdown js-edition-picker-trigger"
-            data-link-name="nav2 : topnav : edition-picker: toggle">
+            data-link-name="nav2 : topnav : edition-picker: toggle"
+            tabindex="-1">
 
         <span class="u-h">current edition: </span>
         @Edition(request).displayName

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -56,14 +56,14 @@
         </li>
     </ul>
 
-    <button class="u-h js-user-account-trigger"
+    <button class="is-hidden dropdown-menu-fallback js-user-account-trigger"
         id="my-account-toggle"
         title="user account toggle"
         data-link-name="nav2 : topbar: my account"
         aria-expanded="false"
         aria-controls="my-account-dropdown"></button>
 
-    <label class="top-bar__item top-bar__item--dropdown u-h js-navigation-account-actions"
+    <label class="top-bar__item top-bar__item--dropdown is-hidden js-navigation-account-actions"
         for="my-account-toggle"
         data-link-name="nav2 : topbar: my account">
 

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -113,7 +113,7 @@
 
             <label for="main-menu-toggle"
                    class="js-change-link new-header__menu-toggle"
-                   tabindex="0"
+                   tabindex="-1"
                    data-link-name="nav2 : veggie-burger : show">
 
                 <span class="veggie-burger hide-from-desktop">

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -39,9 +39,15 @@ const showMyAccountIfNecessary = (): void => {
             commentItems: [
                 ...document.querySelectorAll('.js-show-comment-activity'),
             ],
+            accountTrigger: document.querySelector('.js-user-account-trigger'),
         }))
         .then(els => {
-            const { signIns, accountActionsLists, commentItems } = els;
+            const {
+                signIns,
+                accountActionsLists,
+                commentItems,
+                accountTrigger,
+            } = els;
 
             return fastdom
                 .write(() => {
@@ -50,8 +56,14 @@ const showMyAccountIfNecessary = (): void => {
                     });
 
                     accountActionsLists.forEach(accountActions => {
-                        accountActions.classList.remove('u-h');
+                        accountActions.classList.remove('is-hidden');
                     });
+
+                    // We still want the button to be hidden, but tabbable now
+                    if (accountTrigger) {
+                        accountTrigger.classList.remove('is-hidden');
+                        accountTrigger.classList.add('u-h');
+                    }
                 })
                 .then(() => {
                     updateCommentLink(commentItems);

--- a/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
+++ b/static/src/stylesheets/layout/new-header/_top-bar-dropdown.scss
@@ -1,15 +1,21 @@
-.dropdown-menu-fallback:checked {
-
-    & ~ .dropdown-menu {
-        display: block;
+.dropdown-menu-fallback {
+    &:focus ~ .top-bar__item--dropdown {
+        color: #ffffff;
     }
 
-    & ~ .top-bar__item--dropdown {
-        color: #ffffff;
-        background-color: $guardian-brand-dark;
+    &:checked {
 
-        &:after {
-            transform: translateY(0) rotate(45deg);
+        & ~ .dropdown-menu {
+            display: block;
+        }
+
+        & ~ .top-bar__item--dropdown {
+            color: #ffffff;
+            background-color: $guardian-brand-dark;
+
+            &:after {
+                transform: translateY(0) rotate(45deg);
+            }
         }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
+++ b/static/src/stylesheets/layout/new-header/_veggie-burger-fallback.scss
@@ -87,4 +87,8 @@
             }
         }
     }
+
+    &:focus ~ .new-header__menu-toggle .pillar-link--sections {
+        color: #ffffff;
+    }
 }


### PR DESCRIPTION
## What does this change?
This makes the tab order just a bit more reasonable. 

@zeftilldeath is going to work on better focus styling so it is even more clear when you are tabbing. That will be done in a separate PR. 

## What is the value of this and can you measure success?
For users that tab they can navigate just a bit easier in the nav

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![tab order](https://user-images.githubusercontent.com/8774970/33768964-2385a2ec-dc20-11e7-8789-eae573f659d7.gif)


## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
