### PR TITLE
Australian sports isn't in being used in the nav, so lets remove the id from the tag list

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -537,7 +537,6 @@ object NavLinks {
     "sport/afl",
     "football/a-league",
     "sport/nrl",
-    "sport/australia-sport",
     "music/classicalmusicandopera",
     "lifeandstyle/food-and-drink",
     "tone/recipes",


### PR DESCRIPTION
## What does this change?
If an article belongs in australia sport, then no pillar is found as it isn't part of any of the pillar lists. To prevent this I am removing it from the tag pages list so that it falls back to the section. This behaviour makes more sense anyway.

For example this article: https://www.theguardian.com/football/2017/dec/12/it-looks-like-someones-gran-diego-maradona-statue-unveiled-in-india should show up as a football article, as that is the section its in. 

## What is the value of this and can you measure success?
Clearer subnav for all articles with this tag

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
