### PR TITLE
Repermission if user has v1 newsletters (reincarnated)

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -206,6 +206,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val IdentityGdprV2NewslettersConsents = Switch(
+    SwitchGroup.Identity,
+    "id-gdpr-use-v2-newsletters-list-ids-in-edit-profile",
+    "If switched on, users will subscribe to new V2 newsletter lists in email-prefs and consents journey",
+    owners = Seq(Owner.withGithub("mario-galic")),
+    safeState = Off,
+    sellByDate = new LocalDate(2018, 1, 15),
+    exposeClientSide = false
+  )
+
   val EnhanceTweetsSwitch = Switch(
     SwitchGroup.Feature,
     "enhance-tweets",

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -38,11 +38,11 @@ class AuthenticatedActions(
     SeeOther(identityUrlBuilder.buildUrl(redirectUrlWithParams))
   }
 
-  def sendUserToConsentJourney(request: RequestHeader): Result =
-    redirectWithReturn(request, "/consent?journey=repermission")
+  def sendUserToAllConsentsJourney(request: RequestHeader): Result =
+    redirectWithReturn(request, "/consents/all")
 
-  def sendUserToNarrowConsentJourney(request: RequestHeader): Result =
-    redirectWithReturn(request, "/consent?journey=repermission-narrow")
+  def sendUserToNewslettersConsentsJourney(request: RequestHeader): Result =
+    redirectWithReturn(request, "/consents/newsletters")
 
   def sendUserToSignin(request: RequestHeader): Result =
     redirectWithReturn(request, "/signin")
@@ -127,9 +127,9 @@ class AuthenticatedActions(
           if (newsletterService.getV1EmailSubscriptions(emailFilledForm).isEmpty)
             Right(request)
           else
-            Left(sendUserToNarrowConsentJourney(request))
+            Left(sendUserToNewslettersConsentsJourney(request))
         }
-      else Future.successful(Left(sendUserToConsentJourney(request)))
+      else Future.successful(Left(sendUserToAllConsentsJourney(request)))
 
     private def userHasRepermissioned[A](request: AuthRequest[A]): Boolean =
       request.user.statusFields.hasRepermissioned.contains(true)

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -116,10 +116,10 @@ class AuthenticatedActions(
     override val executionContext = ec
 
     def refine[A](request: AuthRequest[A]) =
-//      if (IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
+      if (IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
         decideConsentJourney(request)
-//      else
-//        Future.successful(Right(request))
+      else
+        Future.successful(Right(request))
 
     private def decideConsentJourney[A](request: AuthRequest[A]) =
       if (userHasRepermissioned(request))

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -116,10 +116,10 @@ class AuthenticatedActions(
     override val executionContext = ec
 
     def refine[A](request: AuthRequest[A]) =
-      if (IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
+//      if (IdentityRedirectUsersWithLingeringV1ConsentsSwitch.isSwitchedOn && IdentityAllowAccessToGdprJourneyPageSwitch.isSwitchedOn)
         decideConsentJourney(request)
-      else
-        Future.successful(Right(request))
+//      else
+//        Future.successful(Right(request))
 
     private def decideConsentJourney[A](request: AuthRequest[A]) =
       if (userHasRepermissioned(request))

--- a/identity/app/services/NewsletterService.scala
+++ b/identity/app/services/NewsletterService.scala
@@ -81,8 +81,7 @@ class NewsletterService(
       form: Form[EmailPrefsData],
       add: List[String] = List(),
       remove: List[String] = List()): List[String] = {
-    //TODO: only return V1 subscriptions when V2 subscriptions are in place
-    getEmailSubscriptions(form,add,remove)
+    getEmailSubscriptions(form, add, remove).filter(EmailNewsletters.v1ListIds.contains)
   }
 }
 

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -22,7 +22,7 @@
     availableLists: EmailNewsletters,
     consentHint: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 
-@onlySubscribedToNewsletters = @{
+@onlySubscribedToV1Newsletters = @{
     EmailNewsletters.all.subscriptions.filter { newsletter =>
         emailSubscriptions.contains(newsletter.listId.toString)
     }
@@ -91,7 +91,7 @@
 }
 
 @emailStep(isNarrow: Boolean = false) = {
-    @if( onlySubscribedToNewsletters.nonEmpty ) {
+    @if(onlySubscribedToV1Newsletters.nonEmpty) {
         <div class="manage-account-wizard__step" data-wizard-step-name="email">
 
             <form novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
@@ -111,12 +111,13 @@
                 }
                 <div class="manage-account__switches">
                     <ul>
-                    @onlySubscribedToNewsletters.zipWithRowInfo.map { case (newsletter, row) =>
+                    @onlySubscribedToV1Newsletters.zipWithRowInfo.map { case (newsletter, row) =>
                     <li>
                         @fragments.newsletterSwitch(
                             emailPrefsForm,
                             emailSubscriptions,
-                            newsletter = newsletter
+                            newsletter = newsletter,
+                            unchecked = true
                         )(nonInputFields, messages, request)
                     </li>
                     }

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -8,7 +8,8 @@
 @(
     emailPrefsForm: Form[_],
     emailSubscriptions: List[String],
-    newsletter: EmailNewsletter
+    newsletter: EmailNewsletter,
+    unchecked: Boolean = false
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages, request: RequestHeader)
 
 @buildFooter(newsletter: EmailNewsletter) = {
@@ -17,20 +18,39 @@
         @newsletter.frequency
     </div>
     @if(newsletter.exampleUrl.isDefined){
-        <a class="manage-account__switch-footer-email-preview" target="preview-email-@newsletter.listId" href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })">
+        <a class="manage-account__switch-footer-email-preview" target="preview-email-@newsletterListId" href="@LinkTo({ newsletter.exampleUrl.getOrElse("") })">
             See the latest email
         </a>
     }
 }
 
+@newsletterListId = @{
+    if (true) // switch
+        newsletter.listIdV2.toString
+    else
+        newsletter.listId.toString
+}
+
+@checkboxValue = @{
+    if (unchecked)
+        None
+    else {
+        if (true) // switch
+            Some(newsletter.subscribedToV2(emailSubscriptions).toString)
+        else
+            Some(newsletter.subscribedTo(emailSubscriptions).toString)
+    }
+}
+
+
 @newsletterField = @{
     new Field(
         form = emailPrefsForm,
-        name = newsletter.listId.toString,
+        name = newsletterListId,
         constraints = Nil,
         format = None,
         errors = Nil,
-        value = Some(newsletter.subscribedTo(emailSubscriptions).toString)
+        value = checkboxValue
     )
 }
 

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -1,7 +1,8 @@
-@import com.gu.identity.model.{EmailNewsletters, EmailNewsletter}
+@import com.gu.identity.model.EmailNewsletter
 @import common.LinkTo
 @import _root_.form.IdFormHelpers.nonInputFields
 @import views.support.fragment.Switch._
+@import conf.switches.Switches.IdentityGdprV2NewslettersConsents
 
 @* Editorial Newsletter switch/checkbox *@
 
@@ -25,7 +26,7 @@
 }
 
 @newsletterListId = @{
-    if (true) // switch
+    if (IdentityGdprV2NewslettersConsents.isSwitchedOn)
         newsletter.listIdV2.toString
     else
         newsletter.listId.toString
@@ -35,13 +36,12 @@
     if (unchecked)
         None
     else {
-        if (true) // switch
+        if (IdentityGdprV2NewslettersConsents.isSwitchedOn)
             Some(newsletter.subscribedToV2(emailSubscriptions).toString)
         else
             Some(newsletter.subscribedTo(emailSubscriptions).toString)
     }
 }
-
 
 @newsletterField = @{
     new Field(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.98-SNAPSHOT"
+  val identityLibVersion = "3.98"
   val awsVersion = "1.11.240"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.43"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.96"
+  val identityLibVersion = "3.98-SNAPSHOT"
   val awsVersion = "1.11.240"
   val faciaVersion = "2.5.0"
   val capiVersion = "11.43"


### PR DESCRIPTION
# What does this change?

Redirects user to narrow consent journey `/consents/newsletters` if user has re-permissioned before but somehow still has V1 newsletters. User is prompted to re-subscribe to these particular newsletters.

Say, user tried to go to `/email-prefs`, then they are re-directed to:

`/consents/newsletters?INTCMP=email&returnUrl=https%3A%2F%2Fprofile.thegulocal.com%2Femail-prefs`

Using V2 list ids is behind a switch and it uses a single test V2 list id.

Related ID API PR: https://github.com/guardian/identity/pull/745

Reincarnated PR: https://github.com/guardian/frontend/pull/18477

## What is the value of this and can you measure success?

GDPR work.

## Screenshots


![image](https://user-images.githubusercontent.com/13835317/33881017-655e7a8c-df2b-11e7-9f6e-21c89ab1cc23.png)

