### PR TITLE
Remove feedback form for the desktop header

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -545,14 +545,4 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2018, 1, 15),
     exposeClientSide = true
   )
-
-  val HeaderFeedback = Switch(
-    SwitchGroup.Feature,
-    "header-feedback",
-    "When ON a feedback prompt will be visible within the header test",
-    owners = Seq(Owner.withGithub("zeftilldeath")),
-    safeState = Off,
-    sellByDate = new LocalDate(2018, 12, 4),
-    exposeClientSide = false
-  )
 }

--- a/common/app/views/fragments/nav/newHeaderMenu.scala.html
+++ b/common/app/views/fragments/nav/newHeaderMenu.scala.html
@@ -1,5 +1,5 @@
 @import common.{ LinkTo, Edition }
-@import conf.switches.Switches.{SearchSwitch, HeaderFeedback}
+@import conf.switches.Switches.SearchSwitch
 @import navigation.{ NavMenu, NavigationHelpers, NavLink }
 @import views.support.RenderClasses
 
@@ -179,19 +179,6 @@
             <ul class="menu-group menu-group--brand-extensions hide-until-desktop">
                 @navMenu.brandExtensions.map { item =>
                     @brandExtensions(item)
-                }
-
-                @if(HeaderFeedback.isSwitchedOn) {
-                    <a data-link-name="nav2 : feedback-form"
-                        href="https://goo.gl/forms/j5pMsPSWINu7X2R62">
-
-                        <li class="hide-until-desktop feedback-form">
-                            @fragments.inlineSvg("information-circle", "icon", List("feedback-form__icon"))
-                            We&rsquo;d appreciate your feedback on our new navigation.
-                            <span class="feedback-form__link">
-                            Share your thoughts here.</span>
-                        </li>
-                    </a>
                 }
             </ul>
         </div>

--- a/static/src/stylesheets/layout/new-header/_new-header.scss
+++ b/static/src/stylesheets/layout/new-header/_new-header.scss
@@ -196,38 +196,3 @@ from scrolling */
 x:-o-prefocus, .new-header__cta-container  {
     display: none;
 }
-
-.feedback-form {
-    background-color: $multimedia-main-2;
-    box-sizing: border-box;
-    bottom: 0;
-    color: $neutral-1;
-    font-size: 14px;
-    line-height: 18px;
-    padding: ($gs-baseline / 2) ($gs-gutter / 4) ($gs-baseline + $gs-baseline / 2);
-    float: right;
-    margin-top: 6px;
-    max-width: gs-span(4);
-
-    body:not(.has-page-skin) & {
-        @include mq(leftCol) {
-            float: none;
-            position: absolute;
-        }
-    }
-}
-
-.feedback-form__link {
-    color: $guardian-brand;
-    cursor: pointer;
-    text-decoration: none;
-
-    &:hover {
-        text-decoration: underline;
-    }
-}
-
-.feedback-form__icon__svg {
-    margin-bottom: -2px;
-    fill: $neutral-1;
-}


### PR DESCRIPTION
## What does this change?
Removing the feedback form, as we have enough responses now. The feedback form was added here: https://github.com/guardian/frontend/pull/18402

## What is the value of this and can you measure success?
We got lots of valuable responses now!

## Does this affect other platforms - Amp, Apps, etc?
Nope

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
Nope

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
