### PR TITLE
Up identity-library version, new V2 consent names

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.95"
+  val identityLibVersion = "3.96"
   val awsVersion = "1.11.181"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.43"


### PR DESCRIPTION
## What does this change?
Updates the version of `identity-library` to the one with final-ish V2 consent names that can be collected