### PR TITLE
Adjust specificity of quote selector

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -178,11 +178,9 @@ $fc-item-gutter: $gs-gutter / 4;
     overflow: hidden;
 }
 
-.fc-item__title--quoted {
-    .inline-garnett-quote {
-        @include fs-headline-quote(2);
-        fill: $neutral-2;
-    }
+.inline-garnett-quote {
+    @include fs-headline-quote(2);
+    fill: $neutral-2;
 }
 
 .fc-item__kicker,


### PR DESCRIPTION
## What does this change?

Adjust specificity of quote selector, it was too specific before meaning overrides failed to override

## What is the value of this and can you measure success?

Better quotes

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No