### PR TITLE
config doc edit

### DIFF
--- a/docs/03-dev-howtos/12-Update-configuration.md
+++ b/docs/03-dev-howtos/12-Update-configuration.md
@@ -24,9 +24,9 @@ and use the console UI to edit the config.
 
 ### Finding your properties
 
-[Admin Property Search](https://frontend.code.dev-gutools.co.uk/)
+[Admin Property Search](https://frontend.code.dev-gutools.co.uk/config)
 
 The AWS console UI only enables search by prefix with no wildcard support. 
 A parameter could potentially have 8 different prefixes if it were overridden by all the frontend apps.
-The [admin tool](https://frontend.code.dev-gutools.co.uk/) enables property search across all apps and stages.
+The [admin tool](https://frontend.code.dev-gutools.co.uk/config) enables property search across all apps and stages.
 


### PR DESCRIPTION
## What does this change?

/config on admin tool path for config readme doc

## What is the value of this and can you measure success?

docs link to correct admin tool URL

This change is tiny so merging