### PR TITLE
Fix kicker on Safari

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -196,8 +196,7 @@ $fc-item-gutter: $gs-gutter / 4;
     position: relative;
     margin-right: $gs-gutter / 4;
     font-weight: 700;
-    border-right-style: solid;
-    border-width: 0 1px 0 0;
+    border-right: 1px solid transparent;
     padding-right: .375em;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -197,7 +197,7 @@ $fc-item-gutter: $gs-gutter / 4;
     margin-right: $gs-gutter / 4;
     font-weight: 700;
     border-right-style: solid;
-    border-right-width: 1px;
+    border-width: 0 1px 0 0;
     padding-right: .375em;
 }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -98,7 +98,7 @@ $pillars: (
 
     .fc-item__kicker {
         color: map-get($palette, kicker);
-        border-image: linear-gradient(to top, transparent, transparent .25em, $lines .25em) 0 1;
+        border-image: linear-gradient(to top, transparent, transparent .125em, $lines .125em) 0 1;
     }
 
     //this is to make the colour lighter for the media cards

--- a/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
+++ b/static/src/stylesheets/module/facia-garnett/item-types/_fc-item--type-liveblog.scss
@@ -12,7 +12,7 @@
 
         .fc-item__kicker {
             color: $color2;
-            border-image: linear-gradient(to top, transparent, transparent .25em, $color2 .25em) 0 1;
+            border-image: linear-gradient(to top, transparent, transparent .125em, $color2 .125em) 0 1;
         }
 
         .fc-item__headline {


### PR DESCRIPTION
The kicker had a 3px border all around, this fix removes it. Also slightly tweak the border height to go a couple of pixels below the baseline.