### PR TITLE
Remove video slots switch now we are going 100% Unruly.

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -15,16 +15,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val VideoSlotsSwitch = Switch(
-    SwitchGroup.Commercial,
-    "keep-video-ad-slots-open",
-    "Deactivates the sizecallback for videos (620x1) that hides the slot.",
-    owners = Seq(Owner.withGithub("JonNorman")),
-    safeState = Off,
-    sellByDate = new LocalDate(2017, 12, 20),
-    exposeClientSide = true
-  )
-
   Switch(
     SwitchGroup.Commercial,
     "ias-ad-targeting",

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -12,7 +12,6 @@ import renderAdvertLabel from 'commercial/modules/dfp/render-advert-label';
 import { geoMostPopular } from 'common/modules/onward/geo-most-popular';
 import { Toggles } from 'common/modules/ui/toggles';
 import { recordUserAdFeedback } from 'commercial/modules/user-ad-feedback';
-import config from 'lib/config';
 /**
  * ADVERT RENDERING
  * ----------------
@@ -82,13 +81,11 @@ sizeCallbacks[adSizes.halfPage] = () => {
     mediator.emit('page:commercial:sticky-mpu');
 };
 
-if (!config.switches.keepVideoAdSlotsOpen) {
-    sizeCallbacks[adSizes.video] = (_, advert) => {
-        fastdom.write(() => {
-            advert.node.classList.add('u-h');
-        });
-    };
-}
+sizeCallbacks[adSizes.video] = (_, advert) => {
+    fastdom.write(() => {
+        advert.node.classList.add('u-h');
+    });
+};
 
 sizeCallbacks[adSizes.video2] = (_, advert) => {
     fastdom.write(() => {


### PR DESCRIPTION
## What does this change?
Removes the keep-video-slots-open switch; this was going to be used with a number of different video ad formats that are no longer going ahead.