### PR TITLE
Fixed order of pillars

### DIFF
--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -80,10 +80,10 @@ case class NavRoot private(children: Seq[NavLink], otherLinks: Seq[NavLink], bra
 object NavRoot {
   def apply(edition: Edition): NavRoot = {
     edition match {
-      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukSportPillar, ukOpinionPillar, ukArtsPillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
-      case editions.Us => NavRoot(Seq(usNewsPillar, usSportPillar, usOpinionPillar, usArtsPillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
-      case editions.Au => NavRoot(Seq(auNewsPillar, auSportPillar, auOpinionPillar, auArtsPillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
-      case editions.International => NavRoot(Seq(intNewsPillar, intSportPillar, intOpinionPillar, intArtsPillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
+      case editions.Uk => NavRoot(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukArtsPillar, ukLifestylePillar), ukOtherLinks, ukBrandExtensions)
+      case editions.Us => NavRoot(Seq(usNewsPillar, usOpinionPillar, usSportPillar, usArtsPillar, usLifestylePillar), usOtherLinks, usBrandExtensions)
+      case editions.Au => NavRoot(Seq(auNewsPillar, auOpinionPillar, auSportPillar, auArtsPillar, auLifestylePillar), auOtherLinks, auBrandExtensions)
+      case editions.International => NavRoot(Seq(intNewsPillar, intOpinionPillar, intSportPillar, intArtsPillar, intLifestylePillar), intOtherLinks, intBrandExtensions)
     }
   }
 }

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -24,7 +24,7 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   }
 
   "Simple menu" should "just return the 5 primary links" in {
-    NavMenu(Uk).pillars should be(Seq(ukNewsPillar, ukSportPillar, ukOpinionPillar, ukArtsPillar, ukLifestylePillar))
+    NavMenu(Uk).pillars should be(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukArtsPillar, ukLifestylePillar))
   }
 
   "the route `/cities`" should "return the NavLink for cities" in {


### PR DESCRIPTION
The order of the pillars has switched over incorrectly.

This PR restores the correct order.

# before
<img width="319" alt="screen shot 2017-12-11 at 13 52 00" src="https://user-images.githubusercontent.com/14570016/33834338-8cd8ca6a-de7a-11e7-9a46-45226613453d.png">

# after
<img width="320" alt="screen shot 2017-12-11 at 13 51 46" src="https://user-images.githubusercontent.com/14570016/33834342-8f3752e0-de7a-11e7-8dfb-8d300e92c548.png">
