### PR TITLE
Increasing the new desktop header test to 20%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -50,7 +50,7 @@ object ABNewDesktopHeader extends Experiment(
   description = "Users in this experiment will see the new desktop design.",
   owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
   sellByDate = new LocalDate(2018, 1, 10),
-  participationGroup = Perc1B
+  participationGroup = Perc20A
 )
 
 object Garnett extends Experiment(


### PR DESCRIPTION
## What does this change?
This afternoon we will increase the desktop header test to 20%

cc @guardian/guardian-frontend-team @stephanfowler @zeftilldeath 

## What is the value of this and can you measure success?
Nope
## Does this affect other platforms - Amp, Apps, etc?
Nope
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Nope
## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
