### PR TITLE
use s3 config temporarily

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -119,19 +119,19 @@ object GuardianConfiguration extends Logging {
     else {
       val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
       val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
-      val frontendConfig = configFromParameterStore("/frontend")
-      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
-      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+//      val frontendConfig = configFromParameterStore("/frontend")
+//      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
+//      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
-      val parameterStoreConfig = frontendAppConfig
-        .withFallback(frontendStageConfig)
-        .withFallback(frontendConfig)
+//      val parameterStoreConfig = frontendAppConfig
+//        .withFallback(frontendStageConfig)
+//        .withFallback(frontendConfig)
 
-      diffLegacyConfig(s3Config, parameterStoreConfig)
+//      diffLegacyConfig(s3Config, parameterStoreConfig)
 
       userPrivate
         .withFallback(runtimeOnly)
-        .withFallback(parameterStoreConfig)
+        .withFallback(s3Config)
     }
   }
 


### PR DESCRIPTION
## What does this change?

use s3 config temporarily to enable local dev without ssm permissions

## What is the value of this and can you measure success?

Everyone can run frontend locally until SSM permissions are added to Janus for all users
