### PR TITLE
Garnett - Timestamp on Comment Cards

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -216,7 +216,10 @@ data-test-id="facia-card"
                     @standfirst(item)
                     @mediaMeta(item)
                 } else {
-                    <div class="fc-item__standfirst-wrapper">
+                    <div class="@RenderClasses(Map(
+                        ("fc-item__standfirst-wrapper", true),
+                        ("fc-item__standfirst-wrapper--timestamp", !item.timeStampDisplay.isEmpty)
+                    ))">
                         @standfirst(item)
                         @meta(item)
                     </div>

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -333,6 +333,22 @@ $block-height: 58px;
     display: none;
 }
 
+.fc-item__timestamp {
+    display: flex;
+
+    .inline-icon {
+        margin-top: -2px;
+        padding-right: 4px;
+        height: 11px;
+        width: 11px;
+    }
+
+    .fc-timestamp__text {
+        display: block;
+        line-height: 10px;
+    }
+}
+
 .fc-trail__count {
     display: flex;
     line-height: 10px;
@@ -341,8 +357,6 @@ $block-height: 58px;
         padding-right: 2px;
         height: 14px;
         width: 14px;
-        bottom: 0;
-        top: 0;
 
         svg {
             height: 14px;

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -333,35 +333,33 @@ $block-height: 58px;
     display: none;
 }
 
-.fc-item__timestamp {
-    display: flex;
-
-    .inline-icon {
-        margin-top: -2px;
-        padding-right: 4px;
-        height: 11px;
-        width: 11px;
-    }
-
-    .fc-timestamp__text {
-        display: block;
-        line-height: 10px;
-    }
-}
-
+.fc-item__timestamp,
 .fc-trail__count {
     display: flex;
     line-height: 10px;
 
     .inline-icon {
         padding-right: 2px;
+    }
+}
+
+.fc-item__timestamp .inline-icon {
+    height: 11px;
+    width: 11px;
+
+    svg {
+        height: 11px;
+        width: 11px;
+    }
+}
+
+.fc-trail__count .inline-icon {
+    height: 14px;
+    width: 14px;
+
+    svg {
         height: 14px;
         width: 14px;
-
-        svg {
-            height: 14px;
-            width: 14px;
-        }
     }
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -217,6 +217,19 @@ $fc-item-gutter: $gs-gutter / 4;
     @include mq($from: tablet) {
         padding-bottom: $gs-gutter * .25;
     }
+
+    &.fc-item__standfirst-wrapper--timestamp {
+        flex-direction: column;
+
+        .fc-item__meta {
+            width: 100%;
+            flex-direction: row;
+        }
+
+        .fc-item__timestamp {
+            flex: 1;
+        }
+    }
 }
 
 .fc-item__standfirst {
@@ -336,7 +349,6 @@ $block-height: 58px;
 .fc-item__timestamp,
 .fc-trail__count {
     display: flex;
-    line-height: 10px;
 
     .inline-icon {
         padding-right: 2px;
@@ -346,6 +358,7 @@ $block-height: 58px;
 .fc-item__timestamp .inline-icon {
     height: 11px;
     width: 11px;
+    margin-top: 1px;
 
     svg {
         height: 11px;
@@ -356,6 +369,7 @@ $block-height: 58px;
 .fc-trail__count .inline-icon {
     height: 14px;
     width: 14px;
+    margin-top: 3px;
 
     svg {
         height: 14px;

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -214,10 +214,6 @@ $fc-item-gutter: $gs-gutter / 4;
     flex-direction: row;
     padding-bottom: 0;
 
-    @include mq($from: tablet) {
-        padding-bottom: $gs-gutter * .25;
-    }
-
     &.fc-item__standfirst-wrapper--timestamp {
         flex-direction: column;
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -82,11 +82,8 @@ $pillars: (
                 background-color: darken(map-get($palette, cutoutBackground), 3%);
             }
     
+            .fc-item__timestamp,
             .fc-trail__count--commentcount {
-                background-color: $darkerCardBackground;
-            }
-
-            .fc-item__timestamp {
                 background-color: $darkerCardBackground;
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -85,6 +85,10 @@ $pillars: (
             .fc-trail__count--commentcount {
                 background-color: $darkerCardBackground;
             }
+
+            .fc-item__timestamp {
+                background-color: $darkerCardBackground;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -173,6 +173,7 @@ $pillars: (
             background-color: map-get($palette, cutoutBackground);
         }
 
+        .fc-item__timestamp,
         .fc-trail__count--commentcount {
             color: map-get($palette, commentCount);
             background-color: map-get($palette, cardBackground);

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -10,39 +10,21 @@
     }
 
     .fc-item__container > .fc-item__meta {
+        @include multiline(4, $garnett-neutral-4);
+
         display: flex;
         position: absolute;
         bottom: 0;
         width: 100%;
-        height: 13px;
-        box-sizing: border-box;
-        border-top: 1px solid $garnett-neutral-4;
-        border-bottom: 1px solid $garnett-neutral-4;
-
-        &:before,
-        &:after {
-            content: '';
-            position: absolute;
-            height: 1px;
-            width: 100%;
-            background-color: $garnett-neutral-4;
-        }
-
-        &:before {
-            top: 3px;
-        }
-
-        &:after {
-            bottom: 3px;
-        }
+        margin-bottom: -3px;
 
         .fc-trail__count,
         .fc-item__timestamp {
             position: absolute;
             padding-right: $gs-gutter * .25;
             padding-left: $gs-gutter * .25;
-            bottom: -1px;
-            top: -1px;
+            bottom: 3px;
+            top: 0;
             z-index: 1;
         }
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -36,14 +36,22 @@
             bottom: 3px;
         }
 
-        .fc-trail__count {
+        .fc-trail__count,
+        .fc-item__timestamp {
             position: absolute;
-            padding-bottom: $gs-gutter * .1;
             padding-right: $gs-gutter * .25;
             padding-left: $gs-gutter * .25;
-            right: 0;
             bottom: -1px;
             top: -1px;
+            z-index: 1;
+        }
+
+        .fc-trail__count {
+            right: 0;
+        }
+
+        .fc-item__timestamp {
+            left: 0;
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -16,14 +16,15 @@
         position: absolute;
         bottom: 0;
         width: 100%;
-        margin-bottom: -3px;
+        height: 16px;
 
         .fc-trail__count,
         .fc-item__timestamp {
             position: absolute;
+            padding-top: 2px;
             padding-right: $gs-gutter * .25;
             padding-left: $gs-gutter * .25;
-            bottom: 3px;
+            bottom: 0;
             top: 0;
             z-index: 1;
             line-height: 10px;

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -6,7 +6,7 @@
     }
 
     .fc-item__container {
-        padding-bottom: 13px;
+        padding-bottom: $gs-gutter;
     }
 
     .fc-item__container > .fc-item__meta {
@@ -72,7 +72,6 @@
         .fc-item__avatar {
             border-radius: 50%;
             right: $gs-gutter * .5;
-            bottom: $gs-baseline / 2;
             overflow: hidden;
         }
 

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-comment.scss
@@ -26,14 +26,23 @@
             bottom: 3px;
             top: 0;
             z-index: 1;
+            line-height: 10px;
         }
 
         .fc-trail__count {
             right: 0;
+
+            .inline-icon {
+                margin-top: 0;
+            }
         }
 
         .fc-item__timestamp {
             left: 0;
+
+            .inline-icon {
+                margin-top: -1px;
+            }
         }
     }
 


### PR DESCRIPTION
## What does this change?

Sometimes the meta container for a Facia Card can contain a timestamp this fixes the display of the timestamp, including comment card overrrides.

## What is the value of this and can you measure success?

Fixes broken layout

## Does this affect other platforms - Amp, Apps, etc?

No

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

N/A

## Screenshots

N/A

## Tested in CODE?

No
