### PR TITLE
Apply default size to inline-quote svg in Garnett

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -178,6 +178,14 @@ $fc-item-gutter: $gs-gutter / 4;
     overflow: hidden;
 }
 
+.fc-item__title--quoted {
+    .inline-garnett-quote {
+        fill: $neutral-2;
+
+        @include fs-headline-quote(2);
+    }
+}
+
 .fc-item__kicker,
 .fc-sublink__kicker,
 .rich-link__kicker {

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -180,9 +180,8 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__title--quoted {
     .inline-garnett-quote {
-        fill: $neutral-2;
-
         @include fs-headline-quote(2);
+        fill: $neutral-2;
     }
 }
 


### PR DESCRIPTION
## What does this change?

Applies default size to inline-quote svg in Garnett so it looks ok in most read list

## What is the value of this and can you measure success?

Fixes bug

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No