### PR TITLE
fix position of play icon on list-media cards on mobile

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
@@ -54,6 +54,17 @@ Media list item. Looks a bit like this:
         }
     }
 
+    .fc-item__video {
+        @include mq($until: tablet) {
+            position: absolute;
+            width: $image-width;
+            
+            .fc-item__video-play {
+                padding-bottom: 60%;
+            }
+        }
+    }
+
     &[class*='fc-item--has-sublinks'] {
         .fc-item__footer--vertical {
             display: none;

--- a/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-layouts/_fc-item--list-media.scss
@@ -54,17 +54,6 @@ Media list item. Looks a bit like this:
         }
     }
 
-    .fc-item__video {
-        @include mq($until: tablet) {
-            position: absolute;
-            width: $image-width;
-            
-            .fc-item__video-play {
-                padding-bottom: 60%;
-            }
-        }
-    }
-
     &[class*='fc-item--has-sublinks'] {
         .fc-item__footer--vertical {
             display: none;
@@ -106,6 +95,18 @@ Media list item. Looks a bit like this:
         .fc-item__avatar__media {
             right: - $gs-gutter;
             height: gs-span(1) + $gs-baseline * 3;
+        }
+    }
+
+    &.fc-item--list-media-mobile {
+        @include mq($until: tablet) {
+            .fc-item__video {
+                width: $image-width;
+                
+                .fc-item__video-play {
+                    padding-bottom: 60%;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this change?

List media facia containers at a mobile breakpoint had a bug which mispositioned the video play button. This fixes that bug on Garnett.

## What is the value of this and can you measure success?

Fixes broken layout

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

No

## Screenshots

N/A

## Tested in CODE?

No