### PR TITLE
Fallback for if viewport units are not supported for opening the desktop menu

### DIFF
--- a/static/src/stylesheets/layout/new-header/_menu.scss
+++ b/static/src/stylesheets/layout/new-header/_menu.scss
@@ -33,18 +33,25 @@
         margin-right: $gutter-medium + ($veggie-burger-medium / 2);
     }
 
-    // based on https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6
     @include mq(desktop) {
         display: none;
-        left: 50%;
-        margin-left: -50vw;
-        margin-right: -50vw;
+        position: absolute;
         padding-bottom: 0;
         padding-top: 0;
-        position: absolute;
-        right: 50%;
         top: 100%;
-        width: 100vw;
+        // Left, right and width values are fallback for if vw is not supported
+        left: 0;
+        right: 0;
+        width: 100%;
+
+        @supports (width: 100vw) {
+            // based on https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6
+            left: 50%;
+            right: 50%;
+            width: 100vw;
+            margin-left: -50vw;
+            margin-right: -50vw;
+        }
 
         .new-header--slim & {
             top: $slim-nav-height;


### PR DESCRIPTION
## What does this change?
If `vw` isn't supported then currently the open menu looks pretty broken. This adds a fallback

## What is the value of this and can you measure success?
Users still using IE8 or Safari 5.1 can access the nav 🎉 

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots (of safari 5.1)
Before:
![image](https://user-images.githubusercontent.com/8774970/33830657-ebfe6d82-de6c-11e7-82ea-b4de6b59afe1.png)

After:
![image](https://user-images.githubusercontent.com/8774970/33830621-cae26720-de6c-11e7-9c48-75a60c47127a.png)

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
