### PR TITLE
Desktop Header: bigger click areas for links

### DIFF
--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -182,14 +182,16 @@
                 }
 
                 @if(HeaderFeedback.isSwitchedOn) {
-                    <li class="hide-until-desktop feedback-form">
-                        @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
-                        We&rsquo;d appreciate your feedback on our new navigation.
-                        <a class="feedback-form__link"
-                        data-link-name="nav2 : feedback-form"
+                    <a data-link-name="nav2 : feedback-form"
                         href="https://goo.gl/forms/j5pMsPSWINu7X2R62">
-                        Share your thoughts here.</a>
-                    </li>
+
+                        <li class="hide-until-desktop feedback-form">
+                            @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
+                            We&rsquo;d appreciate your feedback on our new navigation.
+                            <span class="feedback-form__link">
+                            Share your thoughts here.</span>
+                        </li>
+                    </a>
                 }
             </ul>
         </div>

--- a/static/src/stylesheets/layout/new-header/_menu-item.scss
+++ b/static/src/stylesheets/layout/new-header/_menu-item.scss
@@ -46,7 +46,6 @@
         letter-spacing: .3px;
         padding: ($gs-baseline / 2) 0;
         transition: color 80ms ease-out;
-        width: auto;
     }
 
     &:hover,

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -217,6 +217,16 @@ x:-o-prefocus, .new-header__cta-container  {
     }
 }
 
+.feedback-form__link {
+    color: $guardian-brand;
+    cursor: pointer;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
 .feedback-form__icon__svg {
     margin-bottom: -2px;
     fill: $neutral-1;


### PR DESCRIPTION
## What does this change?
Lets make click areas bigger! This affects the menu items underneath the pillars, and the feedback form in the open menu.
![image](https://user-images.githubusercontent.com/8774970/33884674-83fffbc0-df38-11e7-8aa7-c3a89b163741.png)


## What is the value of this and can you measure success?
Easier to click things

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
