### PR TITLE
Desktop Header: don't use calc for logo height

### DIFF
--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -129,14 +129,14 @@ from scrolling */
 
 .new-header__logo__svg {
     display: block;
-    height: calc(3 / 16 * 180px);
+    height: 34px;
     margin-bottom: $gs-baseline / 2;
     margin-right: $gs-gutter / 2;
     margin-top: $gs-baseline / 2;
     width: 180px;
 
     @include mq(mobileMedium) {
-        height: calc(3 / 16 * 225px);
+        height: 42px;
         width: 225px;
     }
 
@@ -146,15 +146,15 @@ from scrolling */
     }
 
     @include mq(tablet) {
-        height: calc(3 / 16 * 345px);
-        margin-top: $gs-baseline + $gs-baseline / 4;
+        height: 65px;
         width: 345px;
+        margin-top: $gs-baseline + $gs-baseline / 4;
     }
 
     @include mq(desktop) {
-        height: calc(3 / 16 * 411px);
-        margin-bottom: $gs-baseline / 2;
+        height: 77px;
         width: 411px;
+        margin-bottom: $gs-baseline / 2;
     }
 
     body:not(.has-page-skin) & {
@@ -164,9 +164,9 @@ from scrolling */
     }
 
     .new-header--slim & {
-        height: calc(3 / 16 * 180px);
-        margin: 5px ($veggie-burger-large + $gs-gutter) 0 0;
+        height: 34px;
         width: 180px;
+        margin: 5px ($veggie-burger-large + $gs-gutter) 0 0;
 
         @include mq(mobileLandscape) {
             margin-right: $veggie-burger-large + $gs-gutter + ($gs-gutter / 2);


### PR DESCRIPTION
## What does this change?
Calc isn't supported on 5.1, but we can just use px values

## What is the value of this and can you measure success?
Not broken on old safari!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Broken:
![image](https://user-images.githubusercontent.com/8774970/33774078-fc2adfc0-dc31-11e7-8622-52facb18a53f.png)

Fixed:
![image](https://user-images.githubusercontent.com/8774970/33774207-67f63952-dc32-11e7-9bd0-11d8bd026b5c.png)



## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
