### PR TITLE
Remove config validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,7 @@ val common = library("common").settings(
     jodaForms,
     jacksonDataFormat,
     atomRenderer,
-    identityModel,
-    configMagic
+    identityModel
   )
 ).settings(
     mappings in TestAssets ~= filterAssets

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -61,33 +61,11 @@ object GuardianConfiguration extends Logging {
 
   import com.typesafe.config.Config
 
-  private def configToMap(config: Config): Map[String, String] = {
-    config.entrySet().asScala.map { entry =>
-     entry.getKey -> unwrapQuotedString(entry.getValue.render)
-    }.toMap
-  }
-
   def unwrapQuotedString(input: String): String = {
     val quotedString = "\"(.*)\"".r
     input match {
       case quotedString(content) => content
       case content => content
-    }
-  }
-
-  private def mapDiff(map1: Map[String, String], map2: Map[String, String]): Seq[String] = {
-    val missingKeys = map1.toSeq.diff(map2.toSeq) ++ map2.toSeq.diff(map1.toSeq)
-    missingKeys.map(_._1).sorted.distinct
-  }
-
-  private def diffLegacyConfig(s3Config: Config, parameterStoreConfig: Config): Unit = {
-    val s3ConfigMap = configToMap(s3Config)
-    val parameterStoreConfigMap = configToMap(parameterStoreConfig)
-    val confDiff = mapDiff(s3ConfigMap, parameterStoreConfigMap)
-    if (confDiff.nonEmpty || s3ConfigMap != parameterStoreConfigMap) {
-      throw new RuntimeException(s"Legacy S3 configuration does not match parameter store configuration, $confDiff")
-    } else {
-      log.info("Parameter config is identical to legacy S3 Config, which is good!")
     }
   }
 
@@ -106,13 +84,6 @@ object GuardianConfiguration extends Logging {
 
   private lazy val parameterStore = new ParameterStore(awsRegion)
 
-  private lazy val s3Config: Config = {
-    val s3ConfigVersion = 51
-    val identity = AwsApplication(Environment.stack, app, stage, awsRegion)
-    val config = S3ConfigurationSource(identity, Environment.configBucket, Configuration.aws.mandatoryCredentials, Some(s3ConfigVersion)).load.resolve()
-    config.getConfig(identity.app + "." + identity.stage)
-  }
-
   lazy val configuration: Config = {
     if (stage == "DEVINFRA")
       ConfigFactory.parseResourcesAnySyntax("env/DEVINFRA.properties")
@@ -123,15 +94,11 @@ object GuardianConfiguration extends Logging {
       val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
       val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
-      val parameterStoreConfig = frontendAppConfig
-        .withFallback(frontendStageConfig)
-        .withFallback(frontendConfig)
-
-      diffLegacyConfig(s3Config, parameterStoreConfig)
-
       userPrivate
         .withFallback(runtimeOnly)
-        .withFallback(parameterStoreConfig)
+        .withFallback(frontendAppConfig)
+        .withFallback(frontendStageConfig)
+        .withFallback(frontendConfig)
     }
   }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -7,7 +7,6 @@ import java.util.Map.Entry
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.gu.cm.{AwsApplication, S3ConfigurationSource}
 import com.typesafe.config.{ConfigException, ConfigFactory}
 import common.Environment.{app, awsRegion, stage}
 import conf.switches.Switches

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,6 @@ object Dependencies {
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "3.7.0"
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.26"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play26" % faciaVersion
-  val configMagic = "com.gu" %% "configuration-magic-core" %  "1.4.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityRequest = "com.gu.identity" %% "identity-request" % identityLibVersion


### PR DESCRIPTION
## What does this change?

Remove S3/Parameter store config diff fail on start validation.
This was used for initially deploying parameter store configuration

## What is the value of this and can you measure success?

Users only need to update parameter store when modifying configuration. S3 config dependency is completely removed.

## Tested in CODE?

Will check all the apps startup correctly