### PR TITLE
Use acast url for mp3 downloading and playing podcast episodes on the web

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -551,6 +551,8 @@ object Audio {
 
     Audio(contentOverrides)
   }
+
+  def acastUrl(player: AudioPlayer, url: String): String = if (player.audio.tags.isPodcast) "https://flex.acast.com/" + url.replace("https://", "") else url
 }
 
 final case class Audio (override val content: Content) extends ContentType {

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -8,7 +8,7 @@
         data-auto-play="@player.autoPlay" preload="none">
 
         @player.audioElement.audio.encodings.map { encoding =>
-            <source src="@encoding.url" type="@encoding.format" />
+            <source src="@model.Audio.acastUrl(player, encoding.url)" type="@encoding.format" />
         }
     </audio>
     @player.audio match {
@@ -24,7 +24,7 @@
                 @audio.downloadUrl.map { downloadUrl =>
                     <li class="podcast-meta__item podcast-meta__item--download">
                         <a class="podcast-meta__item__link pseudo-icon pseudo-icon--download--white"
-                           href="@downloadUrl"
+                           href="@model.Audio.acastUrl(player, downloadUrl)"
                            data-link-name="@trackingCode("download")">Download MP3</a>
                     </li>
                 }


### PR DESCRIPTION
## What does this change?

We have been using [acast](https://www.acast.com) for some of our podcast on [our RSS platform](https://github.com/guardian/itunes-rss/pull/40).
The syndication team has now asked that the download and playing of all episodes on the web use that platform.

## What is the value of this and can you measure success?

Our download links and play use the acast mp3 file instead of the default one.

## Does this affect other platforms - Amp, Apps, etc?

I think the apps may be currently using some of the templates from the server side frontend. There have been some changes or at least hack days ideas around podcast in apps, so I am unsure on the current status.
      
@fgauchet if you know more about this I will be interested to know!

## Tested in CODE?

no but works locally. 

@oilnam 
