### PR TITLE
Clicking outside the menu, closes it

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -155,6 +155,19 @@ const toggleMenu = (): void => {
                     passive: true,
                 });
             });
+
+            mediator.on('module:clickstream:click', function triggerToggle(
+                clickSpec
+            ) {
+                const elem = clickSpec ? clickSpec.target : null;
+
+                // if anywhere else but the links are clicked, the dropdown will close
+                if (elem !== menu) {
+                    toggleMenu();
+                    // remove event when the dropdown closes
+                    mediator.off('module:clickstream:click', triggerToggle);
+                }
+            });
         } else {
             removeEnhancedMenuMargin().then(() => {
                 window.removeEventListener('resize', debouncedMenuEnhancement);


### PR DESCRIPTION
## What does this change?
When the menu is open, if you click outside of it the menu should close. 

(In this gif you can't see my mouse, so I hovered of the stories. I actually only clicked on the side of the page)
![dec-11-2017 17-55-33](https://user-images.githubusercontent.com/8774970/33845868-ba1f7b64-de9c-11e7-9c4d-a106633760d4.gif)


## What is the value of this and can you measure success?
More expected UX

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
