### PR TITLE
Align /consent wording with final copy

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -41,9 +41,9 @@
                 <p class="manage-account-headerNote">Tick the boxes you are interested in. We have featured some you might be interested in.</p>
             } else {
                 <h1 class="identity-title">
-                    Would you like to receive communications from us?
+                    What would you like to hear about?
                 </h1>
-                <p class="manage-account-headerNote">Tick the boxes you are interested in</p>
+                <p class="manage-account-headerNote">Just take a couple of minutes to tell us what you’re interested in, so we can send you emails that we think you’ll find useful.</p>
             }
             <div class="fieldset fieldset--manage-account-noborder fieldset--manage-account-block">
                 <div class="manage-account__switches manage-account__switches--wide">
@@ -75,12 +75,12 @@
             @if(isNarrow) {
                 <h2 class="identity-title">Sorry for the interruption</h2>
                 <p class="manage-account-headerNote">
-                    Do you still want to receive the following newsletters? Please check them again if you do.
+                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
                 </p>
             } else {
-                <h2 class="identity-title">Email Preferences</h2>
+                <h2 class="identity-title">Your existing newsletters</h2>
                 <p class="manage-account-headerNote">
-                    You were receiving these newsletters, check them again to confirm you want to keep receiving them.
+                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
                 </p>
             }
             <div class="manage-account__switches">
@@ -107,9 +107,9 @@
             @views.html.helper.CSRF.formField
             @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-            <h2 class="identity-title">Love email? Gosh, so do we!</h2>
+            <h2 class="identity-title">Your newsletters</h2>
             <p class="manage-account-headerNote">
-                Sign up to whatever newsletters tickle your fancy and we'll make sure you get them on time.
+                Our regular newsletters help you get closer to our quality, independent journalism. You can tailor your experience by picking the issues and topics that interest you below. Just so you know, your newsletter might include messages about how you can support the Guardian, as well as our events, jobs, masterclasses and holidays.
             </p>
 
             <div class="manage-account__switches">


### PR DESCRIPTION
## What does this change?
Minor changes to the consent page copy to make it closer to the suggested version