### PR TITLE
Change accuweather api to use fastly config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ever thought about joining us?
 https://workforus.theguardian.com/careers/digital-development/
 
 # Frontend
-[The Guardian](http://www.theguardian.com) website frontend.
+[The Guardian](https://www.theguardian.com) website frontend.
 
 Frontend is [a set of Play Framework 2 Scala applications](https://github.com/guardian/frontend/wiki/Applications-architecture).
 

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -20,6 +20,8 @@ import scala.util.control.NonFatal
 import akka.pattern.after
 
 class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit ec: ExecutionContext) extends ResourcesHelper with Logging {
+
+  // NOTE: If you change the API Key, you must also update the weatherapi fastly configuration, as it is enforced there
   lazy val weatherApiKey: String = Configuration.weather.apiKey.getOrElse(
     throw new RuntimeException("Weather API Key not set")
   )

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -28,17 +28,19 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
   val requestRetryMax: Int = 3
   val requestRetryDelay: FiniteDuration = 100.milliseconds
 
+  val accuWeatherApiUri = "https://weather.guardianapis.com"
+
   private def autocompleteUrl(query: String): String =
-    s"http://api.accuweather.com/locations/v1/cities/autocomplete?apikey=$weatherApiKey&q=${URLEncoder.encode(query, "utf-8")}"
+    s"$accuWeatherApiUri/locations/v1/cities/autocomplete?apikey=$weatherApiKey&q=${URLEncoder.encode(query, "utf-8")}"
 
   private def cityLookUp(cityId: CityId): String =
-    s"http://api.accuweather.com/currentconditions/v1/${cityId.id}.json?apikey=$weatherApiKey"
+    s"$accuWeatherApiUri/currentconditions/v1/${cityId.id}.json?apikey=$weatherApiKey"
 
   private def forecastLookUp(cityId: CityId): String =
-    s"http://api.accuweather.com/forecasts/v1/hourly/24hour/${cityId.id}.json?details=true&apikey=$weatherApiKey"
+    s"$accuWeatherApiUri/forecasts/v1/hourly/24hour/${cityId.id}.json?details=true&apikey=$weatherApiKey"
 
   private def latitudeLongitudeUrl(latitudeLongitude: LatitudeLongitude): String = {
-    s"http://api.accuweather.com/locations/v1/cities/geoposition/search.json?q=$latitudeLongitude&apikey=$weatherApiKey"
+    s"$accuWeatherApiUri/locations/v1/cities/geoposition/search.json?q=$latitudeLongitude&apikey=$weatherApiKey"
   }
 
   private def getJson(url: String): Future[JsValue] = {


### PR DESCRIPTION
## What does this change?
Sets onward to use the new weather.guardianapis.com fastly endpoint as opposed to hitting api.accuweather.com directly

![weather gif](https://cdn.dribbble.com/users/28455/screenshots/1389791/weather.gif)
## What is the value of this and can you measure success?
This should help reduce spikes of errors like [this](https://kibana.gu-web.net/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2017-12-11T12:57:13.420Z',mode:absolute,to:'2017-12-11T13:04:24.147Z'))&_a=(columns:!(_source),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'app:onward%20AND%20level:ERROR')),sort:!('@timestamp',desc)))

In the current implementation I've not set the fastly config up to serve stale. Let's see if this makes a difference, and if necessary we can add some vcl to get it to serve stale if accuweather is down.
## Does this affect other platforms - Amp, Apps, etc?
No - all server side
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No - all server side

## Screenshots
-
## Tested in CODE?
Yes
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
