### PR TITLE
Garnett: Fix spacing issue with media cards meta and sublinks 

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -214,7 +214,6 @@ data-test-id="facia-card"
             @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
                 @if(item.isMediaLink) {
                     @standfirst(item)
-                    @mediaMeta(item)
                 } else {
                     <div class="fc-item__standfirst-wrapper">
                         @standfirst(item)
@@ -239,15 +238,25 @@ data-test-id="facia-card"
             @if(item.isLive && item.displaySettings.showLivePlayable && !isList) {
                 <div class="js-liveblog-blocks fc-item__liveblog-blocks" data-article-id="@item.id"></div>
             }
-
-            @if(item.sublinks.nonEmpty) {
-                <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
-            }
-
-            @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
+            @if(experiments.ActiveExperiments.isParticipating(experiments.Garnett)) {
+                @if(item.isMediaLink) {
+                    <div class="fc-item__footer-meta-wrapper">
+                        @mediaMeta(item)
+                        @if(item.sublinks.nonEmpty) {
+                            <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
+                        }
+                    </div>
+                } else {
+                    @if(item.sublinks.nonEmpty) {
+                        <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
+                    }
+                }
+            } else {
+                @if(item.sublinks.nonEmpty) {
+                    <div class="fc-item__footer--vertical" aria-hidden="true">@sublinks(item.sublinks)</div>
+                }
                 @meta(item)
             }
-        </div>
 
         @if(!experiments.ActiveExperiments.isParticipating(experiments.Garnett) && item.cardTypes.showCutOut) {
             @item.cutOut.map { case cutOut@CutOut(imageUrl, _) =>
@@ -260,7 +269,7 @@ data-test-id="facia-card"
             </div>
             }
         }
-        
+
 
         @if(item.sublinks.nonEmpty) {
             <footer class="fc-item__footer--horizontal">@sublinks(item.sublinks)</footer>

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -413,6 +413,13 @@ $block-height: 58px;
 
     }
 
+    .fc-item__footer-meta-wrapper {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+    }
+
     .fc-item__media-meta,
     .fc-item__meta {
         flex: 0 0 auto;


### PR DESCRIPTION
Previously, for a media card, the meta would be shown in the middle by virtue of being the middle element in the float. This PR combines the sublinks and meta into a single div so that they both appear at the bottom.

https://trello.com/c/dLuSE8Jh/113-podcast-label-with-sublink