### PR TITLE
Garnett: You no wrap timestamp

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -323,6 +323,10 @@ $fc-item-gutter: $gs-gutter / 4;
     display: none;
 }
 
+.fc-item__timestamp {
+    white-space: nowrap;
+}
+
 // Common media card styles
 .fc-item--type-video,
 .fc-item--type-audio,


### PR DESCRIPTION
## What does this change?

Prevent timestamps from wrapping on Garnett facia cards

![picture 421](https://user-images.githubusercontent.com/5931528/33770511-ba6b3a28-dc25-11e7-9e99-4475c4ec9b4f.png)
