### PR TITLE
Update consent journey footer

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -21,6 +21,8 @@ import scala.concurrent.Future
 import conf.switches.Switches.IdentityAllowAccessToGdprJourneyPageSwitch
 import play.api.http.HttpConfiguration
 
+import pages.JourneyHtmlPage
+
 object PublicEditProfilePage extends IdentityPage("/public/edit", "Edit Public Profile")
 object AccountEditProfilePage extends IdentityPage("/account/edit", "Edit Account Details")
 object EmailPrefsProfilePage extends IdentityPage("/email-prefs", "Emails")
@@ -227,20 +229,22 @@ class EditProfileController(
 
     newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
 
-      NoCache(Ok(views.html.consentJourney(
-        page,
-        user,
-        forms,
-        journey,
-        returnUrlVerifier.getVerifiedReturnUrl(request).getOrElse(returnUrlVerifier.defaultReturnUrl),
-        idRequestParser(request),
-        idUrlBuilder,
-        emailFilledForm,
-        newsletterService.getEmailSubscriptions(emailFilledForm),
-        EmailNewsletters.all,
-        consentHint,
-        newsletterHint
-      )))
+      NoCache(Ok(
+          JourneyHtmlPage.html(content = views.html.consentJourney(
+          page,
+          user,
+          forms,
+          journey,
+          returnUrlVerifier.getVerifiedReturnUrl(request).getOrElse(returnUrlVerifier.defaultReturnUrl),
+          idRequestParser(request),
+          idUrlBuilder,
+          emailFilledForm,
+          newsletterService.getEmailSubscriptions(emailFilledForm),
+          EmailNewsletters.all,
+          consentHint,
+          newsletterHint
+        ))(page, request, context)
+      ))
 
     }
   }

--- a/identity/app/pages/JourneyHtmlPage.scala
+++ b/identity/app/pages/JourneyHtmlPage.scala
@@ -1,0 +1,58 @@
+package pages
+
+import html.HtmlPageHelpers._
+import html.Styles
+import model.{ApplicationContext, Page}
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+import views.html.fragments.{_}
+import views.html.fragments.page._
+import views.html.fragments.page.body._
+import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
+import views.html.fragments.page.head.{fixIEReferenceErrors, headTag, titleTag, weAreHiring}
+import html.HtmlPageHelpers.ContentCSSFile
+
+object JourneyHtmlPage {
+
+  def allStyles(implicit applicationContext: ApplicationContext, request: RequestHeader): Styles = new Styles {
+    override def criticalCssLink: Html = criticalStyleLink("identity")
+    override def criticalCssInline: Html = criticalStyleInline(Html(common.Assets.css.head(None)))
+    override def linkCss: Html = stylesheetLink(s"stylesheets/$ContentCSSFile.css")
+    override def oldIECriticalCss: Html = stylesheetLink(s"stylesheets/old-ie.head.$ContentCSSFile.css")
+    override def oldIELinkCss: Html = stylesheetLink(s"stylesheets/old-ie.$ContentCSSFile.css")
+    override def IE9LinkCss: Html = stylesheetLink(s"stylesheets/ie9.head.$ContentCSSFile.css")
+    override def IE9CriticalCss: Html = stylesheetLink(s"stylesheets/ie9.$ContentCSSFile.css")
+  }
+
+  def html(
+            content: Html,
+            maybeHeadContent: Option[Html] = None
+          )(implicit page: Page, request: RequestHeader, applicationContext: ApplicationContext): Html = {
+
+    val head: Html = maybeHeadContent.getOrElse(Html(""))
+    val bodyClasses: Map[String, Boolean] = defaultBodyClasses()
+
+    htmlTag(
+      headTag(
+        titleTag(),
+        metaData(),
+        head,
+        styles(allStyles),
+        fixIEReferenceErrors(),
+        inlineJSBlocking()
+      ),
+      bodyTag(classes = bodyClasses)(
+        skipToMainContent(),
+        guardianHeaderHtml(),
+        mainContent(),
+        content,
+        inlineJSNonBlocking(),
+        views.html.fragments.identitySlimFooter(),
+        analytics.base()
+      ),
+      devTakeShot()
+    )
+  }
+
+}
+

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -137,57 +137,53 @@
     </div>
 }
 
+<div class="identity-wrapper-for-bg identity-wrapper-for-bg--overflows">
+    <div class="gs-container">
+        <div class="monocol-wrapper">
 
