### PR TITLE
Fix consents not being retrieved by permissionAuthentication action

### DIFF
--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -156,6 +156,6 @@ class AuthenticatedActions(
     recentlyAuthenticated andThen apiUserShouldRepermissionRefiner
 
   def permissionAuthentication: ActionBuilder[AuthRequest, AnyContent] =
-    noOpActionBuilder andThen permissionRefiner
+    noOpActionBuilder andThen permissionRefiner andThen apiVerifiedUserRefiner
 
 }


### PR DESCRIPTION
## What does this change?

`permissionAuthentication` did not compose retrieval of user from IDAPI which means consents were missing. 
