### PR TITLE
Quote sizes on Garnett comment cards

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -5,7 +5,7 @@ $fc-item-gutter: $gs-gutter / 4;
 */
 
 @mixin fs-headline-quote($level) {
-    .inline-garnett-quote__svg {
+    .fc-item__title--quoted .inline-garnett-quote__svg {
         height: get-font-size(headline, $level);
         width: get-font-size(headline, $level) * .5;
         margin-right: get-font-size(headline, $level) * .5;
@@ -59,6 +59,8 @@ $fc-item-gutter: $gs-gutter / 4;
         padding-right: gs-span(3);
     }
 }
+
+@include fs-headline-quote(2);
 
 .fc-item {
     @include mq($until: tablet) {
@@ -178,10 +180,10 @@ $fc-item-gutter: $gs-gutter / 4;
     overflow: hidden;
 }
 
-.inline-garnett-quote {
+// .fc-item {
     @include fs-headline-quote(2);
-    fill: $neutral-2;
-}
+    // fill: $neutral-2;
+// }
 
 .fc-item__kicker,
 .fc-sublink__kicker,

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -180,11 +180,6 @@ $fc-item-gutter: $gs-gutter / 4;
     overflow: hidden;
 }
 
-// .fc-item {
-    @include fs-headline-quote(2);
-    // fill: $neutral-2;
-// }
-
 .fc-item__kicker,
 .fc-sublink__kicker,
 .rich-link__kicker {


### PR DESCRIPTION
## What does this change?

The size of the quote icon on some Garnett comment cards was still broken despite this PR https://github.com/guardian/frontend/pull/18518 😢 . I've adjusted the selectors and cross checked every card to be sure the correct size is now being applied with this change!

## What is the value of this and can you measure success?

Correctly sized quote icon

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No