### PR TITLE
Remove the 'As we move into 2018' variant from end of year countdown test

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-copy.js
@@ -75,13 +75,6 @@ export const endOfYearCountdown = (
     p2: controlP2(),
 });
 
-export const asWeHeadInto2018: AcquisitionsEpicTemplateCopy = {
-    heading: 'As we head into 2018 &hellip;',
-    p1:
-        '&hellip; Please consider giving to the Guardian. More people are reading our independent, investigative journalism than ever but advertising revenues across the media are falling fast. And unlike many news organisations, we haven’t put up a paywall – we want to keep our journalism as open as we can. So you can see why we need to ask for your help. The Guardian’s journalism takes a lot of time, money and hard work to produce. But we do it because we believe our perspective matters &ndash; because it might well be your perspective, too',
-    p2: controlP2(),
-};
-
 export const liveblog = (
     membershipUrl: string,
     contributionsUrl: string

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-end-of-year-countdown.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-end-of-year-countdown.js
@@ -1,9 +1,6 @@
 // @flow
 import { makeABTest } from 'common/modules/commercial/contributions-utilities';
-import {
-    endOfYearCountdown,
-    asWeHeadInto2018,
-} from 'common/modules/commercial/acquisitions-copy';
+import { endOfYearCountdown } from 'common/modules/commercial/acquisitions-copy';
 
 const daysLeftUntilEndOfYear = (): string => {
     const now = Date.now();
@@ -41,13 +38,6 @@ export const acquisitionsEpicEndOfYearCountdown = makeABTest({
             products: [],
             options: {
                 copy: endOfYearCountdown(daysLeftUntilEndOfYear()),
-            },
-        },
-        {
-            id: 'as_we_head_into_2018',
-            products: [],
-            options: {
-                copy: asWeHeadInto2018,
             },
         },
     ],


### PR DESCRIPTION
## What does this change?
This variant was performing significantly worse than the other variants, so we are killing it off now