### PR TITLE
Remove media icons from title on Garnett

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -7,11 +7,14 @@
 
 @icon = {
     @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon") }
-    @if(header.isVideo) { @fragments.inlineSvg("video-icon", "icon") }
-    @if(header.isGallery) { @fragments.inlineSvg("camera", "icon") }
-    @if(header.isAudio) { @fragments.inlineSvg("volume-high", "icon") }
-    @if(header.quoted && !experiments.ActiveExperiments.isParticipating(experiments.Garnett)) { @fragments.inlineSvg("quote", "icon") }
-    @if(header.quoted && experiments.ActiveExperiments.isParticipating(experiments.Garnett)) { @fragments.inlineSvg("garnett-quote", "icon") }
+    @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett)) { 
+        @if(header.isVideo) { @fragments.inlineSvg("video-icon", "icon") }
+        @if(header.isGallery) { @fragments.inlineSvg("camera", "icon") }
+        @if(header.isAudio) { @fragments.inlineSvg("volume-high", "icon") }
+        @if(header.quoted) { @fragments.inlineSvg("quote", "icon") }
+    } else {
+        @if(header.quoted) { @fragments.inlineSvg("garnett-quote", "icon") }
+    }
 }
 
 @headline() = {


### PR DESCRIPTION
## What does this change?

When this PR https://github.com/guardian/frontend/pull/18507 was merged it caused a bug in media cards on Garnett. In the Media Card's HTML a media icon sits beside title. Before `18507` was merged this icon had `display:none` on so the card looked ok, however after `18507` they became visible, which isn't desired.

This PR prevents adding the media icons in the HTML template for the title if Garnett is on as we don't want them there.

## What is the value of this and can you measure success?

Fixes Media cards

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No