### PR TITLE
Change cancel contribution default switch state

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -541,7 +541,7 @@ trait FeatureSwitches {
     "profile-show-cancel-contributor",
     "When ON, the edit profile page will include the cancel contribution button",
     owners = Seq(Owner.withGithub("svillafe")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2018, 1, 15),
     exposeClientSide = true
   )


### PR DESCRIPTION
## What does this change?
We want the cancel contribution feature switch to be ON by default.

## What is the value of this and can you measure success?
The feature won't disappear unexpectedly.

## Does this affect other platforms - Amp, Apps, etc?
No.

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
No.

## Screenshots
N/A

## Tested in CODE?
No.

<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

cc @svillafe 