### PR TITLE
Temporary fix for missing stories on email front bug

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -108,8 +108,16 @@ trait FaciaController extends BaseController with Logging with ImplicitControlle
         case None => Cached(CacheTime.Facia)(JsonComponent(JsObject(Nil)))}
   }
 
+  private def findPressedPage(path: String): Future[Option[PressedPage]] = {
+    if (path.startsWith("email/")) {
+      frontJsonFapi.get(path)
+    } else {
+      frontJsonFapi.getLite(path)
+    }
+  }
+
   private[controllers] def renderFrontPressResult(path: String)(implicit request: RequestHeader) = {
-    val futureResult = frontJsonFapi.getLite(path).flatMap {
+    val futureResult = findPressedPage(path).flatMap {
       case Some(faciaPage) =>
         successful(
           if (request.isRss) {


### PR DESCRIPTION
## What does this change?

Temporary fix for missing stories on email front bug. For email fronts, use the full pressed front.

## What is the value of this and can you measure success?

Email fronts display the configured number of stories

## Tested in CODE?

locally

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
