### PR TITLE
Added clearer focus/hover states to new nav

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -51,16 +51,8 @@
 
     &:hover,
     &:focus {
-        text-decoration: none;
-
         @include mq(desktop) {
             color: #ffffff;
-        }
-    }
-
-    &:focus {
-        @include mq(desktop) {
-            text-decoration: underline;
         }
     }
 

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -123,6 +123,7 @@ from scrolling */
     }
 
     &:focus {
+        // Prevents distracting focus state on click
         outline: 0;
     }
 }

--- a/static/src/stylesheets/layout/new-header/_pillar-link.scss
+++ b/static/src/stylesheets/layout/new-header/_pillar-link.scss
@@ -59,12 +59,17 @@
         color: #ffffff;
         text-decoration: none;
 
-        &:not(.pillar-link--dropdown):after {
+        &:after {
             border-bottom-width: 4px;
         }
     }
 
     .new-header--open & {
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
+
         &:before,
         &:after {
             content: none;
@@ -111,7 +116,8 @@
     vertical-align: middle;
     width: 6px;
 
-    .pillar-link--dropdown:hover & {
+    .pillar-link--dropdown:hover &,
+    .new-header__menu-toggle:focus & {
         transform: translateY(0) rotate(45deg);
     }
 }
@@ -126,5 +132,9 @@
 
     .new-header__menu-toggle:focus & {
         color: #ffffff;
+
+        &:after {
+            border-bottom-width: 4px;
+        }
     }
 }

--- a/static/src/stylesheets/layout/new-header/_subnav-link.scss
+++ b/static/src/stylesheets/layout/new-header/_subnav-link.scss
@@ -7,7 +7,6 @@
     line-height: $veggie-burger-medium - $gs-baseline;
     padding: 0 ($gs-gutter / 4);
     position: relative;
-    transition: color 150ms ease-out;
 
     @include mq(mobileMedium) {
         font-size: 17px;
@@ -19,18 +18,14 @@
     }
 
     &:after {
-        border-bottom: 1px solid $neutral-5;
-        bottom: -1px;
-        content: '';
-        left: $gs-gutter / 4;
-        position: absolute;
-        right: -9999px;
-    }
-
-    &:hover,
-    &:focus {
-        color: $guardian-brand;
-        text-decoration: none;
+        @include mq($until: tablet) {
+            border-bottom: 1px solid $neutral-5;
+            bottom: -1px;
+            content: '';
+            left: $gs-gutter / 4;
+            position: absolute;
+            right: -9999px;
+        }
     }
 
     .subnav__item--parent & {


### PR DESCRIPTION
Improved focus state of sections drop down and used clearer underline hover and focus states across pillars and items in subnav. 

<img width="249" alt="screen shot 2017-12-08 at 15 27 25" src="https://user-images.githubusercontent.com/14570016/33772675-577c7898-dc2d-11e7-8cff-8b98df4ae19e.png">
<img width="578" alt="screen shot 2017-12-08 at 15 27 46" src="https://user-images.githubusercontent.com/14570016/33772676-57976ac2-dc2d-11e7-880b-8bed198e8b03.png">
