### PR TITLE
Changes to US News Pillar in the Navigation based on editorial input

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -55,6 +55,7 @@ object NavLinks {
   val ukBusiness = NavLink("business", "/business", children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness))
   val usBusiness = ukBusiness.copy(children = List(economics, sustainableBusiness, diversityEquality, smallBusiness))
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate))
+  val homelessness = NavLink("homelessness", "/us-news/series/outside-in-america")
 
   /* OPINION */
   val columnists = NavLink("columnists", "/index/contributors")
@@ -208,10 +209,9 @@ object NavLinks {
       soccer,
       usPolitics,
       usBusiness,
-      science,
-      money,
       tech,
-      obituaries
+      science,
+      homelessness
     )
   )
   val intNewsPillar = ukNewsPillar.copy(


### PR DESCRIPTION
## What does this change?
This changed some of the items in the US News pillar based on feedback from editorial. 

## What is the value of this and can you measure success?
US are happier with the content in the Nav

## Does this affect other platforms - Amp, Apps, etc?
This would affect the AMP open nav too

## Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->
Nope

## Screenshots
![image](https://user-images.githubusercontent.com/8774970/34214554-c05dce9a-e59a-11e7-8325-f5f267dd97d4.png)

## Tested in CODE?
Nope
<!-- AB test? https://git.io/v1V0x -->
<!-- AMP question? https://git.io/v9zIE -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
