### PR TITLE
Add beauty and cars links to the Lifestyle pillar in the Navigation

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -115,6 +115,8 @@ object NavLinks {
   val relationshipsAu = NavLink("relationships", "/au/lifeandstyle/relationships")
   val loveAndSex = NavLink("love & sex", "/lifeandstyle/love-and-sex")
   val family = NavLink("family", "/lifeandstyle/family")
+  val beauty = NavLink("beauty", "/fashion/beauty")
+  val cars = NavLink("cars", "/technology/motoring")
   val home = NavLink("home & garden", "/lifeandstyle/home-and-garden")
   val health = NavLink("health & fitness", "/lifeandstyle/health-and-wellbeing")
   val healthAu = NavLink("health & fitness", "/au/lifeandstyle/health-and-wellbeing")
@@ -374,11 +376,12 @@ object NavLinks {
       recipes,
       ukTravel,
       loveAndSex,
-      family,
+      beauty,
       home,
       health,
       women,
-      money
+      money,
+      cars
     )
   )
   val auLifestylePillar = ukLifestylePillar.copy(
@@ -573,6 +576,8 @@ object NavLinks {
     "crosswords/series/genius",
     "crosswords/series/speedy",
     "crosswords/series/everyman",
-    "crosswords/series/azed"
+    "crosswords/series/azed",
+    "fashion/beauty",
+    "technology/motoring"
   )
 }


### PR DESCRIPTION
## What does this change?
Katie (editorial) has asked for the UK lifestyle pillar to contain links to Beauty and Cars. She also asked to remove Family.

## What is the value of this and can you measure success?
:woman_shrugging: 
## Does this affect other platforms - Amp, Apps, etc?
Nope
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
Nope

<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
