### PR TITLE
Refactor out identity colors

### DIFF
--- a/static/src/stylesheets/module/identity/_consent.scss
+++ b/static/src/stylesheets/module/identity/_consent.scss
@@ -7,7 +7,7 @@
         padding: $gs-gutter;
         margin-top: $gs-gutter;
         background: #ffffff;
-        border-top: 1px solid transparentize($guardian-brand, .5);
+        border-top: 1px solid transparentize($identity-main, .5);
         position: sticky;
         bottom: 0;
         left: 0;
@@ -40,7 +40,7 @@
 
 .manage-account-consent-wizard-counter {
     @include fs-textSans(2);
-    color: $guardian-brand;
+    color: $identity-main;
 }
 
 .manage-account-consent-wizard-counter__indicator {
@@ -55,7 +55,7 @@
         align-items: center;
         justify-content: center;
         border-radius: 100%;
-        box-shadow: inset 0 0 0 1px $guardian-brand;
+        box-shadow: inset 0 0 0 1px $identity-main;
 
     }
 }

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -309,7 +309,7 @@
 ========================================================================== */
 .manage-account-header {
     @include fs-header(3);
-    color: $guardian-brand-dark;
+    color: $identity-main;
 }
 .manage-account-headerNote {
     @include fs-bodyCopy(2);
@@ -331,7 +331,7 @@
 .manage-account-divider {
     display: block;
     width: 100%;
-    border-top: 1px solid $news-main-2;
+    border-top: 1px solid #d9d9d9;
     margin-bottom: gs-span(.5);
     transform: scaleX(3);
     @include mq(desktop) {
@@ -431,7 +431,7 @@
 ========================================================================== */
 .manage-account__button {
     @include fs-textSans(2);
-    background-color: $guardian-brand;
+    background-color: $identity-main;
     height: $gs-gutter * 2;
     border-radius: 100px;
     border: 0;
@@ -454,7 +454,7 @@
     justify-content: center;
 
     &:not(.is-updating, .is-disabled):hover {
-        background-color: $guardian-brand-dark;
+        background-color: darken($identity-main, 10%);
     }
 
     &:hover, &:active, &:focus {
@@ -496,13 +496,12 @@
 }
 
 %manage-account__button--light {
-    color: $guardian-brand;
+    color: $identity-main;
     background-color: transparent;
-    border: 1px solid $news-main-2;
+    border: 1px solid lighten($identity-main, 50%);
     &:not(.is-updating, .is-disabled):hover {
-        color: $guardian-brand-dark;
-        background-color: transparent;
-        border-color: currentColor;
+        color: #fff;
+        border-color: $identity-main;
     }
 }
 

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -500,7 +500,7 @@
     background-color: transparent;
     border: 1px solid lighten($identity-main, 50%);
     &:not(.is-updating, .is-disabled):hover {
-        color: #fff;
+        color: #ffffff;
         border-color: $identity-main;
     }
 }

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -73,7 +73,7 @@ $checkbox-size: $gs-gutter / 1.25;
         top: 0;
         left: 0;
         right: 0;
-        background-color: $guardian-brand;
+        background-color: $identity-main;
         height: 2px;
         transform-origin: center;
         opacity: 0;
@@ -106,7 +106,7 @@ $checkbox-size: $gs-gutter / 1.25;
     &.is-just-updated {
         &:before {
             animation: manage-account__switch-anim-loaded .5s 1 both;
-            background-color: $news-main-2;
+            background-color: $identity-support;
             opacity: 1;
         }
     }
@@ -131,7 +131,9 @@ $checkbox-size: $gs-gutter / 1.25;
         }
 
         input:checked + .manage-account__switch-checkbox {
-            background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210.79%22%20height%3D%228.61%22%20viewBox%3D%220%200%2010.79%208.608%22%3E%3Cpath%20fill%3D%22%23005689%22%20d%3D%22M3%206.58L10.23%200l.55.53L3%208.6h-.27L0%204.8l.55-.56%202.44%202.33z%22%2F%3E%3C%2Fsvg%3E')
+            background-color: $identity-main;
+            border-color: lighten($identity-main,10%);
+            background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210.79%22%20height%3D%228.61%22%20viewBox%3D%220%200%2010.79%208.608%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M3%206.58l7.23-6.58.55.53-7.78%208.07h-.27l-2.73-3.8.55-.56%202.44%202.33z%22%2F%3E%3C%2Fsvg%3E')
         }
 
     }
@@ -148,6 +150,7 @@ $checkbox-size: $gs-gutter / 1.25;
     background-size: $checkbox-size / 1.5;
     background: #ffffff no-repeat center center;
     cursor: pointer;
+    transition: background-color .125s;
 }
 
 .manage-account__switch-content {

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -132,7 +132,7 @@ $checkbox-size: $gs-gutter / 1.25;
 
         input:checked + .manage-account__switch-checkbox {
             background-color: $identity-main;
-            border-color: lighten($identity-main,10%);
+            border-color: lighten($identity-main, 10%);
             background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210.79%22%20height%3D%228.61%22%20viewBox%3D%220%200%2010.79%208.608%22%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M3%206.58l7.23-6.58.55.53-7.78%208.07h-.27l-2.73-3.8.55-.56%202.44%202.33z%22%2F%3E%3C%2Fsvg%3E')
         }
 

--- a/static/src/stylesheets/pasteup/palette/_src.scss
+++ b/static/src/stylesheets/pasteup/palette/_src.scss
@@ -69,3 +69,7 @@ $maps-support-4:         #72af7e;
 // External content palette
 $external-main-1:        #1c6326;
 $external-support-1:     #a9af2b;
+
+// Identity palette
+$identity-main:          #005689;
+$identity-support:       #4bc6df;


### PR DESCRIPTION
## What does this change?
Refactors out references to `$guardian-brand` in identity modules to use `$identity-main` instead. At this moment it's still the same colour but we have discussed potentially changing in the future.

## What is the value of this and can you measure success?
Happier codebase, plus as a cool side feature, checked checkboxes now look extremely checked because they are a white tick (svgs can't be tinted) over brand colours