### PR TITLE
[bugfix] wrap js nodelist in array

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -68,7 +68,7 @@ const buildFormDataForFields = (
 ): FormData => {
     const formData: FormData = new FormData();
     formData.append('csrfToken', csrfToken);
-    fields.forEach((field: HTMLInputElement) => {
+    [...fields].forEach((field: HTMLInputElement) => {
         switch (field.type) {
             case 'checkbox':
                 formData.append(field.name, field.checked.toString());


### PR DESCRIPTION
Super minor teeny bug, `nodelist.forEach` is not polyfilled and breaks on Edge 15 :(