-@mainLegacy(page, projectName = Option("identity")) { } {
+            <div class="u-cf identity-section identity-wrapper identity-wrapper--with-wizard">
 
-    <div class="identity-wrapper-for-bg identity-wrapper-for-bg--overflows">
-        <div class="gs-container">
-            <div class="monocol-wrapper">
+                <div class="js-errorHolder manage-account__errors"></div>
 
-                <div class="u-cf identity-section identity-wrapper">
+                <div class="manage-account-wizard manage-account-wizard--consent" data-journey="@journey">
 
-                    <div class="js-errorHolder manage-account__errors"></div>
-
-                    <div class="manage-account-wizard manage-account-wizard--consent" data-journey="@journey">
-
-                        @journey match {
-                            case "repermission-narrow" => {
-                                @emailStep(isNarrow = true)
-                            }
-                            case "repermission" => {
-                                @consentStep(journey = "repermission")
-                                @emailStep()
-                            }
-                            case "signup" => {
-                                @consentStep(journey = "signup")
-                                @emailSignupStep()
-                            }
+                    @journey match {
+                        case "repermission-narrow" => {
+                            @emailStep(isNarrow = true)
                         }
+                        case "repermission" => {
+                            @consentStep(journey = "repermission")
+                            @emailStep()
+                        }
+                        case "signup" => {
+                            @consentStep(journey = "signup")
+                            @emailSignupStep()
+                        }
+                    }
 
-                        @endcardStep()
+                    @endcardStep()
 
-                        <div class="manage-account-wizard__controls">
-                            <button
-                                data-link-name="consent : @journey : navigation : prev"
-                                class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev"
-                            >
-                                <span class="u-h">Previous</span>
-                                @fragments.inlineSvg("arrow-left-stem", "icon")
-                            </button>
-                            <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
-                            </div>
-                            <button
-                                data-link-name="consent : @journey : navigation : next"
-                                class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next"
-                            >
-                                <span>Next</span>
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </button>
+                    <div class="manage-account-wizard__controls">
+                        <button
+                            data-link-name="consent : @journey : navigation : prev"
+                            class="manage-account-consent-wizard-button-back manage-account-consent-wizard__revealable manage-account__button--round manage-account__button js-manage-account-wizard__prev"
+                        >
+                            <span class="u-h">Previous</span>
+                            @fragments.inlineSvg("arrow-left-stem", "icon")
+                        </button>
+                        <div class="manage-account-consent-wizard__revealable manage-account-consent-wizard-counter">
                         </div>
+                        <button
+                            data-link-name="consent : @journey : navigation : next"
+                            class="manage-account__button--icon manage-account__button js-manage-account-consent-wizard__next"
+                        >
+                            <span>Next</span>
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </button>
                     </div>
-
                 </div>
+
             </div>
         </div>
     </div>
-}
+</div>

--- a/identity/app/views/fragments/identitySlimFooter.scala.html
+++ b/identity/app/views/fragments/identitySlimFooter.scala.html
@@ -1,7 +1,9 @@
+@import org.joda.time.LocalDate
+
 @()
 
 <footer class="manage-account-consent-slim-footer">
     <div class="gs-container">
-        © Guardian News and Media Limited or its affiliated companies. All rights reserved.
+        © @(new LocalDate().getYear) Guardian News and Media Limited or its affiliated companies. All rights reserved.
     </div>
 </footer>

--- a/identity/app/views/fragments/identitySlimFooter.scala.html
+++ b/identity/app/views/fragments/identitySlimFooter.scala.html
@@ -1,0 +1,7 @@
+@()
+
+<footer class="manage-account-consent-slim-footer">
+    <div class="gs-container">
+        © Guardian News and Media Limited or its affiliated companies. All rights reserved.
+    </div>
+</footer>

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -1,6 +1,6 @@
 .manage-account-wizard--consent {
     .manage-account-wizard__step {
-        min-height: 50vh;
+        min-height: 72vh;
         padding: $gs-gutter 0;
     }
     .manage-account-wizard__controls {

--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -104,3 +104,14 @@
         @include fs-textSans(2);
     }
 }
+
+.manage-account-consent-slim-footer {
+    @include fs-textSans(1);
+    background: $neutral-1;
+    color: $neutral-3;
+    padding: $gs-gutter 0;
+
+    @include mq($until: desktop) {
+        padding: $gs-gutter * 1;
+    }
+}

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -56,6 +56,10 @@
     padding-bottom: $gs-baseline*4;
     padding-top: $gs-baseline*4;
 
+    &.identity-wrapper--with-wizard {
+        padding-bottom: 0;
+    }
+
     @include mq(desktop) {
         max-width: gs-span(10);
     }

--- a/static/src/stylesheets/module/identity/_wizard.scss
+++ b/static/src/stylesheets/module/identity/_wizard.scss
@@ -6,7 +6,8 @@
 }
 .manage-account-wizard--completed {
     .manage-account-wizard__controls {
-        display: none;
+        visibility: hidden;
+        pointer-events: none;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Makes the footer in the consent journey page significantly smaller, also upgrades the page to the new `HtmlPage` infra making future changes trivial

## What is the value of this and can you measure success?
Oh wow scrolling down at the moment is ROUGH. Should also help retention, ideally we don't want any links to the outside on this whole flow

## Can i see it?
Sure thing! But we are still on hold for the final design and this PR is more about changing the page so any hypothetical header/footer may wrap it. Seeing it now it really should be over the bar instead of doing a weird scroll thing at all really.

![screen shot 2017-12-11 at 18 22 03](https://user-images.githubusercontent.com/11539094/33847148-85b4ae08-dea1-11e7-80fe-29f01b060ba6.png)
