### PR TITLE
New header mobile bug fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -156,18 +156,28 @@ const toggleMenu = (): void => {
                 });
             });
 
-            mediator.on('module:clickstream:click', function triggerToggle(
-                clickSpec
-            ) {
-                const elem = clickSpec ? clickSpec.target : null;
+            // On desktop clicking outside menu should close it
 
-                // if anywhere else but the links are clicked, the dropdown will close
-                if (elem !== menu) {
-                    toggleMenu();
-                    // remove event when the dropdown closes
-                    mediator.off('module:clickstream:click', triggerToggle);
-                }
-            });
+            console.log('***', isBreakpoint({
+                min: 'desktop'
+            }));
+
+            if (isBreakpoint({
+                min: 'desktop'
+            })) {
+                mediator.on('module:clickstream:click', function triggerToggle(
+                    clickSpec
+                ) {
+                    const elem = clickSpec ? clickSpec.target : null;
+    
+                    // if anywhere else but the links are clicked, the dropdown will close
+                    if (elem !== menu) {
+                        toggleMenu();
+                        // remove event when the dropdown closes
+                        mediator.off('module:clickstream:click', triggerToggle);
+                    }
+                });
+            }
         } else {
             removeEnhancedMenuMargin().then(() => {
                 window.removeEventListener('resize', debouncedMenuEnhancement);

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -158,18 +158,23 @@ const toggleMenu = (): void => {
 
             // On desktop clicking outside menu should close it
 
-            console.log('***', isBreakpoint({
-                min: 'desktop'
-            }));
+            console.log(
+                '***',
+                isBreakpoint({
+                    min: 'desktop',
+                })
+            );
 
-            if (isBreakpoint({
-                min: 'desktop'
-            })) {
+            if (
+                isBreakpoint({
+                    min: 'desktop',
+                })
+            ) {
                 mediator.on('module:clickstream:click', function triggerToggle(
                     clickSpec
                 ) {
                     const elem = clickSpec ? clickSpec.target : null;
-    
+
                     // if anywhere else but the links are clicked, the dropdown will close
                     if (elem !== menu) {
                         toggleMenu();

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -157,14 +157,6 @@ const toggleMenu = (): void => {
             });
 
             // On desktop clicking outside menu should close it
-
-            console.log(
-                '***',
-                isBreakpoint({
-                    min: 'desktop',
-                })
-            );
-
             if (
                 isBreakpoint({
                     min: 'desktop',


### PR DESCRIPTION
## What does this change?

Fixes issue from https://github.com/guardian/frontend/pull/18471 that was caused the new header to close when the user clicked on it on Mobile. 

## What is the value of this and can you measure success?

Fixes bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

