### PR TITLE
Fixing is-disabled styles

### DIFF
--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -488,7 +488,7 @@
     color: $guardian-brand;
     background-color: transparent;
     border: 1px solid $news-main-2;
-    &:not(.is-updating):hover {
+    &:not(.is-updating, .is-disabled):hover {
         color: $guardian-brand-dark;
         background-color: transparent;
         border-color: currentColor;


### PR DESCRIPTION
## What does this change?

Fix a hover CSS bug introduced in https://github.com/guardian/frontend/pull/18422

## What is the value of this and can you measure success?

## Does this affect other platforms - Amp, Apps, etc?

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->


## Screenshots

### Before
<img width="806" alt="picture 477" src="https://user-images.githubusercontent.com/825398/33772301-10cc6468-dc2c-11e7-8cd1-58bd9617a4aa.png">

### After 
<img width="786" alt="picture 476" src="https://user-images.githubusercontent.com/825398/33772235-e0b62ac0-dc2b-11e7-859d-137f3bbff1d4.png">
