### PR TITLE
Config admin tools

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -23,8 +23,9 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.i18n.{I18nComponents, Lang, Messages}
 import play.api.libs.ws.WSClient
-import services._
+import services.{ParameterStoreService, _}
 import router.Routes
+
 import scala.concurrent.ExecutionContext
 
 class AppLoader extends FrontendApplicationLoader {
@@ -69,6 +70,7 @@ trait AdminServices extends I18nComponents  {
   lazy val dfpAdUnitCacheJob: DfpAdUnitCacheJob = wire[DfpAdUnitCacheJob]
   lazy val dfpMobileAppUnitCacheJob: DfpMobileAppAdUnitCacheJob = wire[DfpMobileAppAdUnitCacheJob]
   lazy val dfpTemplateCreativeCacheJob: DfpTemplateCreativeCacheJob = wire[DfpTemplateCreativeCacheJob]
+  lazy val parameterStoreService: ParameterStoreService = wire[ParameterStoreService]
 }
 
 trait AppComponents extends FrontendComponents with AdminControllers with AdminServices {

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -71,6 +71,7 @@ trait AdminServices extends I18nComponents  {
   lazy val dfpMobileAppUnitCacheJob: DfpMobileAppAdUnitCacheJob = wire[DfpMobileAppAdUnitCacheJob]
   lazy val dfpTemplateCreativeCacheJob: DfpTemplateCreativeCacheJob = wire[DfpTemplateCreativeCacheJob]
   lazy val parameterStoreService: ParameterStoreService = wire[ParameterStoreService]
+  lazy val parameterStoreProvider: ParameterStoreProvider = wire[ParameterStoreProvider]
 }
 
 trait AppComponents extends FrontendComponents with AdminControllers with AdminServices {

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -10,7 +10,7 @@ import model.ApplicationContext
 import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
-import services.{OphanApi, RedirectService}
+import services.{OphanApi, ParameterStoreService, RedirectService}
 
 trait AdminControllers {
   def akkaAsync: AkkaAsync
@@ -38,6 +38,7 @@ trait AdminControllers {
   def placementAgent: PlacementAgent
   def placementService: PlacementService
   def dfpApi: DfpApi
+  def parameterStoreService: ParameterStoreService
 
   lazy val oAuthLoginController = wire[OAuthLoginAdminController]
   lazy val uncachedWebAssets = wire[UncachedWebAssets]
@@ -48,6 +49,7 @@ trait AdminControllers {
   lazy val apiController = wire[Api]
   lazy val imageDecacheController = wire[ImageDecacheController]
   lazy val pageDecacheController = wire[PageDecacheController]
+  lazy val appConfigController = wire[AppConfigController]
   lazy val ophanApiController = wire[OphanApiController]
   lazy val switchboardController = wire[SwitchboardController]
   lazy val switchboardPlistaController = wire[SwitchboardPlistaController]

--- a/admin/app/controllers/AppConfigController.scala
+++ b/admin/app/controllers/AppConfigController.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import common.{ImplicitControllerExecutionContext, Logging}
+import model.{ApplicationContext, NoCache}
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+import services.ParameterStoreService
+
+class AppConfigController(val controllerComponents: ControllerComponents,
+                          parameterStoreService: ParameterStoreService)
+               (implicit context: ApplicationContext) extends BaseController with Logging with ImplicitControllerExecutionContext {
+
+  def renderAppConfig(): Action[AnyContent] = Action { implicit request =>
+    NoCache(Ok(views.html.appConfig()))
+  }
+
+  def findParameter(key: String): Action[AnyContent] = Action.async { implicit request =>
+    parameterStoreService.findParameterBySubstring(key).map { result =>
+      NoCache(Ok(Json.toJson(result)))
+    }
+  }
+}

--- a/admin/app/services/ParameterStoreService.scala
+++ b/admin/app/services/ParameterStoreService.scala
@@ -1,14 +1,20 @@
 package services
 
+import javax.inject.Provider
+
 import concurrent.BlockingOperations
 import conf.Configuration
 
 import scala.concurrent.Future
 
-class ParameterStoreService(blockingOperations: BlockingOperations) {
-  lazy val parameterStore = new ParameterStore(Configuration.aws.region)
+class ParameterStoreService(parameterStoreProvider: ParameterStoreProvider, blockingOperations: BlockingOperations) {
+  private lazy val parameterStore = parameterStoreProvider.get
 
   def findParameterBySubstring(substring: String): Future[Map[String, String]] = blockingOperations.executeBlocking {
     parameterStore.getPath("/frontend", isRecursiveSearch = true).filter(_._1.contains(substring))
   }
+}
+
+class ParameterStoreProvider extends Provider[ParameterStore] {
+  override lazy val get: ParameterStore = new ParameterStore(Configuration.aws.region)
 }

--- a/admin/app/services/ParameterStoreService.scala
+++ b/admin/app/services/ParameterStoreService.scala
@@ -1,0 +1,14 @@
+package services
+
+import concurrent.BlockingOperations
+import conf.Configuration
+
+import scala.concurrent.Future
+
+class ParameterStoreService(blockingOperations: BlockingOperations) {
+  lazy val parameterStore = new ParameterStore(Configuration.aws.region)
+
+  def findParameterBySubstring(substring: String): Future[Map[String, String]] = blockingOperations.executeBlocking {
+    parameterStore.getPath("/frontend", isRecursiveSearch = true).filter(_._1.contains(substring))
+  }
+}

--- a/admin/app/services/ParameterStoreService.scala
+++ b/admin/app/services/ParameterStoreService.scala
@@ -10,8 +10,10 @@ import scala.concurrent.Future
 class ParameterStoreService(parameterStoreProvider: ParameterStoreProvider, blockingOperations: BlockingOperations) {
   private lazy val parameterStore = parameterStoreProvider.get
 
-  def findParameterBySubstring(substring: String): Future[Map[String, String]] = blockingOperations.executeBlocking {
-    parameterStore.getPath("/frontend", isRecursiveSearch = true).filter(_._1.contains(substring))
+  def findParameterBySubstring(substring: String): Future[Seq[String]] = blockingOperations.executeBlocking {
+    parameterStore.getPath("/frontend", isRecursiveSearch = true).collect {
+      case (key, _) if key.contains(substring) => key
+    }.toSeq
   }
 }
 

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -38,6 +38,7 @@
                         <li><a href="@controllers.admin.routes.RedirectController.redirect()">Redirects</a></li>
                         <li><a href="@controllers.cache.routes.ImageDecacheController.renderImageDecacheForm()">Clear cache (images)</a></li>
                         <li><a href="@controllers.cache.routes.PageDecacheController.renderPageDecache()">Clear cache (content)</a></li>
+                        <li><a href="@controllers.routes.AppConfigController.renderAppConfig()">App Config</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/admin_main.scala.html
+++ b/admin/app/views/admin_main.scala.html
@@ -75,11 +75,6 @@
 
             @content
 
-            @if(isAuthed){
-                <hr/>
-                <footer><p>&copy; The Grauniad</p></footer>
-            }
-
         </div>
 
         <link href='//fonts.googleapis.com/css?family=Merriweather' rel='stylesheet' type='text/css'>

--- a/admin/app/views/appConfig.scala.html
+++ b/admin/app/views/appConfig.scala.html
@@ -14,7 +14,7 @@
     </ol>
 
     Properties can override each other. <br/>
-    Parameter store configuration can be modified via the <a href="https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Parameters:sort=Name">AWS console</a> <br/>.
+    Parameter store configuration can be modified via the <a href="https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Parameters:sort=Name">AWS console</a>. <br/>
 
 
     <h3>Find parameters</h3>
@@ -41,10 +41,9 @@
         <b>Status:</b> <span id="status">Ready</span> <br/>
         <b>Results:</b>
         <br/>
-        <dl class="key-value" id="key-values">
-            <dt>Key</dt>
-            <dd>Value</dd>
-        </dl>
+        <div class="key-value" id="key-values">
+            key : value
+        </div>
         <br/>
         <br/>
     </div>
@@ -54,26 +53,21 @@
             $("#key-values").empty();
             $("#status").text("Finding config...");
 
-            /* stop form from submitting normally */
             event.preventDefault();
 
-            /* get some values from elements on the page: */
             var $form = $(this),
                 term = $form.find('input[name="property"]').val(),
                 url = "/config/parameter/" + term;
 
-            /* Send the data using post */
-            var getting = $.get(url);
+            var getParametersEvent = $.get(url);
 
-            /* Put the results in a div */
-            getting.done(function(data) {
+            getParametersEvent.done(function(data) {
                 $("#status").text("Ready");
                 Object.keys(data).forEach(function(key) {
-                    $("#key-values").append("<dt>"+key+"</dt>");
-                    $("#key-values").append("<dd>"+data[key]+"</dd>");
+                    $("#key-values").append("<p>"+key+" <b>:</b> "+data[key]+"</p>");
                 });
             });
-            getting.fail(function() {
+            getParametersEvent.fail(function() {
                 $("#status").text("Failed to find config");
             });
         });

--- a/admin/app/views/appConfig.scala.html
+++ b/admin/app/views/appConfig.scala.html
@@ -1,0 +1,81 @@
+@(message: String = "")(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@admin_main("App Config", isAuthed = true) {
+
+    <h1>App Config</h1>
+
+    <h3>Information:</h3>
+    Configuration is loaded by each app from parameter store. Properties are loaded from the following levels:
+    <ol>
+        <li>Local filesystem overrides</li>
+        <li>/frontend/{stage}/{app}/{config.property.name}</li>
+        <li>/frontend/{stage}/{config.property.name}</li>
+        <li>/frontend/{config.property.name}</li>
+    </ol>
+
+    Properties can override each other. <br/>
+    Parameter store configuration can be modified via the <a href="https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Parameters:sort=Name">AWS console</a> <br/>.
+
+
+    <h3>Find parameters</h3>
+        Searching for properties via the console is difficult - you must supply a full prefix including the config path.<br/>
+        The following tool provides a parameter store substring search for frontend properties existing in:
+    <ol>
+        <li>/frontend/{stage}/{app}/{config.property.name}</li>
+        <li>/frontend/{stage}/{config.property.name}</li>
+        <li>/frontend/{config.property.name}</li>
+    </ol>
+
+    <hr/>
+
+    <style>
+
+    </style>
+
+    <form method="GET" id="findForm">
+        <input class="img-url form-control" name="property" type="text" value="" placeholder="config.property.name"/>
+        <button class="btn btn-default" type="submit">Find</button>
+    </form>
+    <br>
+    <div>
+        <b>Status:</b> <span id="status">Ready</span> <br/>
+        <b>Results:</b>
+        <br/>
+        <dl class="key-value" id="key-values">
+            <dt>Key</dt>
+            <dd>Value</dd>
+        </dl>
+        <br/>
+        <br/>
+    </div>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script>
+        $("#findForm").submit(function(event) {
+            $("#key-values").empty();
+            $("#status").text("Finding config...");
+
+            /* stop form from submitting normally */
+            event.preventDefault();
+
+            /* get some values from elements on the page: */
+            var $form = $(this),
+                term = $form.find('input[name="property"]').val(),
+                url = "/config/parameter/" + term;
+
+            /* Send the data using post */
+            var getting = $.get(url);
+
+            /* Put the results in a div */
+            getting.done(function(data) {
+                $("#status").text("Ready");
+                Object.keys(data).forEach(function(key) {
+                    $("#key-values").append("<dt>"+key+"</dt>");
+                    $("#key-values").append("<dd>"+data[key]+"</dd>");
+                });
+            });
+            getting.fail(function() {
+                $("#status").text("Failed to find config");
+            });
+        });
+    </script>
+}

--- a/admin/app/views/appConfig.scala.html
+++ b/admin/app/views/appConfig.scala.html
@@ -59,15 +59,15 @@
                 term = $form.find('input[name="property"]').val(),
                 url = "/config/parameter/" + term;
 
-            var getParametersEvent = $.get(url);
+            var eventGetParams = $.get(url);
 
-            getParametersEvent.done(function(data) {
+            eventGetParams.done(function(data) {
                 $("#status").text("Ready");
                 Object.keys(data).forEach(function(key) {
                     $("#key-values").append("<p>"+key+" <b>:</b> "+data[key]+"</p>");
                 });
             });
-            getParametersEvent.fail(function() {
+            eventGetParams.fail(function() {
                 $("#status").text("Failed to find config");
             });
         });

--- a/admin/app/views/appConfig.scala.html
+++ b/admin/app/views/appConfig.scala.html
@@ -63,8 +63,8 @@
 
             eventGetParams.done(function(data) {
                 $("#status").text("Ready");
-                Object.keys(data).forEach(function(key) {
-                    $("#key-values").append("<p>"+key+" <b>:</b> "+data[key]+"</p>");
+                data.forEach(function(key) {
+                    $("#key-values").append("<p>"+key+" <b>:</b> ***</p>");
                 });
             });
             eventGetParams.fail(function() {

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -93,6 +93,12 @@ GET         /commercial/adgrabber/order/:orderId                                
 GET         /commercial/adgrabber/previewUrls/:lineItemId/:section                                  controllers.admin.CommercialController.getCreativesListing(lineItemId: String, section: String)
 GET         /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.renderAdsDotText()
 POST        /commercial/adops/ads-txt                                                               controllers.admin.commercial.AdsDotTextEditController.postAdsDotText()
+
+# Config
+
+GET         /config                                                                                 controllers.AppConfigController.renderAppConfig()
+GET         /config/parameter/*key                                                                  controllers.AppConfigController.findParameter(key: String)
+
 # Metrics
 GET         /metrics/loadbalancers                                                                  controllers.admin.MetricsController.renderLoadBalancers()
 GET         /metrics/fastly                                                                         controllers.admin.FastlyController.renderFastly()

--- a/admin/public/css/admin.css
+++ b/admin/public/css/admin.css
@@ -63,3 +63,19 @@
     padding: 10px 0;
     margin-top: 10px;
 }
+
+dl.key-value dt, dd {
+    font-family:sans-serif;
+}
+
+dl.key-value dt {
+    float:left;
+    clear:left;
+    text-align:right;
+    width:5%;
+}
+
+dl.key-value dd {
+    float:left;
+    margin-left:30em;
+}

--- a/admin/public/css/admin.css
+++ b/admin/public/css/admin.css
@@ -63,19 +63,3 @@
     padding: 10px 0;
     margin-top: 10px;
 }
-
-dl.key-value dt, dd {
-    font-family:sans-serif;
-}
-
-dl.key-value dt {
-    float:left;
-    clear:left;
-    text-align:right;
-    width:5%;
-}
-
-dl.key-value dd {
-    float:left;
-    margin-left:30em;
-}

--- a/admin/test/services/ParameterStoreServiceTest.scala
+++ b/admin/test/services/ParameterStoreServiceTest.scala
@@ -1,0 +1,32 @@
+package services
+
+import akka.actor.ActorSystem
+import concurrent.BlockingOperations
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
+
+class ParameterStoreServiceTest extends FlatSpec with ScalaFutures with Matchers with MockitoSugar {
+
+  "findParameterBySubstring" should "retrieve a parameter from the parameter store by substring" in {
+    val actorSystem = ActorSystem()
+    val blockingOperations = new BlockingOperations(actorSystem)
+
+    val parameterStore = mock[ParameterStore]
+    when(parameterStore.getPath("/frontend", isRecursiveSearch = true)) thenReturn Map(
+      "key" -> "value",
+      "some_test_key" -> "test_value",
+      "test" -> "last_value"
+    )
+
+    val parameterStoreProvider = mock[ParameterStoreProvider]
+    when(parameterStoreProvider.get) thenReturn parameterStore
+
+    val parameterStoreService = new ParameterStoreService(parameterStoreProvider, blockingOperations)
+    whenReady(parameterStoreService.findParameterBySubstring("test")) {
+      _ shouldBe Map("some_test_key" -> "test_value", "test" -> "last_value")
+    }
+  }
+
+}

--- a/admin/test/services/ParameterStoreServiceTest.scala
+++ b/admin/test/services/ParameterStoreServiceTest.scala
@@ -25,7 +25,7 @@ class ParameterStoreServiceTest extends FlatSpec with ScalaFutures with Matchers
 
     val parameterStoreService = new ParameterStoreService(parameterStoreProvider, blockingOperations)
     whenReady(parameterStoreService.findParameterBySubstring("test")) {
-      _ shouldBe Map("some_test_key" -> "test_value", "test" -> "last_value")
+      _ shouldBe Seq("some_test_key", "test")
     }
   }
 

--- a/common/app/services/ParameterStore.scala
+++ b/common/app/services/ParameterStore.scala
@@ -23,7 +23,7 @@ class ParameterStore(region: String) {
     client.getParameter(parameterRequest).getParameter.getValue
   }
 
-  def getPath(path: String): Map[String, String] = {
+  def getPath(path: String, isRecursiveSearch: Boolean = false): Map[String, String] = {
 
     @tailrec
     def pagination(accum: Map[String, String], nextToken: Option[String]): Map[String, String] = {
@@ -31,7 +31,7 @@ class ParameterStore(region: String) {
       val parameterRequest = new GetParametersByPathRequest()
         .withWithDecryption(true)
         .withPath(path)
-        .withRecursive(false)
+        .withRecursive(isRecursiveSearch)
 
       val parameterRequestWithNextToken = nextToken.map(parameterRequest.withNextToken).getOrElse(parameterRequest)
 

--- a/docs/03-dev-howtos/12-Update-configuration.md
+++ b/docs/03-dev-howtos/12-Update-configuration.md
@@ -21,3 +21,12 @@ To add or update a configuration item you need to:
 
 Nativgate to [Systems Manager Parameter Store](https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#Parameters:sort=Name)
 and use the console UI to edit the config.
+
+### Finding your properties
+
+[Admin Property Search](https://frontend.code.dev-gutools.co.uk/)
+
+The AWS console UI only enables search by prefix with no wildcard support. 
+A parameter could potentially have 8 different prefixes if it were overridden by all the frontend apps.
+The [admin tool](https://frontend.code.dev-gutools.co.uk/) enables property search across all apps and stages.
+


### PR DESCRIPTION
## What does this change?

Admin tool for finding parameter store configuration by a key substring. 

The AWS console UI only enables search by prefix with no wildcard support. This would mean you'd have to know all the apps using a parameter to find it successfully. A parameter could potentially have 8 different prefixes if it were overridden by all the frontend apps. 

## What is the value of this and can you measure success?

Developers find it easier to search parameter store configuration

## Screenshots

![picture 8](https://user-images.githubusercontent.com/29203769/34103671-855bd0be-e3e5-11e7-88ad-98c2a4b447af.png)


## Tested in CODE?

No
