### PR TITLE
Track consent journey events in ophan

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -127,7 +127,11 @@
             <h2 class="manage-account-consent-thanks__title">Thank you</h2>
             <aside class="manage-account-consent-thanks__content">
                 <p>Your support helps us deliver the quality independent journalism the world needs</p>
-                <button type="submit" class="manage-account__button">Continue</button>
+                <button
+                    type="submit"
+                    class="manage-account__button"
+                    data-link-name="consent : @journey : submit"
+                >Continue</button>
             </aside>
         </form>
     </div>
@@ -163,16 +167,20 @@
                         @endcardStep()
 
                         <div class="manage-account-wizard__controls">
-                            <a class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev">
+                            <button
+                            data-link-name="consent : @journey : navigation : prev"
+                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev">
                                 <span class="u-h">Previous</span>
                                 @fragments.inlineSvg("arrow-left-stem", "icon")
-                            </a>
+                            </button>
                             <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
                             </div>
-                            <a class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next">
+                            <button
+                            data-link-name="consent : @journey : navigation : next"
+                            class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next">
                                 <span>Next</span>
                                 @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
+                            </button>
                         </div>
                     </div>
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -168,16 +168,18 @@
 
                         <div class="manage-account-wizard__controls">
                             <button
-                            data-link-name="consent : @journey : navigation : prev"
-                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev">
+                                data-link-name="consent : @journey : navigation : prev"
+                                class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev"
+                            >
                                 <span class="u-h">Previous</span>
                                 @fragments.inlineSvg("arrow-left-stem", "icon")
                             </button>
                             <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
                             </div>
                             <button
-                            data-link-name="consent : @journey : navigation : next"
-                            class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next">
+                                data-link-name="consent : @journey : navigation : next"
+                                class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next"
+                            >
                                 <span>Next</span>
                                 @fragments.inlineSvg("arrow-right", "icon")
                             </button>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -30,6 +30,7 @@
             "u-h" -> (page.metadata.id != url)
          ), "tabs__pane u-cf @optionalClass")"
          role="tabpanel"
+         data-link-name="profile : top-nav : @url"
          aria-labelledby="tabs-account-profile-@i-tab"
          data-link-name="Public Profile"
          data-link-context="Identity/profile">

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -30,7 +30,6 @@
             "u-h" -> (page.metadata.id != url)
          ), "tabs__pane u-cf @optionalClass")"
          role="tabpanel"
-         data-link-name="profile : top-nav : @url"
          aria-labelledby="tabs-account-profile-@i-tab"
          data-link-name="Public Profile"
          data-link-context="Identity/profile">


### PR DESCRIPTION
## What does this change?
Adds tracking tags to the step and completion buttons on the consent journey so we can infer an estimate of how many people drop out from them

## What is the value of this and can you measure success?
This is a key piece in the signup process and we really don't want this to be a bad performer. Understanding if people struggle completing it is crucial information