### PR TITLE
Log weather timeout exceptions at WARN level.

### DIFF
--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -63,7 +63,7 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
           s"Request to weather api ($url) timed out (this is expected, especially at 0 and 30 mins past the hour due to" +
           s" a problem with accuweather).", error)(weatherLogsMarkerContext)
         throw error
-      case NonFatal(error) =>
+      case NonFatal(error: Throwable) =>
         log.error("Weather API request failed", error)(weatherLogsMarkerContext)
         throw error
     }

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -57,16 +57,16 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
 
   private def getJsonWithRetry(url: String): Future[JsValue] = {
     val weatherLogsMarkerContext: MarkerContext = MarkerContext(append("weatherRequestPath", url))
-    WeatherApi.retryWeatherRequest(() => getJsonRequest(url), requestRetryDelay, actorSystem.scheduler, requestRetryMax).recover {
+    val weatherApiResponse: Future[JsValue] = WeatherApi.retryWeatherRequest(() => getJsonRequest(url), requestRetryDelay, actorSystem.scheduler, requestRetryMax)
+    weatherApiResponse.foreach {
       case NonFatal(error: TimeoutException) =>
         log.warn(
           s"Request to weather api ($url) timed out (this is expected, especially at 0 and 30 mins past the hour due to" +
           s" a problem with accuweather).", error)(weatherLogsMarkerContext)
-        throw error
       case NonFatal(error: Throwable) =>
         log.error("Weather API request failed", error)(weatherLogsMarkerContext)
-        throw error
     }
+    weatherApiResponse
   }
 
   private def getJsonRequest(url: String): Future[JsValue] = {


### PR DESCRIPTION
## What does this change?
It changes the logging level of timeout exceptions in the WeatherApi from ERROR to WARN, as these errors happen all the time and there's not a lot we can do about it. This way 'bad' errors won't get hidden under a sea of weather related ones.

## What is the value of this and can you measure success?
Helps us notice production issues faster
## Does this affect other platforms - Amp, Apps, etc?
No
## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
No

## Screenshots
-
## Tested in CODE?
Yes
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
