### PR TITLE
Use parameter store configuration again

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -119,19 +119,19 @@ object GuardianConfiguration extends Logging {
     else {
       val userPrivate = configFromFile(s"${System.getProperty("user.home")}/.gu/frontend.conf", "devOverrides")
       val runtimeOnly =  configFromFile("/etc/gu/frontend.conf", "parameters")
-//      val frontendConfig = configFromParameterStore("/frontend")
-//      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
-//      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
+      val frontendConfig = configFromParameterStore("/frontend")
+      val frontendStageConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}")
+      val frontendAppConfig = configFromParameterStore(s"/frontend/${stage.toLowerCase}/${app.toLowerCase}")
 
-//      val parameterStoreConfig = frontendAppConfig
-//        .withFallback(frontendStageConfig)
-//        .withFallback(frontendConfig)
+      val parameterStoreConfig = frontendAppConfig
+        .withFallback(frontendStageConfig)
+        .withFallback(frontendConfig)
 
-//      diffLegacyConfig(s3Config, parameterStoreConfig)
+      diffLegacyConfig(s3Config, parameterStoreConfig)
 
       userPrivate
         .withFallback(runtimeOnly)
-        .withFallback(s3Config)
+        .withFallback(parameterStoreConfig)
     }
   }
 


### PR DESCRIPTION
This reverts commit 0f2904dbead79c59e9406d3822e7453e09d595c0.

## What does this change?

Janus permissions have been added for frontend users for parameter store, so everyone should be able to run parameter store locally.

## What is the value of this and can you measure success?

All frontend users should be able to run frontend locally


## Tested in CODE?

No