### PR TITLE
Account Dropdown: u-h should be is-hidden

### DIFF
--- a/common/app/views/fragments/nav/userAccountLinks.scala.html
+++ b/common/app/views/fragments/nav/userAccountLinks.scala.html
@@ -12,7 +12,7 @@
         </a>
     </li>
 
-    <li class="menu-item menu-item--membership u-h js-navigation-account-actions hide-from-desktop">
+    <li class="menu-item menu-item--membership is-hidden js-navigation-account-actions hide-from-desktop">
         <button class="menu-item__title hide-from-desktop js-navigation-toggle"
                 data-link-name="nav2 : my account"
                 aria-haspopup="true"


### PR DESCRIPTION
## What does this change?
Right now if you are signed in, account links doesn't show up, but sign in disappears. 
![image](https://user-images.githubusercontent.com/8774970/33827437-3dacd84c-de60-11e7-915e-b3175cda479d.png)

This fixes it:
![image](https://user-images.githubusercontent.com/8774970/33827447-4791ce58-de60-11e7-88eb-0629575dddc5.png)

The `is-hidden` class is removed here: https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/navigation/user-account.js#L64


## What is the value of this and can you measure success?
Users on mobile can access their account again

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
