### PR TITLE
Don't include campaign rules in page config.

### DIFF
--- a/common/app/commercial/targeting/CampaignAgent.scala
+++ b/common/app/commercial/targeting/CampaignAgent.scala
@@ -35,7 +35,7 @@ object CampaignAgent extends Logging {
 
   def getCampaignsForTags(tags: Seq[String]): List[Campaign] = {
     if (Targeting.isSwitchedOn) {
-      agent().getCampaignsForTags(tags)
+      agent().getCampaignsForTags(tags, stripRules=true)
     } else {
       Nil
     }


### PR DESCRIPTION
Sometimes a campaign can include rules called something like 'panama papers' which we don't want to reveal until a story has been published. This change simply strips the rules from the campaign before they are added to the config.

In future it might be worth modifying the targeting client to strip rules by default.