### PR TITLE
Enable styles for onward cards in Garnett

### DIFF
--- a/static/src/stylesheets/content.garnett.scss
+++ b/static/src/stylesheets/content.garnett.scss
@@ -90,17 +90,17 @@
    Facia
    ========================================================================== */
 
-   @import 'module/facia-garnett/_tag-meta';
-   @import 'module/facia-garnett/_l-list';
-   @import 'module/facia-garnett/_container';
-   @import 'module/facia-garnett/_containers';
-   @import 'module/facia-garnett/_slices';
-   @import 'module/facia-garnett/_sublinks';
-   @import 'module/facia-garnett/_pillars';
-   @import 'module/facia-garnett/_item';
-   @import 'module/facia-garnett/_items';
-   @import 'module/facia-garnett/_linkslist';
-   @import 'module/facia-garnett/_treats';
+@import 'module/facia-garnett/_tag-meta';
+@import 'module/facia-garnett/_l-list';
+@import 'module/facia-garnett/_container';
+@import 'module/facia-garnett/_containers';
+@import 'module/facia-garnett/_slices';
+@import 'module/facia-garnett/_sublinks';
+@import 'module/facia-garnett/_pillars';
+@import 'module/facia-garnett/_item';
+@import 'module/facia-garnett/_items';
+@import 'module/facia-garnett/_linkslist';
+@import 'module/facia-garnett/_treats';
 
 /* ==========================================================================
    Experiments

--- a/static/src/stylesheets/content.garnett.scss
+++ b/static/src/stylesheets/content.garnett.scss
@@ -90,13 +90,17 @@
    Facia
    ========================================================================== */
 
-@import 'module/facia-garnett/_tag-meta';
-@import 'module/facia-garnett/_l-list';
-@import 'module/facia-garnett/_container';
-@import 'module/facia-garnett/_containers';
-@import 'module/facia-garnett/_item';
-@import 'module/facia-garnett/_linkslist';
-@import 'module/facia-garnett/_treats';
+   @import 'module/facia-garnett/_tag-meta';
+   @import 'module/facia-garnett/_l-list';
+   @import 'module/facia-garnett/_container';
+   @import 'module/facia-garnett/_containers';
+   @import 'module/facia-garnett/_slices';
+   @import 'module/facia-garnett/_sublinks';
+   @import 'module/facia-garnett/_pillars';
+   @import 'module/facia-garnett/_item';
+   @import 'module/facia-garnett/_items';
+   @import 'module/facia-garnett/_linkslist';
+   @import 'module/facia-garnett/_treats';
 
 /* ==========================================================================
    Experiments


### PR DESCRIPTION
## What does this change?

Adds facia-garnett includes that enable styles for onward cards

## What is the value of this and can you measure success?

Adds facia-garnett includes that enable styles for onward cards

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

No

## Tested in CODE?

No