### PR TITLE
Fix paypal logos for membership banner for IE 11

### DIFF
--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -473,32 +473,29 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
  * Prominent membership message as a feature
  */
 
-
+@mixin scale-paypal-logo($width) {
+    width: $width;
+    height: $width * .14;
+}
 
 .membership__paypal-logo {
+    @include scale-paypal-logo(100px);
     display: inline-block;
-    height: auto;
-    object-fit: contain;
-    margin-top: 0;
-    margin-bottom: -2px;
-    margin-right: 7px;
-    width: 100px;
+    padding-right: 7px;
+    padding-top: 16px;
 
     @include mq($from: mobileMedium) {
-        margin-right: $gs-gutter/2;
-        margin-bottom: -4px;
-        width: 130px;
+        @include scale-paypal-logo(130px);
+        padding-top: 15px;
     }
 
 
     @include mq(desktop) {
-        width: 175px;
-        margin-bottom: 2px;
+        @include scale-paypal-logo(175px);
     }
 
     @include mq($from: wide) {
-        margin-top: 2px;
-        margin-bottom: 0;
+        padding-top: 21px;
     }
 }
 


### PR DESCRIPTION
Previously, the banner was using object-fit: contain; to size and position the paypal logo in the banner. This attribute is not supported in IE 11, so the logos were being distorted. This PR implements the height and positioning of the paypal logos in such a way that it will work on all browsers.

@guardian/contributions @SiAdcock