### PR TITLE
Navigation: international edition should serve international pillars

### DIFF
--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -83,7 +83,7 @@ object NavRoot {
       case editions.Uk => NavRoot(Seq(ukNewsPillar, ukSportPillar, ukOpinionPillar, ukArtsPillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
       case editions.Us => NavRoot(Seq(usNewsPillar, usSportPillar, usOpinionPillar, usArtsPillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
       case editions.Au => NavRoot(Seq(auNewsPillar, auSportPillar, auOpinionPillar, auArtsPillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
-      case editions.International => NavRoot(Seq(auNewsPillar, auSportPillar, auOpinionPillar, auArtsPillar, auLifestylePillar), intOtherLinks, intBrandExtensions)
+      case editions.International => NavRoot(Seq(intNewsPillar, intSportPillar, intOpinionPillar, intArtsPillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
     }
   }
 }


### PR DESCRIPTION
## What does this change?
I refactored the Navigation (https://github.com/guardian/frontend/pull/18379) and when I did made a mistake. The International edition should serve international pillars. This is fixing it!

## What is the value of this and can you measure success?
International audience will get a nav which makes more sense 😓 

## Does this affect other platforms - Amp, Apps, etc?
This will also fix this problem on AMP

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
