### PR TITLE
Consent journey email validation

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -175,6 +175,17 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val IdentityPointToConsentJourneyPage = Switch(
+    SwitchGroup.Identity,
+    "id-point-to-consent-journey-page",
+    "If switched on, public facing links will redirect to journey page",
+    owners = Seq(Owner.withGithub("calum-campbell")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 15),
+    exposeClientSide = false
+
+  )
+
   val IdentityRedirectUsersWithLingeringV1ConsentsSwitch = Switch(
     SwitchGroup.Identity,
     "id-redirect-users-with-lingering-v1-consents",

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -61,7 +61,7 @@ class EditProfileController(
   def displayEmailPrefsForm(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] =
     displayForm(EmailPrefsProfilePage, consentsUpdated, consentHint)
 
-  def displayConsentJourneyForm(journey: Option[String], consentHint: Option[String], newsletterHint: Option[String]): Action[AnyContent] = {
+  def displayConsentJourneyForm(journey: String, consentHint: Option[String], newsletterHint: Option[String]): Action[AnyContent] = {
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
       recentlyAuthenticated { implicit request =>
         NotFound(views.html.errors._404())
@@ -72,7 +72,7 @@ class EditProfileController(
         permissionAuthentication.async { implicit request =>
           consentJourneyView(
             page = ConsentJourneyPage,
-            journey = journey.getOrElse("repermission"),
+            journey = journey,
             forms = ProfileForms(userWithHintedConsent(consentHint), PublicEditProfilePage),
             request.user,
             consentHint,

--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -64,14 +64,14 @@ class EditProfileController(
   def displayRecurringContributionForm: Action[AnyContent] = displayForm(recurringContributionPage)
   def displayDigitalPackForm: Action[AnyContent] = displayForm(DigiPackEditProfilePage)
 
-  def displayConsentsJourneyAll(consentHint: Option[String] = None, newsletterHint: Option[String] = None): Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageAll, consentHint, newsletterHint)
-  def displayConsentsJourneyNewsletters: Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageNewsletters, None, None)
-  def displayConsentsJourney(consentHint: Option[String] = None, newsletterHint: Option[String] = None): Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint, newsletterHint)
+  def displayConsentsJourneyAll(consentHint: Option[String] = None, newsletterHint: Option[String] = None): Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageAll, consentHint)
+  def displayConsentsJourneyNewsletters: Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageNewsletters, None)
+  def displayConsentsJourney(consentHint: Option[String] = None): Action[AnyContent] = displayConsentJourneyForm(ConsentJourneyPageDefault, consentHint)
 
   def displayEmailPrefsForm(consentsUpdated: Boolean, consentHint: Option[String]): Action[AnyContent] =
     displayForm(EmailPrefsProfilePage, consentsUpdated, consentHint)
 
-  def displayConsentJourneyForm(page: ConsentJourneyPage, consentHint: Option[String], newsletterHint: Option[String]): Action[AnyContent] = {
+  def displayConsentJourneyForm(page: ConsentJourneyPage, consentHint: Option[String]): Action[AnyContent] = {
     if (IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOff) {
       recentlyAuthenticated { implicit request =>
         NotFound(views.html.errors._404())
@@ -85,8 +85,7 @@ class EditProfileController(
             journey = page.journeyParam,
             forms = ProfileForms(userWithHintedConsent(consentHint), PublicEditProfilePage),
             request.user,
-            consentHint,
-            newsletterHint
+            consentHint
           )
         }
       }
@@ -234,8 +233,7 @@ class EditProfileController(
       journey: String,
       forms: ProfileForms,
       user: User,
-      consentHint: Option[String],
-      newsletterHint: Option[String])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
+      consentHint: Option[String])(implicit request: AuthRequest[AnyContent]): Future[Result] = {
 
     newsletterService.subscriptions(request.user.getId, idRequestParser(request).trackingData).map { emailFilledForm =>
 
@@ -251,7 +249,6 @@ class EditProfileController(
           newsletterService.getEmailSubscriptions(emailFilledForm),
           EmailNewsletters.all,
           consentHint,
-          newsletterHint
         ))(page, request, context)
       ))
 

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -27,7 +27,7 @@ class EmailVerificationController(api: IdApiClient,
 
   val page = IdentityPage("/verify-email", "Verify Email")
 
-  def verify(token: String, journey: String): Action[AnyContent] = Action.async {
+  def verify(token: String): Action[AnyContent] = Action.async {
     implicit request =>
       val idRequest = idRequestParser(request)
 
@@ -51,8 +51,7 @@ class EmailVerificationController(api: IdApiClient,
           if(validationState.isExpired || IdentityPointToConsentJourneyPage.isSwitchedOff) {
             Ok(views.html.emailVerified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn, verifiedReturnUrl))
           } else {
-            // journey param passed by link sent in email validation email (Registration/AccountUpdate/EmailValidation)
-            SeeOther(idUrlBuilder.buildUrl(s"/consent?journey=${journey}&returnUrl=${encodedReturnUrl}"))
+            SeeOther(idUrlBuilder.buildUrl(s"/consents/?returnUrl=${encodedReturnUrl}"))
           }
       }
   }

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -27,7 +27,7 @@ class EmailVerificationController(api: IdApiClient,
 
   val page = IdentityPage("/verify-email", "Verify Email")
 
-  def verify(token: String, isSignUp: Option[String]): Action[AnyContent] = Action.async {
+  def verify(token: String, journeyParam: String): Action[AnyContent] = Action.async {
     implicit request =>
       val idRequest = idRequestParser(request)
 
@@ -47,7 +47,10 @@ class EmailVerificationController(api: IdApiClient,
           val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
           val verifiedReturnUrl = verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl)
           val encodedReturnUrl = URLEncoder.encode(verifiedReturnUrl, "utf-8")
-          val journey = if(isSignUp.forall(_.toBoolean)) "signup" else "repermission"
+          val journey = journeyParam match {
+            case "Registration" => "signup"
+            case _ => journeyParam
+          }
 
           if(validationState.isExpired || IdentityPointToConsentJourneyPage.isSwitchedOff) {
             Ok(views.html.emailVerified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn, verifiedReturnUrl))

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -51,6 +51,7 @@ class EmailVerificationController(api: IdApiClient,
           if(validationState.isExpired || IdentityPointToConsentJourneyPage.isSwitchedOff) {
             Ok(views.html.emailVerified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn, verifiedReturnUrl))
           } else {
+            // journey param passed by link sent in email validation email (Registration/AccountUpdate/EmailValidation)
             SeeOther(idUrlBuilder.buildUrl(s"/consent?journey=${journey}&returnUrl=${encodedReturnUrl}"))
           }
       }

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -51,7 +51,7 @@ class EmailVerificationController(api: IdApiClient,
           if(validationState.isExpired || IdentityPointToConsentJourneyPage.isSwitchedOff) {
             Ok(views.html.emailVerified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn, verifiedReturnUrl))
           } else {
-            SeeOther(idUrlBuilder.buildUrl(s"/consents/?returnUrl=${encodedReturnUrl}"))
+            SeeOther(idUrlBuilder.buildUrl(s"/consents?returnUrl=${encodedReturnUrl}"))
           }
       }
   }

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -27,7 +27,7 @@ class EmailVerificationController(api: IdApiClient,
 
   val page = IdentityPage("/verify-email", "Verify Email")
 
-  def verify(token: String, journeyParam: String): Action[AnyContent] = Action.async {
+  def verify(token: String, journey: String): Action[AnyContent] = Action.async {
     implicit request =>
       val idRequest = idRequestParser(request)
 
@@ -47,10 +47,6 @@ class EmailVerificationController(api: IdApiClient,
           val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
           val verifiedReturnUrl = verifiedReturnUrlAsOpt.getOrElse(returnUrlVerifier.defaultReturnUrl)
           val encodedReturnUrl = URLEncoder.encode(verifiedReturnUrl, "utf-8")
-          val journey = journeyParam match {
-            case "Registration" => "signup"
-            case _ => journeyParam
-          }
 
           if(validationState.isExpired || IdentityPointToConsentJourneyPage.isSwitchedOff) {
             Ok(views.html.emailVerified(validationState, page, idRequest, idUrlBuilder, userIsLoggedIn, verifiedReturnUrl))

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -148,7 +148,7 @@
 
 @endcardStep() = {
     <div class="manage-account-wizard__step" data-wizard-step-name="endcard">
-        <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consent", idRequest)">
+        <form class="manage-account-consent-thanks" method="POST" action="@idUrlBuilder.buildUrl("/complete-consents", idRequest)">
             <input type="hidden" name="returnUrl" value="@verifiedReturnUrl" />
             @views.html.helper.CSRF.formField
             <h2 class="manage-account-consent-thanks__title">Thank you</h2>

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -93,38 +93,40 @@
 }
 
 @emailStep(isNarrow: Boolean = false) = {
-    <div class="manage-account-wizard__step" data-wizard-step-name="email">
+    @if( onlySubscribedToNewsletters.nonEmpty ) {
+        <div class="manage-account-wizard__step" data-wizard-step-name="email">
 
-        <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
-            @views.html.helper.CSRF.formField
-            @fragments.form.hidden(emailPrefsForm("htmlPreference"))
+            <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+                @views.html.helper.CSRF.formField
+                @fragments.form.hidden(emailPrefsForm("htmlPreference"))
 
-            @if(isNarrow) {
-                <h2 class="identity-title">Sorry for the interruption</h2>
-                <p class="manage-account-headerNote">
-                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                </p>
-            } else {
-                <h2 class="identity-title">Your existing newsletters</h2>
-                <p class="manage-account-headerNote">
-                    You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
-                </p>
-            }
-            <div class="manage-account__switches">
-                <ul>
+                @if(isNarrow) {
+                    <h2 class="identity-title">Sorry for the interruption</h2>
+                    <p class="manage-account-headerNote">
+                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
+                    </p>
+                } else {
+                    <h2 class="identity-title">Your existing newsletters</h2>
+                    <p class="manage-account-headerNote">
+                        You were receiving the following newsletters, tick their boxes again to confirm you want to keep receiving them.
+                    </p>
+                }
+                <div class="manage-account__switches">
+                    <ul>
                     @onlySubscribedToNewsletters.zipWithRowInfo.map { case (newsletter, row) =>
-                        <li>
-                            @fragments.newsletterSwitch(
-                                emailPrefsForm,
-                                emailSubscriptions,
-                                newsletter = newsletter
-                            )(nonInputFields, messages, request)
-                        </li>
+                    <li>
+                        @fragments.newsletterSwitch(
+                            emailPrefsForm,
+                            emailSubscriptions,
+                            newsletter = newsletter
+                        )(nonInputFields, messages, request)
+                    </li>
                     }
-                </ul>
-            </div>
-        </form>
-    </div>
+                    </ul>
+                </div>
+            </form>
+        </div>
+    }
 }
 
 @emailSignupStep() = {

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -61,7 +61,7 @@
         <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
             @views.html.helper.CSRF.formField
 
-            @if(journey == "repermission") {
+            @if(journey == "all") {
                 <h1 class="identity-title">
                     We need you to consent again to receiving communications from The Guardian
                 </h1>
@@ -175,18 +175,18 @@
                 <div class="manage-account-wizard manage-account-wizard--consent" data-journey="@journey">
 
                     @journey match {
-                        case "repermission-narrow" => {
+                        case "newsletters" => {
                             @emailStep(isNarrow = true)
                             @channelStep()
                         }
-                        case "repermission" => {
-                            @consentStep(journey = "repermission")
+                        case "all" => {
+                            @consentStep(journey = "all")
                             @emailStep()
                             @channelStep()
                         }
-                        case "signup" => {
-                            @consentStep(journey = "signup")
-                            @emailSignupStep()
+                        case _ => {
+                            @consentStep("consent")
+                            @emailStep()
                             @channelStep()
                         }
                     }

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -20,9 +20,7 @@
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
     availableLists: EmailNewsletters,
-    consentHint: Option[String] = None,
-    newsletterHint: Option[String] = None
-)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
+    consentHint: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
 @onlySubscribedToNewsletters = @{
     EmailNewsletters.all.subscriptions.filter { newsletter =>

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -21,7 +21,7 @@ GET         /user/id/:id                            controllers.PublicProfileCon
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
-GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String, journey: String)
+GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
 GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail()
 
 GET         /form/complete                          controllers.FormstackController.complete
@@ -62,6 +62,7 @@ POST        /privacy/edit-ajax                      controllers.EditProfileContr
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
-GET         /consent                                controllers.EditProfileController.displayConsentJourneyForm(journey: Option[String], consentHint: Option[String], newsletterHint: Option[String])
-POST        /complete-consent                         controllers.EditProfileController.submitRepermissionedFlag
+GET         /consents                               controllers.EditProfileController.displayConsentJourneyForm(journey = "consent", consentHint: Option[String], newsletterHint: Option[String])
+GET         /consents/:journey                      controllers.EditProfileController.displayConsentJourneyForm(journey: String, consentHint: Option[String], newsletterHint: Option[String])
+POST        /complete-consent                       controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -64,5 +64,5 @@ POST        /email-prefs                            controllers.EditProfileContr
 
 GET         /consents                               controllers.EditProfileController.displayConsentJourneyForm(journey = "consent", consentHint: Option[String], newsletterHint: Option[String])
 GET         /consents/:journey                      controllers.EditProfileController.displayConsentJourneyForm(journey: String, consentHint: Option[String], newsletterHint: Option[String])
-POST        /complete-consent                       controllers.EditProfileController.submitRepermissionedFlag
+POST        /complete-consents                       controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -64,6 +64,6 @@ POST        /email-prefs                            controllers.EditProfileContr
 
 GET         /consents/all                           controllers.EditProfileController.displayConsentsJourneyAll(consentHint: Option[String])
 GET         /consents/newsletters                   controllers.EditProfileController.displayConsentsJourneyNewsletters
-GET         /consents                               controllers.EditProfileController.displayConsentsJourney(consentHint: Option[String], newsletterHint: Option[String])
+GET         /consents                               controllers.EditProfileController.displayConsentsJourney(consentHint: Option[String])
 POST        /complete-consents                      controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -21,7 +21,7 @@ GET         /user/id/:id                            controllers.PublicProfileCon
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
-GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String, isSignUp:Option[String])
+GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String, journey: String)
 GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail()
 
 GET         /form/complete                          controllers.FormstackController.complete

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -21,7 +21,7 @@ GET         /user/id/:id                            controllers.PublicProfileCon
 GET         /user/id/:id/:activityType              controllers.PublicProfileController.renderProfileFromId(id: String, activityType: String)
 GET         /user/:vanityUrl                        controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType = "discussions")
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
-GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String)
+GET         /verify-email/:token                    controllers.EmailVerificationController.verify(token: String, isSignUp:Option[String])
 GET         /verify-email                           controllers.EmailVerificationController.resendEmailValidationEmail()
 
 GET         /form/complete                          controllers.FormstackController.complete

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -62,7 +62,8 @@ POST        /privacy/edit-ajax                      controllers.EditProfileContr
 GET         /email-prefs                            controllers.EditProfileController.displayEmailPrefsForm(consentsUpdated: Boolean ?= false, consentHint: Option[String])
 POST        /email-prefs                            controllers.EditProfileController.saveEmailPreferencesAjax
 
-GET         /consents                               controllers.EditProfileController.displayConsentJourneyForm(journey = "consent", consentHint: Option[String], newsletterHint: Option[String])
-GET         /consents/:journey                      controllers.EditProfileController.displayConsentJourneyForm(journey: String, consentHint: Option[String], newsletterHint: Option[String])
-POST        /complete-consents                       controllers.EditProfileController.submitRepermissionedFlag
+GET         /consents/all                           controllers.EditProfileController.displayConsentsJourneyAll(consentHint: Option[String])
+GET         /consents/newsletters                   controllers.EditProfileController.displayConsentsJourneyNewsletters
+GET         /consents                               controllers.EditProfileController.displayConsentsJourney(consentHint: Option[String], newsletterHint: Option[String])
+POST        /complete-consents                      controllers.EditProfileController.submitRepermissionedFlag
 ########################################################################################################################

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -51,7 +51,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
     "when the api call succeeds" - {
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Right(())))
-      val result = controller.verify(token, "EmailValidation")(testRequest)
+      val result = controller.verify(token)(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -65,7 +65,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns already validated error" - {
       val err = Error("User Already Validated", "This user account has already been validated")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token, "EmailValidation")(testRequest)
+      val result = controller.verify(token)(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -79,7 +79,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns token expired error" - {
       val err = Error("Token expired", "The activation token is no longer valid")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token, "EmailValidation")(testRequest)
+      val result = controller.verify(token)(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -93,7 +93,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns invalid token error" - {
       val err = Error("Invalid json", "This request contains invalid json")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token, "EmailValidation")(testRequest)
+      val result = controller.verify(token)(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -51,7 +51,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
 
     "when the api call succeeds" - {
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Right(())))
-      val result = controller.verify(token)(testRequest)
+      val result = controller.verify(token, "EmailValidation")(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -65,7 +65,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns already validated error" - {
       val err = Error("User Already Validated", "This user account has already been validated")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token)(testRequest)
+      val result = controller.verify(token, "EmailValidation")(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -79,7 +79,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns token expired error" - {
       val err = Error("Token expired", "The activation token is no longer valid")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token)(testRequest)
+      val result = controller.verify(token, "EmailValidation")(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)
@@ -93,7 +93,7 @@ class EmailVerificationControllerTest extends path.FreeSpec
     "when the api call returns invalid token error" - {
       val err = Error("Invalid json", "This request contains invalid json")
       when(api.validateEmail(token, trackingData)).thenReturn(Future.successful(Left(List(err))))
-      val result = controller.verify(token)(testRequest)
+      val result = controller.verify(token, "EmailValidation")(testRequest)
 
       "should display the validation completed page" in {
         status(result) should be(OK)


### PR DESCRIPTION
## What does this change?

### Two changes
1.
 - Link sent in the email validation should redirect to consents journey page
- The link will always go to the default which is just /consents
- Behind a switch as shouldn't be live in production until we want to expose the journey page. 
2.
- Now use endpoint syntax rather than query param syntax for consents journey (consents/all, /consents/newsletters, /consents)

Related PR: 
https://github.com/guardian/identity/pull/740
## What is the value of this and can you measure success?
- Repermission
## Does this affect other platforms - Amp, Apps, etc?
- Emails will be sent when registering in App

## Tested in CODE?
No
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
