### PR TITLE
Adding a switch for the Garnett version of the header

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -49,9 +49,17 @@ object CommercialPaidContentTemplate extends Experiment(
 object ABNewDesktopHeader extends Experiment(
   name = "ab-new-desktop-header",
   description = "Users in this experiment will see the new desktop design.",
-  owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("gustavpursche")),
-  sellByDate = new LocalDate(2018, 1, 10),
+  owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("zeftilldeath")),
+  sellByDate = new LocalDate(2018, 2, 1),
   participationGroup = Perc20A
+)
+
+object GarnettHeader extends Experiment(
+  name = "garnett-header",
+  description = "Users in this experiment will see the new desktop design, but with garnett styling",
+  owners = Seq(Owner.withGithub("natalialkb"), Owner.withGithub("zeftilldeath")),
+  sellByDate = new LocalDate(2018, 2, 1),
+  participationGroup = Perc0A
 )
 
 object Garnett extends Experiment(

--- a/common/app/views/fragments/newHeader.scala.html
+++ b/common/app/views/fragments/newHeader.scala.html
@@ -5,10 +5,12 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, getContributionOrSupporterUrl, NewHeader, getSupportOrSubscriptionUrl}
 @import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
+@import experiments.{ ABNewDesktopHeader, GarnettHeader, ActiveExperiments}
 
 <header class="@RenderClasses(Map(
-            "new-header--mvt-desktop" -> experiments.ActiveExperiments.isParticipating(experiments.ABNewDesktopHeader),
-            "new-header--slim" -> page.metadata.hasSlimHeader
+            "new-header--mvt-desktop" -> ActiveExperiments.isParticipating(ABNewDesktopHeader),
+            "new-header--slim" -> page.metadata.hasSlimHeader,
+            "new-header--garnett" -> ActiveExperiments.isParticipating(GarnettHeader)
         ), "new-header")"
         role="banner">
 


### PR DESCRIPTION
## What does this change?
Zef is going to add styling for the Garnett version of the header. This just adds the switch to help that.

## What is the value of this and can you measure success?
Styling will be aligned

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
n/a

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
