### PR TITLE
Fix AJAX post when user has no consents

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -139,7 +139,9 @@ class EditProfileController(
                 InternalServerError(Json.toJson(idapiErrors))
 
               case Right(updatedUser) =>
-                Ok(s"Successfully updated marketing consent for user ${userDO.getId}")
+                val successMsg = s"Successfully updated marketing consent for user ${userDO.getId}"
+                logger.info(successMsg)
+                Ok(successMsg)
             }
           }
         ) // end bindFromRequest.fold(

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -90,15 +90,16 @@ case class PrivacyFormData(
       case Some(_) => allowThirdPartyProfiling
     }
 
-    val newConsents = for {
-      oldConsent <- oldUserDO.consents
-      newConsent <- consents
-    } yield {
-      if (oldConsent.id == newConsent.id)
-        newConsent
-      else
-        oldConsent
-    }
+    val newConsents =
+        for {
+          oldConsent <- if (oldUserDO.consents.isEmpty) defaultConsents else oldUserDO.consents
+          newConsent <- consents
+        } yield {
+          if (oldConsent.id == newConsent.id)
+            newConsent
+          else
+            oldConsent
+        }
 
     UserUpdateDTO(
       statusFields = Some(oldUserDO.statusFields.copy(


### PR DESCRIPTION
## What does this change?

With respect to AJAX post of consent, If users have no consents in DB, then make sure to post the remaining default consents along with the particular new consent being set.

This error does not exist for non-ajax post.

## What is the value of this and can you measure success?

Bug fix.

