### PR TITLE
[minor] Improve consent checkbox a11y, IE11 looks

### DIFF
--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -164,7 +164,7 @@ $checkbox-size: $gs-gutter / 1.25;
     background-size: $checkbox-size / 1.5;
     background: #ffffff no-repeat center center;
     cursor: pointer;
-    transition: background-color .125s;
+    transition: background-color .125s, border-color .125s;
 }
 
 .manage-account__switch-content {

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -55,6 +55,9 @@ $checkbox-size: $gs-gutter / 1.25;
 
     &:hover {
         background-color: darken($neutral-8, 1%);
+        .manage-account__switch-checkbox {
+            border-color: $identity-main;
+        }
     }
 
     &.manage-account__switch--hinted {
@@ -115,19 +118,34 @@ $checkbox-size: $gs-gutter / 1.25;
     show normal checkboxes on
     older browsers
     */
+
+    /*override pasteup*/
+    input[type=checkbox] {
+        float: none;
+        margin: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 10;
+        height: $checkbox-size;
+        width: $checkbox-size;
+    }
+
     @supports (transform: scale(1)) {
 
         input[type=checkbox] {
-            visibility: hidden;
-            position: absolute;
-            top: 0;
-            right: 0;
+            opacity: 0;
             & + .manage-account__switch-checkbox {
                 display: block;
                 position: absolute;
                 top: 0;
                 left: 0;
+                z-index: 11;
             }
+        }
+
+        input:focus, input:focus + .manage-account__switch-checkbox {
+            outline: 5px auto $identity-main;
         }
 
         input:checked + .manage-account__switch-checkbox {

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -99,11 +99,6 @@ $checkbox-size: $gs-gutter / 1.25;
         > * {
             opacity: .5;
         }
-
-        input[type=checkbox],
-        .manage-account__switch-checkbox {
-            opacity: .25!important;
-        }
     }
 
     &.is-just-updated {

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -134,7 +134,7 @@ $checkbox-size: $gs-gutter / 1.25;
     @supports (transform: scale(1)) {
 
         input[type=checkbox] {
-            opacity: 0;
+            opacity: 0!important;
             & + .manage-account__switch-checkbox {
                 display: block;
                 position: absolute;
@@ -146,6 +146,7 @@ $checkbox-size: $gs-gutter / 1.25;
 
         input:focus, input:focus + .manage-account__switch-checkbox {
             outline: 5px auto $identity-main;
+            border-color: $identity-main;
         }
 
         input:checked + .manage-account__switch-checkbox {

--- a/static/src/stylesheets/module/identity/_switches.scss
+++ b/static/src/stylesheets/module/identity/_switches.scss
@@ -154,10 +154,11 @@ $checkbox-size: $gs-gutter / 1.25;
 }
 
 .manage-account__switch-content {
-    width: auto;
+    width: 100%;
     position: relative;
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     padding-left: $local-gutter * 1.5 + $checkbox-size;
 }
 


### PR DESCRIPTION
## What does this change?
Updates a couple of unpleasant behaviours with the gdpr consent checkboxes, namely

- The focus rings were missing (sorry!)
- They looked bad on IE11 (and it was pretty trivial to fix)

## What is the value of this and can you measure success?
Improved accessibility plus a nicer layout on legacy browsers

## Screenshots?
<div align=center>

before
![screen shot 2017-12-20 at 13 22 40](https://user-images.githubusercontent.com/11539094/34211296-8899fa24-e590-11e7-8526-3cbf3662ae71.png)
after
![screen shot 2017-12-20 at 14 17 15](https://user-images.githubusercontent.com/11539094/34211299-8ac65da6-e590-11e7-8c99-ceaa74cc17c3.png)
